### PR TITLE
fix(material/select): fix arrow alignment

### DIFF
--- a/src/material/form-field/_form-field-native-select.scss
+++ b/src/material/form-field/_form-field-native-select.scss
@@ -46,6 +46,8 @@ $mat-form-field-select-horizontal-end-padding: $mat-form-field-select-arrow-widt
       border-top: $mat-form-field-select-arrow-height solid;
       position: absolute;
       right: 0;
+      top: 50%;
+      margin-top: -#{math.div($mat-form-field-select-arrow-height, 2)};
 
       // Make the arrow non-clickable so the user can click on the form control under it.
       pointer-events: none;

--- a/src/material/select/select.scss
+++ b/src/material/select/select.scss
@@ -57,9 +57,13 @@ $scale: 0.75 !default;
   display: inline-flex;
   align-items: center;
 
-  // When used in a box appearance form-field the arrow should be shifted up 40%.
+  // When used in a fill appearance with a label, form-field the arrow should be shifted up 8px.
   .mat-form-field-appearance-fill & {
-    transform: translateY(-40%);
+    transform: translateY(-8px);
+  }
+
+  .mat-form-field-appearance-fill .mdc-text-field--no-label & {
+    transform: none;
   }
 }
 


### PR DESCRIPTION
before: 
![select-before](https://user-images.githubusercontent.com/14793288/189760992-c0144936-59a0-43c5-80e1-611d44879e37.png)

after:
![select-after](https://user-images.githubusercontent.com/14793288/189761014-40d8cb87-fd76-4a08-bfd5-69384c00eb38.png)

