### PR TITLE
refactor(material/core): fix deprecation warning

### DIFF
--- a/src/material/core/typography/_all-typography.scss
+++ b/src/material/core/typography/_all-typography.scss
@@ -56,7 +56,7 @@
     @return $x;
   }
   @if meta.type-of($x) == 'number' and math.unit($x) == 'rem' {
-    @return ($x / 1rem) * $px-per-rem;
+    @return math.div($x, 1rem) * $px-per-rem;
   }
   @else {
     @return $x;


### PR DESCRIPTION
Fixes a deprecation warning, because we were using a slash for division instead of `math.div`.