### PR TITLE
feat(material/datepicker): expose datepicker symbols

### DIFF
--- a/src/material/datepicker/public-api.ts
+++ b/src/material/datepicker/public-api.ts
@@ -23,6 +23,8 @@ export {
   MatDatepickerContent,
   DatepickerDropdownPositionX,
   DatepickerDropdownPositionY,
+  MatDatepickerControl,
+  MatDatepickerPanel,
 } from './datepicker-base';
 export {MatDatepickerInputEvent, DateFilterFn} from './datepicker-input-base';
 export {

--- a/tools/public_api_guard/material/datepicker.md
+++ b/tools/public_api_guard/material/datepicker.md
@@ -466,7 +466,7 @@ export class MatDatepickerContent<S, D = ExtractDateTypeFromSelection<S>> extend
 }
 
 // @public
-interface MatDatepickerControl<D> {
+export interface MatDatepickerControl<D> {
     // (undocumented)
     dateFilter: DateFilterFn<D>;
     // (undocumented)
@@ -567,7 +567,7 @@ export class MatDatepickerModule {
 }
 
 // @public
-interface MatDatepickerPanel<C extends MatDatepickerControl<D>, S, D = ExtractDateTypeFromSelection<S>> {
+export interface MatDatepickerPanel<C extends MatDatepickerControl<D>, S, D = ExtractDateTypeFromSelection<S>> {
     closedStream: EventEmitter<void>;
     color: ThemePalette;
     datepickerInput: C;


### PR DESCRIPTION
These have been used internally but required special importing since they were not exported