### PR TITLE
feat(material/chips): allow custom default color

### DIFF
--- a/src/material/chips/chip-row.ts
+++ b/src/material/chips/chip-row.ts
@@ -31,7 +31,7 @@ import {FocusMonitor} from '@angular/cdk/a11y';
 import {MatChip, MatChipEvent} from './chip';
 import {MatChipEditInput} from './chip-edit-input';
 import {takeUntil} from 'rxjs/operators';
-import {MAT_CHIP} from './tokens';
+import {MAT_CHIP, MAT_CHIPS_DEFAULT_OPTIONS, MatChipsDefaultOptions} from './tokens';
 
 /** Represents an event fired on an individual `mat-chip` when it is edited. */
 export interface MatChipEditedEvent extends MatChipEvent {
@@ -110,6 +110,7 @@ export class MatChipRow extends MatChip implements AfterViewInit {
     @Inject(MAT_RIPPLE_GLOBAL_OPTIONS)
     globalRippleOptions?: RippleGlobalOptions,
     @Attribute('tabindex') tabIndex?: string,
+    @Optional() @Inject(MAT_CHIPS_DEFAULT_OPTIONS) _defaultOptions?: MatChipsDefaultOptions,
   ) {
     super(
       changeDetectorRef,
@@ -120,6 +121,7 @@ export class MatChipRow extends MatChip implements AfterViewInit {
       animationMode,
       globalRippleOptions,
       tabIndex,
+      _defaultOptions,
     );
 
     this.role = 'row';

--- a/src/material/chips/chip.spec.ts
+++ b/src/material/chips/chip.spec.ts
@@ -15,7 +15,7 @@ import {
 
 describe('MDC-based MatChip', () => {
   let fixture: ComponentFixture<any>;
-  let fixtureDefaultChip: ComponentFixture<DefaultChip>;
+  let fixtureBasicChip: ComponentFixture<BasicChip>;
   let chipDebugElement: DebugElement;
   let chipNativeElement: HTMLElement;
   let chipInstance: MatChip;
@@ -28,7 +28,6 @@ describe('MDC-based MatChip', () => {
     TestBed.configureTestingModule({
       imports: [MatChipsModule],
       declarations: [
-        DefaultChip,
         BasicChip,
         SingleChip,
         BasicChipWithStaticTabindex,
@@ -99,8 +98,8 @@ describe('MDC-based MatChip', () => {
       fixture = TestBed.createComponent(SingleChip);
       fixture.detectChanges();
 
-      fixtureDefaultChip = TestBed.createComponent(DefaultChip);
-      fixtureDefaultChip.detectChanges();
+      fixtureBasicChip = TestBed.createComponent(BasicChip);
+      fixtureBasicChip.detectChanges();
 
       chipDebugElement = fixture.debugElement.query(By.directive(MatChip))!;
       chipNativeElement = chipDebugElement.nativeElement;
@@ -140,16 +139,16 @@ describe('MDC-based MatChip', () => {
     });
 
     it('can default the color via MAT_CHIPS_DEFAULT_OPTIONS provider', () => {
-      let chipDefaultDebugElement = fixtureDefaultChip.debugElement.query(By.directive(MatChip))!;
-      let chipDefaultNativeElement = chipDefaultDebugElement.nativeElement;
-      expect(chipDefaultNativeElement.classList).toContain('mat-primary');
+      let basicChipDebugElement = fixtureBasicChip.debugElement.query(By.directive(MatChip))!;
+      let basicChipNativeElement = basicChipDebugElement.nativeElement;
+      expect(basicChipNativeElement.classList).toContain('mat-primary');
 
-      fixtureDefaultChip.destroy();
+      fixtureBasicChip.destroy();
 
       TestBed.resetTestingModule()
         .configureTestingModule({
           imports: [MatChipsModule],
-          declarations: [DefaultChip],
+          declarations: [BasicChip],
           providers: [
             {
               provide: MAT_CHIPS_DEFAULT_OPTIONS,
@@ -158,11 +157,11 @@ describe('MDC-based MatChip', () => {
           ],
         })
         .compileComponents();
-      fixtureDefaultChip = TestBed.createComponent(DefaultChip);
-      fixtureDefaultChip.detectChanges();
-      chipDefaultDebugElement = fixtureDefaultChip.debugElement.query(By.directive(MatChip))!;
-      chipDefaultNativeElement = chipDefaultDebugElement.nativeElement;
-      expect(chipDefaultNativeElement.classList).not.toContain('mat-primary');
+      fixtureBasicChip = TestBed.createComponent(BasicChip);
+      fixtureBasicChip.detectChanges();
+      basicChipDebugElement = fixtureBasicChip.debugElement.query(By.directive(MatChip))!;
+      basicChipNativeElement = basicChipDebugElement.nativeElement;
+      expect(basicChipNativeElement.classList).not.toContain('mat-primary');
     });
 
     it('allows removal', () => {

--- a/src/material/chips/chip.spec.ts
+++ b/src/material/chips/chip.spec.ts
@@ -19,6 +19,7 @@ import {COMMA} from '@angular/cdk/keycodes';
 
 describe('MDC-based MatChip', () => {
   let fixture: ComponentFixture<any>;
+  let fixtureDefaultChip: ComponentFixture<DefaultChip>;
   let chipDebugElement: DebugElement;
   let chipNativeElement: HTMLElement;
   let chipInstance: MatChip;
@@ -31,6 +32,7 @@ describe('MDC-based MatChip', () => {
     TestBed.configureTestingModule({
       imports: [MatChipsModule],
       declarations: [
+        DefaultChip,
         BasicChip,
         SingleChip,
         BasicChipWithStaticTabindex,
@@ -101,6 +103,9 @@ describe('MDC-based MatChip', () => {
       fixture = TestBed.createComponent(SingleChip);
       fixture.detectChanges();
 
+      fixtureDefaultChip = TestBed.createComponent(DefaultChip);
+      fixtureDefaultChip.detectChanges();
+
       chipDebugElement = fixture.debugElement.query(By.directive(MatChip))!;
       chipNativeElement = chipDebugElement.nativeElement;
       chipInstance = chipDebugElement.injector.get<MatChip>(MatChip);
@@ -138,17 +143,17 @@ describe('MDC-based MatChip', () => {
       expect(chipNativeElement.classList).toContain('mat-warn');
     });
 
-    it('can default the color to undefined', () => {
-      fixture.destroy();
+    it('can default the color via MAT_CHIPS_DEFAULT_OPTIONS provider', () => {
+      let chipDefaultDebugElement = fixtureDefaultChip.debugElement.query(By.directive(MatChip))!;
+      let chipDefaultNativeElement = chipDefaultDebugElement.nativeElement;
+      expect(chipDefaultNativeElement.classList).toContain('mat-primary');
+
+      fixtureDefaultChip.destroy();
+
       TestBed.resetTestingModule()
         .configureTestingModule({
           imports: [MatChipsModule],
-          declarations: [
-            BasicChip,
-            SingleChip,
-            BasicChipWithStaticTabindex,
-            BasicChipWithBoundTabindex,
-          ],
+          declarations: [DefaultChip],
           providers: [
             {
               provide: MAT_CHIPS_DEFAULT_OPTIONS,
@@ -157,11 +162,11 @@ describe('MDC-based MatChip', () => {
           ],
         })
         .compileComponents();
-      fixture = TestBed.createComponent(SingleChip);
-      fixture.detectChanges();
-      chipDebugElement = fixture.debugElement.query(By.directive(MatChip))!;
-      chipNativeElement = chipDebugElement.nativeElement;
-      expect(chipNativeElement.classList).not.toContain('mat-primary');
+      fixtureDefaultChip = TestBed.createComponent(DefaultChip);
+      fixtureDefaultChip.detectChanges();
+      chipDefaultDebugElement = fixtureDefaultChip.debugElement.query(By.directive(MatChip))!;
+      chipDefaultNativeElement = chipDefaultDebugElement.nativeElement;
+      expect(chipDefaultNativeElement.classList).not.toContain('mat-primary');
     });
 
     it('allows removal', () => {
@@ -242,7 +247,7 @@ class SingleChip {
   @ViewChild(MatChipSet) chipList: MatChipSet;
   disabled: boolean = false;
   name: string = 'Test';
-  color: ThemePalette = undefined;
+  color: ThemePalette = 'primary';
   removable: boolean = true;
   shouldShow: boolean = true;
   value: any;
@@ -250,6 +255,15 @@ class SingleChip {
 
   chipDestroy: (event?: MatChipEvent) => void = () => {};
   chipRemove: (event?: MatChipEvent) => void = () => {};
+}
+
+@Component({
+  template: `
+    <mat-chip>{{ name }}</mat-chip>
+  `,
+})
+class DefaultChip {
+  name = 'test';
 }
 
 @Component({

--- a/src/material/chips/chip.spec.ts
+++ b/src/material/chips/chip.spec.ts
@@ -1,10 +1,21 @@
 import {Directionality} from '@angular/cdk/bidi';
 import {Component, DebugElement, ViewChild} from '@angular/core';
 import {waitForAsync, ComponentFixture, TestBed} from '@angular/core/testing';
-import {MatRipple} from '@angular/material/core';
+import {MatRipple, ThemePalette} from '@angular/material/core';
 import {By} from '@angular/platform-browser';
 import {Subject} from 'rxjs';
-import {MatChip, MatChipEvent, MatChipSet, MatChipsModule} from './index';
+import {
+  MAT_CHIPS_DEFAULT_OPTIONS,
+  MatChip,
+  MatChipEvent,
+  MatChipsDefaultOptions,
+  MatChipSet,
+  MatChipsModule,
+} from './index';
+import {MatFormFieldModule} from '@angular/material/form-field';
+import {PlatformModule} from '@angular/cdk/platform';
+import {NoopAnimationsModule} from '@angular/platform-browser/animations';
+import {COMMA} from '@angular/cdk/keycodes';
 
 describe('MDC-based MatChip', () => {
   let fixture: ComponentFixture<any>;
@@ -127,6 +138,32 @@ describe('MDC-based MatChip', () => {
       expect(chipNativeElement.classList).toContain('mat-warn');
     });
 
+    it('can default the color to undefined', () => {
+      fixture.destroy();
+      TestBed.resetTestingModule()
+        .configureTestingModule({
+          imports: [MatChipsModule],
+          declarations: [
+            BasicChip,
+            SingleChip,
+            BasicChipWithStaticTabindex,
+            BasicChipWithBoundTabindex,
+          ],
+          providers: [
+            {
+              provide: MAT_CHIPS_DEFAULT_OPTIONS,
+              useValue: {color: undefined} as MatChipsDefaultOptions,
+            },
+          ],
+        })
+        .compileComponents();
+      fixture = TestBed.createComponent(SingleChip);
+      fixture.detectChanges();
+      chipDebugElement = fixture.debugElement.query(By.directive(MatChip))!;
+      chipNativeElement = chipDebugElement.nativeElement;
+      expect(chipNativeElement.classList).not.toContain('mat-primary');
+    });
+
     it('allows removal', () => {
       spyOn(testComponent, 'chipRemove');
 
@@ -205,7 +242,7 @@ class SingleChip {
   @ViewChild(MatChipSet) chipList: MatChipSet;
   disabled: boolean = false;
   name: string = 'Test';
-  color: string = 'primary';
+  color: ThemePalette = undefined;
   removable: boolean = true;
   shouldShow: boolean = true;
   value: any;

--- a/src/material/chips/chip.spec.ts
+++ b/src/material/chips/chip.spec.ts
@@ -12,10 +12,6 @@ import {
   MatChipSet,
   MatChipsModule,
 } from './index';
-import {MatFormFieldModule} from '@angular/material/form-field';
-import {PlatformModule} from '@angular/cdk/platform';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
-import {COMMA} from '@angular/cdk/keycodes';
 
 describe('MDC-based MatChip', () => {
   let fixture: ComponentFixture<any>;

--- a/src/material/chips/chip.spec.ts
+++ b/src/material/chips/chip.spec.ts
@@ -15,7 +15,6 @@ import {
 
 describe('MDC-based MatChip', () => {
   let fixture: ComponentFixture<any>;
-  let fixtureBasicChip: ComponentFixture<BasicChip>;
   let chipDebugElement: DebugElement;
   let chipNativeElement: HTMLElement;
   let chipInstance: MatChip;
@@ -88,6 +87,34 @@ describe('MDC-based MatChip', () => {
         .withContext('Expected basic chip ripples to be disabled.')
         .toBe(true);
     });
+
+    it('can default the color via MAT_CHIPS_DEFAULT_OPTIONS provider', () => {
+      fixture = TestBed.createComponent(BasicChip);
+      fixture.detectChanges();
+      chipDebugElement = fixture.debugElement.query(By.directive(MatChip))!;
+      chipNativeElement = chipDebugElement.nativeElement;
+      expect(chipNativeElement.classList).toContain('mat-primary');
+
+      fixture.destroy();
+
+      TestBed.resetTestingModule()
+        .configureTestingModule({
+          imports: [MatChipsModule],
+          declarations: [BasicChip],
+          providers: [
+            {
+              provide: MAT_CHIPS_DEFAULT_OPTIONS,
+              useValue: {color: undefined} as MatChipsDefaultOptions,
+            },
+          ],
+        })
+        .compileComponents();
+      fixture = TestBed.createComponent(BasicChip);
+      fixture.detectChanges();
+      chipDebugElement = fixture.debugElement.query(By.directive(MatChip))!;
+      chipNativeElement = chipDebugElement.nativeElement;
+      expect(chipNativeElement.classList).not.toContain('mat-primary');
+    });
   });
 
   describe('MatChip', () => {
@@ -97,9 +124,6 @@ describe('MDC-based MatChip', () => {
     beforeEach(() => {
       fixture = TestBed.createComponent(SingleChip);
       fixture.detectChanges();
-
-      fixtureBasicChip = TestBed.createComponent(BasicChip);
-      fixtureBasicChip.detectChanges();
 
       chipDebugElement = fixture.debugElement.query(By.directive(MatChip))!;
       chipNativeElement = chipDebugElement.nativeElement;
@@ -136,32 +160,6 @@ describe('MDC-based MatChip', () => {
 
       expect(chipNativeElement.classList).not.toContain('mat-primary');
       expect(chipNativeElement.classList).toContain('mat-warn');
-    });
-
-    it('can default the color via MAT_CHIPS_DEFAULT_OPTIONS provider', () => {
-      let basicChipDebugElement = fixtureBasicChip.debugElement.query(By.directive(MatChip))!;
-      let basicChipNativeElement = basicChipDebugElement.nativeElement;
-      expect(basicChipNativeElement.classList).toContain('mat-primary');
-
-      fixtureBasicChip.destroy();
-
-      TestBed.resetTestingModule()
-        .configureTestingModule({
-          imports: [MatChipsModule],
-          declarations: [BasicChip],
-          providers: [
-            {
-              provide: MAT_CHIPS_DEFAULT_OPTIONS,
-              useValue: {color: undefined} as MatChipsDefaultOptions,
-            },
-          ],
-        })
-        .compileComponents();
-      fixtureBasicChip = TestBed.createComponent(BasicChip);
-      fixtureBasicChip.detectChanges();
-      basicChipDebugElement = fixtureBasicChip.debugElement.query(By.directive(MatChip))!;
-      basicChipNativeElement = basicChipDebugElement.nativeElement;
-      expect(basicChipNativeElement.classList).not.toContain('mat-primary');
     });
 
     it('allows removal', () => {

--- a/src/material/chips/chip.spec.ts
+++ b/src/material/chips/chip.spec.ts
@@ -251,15 +251,6 @@ class SingleChip {
 }
 
 @Component({
-  template: `
-    <mat-chip>{{ name }}</mat-chip>
-  `,
-})
-class DefaultChip {
-  name = 'test';
-}
-
-@Component({
   template: `<mat-basic-chip>Hello</mat-basic-chip>`,
 })
 class BasicChip {}

--- a/src/material/chips/chip.ts
+++ b/src/material/chips/chip.ts
@@ -216,6 +216,9 @@ export class MatChip
   /** Reference to the MatRipple instance of the chip. */
   @ViewChild(MatRipple) ripple: MatRipple;
 
+  /** Action receiving the primary set of user interactions. */
+  @ViewChild(MatChipAction) primaryAction: MatChipAction;
+
   constructor(
     public _changeDetectorRef: ChangeDetectorRef,
     elementRef: ElementRef<HTMLElement>,
@@ -242,9 +245,6 @@ export class MatChip
     this._monitorFocus();
     this.color = _defaultOptions?.color;
   }
-
-  /** Action receiving the primary set of user interactions. */
-  @ViewChild(MatChipAction) primaryAction: MatChipAction;
 
   ngAfterViewInit() {
     this._textElement = this._elementRef.nativeElement.querySelector('.mat-mdc-chip-action-label')!;

--- a/src/material/chips/chip.ts
+++ b/src/material/chips/chip.ts
@@ -240,7 +240,7 @@ export class MatChip
       this.tabIndex = parseInt(tabIndex) ?? this.defaultTabIndex;
     }
     this._monitorFocus();
-    this.defaultColor = _defaultOptions?.color;
+    this.color = _defaultOptions?.color;
   }
 
   /** Action receiving the primary set of user interactions. */

--- a/src/material/chips/chip.ts
+++ b/src/material/chips/chip.ts
@@ -227,7 +227,7 @@ export class MatChip
     @Inject(MAT_RIPPLE_GLOBAL_OPTIONS)
     private _globalRippleOptions?: RippleGlobalOptions,
     @Attribute('tabindex') tabIndex?: string,
-    @Optional() @Inject(MAT_CHIPS_DEFAULT_OPTIONS) private _defaultOptions?: MatChipsDefaultOptions,
+    @Optional() @Inject(MAT_CHIPS_DEFAULT_OPTIONS) _defaultOptions?: MatChipsDefaultOptions,
   ) {
     super(elementRef);
     const element = elementRef.nativeElement;

--- a/src/material/chips/chip.ts
+++ b/src/material/chips/chip.ts
@@ -46,7 +46,14 @@ import {take} from 'rxjs/operators';
 import {MatChipAvatar, MatChipTrailingIcon, MatChipRemove} from './chip-icons';
 import {MatChipAction} from './chip-action';
 import {BACKSPACE, DELETE} from '@angular/cdk/keycodes';
-import {MAT_CHIP, MAT_CHIP_AVATAR, MAT_CHIP_REMOVE, MAT_CHIP_TRAILING_ICON} from './tokens';
+import {
+  MAT_CHIP,
+  MAT_CHIP_AVATAR,
+  MAT_CHIP_REMOVE,
+  MAT_CHIP_TRAILING_ICON,
+  MAT_CHIPS_DEFAULT_OPTIONS,
+  MatChipsDefaultOptions,
+} from './tokens';
 
 let uid = 0;
 
@@ -69,7 +76,6 @@ const _MatChipMixinBase = mixinTabIndex(
         },
       ),
     ),
-    'primary',
   ),
   -1,
 );
@@ -210,9 +216,6 @@ export class MatChip
   /** Reference to the MatRipple instance of the chip. */
   @ViewChild(MatRipple) ripple: MatRipple;
 
-  /** Action receiving the primary set of user interactions. */
-  @ViewChild(MatChipAction) primaryAction: MatChipAction;
-
   constructor(
     public _changeDetectorRef: ChangeDetectorRef,
     elementRef: ElementRef<HTMLElement>,
@@ -224,6 +227,7 @@ export class MatChip
     @Inject(MAT_RIPPLE_GLOBAL_OPTIONS)
     private _globalRippleOptions?: RippleGlobalOptions,
     @Attribute('tabindex') tabIndex?: string,
+    @Optional() @Inject(MAT_CHIPS_DEFAULT_OPTIONS) private _defaultOptions?: MatChipsDefaultOptions,
   ) {
     super(elementRef);
     const element = elementRef.nativeElement;
@@ -236,7 +240,11 @@ export class MatChip
       this.tabIndex = parseInt(tabIndex) ?? this.defaultTabIndex;
     }
     this._monitorFocus();
+    this.defaultColor = _defaultOptions?.color;
   }
+
+  /** Action receiving the primary set of user interactions. */
+  @ViewChild(MatChipAction) primaryAction: MatChipAction;
 
   ngAfterViewInit() {
     this._textElement = this._elementRef.nativeElement.querySelector('.mat-mdc-chip-action-label')!;

--- a/src/material/chips/module.ts
+++ b/src/material/chips/module.ts
@@ -46,6 +46,7 @@ const CHIP_DECLARATIONS = [
       provide: MAT_CHIPS_DEFAULT_OPTIONS,
       useValue: {
         separatorKeyCodes: [ENTER],
+        color: 'primary',
       } as MatChipsDefaultOptions,
     },
   ],

--- a/src/material/chips/tokens.ts
+++ b/src/material/chips/tokens.ts
@@ -7,11 +7,14 @@
  */
 
 import {InjectionToken} from '@angular/core';
+import {ThemePalette} from '@angular/material/core';
 
 /** Default options, for the chips module, that can be overridden. */
 export interface MatChipsDefaultOptions {
   /** The list of key codes that will trigger a chipEnd event. */
   separatorKeyCodes: readonly number[] | ReadonlySet<number>;
+  /** Default color for a chip */
+  color?: ThemePalette;
 }
 
 /** Injection token to be used to override the default options for the chips module. */

--- a/tools/public_api_guard/material/chips.md
+++ b/tools/public_api_guard/material/chips.md
@@ -42,6 +42,7 @@ import { OnInit } from '@angular/core';
 import { QueryList } from '@angular/core';
 import { RippleGlobalOptions } from '@angular/material/core';
 import { Subject } from 'rxjs';
+import { ThemePalette } from '@angular/material/core';
 
 // @public
 export const MAT_CHIP: InjectionToken<unknown>;
@@ -63,7 +64,7 @@ export const MAT_CHIPS_DEFAULT_OPTIONS: InjectionToken<MatChipsDefaultOptions>;
 
 // @public
 export class MatChip extends _MatChipMixinBase implements AfterViewInit, CanColor, CanDisableRipple, CanDisable, HasTabIndex, OnDestroy {
-    constructor(_changeDetectorRef: ChangeDetectorRef, elementRef: ElementRef<HTMLElement>, _ngZone: NgZone, _focusMonitor: FocusMonitor, _document: any, animationMode?: string, _globalRippleOptions?: RippleGlobalOptions | undefined, tabIndex?: string);
+    constructor(_changeDetectorRef: ChangeDetectorRef, elementRef: ElementRef<HTMLElement>, _ngZone: NgZone, _focusMonitor: FocusMonitor, _document: any, animationMode?: string, _globalRippleOptions?: RippleGlobalOptions | undefined, tabIndex?: string, _defaultOptions?: MatChipsDefaultOptions);
     _animationsDisabled: boolean;
     ariaLabel: string | null;
     protected basicChipAttrName: string;
@@ -115,7 +116,7 @@ export class MatChip extends _MatChipMixinBase implements AfterViewInit, CanColo
     // (undocumented)
     static ɵcmp: i0.ɵɵComponentDeclaration<MatChip, "mat-basic-chip, mat-chip", ["matChip"], { "color": "color"; "disabled": "disabled"; "disableRipple": "disableRipple"; "tabIndex": "tabIndex"; "role": "role"; "id": "id"; "ariaLabel": "aria-label"; "value": "value"; "removable": "removable"; "highlighted": "highlighted"; }, { "removed": "removed"; "destroyed": "destroyed"; }, ["leadingIcon", "trailingIcon", "removeIcon"], ["mat-chip-avatar, [matChipAvatar]", "*", "mat-chip-trailing-icon,[matChipRemove],[matChipTrailingIcon]"], false, never>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<MatChip, [null, null, null, null, null, { optional: true; }, { optional: true; }, { attribute: "tabindex"; }]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MatChip, [null, null, null, null, null, { optional: true; }, { optional: true; }, { attribute: "tabindex"; }, { optional: true; }]>;
 }
 
 // @public
@@ -403,6 +404,7 @@ export class MatChipRow extends MatChip implements AfterViewInit {
 
 // @public
 export interface MatChipsDefaultOptions {
+    color?: ThemePalette;
     separatorKeyCodes: readonly number[] | ReadonlySet<number>;
 }
 

--- a/tools/public_api_guard/material/chips.md
+++ b/tools/public_api_guard/material/chips.md
@@ -379,7 +379,7 @@ export class MatChipRemove extends MatChipAction {
 
 // @public
 export class MatChipRow extends MatChip implements AfterViewInit {
-    constructor(changeDetectorRef: ChangeDetectorRef, elementRef: ElementRef, ngZone: NgZone, focusMonitor: FocusMonitor, _document: any, animationMode?: string, globalRippleOptions?: RippleGlobalOptions, tabIndex?: string);
+    constructor(changeDetectorRef: ChangeDetectorRef, elementRef: ElementRef, ngZone: NgZone, focusMonitor: FocusMonitor, _document: any, animationMode?: string, globalRippleOptions?: RippleGlobalOptions, tabIndex?: string, _defaultOptions?: MatChipsDefaultOptions);
     // (undocumented)
     protected basicChipAttrName: string;
     contentEditInput?: MatChipEditInput;
@@ -399,7 +399,7 @@ export class MatChipRow extends MatChip implements AfterViewInit {
     // (undocumented)
     static ɵcmp: i0.ɵɵComponentDeclaration<MatChipRow, "mat-chip-row, mat-basic-chip-row", never, { "color": "color"; "disabled": "disabled"; "disableRipple": "disableRipple"; "tabIndex": "tabIndex"; "editable": "editable"; }, { "edited": "edited"; }, ["contentEditInput"], ["mat-chip-avatar, [matChipAvatar]", "*", "[matChipEditInput]", "mat-chip-trailing-icon,[matChipRemove],[matChipTrailingIcon]"], false, never>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<MatChipRow, [null, null, null, null, null, { optional: true; }, { optional: true; }, { attribute: "tabindex"; }]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MatChipRow, [null, null, null, null, null, { optional: true; }, { optional: true; }, { attribute: "tabindex"; }, { optional: true; }]>;
 }
 
 // @public


### PR DESCRIPTION
Lets the user choose what color will be the default instead of 'primary' via mixinColor

✅ Tests adapted
✅ No breaking change: I keep the same default color `primary` 