### PR TITLE
feat(material/checkbox): update pseudo-checkbox size

### DIFF
--- a/src/material/core/selection/pseudo-checkbox/pseudo-checkbox.scss
+++ b/src/material/core/selection/pseudo-checkbox/pseudo-checkbox.scss
@@ -56,6 +56,4 @@
   box-sizing: content-box;
 }
 
-// TODO(andrewseguin): Change this to the non-legacy size once
-// the above mixins have landed internally.
-@include pseudo-checkbox-common.size(checkbox-common.$legacy-size);
+@include pseudo-checkbox-common.size(checkbox-common.$size);

--- a/src/material/core/style/_checkbox-common.scss
+++ b/src/material/core/style/_checkbox-common.scss
@@ -1,5 +1,5 @@
 // The width/height of the checkbox element.
-$size: 16px !default;
+$size: 18px !default;
 
 // The width/height of the legacy-checkbox element.
 $legacy-size: 16px !default;


### PR DESCRIPTION
BREAKING CHANGE:
- Pseudo checkbox is now 18px height/width instead of 16px. Import the mat.pseudo-checkbox-legacy-size() to apply the legacy size styles