### PR TITLE
fix(material/datepicker): add aria descriptions for comparison range

### DIFF
--- a/src/material/datepicker/calendar-body.html
+++ b/src/material/datepicker/calendar-body.html
@@ -83,3 +83,9 @@
 <label [id]="_endDateLabelId" class="mat-calendar-body-hidden-label">
   {{endDateAccessibleName}}
 </label>
+<label [id]="_comparisonStartLabelId" class="mat-calendar-body-hidden-label">
+  {{_getComparisonStartLabel()}}
+</label>
+<label [id]="_comparisonEndLabelId" class="mat-calendar-body-hidden-label">
+  {{_getComparisonEndLabel()}}
+</label>

--- a/src/material/datepicker/calendar-body.ts
+++ b/src/material/datepicker/calendar-body.ts
@@ -19,8 +19,10 @@ import {
   SimpleChanges,
   OnDestroy,
   AfterViewChecked,
+  inject,
 } from '@angular/core';
 import {take} from 'rxjs/operators';
+import {MatDatepickerIntl} from './datepicker-intl';
 
 /** Extra CSS classes that can be associated with a calendar cell. */
 export type MatCalendarCellCssClasses = string | string[] | Set<string> | {[key: string]: any};
@@ -158,6 +160,8 @@ export class MatCalendarBody implements OnChanges, OnDestroy, AfterViewChecked {
 
   /** Width of an individual cell. */
   _cellWidth: string;
+
+  private _intl = inject(MatDatepickerIntl);
 
   constructor(private _elementRef: ElementRef<HTMLElement>, private _ngZone: NgZone) {
     _ngZone.runOutsideAngular(() => {
@@ -370,14 +374,36 @@ export class MatCalendarBody implements OnChanges, OnDestroy, AfterViewChecked {
       return null;
     }
 
-    if (this.startValue === value && this.endValue === value) {
-      return `${this._startDateLabelId} ${this._endDateLabelId}`;
-    } else if (this.startValue === value) {
-      return this._startDateLabelId;
-    } else if (this.endValue === value) {
-      return this._endDateLabelId;
+    let describedby = '';
+
+    // Add ids of relevant labels.
+    if (this.startValue === value) {
+      describedby += ` ${this._startDateLabelId}`;
     }
-    return null;
+    if (this.endValue === value) {
+      describedby += ` ${this._endDateLabelId}`;
+    }
+
+    if (this.comparisonStart === value) {
+      describedby += ` ${this._comparisonStartLabelId}`;
+    }
+    if (this.comparisonEnd === value) {
+      describedby += ` ${this._comparisonEndLabelId}`;
+    }
+
+    // Remove leading space character. Prefer passing null over empty string to avoid adding
+    // aria-describedby attribute with an empty value.
+    return describedby.trim() || null;
+  }
+
+  /** Gets the label for the start of comparison range (used by screen readers). */
+  _getComparisonStartLabel(): string | null {
+    return this._intl.comparisonRangeStartLabel;
+  }
+
+  /** Gets the label for the end of comparison range (used by screen readers). */
+  _getComparisonEndLabel(): string | null {
+    return this._intl.comparisonRangeEndLabel;
   }
 
   /**
@@ -441,8 +467,10 @@ export class MatCalendarBody implements OnChanges, OnDestroy, AfterViewChecked {
   private _id = `mat-calendar-body-${calendarBodyId++}`;
 
   _startDateLabelId = `${this._id}-start-date`;
-
   _endDateLabelId = `${this._id}-end-date`;
+
+  _comparisonStartLabelId = `${this._id}-comparison-start`;
+  _comparisonEndLabelId = `${this._id}-comparison-end`;
 }
 
 /** Checks whether a node is a table cell element. */

--- a/src/material/datepicker/datepicker-intl.ts
+++ b/src/material/datepicker/datepicker-intl.ts
@@ -57,6 +57,12 @@ export class MatDatepickerIntl {
   /** A label for the last date of a range of dates (used by screen readers). */
   endDateLabel = 'End date';
 
+  /** A label for the first date of a comparison range (used by screen readers). */
+  comparisonRangeStartLabel = 'Start of comparison range';
+
+  /** A label for the last date of a comparison range (used by screen readers). */
+  comparisonRangeEndLabel = 'End of comparison range';
+
   /** Formats a range of years (used for visuals). */
   formatYearRange(start: string, end: string): string {
     return `${start} \u2013 ${end}`;

--- a/tools/public_api_guard/material/datepicker.md
+++ b/tools/public_api_guard/material/datepicker.md
@@ -209,7 +209,11 @@ export class MatCalendarBody implements OnChanges, OnDestroy, AfterViewChecked {
     _cellPadding: string;
     _cellWidth: string;
     comparisonEnd: number | null;
+    // (undocumented)
+    _comparisonEndLabelId: string;
     comparisonStart: number | null;
+    // (undocumented)
+    _comparisonStartLabelId: string;
     // (undocumented)
     _emitActiveDateChange(cell: MatCalendarCell, event: FocusEvent): void;
     endDateAccessibleName: string | null;
@@ -218,6 +222,8 @@ export class MatCalendarBody implements OnChanges, OnDestroy, AfterViewChecked {
     endValue: number;
     _firstRowOffset: number;
     _focusActiveCell(movePreview?: boolean): void;
+    _getComparisonEndLabel(): string | null;
+    _getComparisonStartLabel(): string | null;
     _getDescribedby(value: number): string | null;
     _isActiveCell(rowIndex: number, colIndex: number): boolean;
     _isComparisonBridgeEnd(value: number, rowIndex: number, colIndex: number): boolean;
@@ -537,6 +543,8 @@ export class MatDatepickerIntl {
     calendarLabel: string;
     readonly changes: Subject<void>;
     closeCalendarLabel: string;
+    comparisonRangeEndLabel: string;
+    comparisonRangeStartLabel: string;
     endDateLabel: string;
     formatYearRange(start: string, end: string): string;
     formatYearRangeLabel(start: string, end: string): string;


### PR DESCRIPTION
Add aria descriptions to the calendar for the start and end of comparison range.

Fixes #23464

<img width="1117" alt="Screen Shot 2022-09-20 at 1 15 03 PM" src="https://user-images.githubusercontent.com/7720245/191356512-3f9cee5a-143e-4e57-831d-1f0570b2ee7e.png">
