### PR TITLE
build: account for new dev-infra packages `@angular/ng-dev` and `@angular/build-tooling`

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -83,11 +83,11 @@ build:remote --google_default_credentials=true
 
 # Setup the toolchain and platform for the remote build execution. The platform
 # is provided by the shared dev-infra package and targets k8 remote containers.
-build:remote --crosstool_top=@npm//@angular/dev-infra-private/bazel/remote-execution/cpp:cc_toolchain_suite
-build:remote --extra_toolchains=@npm//@angular/dev-infra-private/bazel/remote-execution/cpp:cc_toolchain
-build:remote --extra_execution_platforms=@npm//@angular/dev-infra-private/bazel/remote-execution:platform_with_network
-build:remote --host_platform=@npm//@angular/dev-infra-private/bazel/remote-execution:platform_with_network
-build:remote --platforms=@npm//@angular/dev-infra-private/bazel/remote-execution:platform_with_network
+build:remote --crosstool_top=@npm//@angular/build-tooling/bazel/remote-execution/cpp:cc_toolchain_suite
+build:remote --extra_toolchains=@npm//@angular/build-tooling/bazel/remote-execution/cpp:cc_toolchain
+build:remote --extra_execution_platforms=@npm//@angular/build-tooling/bazel/remote-execution:platform_with_network
+build:remote --host_platform=@npm//@angular/build-tooling/bazel/remote-execution:platform_with_network
+build:remote --platforms=@npm//@angular/build-tooling/bazel/remote-execution:platform_with_network
 
 ################################
 #  Sandbox settings            #

--- a/.ng-dev/caretaker.mts
+++ b/.ng-dev/caretaker.mts
@@ -1,4 +1,4 @@
-import {CaretakerConfig} from '@angular/dev-infra-private/ng-dev';
+import {CaretakerConfig} from '@angular/ng-dev';
 
 /** The configuration for `ng-dev caretaker` commands. */
 export const caretaker: CaretakerConfig = {

--- a/.ng-dev/commit-message.mts
+++ b/.ng-dev/commit-message.mts
@@ -1,4 +1,4 @@
-import {CommitMessageConfig} from '@angular/dev-infra-private/ng-dev';
+import {CommitMessageConfig} from '@angular/ng-dev';
 
 /**
  * The configuration for `ng-dev commit-message` commands.

--- a/.ng-dev/format.mts
+++ b/.ng-dev/format.mts
@@ -1,4 +1,4 @@
-import {FormatConfig} from '@angular/dev-infra-private/ng-dev';
+import {FormatConfig} from '@angular/ng-dev';
 
 /**
  * Configuration for the ng-dev format command. We currently only use the buildifier

--- a/.ng-dev/github.mts
+++ b/.ng-dev/github.mts
@@ -1,4 +1,4 @@
-import {GithubConfig} from '@angular/dev-infra-private/ng-dev';
+import {GithubConfig} from '@angular/ng-dev';
 
 /**
  * Github configuration for the ng-dev command. This repository is

--- a/.ng-dev/pull-request.mts
+++ b/.ng-dev/pull-request.mts
@@ -1,4 +1,4 @@
-import {PullRequestConfig} from '@angular/dev-infra-private/ng-dev';
+import {PullRequestConfig} from '@angular/ng-dev';
 
 /**
  * Configuration for the pull request commands in `ng-dev`. This includes the

--- a/.ng-dev/release.mts
+++ b/.ng-dev/release.mts
@@ -1,5 +1,5 @@
 import semver from 'semver';
-import {ReleaseConfig} from '@angular/dev-infra-private/ng-dev';
+import {ReleaseConfig} from '@angular/ng-dev';
 import {assertValidFrameworkPeerDependency} from '../tools/release-checks/check-framework-peer-dependency.mjs';
 import {assertValidUpdateMigrationCollections} from '../tools/release-checks/check-migration-collections.mjs';
 import {assertValidNpmPackageOutput} from '../tools/release-checks/npm-package-output/index.mjs';

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -109,7 +109,7 @@ sass_repositories(
 
 # Setup repositories for browsers provided by the shared dev-infra package.
 load(
-    "@npm//@angular/dev-infra-private/bazel/browsers:browser_repositories.bzl",
+    "@npm//@angular/build-tooling/bazel/browsers:browser_repositories.bzl",
     _dev_infra_browser_repositories = "browser_repositories",
 )
 

--- a/integration/size-test/index.bzl
+++ b/integration/size-test/index.bzl
@@ -1,4 +1,4 @@
-load("@npm//@angular/dev-infra-private/bazel:expand_template.bzl", "expand_template")
+load("@npm//@angular/build-tooling/bazel:expand_template.bzl", "expand_template")
 load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary", "nodejs_test")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@npm//@bazel/esbuild:index.bzl", "esbuild")

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "postinstall": "node tools/postinstall/apply-patches.js",
-    "ng-dev": "cross-env TS_NODE_PROJECT=$PWD/.ng-dev/tsconfig.json TS_NODE_TRANSPILE_ONLY=1 node --no-warnings --loader ts-node/esm node_modules/@angular/dev-infra-private/ng-dev/bundles/cli.mjs",
+    "ng-dev": "cross-env TS_NODE_PROJECT=$PWD/.ng-dev/tsconfig.json TS_NODE_TRANSPILE_ONLY=1 node --no-warnings --loader ts-node/esm node_modules/@angular/ng-dev/bundles/cli.mjs",
     "build": "ts-node --esm --project scripts/tsconfig.json ./scripts/build-packages-dist-main.mts",
     "build-docs-content": "ts-node --esm --project scripts/tsconfig.json ./scripts/build-docs-content-main.mts",
     "build-and-check-release-output": "ts-node --esm --project scripts/tsconfig.json scripts/build-and-check-release-output.mts",
@@ -75,10 +75,11 @@
     "@angular-devkit/core": "^14.0.1",
     "@angular-devkit/schematics": "^14.0.1",
     "@angular/bazel": "^14.0.1",
+    "@angular/build-tooling": "https://github.com/angular/dev-infra-private-build-tooling-builds.git#1addc303bef0b6acc0dca0961e9e642629f3a5cd",
     "@angular/cli": "^14.0.1",
     "@angular/compiler-cli": "^14.0.1",
-    "@angular/dev-infra-private": "https://github.com/angular/dev-infra-private-builds.git#c1b330bfbd79adf076039c872b966cfef76c5781",
     "@angular/localize": "^14.0.1",
+    "@angular/ng-dev": "https://github.com/angular/dev-infra-private-ng-dev-builds.git#865c7687cdca2bd512040330e1677eecaa26e46a",
     "@angular/platform-browser-dynamic": "^14.0.1",
     "@angular/platform-server": "^14.0.1",
     "@angular/router": "^14.0.1",
@@ -224,7 +225,8 @@
     "zx": "^6.2.4"
   },
   "resolutions": {
-    "@angular/dev-infra-private/typescript": "~4.7.2",
+    "@angular/build-tooling/typescript": "~4.7.2",
+    "@angular/ng-dev/typescript": "~4.7.2",
     "browser-sync-client": "2.26.13",
     "dgeni-packages/typescript": "~4.7.2",
     "**/https-proxy-agent": "5.0.0"

--- a/renovate.json
+++ b/renovate.json
@@ -24,7 +24,7 @@
       "enabled": false
     },
     {
-      "matchPackageNames": ["@angular/dev-infra-private", "angular/dev-infra"],
+      "matchPackageNames": ["@angular/ng-dev", "@angular/build-tooling", "angular/dev-infra"],
       "groupName": "angular shared dev-infra code",
       "enabled": true
     },

--- a/scripts/build-docs-content.mts
+++ b/scripts/build-docs-content.mts
@@ -4,7 +4,7 @@
  */
 
 import sh from 'shelljs';
-import {BuiltPackage} from '@angular/dev-infra-private/ng-dev';
+import {BuiltPackage} from '@angular/ng-dev';
 import {fileURLToPath} from 'url';
 import {join, dirname} from 'path';
 

--- a/scripts/build-packages-dist.mts
+++ b/scripts/build-packages-dist.mts
@@ -6,7 +6,7 @@
 
 import {execSync} from 'child_process';
 import {join, dirname} from 'path';
-import {BuiltPackage} from '@angular/dev-infra-private/ng-dev';
+import {BuiltPackage} from '@angular/ng-dev';
 import {fileURLToPath} from 'url';
 import sh from 'shelljs';
 

--- a/scripts/circleci/notify-slack-job-failure.mts
+++ b/scripts/circleci/notify-slack-job-failure.mts
@@ -6,11 +6,7 @@
  */
 
 import sh from 'shelljs';
-import {
-  isVersionBranch,
-  getConfig,
-  assertValidGithubConfig,
-} from '@angular/dev-infra-private/ng-dev';
+import {isVersionBranch, getConfig, assertValidGithubConfig} from '@angular/ng-dev';
 
 if (process.env.CIRCLE_PR_NUMBER !== undefined) {
   console.info('Skipping notifications for pull requests.');

--- a/scripts/circleci/setup-angular-snapshots.js
+++ b/scripts/circleci/setup-angular-snapshots.js
@@ -28,10 +28,11 @@ const snapshotPackages = [
 
 /** List of packages which should not be updated to a snapshot build. */
 const ignorePackages = [
-  // Skip update for the shared dev-infra package. We do not want to update to a snapshot
+  // Skip update for the shared dev-infra packages. We do not want to update to a snapshot
   // version of the dev-infra tooling as that could break tooling from running snapshot
   // tests for the actual snapshot Angular framework code.
-  '@angular/dev-infra-private',
+  '@angular/build-tooling',
+  '@angular/ng-dev',
 ];
 
 const {writeFileSync} = require('fs');

--- a/scripts/create-legacy-tests-bundle.mjs
+++ b/scripts/create-legacy-tests-bundle.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import {createLinkerEsbuildPlugin} from '@angular/dev-infra-private/shared-scripts/angular-linker/esbuild-plugin.mjs';
+import {createLinkerEsbuildPlugin} from '@angular/build-tooling/shared-scripts/angular-linker/esbuild-plugin.mjs';
 import child_process from 'child_process';
 import esbuild from 'esbuild';
 import fs from 'fs';

--- a/scripts/docs-deploy/deploy-ci-push.mts
+++ b/scripts/docs-deploy/deploy-ci-push.mts
@@ -5,7 +5,7 @@ import {
   getBranchesForMajorVersions,
   getVersionForVersionBranch,
   isVersionBranch,
-} from '@angular/dev-infra-private/ng-dev';
+} from '@angular/ng-dev';
 import {firebaseConfig, sites} from './utils.mjs';
 
 import {buildAndDeployWithSnapshots} from './snapshot-deploy.mjs';

--- a/scripts/docs-deploy/github-versioning.mts
+++ b/scripts/docs-deploy/github-versioning.mts
@@ -5,7 +5,7 @@ import {
   assertValidGithubConfig,
   getConfig,
   getNextBranchName,
-} from '@angular/dev-infra-private/ng-dev';
+} from '@angular/ng-dev';
 
 import {githubAccessToken} from './utils.mjs';
 

--- a/scripts/docs-deploy/install-built-packages.mts
+++ b/scripts/docs-deploy/install-built-packages.mts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as url from 'url';
 
-import {BuiltPackage} from '@angular/dev-infra-private/ng-dev';
+import {BuiltPackage} from '@angular/ng-dev';
 import {getPackageJsonOfProject} from './utils.mjs';
 
 export async function installBuiltPackagesInRepo(repoPath: string, builtPackages: BuiltPackage[]) {

--- a/scripts/docs-deploy/monitoring/index.mts
+++ b/scripts/docs-deploy/monitoring/index.mts
@@ -2,7 +2,7 @@ import {$, cd} from 'zx';
 
 import {ProductionDeployment} from '../deploy-to-site.mjs';
 import {cloneDocsRepositoryForMajor} from '../clone-docs-repo.mjs';
-import {ActiveReleaseTrains} from '@angular/dev-infra-private/ng-dev';
+import {ActiveReleaseTrains} from '@angular/ng-dev';
 import {getReleaseRepoWithApi} from '../github-versioning.mjs';
 import {installDepsForDocsSite} from '../docs-deps-install.mjs';
 import {sites} from '../utils.mjs';

--- a/scripts/docs-deploy/update-versions-file.mts
+++ b/scripts/docs-deploy/update-versions-file.mts
@@ -6,7 +6,7 @@ import {
   assertValidReleaseConfig,
   fetchLongTermSupportBranchesFromNpm,
   getConfig,
-} from '@angular/dev-infra-private/ng-dev';
+} from '@angular/ng-dev';
 
 import {sites} from './utils.mjs';
 

--- a/src/cdk/testing/tests/webdriver-test.bzl
+++ b/src/cdk/testing/tests/webdriver-test.bzl
@@ -19,7 +19,7 @@ def webdriver_test(name, deps, tags = [], **kwargs):
 
     web_test(
         name = "%s_chromium_web_test" % name,
-        browser = "@npm//@angular/dev-infra-private/bazel/browsers/chromium:chromium",
+        browser = "@npm//@angular/build-tooling/bazel/browsers/chromium:chromium",
         tags = tags + ["manual"],
         test = ":%s_jasmine_test" % name,
     )

--- a/test/benchmarks/cdk/testing/component-harness/BUILD.bazel
+++ b/test/benchmarks/cdk/testing/component-harness/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@npm//@angular/dev-infra-private/bazel/benchmark/component_benchmark:component_benchmark.bzl", "component_benchmark")
+load("@npm//@angular/build-toolinge/bazel/benchmark/component_benchmark:component_benchmark.bzl", "component_benchmark")
 load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
 
 package(default_visibility = ["//visibility:public"])
@@ -20,7 +20,7 @@ ts_library(
     srcs = [":protractor-benchmark-utilities.ts"],
     deps = [
         ":constants",
-        "@npm//@angular/dev-infra-private/bazel/benchmark/driver-utilities",
+        "@npm//@angular/build-tooling/bazel/benchmark/driver-utilities",
         "@npm//@types/node",
     ],
 )
@@ -69,7 +69,7 @@ ng_test_library(
         "//src/cdk/testing/testbed",
         "//src/material/button",
         "//src/material/button/testing",
-        "@npm//@angular/dev-infra-private/bazel/benchmark/driver-utilities",
+        "@npm//@angular/build-tooling/bazel/benchmark/driver-utilities",
     ],
 )
 

--- a/test/benchmarks/cdk/testing/component-harness/protractor-benchmark-utilities.ts
+++ b/test/benchmarks/cdk/testing/component-harness/protractor-benchmark-utilities.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {runBenchmark} from '@angular/dev-infra-private/bazel/benchmark/driver-utilities';
+import {runBenchmark} from '@angular/build-tooling/bazel/benchmark/driver-utilities';
 import {USE_BENCHPRESS} from './constants';
 
 /**

--- a/test/benchmarks/material/button/BUILD.bazel
+++ b/test/benchmarks/material/button/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@npm//@angular/dev-infra-private/bazel/benchmark/component_benchmark:component_benchmark.bzl", "component_benchmark")
+load("@npm//@angular/build-tooling/bazel/benchmark/component_benchmark:component_benchmark.bzl", "component_benchmark")
 
 # TODO(wagnermaciel): Update this target to provide indigo-pink in a way that doesn't require having to import it with
 # stylesUrls inside the components once `component_benchmark` supports asset injection.
@@ -7,7 +7,7 @@ component_benchmark(
     name = "benchmark",
     driver = ":button.perf-spec.ts",
     driver_deps = [
-        "@npm//@angular/dev-infra-private/bazel/benchmark/driver-utilities",
+        "@npm//@angular/build-tooling/bazel/benchmark/driver-utilities",
         "@npm//protractor",
         "@npm//@types/jasmine",
     ],

--- a/test/benchmarks/material/button/button.perf-spec.ts
+++ b/test/benchmarks/material/button/button.perf-spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {$, browser} from 'protractor';
-import {runBenchmark} from '@angular/dev-infra-private/bazel/benchmark/driver-utilities';
+import {runBenchmark} from '@angular/build-tooling/bazel/benchmark/driver-utilities';
 
 describe('button performance benchmarks', () => {
   beforeAll(() => {

--- a/test/benchmarks/material/card/BUILD.bazel
+++ b/test/benchmarks/material/card/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@npm//@angular/dev-infra-private/bazel/benchmark/component_benchmark:component_benchmark.bzl", "component_benchmark")
+load("@npm//@angular/build-tooling/bazel/benchmark/component_benchmark:component_benchmark.bzl", "component_benchmark")
 
 # TODO(wagnermaciel): Update this target to provide indigo-pink in a way that doesn't require having to import it with
 # stylesUrls inside the components once `component_benchmark` supports asset injection.
@@ -7,7 +7,7 @@ component_benchmark(
     name = "benchmark",
     driver = ":card.perf-spec.ts",
     driver_deps = [
-        "@npm//@angular/dev-infra-private/bazel/benchmark/driver-utilities",
+        "@npm//@angular/build-tooling/bazel/benchmark/driver-utilities",
         "@npm//protractor",
         "@npm//@types/jasmine",
     ],

--- a/test/benchmarks/material/card/card.perf-spec.ts
+++ b/test/benchmarks/material/card/card.perf-spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {$, browser} from 'protractor';
-import {runBenchmark} from '@angular/dev-infra-private/bazel/benchmark/driver-utilities';
+import {runBenchmark} from '@angular/build-tooling/bazel/benchmark/driver-utilities';
 
 describe('card performance benchmarks', () => {
   beforeAll(() => {

--- a/test/benchmarks/material/checkbox/BUILD.bazel
+++ b/test/benchmarks/material/checkbox/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@npm//@angular/dev-infra-private/bazel/benchmark/component_benchmark:component_benchmark.bzl", "component_benchmark")
+load("@npm//@angular/build-tooling/bazel/benchmark/component_benchmark:component_benchmark.bzl", "component_benchmark")
 
 # TODO(wagnermaciel): Update this target to provide indigo-pink in a way that doesn't require having to import it with
 # stylesUrls inside the components once `component_benchmark` supports asset injection.
@@ -7,7 +7,7 @@ component_benchmark(
     name = "benchmark",
     driver = ":checkbox.perf-spec.ts",
     driver_deps = [
-        "@npm//@angular/dev-infra-private/bazel/benchmark/driver-utilities",
+        "@npm//@angular/build-tooling/bazel/benchmark/driver-utilities",
         "@npm//protractor",
         "@npm//@types/jasmine",
     ],

--- a/test/benchmarks/material/checkbox/checkbox.perf-spec.ts
+++ b/test/benchmarks/material/checkbox/checkbox.perf-spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {$, browser} from 'protractor';
-import {runBenchmark} from '@angular/dev-infra-private/bazel/benchmark/driver-utilities';
+import {runBenchmark} from '@angular/build-tooling/bazel/benchmark/driver-utilities';
 
 describe('checkbox performance benchmarks', () => {
   beforeAll(() => {

--- a/test/benchmarks/material/chips/BUILD.bazel
+++ b/test/benchmarks/material/chips/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@npm//@angular/dev-infra-private/bazel/benchmark/component_benchmark:component_benchmark.bzl", "component_benchmark")
+load("@npm//@angular/build-tooling/bazel/benchmark/component_benchmark:component_benchmark.bzl", "component_benchmark")
 
 # TODO(wagnermaciel): Update this target to provide indigo-pink in a way that doesn't require having to import it with
 # stylesUrls inside the components once `component_benchmark` supports asset injection.
@@ -7,7 +7,7 @@ component_benchmark(
     name = "benchmark",
     driver = ":chips.perf-spec.ts",
     driver_deps = [
-        "@npm//@angular/dev-infra-private/bazel/benchmark/driver-utilities",
+        "@npm//@angular/build-tooling/bazel/benchmark/driver-utilities",
         "@npm//protractor",
         "@npm//@types/jasmine",
     ],

--- a/test/benchmarks/material/chips/chips.perf-spec.ts
+++ b/test/benchmarks/material/chips/chips.perf-spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {$, browser} from 'protractor';
-import {runBenchmark} from '@angular/dev-infra-private/bazel/benchmark/driver-utilities';
+import {runBenchmark} from '@angular/build-tooling/bazel/benchmark/driver-utilities';
 
 describe('chip performance benchmarks', () => {
   beforeAll(() => {

--- a/test/benchmarks/material/form-field/BUILD.bazel
+++ b/test/benchmarks/material/form-field/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@npm//@angular/dev-infra-private/bazel/benchmark/component_benchmark:component_benchmark.bzl", "component_benchmark")
+load("@npm//@angular/build-tooling/bazel/benchmark/component_benchmark:component_benchmark.bzl", "component_benchmark")
 
 # TODO(wagnermaciel): Update this target to provide indigo-pink in a way that doesn't require having to import it with
 # stylesUrls inside the components once `component_benchmark` supports asset injection.
@@ -7,7 +7,7 @@ component_benchmark(
     name = "benchmark",
     driver = ":form-field.perf-spec.ts",
     driver_deps = [
-        "@npm//@angular/dev-infra-private/bazel/benchmark/driver-utilities",
+        "@npm//@angular/build-tooling/bazel/benchmark/driver-utilities",
         "@npm//protractor",
         "@npm//@types/jasmine",
     ],

--- a/test/benchmarks/material/form-field/form-field.perf-spec.ts
+++ b/test/benchmarks/material/form-field/form-field.perf-spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {$, browser} from 'protractor';
-import {runBenchmark} from '@angular/dev-infra-private/bazel/benchmark/driver-utilities';
+import {runBenchmark} from '@angular/build-tooling/bazel/benchmark/driver-utilities';
 
 function runFormFieldRenderBenchmark(testId: string, showBtnId: string) {
   return runBenchmark({

--- a/test/benchmarks/material/menu/BUILD.bazel
+++ b/test/benchmarks/material/menu/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@npm//@angular/dev-infra-private/bazel/benchmark/component_benchmark:component_benchmark.bzl", "component_benchmark")
+load("@npm//@angular/build-tooling/bazel/benchmark/component_benchmark:component_benchmark.bzl", "component_benchmark")
 
 # TODO(wagnermaciel): Update this target to provide indigo-pink in a way that doesn't require having to import it with
 # stylesUrls inside the components once `component_benchmark` supports asset injection.
@@ -7,7 +7,7 @@ component_benchmark(
     name = "benchmark",
     driver = ":menu.perf-spec.ts",
     driver_deps = [
-        "@npm//@angular/dev-infra-private/bazel/benchmark/driver-utilities",
+        "@npm//@angular/build-tooling/bazel/benchmark/driver-utilities",
         "@npm//protractor",
         "@npm//@types/jasmine",
     ],

--- a/test/benchmarks/material/menu/menu.perf-spec.ts
+++ b/test/benchmarks/material/menu/menu.perf-spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {$, by, element, ElementFinder, Key} from 'protractor';
-import {runBenchmark} from '@angular/dev-infra-private/bazel/benchmark/driver-utilities';
+import {runBenchmark} from '@angular/build-tooling/bazel/benchmark/driver-utilities';
 
 // Clicking to close a menu is problematic. This is a solution that uses `.sendKeys()` avoids
 // issues with `.click()`.

--- a/test/benchmarks/material/radio/BUILD.bazel
+++ b/test/benchmarks/material/radio/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@npm//@angular/dev-infra-private/bazel/benchmark/component_benchmark:component_benchmark.bzl", "component_benchmark")
+load("@npm//@angular/build-tooling/bazel/benchmark/component_benchmark:component_benchmark.bzl", "component_benchmark")
 
 # TODO(wagnermaciel): Update this target to provide indigo-pink in a way that doesn't require having to import it with
 # stylesUrls inside the components once `component_benchmark` supports asset injection.
@@ -7,7 +7,7 @@ component_benchmark(
     name = "benchmark",
     driver = ":radio.perf-spec.ts",
     driver_deps = [
-        "@npm//@angular/dev-infra-private/bazel/benchmark/driver-utilities",
+        "@npm//@angular/build-tooling/bazel/benchmark/driver-utilities",
         "@npm//protractor",
         "@npm//@types/jasmine",
     ],

--- a/test/benchmarks/material/radio/radio.perf-spec.ts
+++ b/test/benchmarks/material/radio/radio.perf-spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {$, browser} from 'protractor';
-import {runBenchmark} from '@angular/dev-infra-private/bazel/benchmark/driver-utilities';
+import {runBenchmark} from '@angular/build-tooling/bazel/benchmark/driver-utilities';
 
 describe('radio button performance benchmarks', () => {
   beforeAll(() => {

--- a/test/benchmarks/material/slide-toggle/BUILD.bazel
+++ b/test/benchmarks/material/slide-toggle/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@npm//@angular/dev-infra-private/bazel/benchmark/component_benchmark:component_benchmark.bzl", "component_benchmark")
+load("@npm//@angular/build-tooling/bazel/benchmark/component_benchmark:component_benchmark.bzl", "component_benchmark")
 
 # TODO(wagnermaciel): Update this target to provide indigo-pink in a way that doesn't require having to import it with
 # stylesUrls inside the components once `component_benchmark` supports asset injection.
@@ -7,7 +7,7 @@ component_benchmark(
     name = "benchmark",
     driver = ":slide-toggle.perf-spec.ts",
     driver_deps = [
-        "@npm//@angular/dev-infra-private/bazel/benchmark/driver-utilities",
+        "@npm//@angular/build-tooling/bazel/benchmark/driver-utilities",
         "@npm//protractor",
         "@npm//@types/jasmine",
     ],

--- a/test/benchmarks/material/slide-toggle/slide-toggle.perf-spec.ts
+++ b/test/benchmarks/material/slide-toggle/slide-toggle.perf-spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {$, browser} from 'protractor';
-import {runBenchmark} from '@angular/dev-infra-private/bazel/benchmark/driver-utilities';
+import {runBenchmark} from '@angular/build-tooling/bazel/benchmark/driver-utilities';
 
 describe('slide toggle performance benchmarks', () => {
   beforeAll(() => {

--- a/test/benchmarks/material/table/BUILD.bazel
+++ b/test/benchmarks/material/table/BUILD.bazel
@@ -1,10 +1,10 @@
-load("@npm//@angular/dev-infra-private/bazel/benchmark/component_benchmark:component_benchmark.bzl", "component_benchmark")
+load("@npm//@angular/build-tooling/bazel/benchmark/component_benchmark:component_benchmark.bzl", "component_benchmark")
 
 component_benchmark(
     name = "benchmark",
     driver = ":table.perf-spec.ts",
     driver_deps = [
-        "@npm//@angular/dev-infra-private/bazel/benchmark/driver-utilities",
+        "@npm//@angular/build-tooling/bazel/benchmark/driver-utilities",
         "@npm//protractor",
         "@npm//@types/jasmine",
     ],

--- a/test/benchmarks/material/table/table.perf-spec.ts
+++ b/test/benchmarks/material/table/table.perf-spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {$, browser} from 'protractor';
-import {runBenchmark} from '@angular/dev-infra-private/bazel/benchmark/driver-utilities';
+import {runBenchmark} from '@angular/build-tooling/bazel/benchmark/driver-utilities';
 
 function runTableRenderBenchmark(testId: string, buttonId: string) {
   return runBenchmark({

--- a/test/benchmarks/material/tabs/BUILD.bazel
+++ b/test/benchmarks/material/tabs/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@npm//@angular/dev-infra-private/bazel/benchmark/component_benchmark:component_benchmark.bzl", "component_benchmark")
+load("@npm//@angular/build-tooling/bazel/benchmark/component_benchmark:component_benchmark.bzl", "component_benchmark")
 
 # TODO(wagnermaciel): Update this target to provide indigo-pink in a way that doesn't require having to import it with
 # stylesUrls inside the components once `component_benchmark` supports asset injection.
@@ -7,7 +7,7 @@ component_benchmark(
     name = "benchmark",
     driver = ":tabs.perf-spec.ts",
     driver_deps = [
-        "@npm//@angular/dev-infra-private/bazel/benchmark/driver-utilities",
+        "@npm//@angular/build-tooling/bazel/benchmark/driver-utilities",
         "@npm//protractor",
         "@npm//@types/jasmine",
     ],

--- a/test/benchmarks/material/tabs/tabs.perf-spec.ts
+++ b/test/benchmarks/material/tabs/tabs.perf-spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {$, browser, ElementFinder} from 'protractor';
-import {runBenchmark} from '@angular/dev-infra-private/bazel/benchmark/driver-utilities';
+import {runBenchmark} from '@angular/build-tooling/bazel/benchmark/driver-utilities';
 
 describe('tabs performance benchmarks', () => {
   beforeAll(() => {

--- a/test/benchmarks/mdc/button/BUILD.bazel
+++ b/test/benchmarks/mdc/button/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@npm//@angular/dev-infra-private/bazel/benchmark/component_benchmark:component_benchmark.bzl", "component_benchmark")
+load("@npm//@angular/build-tooling/bazel/benchmark/component_benchmark:component_benchmark.bzl", "component_benchmark")
 
 # TODO(wagnermaciel): Update this target to provide indigo-pink in a way that doesn't require having to import it with
 # stylesUrls inside the components once `component_benchmark` supports asset injection.
@@ -7,7 +7,7 @@ component_benchmark(
     name = "benchmark",
     driver = ":button.perf-spec.ts",
     driver_deps = [
-        "@npm//@angular/dev-infra-private/bazel/benchmark/driver-utilities",
+        "@npm//@angular/build-tooling/bazel/benchmark/driver-utilities",
         "@npm//protractor",
         "@npm//@types/jasmine",
     ],

--- a/test/benchmarks/mdc/button/button.perf-spec.ts
+++ b/test/benchmarks/mdc/button/button.perf-spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {$, browser} from 'protractor';
-import {runBenchmark} from '@angular/dev-infra-private/bazel/benchmark/driver-utilities';
+import {runBenchmark} from '@angular/build-tooling/bazel/benchmark/driver-utilities';
 
 describe('button performance benchmarks', () => {
   beforeAll(() => {

--- a/test/benchmarks/mdc/card/BUILD.bazel
+++ b/test/benchmarks/mdc/card/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@npm//@angular/dev-infra-private/bazel/benchmark/component_benchmark:component_benchmark.bzl", "component_benchmark")
+load("@npm//@angular/build-tooling/bazel/benchmark/component_benchmark:component_benchmark.bzl", "component_benchmark")
 
 # TODO(wagnermaciel): Update this target to provide indigo-pink in a way that doesn't require having to import it with
 # stylesUrls inside the components once `component_benchmark` supports asset injection.
@@ -7,7 +7,7 @@ component_benchmark(
     name = "benchmark",
     driver = ":card.perf-spec.ts",
     driver_deps = [
-        "@npm//@angular/dev-infra-private/bazel/benchmark/driver-utilities",
+        "@npm//@angular/build-tooling/bazel/benchmark/driver-utilities",
         "@npm//protractor",
         "@npm//@types/jasmine",
     ],

--- a/test/benchmarks/mdc/card/card.perf-spec.ts
+++ b/test/benchmarks/mdc/card/card.perf-spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {$, browser} from 'protractor';
-import {runBenchmark} from '@angular/dev-infra-private/bazel/benchmark/driver-utilities';
+import {runBenchmark} from '@angular/build-tooling/bazel/benchmark/driver-utilities';
 
 describe('card performance benchmarks', () => {
   beforeAll(() => {

--- a/test/benchmarks/mdc/checkbox/BUILD.bazel
+++ b/test/benchmarks/mdc/checkbox/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@npm//@angular/dev-infra-private/bazel/benchmark/component_benchmark:component_benchmark.bzl", "component_benchmark")
+load("@npm//@angular/build-tooling/bazel/benchmark/component_benchmark:component_benchmark.bzl", "component_benchmark")
 
 # TODO(wagnermaciel): Update this target to provide indigo-pink in a way that doesn't require having to import it with
 # stylesUrls inside the components once `component_benchmark` supports asset injection.
@@ -7,7 +7,7 @@ component_benchmark(
     name = "benchmark",
     driver = ":checkbox.perf-spec.ts",
     driver_deps = [
-        "@npm//@angular/dev-infra-private/bazel/benchmark/driver-utilities",
+        "@npm//@angular/build-tooling/bazel/benchmark/driver-utilities",
         "@npm//protractor",
         "@npm//@types/jasmine",
     ],

--- a/test/benchmarks/mdc/checkbox/checkbox.perf-spec.ts
+++ b/test/benchmarks/mdc/checkbox/checkbox.perf-spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {$, browser} from 'protractor';
-import {runBenchmark} from '@angular/dev-infra-private/bazel/benchmark/driver-utilities';
+import {runBenchmark} from '@angular/build-tooling/bazel/benchmark/driver-utilities';
 
 describe('checkbox performance benchmarks', () => {
   beforeAll(() => {

--- a/test/benchmarks/mdc/chips/BUILD.bazel
+++ b/test/benchmarks/mdc/chips/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@npm//@angular/dev-infra-private/bazel/benchmark/component_benchmark:component_benchmark.bzl", "component_benchmark")
+load("@npm//@angular/build-tooling/bazel/benchmark/component_benchmark:component_benchmark.bzl", "component_benchmark")
 
 # TODO(wagnermaciel): Update this target to provide indigo-pink in a way that doesn't require having to import it with
 # stylesUrls inside the components once `component_benchmark` supports asset injection.
@@ -7,7 +7,7 @@ component_benchmark(
     name = "benchmark",
     driver = ":chips.perf-spec.ts",
     driver_deps = [
-        "@npm//@angular/dev-infra-private/bazel/benchmark/driver-utilities",
+        "@npm//@angular/build-tooling/bazel/benchmark/driver-utilities",
         "@npm//protractor",
         "@npm//@types/jasmine",
     ],

--- a/test/benchmarks/mdc/chips/chips.perf-spec.ts
+++ b/test/benchmarks/mdc/chips/chips.perf-spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {$, browser} from 'protractor';
-import {runBenchmark} from '@angular/dev-infra-private/bazel/benchmark/driver-utilities';
+import {runBenchmark} from '@angular/build-tooling/bazel/benchmark/driver-utilities';
 
 async function runRenderBenchmark(testId: string, showBtnId: string) {
   return runBenchmark({

--- a/test/benchmarks/mdc/form-field/BUILD.bazel
+++ b/test/benchmarks/mdc/form-field/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@npm//@angular/dev-infra-private/bazel/benchmark/component_benchmark:component_benchmark.bzl", "component_benchmark")
+load("@npm//@angular/build-tooling/bazel/benchmark/component_benchmark:component_benchmark.bzl", "component_benchmark")
 
 # TODO(wagnermaciel): Update this target to provide indigo-pink in a way that doesn't require having to import it with
 # stylesUrls inside the components once `component_benchmark` supports asset injection.
@@ -7,7 +7,7 @@ component_benchmark(
     name = "benchmark",
     driver = ":form-field.perf-spec.ts",
     driver_deps = [
-        "@npm//@angular/dev-infra-private/bazel/benchmark/driver-utilities",
+        "@npm//@angular/build-tooling/bazel/benchmark/driver-utilities",
         "@npm//protractor",
         "@npm//@types/jasmine",
     ],

--- a/test/benchmarks/mdc/form-field/form-field.perf-spec.ts
+++ b/test/benchmarks/mdc/form-field/form-field.perf-spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {$, browser} from 'protractor';
-import {runBenchmark} from '@angular/dev-infra-private/bazel/benchmark/driver-utilities';
+import {runBenchmark} from '@angular/build-tooling/bazel/benchmark/driver-utilities';
 
 function runFormFieldRenderBenchmark(testId: string, showBtnId: string) {
   return runBenchmark({

--- a/test/benchmarks/mdc/menu/BUILD.bazel
+++ b/test/benchmarks/mdc/menu/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@npm//@angular/dev-infra-private/bazel/benchmark/component_benchmark:component_benchmark.bzl", "component_benchmark")
+load("@npm//@angular/build-tooling/bazel/benchmark/component_benchmark:component_benchmark.bzl", "component_benchmark")
 
 # TODO(wagnermaciel): Update this target to provide indigo-pink in a way that doesn't require having to import it with
 # stylesUrls inside the components once `component_benchmark` supports asset injection.
@@ -7,7 +7,7 @@ component_benchmark(
     name = "benchmark",
     driver = ":menu.perf-spec.ts",
     driver_deps = [
-        "@npm//@angular/dev-infra-private/bazel/benchmark/driver-utilities",
+        "@npm//@angular/build-tooling/bazel/benchmark/driver-utilities",
         "@npm//protractor",
         "@npm//@types/jasmine",
     ],

--- a/test/benchmarks/mdc/menu/menu.perf-spec.ts
+++ b/test/benchmarks/mdc/menu/menu.perf-spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {$, by, element, ElementFinder, Key} from 'protractor';
-import {runBenchmark} from '@angular/dev-infra-private/bazel/benchmark/driver-utilities';
+import {runBenchmark} from '@angular/build-tooling/bazel/benchmark/driver-utilities';
 
 // Clicking to close a menu is problematic. This is a solution that uses `.sendKeys()` avoids
 // issues with `.click()`.

--- a/test/benchmarks/mdc/radio/BUILD.bazel
+++ b/test/benchmarks/mdc/radio/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@npm//@angular/dev-infra-private/bazel/benchmark/component_benchmark:component_benchmark.bzl", "component_benchmark")
+load("@npm//@angular/build-tooling/bazel/benchmark/component_benchmark:component_benchmark.bzl", "component_benchmark")
 
 # TODO(wagnermaciel): Update this target to provide indigo-pink in a way that doesn't require having to import it with
 # stylesUrls inside the components once `component_benchmark` supports asset injection.
@@ -7,7 +7,7 @@ component_benchmark(
     name = "benchmark",
     driver = ":radio.perf-spec.ts",
     driver_deps = [
-        "@npm//@angular/dev-infra-private/bazel/benchmark/driver-utilities",
+        "@npm//@angular/build-tooling/bazel/benchmark/driver-utilities",
         "@npm//protractor",
         "@npm//@types/jasmine",
     ],

--- a/test/benchmarks/mdc/radio/radio.perf-spec.ts
+++ b/test/benchmarks/mdc/radio/radio.perf-spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {$, browser} from 'protractor';
-import {runBenchmark} from '@angular/dev-infra-private/bazel/benchmark/driver-utilities';
+import {runBenchmark} from '@angular/build-tooling/bazel/benchmark/driver-utilities';
 
 describe('radio button performance benchmarks', () => {
   beforeAll(() => {

--- a/test/benchmarks/mdc/slide-toggle/BUILD.bazel
+++ b/test/benchmarks/mdc/slide-toggle/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@npm//@angular/dev-infra-private/bazel/benchmark/component_benchmark:component_benchmark.bzl", "component_benchmark")
+load("@npm//@angular/build-tooling/bazel/benchmark/component_benchmark:component_benchmark.bzl", "component_benchmark")
 
 # TODO(wagnermaciel): Update this target to provide indigo-pink in a way that doesn't require having to import it with
 # stylesUrls inside the components once `component_benchmark` supports asset injection.
@@ -7,7 +7,7 @@ component_benchmark(
     name = "benchmark",
     driver = ":slide-toggle.perf-spec.ts",
     driver_deps = [
-        "@npm//@angular/dev-infra-private/bazel/benchmark/driver-utilities",
+        "@npm//@angular/build-tooling/bazel/benchmark/driver-utilities",
         "@npm//protractor",
         "@npm//@types/jasmine",
     ],

--- a/test/benchmarks/mdc/slide-toggle/slide-toggle.perf-spec.ts
+++ b/test/benchmarks/mdc/slide-toggle/slide-toggle.perf-spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {$, browser} from 'protractor';
-import {runBenchmark} from '@angular/dev-infra-private/bazel/benchmark/driver-utilities';
+import {runBenchmark} from '@angular/build-tooling/bazel/benchmark/driver-utilities';
 
 describe('slide toggle performance benchmarks', () => {
   beforeAll(() => {

--- a/test/benchmarks/mdc/table/BUILD.bazel
+++ b/test/benchmarks/mdc/table/BUILD.bazel
@@ -1,10 +1,10 @@
-load("@npm//@angular/dev-infra-private/bazel/benchmark/component_benchmark:component_benchmark.bzl", "component_benchmark")
+load("@npm//@angular/build-tooling/bazel/benchmark/component_benchmark:component_benchmark.bzl", "component_benchmark")
 
 component_benchmark(
     name = "benchmark",
     driver = ":table.perf-spec.ts",
     driver_deps = [
-        "@npm//@angular/dev-infra-private/bazel/benchmark/driver-utilities",
+        "@npm//@angular/build-tooling/bazel/benchmark/driver-utilities",
         "@npm//protractor",
         "@npm//@types/jasmine",
     ],

--- a/test/benchmarks/mdc/table/table.perf-spec.ts
+++ b/test/benchmarks/mdc/table/table.perf-spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {$, browser} from 'protractor';
-import {runBenchmark} from '@angular/dev-infra-private/bazel/benchmark/driver-utilities';
+import {runBenchmark} from '@angular/build-tooling/bazel/benchmark/driver-utilities';
 
 function runTableRenderBenchmark(testId: string, buttonId: string) {
   return runBenchmark({

--- a/test/benchmarks/mdc/tabs/BUILD.bazel
+++ b/test/benchmarks/mdc/tabs/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@npm//@angular/dev-infra-private/bazel/benchmark/component_benchmark:component_benchmark.bzl", "component_benchmark")
+load("@npm//@angular/build-tooling/bazel/benchmark/component_benchmark:component_benchmark.bzl", "component_benchmark")
 
 # TODO(wagnermaciel): Update this target to provide indigo-pink in a way that doesn't require having to import it with
 # stylesUrls inside the components once `component_benchmark` supports asset injection.
@@ -7,7 +7,7 @@ component_benchmark(
     name = "benchmark",
     driver = "tabs.perf-spec.ts",
     driver_deps = [
-        "@npm//@angular/dev-infra-private/bazel/benchmark/driver-utilities",
+        "@npm//@angular/build-tooling/bazel/benchmark/driver-utilities",
         "@npm//protractor",
         "@npm//@types/jasmine",
     ],

--- a/test/benchmarks/mdc/tabs/tabs.perf-spec.ts
+++ b/test/benchmarks/mdc/tabs/tabs.perf-spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {$, browser, ElementFinder} from 'protractor';
-import {runBenchmark} from '@angular/dev-infra-private/bazel/benchmark/driver-utilities';
+import {runBenchmark} from '@angular/build-tooling/bazel/benchmark/driver-utilities';
 
 describe('tabs performance benchmarks', () => {
   beforeAll(() => {

--- a/tools/angular/BUILD.bazel
+++ b/tools/angular/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@npm//@angular/dev-infra-private/bazel/esbuild:index.bzl", "esbuild_config")
+load("@npm//@angular/build-tooling/bazel/esbuild:index.bzl", "esbuild_config")
 load(":index.bzl", "create_angular_bundle_targets")
 
 package(default_visibility = ["//visibility:public"])
@@ -7,7 +7,7 @@ esbuild_config(
     name = "esbuild_config",
     config_file = "esbuild.config.mjs",
     deps = [
-        "@npm//@angular/dev-infra-private/shared-scripts/angular-linker:js_lib",
+        "@npm//@angular/build-tooling/shared-scripts/angular-linker:js_lib",
     ],
 )
 

--- a/tools/angular/esbuild.config.mjs
+++ b/tools/angular/esbuild.config.mjs
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {createLinkerEsbuildPlugin} from '@angular/dev-infra-private/shared-scripts/angular-linker/esbuild-plugin.mjs';
+import {createLinkerEsbuildPlugin} from '@angular/build-tooling/shared-scripts/angular-linker/esbuild-plugin.mjs';
 
 export default {
   // Note: We support `.mjs` here as this is the extension used by Angular APF packages.

--- a/tools/angular/index.bzl
+++ b/tools/angular/index.bzl
@@ -1,5 +1,5 @@
 load("//:packages.bzl", "ANGULAR_PACKAGES")
-load("@npm//@angular/dev-infra-private/bazel/esbuild:index.bzl", "esbuild")
+load("@npm//@angular/build-tooling/bazel/esbuild:index.bzl", "esbuild")
 load("@build_bazel_rules_nodejs//internal/linker:link_node_modules.bzl", "LinkerPackageMappingInfo")
 load("@build_bazel_rules_nodejs//:providers.bzl", "ExternalNpmPackageInfo", "JSModuleInfo")
 

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -4,12 +4,12 @@ load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("@build_bazel_rules_nodejs//:index.bzl", _pkg_npm = "pkg_npm")
 load("@io_bazel_rules_sass//:defs.bzl", _npm_sass_library = "npm_sass_library", _sass_binary = "sass_binary", _sass_library = "sass_library")
 load("@npm//@angular/bazel:index.bzl", _ng_module = "ng_module", _ng_package = "ng_package")
-load("@npm//@angular/dev-infra-private/bazel/integration:index.bzl", _integration_test = "integration_test")
-load("@npm//@angular/dev-infra-private/bazel/karma:index.bzl", _karma_web_test_suite = "karma_web_test_suite")
-load("@npm//@angular/dev-infra-private/bazel/esbuild:index.bzl", _esbuild = "esbuild", _esbuild_config = "esbuild_config")
-load("@npm//@angular/dev-infra-private/bazel/spec-bundling:index.bzl", _spec_bundle = "spec_bundle")
-load("@npm//@angular/dev-infra-private/bazel/http-server:index.bzl", _http_server = "http_server")
-load("@npm//@angular/dev-infra-private/bazel:extract_js_module_output.bzl", "extract_js_module_output")
+load("@npm//@angular/build-tooling/bazel/integration:index.bzl", _integration_test = "integration_test")
+load("@npm//@angular/build-tooling/bazel/karma:index.bzl", _karma_web_test_suite = "karma_web_test_suite")
+load("@npm//@angular/build-tooling/bazel/esbuild:index.bzl", _esbuild = "esbuild", _esbuild_config = "esbuild_config")
+load("@npm//@angular/build-tooling/bazel/spec-bundling:index.bzl", _spec_bundle = "spec_bundle")
+load("@npm//@angular/build-tooling/bazel/http-server:index.bzl", _http_server = "http_server")
+load("@npm//@angular/build-tooling/bazel:extract_js_module_output.bzl", "extract_js_module_output")
 load("@npm//@bazel/jasmine:index.bzl", _jasmine_node_test = "jasmine_node_test")
 load("@npm//@bazel/protractor:index.bzl", _protractor_web_test_suite = "protractor_web_test_suite")
 load("@npm//@bazel/concatjs:index.bzl", _ts_library = "ts_library")
@@ -298,12 +298,12 @@ def karma_web_test_suite(name, **kwargs):
         kwargs["browsers"] = [
             # Note: when changing the browser names here, also update the "yarn test"
             # script to reflect the new browser names.
-            "@npm//@angular/dev-infra-private/bazel/browsers/chromium:chromium",
-            "@npm//@angular/dev-infra-private/bazel/browsers/firefox:firefox",
+            "@npm//@angular/build-tooling/bazel/browsers/chromium:chromium",
+            "@npm//@angular/build-tooling/bazel/browsers/firefox:firefox",
         ]
 
     # Default test suite with all configured browsers, and the debug target being
-    # setup from `@angular/dev-infra-private`.
+    # setup from `angular/dev-infra`.
     _karma_web_test_suite(
         name = name,
         **kwargs
@@ -319,7 +319,7 @@ def protractor_web_test_suite(name, deps, **kwargs):
 
     _protractor_web_test_suite(
         name = name,
-        browsers = ["@npm//@angular/dev-infra-private/bazel/browsers/chromium:chromium"],
+        browsers = ["@npm//@angular/build-tooling/bazel/browsers/chromium:chromium"],
         deps = ["%s_bundle" % name],
         **kwargs
     )
@@ -344,8 +344,8 @@ def node_integration_test(setup_chromium = False, node_repository = "nodejs", **
     # If Chromium should be configured, add it to the runfiles and expose its binaries
     # through test environment variables. The variables are auto-detected by e.g. Karma.
     if setup_chromium:
-        data.append("@npm//@angular/dev-infra-private/bazel/browsers/chromium")
-        toolchains.append("@npm//@angular/dev-infra-private/bazel/browsers/chromium:toolchain_alias")
+        data.append("@npm//@angular/build-tooling/bazel/browsers/chromium")
+        toolchains.append("@npm//@angular/build-tooling/bazel/browsers/chromium:toolchain_alias")
         environment.update({
             "CHROMEDRIVER_BIN": "$(CHROMEDRIVER)",
             "CHROME_BIN": "$(CHROMIUM)",

--- a/tools/public_api_guard/generate-guard-tests.bzl
+++ b/tools/public_api_guard/generate-guard-tests.bzl
@@ -1,4 +1,4 @@
-load("@npm//@angular/dev-infra-private/bazel/api-golden:index.bzl", "api_golden_test")
+load("@npm//@angular/build-tooling/bazel/api-golden:index.bzl", "api_golden_test")
 
 def generate_test_targets(targets, types = []):
     """Macro for generating `api_golden_test` Bazel test targets. Since there are multiple

--- a/tools/release-checks/check-framework-peer-dependency.mts
+++ b/tools/release-checks/check-framework-peer-dependency.mts
@@ -1,4 +1,4 @@
-import {Log, ReleasePrecheckError} from '@angular/dev-infra-private/ng-dev';
+import {Log, ReleasePrecheckError} from '@angular/ng-dev';
 import {join, dirname} from 'path';
 import {fileURLToPath} from 'url';
 import {existsSync, readFileSync} from 'fs';

--- a/tools/release-checks/check-migration-collections.mts
+++ b/tools/release-checks/check-migration-collections.mts
@@ -1,4 +1,4 @@
-import {Log, bold, yellow, ReleasePrecheckError} from '@angular/dev-infra-private/ng-dev';
+import {Log, bold, yellow, ReleasePrecheckError} from '@angular/ng-dev';
 import {existsSync, readFileSync} from 'fs';
 import {fileURLToPath} from 'url';
 import {dirname, join} from 'path';

--- a/tools/release-checks/npm-package-output/check-package.mts
+++ b/tools/release-checks/npm-package-output/check-package.mts
@@ -1,4 +1,4 @@
-import {Log, bold, yellow} from '@angular/dev-infra-private/ng-dev';
+import {Log, bold, yellow} from '@angular/ng-dev';
 import {existsSync} from 'fs';
 import glob from 'glob';
 import {basename, dirname, join} from 'path';

--- a/tools/release-checks/npm-package-output/index.mts
+++ b/tools/release-checks/npm-package-output/index.mts
@@ -1,6 +1,6 @@
 import semver from 'semver';
 import {checkReleasePackage} from './check-package.mjs';
-import {BuiltPackage, Log, ReleasePrecheckError} from '@angular/dev-infra-private/ng-dev';
+import {BuiltPackage, Log, ReleasePrecheckError} from '@angular/ng-dev';
 
 /** Asserts that the given built packages are valid for public consumption. */
 export async function assertValidNpmPackageOutput(

--- a/yarn.lock
+++ b/yarn.lock
@@ -247,6 +247,42 @@
     "@angular/core" "^13.0.0 || ^14.0.0-0"
     reflect-metadata "^0.1.13"
 
+"@angular/build-tooling@https://github.com/angular/dev-infra-private-build-tooling-builds.git#1addc303bef0b6acc0dca0961e9e642629f3a5cd":
+  version "0.0.0-fa61d03a603e04af2b66f3598f1af01da1e1cfb1"
+  resolved "https://github.com/angular/dev-infra-private-build-tooling-builds.git#1addc303bef0b6acc0dca0961e9e642629f3a5cd"
+  dependencies:
+    "@angular-devkit/build-angular" "14.1.0-rc.3"
+    "@angular/benchpress" "0.3.0"
+    "@babel/core" "^7.16.0"
+    "@bazel/buildifier" "5.1.0"
+    "@bazel/concatjs" "5.5.2"
+    "@bazel/esbuild" "5.5.2"
+    "@bazel/protractor" "5.5.2"
+    "@bazel/runfiles" "5.5.2"
+    "@bazel/terser" "5.5.2"
+    "@bazel/typescript" "5.5.2"
+    "@microsoft/api-extractor" "7.28.4"
+    "@types/browser-sync" "^2.26.3"
+    "@types/node" "16.10.9"
+    "@types/selenium-webdriver" "^4.0.18"
+    "@types/send" "^0.17.1"
+    "@types/tmp" "^0.2.1"
+    "@types/uuid" "^8.3.1"
+    "@types/yargs" "^17.0.0"
+    browser-sync "^2.27.7"
+    clang-format "1.8.0"
+    prettier "2.7.1"
+    protractor "^7.0.0"
+    selenium-webdriver "4.3.1"
+    send "^0.18.0"
+    source-map "^0.7.4"
+    tmp "^0.2.1"
+    "true-case-path" "^2.2.1"
+    tslib "^2.3.0"
+    typescript "~4.7.3"
+    uuid "^8.3.2"
+    yargs "^17.0.0"
+
 "@angular/cli@^14.0.1":
   version "14.0.1"
   resolved "https://registry.yarnpkg.com/@angular/cli/-/cli-14.0.1.tgz#3cfefc32155140812ce6145e3d1021026d971aed"
@@ -327,44 +363,6 @@
   dependencies:
     tslib "^2.3.0"
 
-"@angular/dev-infra-private@https://github.com/angular/dev-infra-private-builds.git#c1b330bfbd79adf076039c872b966cfef76c5781":
-  version "0.0.0-f896fed3ab4d8bd57e06e2b7ff15cf448624cdc8"
-  uid c1b330bfbd79adf076039c872b966cfef76c5781
-  resolved "https://github.com/angular/dev-infra-private-builds.git#c1b330bfbd79adf076039c872b966cfef76c5781"
-  dependencies:
-    "@angular-devkit/build-angular" "14.1.0-rc.3"
-    "@angular/benchpress" "0.3.0"
-    "@babel/core" "^7.16.0"
-    "@bazel/buildifier" "5.1.0"
-    "@bazel/concatjs" "5.5.2"
-    "@bazel/esbuild" "5.5.2"
-    "@bazel/protractor" "5.5.2"
-    "@bazel/runfiles" "5.5.2"
-    "@bazel/terser" "5.5.2"
-    "@bazel/typescript" "5.5.2"
-    "@microsoft/api-extractor" "7.28.4"
-    "@types/browser-sync" "^2.26.3"
-    "@types/node" "16.10.9"
-    "@types/selenium-webdriver" "^4.0.18"
-    "@types/send" "^0.17.1"
-    "@types/tmp" "^0.2.1"
-    "@types/uuid" "^8.3.1"
-    "@types/yargs" "^17.0.0"
-    "@yarnpkg/lockfile" "^1.1.0"
-    browser-sync "^2.27.7"
-    clang-format "1.8.0"
-    prettier "2.7.1"
-    protractor "^7.0.0"
-    selenium-webdriver "4.3.1"
-    send "^0.18.0"
-    source-map "^0.7.4"
-    tmp "^0.2.1"
-    "true-case-path" "^2.2.1"
-    tslib "^2.3.0"
-    typescript "~4.7.3"
-    uuid "^8.3.2"
-    yargs "^17.0.0"
-
 "@angular/forms@^14.0.1":
   version "14.0.1"
   resolved "https://registry.yarnpkg.com/@angular/forms/-/forms-14.0.1.tgz#9286b25ac59de8ba8355bf200eabfaae40cf1d2d"
@@ -380,6 +378,13 @@
     "@babel/core" "7.17.12"
     glob "8.0.3"
     yargs "^17.2.1"
+
+"@angular/ng-dev@https://github.com/angular/dev-infra-private-ng-dev-builds.git#865c7687cdca2bd512040330e1677eecaa26e46a":
+  version "0.0.0-fa61d03a603e04af2b66f3598f1af01da1e1cfb1"
+  resolved "https://github.com/angular/dev-infra-private-ng-dev-builds.git#865c7687cdca2bd512040330e1677eecaa26e46a"
+  dependencies:
+    "@yarnpkg/lockfile" "^1.1.0"
+    typescript "~4.7.3"
 
 "@angular/platform-browser-dynamic@^14.0.1":
   version "14.0.1"


### PR DESCRIPTION
We split the dev-infra-private packagve to decouple the ng-dev tool from
the build tooling. This allows us to easily update ng-dev e.g. in LTS
branches without needing to update Bazel.

It is important that ng-dev can be updated as much as possilbe in all
branches to ensure the release IPC reliably works.