### PR TITLE
fix(cdk/dialog): use config injector if provided

### DIFF
--- a/src/cdk/dialog/dialog.ts
+++ b/src/cdk/dialog/dialog.ts
@@ -308,7 +308,7 @@ export class Dialog implements OnDestroy {
     dialogRef: DialogRef<R, C>,
     dialogContainer: BasePortalOutlet,
   ): Injector {
-    const userInjector = config && config.viewContainerRef && config.viewContainerRef.injector;
+    const userInjector = config.injector ?? config.viewContainerRef?.injector;
     const providers: StaticProvider[] = [
       {provide: DIALOG_DATA, useValue: config.data},
       {provide: DialogRef, useValue: dialogRef},


### PR DESCRIPTION
Cdk Dialog provides a field injector in config object. We would gladly use it to provide an injector issued from our lazy-loaded module.
It is correctly used on line 224 : const userInjector = config.injector ?? config.viewContainerRef?.injector;
But not on line 311.
So I guess it would be better to use the same "user" injector on both lines.