### PR TITLE
build: fix loose yarn engine range

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "engines": {
     "node": ">=14.0.0 <17.0.0",
-    "yarn": ">= 1.0.0",
+    "yarn": "^1.22.17",
     "npm": "Please use Yarn instead of NPM to install dependencies. See: https://yarnpkg.com/lang/en/docs/install/"
   },
   "scripts": {


### PR DESCRIPTION
Renovate incorrectly is fine using Yarn 2+ for the components
repo because our enignes field is too loose.