### PR TITLE
build: fix missing sass import in `mdc-core/option/option.scss`

### DIFF
--- a/src/material-experimental/mdc-core/BUILD.bazel
+++ b/src/material-experimental/mdc-core/BUILD.bazel
@@ -43,6 +43,7 @@ sass_binary(
         "external/npm/node_modules",
     ],
     deps = [
+        "//src/cdk:sass_lib",
         "//src/material:sass_lib",
         "//src/material-experimental/mdc-core/mdc-helpers:mdc_helpers_scss_lib",
         "//src/material-experimental/mdc-core/mdc-helpers:mdc_scss_deps_lib",

--- a/src/material-experimental/mdc-core/option/option.scss
+++ b/src/material-experimental/mdc-core/option/option.scss
@@ -1,3 +1,4 @@
+@use '@angular/cdk';
 @use '@angular/material' as mat;
 @use '@material/list/evolution-mixins' as mdc-list-mixins;
 @use '@material/list/evolution-variables' as mdc-list-variables;


### PR DESCRIPTION
There were some imports removed accidentally due to us having
to land changes in three branches.