### PR TITLE
fix(material-luxon-adapter) Update peerDependency on Luxon to include 3.x

### DIFF
--- a/src/material-luxon-adapter/package.json
+++ b/src/material-luxon-adapter/package.json
@@ -14,7 +14,7 @@
   "peerDependencies": {
     "@angular/material": "0.0.0-PLACEHOLDER",
     "@angular/core": "0.0.0-NG",
-    "luxon": "^2.0.0"
+    "luxon": "^2.0.0 || ^3.0.0"
   },
   "dependencies": {
     "tslib": "0.0.0-TSLIB"


### PR DESCRIPTION
Fixes #25408 Update peerDependency on Luxon to include 3.x