### PR TITLE
fix(material/autocomplete): trigger to open panel when called outside

### DIFF
--- a/src/material/autocomplete/autocomplete-trigger.ts
+++ b/src/material/autocomplete/autocomplete-trigger.ts
@@ -254,6 +254,7 @@ export abstract class _MatAutocompleteTriggerBase
 
   /** Opens the autocomplete suggestion panel. */
   openPanel(): void {
+    this._preventPropagationClickFromOutside();
     this._attachOverlay();
     this._floatLabel();
   }
@@ -841,6 +842,19 @@ export abstract class _MatAutocompleteTriggerBase
     // TODO(crisbeto): we should switch `_getOutsideClickStream` eventually to use this stream,
     // but the behvior isn't exactly the same and it ends up breaking some internal tests.
     overlayRef.outsidePointerEvents().subscribe();
+  }
+
+  /** This stopPropagation is needed to openPanel works from outside through matAutocompleteTrigger. */
+  _preventPropagationClickFromOutside(): void {
+    if (!this.panelOpen) {
+      fromEvent(this._document, 'click')
+        .pipe(take(1))
+        .subscribe((event: any) => {
+          if (this._element.nativeElement !== event.srcElement && event.isTrusted) {
+            event.stopImmediatePropagation();
+          }
+        });
+    }
   }
 }
 

--- a/src/material/autocomplete/autocomplete-trigger.ts
+++ b/src/material/autocomplete/autocomplete-trigger.ts
@@ -845,7 +845,7 @@ export abstract class _MatAutocompleteTriggerBase
   }
 
   /** This stopPropagation is needed to openPanel works from outside through matAutocompleteTrigger. */
-  _preventPropagationClickFromOutside(): void {
+  private _preventPropagationClickFromOutside(): void {
     if (!this.panelOpen) {
       fromEvent(this._document, 'click')
         .pipe(take(1))


### PR DESCRIPTION
Fix https://github.com/angular/components/issues/13547 that when using the **matAutocompleteTrigger** directive to open the autocomplete through any html tag, it closed instantly giving the perception that it was never opened. A workaround to solve was always calling **trigger.openModal** followed by **.stopPropagation**, this PR solves that.