### PR TITLE
feat(material/core): add option to disable core typography

### DIFF
--- a/src/material/core/_core.scss
+++ b/src/material/core/_core.scss
@@ -6,8 +6,12 @@
 @use './typography/all-typography';
 
 // Mixin that renders all of the core styles that are not theme-dependent.
-@mixin core($typography-config: null) {
-  @include all-typography.all-component-typographies($typography-config);
+// TODO: Remove the `$exclude-typography` parameter once `ng update` automatically migrates
+// client theme applications to manually include the typography mixin.
+@mixin core($typography-config: null, $exclude-typography: false) {
+  @if not $exclude-typography {
+    @include all-typography.all-component-typographies($typography-config);
+  }
   @include ripple.ripple();
   @include cdk.a11y-visually-hidden();
   @include cdk.overlay();

--- a/src/material/legacy-core/_core.scss
+++ b/src/material/legacy-core/_core.scss
@@ -7,10 +7,14 @@
 @use '../core/focus-indicators/private';
 
 // Mixin that renders all of the core styles that are not theme-dependent.
+// TODO: Remove the `$exclude-typography` parameter once `ng update` automatically migrates
+// client theme applications to manually include the typography mixin.
 /// @deprecated Use `mat.core` instead. See https://material.angular.io/guide/mdc-migration for information about migrating.
 /// @breaking-change 17.0.0
-@mixin core($typography-config: null) {
-  @include all-typography.all-legacy-component-typographies($typography-config);
+@mixin core($typography-config: null, $exclude-typography: false) {
+  @if not $exclude-typography {
+    @include all-typography.all-legacy-component-typographies($typography-config);
+  }
   @include ripple.ripple();
   @include cdk.a11y-visually-hidden();
   @include cdk.overlay();


### PR DESCRIPTION
Adds an optional flag to the `core` mixin that can controls whether typography styles are emitted. This is planned to be a temporary addition before the v15 launch in order to migrate google3. Once all clients use this flag, it can be removed and the typography can be removed. For backwards compatibility, the `ng update` script will take care of external clients when they upgrade so that `mat.core()` will turn into `mat.all-component-typographies(); mat.core()`.