### PR TITLE
fix(cdk/clipboard): page jumping on iOS

### DIFF
--- a/src/cdk/clipboard/pending-copy.ts
+++ b/src/cdk/clipboard/pending-copy.ts
@@ -34,6 +34,8 @@ export class PendingCopy {
     styles.left = '-999em';
     textarea.setAttribute('aria-hidden', 'true');
     textarea.value = text;
+    // Making the textarea `readonly` prevents the screen from jumping on iOS Safari (see #25169).
+    textarea.readOnly = true;
     this._document.body.appendChild(textarea);
   }
 


### PR DESCRIPTION
Fixes the page jump when copying to the clipboard on newer versions of iOS by making the temporary `textarea` readonly.

Fixes #25169.