### PR TITLE
fix(material/tabs): ink bar not shown in some cases

### DIFF
--- a/src/material/tabs/ink-bar.ts
+++ b/src/material/tabs/ink-bar.ts
@@ -66,11 +66,16 @@ export class MatInkBar {
    */
   alignToElement(element: HTMLElement) {
     this.show();
-    this._ngZone.onStable.pipe(take(1)).subscribe(() => {
-      const positions = this._inkBarPositioner(element);
-      const inkBar: HTMLElement = this._elementRef.nativeElement;
-      inkBar.style.left = positions.left;
-      inkBar.style.width = positions.width;
+
+    // `onStable` might not run for a while if the zone has already stabilized.
+    // Wrap the call in `NgZone.run` to ensure that it runs relatively soon.
+    this._ngZone.run(() => {
+      this._ngZone.onStable.pipe(take(1)).subscribe(() => {
+        const positions = this._inkBarPositioner(element);
+        const inkBar = this._elementRef.nativeElement;
+        inkBar.style.left = positions.left;
+        inkBar.style.width = positions.width;
+      });
     });
   }
 


### PR DESCRIPTION
In #24000 the ink bar was switched from `requestAnimationFrame` to `NgZone.onStable` in order to avoids timeouts when the browser is in the background. The problem is that if the zone is already stable, it may take some user interaction before it becomes unstable again and emits to `onStable`.

These changes wrap the call in `NgZone.run` to guarantee that it'll be unstable.

Fixes #25117.