### PR TITLE
docs: fix material paginator comment style by adding missing periods.

### DIFF
--- a/src/material/paginator/paginator.ts
+++ b/src/material/paginator/paginator.ts
@@ -64,10 +64,10 @@ export class PageEvent {
    */
   previousPageIndex?: number;
 
-  /** The current page size */
+  /** The current page size. */
   pageSize: number;
 
-  /** The current total number of items being paged */
+  /** The current total number of items being paged. */
   length: number;
 }
 


### PR DESCRIPTION
Two periods were missing.