### PR TITLE
feat(material/table): improve possibilities to extend MatTableDataSource

### DIFF
--- a/src/material-experimental/mdc-table/table-data-source.ts
+++ b/src/material-experimental/mdc-table/table-data-source.ts
@@ -23,5 +23,6 @@ import {_MatTableDataSource, MatTableDataSourcePaginator} from '@angular/materia
  */
 export class MatTableDataSource<
   T,
+  F,
   P extends MatTableDataSourcePaginator = MatTableDataSourcePaginator,
-> extends _MatTableDataSource<T, P> {}
+> extends _MatTableDataSource<T, F, P> {}

--- a/src/material/table/table.spec.ts
+++ b/src/material/table/table.spec.ts
@@ -352,7 +352,7 @@ describe('MatTable', () => {
             dataStr = '';
         }
 
-        return dataStr.indexOf(filter) != -1;
+        return dataStr.indexOf(filter ?? '') != -1;
       };
       dataSource.filter = 'zebra';
       fixture.detectChanges();


### PR DESCRIPTION
For more sophisticated filters it should be possible to have something different than a string as a filter. This change allows to overwrite the filter predicate with a function that uses a filter object instead of just a string.