### PR TITLE
build: fix select e2e tests

### DIFF
--- a/src/material/legacy-select/BUILD.bazel
+++ b/src/material/legacy-select/BUILD.bazel
@@ -1,8 +1,6 @@
-load("//src/e2e-app:test_suite.bzl", "e2e_test_suite")
 load(
     "//tools:defaults.bzl",
     "markdown_to_html",
-    "ng_e2e_test_library",
     "ng_module",
     "ng_test_library",
     "ng_web_test_suite",
@@ -43,10 +41,7 @@ sass_binary(
 
 ng_test_library(
     name = "unit_test_sources",
-    srcs = glob(
-        ["**/*.spec.ts"],
-        exclude = ["**/*.e2e.spec.ts"],
-    ),
+    srcs = glob(["**/*.spec.ts"]),
     deps = [
         ":legacy-select",
         "//src/cdk/a11y",
@@ -68,19 +63,6 @@ ng_test_library(
 ng_web_test_suite(
     name = "unit_tests",
     deps = [":unit_test_sources"],
-)
-
-ng_e2e_test_library(
-    name = "e2e_test_sources",
-    srcs = glob(["**/*.e2e.spec.ts"]),
-    deps = [
-        "//src/cdk/testing/private/e2e",
-    ],
-)
-
-e2e_test_suite(
-    name = "e2e_tests",
-    deps = [":e2e_test_sources"],
 )
 
 markdown_to_html(

--- a/src/material/select/BUILD.bazel
+++ b/src/material/select/BUILD.bazel
@@ -1,4 +1,14 @@
-load("//tools:defaults.bzl", "markdown_to_html", "ng_module", "ng_test_library", "ng_web_test_suite", "sass_binary", "sass_library")
+load("//src/e2e-app:test_suite.bzl", "e2e_test_suite")
+load(
+    "//tools:defaults.bzl",
+    "markdown_to_html",
+    "ng_e2e_test_library",
+    "ng_module",
+    "ng_test_library",
+    "ng_web_test_suite",
+    "sass_binary",
+    "sass_library",
+)
 
 package(default_visibility = ["//visibility:public"])
 
@@ -51,7 +61,10 @@ sass_binary(
 
 ng_test_library(
     name = "select_tests_lib",
-    srcs = glob(["**/*.spec.ts"]),
+    srcs = glob(
+        ["**/*.spec.ts"],
+        exclude = ["**/*.e2e.spec.ts"],
+    ),
     deps = [
         ":select",
         "//src/cdk/a11y",
@@ -73,6 +86,19 @@ ng_web_test_suite(
     deps = [
         ":select_tests_lib",
     ],
+)
+
+ng_e2e_test_library(
+    name = "e2e_test_sources",
+    srcs = glob(["**/*.e2e.spec.ts"]),
+    deps = [
+        "//src/cdk/testing/private/e2e",
+    ],
+)
+
+e2e_test_suite(
+    name = "e2e_tests",
+    deps = [":e2e_test_sources"],
 )
 
 markdown_to_html(

--- a/src/material/select/select.e2e.spec.ts
+++ b/src/material/select/select.e2e.spec.ts
@@ -11,8 +11,8 @@ describe('select', () => {
   // accidentally. This could happen because the select panel is removed from DOM
   // immediately when an option is clicked. Usually ripples still fade-in at that point.
   it('should not accidentally persist ripples', async () => {
-    const select = getElement('.mat-select');
-    const options = element.all(by.css('.mat-option'));
+    const select = getElement('.mat-mdc-select');
+    const options = element.all(by.css('.mat-mdc-option'));
     const ripples = element.all(by.css('.mat-ripple-element'));
 
     // Wait for select to be rendered.


### PR DESCRIPTION
In a previous PR I assumed that a timeout in the select e2e tests was a flake, but it was actually a failure, because the test is running against the docs examples which were switched over to MDC.