### PR TITLE
perf(material-experimental/mdc-chips): Fix runaway change detections

### DIFF
--- a/src/material-experimental/mdc-chips/chip-grid.ts
+++ b/src/material-experimental/mdc-chips/chip-grid.ts
@@ -364,17 +364,32 @@ export class MatChipGrid
    * @docs-private
    */
   setDescribedByIds(ids: string[]) {
+    // This gets called a lot, so avoid doing unnecessary work.
+    if (this._ariaDescribedbyIds === ids) {
+      return;
+    }
+    if (this._ariaDescribedbyIds.length === ids.length) {
+      if (this._ariaDescribedbyIds.join(' ') === ids.join(' ')) {
+        return;
+      }
+    }
+
     // We must keep this up to date to handle the case where ids are set
     // before the chip input is registered.
     this._ariaDescribedbyIds = ids;
 
     if (this._chipInput) {
-      // Use a setTimeout in case this is being run during change detection
-      // and the chip input has already determined its host binding for
-      // aria-describedBy.
-      setTimeout(() => {
+      // Run in the next change detection cycle in case this is being run during
+      // change detection and the chip input has already determined its host binding
+      // for aria-describedBy.
+      // Using a promise instead of setTimeout() here is much better in terms of
+      // performance since multiple calls to setDescribedByIds() in multiple instances
+      // of the component will result in just one extra change detection after all
+      // microtasks have run, while setTimeout() would result in a separate change
+      // detection per call.
+      Promise.resolve().then(() => {
         this._chipInput.setDescribedByIds(ids);
-      }, 0);
+      });
     }
   }
 


### PR DESCRIPTION
Fixes #25325 by reducing the overhead of having multiple instances of the component by ignoring calls to `setDescribedByIds()` where the value does not change, and using macroTasks (promise) instead of macroTasks (setTimeout) to schedule work to be done in the next change detection cycle.


In the example demonstrated in #25325, this PR improves performance by over **60%**.

**Before:**

<img width="1025" alt="52fnPoLhetQ2dyk" src="https://user-images.githubusercontent.com/168725/180358924-f36afe98-c7cf-46e8-bd4f-625081214f18.png">

**After:**

<img width="930" alt="5WJ87evzPtjeSsx" src="https://user-images.githubusercontent.com/168725/180358982-563f301b-c044-4e7a-875a-4995f39b225d.png">



