### PR TITLE
test: fix incorrect usage in theming tests

### DIFF
--- a/src/material/core/theming/tests/test-legacy-theming-bundle.scss
+++ b/src/material/core/theming/tests/test-legacy-theming-bundle.scss
@@ -12,8 +12,8 @@ $mat-theme-ignore-duplication-warnings: true;
 
 $theme: mat-light-theme((
   color: (
-    primary: $mat-red,
-    accent: $mat-blue,
+    primary: mat-define-palette($mat-red),
+    accent: mat-define-palette($mat-blue),
   ),
   density: -2,
 ));

--- a/src/material/core/theming/tests/theming-api.spec.ts
+++ b/src/material/core/theming/tests/theming-api.spec.ts
@@ -45,8 +45,8 @@ describe('theming api', () => {
     transpile(`
       $theme: mat-light-theme((
         color: (
-          primary: $mat-red,
-          accent: $mat-red,
+          primary: mat-define-palette($mat-red),
+          accent: mat-define-palette($mat-red),
         )
       ));
 
@@ -65,14 +65,14 @@ describe('theming api', () => {
       transpile(`
       $theme: mat-light-theme((
         color: (
-          primary: $mat-red,
-          accent: $mat-red,
+          primary: mat-define-palette($mat-red),
+          accent: mat-define-palette($mat-red),
         )
       ));
       $theme2: mat-light-theme((
         color: (
-          primary: $mat-red,
-          accent: $mat-blue,
+          primary: mat-define-palette($mat-red),
+          accent: mat-define-palette($mat-blue),
         )
       ));
 
@@ -255,14 +255,14 @@ describe('theming api', () => {
     it('should be possible to specify palettes by keyword', () => {
       transpile(`
         $light-theme: mat-light-theme(
-          $primary: $mat-red,
-          $accent: $mat-blue,
-          $warn: $mat-red,
+          $primary: mat-define-palette($mat-red),
+          $accent: mat-define-palette($mat-blue),
+          $warn: mat-define-palette($mat-red),
         );
         $dark-theme: mat-dark-theme(
-          $primary: $mat-red,
-          $accent: $mat-blue,
-          $warn: $mat-red,
+          $primary: mat-define-palette($mat-red),
+          $accent: mat-define-palette($mat-blue),
+          $warn: mat-define-palette($mat-red),
         );
       `);
     });


### PR DESCRIPTION
When we switched to the `@use` API we did not update some of the tests.
https://github.com/angular/components/pull/22173