### PR TITLE
Revert "fix(material/tooltip): avoid problem when triggers hide anima…

### DIFF
--- a/src/material/tooltip/tooltip.ts
+++ b/src/material/tooltip/tooltip.ts
@@ -1018,22 +1018,8 @@ export abstract class _TooltipComponentBase implements OnDestroy {
     const tooltip = this._tooltip.nativeElement;
     const showClass = this._showAnimation;
     const hideClass = this._hideAnimation;
-
-    if (isVisible) {
-      tooltip.classList.remove(hideClass);
-      tooltip.classList.add(showClass);
-    }
-
-    if (!isVisible) {
-      // It's avoids the problem when `mat-tooltip-hide` triggers the animation of
-      // a tooltip that has not been shown yet.
-      if (tooltip.classList.contains(showClass)) {
-        tooltip.classList.add(hideClass);
-      }
-
-      tooltip.classList.remove(showClass);
-    }
-
+    tooltip.classList.remove(isVisible ? hideClass : showClass);
+    tooltip.classList.add(isVisible ? showClass : hideClass);
     this._isVisible = isVisible;
 
     // It's common for internal apps to disable animations using `* { animation: none !important }`


### PR DESCRIPTION
…tion for not visible tooltip (#24652)"

This reverts commit 3041cdab6af72cc5d81cb0f9ee9e2c60ebed5c5a.

This introduced a race condition which caused tooltips to get stuck in the DOM in an invisible state.