### PR TITLE
test(cdk/testing): Allow TestComponentsModule to be bootable as a mod…

### DIFF
--- a/src/cdk/testing/tests/test-components-module.ts
+++ b/src/cdk/testing/tests/test-components-module.ts
@@ -9,13 +9,15 @@
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
+import {BrowserModule} from '@angular/platform-browser';
 import {TestMainComponent} from './test-main-component';
 import {TestShadowBoundary, TestSubShadowBoundary} from './test-shadow-boundary';
 import {TestSubComponent} from './test-sub-component';
 
 @NgModule({
-  imports: [CommonModule, FormsModule, ReactiveFormsModule],
+  imports: [BrowserModule, CommonModule, FormsModule, ReactiveFormsModule],
   declarations: [TestMainComponent, TestSubComponent, TestShadowBoundary, TestSubShadowBoundary],
   exports: [TestMainComponent, TestSubComponent, TestShadowBoundary, TestSubShadowBoundary],
+  bootstrap: [TestMainComponent],
 })
 export class TestComponentsModule {}


### PR DESCRIPTION
…ule for a standalone app

This is required by downstream tests that use the cross-environment tests but do not start up the entire e2e test app in this repo. This change will be copybara'ed down to google3.