### PR TITLE
build: fix snapshot tests failure

### DIFF
--- a/src/material/schematics/ng-update/BUILD.bazel
+++ b/src/material/schematics/ng-update/BUILD.bazel
@@ -78,6 +78,7 @@ spec_bundle(
     name = "spec_bundle",
     external = ["*/paths.js"],
     platform = "cjs-legacy",
+    target = "es2020",
     deps = [":test_lib"],
 )
 


### PR DESCRIPTION
Fixes the build error in the snapshots check by applying a similar fix to #25303.