### PR TITLE
feat(material/form-field): add error harness

### DIFF
--- a/src/material/form-field/testing/error-harness.ts
+++ b/src/material/form-field/testing/error-harness.ts
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {
+  BaseHarnessFilters,
+  ComponentHarness,
+  ComponentHarnessConstructor,
+  HarnessPredicate,
+} from '@angular/cdk/testing';
+
+/** A set of criteria that can be used to filter a list of error harness instances. */
+export interface ErrorHarnessFilters extends BaseHarnessFilters {
+  /** Only find instances whose text matches the given value. */
+  text?: string | RegExp;
+}
+
+export abstract class _MatErrorHarnessBase extends ComponentHarness {
+  /** Gets a promise for the error's label text. */
+  async getText(): Promise<string> {
+    return (await this.host()).text();
+  }
+
+  protected static _getErrorPredicate<T extends MatErrorHarness>(
+    type: ComponentHarnessConstructor<T>,
+    options: ErrorHarnessFilters,
+  ): HarnessPredicate<T> {
+    return new HarnessPredicate(type, options).addOption('text', options.text, (harness, text) =>
+      HarnessPredicate.stringMatches(harness.getText(), text),
+    );
+  }
+}
+
+/** Harness for interacting with an MDC-based `mat-error` in tests. */
+export class MatErrorHarness extends _MatErrorHarnessBase {
+  static hostSelector = '.mat-mdc-form-field-error';
+
+  /**
+   * Gets a `HarnessPredicate` that can be used to search for an error with specific
+   * attributes.
+   * @param options Options for filtering which error instances are considered a match.
+   * @return a `HarnessPredicate` configured with the given options.
+   */
+  static with<T extends MatErrorHarness>(
+    this: ComponentHarnessConstructor<T>,
+    options: ErrorHarnessFilters = {},
+  ): HarnessPredicate<T> {
+    return _MatErrorHarnessBase._getErrorPredicate(this, options);
+  }
+}

--- a/src/material/form-field/testing/form-field-harness.spec.ts
+++ b/src/material/form-field/testing/form-field-harness.spec.ts
@@ -1,4 +1,5 @@
 import {MatFormFieldModule} from '@angular/material/form-field';
+import {MatErrorHarness} from './error-harness';
 import {MatInputModule} from '@angular/material/input';
 import {MatAutocompleteModule} from '@angular/material/autocomplete';
 import {MatInputHarness} from '@angular/material/input/testing';
@@ -30,6 +31,7 @@ describe('MDC-based MatFormFieldHarness', () => {
       datepickerInputHarness: MatDatepickerInputHarness,
       dateRangeInputHarness: MatDateRangeInputHarness,
       isMdcImplementation: true,
+      errorHarness: MatErrorHarness,
     },
   );
 });

--- a/src/material/form-field/testing/form-field-harness.ts
+++ b/src/material/form-field/testing/form-field-harness.ts
@@ -38,7 +38,6 @@ export abstract class _MatFormFieldHarnessBase<
   protected abstract _prefixContainer: AsyncFactoryFn<TestElement | null>;
   protected abstract _suffixContainer: AsyncFactoryFn<TestElement | null>;
   protected abstract _label: AsyncFactoryFn<TestElement | null>;
-  protected abstract _errors: AsyncFactoryFn<TestElement[]>;
   protected abstract _hints: AsyncFactoryFn<TestElement[]>;
   protected abstract _inputControl: AsyncFactoryFn<ControlHarness | null>;
   protected abstract _selectControl: AsyncFactoryFn<ControlHarness | null>;
@@ -131,8 +130,8 @@ export abstract class _MatFormFieldHarnessBase<
 
   /** Gets error messages which are currently displayed in the form-field. */
   async getTextErrors(): Promise<string[]> {
-    const errors = await this._errors();
-    return parallel(() => errors.map(e => e.text()));
+    const errors = await this.getErrors();
+    return parallel(() => errors.map(e => e.getText()));
   }
 
   /** Gets all of the error harnesses in the form field. */
@@ -255,7 +254,6 @@ export class MatFormFieldHarness extends _MatFormFieldHarnessBase<
   protected _prefixContainer = this.locatorForOptional('.mat-mdc-form-field-text-prefix');
   protected _suffixContainer = this.locatorForOptional('.mat-mdc-form-field-text-suffix');
   protected _label = this.locatorForOptional('.mdc-floating-label');
-  protected _errors = this.locatorForAll('.mat-mdc-form-field-error');
   protected _hints = this.locatorForAll('.mat-mdc-form-field-hint');
   protected _inputControl = this.locatorForOptional(MatInputHarness);
   protected _selectControl = this.locatorForOptional(MatSelectHarness);

--- a/src/material/form-field/testing/public-api.ts
+++ b/src/material/form-field/testing/public-api.ts
@@ -13,3 +13,4 @@ export {MatFormFieldControlHarness} from '@angular/material/form-field/testing/c
 
 export * from './form-field-harness-filters';
 export * from './form-field-harness';
+export * from './error-harness';

--- a/src/material/legacy-form-field/testing/BUILD.bazel
+++ b/src/material/legacy-form-field/testing/BUILD.bazel
@@ -31,6 +31,7 @@ ng_test_library(
         "//src/material/core",
         "//src/material/datepicker",
         "//src/material/datepicker/testing",
+        "//src/material/form-field/testing",
         "//src/material/form-field/testing:harness_tests_lib",
         "//src/material/legacy-autocomplete",
         "//src/material/legacy-form-field",

--- a/src/material/legacy-form-field/testing/error-harness.ts
+++ b/src/material/legacy-form-field/testing/error-harness.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ComponentHarnessConstructor, HarnessPredicate} from '@angular/cdk/testing';
+
+import {_MatErrorHarnessBase, ErrorHarnessFilters} from '@angular/material/form-field/testing';
+
+/** Harness for interacting with a `mat-error` in tests. */
+export class MatErrorHarness extends _MatErrorHarnessBase {
+  static hostSelector = '.mat-error';
+
+  /**
+   * Gets a `HarnessPredicate` that can be used to search for an error with specific
+   * attributes.
+   * @param options Options for filtering which error instances are considered a match.
+   * @return a `HarnessPredicate` configured with the given options.
+   */
+  static with<T extends MatErrorHarness>(
+    this: ComponentHarnessConstructor<T>,
+    options: ErrorHarnessFilters = {},
+  ): HarnessPredicate<T> {
+    return _MatErrorHarnessBase._getErrorPredicate(this, options);
+  }
+}

--- a/src/material/legacy-form-field/testing/error-harness.ts
+++ b/src/material/legacy-form-field/testing/error-harness.ts
@@ -10,8 +10,12 @@ import {ComponentHarnessConstructor, HarnessPredicate} from '@angular/cdk/testin
 
 import {_MatErrorHarnessBase, ErrorHarnessFilters} from '@angular/material/form-field/testing';
 
-/** Harness for interacting with a `mat-error` in tests. */
-export class MatErrorHarness extends _MatErrorHarnessBase {
+/**
+ * Harness for interacting with a `mat-error` in tests.
+ * @deprecated Use `MatErrorHarness` from `@angular/material/form-field/testing` instead. See https://material.angular.io/guide/mdc-migration for information about migrating.
+ * @breaking-change 17.0.0
+ */
+export class MatLegacyErrorHarness extends _MatErrorHarnessBase {
   static hostSelector = '.mat-error';
 
   /**
@@ -20,7 +24,7 @@ export class MatErrorHarness extends _MatErrorHarnessBase {
    * @param options Options for filtering which error instances are considered a match.
    * @return a `HarnessPredicate` configured with the given options.
    */
-  static with<T extends MatErrorHarness>(
+  static with<T extends MatLegacyErrorHarness>(
     this: ComponentHarnessConstructor<T>,
     options: ErrorHarnessFilters = {},
   ): HarnessPredicate<T> {

--- a/src/material/legacy-form-field/testing/form-field-harness.spec.ts
+++ b/src/material/legacy-form-field/testing/form-field-harness.spec.ts
@@ -1,3 +1,4 @@
+import {MatErrorHarness} from './error-harness';
 import {MatLegacyAutocompleteModule} from '@angular/material/legacy-autocomplete';
 import {MatNativeDateModule} from '@angular/material/core';
 import {MatDatepickerModule} from '@angular/material/datepicker';
@@ -31,6 +32,7 @@ describe('Non-MDC-based MatFormFieldHarness', () => {
       datepickerInputHarness: MatDatepickerInputHarness,
       dateRangeInputHarness: MatDateRangeInputHarness,
       isMdcImplementation: false,
+      errorHarness: MatErrorHarness,
     },
   );
 });

--- a/src/material/legacy-form-field/testing/form-field-harness.spec.ts
+++ b/src/material/legacy-form-field/testing/form-field-harness.spec.ts
@@ -1,4 +1,4 @@
-import {MatErrorHarness} from './error-harness';
+import {MatLegacyErrorHarness} from './error-harness';
 import {MatLegacyAutocompleteModule} from '@angular/material/legacy-autocomplete';
 import {MatNativeDateModule} from '@angular/material/core';
 import {MatDatepickerModule} from '@angular/material/datepicker';
@@ -32,7 +32,7 @@ describe('Non-MDC-based MatFormFieldHarness', () => {
       datepickerInputHarness: MatDatepickerInputHarness,
       dateRangeInputHarness: MatDateRangeInputHarness,
       isMdcImplementation: false,
-      errorHarness: MatErrorHarness,
+      errorHarness: MatLegacyErrorHarness,
     },
   );
 });

--- a/src/material/legacy-form-field/testing/form-field-harness.ts
+++ b/src/material/legacy-form-field/testing/form-field-harness.ts
@@ -17,7 +17,7 @@ import {
 } from '@angular/material/form-field/testing';
 import {MatLegacyInputHarness} from '@angular/material/legacy-input/testing';
 import {MatLegacySelectHarness} from '@angular/material/legacy-select/testing';
-import {MatErrorHarness} from './error-harness';
+import {MatLegacyErrorHarness} from './error-harness';
 
 // TODO(devversion): support support chip list harness
 /**
@@ -38,7 +38,7 @@ export type LegacyFormFieldControlHarness =
  */
 export class MatLegacyFormFieldHarness extends _MatFormFieldHarnessBase<
   LegacyFormFieldControlHarness,
-  typeof MatErrorHarness
+  typeof MatLegacyErrorHarness
 > {
   static hostSelector = '.mat-form-field';
 
@@ -69,7 +69,7 @@ export class MatLegacyFormFieldHarness extends _MatFormFieldHarnessBase<
   protected _selectControl = this.locatorForOptional(MatLegacySelectHarness);
   protected _datepickerInputControl = this.locatorForOptional(MatDatepickerInputHarness);
   protected _dateRangeInputControl = this.locatorForOptional(MatDateRangeInputHarness);
-  protected _errorHarness = MatErrorHarness;
+  protected _errorHarness = MatLegacyErrorHarness;
 
   /** Gets the appearance of the form-field. */
   async getAppearance(): Promise<'legacy' | 'standard' | 'fill' | 'outline'> {

--- a/src/material/legacy-form-field/testing/form-field-harness.ts
+++ b/src/material/legacy-form-field/testing/form-field-harness.ts
@@ -17,6 +17,7 @@ import {
 } from '@angular/material/form-field/testing';
 import {MatLegacyInputHarness} from '@angular/material/legacy-input/testing';
 import {MatLegacySelectHarness} from '@angular/material/legacy-select/testing';
+import {MatErrorHarness} from './error-harness';
 
 // TODO(devversion): support support chip list harness
 /**
@@ -35,7 +36,10 @@ export type LegacyFormFieldControlHarness =
  * @deprecated Use `MatFormFieldHarness` from `@angular/material/form-field/testing` instead. See https://material.angular.io/guide/mdc-migration for information about migrating.
  * @breaking-change 17.0.0
  */
-export class MatLegacyFormFieldHarness extends _MatFormFieldHarnessBase<LegacyFormFieldControlHarness> {
+export class MatLegacyFormFieldHarness extends _MatFormFieldHarnessBase<
+  LegacyFormFieldControlHarness,
+  typeof MatErrorHarness
+> {
   static hostSelector = '.mat-form-field';
 
   /**
@@ -65,6 +69,7 @@ export class MatLegacyFormFieldHarness extends _MatFormFieldHarnessBase<LegacyFo
   protected _selectControl = this.locatorForOptional(MatLegacySelectHarness);
   protected _datepickerInputControl = this.locatorForOptional(MatDatepickerInputHarness);
   protected _dateRangeInputControl = this.locatorForOptional(MatDateRangeInputHarness);
+  protected _errorHarness = MatErrorHarness;
 
   /** Gets the appearance of the form-field. */
   async getAppearance(): Promise<'legacy' | 'standard' | 'fill' | 'outline'> {

--- a/src/material/legacy-form-field/testing/public-api.ts
+++ b/src/material/legacy-form-field/testing/public-api.ts
@@ -7,6 +7,7 @@
  */
 
 export {LegacyFormFieldControlHarness, MatLegacyFormFieldHarness} from './form-field-harness';
+export {MatLegacyErrorHarness} from './error-harness';
 
 // Re-export the base control harness from the "form-field/testing/control" entry-point. To
 // avoid circular dependencies, harnesses for form-field controls (i.e. input, select)
@@ -25,4 +26,12 @@ export {
    * @breaking-change 17.0.0
    */
   FormFieldHarnessFilters as LegacyFormFieldHarnessFilters,
+} from '@angular/material/form-field/testing';
+
+export {
+  /**
+   * @deprecated Use `ErrorHarnessFilters` from `@angular/material/form-field/testing` instead. See https://material.angular.io/guide/mdc-migration for information about migrating.
+   * @breaking-change 17.0.0
+   */
+  ErrorHarnessFilters as LegacyErrorHarnessFilters,
 } from '@angular/material/form-field/testing';

--- a/tools/public_api_guard/material/form-field-testing.md
+++ b/tools/public_api_guard/material/form-field-testing.md
@@ -17,6 +17,11 @@ import { MatSelectHarness } from '@angular/material/select/testing';
 import { TestElement } from '@angular/cdk/testing';
 
 // @public
+export interface ErrorHarnessFilters extends BaseHarnessFilters {
+    text?: string | RegExp;
+}
+
+// @public
 export type FormFieldControlHarness = MatInputHarness | MatSelectHarness | MatDatepickerInputHarness | MatDateRangeInputHarness;
 
 // @public
@@ -25,14 +30,30 @@ export interface FormFieldHarnessFilters extends BaseHarnessFilters {
     hasErrors?: boolean;
 }
 
+// @public
+export class MatErrorHarness extends _MatErrorHarnessBase {
+    // (undocumented)
+    static hostSelector: string;
+    static with<T extends MatErrorHarness>(this: ComponentHarnessConstructor<T>, options?: ErrorHarnessFilters): HarnessPredicate<T>;
+}
+
+// @public (undocumented)
+export abstract class _MatErrorHarnessBase extends ComponentHarness {
+    // (undocumented)
+    protected static _getErrorPredicate<T extends MatErrorHarness>(type: ComponentHarnessConstructor<T>, options: ErrorHarnessFilters): HarnessPredicate<T>;
+    getText(): Promise<string>;
+}
+
 export { MatFormFieldControlHarness }
 
 // @public
-export class MatFormFieldHarness extends _MatFormFieldHarnessBase<FormFieldControlHarness> {
+export class MatFormFieldHarness extends _MatFormFieldHarnessBase<FormFieldControlHarness, typeof MatErrorHarness> {
     // (undocumented)
     protected _datepickerInputControl: AsyncFactoryFn<MatDatepickerInputHarness | null>;
     // (undocumented)
     protected _dateRangeInputControl: AsyncFactoryFn<MatDateRangeInputHarness | null>;
+    // (undocumented)
+    protected _errorHarness: typeof MatErrorHarness;
     // (undocumented)
     protected _errors: AsyncFactoryFn<TestElement[]>;
     getAppearance(): Promise<'fill' | 'outline'>;
@@ -56,17 +77,22 @@ export class MatFormFieldHarness extends _MatFormFieldHarnessBase<FormFieldContr
 }
 
 // @public (undocumented)
-export abstract class _MatFormFieldHarnessBase<ControlHarness extends MatFormFieldControlHarness> extends ComponentHarness {
+export abstract class _MatFormFieldHarnessBase<ControlHarness extends MatFormFieldControlHarness, ErrorType extends ComponentHarnessConstructor<ErrorBase> & {
+    with: (options?: ErrorHarnessFilters) => HarnessPredicate<ErrorBase>;
+}> extends ComponentHarness {
     // (undocumented)
     protected abstract _datepickerInputControl: AsyncFactoryFn<ControlHarness | null>;
     // (undocumented)
     protected abstract _dateRangeInputControl: AsyncFactoryFn<ControlHarness | null>;
+    // (undocumented)
+    protected abstract _errorHarness: ErrorType;
     // (undocumented)
     protected abstract _errors: AsyncFactoryFn<TestElement[]>;
     abstract getAppearance(): Promise<string>;
     getControl(): Promise<ControlHarness | null>;
     getControl<X extends MatFormFieldControlHarness>(type: ComponentHarnessConstructor<X>): Promise<X | null>;
     getControl<X extends MatFormFieldControlHarness>(type: HarnessPredicate<X>): Promise<X | null>;
+    getErrors(filter?: ErrorHarnessFilters): Promise<MatErrorHarness[]>;
     getLabel(): Promise<string | null>;
     getPrefixText(): Promise<string>;
     getSuffixText(): Promise<string>;

--- a/tools/public_api_guard/material/form-field-testing.md
+++ b/tools/public_api_guard/material/form-field-testing.md
@@ -54,8 +54,6 @@ export class MatFormFieldHarness extends _MatFormFieldHarnessBase<FormFieldContr
     protected _dateRangeInputControl: AsyncFactoryFn<MatDateRangeInputHarness | null>;
     // (undocumented)
     protected _errorHarness: typeof MatErrorHarness;
-    // (undocumented)
-    protected _errors: AsyncFactoryFn<TestElement[]>;
     getAppearance(): Promise<'fill' | 'outline'>;
     hasLabel(): Promise<boolean>;
     // (undocumented)
@@ -86,8 +84,6 @@ export abstract class _MatFormFieldHarnessBase<ControlHarness extends MatFormFie
     protected abstract _dateRangeInputControl: AsyncFactoryFn<ControlHarness | null>;
     // (undocumented)
     protected abstract _errorHarness: ErrorType;
-    // (undocumented)
-    protected abstract _errors: AsyncFactoryFn<TestElement[]>;
     abstract getAppearance(): Promise<string>;
     getControl(): Promise<ControlHarness | null>;
     getControl<X extends MatFormFieldControlHarness>(type: ComponentHarnessConstructor<X>): Promise<X | null>;

--- a/tools/public_api_guard/material/legacy-form-field-testing.md
+++ b/tools/public_api_guard/material/legacy-form-field-testing.md
@@ -5,10 +5,13 @@
 ```ts
 
 import { AsyncFactoryFn } from '@angular/cdk/testing';
+import { ComponentHarnessConstructor } from '@angular/cdk/testing';
+import { ErrorHarnessFilters } from '@angular/material/form-field/testing';
 import { HarnessPredicate } from '@angular/cdk/testing';
 import { FormFieldHarnessFilters as LegacyFormFieldHarnessFilters } from '@angular/material/form-field/testing';
 import { MatDatepickerInputHarness } from '@angular/material/datepicker/testing';
 import { MatDateRangeInputHarness } from '@angular/material/datepicker/testing';
+import { _MatErrorHarnessBase } from '@angular/material/form-field/testing';
 import { _MatFormFieldHarnessBase } from '@angular/material/form-field/testing';
 import { MatFormFieldControlHarness as MatLegacyFormFieldControlHarness } from '@angular/material/form-field/testing/control';
 import { MatLegacyInputHarness } from '@angular/material/legacy-input/testing';
@@ -23,11 +26,13 @@ export { LegacyFormFieldHarnessFilters }
 export { MatLegacyFormFieldControlHarness }
 
 // @public @deprecated
-export class MatLegacyFormFieldHarness extends _MatFormFieldHarnessBase<LegacyFormFieldControlHarness> {
+export class MatLegacyFormFieldHarness extends _MatFormFieldHarnessBase<LegacyFormFieldControlHarness, typeof MatErrorHarness> {
     // (undocumented)
     protected _datepickerInputControl: AsyncFactoryFn<MatDatepickerInputHarness | null>;
     // (undocumented)
     protected _dateRangeInputControl: AsyncFactoryFn<MatDateRangeInputHarness | null>;
+    // (undocumented)
+    protected _errorHarness: typeof MatErrorHarness;
     // (undocumented)
     protected _errors: AsyncFactoryFn<TestElement[]>;
     getAppearance(): Promise<'legacy' | 'standard' | 'fill' | 'outline'>;

--- a/tools/public_api_guard/material/legacy-form-field-testing.md
+++ b/tools/public_api_guard/material/legacy-form-field-testing.md
@@ -6,8 +6,8 @@
 
 import { AsyncFactoryFn } from '@angular/cdk/testing';
 import { ComponentHarnessConstructor } from '@angular/cdk/testing';
-import { ErrorHarnessFilters } from '@angular/material/form-field/testing';
 import { HarnessPredicate } from '@angular/cdk/testing';
+import { ErrorHarnessFilters as LegacyErrorHarnessFilters } from '@angular/material/form-field/testing';
 import { FormFieldHarnessFilters as LegacyFormFieldHarnessFilters } from '@angular/material/form-field/testing';
 import { MatDatepickerInputHarness } from '@angular/material/datepicker/testing';
 import { MatDateRangeInputHarness } from '@angular/material/datepicker/testing';
@@ -18,21 +18,30 @@ import { MatLegacyInputHarness } from '@angular/material/legacy-input/testing';
 import { MatLegacySelectHarness } from '@angular/material/legacy-select/testing';
 import { TestElement } from '@angular/cdk/testing';
 
+export { LegacyErrorHarnessFilters }
+
 // @public @deprecated
 export type LegacyFormFieldControlHarness = MatLegacyInputHarness | MatLegacySelectHarness | MatDatepickerInputHarness | MatDateRangeInputHarness;
 
 export { LegacyFormFieldHarnessFilters }
 
+// @public @deprecated
+export class MatLegacyErrorHarness extends _MatErrorHarnessBase {
+    // (undocumented)
+    static hostSelector: string;
+    static with<T extends MatLegacyErrorHarness>(this: ComponentHarnessConstructor<T>, options?: LegacyErrorHarnessFilters): HarnessPredicate<T>;
+}
+
 export { MatLegacyFormFieldControlHarness }
 
 // @public @deprecated
-export class MatLegacyFormFieldHarness extends _MatFormFieldHarnessBase<LegacyFormFieldControlHarness, typeof MatErrorHarness> {
+export class MatLegacyFormFieldHarness extends _MatFormFieldHarnessBase<LegacyFormFieldControlHarness, typeof MatLegacyErrorHarness> {
     // (undocumented)
     protected _datepickerInputControl: AsyncFactoryFn<MatDatepickerInputHarness | null>;
     // (undocumented)
     protected _dateRangeInputControl: AsyncFactoryFn<MatDateRangeInputHarness | null>;
     // (undocumented)
-    protected _errorHarness: typeof MatErrorHarness;
+    protected _errorHarness: typeof MatLegacyErrorHarness;
     // (undocumented)
     protected _errors: AsyncFactoryFn<TestElement[]>;
     getAppearance(): Promise<'legacy' | 'standard' | 'fill' | 'outline'>;


### PR DESCRIPTION
Add an error harness for client tests checking whether there are certain errors on the page. This is very common internally for tests checking validation. 

The harness can be retrieved directly or through the form field.

I tried to check the right inheritance structure of other harnesses - might have gotten something mixed up on the way. Would appreciate a review making sure I've got the right inheritance of things. The harness tests passed so that's a good sign.