### PR TITLE
build: use `pin` instead of `replace` range strategy

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,7 @@
   "lockFileMaintenance": {
     "enabled": false
   },
+  "rangeStrategy": "pin",
   "pinDigests": true,
   "prHourlyLimit": 2,
   "rebaseWhen": "behind-base-branch",


### PR DESCRIPTION
We always want to pin to the versions we use, and not rely on
version ranges. This is an attempt to fix that the Bazel workspace
file has not been updated.

https://github.com/angular/dev-infra/runs/7289796990?check_suite_focus=true.