### PR TITLE
fix: making the parse format available for native date adapter extension

### DIFF
--- a/src/material/core/datetime/native-date-adapter.ts
+++ b/src/material/core/datetime/native-date-adapter.ts
@@ -125,7 +125,7 @@ export class NativeDateAdapter extends DateAdapter<Date> {
     return new Date();
   }
 
-  parse(value: any): Date | null {
+  parse(value: any, parseFormat: any): Date | null {
     // We have no way using the native JS Date to set the parse format or locale, so we ignore these
     // parameters.
     if (typeof value == 'number') {


### PR DESCRIPTION
It's a well-known problem that the `NativeDateAdapter` is not capable of parsing date formats besides the ones supported by `Date.parse`. A common solution is to use a library like momentjs or dayjs or write our own adapter, but if we want to continue using native dates the best way is to just extend the `NativeDateAdapter` and override its `parse` method with a more sophisticated implementation. The problem is that we cannot just extend the `NativeDateAdapter` since the `parse` method signature narrows down the arguments from `value: any, parseFormat: any` to just `value: any` because the current implementation does not honor the `parseFormat`. This is suboptimal since I want to use the `parseFormat` when overriding the implementation and I do not want to extend `DateAdapter` directly. This would cause a lot of overhead.

Please let me know if I overlooked something and there may be a better way to achieve what I want.