### PR TITLE
ci: re-enable until front of line blocking in publish snapshot job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -459,9 +459,8 @@ jobs:
       # after a delay. We do this as the CircleCI API does not refresh immediately when a job
       # completes/starts, and this will improve stability of the queue step. See source:
       # https://github.com/eddiewebb/circleci-queue/commit/5d42add5bbcff5e8ac7fe189448a61fea98b0839.
-      # TODO(devversion): re-enable once https://github.com/eddiewebb/circleci-queue/issues/79 is resolved.
-      # - queue/until_front_of_line:
-      #    confidence: '2'
+      - queue/until_front_of_line:
+          confidence: '2'
 
       - run: ./scripts/circleci/publish-snapshots.sh
       - *slack_notify_on_failure


### PR DESCRIPTION
We had to temporarily disable the CircleCI orb command that helps ensuring snapshot jobs
do not conflict when running concurrently.

It seems like the CircleCI API has been fixed to no longer cause issues with the Orb. This commit
attempts to re-enable the command.