### PR TITLE
fix(cdk/overlay): scroll blocking sometimes clipping content

### DIFF
--- a/src/cdk/overlay/_index.scss
+++ b/src/cdk/overlay/_index.scss
@@ -174,6 +174,9 @@ $backdrop-animation-timing-function: cubic-bezier(0.25, 0.8, 0.25, 1) !default;
     // that the element had before we made it `fixed`.
     width: 100%;
 
+    // Prevents the content from becoming scrollable in some cases. See #15051.
+    height: auto;
+
     // Note: this will always add a scrollbar to whatever element it is on, which can
     // potentially result in double scrollbars. It shouldn't be an issue, because we won't
     // block scrolling on a page that doesn't have a scrollbar in the first place.


### PR DESCRIPTION
Fixes that under some circumstances the `cdk-global-scrollblock` class was causing the body content to be clipped in the background.

Fixes #15051.