### PR TITLE
feat(material/table): pass `this` rather than concrete classes in the harnesses

### DIFF
--- a/src/material/legacy-table/testing/cell-harness.ts
+++ b/src/material/legacy-table/testing/cell-harness.ts
@@ -20,7 +20,7 @@ export class MatLegacyCellHarness extends _MatCellHarnessBase {
    * @return a `HarnessPredicate` configured with the given options.
    */
   static with(options: CellHarnessFilters = {}): HarnessPredicate<MatLegacyCellHarness> {
-    return _MatCellHarnessBase._getCellPredicate(MatLegacyCellHarness, options);
+    return _MatCellHarnessBase._getCellPredicate(this, options);
   }
 }
 
@@ -36,7 +36,7 @@ export class MatLegacyHeaderCellHarness extends _MatCellHarnessBase {
    * @return a `HarnessPredicate` configured with the given options.
    */
   static with(options: CellHarnessFilters = {}): HarnessPredicate<MatLegacyHeaderCellHarness> {
-    return _MatCellHarnessBase._getCellPredicate(MatLegacyHeaderCellHarness, options);
+    return _MatCellHarnessBase._getCellPredicate(this, options);
   }
 }
 
@@ -52,6 +52,6 @@ export class MatLegacyFooterCellHarness extends _MatCellHarnessBase {
    * @return a `HarnessPredicate` configured with the given options.
    */
   static with(options: CellHarnessFilters = {}): HarnessPredicate<MatLegacyFooterCellHarness> {
-    return _MatCellHarnessBase._getCellPredicate(MatLegacyFooterCellHarness, options);
+    return _MatCellHarnessBase._getCellPredicate(this, options);
   }
 }

--- a/src/material/table/testing/cell-harness.ts
+++ b/src/material/table/testing/cell-harness.ts
@@ -64,7 +64,7 @@ export class MatCellHarness extends _MatCellHarnessBase {
    * @return a `HarnessPredicate` configured with the given options.
    */
   static with(options: CellHarnessFilters = {}): HarnessPredicate<MatCellHarness> {
-    return _MatCellHarnessBase._getCellPredicate(MatCellHarness, options);
+    return _MatCellHarnessBase._getCellPredicate(this, options);
   }
 }
 
@@ -80,7 +80,7 @@ export class MatHeaderCellHarness extends _MatCellHarnessBase {
    * @return a `HarnessPredicate` configured with the given options.
    */
   static with(options: CellHarnessFilters = {}): HarnessPredicate<MatHeaderCellHarness> {
-    return _MatCellHarnessBase._getCellPredicate(MatHeaderCellHarness, options);
+    return _MatCellHarnessBase._getCellPredicate(this, options);
   }
 }
 
@@ -96,6 +96,6 @@ export class MatFooterCellHarness extends _MatCellHarnessBase {
    * @return a `HarnessPredicate` configured with the given options.
    */
   static with(options: CellHarnessFilters = {}): HarnessPredicate<MatFooterCellHarness> {
-    return _MatCellHarnessBase._getCellPredicate(MatFooterCellHarness, options);
+    return _MatCellHarnessBase._getCellPredicate(this, options);
   }
 }


### PR DESCRIPTION
some users are extending the harnesses, and passing the concrete class broke them

CARETAKER NOTE: already submitted in g3