### PR TITLE
fix(material/slider): add cancelable checks to touchmove and touchend events

### DIFF
--- a/src/material/slider/slider.ts
+++ b/src/material/slider/slider.ts
@@ -704,7 +704,9 @@ export class MatSlider
 
       if (pointerPosition) {
         // Prevent the slide from selecting anything else.
-        event.preventDefault();
+        if (event.cancelable) {
+          event.preventDefault();
+        }
         const oldValue = this.value;
         this._lastPointerEvent = event;
         this._updateValueFromPosition(pointerPosition);
@@ -727,7 +729,9 @@ export class MatSlider
         // seems like in most cases `touches` is empty for `touchend` events.
         findMatchingTouch(event.changedTouches, this._touchId)
       ) {
-        event.preventDefault();
+        if (event.cancelable) {
+          event.preventDefault();
+        }
         this._removeGlobalEvents();
         this._isSliding = null;
         this._touchId = undefined;


### PR DESCRIPTION
Adds checks to ensure that `touchmove` and `touchend` events are cancelable before we call `preventDefault` on them.

Fixes #25272.