### PR TITLE
docs(material/theming): fix typo in theming guide

### DIFF
--- a/guides/theming.md
+++ b/guides/theming.md
@@ -356,7 +356,7 @@ hue's number identifier with `-contrast`.
 $my-palette: mat.define-palette(mat.$indigo-palette);
 
 .my-custom-style {
- background: mat.get-color-from-palette($my-palette, '500');
+ background: mat.get-color-from-palette($my-palette, 500);
  color: mat.get-color-from-palette($my-palette, '500-contrast');
 }
 ```


### PR DESCRIPTION
In theming guide the mat.get-color-from-palette is shown with a number identifier in quotes, unlike the theming-your-components guide which shows it without quotes.

Fixes #25598