### PR TITLE
fix(material/core): use full theme config definitions to prebuilt themes

### DIFF
--- a/src/material/core/theming/prebuilt/deeppurple-amber.scss
+++ b/src/material/core/theming/prebuilt/deeppurple-amber.scss
@@ -15,7 +15,9 @@ $theme: theming.define-light-theme((
   color: (
     primary: $primary,
     accent: $accent,
-  )
+  ),
+  typography: null,
+  density: 0,
 ));
 
 // Include all theme styles for the components.

--- a/src/material/core/theming/prebuilt/indigo-pink.scss
+++ b/src/material/core/theming/prebuilt/indigo-pink.scss
@@ -15,7 +15,9 @@ $theme: theming.define-light-theme((
   color: (
     primary: $primary,
     accent: $accent
-  )
+  ),
+  typography: null,
+  density: 0,
 ));
 
 // Include all theme styles for the components.

--- a/src/material/core/theming/prebuilt/pink-bluegrey.scss
+++ b/src/material/core/theming/prebuilt/pink-bluegrey.scss
@@ -15,7 +15,9 @@ $theme: theming.define-dark-theme((
   color: (
     primary: $primary,
     accent: $accent
-  )
+  ),
+  typography: null,
+  density: 0,
 ));
 
 // Include all theme styles for the components.

--- a/src/material/core/theming/prebuilt/purple-green.scss
+++ b/src/material/core/theming/prebuilt/purple-green.scss
@@ -15,7 +15,9 @@ $theme: theming.define-dark-theme((
   color: (
     primary: $primary,
     accent: $accent
-  )
+  ),
+  typography: null,
+  density: 0,
 ));
 
 // Include all theme styles for the components.

--- a/src/material/legacy-core/theming/prebuilt/deeppurple-amber.scss
+++ b/src/material/legacy-core/theming/prebuilt/deeppurple-amber.scss
@@ -15,7 +15,9 @@ $theme: theming.define-light-theme((
   color: (
     primary: $primary,
     accent: $accent,
-  )
+  ),
+  typography: null,
+  density: 0,
 ));
 
 // Include all theme styles for the components.

--- a/src/material/legacy-core/theming/prebuilt/indigo-pink.scss
+++ b/src/material/legacy-core/theming/prebuilt/indigo-pink.scss
@@ -15,7 +15,9 @@ $theme: theming.define-light-theme((
   color: (
     primary: $primary,
     accent: $accent
-  )
+  ),
+  typography: null,
+  density: 0,
 ));
 
 // Include all theme styles for the components.

--- a/src/material/legacy-core/theming/prebuilt/pink-bluegrey.scss
+++ b/src/material/legacy-core/theming/prebuilt/pink-bluegrey.scss
@@ -15,7 +15,9 @@ $theme: theming.define-dark-theme((
   color: (
     primary: $primary,
     accent: $accent
-  )
+  ),
+  typography: null,
+  density: 0,
 ));
 
 // Include all theme styles for the components.

--- a/src/material/legacy-core/theming/prebuilt/purple-green.scss
+++ b/src/material/legacy-core/theming/prebuilt/purple-green.scss
@@ -15,7 +15,9 @@ $theme: theming.define-dark-theme((
   color: (
     primary: $primary,
     accent: $accent
-  )
+  ),
+  typography: null,
+  density: 0,
 ));
 
 // Include all theme styles for the components.


### PR DESCRIPTION
Add typography and density keys to the prebuilt theming files. 

While it's probably safe to default typography to `typography.define-typography-config()`, this is a good intermediate step to enable strict theme configs internally. If it can be proven safe to add a real typography config, we can change it.