### PR TITLE
docs(material/custom-form-field): required prop

### DIFF
--- a/guides/creating-a-custom-form-field-control.md
+++ b/guides/creating-a-custom-form-field-control.md
@@ -307,6 +307,18 @@ set required(req) {
 private _required = false;
 ```
 
+You might noticed that now required state should be passed only by `Input()`. To make it reactive, 
+you should bind component's required state with current ngControl required state:
+
+```ts
+@Input()
+get required(): boolean {
+  return Boolean(this._required || this.ngControl?.control?.hasValidator(Validators.required));
+}
+```
+
+Now `required` asterisk (\*) will be in sync with form validators
+
 #### `disabled`
 
 This property tells the form field when it should be in the disabled state. In addition to reporting

--- a/src/components-examples/material/form-field/form-field-custom-control/form-field-custom-control-example.ts
+++ b/src/components-examples/material/form-field/form-field-custom-control/form-field-custom-control-example.ts
@@ -94,7 +94,7 @@ export class MyTelInput implements ControlValueAccessor, MatFormFieldControl<MyT
 
   @Input()
   get required(): boolean {
-    return this._required;
+    return Boolean(this._required || this.ngControl?.control?.hasValidator(Validators.required));
   }
   set required(value: BooleanInput) {
     this._required = coerceBooleanProperty(value);


### PR DESCRIPTION
`required` state should also depends on `NgControl`

The same pattern used in material components - https://github.com/angular/components/blob/6883100b4cfea4c822a5173535d7e710cfcac580/src/material/input/input.ts#L211