### PR TITLE
docs(material/datepicker): add aria-label to datepicker text inputs

### DIFF
--- a/src/components-examples/material/datepicker/date-range-picker-comparison/date-range-picker-comparison-example.html
+++ b/src/components-examples/material/datepicker/date-range-picker-comparison/date-range-picker-comparison-example.html
@@ -5,8 +5,8 @@
     [rangePicker]="campaignOnePicker"
     [comparisonStart]="campaignTwo.value.start"
     [comparisonEnd]="campaignTwo.value.end">
-    <input matStartDate placeholder="Start date" formControlName="start">
-    <input matEndDate placeholder="End date" formControlName="end">
+    <input matStartDate placeholder="Start date" aria-label="Start date" formControlName="start">
+    <input matEndDate placeholder="End date" aria-label="End date" formControlName="end">
   </mat-date-range-input>
   <mat-hint>MM/DD/YYYY – MM/DD/YYYY</mat-hint>
   <mat-datepicker-toggle matSuffix [for]="campaignOnePicker"></mat-datepicker-toggle>
@@ -20,8 +20,8 @@
     [rangePicker]="campaignTwoPicker"
     [comparisonStart]="campaignOne.value.start"
     [comparisonEnd]="campaignOne.value.end">
-    <input matStartDate placeholder="Start date" formControlName="start">
-    <input matEndDate placeholder="End date" formControlName="end">
+    <input matStartDate placeholder="Start date" aria-label="Start date" formControlName="start">
+    <input matEndDate placeholder="End date" aria-label="Start date" formControlName="end">
   </mat-date-range-input>
   <mat-datepicker-toggle matSuffix [for]="campaignTwoPicker"></mat-datepicker-toggle>
   <mat-hint>MM/DD/YYYY – MM/DD/YYYY</mat-hint>


### PR DESCRIPTION
Add an aria-label attribute for every datepicker text input in the
examples. This aligns with our documented best practice to "Always
provide the datepicker text input a meaningful label via <mat-label>,
aria-label, aria-labelledby or MatDatepickerIntl."