### PR TITLE
fix(material/core): add optional warning for incomplete themes

### DIFF
--- a/src/material/core/theming/_theming.scss
+++ b/src/material/core/theming/_theming.scss
@@ -20,6 +20,11 @@ $_legacy-theme-warning: 'Angular Material themes should be created from a map co
   'palette values for "primary", "accent", and "warn". ' +
   'See https://material.angular.io/guide/theming for more information.';
 
+// Flag whether theme config getter functions should warn if a key is expected to exist but not
+// present in the config. This can be transformed internally in Google to ensure all clients have
+// comprehensive theme configurations.
+$_enable-strict-theme-config: false;
+
 // These variable are not intended to be overridden externally. They use `!default` to
 // avoid being reset every time this file is imported.
 $_emitted-color: () !default;
@@ -255,6 +260,9 @@ $_emitted-density: () !default;
   @if map.has-key($theme, color) {
     @return map.get($theme, color);
   }
+  @else if ($_enable-strict-theme-config) {
+    @error 'Angular Material theme configuration is missing a "color" value';
+  }
   @return $default;
 }
 
@@ -273,6 +281,9 @@ $_emitted-density: () !default;
   // or fall back to the default density config.
   @if map.has-key($theme-or-config, density) {
     @return map.get($theme-or-config, density);
+  }
+  @else if ($_enable-strict-theme-config) {
+    @error 'Angular Material theme configuration is missing a "density" value';
   }
   @return $default;
 }
@@ -293,6 +304,9 @@ $_emitted-density: () !default;
   // or fall back to the default typography config.
   @if (map.has-key($theme-or-config, typography)) {
     @return map.get($theme-or-config, typography);
+  }
+  @else if ($_enable-strict-theme-config) {
+    @error 'Angular Material theme configuration is missing a "typography" value';
   }
   @return $default;
 }


### PR DESCRIPTION
Add a flag that can be transformed to "true" internally that produces an error if users call a theming function with an incomplete map.

For example, calling `mat.button-typography($theme)` that doesn't have `typography` will error. 

Another example, calling `mat.button-theme($theme)` without color, typography, and density will error.

For cases where users do not want to include certain styles, e.g. typography, they should directly call "-color()" and "-density()" and skip "-typography()"

The intent of this is to standardize theming configurations internally so that all apps explicitly declare what they want to include in their theming, making it more clear what they are not including as well. All apps will default to `typography: null` or `density: 0` if it is missing in their theme config