### PR TITLE
fix(cdk/overlay): backdropClass type mismatch

### DIFF
--- a/src/cdk/overlay/overlay-directives.ts
+++ b/src/cdk/overlay/overlay-directives.ts
@@ -163,7 +163,7 @@ export class CdkConnectedOverlay implements OnDestroy, OnChanges {
   @Input('cdkConnectedOverlayMinHeight') minHeight: number | string;
 
   /** The custom class to be set on the backdrop element. */
-  @Input('cdkConnectedOverlayBackdropClass') backdropClass: string;
+  @Input('cdkConnectedOverlayBackdropClass') backdropClass: string | string[];
 
   /** The custom class to add to the overlay pane element. */
   @Input('cdkConnectedOverlayPanelClass') panelClass: string | string[];

--- a/tools/public_api_guard/cdk/overlay.md
+++ b/tools/public_api_guard/cdk/overlay.md
@@ -62,7 +62,7 @@ function CDK_CONNECTED_OVERLAY_SCROLL_STRATEGY_PROVIDER_FACTORY(overlay: Overlay
 export class CdkConnectedOverlay implements OnDestroy, OnChanges {
     constructor(_overlay: Overlay, templateRef: TemplateRef<any>, viewContainerRef: ViewContainerRef, scrollStrategyFactory: any, _dir: Directionality);
     readonly attach: EventEmitter<void>;
-    backdropClass: string;
+    backdropClass: string | string[];
     readonly backdropClick: EventEmitter<MouseEvent>;
     readonly detach: EventEmitter<void>;
     get dir(): Direction;


### PR DESCRIPTION
Type of backdropClass in overlay-directives.ts was not matching that in overlay-config.ts, which prevented string[] inputs from being passed through with strict templates enabled.