### PR TITLE
fix(material/schematics): split core imports in ng update

### DIFF
--- a/src/material/schematics/ng-update/migrations/legacy-components-v15/constants.ts
+++ b/src/material/schematics/ng-update/migrations/legacy-components-v15/constants.ts
@@ -109,3 +109,21 @@ export const CUSTOM_SASS_MIXIN_RENAMINGS: {[key: string]: string} = {
 export const CUSTOM_SASS_FUNCTION_RENAMINGS: {[key: string]: string} = {
   'define-typography-config': 'define-legacy-typography-config',
 };
+
+export const MIGRATED_CORE_SYMBOLS: {[key: string]: string} = {
+  'MAT_OPTGROUP': 'MAT_LEGACY_OPTGROUP',
+  'MatOptionSelectionChange': 'MatLegacyOptionSelectionChange',
+  'MatOptionParentComponent': 'MatLegacyOptionParentComponent',
+  'MAT_OPTION_PARENT_COMPONENT': 'MAT_LEGACY_OPTION_PARENT_COMPONENT',
+  '_countGroupLabelsBeforeOption': '_countGroupLabelsBeforeLegacyOption',
+  '_getOptionScrollPosition': '_getLegacyOptionScrollPosition',
+  '_MatOptionBase': '_MatLegacyOptionBase',
+  '_MatOptgroupBase': '_MatLegacyOptgroupBase',
+  'MatOptionModule': 'MatLegacyOptionModule',
+  'MatOption': 'MatLegacyOption',
+  'MatOptgroup': 'MatLegacyOptgroup',
+  'MatOptionHarness': 'MatLegacyOptionHarness',
+  'OptionHarnessFilters': 'LegacyOptionHarnessFilters',
+  'MatOptgroupHarness': 'MatLegacyOptgroupHarness',
+  'OptgroupHarnessFilters': 'LegacyOptgroupHarnessFilters',
+};

--- a/src/material/schematics/ng-update/test-cases/v15/legacy-components-v15.spec.ts
+++ b/src/material/schematics/ng-update/test-cases/v15/legacy-components-v15.spec.ts
@@ -118,9 +118,30 @@ describe('v15 legacy components migration', () => {
           old: `import {MatButtonToggleModule} from '@angular/material/button-toggle';`,
           new: `import {MatButtonToggleModule} from '@angular/material/button-toggle';`,
         });
-        await runTypeScriptMigrationTest('non-legacy symbol', {
-          old: `import {VERSION} from '@angular/material/core`,
-          new: `import {VERSION} from '@angular/material/legacy-core`,
+      });
+
+      it('splits @angular/material/core imports', async () => {
+        await runMultilineTypeScriptMigrationTest('core imports', {
+          old: [
+            `import {VERSION, MatOption} from '@angular/material/core';`,
+            `import {CanDisable} from '@angular/material/core';`,
+            `import {MatOptionHarness} from '@angular/material/core/testing';`,
+            `import {VERSION as a, MatOption as b} from '@angular/material/core';`,
+            `const {mixinDisable, MatOptgroup} = await import('@angular/material/core');`,
+            `const {mixinDisable: c, MatOptgroup: d} = await import('@angular/material/core');`,
+          ],
+          new: [
+            `import {VERSION} from '@angular/material/core';`,
+            `import {MatLegacyOption as MatOption} from '@angular/material/legacy-core';`,
+            `import {CanDisable} from '@angular/material/core';`,
+            `import {MatLegacyOptionHarness as MatOptionHarness} from '@angular/material/legacy-core/testing';`,
+            `import {VERSION as a} from '@angular/material/core';`,
+            `import {MatLegacyOption as b} from '@angular/material/legacy-core';`,
+            `const {mixinDisable} = await import('@angular/material/core');`,
+            `const {MatLegacyOptgroup: MatOptgroup} = await import('@angular/material/legacy-core');`,
+            `const {mixinDisable: c} = await import('@angular/material/core');`,
+            `const {MatLegacyOptgroup: d} = await import('@angular/material/legacy-core');`,
+          ],
         });
       });
     });


### PR DESCRIPTION
Some of the imports from @angular/material/core (the ones related to
MatOption) need to be migrated to import from
@angular/material/legacy-core. However, the remaining symbols should
still import from @angular/material/core. This PR changes the ng update
script to separate them into separate import statements.