### PR TITLE
docs(material/table): fix order of sort and paginator

### DIFF
--- a/src/components-examples/material-experimental/mdc-table/table-overview/table-overview-example.ts
+++ b/src/components-examples/material-experimental/mdc-table/table-overview/table-overview-example.ts
@@ -67,8 +67,8 @@ export class TableOverviewExample implements AfterViewInit {
   }
 
   ngAfterViewInit() {
-    this.dataSource.paginator = this.paginator;
     this.dataSource.sort = this.sort;
+    this.dataSource.paginator = this.paginator;
   }
 
   applyFilter(event: Event) {

--- a/src/components-examples/material/table/table-overview/table-overview-example.ts
+++ b/src/components-examples/material/table/table-overview/table-overview-example.ts
@@ -67,8 +67,8 @@ export class TableOverviewExample implements AfterViewInit {
   }
 
   ngAfterViewInit() {
-    this.dataSource.paginator = this.paginator;
     this.dataSource.sort = this.sort;
+    this.dataSource.paginator = this.paginator;
   }
 
   applyFilter(event: Event) {


### PR DESCRIPTION
Fixes a bug in Angular Material example docs. Sort should be set
before paginator inside of ngAfterViewInit. This is in order to
avoid encountering ExpressionChangedAfterItHasBeenCheckedError.