### PR TITLE
build: increase timeout for harness integration test

### DIFF
--- a/integration/harness-e2e-cli/e2e/radio-harness.spec.ts
+++ b/integration/harness-e2e-cli/e2e/radio-harness.spec.ts
@@ -3,6 +3,9 @@ import {SeleniumWebDriverHarnessEnvironment} from '@angular/cdk/testing/selenium
 import {HarnessLoader} from '@angular/cdk/testing';
 import {configureDriver} from './driver.js';
 
+// Tests are flaky on CI unless we increase the timeout.
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 10_000; // 10 seconds
+
 describe('app test', () => {
   let loader: HarnessLoader;
 


### PR DESCRIPTION
Increases the Jasmine timeout interval for the harness integration tests to try and reduce the CI flakes.