### PR TITLE
fix(material/list): prevent navigating to disabled list options

### DIFF
--- a/src/dev-app/list/list-demo.html
+++ b/src/dev-app/list/list-demo.html
@@ -178,8 +178,8 @@
 
       <mat-list-option value="bananas">Bananas</mat-list-option>
       <mat-list-option selected value="oranges">Oranges</mat-list-option>
-      <mat-list-option value="apples">Apples</mat-list-option>
-      <mat-list-option value="strawberries" color="warn">Strawberries</mat-list-option>
+      <mat-list-option value="apples" color="warn">Apples</mat-list-option>
+      <mat-list-option value="strawberries" disabled>Strawberries</mat-list-option>
     </mat-selection-list>
 
     <p>Selected: {{favoriteOptions | json}}</p>

--- a/src/material/legacy-list/selection-list.spec.ts
+++ b/src/material/legacy-list/selection-list.spec.ts
@@ -469,14 +469,14 @@ describe('MatSelectionList without forms', () => {
       expect(listOptions[2].componentInstance.selected).toBe(true);
     });
 
-    it('should be able to focus the first item when pressing HOME', () => {
+    it('should be able to focus the first non-disabled item when pressing HOME', () => {
       const manager = selectionList.componentInstance._keyManager;
       expect(manager.activeItemIndex).toBe(-1);
 
       const event = dispatchKeyboardEvent(selectionList.nativeElement, 'keydown', HOME);
       fixture.detectChanges();
 
-      expect(manager.activeItemIndex).toBe(0);
+      expect(manager.activeItemIndex).toBe(1);
       expect(event.defaultPrevented).toBe(true);
     });
 

--- a/src/material/legacy-list/selection-list.ts
+++ b/src/material/legacy-list/selection-list.ts
@@ -458,9 +458,6 @@ export class MatLegacySelectionList
       .withWrap()
       .withTypeAhead()
       .withHomeAndEnd()
-      // Allow disabled items to be focusable. For accessibility reasons, there must be a way for
-      // screen reader users, that allows reading the different options of the list.
-      .skipPredicate(() => false)
       .withAllowedModifierKeys(['shiftKey']);
 
     if (this._value) {

--- a/src/material/list/selection-list.spec.ts
+++ b/src/material/list/selection-list.spec.ts
@@ -335,14 +335,14 @@ describe('MDC-based MatSelectionList without forms', () => {
       expect(getFocusIndex()).toEqual(3);
     });
 
-    it('should be able to focus the first item when pressing HOME', () => {
+    it('should be able to focus the first non-disabled item when pressing HOME', () => {
       listOptions[2].nativeElement.focus();
       expect(getFocusIndex()).toBe(2);
 
       const event = dispatchKeyboardEvent(listOptions[2].nativeElement, 'keydown', HOME);
       fixture.detectChanges();
 
-      expect(getFocusIndex()).toBe(0);
+      expect(getFocusIndex()).toBe(1);
       expect(event.defaultPrevented).toBe(true);
     });
 

--- a/src/material/list/selection-list.ts
+++ b/src/material/list/selection-list.ts
@@ -366,12 +366,7 @@ export class MatSelectionList
 
   /** Sets up the logic for maintaining the roving tabindex. */
   private _setupRovingTabindex() {
-    this._keyManager = new FocusKeyManager(this._items)
-      .withHomeAndEnd()
-      .withTypeAhead()
-      .withWrap()
-      // Allow navigation to disabled items.
-      .skipPredicate(() => false);
+    this._keyManager = new FocusKeyManager(this._items).withHomeAndEnd().withTypeAhead().withWrap();
 
     // Set the initial focus.
     this._resetActiveOption();


### PR DESCRIPTION
Prevent navigating to disabled `<list-option>`. This fixes a11y issue where disabled element is still able to receive focus.