### PR TITLE
fix(material/tabs): disable tab label color transition when animations are disabled

### DIFF
--- a/src/material-experimental/mdc-tabs/_tabs-common.scss
+++ b/src/material-experimental/mdc-tabs/_tabs-common.scss
@@ -161,8 +161,11 @@ $mat-tab-animation-duration: 500ms !default;
 
   // The `span` is in the selector in order to increase the specificity, ensuring
   // that it's always higher than the selector that declares the transition.
-  ._mat-animation-noopable span.mdc-tab-indicator__content {
-    transition: none;
+  ._mat-animation-noopable {
+    span.mdc-tab-indicator__content,
+    span.mdc-tab__text-label {
+      transition: none;
+    }
   }
 }
 


### PR DESCRIPTION
Fixes that the transition of the tab label color wasn't being disabled when all animations are disabled.