### PR TITLE
docs: Fix two links in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -260,11 +260,11 @@ changes to be accepted, the CLA must be signed. It's a quick process, we promise
 [material-group]: https://groups.google.com/forum/#!forum/angular-material2
 [coc]: https://github.com/angular/code-of-conduct/blob/main/CODE_OF_CONDUCT.md
 [commit-message-format]: https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/preview
-[commit-message-scopes]: https://github.com/angular/components/blob/main/.ng-dev/commit-message.ts#L10
+[commit-message-scopes]: https://github.com/angular/components/blob/main/.ng-dev/commit-message.mts#L10
 [corporate-cla]: http://code.google.com/legal/corporate-cla-v1.0.html
 [dev-doc]: https://github.com/angular/components/blob/main/DEV_ENVIRONMENT.md
 [github]: https://github.com/angular/components
-[gitter]: https://gitter.im/angular/components
+[gitter]: https://gitter.im/angular/material2
 [individual-cla]: http://code.google.com/legal/individual-cla-v1.0.html
 [js-style-guide]: https://google.github.io/styleguide/jsguide.html
 [codepen]: http://codepen.io/


### PR DESCRIPTION
In CONTRIBUTING.md there are two broken links:
1)  `full list` that should point to the renamed `commit-message.mts` file
2) `gitter` that probably should point to `https://gitter.im/angular/material2`