### PR TITLE
ci: fix incorrect style imports

### DIFF
--- a/src/material-experimental/mdc-core/option/option.scss
+++ b/src/material-experimental/mdc-core/option/option.scss
@@ -1,6 +1,5 @@
 @use '@angular/cdk';
 @use '@angular/material' as mat;
-@use '@angular/cdk';
 @use '@material/list/evolution-mixins' as mdc-list-mixins;
 @use '@material/list/evolution-variables' as mdc-list-variables;
 @use 'sass:map';

--- a/src/material-experimental/mdc-form-field/form-field.scss
+++ b/src/material-experimental/mdc-form-field/form-field.scss
@@ -1,3 +1,4 @@
+@use '@angular/material' as mat;
 @use '@material/textfield' as mdc-textfield;
 @use '@material/floating-label' as mdc-floating-label;
 @use '@material/notched-outline' as mdc-notched-outline;


### PR DESCRIPTION
Import of CDK was duplicated in https://github.com/angular/components/commit/25ce8e775c8344407159381fdb61066d216e054e

Material import was missing in https://github.com/angular/components/commit/4727c8b5e4cf8a30ed782262559c42e641911b26