### PR TITLE
build: fix build error in mdc migration against snapshots

### DIFF
--- a/src/material/schematics/ng-generate/mdc-migration/BUILD.bazel
+++ b/src/material/schematics/ng-generate/mdc-migration/BUILD.bazel
@@ -73,6 +73,7 @@ spec_bundle(
     # `chokidar` and `fsevents`. These rely on native bindings and break with ESBuild.
     external = ["@angular-devkit/core/node"],
     platform = "node",
+    target = "es2020",
     deps = [":unit_tests_lib"],
 )
 


### PR DESCRIPTION
The snapshots were failing, because the MDC migration tests were targeting es2016, but the CLI introduced some es2020 syntax.