### PR TITLE
docs: release notes for the v14.1.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+<a name="14.1.2"></a>
+# 14.1.2 "cedar-cicada" (2022-08-11)
+### material
+| Commit | Type | Description |
+| -- | -- | -- |
+| [69b29046d5](https://github.com/angular/components/commit/69b29046d5ce96f3ba4fac3f039c9ac4ae314227) | fix | **chips:** `selectable="false"` doesn't work on initial assignment ([#24906](https://github.com/angular/components/pull/24906)) |
+| [0f2ec70c86](https://github.com/angular/components/commit/0f2ec70c869a1f6f42b02a59c37c922b34c84e9d) | fix | **tooltip:** avoid problem when triggers hide animation for not visible tooltip ([#24652](https://github.com/angular/components/pull/24652)) |
+### material-experimental
+| Commit | Type | Description |
+| -- | -- | -- |
+| [0a4d8e9fc4](https://github.com/angular/components/commit/0a4d8e9fc4a42398b5339ca50c1222f6bd7d66ab) | fix | **mdc-list:** set a role on MatNavList and MatActionList ([#25412](https://github.com/angular/components/pull/25412)) |
+## Special Thanks
+Egor Volvachev, Miles Malerba, Wagner Maciel and Zach Arend
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="14.2.0-next.1"></a>
 # 14.2.0-next.1 "corundum-cat" (2022-08-03)
 ### cdk


### PR DESCRIPTION
Cherry-picks the changelog from the "14.1.x" branch to the next branch (main).