### PR TITLE
fix(material/table): cleanup legacy usage

### DIFF
--- a/src/dev-app/table-scroll-container/BUILD.bazel
+++ b/src/dev-app/table-scroll-container/BUILD.bazel
@@ -13,7 +13,6 @@ ng_module(
         "//src/cdk-experimental/table-scroll-container",
         "//src/material/button",
         "//src/material/button-toggle",
-        "//src/material/legacy-table",
         "//src/material/table",
         "@npm//@angular/common",
         "@npm//@angular/core",

--- a/src/dev-app/table-scroll-container/table-scroll-container-demo.scss
+++ b/src/dev-app/table-scroll-container/table-scroll-container-demo.scss
@@ -3,7 +3,7 @@
   overflow: auto;
 }
 
-.mat-table-sticky {
+.mat-mdc-table-sticky, .mat-mdc-table-sticky.mat-mdc-header-cell {
   background: #59abfd;
   opacity: 1;
 }
@@ -18,7 +18,7 @@
   text-align: center;
 }
 
-.mat-header-cell, .mat-footer-cell, .mat-cell {
+.mat-mdc-header-cell, .mat-mdc-footer-cell, .mat-mdc-cell {
   min-width: 80px;
   box-sizing: border-box;
 }

--- a/src/dev-app/table-scroll-container/table-scroll-container-demo.ts
+++ b/src/dev-app/table-scroll-container/table-scroll-container-demo.ts
@@ -11,7 +11,7 @@ import {CommonModule} from '@angular/common';
 import {CdkTableScrollContainerModule} from '@angular/cdk-experimental/table-scroll-container';
 import {MatButtonModule} from '@angular/material/button';
 import {MatButtonToggleGroup, MatButtonToggleModule} from '@angular/material/button-toggle';
-import {MatLegacyTableModule} from '@angular/material/legacy-table';
+import {MatTableModule} from '@angular/material/table';
 
 /**
  * @title Tables with toggle-able sticky headers, footers, and columns
@@ -26,7 +26,7 @@ import {MatLegacyTableModule} from '@angular/material/legacy-table';
     CommonModule,
     MatButtonModule,
     MatButtonToggleModule,
-    MatLegacyTableModule,
+    MatTableModule,
   ],
 })
 export class TableScrollContainerDemo {

--- a/src/material/legacy-table/testing/BUILD.bazel
+++ b/src/material/legacy-table/testing/BUILD.bazel
@@ -20,26 +20,15 @@ filegroup(
 )
 
 ng_test_library(
-    name = "harness_tests_lib",
-    srcs = ["shared.spec.ts"],
-    deps = [
-        ":testing",
-        "//src/cdk/testing",
-        "//src/cdk/testing/testbed",
-        "//src/material/legacy-table",
-    ],
-)
-
-ng_test_library(
     name = "unit_tests_lib",
     srcs = glob(
         ["**/*.spec.ts"],
         exclude = ["shared.spec.ts"],
     ),
     deps = [
-        ":harness_tests_lib",
         ":testing",
         "//src/material/legacy-table",
+        "//src/material/table/testing:harness_tests_lib",
     ],
 )
 

--- a/src/material/legacy-table/testing/table-harness.spec.ts
+++ b/src/material/legacy-table/testing/table-harness.spec.ts
@@ -1,7 +1,7 @@
 import {MatLegacyTableModule} from '@angular/material/legacy-table';
-import {runHarnessTests} from '@angular/material/legacy-table/testing/shared.spec';
+import {runHarnessTests} from '@angular/material/table/testing/shared.spec';
 import {MatLegacyTableHarness} from './table-harness';
 
 describe('Non-MDC-based MatTableHarness', () => {
-  runHarnessTests(MatLegacyTableModule, MatLegacyTableHarness);
+  runHarnessTests(MatLegacyTableModule, MatLegacyTableHarness as any);
 });

--- a/src/material/table/testing/BUILD.bazel
+++ b/src/material/table/testing/BUILD.bazel
@@ -19,11 +19,25 @@ filegroup(
 )
 
 ng_test_library(
-    name = "unit_tests_lib",
-    srcs = glob(["**/*.spec.ts"]),
+    name = "harness_tests_lib",
+    srcs = ["shared.spec.ts"],
     deps = [
         ":testing",
-        "//src/material/legacy-table/testing:harness_tests_lib",
+        "//src/cdk/testing",
+        "//src/cdk/testing/testbed",
+        "//src/material/table",
+    ],
+)
+
+ng_test_library(
+    name = "unit_tests_lib",
+    srcs = glob(
+        ["**/*.spec.ts"],
+        exclude = ["shared.spec.ts"],
+    ),
+    deps = [
+        ":harness_tests_lib",
+        ":testing",
         "//src/material/table",
     ],
 )

--- a/src/material/table/testing/shared.spec.ts
+++ b/src/material/table/testing/shared.spec.ts
@@ -2,13 +2,13 @@ import {HarnessLoader, parallel} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {Component} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
-import {MatLegacyTableModule} from '@angular/material/legacy-table';
-import {MatLegacyTableHarness} from './table-harness';
+import {MatTableModule} from '../module';
+import {MatTableHarness} from './table-harness';
 
 /** Shared tests to run on both the original and MDC-based table. */
 export function runHarnessTests(
-  tableModule: typeof MatLegacyTableModule,
-  tableHarness: typeof MatLegacyTableHarness,
+  tableModule: typeof MatTableModule,
+  tableHarness: typeof MatTableHarness,
 ) {
   let fixture: ComponentFixture<TableHarnessTest>;
   let loader: HarnessLoader;

--- a/src/material/table/testing/table-harness.spec.ts
+++ b/src/material/table/testing/table-harness.spec.ts
@@ -1,7 +1,7 @@
 import {MatTableModule} from '@angular/material/table';
-import {runHarnessTests} from '@angular/material/legacy-table/testing/shared.spec';
+import {runHarnessTests} from './shared.spec';
 import {MatTableHarness} from './table-harness';
 
 describe('MDC-based MatTableHarness', () => {
-  runHarnessTests(MatTableModule, MatTableHarness as any);
+  runHarnessTests(MatTableModule, MatTableHarness);
 });


### PR DESCRIPTION
Cleanup various places where the legacy table was still present - Swapped where the harness tests were located (previously still in legacy)