### PR TITLE
fix(cdk/a11y): account for Windows 11 high contrast themes in detector

### DIFF
--- a/src/cdk/a11y/high-contrast-mode/high-contrast-mode-detector.ts
+++ b/src/cdk/a11y/high-contrast-mode/high-contrast-mode-detector.ts
@@ -92,9 +92,16 @@ export class HighContrastModeDetector implements OnDestroy {
     testElement.remove();
 
     switch (computedColor) {
+      // Pre Windows 11 dark theme.
       case 'rgb(0,0,0)':
+      // Windows 11 dark themes.
+      case 'rgb(45,50,54)':
+      case 'rgb(32,32,32)':
         return HighContrastMode.WHITE_ON_BLACK;
+      // Pre Windows 11 light theme.
       case 'rgb(255,255,255)':
+      // Windows 11 light theme.
+      case 'rgb(255,250,239)':
         return HighContrastMode.BLACK_ON_WHITE;
     }
     return HighContrastMode.NONE;


### PR DESCRIPTION
Windows 11 has different built in high contrast themes which weren't being picked up by the detector.

Fixes #25580.