### PR TITLE
feat(material/tooltip): add option to open tooltip at mouse position

### DIFF
--- a/src/cdk/overlay/position/flexible-connected-position-strategy.ts
+++ b/src/cdk/overlay/position/flexible-connected-position-strategy.ts
@@ -98,7 +98,7 @@ export class FlexibleConnectedPositionStrategy implements PositionStrategy {
   _preferredPositions: ConnectionPositionPair[] = [];
 
   /** The origin element against which the overlay will be positioned. */
-  private _origin: FlexibleConnectedPositionStrategyOrigin;
+  _origin: FlexibleConnectedPositionStrategyOrigin;
 
   /** The overlay pane element. */
   private _pane: HTMLElement;

--- a/src/components-examples/material/tooltip/index.ts
+++ b/src/components-examples/material/tooltip/index.ts
@@ -16,6 +16,7 @@ import {TooltipMessageExample} from './tooltip-message/tooltip-message-example';
 import {TooltipModifiedDefaultsExample} from './tooltip-modified-defaults/tooltip-modified-defaults-example';
 import {TooltipOverviewExample} from './tooltip-overview/tooltip-overview-example';
 import {TooltipPositionExample} from './tooltip-position/tooltip-position-example';
+import {TooltipPositionAtOriginExample} from './tooltip-position-at-origin/tooltip-position-at-origin-example';
 import {TooltipHarnessExample} from './tooltip-harness/tooltip-harness-example';
 
 export {
@@ -29,6 +30,7 @@ export {
   TooltipModifiedDefaultsExample,
   TooltipOverviewExample,
   TooltipPositionExample,
+  TooltipPositionAtOriginExample,
 };
 
 const EXAMPLES = [
@@ -42,6 +44,7 @@ const EXAMPLES = [
   TooltipModifiedDefaultsExample,
   TooltipOverviewExample,
   TooltipPositionExample,
+  TooltipPositionAtOriginExample,
 ];
 
 @NgModule({

--- a/src/components-examples/material/tooltip/tooltip-position-at-origin/tooltip-position-at-origin-example.css
+++ b/src/components-examples/material/tooltip/tooltip-position-at-origin/tooltip-position-at-origin-example.css
@@ -1,0 +1,8 @@
+button {
+  width: 500px;
+  height: 500px;
+}
+
+.example-enabled-checkbox {
+  margin-left: 8px;
+}

--- a/src/components-examples/material/tooltip/tooltip-position-at-origin/tooltip-position-at-origin-example.html
+++ b/src/components-examples/material/tooltip/tooltip-position-at-origin/tooltip-position-at-origin-example.html
@@ -1,0 +1,10 @@
+<button mat-raised-button
+        matTooltip="Info about the action"
+        [matTooltipPositionAtOrigin]="enabled.value"
+        aria-label="Button that displays a tooltip when focused or hovered over">
+  Action
+</button>
+
+<mat-checkbox [formControl]="enabled" class="example-enabled-checkbox">
+  Position at origin enabled
+</mat-checkbox>

--- a/src/components-examples/material/tooltip/tooltip-position-at-origin/tooltip-position-at-origin-example.ts
+++ b/src/components-examples/material/tooltip/tooltip-position-at-origin/tooltip-position-at-origin-example.ts
@@ -1,0 +1,14 @@
+import {Component} from '@angular/core';
+import {FormControl} from '@angular/forms';
+
+/**
+ * @title Basic tooltip
+ */
+@Component({
+  selector: 'tooltip-position-at-origin-example',
+  templateUrl: 'tooltip-position-at-origin-example.html',
+  styleUrls: ['tooltip-position-at-origin-example.css'],
+})
+export class TooltipPositionAtOriginExample {
+  enabled = new FormControl(false);
+}

--- a/src/dev-app/tooltip/tooltip-demo.html
+++ b/src/dev-app/tooltip/tooltip-demo.html
@@ -24,3 +24,6 @@
 
 <h3>Tooltip positioning</h3>
 <tooltip-position-example></tooltip-position-example>
+
+<h3>Tooltip with position at origin</h3>
+<tooltip-position-at-origin-example></tooltip-position-at-origin-example>

--- a/src/material/legacy-tooltip/tooltip.spec.ts
+++ b/src/material/legacy-tooltip/tooltip.spec.ts
@@ -11,6 +11,7 @@ import {
   dispatchFakeEvent,
   dispatchKeyboardEvent,
   dispatchMouseEvent,
+  dispatchTouchEvent,
   patchElementFocus,
 } from '../../cdk/testing/private';
 import {
@@ -230,6 +231,63 @@ describe('MatTooltip', () => {
       expect(tooltipDirective.position).toBe('right');
       expect(tooltipDirective._getOverlayPosition().main.overlayX).toBe('start');
       expect(tooltipDirective._getOverlayPosition().fallback.overlayX).toBe('end');
+    }));
+
+    it('should position center-bottom by default', fakeAsync(() => {
+      TestBed.resetTestingModule()
+        .configureTestingModule({
+          imports: [MatLegacyTooltipModule, OverlayModule],
+          declarations: [WideTooltipDemo]
+        })
+        .compileComponents();
+
+      const wideFixture = TestBed.createComponent(WideTooltipDemo);
+      wideFixture.detectChanges();
+      tooltipDirective = wideFixture.debugElement
+        .query(By.css('button'))!
+        .injector.get<MatLegacyTooltip>(MatLegacyTooltip);
+      const button: HTMLButtonElement = wideFixture.nativeElement.querySelector('button');
+      const triggerRect = button.getBoundingClientRect();
+
+      dispatchMouseEvent(button, 'mouseenter', triggerRect.right - 100, triggerRect.top + 100);
+      wideFixture.detectChanges();
+      tick();
+      expect(tooltipDirective._isTooltipVisible()).toBe(true);
+
+      expect(tooltipDirective._overlayRef!.overlayElement.offsetLeft).toBeGreaterThan(triggerRect.left + 200);
+      expect(tooltipDirective._overlayRef!.overlayElement.offsetLeft).toBeLessThan(triggerRect.left + 300);
+      expect(tooltipDirective._overlayRef!.overlayElement.offsetTop).toBe(triggerRect.bottom);
+    }));
+
+    it('should be able to override the default positionAtOrigin', fakeAsync(() => {
+      TestBed.resetTestingModule()
+        .configureTestingModule({
+          imports: [MatLegacyTooltipModule, OverlayModule],
+          declarations: [WideTooltipDemo],
+          providers: [
+            {
+              provide: MAT_TOOLTIP_DEFAULT_OPTIONS,
+              useValue: {positionAtOrigin: true},
+            },
+          ],
+        })
+        .compileComponents();
+
+      const wideFixture = TestBed.createComponent(WideTooltipDemo);
+      wideFixture.detectChanges();
+      tooltipDirective = wideFixture.debugElement
+        .query(By.css('button'))!
+        .injector.get<MatLegacyTooltip>(MatLegacyTooltip);
+      const button: HTMLButtonElement = wideFixture.nativeElement.querySelector('button');
+      const triggerRect = button.getBoundingClientRect();
+
+      dispatchMouseEvent(button, 'mouseenter', triggerRect.left + 50, triggerRect.bottom - 10);
+      wideFixture.detectChanges();
+      tick();
+      expect(tooltipDirective._isTooltipVisible()).toBe(true);
+
+      expect(tooltipDirective._overlayRef!.overlayElement.offsetLeft).toBe(triggerRect.left + 28);
+      expect(tooltipDirective._overlayRef!.overlayElement.offsetTop).toBe(triggerRect.bottom - 10);
     }));
 
     it('should be able to disable tooltip interactivity', fakeAsync(() => {
@@ -1169,7 +1227,10 @@ describe('MatTooltip', () => {
       fixture.detectChanges();
       const button: HTMLButtonElement = fixture.nativeElement.querySelector('button');
 
-      dispatchFakeEvent(button, 'touchstart');
+      const triggerRect = button.getBoundingClientRect();
+      const offsetX = triggerRect.right - 10;
+      const offsetY = triggerRect.top + 10;
+      dispatchTouchEvent(button, 'touchstart', offsetX, offsetY, offsetX, offsetY);
       fixture.detectChanges();
       tick(250); // Halfway through the delay.
 
@@ -1188,7 +1249,10 @@ describe('MatTooltip', () => {
       fixture.detectChanges();
       const button: HTMLButtonElement = fixture.nativeElement.querySelector('button');
 
-      dispatchFakeEvent(button, 'touchstart');
+      const triggerRect = button.getBoundingClientRect();
+      const offsetX = triggerRect.right - 10;
+      const offsetY = triggerRect.top + 10;
+      dispatchTouchEvent(button, 'touchstart', offsetX, offsetY, offsetX, offsetY);
       fixture.detectChanges();
       tick(500); // Finish the delay.
       fixture.detectChanges();
@@ -1201,7 +1265,10 @@ describe('MatTooltip', () => {
       const fixture = TestBed.createComponent(BasicTooltipDemo);
       fixture.detectChanges();
       const button: HTMLButtonElement = fixture.nativeElement.querySelector('button');
-      const event = dispatchFakeEvent(button, 'touchstart');
+      const triggerRect = button.getBoundingClientRect();
+      const offsetX = triggerRect.right - 10;
+      const offsetY = triggerRect.top + 10;
+      const event = dispatchTouchEvent(button, 'touchstart', offsetX, offsetY, offsetX, offsetY);
       fixture.detectChanges();
 
       expect(event.defaultPrevented).toBe(false);
@@ -1212,7 +1279,10 @@ describe('MatTooltip', () => {
       fixture.detectChanges();
       const button: HTMLButtonElement = fixture.nativeElement.querySelector('button');
 
-      dispatchFakeEvent(button, 'touchstart');
+      const triggerRect = button.getBoundingClientRect();
+      const offsetX = triggerRect.right - 10;
+      const offsetY = triggerRect.top + 10;
+      dispatchTouchEvent(button, 'touchstart', offsetX, offsetY, offsetX, offsetY);
       fixture.detectChanges();
       tick(500); // Finish the open delay.
       fixture.detectChanges();
@@ -1236,7 +1306,10 @@ describe('MatTooltip', () => {
       fixture.detectChanges();
       const button: HTMLButtonElement = fixture.nativeElement.querySelector('button');
 
-      dispatchFakeEvent(button, 'touchstart');
+      const triggerRect = button.getBoundingClientRect();
+      const offsetX = triggerRect.right - 10;
+      const offsetY = triggerRect.top + 10;
+      dispatchTouchEvent(button, 'touchstart', offsetX, offsetY, offsetX, offsetY);
       fixture.detectChanges();
       tick(500); // Finish the open delay.
       fixture.detectChanges();
@@ -1401,8 +1474,9 @@ describe('MatTooltip', () => {
       const fixture = TestBed.createComponent(BasicTooltipDemo);
       fixture.detectChanges();
       const button: HTMLButtonElement = fixture.nativeElement.querySelector('button');
+      const triggerRect = button.getBoundingClientRect();
 
-      dispatchFakeEvent(button, 'mouseenter');
+      dispatchMouseEvent(button, 'mouseenter', triggerRect.right - 10, triggerRect.top + 10);
       fixture.detectChanges();
       tick(500); // Finish the open delay.
       fixture.detectChanges();
@@ -1410,7 +1484,6 @@ describe('MatTooltip', () => {
       assertTooltipInstance(fixture.componentInstance.tooltip, true);
 
       // Simulate the pointer over the trigger.
-      const triggerRect = button.getBoundingClientRect();
       const wheelEvent = createFakeEvent('wheel');
       Object.defineProperties(wheelEvent, {
         clientX: {get: () => triggerRect.left + 1},
@@ -1552,6 +1625,17 @@ class TooltipOnDraggableElement {
 })
 class TooltipDemoWithoutPositionBinding {
   message: any = initialTooltipMessage;
+  @ViewChild(MatLegacyTooltip) tooltip: MatLegacyTooltip;
+  @ViewChild('button') button: ElementRef<HTMLButtonElement>;
+}
+
+@Component({
+  selector: 'app',
+  styles: [`button { width: 500px; height: 500px; }`],
+  template: `<button #button [matTooltip]="message">Button</button>`,
+})
+class WideTooltipDemo {
+  message = 'Test';
   @ViewChild(MatLegacyTooltip) tooltip: MatLegacyTooltip;
   @ViewChild('button') button: ElementRef<HTMLButtonElement>;
 }

--- a/src/material/tooltip/tooltip.md
+++ b/src/material/tooltip/tooltip.md
@@ -27,6 +27,12 @@ CSS class that can be used for style (e.g. to add an arrow). The possible classe
 
 <!-- example(tooltip-position) -->
 
+To display the tooltip relative to the mouse or touch that triggered it, use the
+`matTooltipPositionAtOrigin` input.
+With this setting turned on, the tooltip will display relative to the origin of the trigger rather
+than the host element. In cases where the tooltip is not triggered by a touch event or mouse click,
+it will display the same as if this setting was turned off.
+
 ### Showing and hiding
 
 By default, the tooltip will be immediately shown when the user's mouse hovers over the tooltip's

--- a/src/material/tooltip/tooltip.spec.ts
+++ b/src/material/tooltip/tooltip.spec.ts
@@ -11,6 +11,7 @@ import {
   dispatchFakeEvent,
   dispatchKeyboardEvent,
   dispatchMouseEvent,
+  dispatchTouchEvent,
   patchElementFocus,
 } from '../../cdk/testing/private';
 import {
@@ -232,6 +233,62 @@ describe('MDC-based MatTooltip', () => {
       expect(tooltipDirective.position).toBe('right');
       expect(tooltipDirective._getOverlayPosition().main.overlayX).toBe('start');
       expect(tooltipDirective._getOverlayPosition().fallback.overlayX).toBe('end');
+    }));
+
+    it('should position on the bottom-left by default', fakeAsync(() => {
+      TestBed.resetTestingModule()
+        .configureTestingModule({
+          imports: [MatTooltipModule, OverlayModule],
+          declarations: [WideTooltipDemo]
+        })
+        .compileComponents();
+
+      const wideFixture = TestBed.createComponent(WideTooltipDemo);
+      wideFixture.detectChanges();
+      tooltipDirective = wideFixture.debugElement
+        .query(By.css('button'))!
+        .injector.get<MatTooltip>(MatTooltip);
+      const button: HTMLButtonElement = wideFixture.nativeElement.querySelector('button');
+      const triggerRect = button.getBoundingClientRect();
+
+      dispatchMouseEvent(button, 'mouseenter', triggerRect.right - 100, triggerRect.top + 100);
+      wideFixture.detectChanges();
+      tick();
+      expect(tooltipDirective._isTooltipVisible()).toBe(true);
+
+      expect(tooltipDirective._overlayRef!.overlayElement.offsetLeft).toBeLessThan(triggerRect.right - 250);
+      expect(tooltipDirective._overlayRef!.overlayElement.offsetTop).toBeGreaterThanOrEqual(triggerRect.bottom);
+    }));
+
+    it('should be able to override the default positionAtOrigin', fakeAsync(() => {
+      TestBed.resetTestingModule()
+        .configureTestingModule({
+          imports: [MatTooltipModule, OverlayModule],
+          declarations: [WideTooltipDemo],
+          providers: [
+            {
+              provide: MAT_TOOLTIP_DEFAULT_OPTIONS,
+              useValue: {positionAtOrigin: true},
+            },
+          ],
+        })
+        .compileComponents();
+
+      const wideFixture = TestBed.createComponent(WideTooltipDemo);
+      wideFixture.detectChanges();
+      tooltipDirective = wideFixture.debugElement
+        .query(By.css('button'))!
+        .injector.get<MatTooltip>(MatTooltip);
+      const button: HTMLButtonElement = wideFixture.nativeElement.querySelector('button');
+      const triggerRect = button.getBoundingClientRect();
+
+      dispatchMouseEvent(button, 'mouseenter', triggerRect.right - 100, triggerRect.top + 100);
+      wideFixture.detectChanges();
+      tick();
+      expect(tooltipDirective._isTooltipVisible()).toBe(true);
+
+      expect(tooltipDirective._overlayRef!.overlayElement.offsetLeft).toBe(triggerRect.right - 100 - 20);
+      expect(tooltipDirective._overlayRef!.overlayElement.offsetTop).toBe(triggerRect.top + 100);
     }));
 
     it('should be able to disable tooltip interactivity', fakeAsync(() => {
@@ -1201,7 +1258,10 @@ describe('MDC-based MatTooltip', () => {
       fixture.detectChanges();
       const button: HTMLButtonElement = fixture.nativeElement.querySelector('button');
 
-      dispatchFakeEvent(button, 'touchstart');
+      const triggerRect = button.getBoundingClientRect();
+      const offsetX = triggerRect.right - 10;
+      const offsetY = triggerRect.top + 10;
+      dispatchTouchEvent(button, 'touchstart', offsetX, offsetY, offsetX, offsetY);
       fixture.detectChanges();
       tick(250); // Halfway through the delay.
 
@@ -1220,7 +1280,10 @@ describe('MDC-based MatTooltip', () => {
       fixture.detectChanges();
       const button: HTMLButtonElement = fixture.nativeElement.querySelector('button');
 
-      dispatchFakeEvent(button, 'touchstart');
+      const triggerRect = button.getBoundingClientRect();
+      const offsetX = triggerRect.right - 10;
+      const offsetY = triggerRect.top + 10;
+      dispatchTouchEvent(button, 'touchstart', offsetX, offsetY, offsetX, offsetY);
       fixture.detectChanges();
       tick(500); // Finish the delay.
       fixture.detectChanges();
@@ -1233,7 +1296,10 @@ describe('MDC-based MatTooltip', () => {
       const fixture = TestBed.createComponent(BasicTooltipDemo);
       fixture.detectChanges();
       const button: HTMLButtonElement = fixture.nativeElement.querySelector('button');
-      const event = dispatchFakeEvent(button, 'touchstart');
+      const triggerRect = button.getBoundingClientRect();
+      const offsetX = triggerRect.right - 10;
+      const offsetY = triggerRect.top + 10;
+      const event = dispatchTouchEvent(button, 'touchstart', offsetX, offsetY, offsetX, offsetY);
       fixture.detectChanges();
 
       expect(event.defaultPrevented).toBe(false);
@@ -1244,7 +1310,10 @@ describe('MDC-based MatTooltip', () => {
       fixture.detectChanges();
       const button: HTMLButtonElement = fixture.nativeElement.querySelector('button');
 
-      dispatchFakeEvent(button, 'touchstart');
+      const triggerRect = button.getBoundingClientRect();
+      const offsetX = triggerRect.right - 10;
+      const offsetY = triggerRect.top + 10;
+      dispatchTouchEvent(button, 'touchstart', offsetX, offsetY, offsetX, offsetY);
       fixture.detectChanges();
       tick(500); // Finish the open delay.
       fixture.detectChanges();
@@ -1268,7 +1337,10 @@ describe('MDC-based MatTooltip', () => {
       fixture.detectChanges();
       const button: HTMLButtonElement = fixture.nativeElement.querySelector('button');
 
-      dispatchFakeEvent(button, 'touchstart');
+      const triggerRect = button.getBoundingClientRect();
+      const offsetX = triggerRect.right - 10;
+      const offsetY = triggerRect.top + 10;
+      dispatchTouchEvent(button, 'touchstart', offsetX, offsetY, offsetX, offsetY);
       fixture.detectChanges();
       tick(500); // Finish the open delay.
       fixture.detectChanges();
@@ -1400,8 +1472,9 @@ describe('MDC-based MatTooltip', () => {
       const fixture = TestBed.createComponent(BasicTooltipDemo);
       fixture.detectChanges();
       const button: HTMLButtonElement = fixture.nativeElement.querySelector('button');
+      const triggerRect = button.getBoundingClientRect();
 
-      dispatchFakeEvent(button, 'mouseenter');
+      dispatchMouseEvent(button, 'mouseenter', triggerRect.right - 10, triggerRect.top + 10);
       fixture.detectChanges();
       tick(500); // Finish the open delay.
       fixture.detectChanges();
@@ -1433,8 +1506,9 @@ describe('MDC-based MatTooltip', () => {
       const fixture = TestBed.createComponent(BasicTooltipDemo);
       fixture.detectChanges();
       const button: HTMLButtonElement = fixture.nativeElement.querySelector('button');
+      const triggerRect = button.getBoundingClientRect();
 
-      dispatchFakeEvent(button, 'mouseenter');
+      dispatchMouseEvent(button, 'mouseenter', triggerRect.right - 10, triggerRect.top + 10);
       fixture.detectChanges();
       tick(500); // Finish the open delay.
       fixture.detectChanges();
@@ -1442,7 +1516,6 @@ describe('MDC-based MatTooltip', () => {
       assertTooltipInstance(fixture.componentInstance.tooltip, true);
 
       // Simulate the pointer over the trigger.
-      const triggerRect = button.getBoundingClientRect();
       const wheelEvent = createFakeEvent('wheel');
       Object.defineProperties(wheelEvent, {
         clientX: {get: () => triggerRect.left + 1},
@@ -1584,6 +1657,17 @@ class TooltipOnDraggableElement {
 })
 class TooltipDemoWithoutPositionBinding {
   message: any = initialTooltipMessage;
+  @ViewChild(MatTooltip) tooltip: MatTooltip;
+  @ViewChild('button') button: ElementRef<HTMLButtonElement>;
+}
+
+@Component({
+  selector: 'app',
+  styles: [`button { width: 500px; height: 500px; }`],
+  template: `<button #button [matTooltip]="message">Button</button>`,
+})
+class WideTooltipDemo {
+  message = 'Test';
   @ViewChild(MatTooltip) tooltip: MatTooltip;
   @ViewChild('button') button: ElementRef<HTMLButtonElement>;
 }

--- a/src/material/tooltip/tooltip.ts
+++ b/src/material/tooltip/tooltip.ts
@@ -128,6 +128,12 @@ export interface MatTooltipDefaultOptions {
   /** Default position for tooltips. */
   position?: TooltipPosition;
 
+  /**
+   * Default value for whether tooltips should be positioned near the click or touch origin
+   * instead of outside the element bounding box.
+   */
+  positionAtOrigin?: boolean;
+
   /** Disables the ability for the user to interact with the tooltip element. */
   disableTooltipInteractivity?: boolean;
 }
@@ -159,6 +165,7 @@ export abstract class _MatTooltipBase<T extends _TooltipComponentBase>
 
   private _portal: ComponentPortal<T>;
   private _position: TooltipPosition = 'below';
+  private _positionAtOrigin: boolean = false;
   private _disabled: boolean = false;
   private _tooltipClass: string | string[] | Set<string> | {[key: string]: any};
   private _scrollStrategy: () => ScrollStrategy;
@@ -185,6 +192,16 @@ export abstract class _MatTooltipBase<T extends _TooltipComponentBase>
         this._overlayRef.updatePosition();
       }
     }
+  }
+
+  @Input('matTooltipPositionAtOrigin')
+  get positionAtOrigin(): boolean {
+    return this._positionAtOrigin;
+  }
+  set positionAtOrigin(value: BooleanInput) {
+    this._positionAtOrigin = coerceBooleanProperty(value);
+    this._detach();
+    this._overlayRef = null;
   }
 
   /** Disables the display of the tooltip. */
@@ -329,6 +346,10 @@ export abstract class _MatTooltipBase<T extends _TooltipComponentBase>
         this.position = _defaultOptions.position;
       }
 
+      if (_defaultOptions.positionAtOrigin) {
+        this.positionAtOrigin = _defaultOptions.positionAtOrigin;
+      }
+
       if (_defaultOptions.touchGestures) {
         this.touchGestures = _defaultOptions.touchGestures;
       }
@@ -386,7 +407,7 @@ export abstract class _MatTooltipBase<T extends _TooltipComponentBase>
   }
 
   /** Shows the tooltip after the delay in ms, defaults to tooltip-delay-show or 0ms if no input */
-  show(delay: number = this.showDelay): void {
+  show(delay: number = this.showDelay, origin?: { x: number, y: number }): void {
     if (
       this.disabled ||
       !this.message ||
@@ -397,7 +418,7 @@ export abstract class _MatTooltipBase<T extends _TooltipComponentBase>
       return;
     }
 
-    const overlayRef = this._createOverlay();
+    const overlayRef = this._createOverlay(origin);
     this._detach();
     this._portal =
       this._portal || new ComponentPortal(this._tooltipComponent, this._viewContainerRef);
@@ -421,8 +442,8 @@ export abstract class _MatTooltipBase<T extends _TooltipComponentBase>
   }
 
   /** Shows/hides the tooltip */
-  toggle(): void {
-    this._isTooltipVisible() ? this.hide() : this.show();
+  toggle(origin?: { x: number; y: number; }): void {
+    this._isTooltipVisible() ? this.hide() : this.show(undefined, origin);
   }
 
   /** Returns true if the tooltip is currently visible to the user */
@@ -431,9 +452,16 @@ export abstract class _MatTooltipBase<T extends _TooltipComponentBase>
   }
 
   /** Create the overlay config and position strategy */
-  private _createOverlay(): OverlayRef {
+  private _createOverlay(origin?: { x: number; y: number; }): OverlayRef {
     if (this._overlayRef) {
-      return this._overlayRef;
+      const existingStrategy =
+        this._overlayRef.getConfig().positionStrategy as FlexibleConnectedPositionStrategy;
+
+      if ((!this.positionAtOrigin || !origin) && existingStrategy._origin instanceof ElementRef) {
+        return this._overlayRef;
+      }
+
+      this._detach();
     }
 
     const scrollableAncestors = this._scrollDispatcher.getAncestorScrollContainers(
@@ -443,7 +471,7 @@ export abstract class _MatTooltipBase<T extends _TooltipComponentBase>
     // Create connected position strategy that listens for scroll events to reposition.
     const strategy = this._overlay
       .position()
-      .flexibleConnectedTo(this._elementRef)
+      .flexibleConnectedTo(this.positionAtOrigin ? (origin || this._elementRef) : this._elementRef)
       .withTransformOriginOn(`.${this._cssClassPrefix}-tooltip`)
       .withFlexibleDimensions(false)
       .withViewportMargin(this._viewportMargin)
@@ -686,9 +714,9 @@ export abstract class _MatTooltipBase<T extends _TooltipComponentBase>
     if (this._platformSupportsMouseEvents()) {
       this._passiveListeners.push([
         'mouseenter',
-        () => {
+        event => {
           this._setupPointerExitEventsIfNeeded();
-          this.show();
+          this.show(undefined, { x: (event as MouseEvent).x, y: (event as MouseEvent).y });
         },
       ]);
     } else if (this.touchGestures !== 'off') {
@@ -696,12 +724,14 @@ export abstract class _MatTooltipBase<T extends _TooltipComponentBase>
 
       this._passiveListeners.push([
         'touchstart',
-        () => {
+        event => {
+          const touch = (event as TouchEvent).targetTouches[0];
+          const origin = touch ? { x: touch.clientX, y: touch.clientY } : undefined;
           // Note that it's important that we don't `preventDefault` here,
           // because it can prevent click events from firing on the element.
           this._setupPointerExitEventsIfNeeded();
           clearTimeout(this._touchstartTimeout);
-          this._touchstartTimeout = setTimeout(() => this.show(), LONGPRESS_DELAY);
+          this._touchstartTimeout = setTimeout(() => this.show(undefined, origin), LONGPRESS_DELAY);
         },
       ]);
     }


### PR DESCRIPTION
Add an input option `matTooltipPositionAtOrigin` to display the tooltip relative to the mouse or touch event that triggered it.

Fixes #8759