### PR TITLE
build: fix dev-app preview action permissions

### DIFF
--- a/.github/workflows/build-dev-app.yml
+++ b/.github/workflows/build-dev-app.yml
@@ -11,6 +11,8 @@ on:
   pull_request:
     types: [synchronize, labeled]
 
+permissions: read-all
+
 jobs:
   dev-app-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-dev-app.yml
+++ b/.github/workflows/deploy-dev-app.yml
@@ -9,8 +9,12 @@ name: Deploying dev-app to Firebase previews
 
 on:
   workflow_run:
-    workflows: [Build dev-app for deployment]
+    workflows: ['Build dev-app for deployment']
     types: [completed]
+
+permissions:
+  # Needed in order to be able to comment on the pull request.
+  pull-requests: write
 
 jobs:
   deploy-dev-app:

--- a/.github/workflows/lock-closed.yml
+++ b/.github/workflows/lock-closed.yml
@@ -5,6 +5,8 @@ on:
     # Run at 00:00 every day
     - cron: '0 0 * * *'
 
+permissions: read-all
+
 jobs:
   lock_closed:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We have changed the default permissions for Github actions as it seems,
and the PR comment cannot be created in actions without having the
necessary write permission. This commit fixes this.