### PR TITLE
aria-expanded attribute needs be present with false value

### DIFF
--- a/src/material/menu/menu-trigger.ts
+++ b/src/material/menu/menu-trigger.ts
@@ -80,7 +80,7 @@ const passiveEventListenerOptions = normalizePassiveListenerOptions({passive: tr
 @Directive({
   host: {
     '[attr.aria-haspopup]': 'menu ? "menu" : null',
-    '[attr.aria-expanded]': 'menuOpen || null',
+    '[attr.aria-expanded]': 'menuOpen',
     '[attr.aria-controls]': 'menuOpen ? menu.panelId : null',
     '(click)': '_handleClick($event)',
     '(mousedown)': '_handleMousedown($event)',


### PR DESCRIPTION
`aria-expanded` has to indicate whether the menu has expanded or collapsed state. It never indicates that it has collapsed state, as attribute gets removed.
https://w3c.github.io/aria-practices/examples/menubar/menubar-navigation.html