### PR TITLE
build: account for rename of angular/code-of-conduct default branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -258,7 +258,7 @@ changes to be accepted, the CLA must be signed. It's a quick process, we promise
 
 
 [material-group]: https://groups.google.com/forum/#!forum/angular-material2
-[coc]: https://github.com/angular/code-of-conduct/blob/master/CODE_OF_CONDUCT.md
+[coc]: https://github.com/angular/code-of-conduct/blob/main/CODE_OF_CONDUCT.md
 [commit-message-format]: https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/preview
 [commit-message-scopes]: https://github.com/angular/components/blob/main/.ng-dev/commit-message.ts#L10
 [corporate-cla]: http://code.google.com/legal/corporate-cla-v1.0.html


### PR DESCRIPTION
We just renamed the Angular code of conduct repository default branch
to `main`. This repository was not part of the large migration and is
now handled separately as a little clean-up.