### PR TITLE
fix(material/button): cdk-focus classes not being applied

### DIFF
--- a/src/material/button/_button-theme-private.scss
+++ b/src/material/button/_button-theme-private.scss
@@ -18,8 +18,11 @@
     opacity: map.get($opacities, hover);
   }
 
-  &:focus .mat-mdc-button-persistent-ripple::before {
-    opacity: map.get($opacities, focus);
+  &.cdk-program-focused,
+  &.cdk-keyboard-focused {
+    .mat-mdc-button-persistent-ripple::before {
+      opacity: map.get($opacities, focus);
+    }
   }
 
   &:active .mat-mdc-button-persistent-ripple::before {

--- a/tools/public_api_guard/material/button.md
+++ b/tools/public_api_guard/material/button.md
@@ -5,6 +5,7 @@
 ```ts
 
 import { _AbstractConstructor } from '@angular/material/core';
+import { AfterViewInit } from '@angular/core';
 import { BooleanInput } from '@angular/cdk/coercion';
 import { CanColor } from '@angular/material/core';
 import { CanDisable } from '@angular/material/core';


### PR DESCRIPTION
Fixes a bug in the Angular Material `button` component where cdk-focused, cdk-keyboard-focused, cdk-mouse-focused were not being applied upon respective focus. This is because there was no FocusManager set up with the MDC buttons like the legacy button did.

Fixes #25618