### PR TITLE
docs(material/input): Fix cdkTextareaAutosize link

### DIFF
--- a/src/material/input/input.md
+++ b/src/material/input/input.md
@@ -75,7 +75,7 @@ globally cause input errors to show when the input is dirty and invalid.
 ### Auto-resizing `<textarea>` elements
 
 `<textarea>` elements can be made to automatically resize by using the
-[`cdkTextareaAutosize` directive](https://material.angular.io/components/input/overview#auto-resizing-textarea-elements)
+[`cdkTextareaAutosize` directive](https://material.angular.io/cdk/text-field/overview#automatically-resizing-a-textarea)
 available in the CDK.
 
 ### Responding to changes in the autofill state of an `<input>`


### PR DESCRIPTION
The link to the `cdkTextareaAutosize` directive in the "Auto-resizing <textarea> elements" section on the overview page links to that section on the same page, have changed it to correctly point to that section within the `cdk/text-field` overview page.