### PR TITLE
fix(multiple): fix disabled label style

### DIFF
--- a/src/material-experimental/mdc-checkbox/_checkbox-theme.scss
+++ b/src/material-experimental/mdc-checkbox/_checkbox-theme.scss
@@ -32,6 +32,7 @@
   $primary: mat.get-color-from-palette(map.get($config, primary));
   $accent: mat.get-color-from-palette(map.get($config, accent));
   $warn: mat.get-color-from-palette(map.get($config, warn));
+  $foreground: map.get($config, foreground);
 
   @include mat.private-using-mdc-theme($config) {
     .mat-mdc-checkbox {
@@ -63,6 +64,11 @@
         @include checkbox-private.private-checkbox-styles-with-color($config, $warn, error);
         @include _selected-ripple-colors($warn, error);
       }
+    }
+
+    .mat-mdc-checkbox-disabled label {
+      // MDC should set the disabled color on the label, but doesn't, so we do it here instead.
+      color: mat.get-color-from-palette($foreground, disabled-text);
     }
   }
 }

--- a/src/material-experimental/mdc-radio/_radio-theme.scss
+++ b/src/material-experimental/mdc-radio/_radio-theme.scss
@@ -21,6 +21,7 @@
   $primary: mat.get-color-from-palette(map.get($config, primary));
   $accent: mat.get-color-from-palette(map.get($config, accent));
   $warn: mat.get-color-from-palette(map.get($config, warn));
+  $foreground: map.get($config, foreground);
 
   @include mat.private-using-mdc-theme($config) {
     $on-surface: rgba(mdc-theme-color.$on-surface, 0.54);
@@ -45,6 +46,11 @@
       ));
 
       --mat-mdc-radio-ripple-color: #{mdc-theme-color.prop-value(on-surface)};
+
+      // MDC should set the disabled color on the label, but doesn't, so we do it here instead.
+      .mdc-radio--disabled + label {
+        color: mat.get-color-from-palette($foreground, disabled-text);
+      }
 
       &.mat-primary {
         @include _color-palette($primary);

--- a/src/material-experimental/mdc-slide-toggle/_slide-toggle-theme.scss
+++ b/src/material-experimental/mdc-slide-toggle/_slide-toggle-theme.scss
@@ -73,6 +73,7 @@
   $accent: mat.get-color-from-palette(map.get($config, accent));
   $warn: mat.get-color-from-palette(map.get($config, warn));
   $is-dark: map.get($config, is-dark);
+  $foreground: map.get($config, foreground);
 
   @include mat.private-using-mdc-theme($config) {
     // MDC's switch doesn't support a `color` property. We add support
@@ -80,6 +81,11 @@
     .mat-mdc-slide-toggle {
       @include mdc-form-field.core-styles($query: mat.$private-mdc-theme-styles-query);
       @include mdc-switch-theme.theme(_get-theme-base-map($is-dark));
+
+      // MDC should set the disabled color on the label, but doesn't, so we do it here instead.
+      .mdc-switch--disabled + label {
+        color: mat.get-color-from-palette($foreground, disabled-text);
+      }
 
       &.mat-primary {
         @include mdc-switch-theme.theme(_get-theme-color-map($primary));


### PR DESCRIPTION
MDC does not set the disabled text color on the label for the checkbox,
radio, or switch. This change applies it on the Angular Material side.

Fixes b/224789079