### PR TITLE
fix(material/dialog): using incorrect mixin for structural styles

### DIFF
--- a/src/material/dialog/_dialog-theme.scss
+++ b/src/material/dialog/_dialog-theme.scss
@@ -19,8 +19,6 @@
 
       @include mdc-dialog-theme.theme((
         container-color: $surface,
-        container-elevation: 24,
-        container-shadow-color: $on-surface,
         with-divider-divider-color: rgba($on-surface, mdc-dialog.$scroll-divider-opacity),
         subhead-color: rgba($on-surface, $text-emphasis-high),
         supporting-text-color: rgba($on-surface, $text-emphasis-medium),

--- a/src/material/dialog/dialog.scss
+++ b/src/material/dialog/dialog.scss
@@ -1,4 +1,5 @@
 @use '@material/dialog' as mdc-dialog;
+@use '@material/dialog/variables' as mdc-dialog-variables;
 @use '@material/dialog/dialog-theme' as mdc-dialog-theme;
 @use './mdc-dialog-structure-overrides';
 @use '../core/mdc-helpers/mdc-helpers';
@@ -26,6 +27,9 @@ $_dialog-initial-theme: (
   supporting-text-size: 14px,
   supporting-text-weight: 500,
   supporting-text-tracking: 1px,
+
+  // Structure
+  container-shape: mdc-dialog-variables.$shape-radius,
 );
 
 // Dialog content max height. This has been copied from the standard dialog
@@ -36,7 +40,7 @@ $mat-dialog-content-max-height: 65vh !default;
 $mat-dialog-button-horizontal-margin: 8px !default;
 
 @include mdc-helpers.disable-mdc-fallback-declarations {
-  @include mdc-dialog.core-styles($query: mdc-helpers.$mdc-base-styles-query);
+  @include mdc-dialog.static-styles($query: mdc-helpers.$mdc-base-styles-query);
 }
 
 @include mdc-dialog-structure-overrides.private-dialog-structure-overrides(


### PR DESCRIPTION
The MDC dialog was using the `core-styles` mixin instead of the `static-styles` which is supposed to be used together with the new theming API. I've also removed the `container-elevation` and `container-shadow-color` variables from the theme since they weren't doing anything.