### PR TITLE
fix(material/paginator): add support page sizes with custom labels

### DIFF
--- a/src/dev-app/mdc-paginator/mdc-paginator-demo.ts
+++ b/src/dev-app/mdc-paginator/mdc-paginator-demo.ts
@@ -34,7 +34,7 @@ export class MdcPaginatorDemo {
   length = 50;
   pageSize = 10;
   pageIndex = 0;
-  pageSizeOptions = [5, 10, 25];
+  pageSizeOptions = [5, 10, 25, {label: 'All', value: this.length}];
 
   hidePageSize = false;
   showPageSizeOptions = true;

--- a/src/dev-app/paginator/paginator-demo.ts
+++ b/src/dev-app/paginator/paginator-demo.ts
@@ -34,7 +34,7 @@ export class PaginatorDemo {
   length = 50;
   pageSize = 10;
   pageIndex = 0;
-  pageSizeOptions = [5, 10, 25];
+  pageSizeOptions = [5, 10, 25, {label: 'All', value: this.length}];
 
   hidePageSize = false;
   showPageSizeOptions = true;

--- a/src/material-experimental/mdc-paginator/BUILD.bazel
+++ b/src/material-experimental/mdc-paginator/BUILD.bazel
@@ -17,8 +17,10 @@ ng_module(
     ),
     assets = [":paginator.css"] + glob(["**/*.html"]),
     deps = [
+        "//src/cdk/testing/testbed",
         "//src/material-experimental/mdc-button",
         "//src/material-experimental/mdc-select",
+        "//src/material-experimental/mdc-select/testing",
         "//src/material-experimental/mdc-tooltip",
         "//src/material/paginator",
         "@npm//@angular/common",
@@ -56,7 +58,9 @@ ng_test_library(
     deps = [
         ":mdc-paginator",
         "//src/cdk/testing/private",
+        "//src/cdk/testing/testbed",
         "//src/material-experimental/mdc-select",
+        "//src/material-experimental/mdc-select/testing",
         "//src/material/core",
         "@npm//@angular/platform-browser",
     ],

--- a/src/material-experimental/mdc-paginator/paginator.html
+++ b/src/material-experimental/mdc-paginator/paginator.html
@@ -17,8 +17,8 @@
           [panelClass]="selectConfig.panelClass || ''"
           [disableOptionCentering]="selectConfig.disableOptionCentering"
           (selectionChange)="_changePageSize($event.value)">
-          <mat-option *ngFor="let pageSizeOption of _displayedPageSizeOptions" [value]="pageSizeOption">
-            {{pageSizeOption}}
+          <mat-option *ngFor="let pageSizeOption of _displayedPageSizeOptions" [value]="pageSizeOption.value">
+            {{pageSizeOption.label}}
           </mat-option>
         </mat-select>
       </mat-form-field>

--- a/src/material-experimental/mdc-paginator/paginator.spec.ts
+++ b/src/material-experimental/mdc-paginator/paginator.spec.ts
@@ -4,6 +4,7 @@ import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {dispatchMouseEvent} from '../../cdk/testing/private';
 import {ThemePalette} from '@angular/material/core';
 import {MatSelect} from '@angular/material-experimental/mdc-select';
+import {MatSelectHarness} from '@angular/material-experimental/mdc-select/testing';
 import {By} from '@angular/platform-browser';
 import {
   MatPaginatorModule,
@@ -12,6 +13,7 @@ import {
   MatPaginatorSelectConfig,
 } from './index';
 import {MAT_PAGINATOR_DEFAULT_OPTIONS, MatPaginatorDefaultOptions} from './paginator';
+import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 
 describe('MDC-based MatPaginator', () => {
   function createComponent<T>(type: Type<T>, providers: Provider[] = []): ComponentFixture<T> {
@@ -343,7 +345,9 @@ describe('MDC-based MatPaginator', () => {
     const fixture = createComponent(MatPaginatorWithoutOptionsApp);
     fixture.detectChanges();
 
-    expect(fixture.componentInstance.paginator._displayedPageSizeOptions).toEqual([10]);
+    expect(fixture.componentInstance.paginator._displayedPageSizeOptions).toEqual([
+      {value: 10, label: '10'},
+    ]);
   });
 
   it('should default the page size to the first page size option if not provided', () => {
@@ -357,16 +361,33 @@ describe('MDC-based MatPaginator', () => {
     const fixture = createComponent(MatPaginatorApp);
     const component = fixture.componentInstance;
     const paginator = component.paginator;
-    expect(paginator._displayedPageSizeOptions).toEqual([5, 10, 25, 100]);
+    expect(paginator._displayedPageSizeOptions).toEqual([
+      {value: 5, label: '5'},
+      {value: 10, label: '10'},
+      {value: 25, label: '25'},
+      {value: 100, label: 'All'},
+    ]);
 
     component.pageSize = 30;
     fixture.detectChanges();
-    expect(paginator.pageSizeOptions).toEqual([5, 10, 25, 100]);
-    expect(paginator._displayedPageSizeOptions).toEqual([5, 10, 25, 30, 100]);
+    expect(paginator.pageSizeOptions).toEqual([5, 10, 25, {value: 100, label: 'All'}]);
+    expect(paginator._displayedPageSizeOptions).toEqual([
+      {value: 5, label: '5'},
+      {value: 10, label: '10'},
+      {value: 25, label: '25'},
+      {value: 30, label: '30'},
+      {value: 100, label: 'All'},
+    ]);
 
-    component.pageSizeOptions = [100, 25, 10, 5];
+    component.pageSizeOptions = [{value: 100, label: 'All'}, 25, 10, 5];
     fixture.detectChanges();
-    expect(paginator._displayedPageSizeOptions).toEqual([5, 10, 25, 30, 100]);
+    expect(paginator._displayedPageSizeOptions).toEqual([
+      {value: 5, label: '5'},
+      {value: 10, label: '10'},
+      {value: 25, label: '25'},
+      {value: 30, label: '30'},
+      {value: 100, label: 'All'},
+    ]);
   });
 
   it('should be able to change the page size while keeping the first item present', () => {
@@ -446,7 +467,12 @@ describe('MDC-based MatPaginator', () => {
     const component = fixture.componentInstance;
     const paginator = component.paginator;
 
-    expect(paginator._displayedPageSizeOptions).toEqual([5, 10, 25, 100]);
+    expect(paginator._displayedPageSizeOptions).toEqual([
+      {value: 5, label: '5'},
+      {value: 10, label: '10'},
+      {value: 25, label: '25'},
+      {value: 100, label: 'All'},
+    ]);
     expect(fixture.nativeElement.querySelector('.mat-mdc-select')).not.toBeNull();
 
     // Remove options so that the paginator only uses the current page size (10) as an option.
@@ -539,8 +565,41 @@ describe('MDC-based MatPaginator', () => {
     const fixture = createComponent(MatPaginatorWithReadonlyOptions);
     fixture.detectChanges();
 
-    expect(fixture.componentInstance.paginator._displayedPageSizeOptions).toEqual([5, 10, 25, 100]);
+    expect(fixture.componentInstance.paginator._displayedPageSizeOptions).toEqual([
+      {value: 5, label: '5'},
+      {value: 10, label: '10'},
+      {value: 25, label: '25'},
+      {value: 100, label: 'All'},
+    ]);
   });
+
+  it('should accept page size options with custom labels', fakeAsync(async () => {
+    const fixture = createComponent(MatPaginatorWithCustomLabelOptions);
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.paginator._displayedPageSizeOptions).toEqual([
+      {value: -1, label: 'Negative'},
+      {value: 0, label: 'None'},
+      {value: 1, label: 'One-by-one'},
+      {value: 10, label: '10'},
+      {value: 25, label: '25'},
+      {value: 100, label: 'All'},
+    ]);
+  }));
+
+  it('should allow selecting page size options with custom labels', fakeAsync(async () => {
+    const fixture = createComponent(MatPaginatorWithCustomLabelOptions);
+    fixture.detectChanges();
+
+    const loader = TestbedHarnessEnvironment.loader(fixture);
+    const selectHarness = await loader.getHarness(MatSelectHarness);
+
+    expect(fixture.componentInstance.paginator.pageSize).toEqual(10);
+
+    await selectHarness.clickOptions({text: /all/i});
+    fixture.detectChanges();
+    expect(fixture.componentInstance.paginator.pageSize).toEqual(100);
+  }));
 });
 
 function getPreviousButton(fixture: ComponentFixture<any>) {
@@ -577,7 +636,7 @@ function getLastButton(fixture: ComponentFixture<any>) {
 class MatPaginatorApp {
   pageIndex = 0;
   pageSize = 10;
-  pageSizeOptions = [5, 10, 25, 100];
+  pageSizeOptions = [5, 10, 25, {value: 100, label: 'All'}];
   hidePageSize = false;
   showFirstLastButtons = false;
   length = 100;
@@ -641,5 +700,30 @@ class MatPaginatorWithStringValues {
 })
 class MatPaginatorWithReadonlyOptions {
   @ViewChild(MatPaginator) paginator: MatPaginator;
-  pageSizeOptions: readonly number[] = [5, 10, 25, 100];
+  pageSizeOptions: readonly (number | {label: string; value: number})[] = [
+    5,
+    10,
+    25,
+    {label: 'All', value: 100},
+  ];
+}
+
+@Component({
+  template: `
+    <mat-paginator pageIndex="0"
+                   pageSize="10"
+                   [pageSizeOptions]="[
+                     {label: 'Negative', value: -1},
+                     {label: 'None', value: 0},
+                     {label: 'One-by-one', value: '1'},
+                     10,
+                     '25',
+                     {label: 'All', value: 100}
+                   ]"
+                   length="100">
+    </mat-paginator>
+  `,
+})
+class MatPaginatorWithCustomLabelOptions {
+  @ViewChild(MatPaginator) paginator: MatPaginator;
 }

--- a/src/material-experimental/mdc-paginator/public-api.ts
+++ b/src/material-experimental/mdc-paginator/public-api.ts
@@ -13,5 +13,6 @@ export {
   MAT_PAGINATOR_INTL_PROVIDER_FACTORY,
   MAT_PAGINATOR_INTL_PROVIDER,
   PageEvent,
+  PageSizeOptions,
   MatPaginatorSelectConfig,
 } from '@angular/material/paginator';

--- a/src/material/paginator/BUILD.bazel
+++ b/src/material/paginator/BUILD.bazel
@@ -19,9 +19,11 @@ ng_module(
     assets = [":paginator.css"] + glob(["**/*.html"]),
     deps = [
         "//src/cdk/coercion",
+        "//src/cdk/testing/testbed",
         "//src/material/button",
         "//src/material/core",
         "//src/material/select",
+        "//src/material/select/testing",
         "//src/material/tooltip",
         "@npm//@angular/common",
         "@npm//@angular/core",
@@ -55,8 +57,10 @@ ng_test_library(
     deps = [
         ":paginator",
         "//src/cdk/testing/private",
+        "//src/cdk/testing/testbed",
         "//src/material/core",
         "//src/material/select",
+        "//src/material/select/testing",
         "@npm//@angular/platform-browser",
     ],
 )

--- a/src/material/paginator/paginator.html
+++ b/src/material/paginator/paginator.html
@@ -17,8 +17,8 @@
           [disableOptionCentering]="selectConfig.disableOptionCentering"
           [aria-label]="_intl.itemsPerPageLabel"
           (selectionChange)="_changePageSize($event.value)">
-          <mat-option *ngFor="let pageSizeOption of _displayedPageSizeOptions" [value]="pageSizeOption">
-            {{pageSizeOption}}
+          <mat-option *ngFor="let pageSizeOption of _displayedPageSizeOptions" [value]="pageSizeOption.value">
+            {{pageSizeOption.label}}
           </mat-option>
         </mat-select>
       </mat-form-field>

--- a/tools/public_api_guard/material/paginator.md
+++ b/tools/public_api_guard/material/paginator.md
@@ -52,14 +52,20 @@ export class MatPaginator extends _MatPaginatorBase<MatPaginatorDefaultOptions> 
 // @public
 export abstract class _MatPaginatorBase<O extends {
     pageSize?: number;
-    pageSizeOptions?: number[];
+    pageSizeOptions?: (number | {
+        value: number;
+        label: string;
+    })[];
     hidePageSize?: boolean;
     showFirstLastButtons?: boolean;
 }> extends _MatPaginatorMixinBase implements OnInit, OnDestroy, CanDisable, HasInitialized {
     constructor(_intl: MatPaginatorIntl, _changeDetectorRef: ChangeDetectorRef, defaults?: O);
     _changePageSize(pageSize: number): void;
     color: ThemePalette;
-    _displayedPageSizeOptions: number[];
+    _displayedPageSizeOptions: {
+        value: number;
+        label: string;
+    }[];
     firstPage(): void;
     getNumberOfPages(): number;
     hasNextPage(): boolean;
@@ -82,8 +88,11 @@ export abstract class _MatPaginatorBase<O extends {
     set pageIndex(value: NumberInput);
     get pageSize(): number;
     set pageSize(value: NumberInput);
-    get pageSizeOptions(): number[];
-    set pageSizeOptions(value: number[] | readonly number[]);
+    get pageSizeOptions(): (number | {
+        value: number;
+        label: string;
+    })[];
+    set pageSizeOptions(value: PageSizeOptions);
     _previousButtonsDisabled(): boolean;
     previousPage(): void;
     selectConfig: MatPaginatorSelectConfig;
@@ -100,7 +109,10 @@ export interface MatPaginatorDefaultOptions {
     formFieldAppearance?: MatFormFieldAppearance;
     hidePageSize?: boolean;
     pageSize?: number;
-    pageSizeOptions?: number[];
+    pageSizeOptions?: (number | {
+        value: number;
+        label: string;
+    })[];
     showFirstLastButtons?: boolean;
 }
 
@@ -144,6 +156,15 @@ export class PageEvent {
     pageSize: number;
     previousPageIndex?: number;
 }
+
+// @public
+export type PageSizeOptions = readonly (number | {
+    value: number;
+    label: string;
+})[] | (number | {
+    value: number;
+    label: string;
+})[];
 
 // (No @packageDocumentation comment for this package)
 


### PR DESCRIPTION
# Add support for page size options with a specified label.
`pageSizeOptions` accepts both strings and pair of string value.

Example `pageSizeOptions`
```
[5, 10, 25, {value: 50, label: 'All']
```

Resolves https://github.com/angular/components/issues/8150