### PR TITLE
dynamic height bug fix on mat tab group

### DIFF
--- a/src/material/legacy-tabs/tab-body.scss
+++ b/src/material/legacy-tabs/tab-body.scss
@@ -3,7 +3,7 @@
   overflow: auto;
 
   .mat-tab-group-dynamic-height & {
-    overflow: hidden;
+    overflow-y: hidden;
   }
 
   // Usually the `visibility: hidden` added by the animation is enough to prevent focus from


### PR DESCRIPTION
this fixes the issue #25538

[bug(mat-tab-group): dynamic height hides   ##overflow-x](https://github.com/angular/components/issues/25538)