### PR TITLE
fix(material/core): warn when legacy theme is created

### DIFF
--- a/src/material/core/theming/_theming.scss
+++ b/src/material/core/theming/_theming.scss
@@ -15,9 +15,10 @@ $_duplicate-warning: 'Read more about how style duplication can be avoided in a 
   'guide. https://github.com/angular/components/blob/main/guides/duplicate-theming-styles.md';
 
 // Warning that will be printed if the legacy theming API is used.
-$_legacy-theme-warning: 'Angular Material themes should be created from a map containing the keys "color", ' +
-  '"typography", and "density". The color value should be a map containing the palette values for ' +
-  '"primary", "accent", and "warn". See https://material.angular.io/guide/theming for more information.';
+$_legacy-theme-warning: 'Angular Material themes should be created from a map containing the ' +
+  'keys "color", "typography", and "density". The color value should be a map containing the ' +
+  'palette values for "primary", "accent", and "warn". ' +
+  'See https://material.angular.io/guide/theming for more information.';
 
 // These variable are not intended to be overridden externally. They use `!default` to
 // avoid being reset every time this file is imported.
@@ -56,20 +57,20 @@ $_emitted-density: () !default;
 @function define-palette($base-palette, $default: 500, $lighter: 100, $darker: 700,
   $text: $default) {
   $result: map.merge($base-palette, (
-    default: _get-color-from-palette($base-palette, $default),
-    lighter: _get-color-from-palette($base-palette, $lighter),
-    darker: _get-color-from-palette($base-palette, $darker),
-    text: _get-color-from-palette($base-palette, $text),
+      default: _get-color-from-palette($base-palette, $default),
+      lighter: _get-color-from-palette($base-palette, $lighter),
+      darker: _get-color-from-palette($base-palette, $darker),
+      text: _get-color-from-palette($base-palette, $text),
 
-    default-contrast: get-contrast-color-from-palette($base-palette, $default),
-    lighter-contrast: get-contrast-color-from-palette($base-palette, $lighter),
-    darker-contrast: get-contrast-color-from-palette($base-palette, $darker)
+      default-contrast: get-contrast-color-from-palette($base-palette, $default),
+      lighter-contrast: get-contrast-color-from-palette($base-palette, $lighter),
+      darker-contrast: get-contrast-color-from-palette($base-palette, $darker)
   ));
 
   // For each hue in the palette, add a "-contrast" color to the map.
   @each $hue, $color in $base-palette {
     $result: map.merge($result, (
-      '#{$hue}-contrast': get-contrast-color-from-palette($base-palette, $hue)
+        '#{$hue}-contrast': get-contrast-color-from-palette($base-palette, $hue)
     ));
   }
 
@@ -129,12 +130,12 @@ $_emitted-density: () !default;
 // primary, accent and warn palettes.
 @function _mat-create-light-color-config($primary, $accent, $warn: null) {
   @return (
-    primary: $primary,
-    accent: $accent,
-    warn: if($warn != null, $warn, define-palette(palette.$red-palette)),
-    is-dark: false,
-    foreground: palette.$light-theme-foreground-palette,
-    background: palette.$light-theme-background-palette,
+      primary: $primary,
+      accent: $accent,
+      warn: if($warn != null, $warn, define-palette(palette.$red-palette)),
+      is-dark: false,
+      foreground: palette.$light-theme-foreground-palette,
+      background: palette.$light-theme-background-palette,
   );
 }
 
@@ -142,12 +143,12 @@ $_emitted-density: () !default;
 // primary, accent and warn palettes.
 @function _mat-create-dark-color-config($primary, $accent, $warn: null) {
   @return (
-    primary: $primary,
-    accent: $accent,
-    warn: if($warn != null, $warn, define-palette(palette.$red-palette)),
-    is-dark: true,
-    foreground: palette.$dark-theme-foreground-palette,
-    background: palette.$dark-theme-background-palette,
+      primary: $primary,
+      accent: $accent,
+      warn: if($warn != null, $warn, define-palette(palette.$red-palette)),
+      is-dark: true,
+      foreground: palette.$dark-theme-foreground-palette,
+      background: palette.$dark-theme-background-palette,
   );
 }
 
@@ -174,8 +175,8 @@ $_emitted-density: () !default;
   @if $accent != null {
     @warn $_legacy-theme-warning;
     @return private-create-backwards-compatibility-theme(_mat-validate-theme((
-      _is-legacy-theme: true,
-      color: _mat-create-light-color-config($primary, $accent, $warn),
+        _is-legacy-theme: true,
+        color: _mat-create-light-color-config($primary, $accent, $warn),
     )));
   }
   // If the map pattern is used (1), we just pass-through the configurations for individual
@@ -215,8 +216,8 @@ $_emitted-density: () !default;
   @if $accent != null {
     @warn $_legacy-theme-warning;
     @return private-create-backwards-compatibility-theme(_mat-validate-theme((
-      _is-legacy-theme: true,
-      color: _mat-create-dark-color-config($primary, $accent, $warn),
+        _is-legacy-theme: true,
+        color: _mat-create-dark-color-config($primary, $accent, $warn),
     )));
   }
   // If the map pattern is used (1), we just pass-through the configurations for individual
@@ -442,8 +443,8 @@ $_emitted-density: () !default;
 
   @warn $_legacy-theme-warning;
   @return private-create-backwards-compatibility-theme((
-    _is-legacy-theme: true,
-    color: $theme-or-color-config
+      _is-legacy-theme: true,
+      color: $theme-or-color-config
   ));
 }
 

--- a/src/material/core/theming/_theming.scss
+++ b/src/material/core/theming/_theming.scss
@@ -15,8 +15,9 @@ $_duplicate-warning: 'Read more about how style duplication can be avoided in a 
   'guide. https://github.com/angular/components/blob/main/guides/duplicate-theming-styles.md';
 
 // Warning that will be printed if the legacy theming API is used.
-$_legacy-theme-warning: 'Themes should be defined by providing a map configuration. ' +
- 'See https://material.angular.io/guide/theming.';
+$_legacy-theme-warning: 'Themes should be created with a map parameter containing the keys "color", ' +
+  '"typography", and "density". The color value should be a map containing the palette values for ' +
+  '"primary", "accent", and "warn". See https://material.angular.io/guide/theming for more information.';
 
 // These variable are not intended to be overridden externally. They use `!default` to
 // avoid being reset every time this file is imported.

--- a/src/material/core/theming/_theming.scss
+++ b/src/material/core/theming/_theming.scss
@@ -14,6 +14,10 @@ $_generate-default-density: true !default;
 $_duplicate-warning: 'Read more about how style duplication can be avoided in a dedicated ' +
   'guide. https://github.com/angular/components/blob/main/guides/duplicate-theming-styles.md';
 
+// Warning that will be printed if the legacy theming API is used.
+$_legacy-theme-warning: 'Themes should be defined by providing a map configuration. ' +
+ 'See https://material.angular.io/guide/theming.';
+
 // These variable are not intended to be overridden externally. They use `!default` to
 // avoid being reset every time this file is imported.
 $_emitted-color: () !default;
@@ -167,6 +171,7 @@ $_emitted-density: () !default;
   // If the legacy pattern is used, we generate a container object only with a light-themed
   // configuration for the `color` theming part.
   @if $accent != null {
+    @warn $_legacy-theme-warning;
     @return private-create-backwards-compatibility-theme(_mat-validate-theme((
       _is-legacy-theme: true,
       color: _mat-create-light-color-config($primary, $accent, $warn),
@@ -207,6 +212,7 @@ $_emitted-density: () !default;
   // If the legacy pattern is used, we generate a container object only with a dark-themed
   // configuration for the `color` theming part.
   @if $accent != null {
+    @warn $_legacy-theme-warning;
     @return private-create-backwards-compatibility-theme(_mat-validate-theme((
       _is-legacy-theme: true,
       color: _mat-create-dark-color-config($primary, $accent, $warn),
@@ -432,6 +438,8 @@ $_emitted-density: () !default;
   @if private-is-theme-object($theme-or-color-config) {
     @return $theme-or-color-config;
   }
+
+  @warn $_legacy-theme-warning;
   @return private-create-backwards-compatibility-theme((
     _is-legacy-theme: true,
     color: $theme-or-color-config

--- a/src/material/core/theming/_theming.scss
+++ b/src/material/core/theming/_theming.scss
@@ -15,7 +15,7 @@ $_duplicate-warning: 'Read more about how style duplication can be avoided in a 
   'guide. https://github.com/angular/components/blob/main/guides/duplicate-theming-styles.md';
 
 // Warning that will be printed if the legacy theming API is used.
-$_legacy-theme-warning: 'Themes should be created with a map parameter containing the keys "color", ' +
+$_legacy-theme-warning: 'Themes should be created from a map containing the keys "color", ' +
   '"typography", and "density". The color value should be a map containing the palette values for ' +
   '"primary", "accent", and "warn". See https://material.angular.io/guide/theming for more information.';
 

--- a/src/material/core/theming/_theming.scss
+++ b/src/material/core/theming/_theming.scss
@@ -57,20 +57,20 @@ $_emitted-density: () !default;
 @function define-palette($base-palette, $default: 500, $lighter: 100, $darker: 700,
   $text: $default) {
   $result: map.merge($base-palette, (
-      default: _get-color-from-palette($base-palette, $default),
-      lighter: _get-color-from-palette($base-palette, $lighter),
-      darker: _get-color-from-palette($base-palette, $darker),
-      text: _get-color-from-palette($base-palette, $text),
+    default: _get-color-from-palette($base-palette, $default),
+    lighter: _get-color-from-palette($base-palette, $lighter),
+    darker: _get-color-from-palette($base-palette, $darker),
+    text: _get-color-from-palette($base-palette, $text),
 
-      default-contrast: get-contrast-color-from-palette($base-palette, $default),
-      lighter-contrast: get-contrast-color-from-palette($base-palette, $lighter),
-      darker-contrast: get-contrast-color-from-palette($base-palette, $darker)
+    default-contrast: get-contrast-color-from-palette($base-palette, $default),
+    lighter-contrast: get-contrast-color-from-palette($base-palette, $lighter),
+    darker-contrast: get-contrast-color-from-palette($base-palette, $darker)
   ));
 
   // For each hue in the palette, add a "-contrast" color to the map.
   @each $hue, $color in $base-palette {
     $result: map.merge($result, (
-        '#{$hue}-contrast': get-contrast-color-from-palette($base-palette, $hue)
+      '#{$hue}-contrast': get-contrast-color-from-palette($base-palette, $hue)
     ));
   }
 
@@ -130,12 +130,12 @@ $_emitted-density: () !default;
 // primary, accent and warn palettes.
 @function _mat-create-light-color-config($primary, $accent, $warn: null) {
   @return (
-      primary: $primary,
-      accent: $accent,
-      warn: if($warn != null, $warn, define-palette(palette.$red-palette)),
-      is-dark: false,
-      foreground: palette.$light-theme-foreground-palette,
-      background: palette.$light-theme-background-palette,
+    primary: $primary,
+    accent: $accent,
+    warn: if($warn != null, $warn, define-palette(palette.$red-palette)),
+    is-dark: false,
+    foreground: palette.$light-theme-foreground-palette,
+    background: palette.$light-theme-background-palette,
   );
 }
 
@@ -143,12 +143,12 @@ $_emitted-density: () !default;
 // primary, accent and warn palettes.
 @function _mat-create-dark-color-config($primary, $accent, $warn: null) {
   @return (
-      primary: $primary,
-      accent: $accent,
-      warn: if($warn != null, $warn, define-palette(palette.$red-palette)),
-      is-dark: true,
-      foreground: palette.$dark-theme-foreground-palette,
-      background: palette.$dark-theme-background-palette,
+    primary: $primary,
+    accent: $accent,
+    warn: if($warn != null, $warn, define-palette(palette.$red-palette)),
+    is-dark: true,
+    foreground: palette.$dark-theme-foreground-palette,
+    background: palette.$dark-theme-background-palette,
   );
 }
 
@@ -175,8 +175,8 @@ $_emitted-density: () !default;
   @if $accent != null {
     @warn $_legacy-theme-warning;
     @return private-create-backwards-compatibility-theme(_mat-validate-theme((
-        _is-legacy-theme: true,
-        color: _mat-create-light-color-config($primary, $accent, $warn),
+      _is-legacy-theme: true,
+      color: _mat-create-light-color-config($primary, $accent, $warn),
     )));
   }
   // If the map pattern is used (1), we just pass-through the configurations for individual
@@ -216,8 +216,8 @@ $_emitted-density: () !default;
   @if $accent != null {
     @warn $_legacy-theme-warning;
     @return private-create-backwards-compatibility-theme(_mat-validate-theme((
-        _is-legacy-theme: true,
-        color: _mat-create-dark-color-config($primary, $accent, $warn),
+      _is-legacy-theme: true,
+      color: _mat-create-dark-color-config($primary, $accent, $warn),
     )));
   }
   // If the map pattern is used (1), we just pass-through the configurations for individual
@@ -443,8 +443,8 @@ $_emitted-density: () !default;
 
   @warn $_legacy-theme-warning;
   @return private-create-backwards-compatibility-theme((
-      _is-legacy-theme: true,
-      color: $theme-or-color-config
+    _is-legacy-theme: true,
+    color: $theme-or-color-config
   ));
 }
 

--- a/src/material/core/theming/_theming.scss
+++ b/src/material/core/theming/_theming.scss
@@ -15,7 +15,7 @@ $_duplicate-warning: 'Read more about how style duplication can be avoided in a 
   'guide. https://github.com/angular/components/blob/main/guides/duplicate-theming-styles.md';
 
 // Warning that will be printed if the legacy theming API is used.
-$_legacy-theme-warning: 'Themes should be created from a map containing the keys "color", ' +
+$_legacy-theme-warning: 'Angular Material themes should be created from a map containing the keys "color", ' +
   '"typography", and "density". The color value should be a map containing the palette values for ' +
   '"primary", "accent", and "warn". See https://material.angular.io/guide/theming for more information.';
 


### PR DESCRIPTION
Warn users when creating a theme using the legacy API (passing palettes). Users should switch to the new theming config API. Legacy API support will be removed in v16. This warning can be converted to an error internally to make it easy to remove in v16