### PR TITLE
fix(material-experimental/mdc-list): set a role on MatNavList and Mat…

### DIFF
--- a/src/material-experimental/mdc-list/action-list.ts
+++ b/src/material-experimental/mdc-list/action-list.ts
@@ -15,6 +15,7 @@ import {MatListBase} from './list-base';
   template: '<ng-content></ng-content>',
   host: {
     'class': 'mat-mdc-action-list mat-mdc-list-base mdc-list',
+    'role': 'group',
   },
   styleUrls: ['list.css'],
   encapsulation: ViewEncapsulation.None,

--- a/src/material-experimental/mdc-list/list.spec.ts
+++ b/src/material-experimental/mdc-list/list.spec.ts
@@ -99,7 +99,7 @@ describe('MDC-based MatList', () => {
     expect(listItem.nativeElement.className).toContain('mdc-list-item--with-three-lines');
   });
 
-  it('should add aria roles properly', () => {
+  it('should not apply aria roles to mat-list', () => {
     const fixture = TestBed.createComponent(ListWithMultipleItems);
     fixture.detectChanges();
 
@@ -111,6 +111,26 @@ describe('MDC-based MatList', () => {
     expect(listItem.nativeElement.getAttribute('role'))
       .withContext('Expect mat-list-item no role')
       .toBeNull();
+  });
+
+  it('should apply role="navigation" to mat-nav-list', () => {
+    const fixture = TestBed.createComponent(NavListWithOneAnchorItem);
+    fixture.detectChanges();
+
+    const list = fixture.debugElement.children[0];
+    expect(list.nativeElement.getAttribute('role'))
+      .withContext('Expect mat-nav-list to have navigation role')
+      .toBe('navigation');
+  });
+
+  it('should apply role="group" to mat-action-list', () => {
+    const fixture = TestBed.createComponent(ActionListWithoutType);
+    fixture.detectChanges();
+
+    const list = fixture.debugElement.children[0];
+    expect(list.nativeElement.getAttribute('role'))
+      .withContext('Expect mat-action-list to have group role')
+      .toBe('group');
   });
 
   it('should not show ripples for non-nav lists', fakeAsync(() => {

--- a/src/material-experimental/mdc-list/nav-list.ts
+++ b/src/material-experimental/mdc-list/nav-list.ts
@@ -15,6 +15,7 @@ import {MatListBase} from './list-base';
   template: '<ng-content></ng-content>',
   host: {
     'class': 'mat-mdc-nav-list mat-mdc-list-base mdc-list',
+    'role': 'navigation',
   },
   styleUrls: ['list.css'],
   encapsulation: ViewEncapsulation.None,

--- a/src/material/list/list.spec.ts
+++ b/src/material/list/list.spec.ts
@@ -99,7 +99,7 @@ describe('MatList', () => {
     expect(listItem.nativeElement.className).toContain('mat-3-line');
   });
 
-  it('should add aria roles properly', () => {
+  it('should not apply aria roles to mat-list', () => {
     const fixture = TestBed.createComponent(ListWithMultipleItems);
     fixture.detectChanges();
 
@@ -111,6 +111,26 @@ describe('MatList', () => {
     expect(listItem.nativeElement.getAttribute('role'))
       .withContext('Expect mat-list-item no role')
       .toBeNull();
+  });
+
+  it('should apply role="navigation" to mat-nav-list', () => {
+    const fixture = TestBed.createComponent(NavListWithOneAnchorItem);
+    fixture.detectChanges();
+
+    const list = fixture.debugElement.children[0];
+    expect(list.nativeElement.getAttribute('role'))
+      .withContext('Expect mat-nav-list to have navigation role')
+      .toBe('navigation');
+  });
+
+  it('should apply role="group" to mat-action-list', () => {
+    const fixture = TestBed.createComponent(ActionListWithoutType);
+    fixture.detectChanges();
+
+    const list = fixture.debugElement.children[0];
+    expect(list.nativeElement.getAttribute('role'))
+      .withContext('Expect mat-action-list to have group role')
+      .toBe('group');
   });
 
   it('should not show ripples for non-nav lists', () => {

--- a/src/material/list/list.ts
+++ b/src/material/list/list.ts
@@ -113,6 +113,7 @@ export class MatList
 
     if (this._getListType() === 'action-list') {
       _elementRef.nativeElement.classList.add('mat-action-list');
+      _elementRef.nativeElement.setAttribute('role', 'group');
     }
   }
 


### PR DESCRIPTION
…ActionList

make the following changes to align with legacy version of list
 - `MatNavList` apply `role="navigation"`
 - `MatActionList` apply `role="group"`