### PR TITLE
fix(material/schematics): remove `node_modules` prefix from prebuilt theme

### DIFF
--- a/integration/ng-update-v13/src/test.ts
+++ b/integration/ng-update-v13/src/test.ts
@@ -7,21 +7,5 @@ import {
   platformBrowserDynamicTesting,
 } from '@angular/platform-browser-dynamic/testing';
 
-declare const require: {
-  context(
-    path: string,
-    deep?: boolean,
-    filter?: RegExp,
-  ): {
-    keys(): string[];
-    <T>(id: string): T;
-  };
-};
-
 // First, initialize the Angular testing environment.
 getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
-
-// Then we find all the tests.
-const context = require.context('./', true, /\.spec\.ts$/);
-// And load the modules.
-context.keys().map(context);

--- a/integration/yarn-pnp-compat/angular.json
+++ b/integration/yarn-pnp-compat/angular.json
@@ -27,7 +27,7 @@
             "tsConfig": "tsconfig.app.json",
             "inlineStyleLanguage": "scss",
             "assets": ["src/favicon.ico", "src/assets"],
-            "styles": ["src/styles.scss"],
+            "styles": ["@angular/material/prebuilt-themes/indigo-pink.css", "src/styles.scss"],
             "scripts": []
           },
           "configurations": {
@@ -90,10 +90,7 @@
             "karmaConfig": "karma.conf.js",
             "inlineStyleLanguage": "scss",
             "assets": ["src/favicon.ico", "src/assets"],
-            "styles": [
-              "./node_modules/@angular/material/prebuilt-themes/indigo-pink.css",
-              "src/styles.scss"
-            ],
+            "styles": ["@angular/material/prebuilt-themes/indigo-pink.css", "src/styles.scss"],
             "scripts": []
           }
         }

--- a/integration/yarn-pnp-compat/package.json
+++ b/integration/yarn-pnp-compat/package.json
@@ -26,8 +26,8 @@
     "zone.js": "~0.11.4"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^15.0.0-next.0",
-    "@angular/cli": "^15.0.0-next.0",
+    "@angular-devkit/build-angular": "^15.0.0-next.6",
+    "@angular/cli": "^15.0.0-next.6",
     "@angular/compiler-cli": "^15.0.0-next.0",
     "@types/jasmine": "~3.10.0",
     "@types/node": "^12.11.1",

--- a/integration/yarn-pnp-compat/src/test.ts
+++ b/integration/yarn-pnp-compat/src/test.ts
@@ -7,21 +7,5 @@ import {
   platformBrowserDynamicTesting,
 } from '@angular/platform-browser-dynamic/testing';
 
-declare const require: {
-  context(
-    path: string,
-    deep?: boolean,
-    filter?: RegExp,
-  ): {
-    <T>(id: string): T;
-    keys(): string[];
-  };
-};
-
 // First, initialize the Angular testing environment.
 getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
-
-// Then we find all the tests.
-const context = require.context('./', true, /\.spec\.ts$/);
-// And load the modules.
-context.keys().map(context);

--- a/integration/yarn-pnp-compat/yarn.lock
+++ b/integration/yarn-pnp-compat/yarn.lock
@@ -5,13 +5,6 @@ __metadata:
   version: 6
   cacheKey: 8
 
-"@adobe/css-tools@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "@adobe/css-tools@npm:4.0.1"
-  checksum: 80226e2229024c21da9ffa6b5cd4a34b931f071e06f45aba4777ade071d7a6c94605cf73b13718b0c4b34e8b124c65c607b82eaa53a326d3eb73d9682a04a593
-  languageName: node
-  linkType: hard
-
 "@ampproject/remapping@npm:2.2.0":
   version: 2.2.0
   resolution: "@ampproject/remapping@npm:2.2.0"
@@ -41,52 +34,54 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@angular-devkit/architect@npm:0.1500.0-next.0":
-  version: 0.1500.0-next.0
-  resolution: "@angular-devkit/architect@npm:0.1500.0-next.0"
+"@angular-devkit/architect@npm:0.1500.0-next.6":
+  version: 0.1500.0-next.6
+  resolution: "@angular-devkit/architect@npm:0.1500.0-next.6"
   dependencies:
-    "@angular-devkit/core": 15.0.0-next.0
+    "@angular-devkit/core": 15.0.0-next.6
     rxjs: 6.6.7
-  checksum: 5253baabb002234607615800db40da1ae2481915488708b44f6781b290bb02df31a593b187279e5fe397dd5ac2aeef73bb3325e6aab67a2c9f59cbd003003462
+  checksum: 73a491347605290b7a6957c6589dc4c2d289773780d22b2d746cdfdb2129de55c5a1bee19111299d031635b58ba9dd2d125748307a2809ca93a045ace665c5d4
   languageName: node
   linkType: hard
 
-"@angular-devkit/build-angular@npm:^15.0.0-next.0":
-  version: 15.0.0-next.0
-  resolution: "@angular-devkit/build-angular@npm:15.0.0-next.0"
+"@angular-devkit/build-angular@npm:^15.0.0-next.6":
+  version: 15.0.0-next.6
+  resolution: "@angular-devkit/build-angular@npm:15.0.0-next.6"
   dependencies:
     "@ampproject/remapping": 2.2.0
-    "@angular-devkit/architect": 0.1500.0-next.0
-    "@angular-devkit/build-webpack": 0.1500.0-next.0
-    "@angular-devkit/core": 15.0.0-next.0
-    "@babel/core": 7.19.0
-    "@babel/generator": 7.19.0
+    "@angular-devkit/architect": 0.1500.0-next.6
+    "@angular-devkit/build-webpack": 0.1500.0-next.6
+    "@angular-devkit/core": 15.0.0-next.6
+    "@babel/core": 7.19.3
+    "@babel/generator": 7.19.5
     "@babel/helper-annotate-as-pure": 7.18.6
-    "@babel/plugin-proposal-async-generator-functions": 7.19.0
+    "@babel/plugin-proposal-async-generator-functions": 7.19.1
     "@babel/plugin-transform-async-to-generator": 7.18.6
-    "@babel/plugin-transform-runtime": 7.18.10
-    "@babel/preset-env": 7.19.0
-    "@babel/runtime": 7.19.0
+    "@babel/plugin-transform-runtime": 7.19.1
+    "@babel/preset-env": 7.19.4
+    "@babel/runtime": 7.19.4
     "@babel/template": 7.18.10
     "@discoveryjs/json-ext": 0.5.7
-    "@ngtools/webpack": 15.0.0-next.0
+    "@ngtools/webpack": 15.0.0-next.6
     ansi-colors: 4.1.3
+    autoprefixer: 10.4.12
     babel-loader: 8.2.5
     babel-plugin-istanbul: 6.1.1
     browserslist: ^4.9.1
-    cacache: 16.1.3
+    cacache: 17.0.0
+    chokidar: 3.5.3
     copy-webpack-plugin: 11.0.0
     critters: 0.0.16
     css-loader: 6.7.1
-    esbuild: 0.15.7
-    esbuild-wasm: 0.15.7
+    esbuild: 0.15.10
+    esbuild-wasm: 0.15.10
     glob: 8.0.3
     https-proxy-agent: 5.0.1
     inquirer: 8.2.4
     jsonc-parser: 3.2.0
     karma-source-map-support: 1.4.0
     less: 4.1.3
-    less-loader: 11.0.0
+    less-loader: 11.1.0
     license-webpack-plugin: 4.0.2
     loader-utils: 3.2.0
     mini-css-extract-plugin: 2.6.1
@@ -95,43 +90,42 @@ __metadata:
     ora: 5.4.1
     parse5-html-rewriting-stream: 6.0.1
     piscina: 3.2.0
-    postcss: 8.4.16
-    postcss-import: 15.0.0
+    postcss: 8.4.18
     postcss-loader: 7.0.1
-    postcss-preset-env: 7.8.1
-    regenerator-runtime: 0.13.9
+    regenerator-runtime: 0.13.10
     resolve-url-loader: 5.0.0
     rxjs: 6.6.7
-    sass: 1.54.9
-    sass-loader: 13.0.2
-    semver: 7.3.7
-    source-map-loader: 4.0.0
+    sass: 1.55.0
+    sass-loader: 13.1.0
+    semver: 7.3.8
+    source-map-loader: 4.0.1
     source-map-support: 0.5.21
-    stylus: 0.59.0
-    stylus-loader: 7.0.0
-    terser: 5.15.0
+    terser: 5.15.1
     text-table: 0.2.0
     tree-kill: 1.2.2
     tslib: 2.4.0
     webpack: 5.74.0
     webpack-dev-middleware: 5.3.3
-    webpack-dev-server: 4.11.0
+    webpack-dev-server: 4.11.1
     webpack-merge: 5.8.0
     webpack-subresource-integrity: 5.1.0
   peerDependencies:
     "@angular/compiler-cli": ^15.0.0-next
     "@angular/localize": ^15.0.0-next
+    "@angular/platform-server": ^15.0.0-next
     "@angular/service-worker": ^15.0.0-next
     karma: ^6.3.0
     ng-packagr: ^15.0.0-next
     protractor: ^7.0.0
     tailwindcss: ^2.0.0 || ^3.0.0
-    typescript: ">=4.6.2 <4.9"
+    typescript: ~4.8.2
   dependenciesMeta:
     esbuild:
       optional: true
   peerDependenciesMeta:
     "@angular/localize":
+      optional: true
+    "@angular/platform-server":
       optional: true
     "@angular/service-worker":
       optional: true
@@ -143,26 +137,26 @@ __metadata:
       optional: true
     tailwindcss:
       optional: true
-  checksum: c869e8026dd8f82a67ac45b0e55e6e030f1d56f43307c35c3c203f09e33e85b3da06f02b66cd345a34fda93da32ad225f2605d8665cf4bdefd4a6748350a1a59
+  checksum: 51738696dd0b4c5bbca3703caae4a598c8d6e0a19c229b9e896f2172bbc6eda2d3d796946e3b09de764fe6daf7cb6c70f7d5390ae59dd6afee8212004080e357
   languageName: node
   linkType: hard
 
-"@angular-devkit/build-webpack@npm:0.1500.0-next.0":
-  version: 0.1500.0-next.0
-  resolution: "@angular-devkit/build-webpack@npm:0.1500.0-next.0"
+"@angular-devkit/build-webpack@npm:0.1500.0-next.6":
+  version: 0.1500.0-next.6
+  resolution: "@angular-devkit/build-webpack@npm:0.1500.0-next.6"
   dependencies:
-    "@angular-devkit/architect": 0.1500.0-next.0
+    "@angular-devkit/architect": 0.1500.0-next.6
     rxjs: 6.6.7
   peerDependencies:
     webpack: ^5.30.0
     webpack-dev-server: ^4.0.0
-  checksum: 921112ebe9b3cd17e614f1a4cfd03a14873f444a3fb6387aea8f7191ddda15d13cdf3669342db76c91e478dcb1b37853dd0aef680e7342e32e124c713da5dba6
+  checksum: 66542a524b7f11fc1ff2e064935e3fdf8f08ddc40662569c1ea66a38e4306c00c9606d134c9544666dd3befe8fd139f2abbdfe77ef74859935c74b61eafb878c
   languageName: node
   linkType: hard
 
-"@angular-devkit/core@npm:15.0.0-next.0":
-  version: 15.0.0-next.0
-  resolution: "@angular-devkit/core@npm:15.0.0-next.0"
+"@angular-devkit/core@npm:15.0.0-next.6":
+  version: 15.0.0-next.6
+  resolution: "@angular-devkit/core@npm:15.0.0-next.6"
   dependencies:
     ajv: 8.11.0
     ajv-formats: 2.1.1
@@ -174,20 +168,20 @@ __metadata:
   peerDependenciesMeta:
     chokidar:
       optional: true
-  checksum: 53b11d9c7c7c10c69ae41dc3f593f592549ccc1afd994845d00649ca208f85d4d7c90c0cc70b5ee206270e61e9113682312d5f02b5768ae15f8115b93ff25382
+  checksum: 2c0e123f5bc4cb812c6f9520942084eb3309feeca6216c57f23fe397cad7e3b41268ff5ba0a083357e6080f1fdfd881cb4916e07ec09756423412c75d462e0bf
   languageName: node
   linkType: hard
 
-"@angular-devkit/schematics@npm:15.0.0-next.0":
-  version: 15.0.0-next.0
-  resolution: "@angular-devkit/schematics@npm:15.0.0-next.0"
+"@angular-devkit/schematics@npm:15.0.0-next.6":
+  version: 15.0.0-next.6
+  resolution: "@angular-devkit/schematics@npm:15.0.0-next.6"
   dependencies:
-    "@angular-devkit/core": 15.0.0-next.0
+    "@angular-devkit/core": 15.0.0-next.6
     jsonc-parser: 3.2.0
-    magic-string: 0.26.3
+    magic-string: 0.26.7
     ora: 5.4.1
     rxjs: 6.6.7
-  checksum: b59e9374c6ed23586bc130f5d37cc64eb47528441f6d0745024b9a9e74b0261fb1ae5186b8601e70507eac87ce6aa129b14075e8df21a813241bb714699c7e5d
+  checksum: 13699eadb7600d6464057777d59a144f452bf24e171f75904e67457bc83e8ed73ecb7aba1969960c067638f744e3366b94aba191cea1590b393fe059f6ad2db1
   languageName: node
   linkType: hard
 
@@ -203,49 +197,47 @@ __metadata:
   linkType: hard
 
 "@angular/cdk@file:../../dist/releases/cdk::locator=yarn-pnp-compat%40workspace%3A.":
-  version: 15.0.0-next.0+sha-8f11370-with-local-changes
-  resolution: "@angular/cdk@file:../../dist/releases/cdk#../../dist/releases/cdk::hash=a7d9c5&locator=yarn-pnp-compat%40workspace%3A."
+  version: 15.1.0-next.0+sha-baaf7c9-with-local-changes
+  resolution: "@angular/cdk@file:../../dist/releases/cdk#../../dist/releases/cdk::hash=7e7cc5&locator=yarn-pnp-compat%40workspace%3A."
   dependencies:
     parse5: ^5.0.0
     tslib: ^2.3.0
   peerDependencies:
-    "@angular/common": ^14.0.0 || ^15.0.0
-    "@angular/core": ^14.0.0 || ^15.0.0
+    "@angular/common": ^15.0.0-0 || ^16.0.0
+    "@angular/core": ^15.0.0-0 || ^16.0.0
     rxjs: ^6.5.3 || ^7.4.0
   dependenciesMeta:
     parse5:
       optional: true
-  checksum: bbcffc7d75b70a6aa9aeba0404e1f296490409d753ebd2b0a7ad4ecb3bf92657f34648b80c0120955ff2dfd69c6d36f1334afcde41ec6b7ada041d2b8f61ded9
+  checksum: afad6530a7268ff520196cbd0cf47f705116169fb42b59357f679aa2b3eeb0add50701030a540aee3ccae913147adefe0d27816136bb8427c29569d4ec38f929
   languageName: node
   linkType: hard
 
-"@angular/cli@npm:^15.0.0-next.0":
-  version: 15.0.0-next.0
-  resolution: "@angular/cli@npm:15.0.0-next.0"
+"@angular/cli@npm:^15.0.0-next.6":
+  version: 15.0.0-next.6
+  resolution: "@angular/cli@npm:15.0.0-next.6"
   dependencies:
-    "@angular-devkit/architect": 0.1500.0-next.0
-    "@angular-devkit/core": 15.0.0-next.0
-    "@angular-devkit/schematics": 15.0.0-next.0
-    "@schematics/angular": 15.0.0-next.0
+    "@angular-devkit/architect": 0.1500.0-next.6
+    "@angular-devkit/core": 15.0.0-next.6
+    "@angular-devkit/schematics": 15.0.0-next.6
+    "@schematics/angular": 15.0.0-next.6
     "@yarnpkg/lockfile": 1.1.0
     ansi-colors: 4.1.3
-    debug: 4.3.4
     ini: 3.0.1
     inquirer: 8.2.4
     jsonc-parser: 3.2.0
-    npm-package-arg: 9.1.0
+    npm-package-arg: 9.1.2
     npm-pick-manifest: 7.0.2
     open: 8.4.0
     ora: 5.4.1
-    pacote: 13.6.2
+    pacote: 15.0.0
     resolve: 1.22.1
-    semver: 7.3.7
+    semver: 7.3.8
     symbol-observable: 4.0.0
-    uuid: 9.0.0
-    yargs: 17.5.1
+    yargs: 17.6.0
   bin:
     ng: bin/ng.js
-  checksum: f56ca287f544f9abccd33fa93381ae68a259fa3f508e6c49038fa93c994090d6add5de8a8d45617b5142b88866a1cbc797a6161d21677176cdf80dd6ebf902a5
+  checksum: 0dd9148f218f28d47a07c0d54f2014224b1cf2ee04a78f7d8a168c7fa2957b17743c754eae5ad795671e1a988536de04385fa9c3fa05c1ba4773d6a812ce95f1
   languageName: node
   linkType: hard
 
@@ -391,66 +383,66 @@ __metadata:
   linkType: hard
 
 "@angular/material@file:../../dist/releases/material::locator=yarn-pnp-compat%40workspace%3A.":
-  version: 15.0.0-next.0+sha-8f11370-with-local-changes
-  resolution: "@angular/material@file:../../dist/releases/material#../../dist/releases/material::hash=c1afc7&locator=yarn-pnp-compat%40workspace%3A."
+  version: 15.1.0-next.0+sha-baaf7c9-with-local-changes
+  resolution: "@angular/material@file:../../dist/releases/material#../../dist/releases/material::hash=59f60e&locator=yarn-pnp-compat%40workspace%3A."
   dependencies:
-    "@material/animation": 15.0.0-canary.10196647d.0
-    "@material/auto-init": 15.0.0-canary.10196647d.0
-    "@material/banner": 15.0.0-canary.10196647d.0
-    "@material/base": 15.0.0-canary.10196647d.0
-    "@material/button": 15.0.0-canary.10196647d.0
-    "@material/card": 15.0.0-canary.10196647d.0
-    "@material/checkbox": 15.0.0-canary.10196647d.0
-    "@material/chips": 15.0.0-canary.10196647d.0
-    "@material/circular-progress": 15.0.0-canary.10196647d.0
-    "@material/data-table": 15.0.0-canary.10196647d.0
-    "@material/density": 15.0.0-canary.10196647d.0
-    "@material/dialog": 15.0.0-canary.10196647d.0
-    "@material/dom": 15.0.0-canary.10196647d.0
-    "@material/drawer": 15.0.0-canary.10196647d.0
-    "@material/elevation": 15.0.0-canary.10196647d.0
-    "@material/fab": 15.0.0-canary.10196647d.0
-    "@material/feature-targeting": 15.0.0-canary.10196647d.0
-    "@material/floating-label": 15.0.0-canary.10196647d.0
-    "@material/form-field": 15.0.0-canary.10196647d.0
-    "@material/icon-button": 15.0.0-canary.10196647d.0
-    "@material/image-list": 15.0.0-canary.10196647d.0
-    "@material/layout-grid": 15.0.0-canary.10196647d.0
-    "@material/line-ripple": 15.0.0-canary.10196647d.0
-    "@material/linear-progress": 15.0.0-canary.10196647d.0
-    "@material/list": 15.0.0-canary.10196647d.0
-    "@material/menu": 15.0.0-canary.10196647d.0
-    "@material/menu-surface": 15.0.0-canary.10196647d.0
-    "@material/notched-outline": 15.0.0-canary.10196647d.0
-    "@material/radio": 15.0.0-canary.10196647d.0
-    "@material/ripple": 15.0.0-canary.10196647d.0
-    "@material/rtl": 15.0.0-canary.10196647d.0
-    "@material/segmented-button": 15.0.0-canary.10196647d.0
-    "@material/select": 15.0.0-canary.10196647d.0
-    "@material/shape": 15.0.0-canary.10196647d.0
-    "@material/slider": 15.0.0-canary.10196647d.0
-    "@material/snackbar": 15.0.0-canary.10196647d.0
-    "@material/switch": 15.0.0-canary.10196647d.0
-    "@material/tab": 15.0.0-canary.10196647d.0
-    "@material/tab-bar": 15.0.0-canary.10196647d.0
-    "@material/tab-indicator": 15.0.0-canary.10196647d.0
-    "@material/tab-scroller": 15.0.0-canary.10196647d.0
-    "@material/textfield": 15.0.0-canary.10196647d.0
-    "@material/theme": 15.0.0-canary.10196647d.0
-    "@material/tooltip": 15.0.0-canary.10196647d.0
-    "@material/top-app-bar": 15.0.0-canary.10196647d.0
-    "@material/touch-target": 15.0.0-canary.10196647d.0
-    "@material/typography": 15.0.0-canary.10196647d.0
+    "@material/animation": 15.0.0-canary.a515a2d18.0
+    "@material/auto-init": 15.0.0-canary.a515a2d18.0
+    "@material/banner": 15.0.0-canary.a515a2d18.0
+    "@material/base": 15.0.0-canary.a515a2d18.0
+    "@material/button": 15.0.0-canary.a515a2d18.0
+    "@material/card": 15.0.0-canary.a515a2d18.0
+    "@material/checkbox": 15.0.0-canary.a515a2d18.0
+    "@material/chips": 15.0.0-canary.a515a2d18.0
+    "@material/circular-progress": 15.0.0-canary.a515a2d18.0
+    "@material/data-table": 15.0.0-canary.a515a2d18.0
+    "@material/density": 15.0.0-canary.a515a2d18.0
+    "@material/dialog": 15.0.0-canary.a515a2d18.0
+    "@material/dom": 15.0.0-canary.a515a2d18.0
+    "@material/drawer": 15.0.0-canary.a515a2d18.0
+    "@material/elevation": 15.0.0-canary.a515a2d18.0
+    "@material/fab": 15.0.0-canary.a515a2d18.0
+    "@material/feature-targeting": 15.0.0-canary.a515a2d18.0
+    "@material/floating-label": 15.0.0-canary.a515a2d18.0
+    "@material/form-field": 15.0.0-canary.a515a2d18.0
+    "@material/icon-button": 15.0.0-canary.a515a2d18.0
+    "@material/image-list": 15.0.0-canary.a515a2d18.0
+    "@material/layout-grid": 15.0.0-canary.a515a2d18.0
+    "@material/line-ripple": 15.0.0-canary.a515a2d18.0
+    "@material/linear-progress": 15.0.0-canary.a515a2d18.0
+    "@material/list": 15.0.0-canary.a515a2d18.0
+    "@material/menu": 15.0.0-canary.a515a2d18.0
+    "@material/menu-surface": 15.0.0-canary.a515a2d18.0
+    "@material/notched-outline": 15.0.0-canary.a515a2d18.0
+    "@material/radio": 15.0.0-canary.a515a2d18.0
+    "@material/ripple": 15.0.0-canary.a515a2d18.0
+    "@material/rtl": 15.0.0-canary.a515a2d18.0
+    "@material/segmented-button": 15.0.0-canary.a515a2d18.0
+    "@material/select": 15.0.0-canary.a515a2d18.0
+    "@material/shape": 15.0.0-canary.a515a2d18.0
+    "@material/slider": 15.0.0-canary.a515a2d18.0
+    "@material/snackbar": 15.0.0-canary.a515a2d18.0
+    "@material/switch": 15.0.0-canary.a515a2d18.0
+    "@material/tab": 15.0.0-canary.a515a2d18.0
+    "@material/tab-bar": 15.0.0-canary.a515a2d18.0
+    "@material/tab-indicator": 15.0.0-canary.a515a2d18.0
+    "@material/tab-scroller": 15.0.0-canary.a515a2d18.0
+    "@material/textfield": 15.0.0-canary.a515a2d18.0
+    "@material/theme": 15.0.0-canary.a515a2d18.0
+    "@material/tooltip": 15.0.0-canary.a515a2d18.0
+    "@material/top-app-bar": 15.0.0-canary.a515a2d18.0
+    "@material/touch-target": 15.0.0-canary.a515a2d18.0
+    "@material/typography": 15.0.0-canary.a515a2d18.0
     tslib: ^2.3.0
   peerDependencies:
-    "@angular/animations": ^14.0.0 || ^15.0.0
-    "@angular/cdk": 15.0.0-next.0+sha-8f11370-with-local-changes
-    "@angular/common": ^14.0.0 || ^15.0.0
-    "@angular/core": ^14.0.0 || ^15.0.0
-    "@angular/forms": ^14.0.0 || ^15.0.0
-    "@angular/platform-browser": ^14.0.0 || ^15.0.0
+    "@angular/animations": ^15.0.0-0 || ^16.0.0
+    "@angular/cdk": 15.1.0-next.0+sha-baaf7c9-with-local-changes
+    "@angular/common": ^15.0.0-0 || ^16.0.0
+    "@angular/core": ^15.0.0-0 || ^16.0.0
+    "@angular/forms": ^15.0.0-0 || ^16.0.0
+    "@angular/platform-browser": ^15.0.0-0 || ^16.0.0
     rxjs: ^6.5.3 || ^7.4.0
-  checksum: b7013d2b09523c0cebe08b31253f9314f395c86adc9372ee270ef32beaaa7713e00276f8ce4ad02c4a9f6caec547581b27e90db48d1dfc5106193023f92de62e
+  checksum: 8d1c79bfcca1b232834a9d603660e445038eadf56d433b13c6cc8cc037a1aab2799c3e276da2dad923e636ec167ac4dd036f43aeb6d8ad507cb1a613749fa202
   languageName: node
   linkType: hard
 
@@ -551,26 +543,33 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/core@npm:7.19.0":
-  version: 7.19.0
-  resolution: "@babel/core@npm:7.19.0"
+"@babel/compat-data@npm:^7.19.3, @babel/compat-data@npm:^7.19.4":
+  version: 7.19.4
+  resolution: "@babel/compat-data@npm:7.19.4"
+  checksum: 757fdaeb6756c2d323ff56f60fb8e670292108cda6abf762a56c0d40910ecc4d2c7e283dbdfbcee6bc28c74ad659144352609e1cb49d31e101ab13ea5ce90072
+  languageName: node
+  linkType: hard
+
+"@babel/core@npm:7.19.3":
+  version: 7.19.3
+  resolution: "@babel/core@npm:7.19.3"
   dependencies:
     "@ampproject/remapping": ^2.1.0
     "@babel/code-frame": ^7.18.6
-    "@babel/generator": ^7.19.0
-    "@babel/helper-compilation-targets": ^7.19.0
+    "@babel/generator": ^7.19.3
+    "@babel/helper-compilation-targets": ^7.19.3
     "@babel/helper-module-transforms": ^7.19.0
     "@babel/helpers": ^7.19.0
-    "@babel/parser": ^7.19.0
+    "@babel/parser": ^7.19.3
     "@babel/template": ^7.18.10
-    "@babel/traverse": ^7.19.0
-    "@babel/types": ^7.19.0
+    "@babel/traverse": ^7.19.3
+    "@babel/types": ^7.19.3
     convert-source-map: ^1.7.0
     debug: ^4.1.0
     gensync: ^1.0.0-beta.2
     json5: ^2.2.1
     semver: ^6.3.0
-  checksum: 0d5b52b552e215802d2fd7b266611c390d90b28dece09db8a142666c32928c5d404eb72a95630b4cb726c4d80a53fcdc2d6464cd7ad28bb26087475f1b2205e2
+  checksum: dd883311209ad5a2c65b227daeb7247d90a382c50f4c6ad60c5ee40927eb39c34f0690d93b775c0427794261b72fa8f9296589a2dbda0782366a9f1c6de00c08
   languageName: node
   linkType: hard
 
@@ -643,14 +642,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/generator@npm:7.19.0, @babel/generator@npm:^7.19.0":
-  version: 7.19.0
-  resolution: "@babel/generator@npm:7.19.0"
+"@babel/generator@npm:7.19.5, @babel/generator@npm:^7.19.3, @babel/generator@npm:^7.19.4":
+  version: 7.19.5
+  resolution: "@babel/generator@npm:7.19.5"
   dependencies:
-    "@babel/types": ^7.19.0
+    "@babel/types": ^7.19.4
     "@jridgewell/gen-mapping": ^0.3.2
     jsesc: ^2.5.1
-  checksum: aa3d5785cf8f8e81672dcc61aef351188efeadb20d9f66d79113d82cbcf3bbbdeb829989fa14582108572ddbc4e4027bdceb06ccaf5ec40fa93c2dda8fbcd4aa
+  checksum: a66eafc540f80fc36c1b009b28bde1d12aff85e7916e7f5adf49c5a8866fecee4906b3c3c6db315d2723ea54e4e5ddfb2913fe6ab424f51dbccf753000930eaf
   languageName: node
   linkType: hard
 
@@ -695,6 +694,17 @@ __metadata:
     "@jridgewell/gen-mapping": ^0.3.2
     jsesc: ^2.5.1
   checksum: 07dd71d255144bb703a80ab0156c35d64172ce81ddfb70ff24e2be687b052080233840c9a28d92fa2c33f7ecb8a8b30aef03b807518afc53b74c7908bf8859b1
+  languageName: node
+  linkType: hard
+
+"@babel/generator@npm:^7.19.0":
+  version: 7.19.0
+  resolution: "@babel/generator@npm:7.19.0"
+  dependencies:
+    "@babel/types": ^7.19.0
+    "@jridgewell/gen-mapping": ^0.3.2
+    jsesc: ^2.5.1
+  checksum: aa3d5785cf8f8e81672dcc61aef351188efeadb20d9f66d79113d82cbcf3bbbdeb829989fa14582108572ddbc4e4027bdceb06ccaf5ec40fa93c2dda8fbcd4aa
   languageName: node
   linkType: hard
 
@@ -782,6 +792,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-compilation-targets@npm:^7.19.3":
+  version: 7.19.3
+  resolution: "@babel/helper-compilation-targets@npm:7.19.3"
+  dependencies:
+    "@babel/compat-data": ^7.19.3
+    "@babel/helper-validator-option": ^7.18.6
+    browserslist: ^4.21.3
+    semver: ^6.3.0
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: aafcb4490c98cddb3255fff98bfbdb881b4def85a1935fd9b1f9b1f0f8b502696839f6b387fb508ca991ea72ba82ce6913bab99f21df4ce80bda2b79e91a09f5
+  languageName: node
+  linkType: hard
+
 "@babel/helper-create-class-features-plugin@npm:^7.18.6":
   version: 7.18.9
   resolution: "@babel/helper-create-class-features-plugin@npm:7.18.9"
@@ -832,22 +856,6 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0
   checksum: 811cc90afe9fc25a74ed37fc0c1361a4a91b0b940235dd3958e3f03b366d40a903b40fc93b51bcb93be774aba573219f8f215664bea1d1301f58797ca6854f3f
-  languageName: node
-  linkType: hard
-
-"@babel/helper-define-polyfill-provider@npm:^0.3.2":
-  version: 0.3.2
-  resolution: "@babel/helper-define-polyfill-provider@npm:0.3.2"
-  dependencies:
-    "@babel/helper-compilation-targets": ^7.17.7
-    "@babel/helper-plugin-utils": ^7.16.7
-    debug: ^4.1.1
-    lodash.debounce: ^4.0.8
-    resolve: ^1.14.2
-    semver: ^6.1.2
-  peerDependencies:
-    "@babel/core": ^7.4.0-0
-  checksum: 8f693ab8e9d73873c2e547c7764c7d32d73c14f8dcefdd67fd3a038eb75527e2222aa53412ea673b9bfc01c32a8779a60e77a7381bbdd83452f05c9b7ef69c2c
   languageName: node
   linkType: hard
 
@@ -1169,6 +1177,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-string-parser@npm:^7.19.4":
+  version: 7.19.4
+  resolution: "@babel/helper-string-parser@npm:7.19.4"
+  checksum: b2f8a3920b30dfac81ec282ac4ad9598ea170648f8254b10f475abe6d944808fb006aab325d3eb5a8ad3bea8dfa888cfa6ef471050dae5748497c110ec060943
+  languageName: node
+  linkType: hard
+
 "@babel/helper-validator-identifier@npm:^7.16.7":
   version: 7.16.7
   resolution: "@babel/helper-validator-identifier@npm:7.16.7"
@@ -1180,6 +1195,13 @@ __metadata:
   version: 7.18.6
   resolution: "@babel/helper-validator-identifier@npm:7.18.6"
   checksum: e295254d616bbe26e48c196a198476ab4d42a73b90478c9842536cf910ead887f5af6b5c4df544d3052a25ccb3614866fa808dc1e3a5a4291acd444e243c0648
+  languageName: node
+  linkType: hard
+
+"@babel/helper-validator-identifier@npm:^7.19.1":
+  version: 7.19.1
+  resolution: "@babel/helper-validator-identifier@npm:7.19.1"
+  checksum: 0eca5e86a729162af569b46c6c41a63e18b43dbe09fda1d2a3c8924f7d617116af39cac5e4cd5d431bb760b4dca3c0970e0c444789b1db42bcf1fa41fbad0a3a
   languageName: node
   linkType: hard
 
@@ -1320,6 +1342,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/parser@npm:^7.19.3, @babel/parser@npm:^7.19.4":
+  version: 7.19.4
+  resolution: "@babel/parser@npm:7.19.4"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: 5ef97da97915085ff3b9c562b04fb6316074ece52d20de95f44c47b46abf87fd754cbcae769a69570a84652b736afe5bb2cb7dc117aa7ad6d81ab40eed0c613b
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@npm:^7.18.6":
   version: 7.18.6
   resolution: "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@npm:7.18.6"
@@ -1344,9 +1375,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-proposal-async-generator-functions@npm:7.19.0, @babel/plugin-proposal-async-generator-functions@npm:^7.19.0":
-  version: 7.19.0
-  resolution: "@babel/plugin-proposal-async-generator-functions@npm:7.19.0"
+"@babel/plugin-proposal-async-generator-functions@npm:7.19.1, @babel/plugin-proposal-async-generator-functions@npm:^7.19.1":
+  version: 7.19.1
+  resolution: "@babel/plugin-proposal-async-generator-functions@npm:7.19.1"
   dependencies:
     "@babel/helper-environment-visitor": ^7.18.9
     "@babel/helper-plugin-utils": ^7.19.0
@@ -1354,7 +1385,7 @@ __metadata:
     "@babel/plugin-syntax-async-generators": ^7.8.4
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: f1876286d608650928f60ac6091b9a6e7839e005941be483df47693b98c90649202aa1793f28f6e9b4ce69bf0773552144fa40f38751f56dc5d02051a8ee0461
+  checksum: f101555b00aee6ee0107c9e40d872ad646bbd3094abdbeda56d17b107df69a0cb49e5d02dcf5f9d8753e25564e798d08429f12d811aaa1b307b6a725c0b8159c
   languageName: node
   linkType: hard
 
@@ -1455,18 +1486,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-proposal-object-rest-spread@npm:^7.18.9":
-  version: 7.18.9
-  resolution: "@babel/plugin-proposal-object-rest-spread@npm:7.18.9"
+"@babel/plugin-proposal-object-rest-spread@npm:^7.19.4":
+  version: 7.19.4
+  resolution: "@babel/plugin-proposal-object-rest-spread@npm:7.19.4"
   dependencies:
-    "@babel/compat-data": ^7.18.8
-    "@babel/helper-compilation-targets": ^7.18.9
-    "@babel/helper-plugin-utils": ^7.18.9
+    "@babel/compat-data": ^7.19.4
+    "@babel/helper-compilation-targets": ^7.19.3
+    "@babel/helper-plugin-utils": ^7.19.0
     "@babel/plugin-syntax-object-rest-spread": ^7.8.3
     "@babel/plugin-transform-parameters": ^7.18.8
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 66b9bae741d46edf1c96776d26dfe5d335981e57164ec2450583e3d20dfaa08a5137ffebb897e443913207789f9816bfec4ae845f38762c0196a60949eaffdba
+  checksum: 90a2a59da305e6c8c83831e16079193df33d727a77a90972e286af2c8c0295fddb91b0978b88f16f63080d08a82b08ce3ee82a88b0488b3c51decc73c1d35786
   languageName: node
   linkType: hard
 
@@ -1745,14 +1776,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-block-scoping@npm:^7.18.9":
-  version: 7.18.9
-  resolution: "@babel/plugin-transform-block-scoping@npm:7.18.9"
+"@babel/plugin-transform-block-scoping@npm:^7.19.4":
+  version: 7.19.4
+  resolution: "@babel/plugin-transform-block-scoping@npm:7.19.4"
   dependencies:
-    "@babel/helper-plugin-utils": ^7.18.9
+    "@babel/helper-plugin-utils": ^7.19.0
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: f8064ea431eb7aa349dc5b6be87a650f912b48cd65afde917e8644f6f840d7f9d2ce4795f2aa3955aa5b23a73d4ad38abd03386ae109b4b8702b746c6d35bda3
+  checksum: 86353ccbb57b4a0513ac2b1209271858f9c3f2c56b15a6225ff5f1c97ffb1c48f8984046a718a9835ecdae100cbe80ed0b9ca15a5554e33386671b56a8cd887c
   languageName: node
   linkType: hard
 
@@ -1786,14 +1817,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-destructuring@npm:^7.18.13":
-  version: 7.18.13
-  resolution: "@babel/plugin-transform-destructuring@npm:7.18.13"
+"@babel/plugin-transform-destructuring@npm:^7.19.4":
+  version: 7.19.4
+  resolution: "@babel/plugin-transform-destructuring@npm:7.19.4"
   dependencies:
-    "@babel/helper-plugin-utils": ^7.18.9
+    "@babel/helper-plugin-utils": ^7.19.0
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 83e44ec93a4cfbf69376db8836d00ec803820081bf0f8b6cea73a9b3cd320b8285768d5b385744af4a27edda4b6502245c52d3ed026ea61356faf57bfe78effb
+  checksum: 0ca40f6abf7273dafefb7a1cc11fef2b9ab3edbd23188cdcff8cd5e30783b89d64e7813e44aae9efab417b90972ae80971bf6c4130eeeb112bcfb44100c72657
   languageName: node
   linkType: hard
 
@@ -1944,15 +1975,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-named-capturing-groups-regex@npm:^7.19.0":
-  version: 7.19.0
-  resolution: "@babel/plugin-transform-named-capturing-groups-regex@npm:7.19.0"
+"@babel/plugin-transform-named-capturing-groups-regex@npm:^7.19.1":
+  version: 7.19.1
+  resolution: "@babel/plugin-transform-named-capturing-groups-regex@npm:7.19.1"
   dependencies:
     "@babel/helper-create-regexp-features-plugin": ^7.19.0
     "@babel/helper-plugin-utils": ^7.19.0
   peerDependencies:
     "@babel/core": ^7.0.0
-  checksum: 60f7b2c537fa3e8392f19b1f1026ba68844c5dc7942867e7a96a636d8a52d4766629b898e59aa690d3806bf02a7fa52e12d1f7c1ca2ef4fa2b53f3fe0a835117
+  checksum: 8a40f5d04f2140c44fe890a5a3fd72abc2a88445443ac2bd92e1e85d9366d3eb8f1ebb7e2c89d2daeaf213d9b28cb65605502ac9b155936d48045eeda6053494
   languageName: node
   linkType: hard
 
@@ -2024,19 +2055,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-runtime@npm:7.18.10":
-  version: 7.18.10
-  resolution: "@babel/plugin-transform-runtime@npm:7.18.10"
+"@babel/plugin-transform-runtime@npm:7.19.1":
+  version: 7.19.1
+  resolution: "@babel/plugin-transform-runtime@npm:7.19.1"
   dependencies:
     "@babel/helper-module-imports": ^7.18.6
-    "@babel/helper-plugin-utils": ^7.18.9
-    babel-plugin-polyfill-corejs2: ^0.3.2
-    babel-plugin-polyfill-corejs3: ^0.5.3
-    babel-plugin-polyfill-regenerator: ^0.4.0
+    "@babel/helper-plugin-utils": ^7.19.0
+    babel-plugin-polyfill-corejs2: ^0.3.3
+    babel-plugin-polyfill-corejs3: ^0.6.0
+    babel-plugin-polyfill-regenerator: ^0.4.1
     semver: ^6.3.0
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 98c18680b4258b8bd3f04926b73c72ae77037d5ea5b50761ca35de15896bf0d04bedabde39a81be56dbd4859c96ffaa7103fbefb5d5b58a36e0a80381e4a146c
+  checksum: d9f693003a546b380a7322087490a51e8c6cd47b44e654f5030f96088cf7888b6c746d6335f723581154aaceed4ef0877acfa642f054ce3beb6ba9bb970987f4
   languageName: node
   linkType: hard
 
@@ -2119,17 +2150,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/preset-env@npm:7.19.0":
-  version: 7.19.0
-  resolution: "@babel/preset-env@npm:7.19.0"
+"@babel/preset-env@npm:7.19.4":
+  version: 7.19.4
+  resolution: "@babel/preset-env@npm:7.19.4"
   dependencies:
-    "@babel/compat-data": ^7.19.0
-    "@babel/helper-compilation-targets": ^7.19.0
+    "@babel/compat-data": ^7.19.4
+    "@babel/helper-compilation-targets": ^7.19.3
     "@babel/helper-plugin-utils": ^7.19.0
     "@babel/helper-validator-option": ^7.18.6
     "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": ^7.18.6
     "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": ^7.18.9
-    "@babel/plugin-proposal-async-generator-functions": ^7.19.0
+    "@babel/plugin-proposal-async-generator-functions": ^7.19.1
     "@babel/plugin-proposal-class-properties": ^7.18.6
     "@babel/plugin-proposal-class-static-block": ^7.18.6
     "@babel/plugin-proposal-dynamic-import": ^7.18.6
@@ -2138,7 +2169,7 @@ __metadata:
     "@babel/plugin-proposal-logical-assignment-operators": ^7.18.9
     "@babel/plugin-proposal-nullish-coalescing-operator": ^7.18.6
     "@babel/plugin-proposal-numeric-separator": ^7.18.6
-    "@babel/plugin-proposal-object-rest-spread": ^7.18.9
+    "@babel/plugin-proposal-object-rest-spread": ^7.19.4
     "@babel/plugin-proposal-optional-catch-binding": ^7.18.6
     "@babel/plugin-proposal-optional-chaining": ^7.18.9
     "@babel/plugin-proposal-private-methods": ^7.18.6
@@ -2162,10 +2193,10 @@ __metadata:
     "@babel/plugin-transform-arrow-functions": ^7.18.6
     "@babel/plugin-transform-async-to-generator": ^7.18.6
     "@babel/plugin-transform-block-scoped-functions": ^7.18.6
-    "@babel/plugin-transform-block-scoping": ^7.18.9
+    "@babel/plugin-transform-block-scoping": ^7.19.4
     "@babel/plugin-transform-classes": ^7.19.0
     "@babel/plugin-transform-computed-properties": ^7.18.9
-    "@babel/plugin-transform-destructuring": ^7.18.13
+    "@babel/plugin-transform-destructuring": ^7.19.4
     "@babel/plugin-transform-dotall-regex": ^7.18.6
     "@babel/plugin-transform-duplicate-keys": ^7.18.9
     "@babel/plugin-transform-exponentiation-operator": ^7.18.6
@@ -2177,7 +2208,7 @@ __metadata:
     "@babel/plugin-transform-modules-commonjs": ^7.18.6
     "@babel/plugin-transform-modules-systemjs": ^7.19.0
     "@babel/plugin-transform-modules-umd": ^7.18.6
-    "@babel/plugin-transform-named-capturing-groups-regex": ^7.19.0
+    "@babel/plugin-transform-named-capturing-groups-regex": ^7.19.1
     "@babel/plugin-transform-new-target": ^7.18.6
     "@babel/plugin-transform-object-super": ^7.18.6
     "@babel/plugin-transform-parameters": ^7.18.8
@@ -2192,15 +2223,15 @@ __metadata:
     "@babel/plugin-transform-unicode-escapes": ^7.18.10
     "@babel/plugin-transform-unicode-regex": ^7.18.6
     "@babel/preset-modules": ^0.1.5
-    "@babel/types": ^7.19.0
-    babel-plugin-polyfill-corejs2: ^0.3.2
-    babel-plugin-polyfill-corejs3: ^0.5.3
-    babel-plugin-polyfill-regenerator: ^0.4.0
-    core-js-compat: ^3.22.1
+    "@babel/types": ^7.19.4
+    babel-plugin-polyfill-corejs2: ^0.3.3
+    babel-plugin-polyfill-corejs3: ^0.6.0
+    babel-plugin-polyfill-regenerator: ^0.4.1
+    core-js-compat: ^3.25.1
     semver: ^6.3.0
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: ae1866b9a6c9749d52618f39aab8c369e0d6dc88e327341fae932411a0d51db2ec51b882cebc62ff3d49443261a6940e3fc03762ff3925d165884e7990eb612c
+  checksum: f12af25281f3c5e7df60fa1e79ad481ddd7f6a111d4c0fabcffdabf0eaed3a01b4f8c647ae5445ed1f58df70f52083ffd283e8919ade7afa73801a49c733d22c
   languageName: node
   linkType: hard
 
@@ -2219,12 +2250,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:7.19.0":
-  version: 7.19.0
-  resolution: "@babel/runtime@npm:7.19.0"
+"@babel/runtime@npm:7.19.4":
+  version: 7.19.4
+  resolution: "@babel/runtime@npm:7.19.4"
   dependencies:
     regenerator-runtime: ^0.13.4
-  checksum: fa69c351bb05e1db3ceb9a02fdcf620c234180af68cdda02152d3561015f6d55277265d3109815992f96d910f3db709458cae4f8df1c3def66f32e0867d82294
+  checksum: 66b7e3c13e9ee1d2c9397ea89144f29a875edee266a0eb2d9971be51b32fdbafc85808c7a45e011e6681899bb804b4e2ee2aed6dc07108dbbd6b11b6cc2afba6
   languageName: node
   linkType: hard
 
@@ -2349,6 +2380,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/traverse@npm:^7.19.3":
+  version: 7.19.4
+  resolution: "@babel/traverse@npm:7.19.4"
+  dependencies:
+    "@babel/code-frame": ^7.18.6
+    "@babel/generator": ^7.19.4
+    "@babel/helper-environment-visitor": ^7.18.9
+    "@babel/helper-function-name": ^7.19.0
+    "@babel/helper-hoist-variables": ^7.18.6
+    "@babel/helper-split-export-declaration": ^7.18.6
+    "@babel/parser": ^7.19.4
+    "@babel/types": ^7.19.4
+    debug: ^4.1.0
+    globals: ^11.1.0
+  checksum: 8ae1ac3dace181620cd0e3078aec99604a48302fb873193a171e37a7cc4f8909ed496f286bf08c6473f9692db36423e2601eb9c771493d19f6a5fd1a56745af5
+  languageName: node
+  linkType: hard
+
 "@babel/types@npm:^7.16.7, @babel/types@npm:^7.17.0, @babel/types@npm:^7.4.4, @babel/types@npm:^7.8.3":
   version: 7.17.0
   resolution: "@babel/types@npm:7.17.0"
@@ -2391,177 +2440,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/types@npm:^7.19.3, @babel/types@npm:^7.19.4":
+  version: 7.19.4
+  resolution: "@babel/types@npm:7.19.4"
+  dependencies:
+    "@babel/helper-string-parser": ^7.19.4
+    "@babel/helper-validator-identifier": ^7.19.1
+    to-fast-properties: ^2.0.0
+  checksum: 4032f6407093f80dd4f4764be676f7527d2a5c0381586967cd79683cf8af01cdc16745a381b9cef045f702f0c9b0dffd880d84ee55dad59ba01bd23d5d52a8e0
+  languageName: node
+  linkType: hard
+
 "@colors/colors@npm:1.5.0":
   version: 1.5.0
   resolution: "@colors/colors@npm:1.5.0"
   checksum: d64d5260bed1d5012ae3fc617d38d1afc0329fec05342f4e6b838f46998855ba56e0a73833f4a80fa8378c84810da254f76a8a19c39d038260dc06dc4e007425
-  languageName: node
-  linkType: hard
-
-"@csstools/postcss-cascade-layers@npm:^1.0.6":
-  version: 1.0.6
-  resolution: "@csstools/postcss-cascade-layers@npm:1.0.6"
-  dependencies:
-    "@csstools/selector-specificity": ^2.0.2
-    postcss-selector-parser: ^6.0.10
-  peerDependencies:
-    postcss: ^8.2
-  checksum: 7c20ec73dc138f5c3bcff9342aa18c0bc70ec56fdda389376d55d631a0b6bf41c81a83ee62d5d47537c2a5244831ebcc1181d6fbff17a9d5e54e3f33bcb11e65
-  languageName: node
-  linkType: hard
-
-"@csstools/postcss-color-function@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "@csstools/postcss-color-function@npm:1.1.1"
-  dependencies:
-    "@csstools/postcss-progressive-custom-properties": ^1.1.0
-    postcss-value-parser: ^4.2.0
-  peerDependencies:
-    postcss: ^8.2
-  checksum: 087595985ebcc2fc42013d6305185d4cdc842d87fb261185db905dc31eaa24fc23a7cc068fa3da814b3c8b98164107ddaf1b4ab24f4ff5b2a7b5fbcd4c6ceec9
-  languageName: node
-  linkType: hard
-
-"@csstools/postcss-font-format-keywords@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "@csstools/postcss-font-format-keywords@npm:1.0.1"
-  dependencies:
-    postcss-value-parser: ^4.2.0
-  peerDependencies:
-    postcss: ^8.2
-  checksum: ed8d9eab9793f0184e000709bcb155d4eb96c49a312e3ea9e549e006b74fd4aafac63cb9f9f01bec5b717a833539ff085c3f1ef7d273b97d587769ef637d50c1
-  languageName: node
-  linkType: hard
-
-"@csstools/postcss-hwb-function@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "@csstools/postcss-hwb-function@npm:1.0.2"
-  dependencies:
-    postcss-value-parser: ^4.2.0
-  peerDependencies:
-    postcss: ^8.2
-  checksum: 352ead754a692f7ed33a712c491012cab5c2f2946136a669a354237cfe8e6faca90c7389ee793cb329b9b0ddec984faa06d47e2f875933aaca417afff74ce6aa
-  languageName: node
-  linkType: hard
-
-"@csstools/postcss-ic-unit@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "@csstools/postcss-ic-unit@npm:1.0.1"
-  dependencies:
-    "@csstools/postcss-progressive-custom-properties": ^1.1.0
-    postcss-value-parser: ^4.2.0
-  peerDependencies:
-    postcss: ^8.2
-  checksum: 09c414c9b7762b5fbe837ff451d7a11e4890f1ed3c92edc3573f02f3d89747f6ac3f2270799b68a332bd7f5de05bb0dfffddb6323fc4020c2bea33ff58314533
-  languageName: node
-  linkType: hard
-
-"@csstools/postcss-is-pseudo-class@npm:^2.0.7":
-  version: 2.0.7
-  resolution: "@csstools/postcss-is-pseudo-class@npm:2.0.7"
-  dependencies:
-    "@csstools/selector-specificity": ^2.0.0
-    postcss-selector-parser: ^6.0.10
-  peerDependencies:
-    postcss: ^8.2
-  checksum: a4494bb8e9a34826944ba6872c91c1e88268caab6d06968897f1a0cc75ca5cfc4989435961fc668a9c6842a6d17f4cda0055fa256d23e598b8bbc6f022956125
-  languageName: node
-  linkType: hard
-
-"@csstools/postcss-nested-calc@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "@csstools/postcss-nested-calc@npm:1.0.0"
-  dependencies:
-    postcss-value-parser: ^4.2.0
-  peerDependencies:
-    postcss: ^8.2
-  checksum: 53bb783dd61621c11c1e6e352f079577e2eb908de67947ceef31a178e070c06c223baae87acd5c3bd51c664515d2adc16166a129159168626111aff548583790
-  languageName: node
-  linkType: hard
-
-"@csstools/postcss-normalize-display-values@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "@csstools/postcss-normalize-display-values@npm:1.0.1"
-  dependencies:
-    postcss-value-parser: ^4.2.0
-  peerDependencies:
-    postcss: ^8.2
-  checksum: 75901daec3869ba15e0adfd50d8e2e754ec06d55ac44fbd540748476388d223d53710fb3a3cbfe6695a2bab015a489fb47d9e3914ff211736923f8deb818dc0b
-  languageName: node
-  linkType: hard
-
-"@csstools/postcss-oklab-function@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "@csstools/postcss-oklab-function@npm:1.1.1"
-  dependencies:
-    "@csstools/postcss-progressive-custom-properties": ^1.1.0
-    postcss-value-parser: ^4.2.0
-  peerDependencies:
-    postcss: ^8.2
-  checksum: d66b789060b37ed810450d9a7d8319a0ae14e913c091f3e0ee482b3471538762e801d5eae3d62fda2f1eb1e88c76786d2c2b06c1172166eba1cca5e2a0dc95f2
-  languageName: node
-  linkType: hard
-
-"@csstools/postcss-progressive-custom-properties@npm:^1.1.0, @csstools/postcss-progressive-custom-properties@npm:^1.3.0":
-  version: 1.3.0
-  resolution: "@csstools/postcss-progressive-custom-properties@npm:1.3.0"
-  dependencies:
-    postcss-value-parser: "npm:^4.2.0"
-  peerDependencies:
-    postcss: ^8.3
-  checksum: e281845fde5b8a80d06ec20147bd74e96a9351bebbec5e5c3a6fb37ea30a597ff84172601786a8a270662f58f708b4a3bf8d822d6318023def9773d2f6589962
-  languageName: node
-  linkType: hard
-
-"@csstools/postcss-stepped-value-functions@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "@csstools/postcss-stepped-value-functions@npm:1.0.1"
-  dependencies:
-    postcss-value-parser: ^4.2.0
-  peerDependencies:
-    postcss: ^8.2
-  checksum: 2fc88713a0d49d142010652be8139b00719e407df1173e46047284f1befd0647e1fff67f259f9f55ac3b46bba6462b21f0aa192bd10a2989c51a8ce0d25fc495
-  languageName: node
-  linkType: hard
-
-"@csstools/postcss-text-decoration-shorthand@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "@csstools/postcss-text-decoration-shorthand@npm:1.0.0"
-  dependencies:
-    postcss-value-parser: ^4.2.0
-  peerDependencies:
-    postcss: ^8.2
-  checksum: d27aaf97872c42bec9f6fde4d8bf924e89f7886f0aca8e4fc5aaf2f9083b09bb43dbbfa29124fa36fcdeb2d4d3e0459a095acf62188260cd1577e9811bb1276e
-  languageName: node
-  linkType: hard
-
-"@csstools/postcss-trigonometric-functions@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "@csstools/postcss-trigonometric-functions@npm:1.0.2"
-  dependencies:
-    postcss-value-parser: ^4.2.0
-  peerDependencies:
-    postcss: ^8.2
-  checksum: f7f5b5f2492606b79a56f09e814ae8f10a2ae9e9c5fb8019f0e347a4a6c07953b2cc663fd4fa43a60e6994dfd958958f39df8ec760e2a646cfe71fe2bb119382
-  languageName: node
-  linkType: hard
-
-"@csstools/postcss-unset-value@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "@csstools/postcss-unset-value@npm:1.0.2"
-  peerDependencies:
-    postcss: ^8.2
-  checksum: 3facdae154d6516ffd964f7582696f406465f11cf8dead503e0afdfecc99ebc25638ab2830affce4516131aa2db004458a235e439f575b04e9ef72ad82f55835
-  languageName: node
-  linkType: hard
-
-"@csstools/selector-specificity@npm:^2.0.0, @csstools/selector-specificity@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "@csstools/selector-specificity@npm:2.0.2"
-  peerDependencies:
-    postcss: ^8.2
-    postcss-selector-parser: ^6.0.10
-  checksum: a2045a27276a6cfe645b6e212afc217d9a43174ea7a1fa1ab8918d5a0ace72380fbd9837fe1920c547985c11a9070dc48c5c80d483d3f581ddf7aa688204d44f
   languageName: node
   linkType: hard
 
@@ -2572,9 +2465,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-loong64@npm:0.15.7":
-  version: 0.15.7
-  resolution: "@esbuild/linux-loong64@npm:0.15.7"
+"@esbuild/android-arm@npm:0.15.10":
+  version: 0.15.10
+  resolution: "@esbuild/android-arm@npm:0.15.10"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-loong64@npm:0.15.10":
+  version: 0.15.10
+  resolution: "@esbuild/linux-loong64@npm:0.15.10"
   conditions: os=linux & cpu=loong64
   languageName: node
   linkType: hard
@@ -2718,6 +2618,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@material/animation@npm:15.0.0-canary.a515a2d18.0":
+  version: 15.0.0-canary.a515a2d18.0
+  resolution: "@material/animation@npm:15.0.0-canary.a515a2d18.0"
+  dependencies:
+    tslib: ^2.1.0
+  checksum: 18790b55eb18fffc6b0d888628e11df7ecbcb0e0f370f093dc5ffb5b9bd6eb0fe1f40ccdbc9dd745af24829da689a978ea073ff9c16f4859fb89f33b25c20ffb
+  languageName: node
+  linkType: hard
+
 "@material/auto-init@npm:15.0.0-canary.10196647d.0":
   version: 15.0.0-canary.10196647d.0
   resolution: "@material/auto-init@npm:15.0.0-canary.10196647d.0"
@@ -2725,6 +2634,16 @@ __metadata:
     "@material/base": 15.0.0-canary.10196647d.0
     tslib: ^2.1.0
   checksum: 6a05ae0c8987a91f47e2a9461e20f89488e1bacfa77bcc17ada4b59d04a8891c17ed64d0832df906d8d571ddf224f4ff8ae49e80aead78cd231cf534e04f1973
+  languageName: node
+  linkType: hard
+
+"@material/auto-init@npm:15.0.0-canary.a515a2d18.0":
+  version: 15.0.0-canary.a515a2d18.0
+  resolution: "@material/auto-init@npm:15.0.0-canary.a515a2d18.0"
+  dependencies:
+    "@material/base": 15.0.0-canary.a515a2d18.0
+    tslib: ^2.1.0
+  checksum: 921c50ea74ad318d1407efa8790bb8ac890b934bbdb4cdd64b7d59b7bfb8b0a8e2825d0da4d80e4d8ca14fc03fed769bcf32065217a66951b879a028d51e3890
   languageName: node
   linkType: hard
 
@@ -2748,12 +2667,41 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@material/banner@npm:15.0.0-canary.a515a2d18.0":
+  version: 15.0.0-canary.a515a2d18.0
+  resolution: "@material/banner@npm:15.0.0-canary.a515a2d18.0"
+  dependencies:
+    "@material/base": 15.0.0-canary.a515a2d18.0
+    "@material/button": 15.0.0-canary.a515a2d18.0
+    "@material/dom": 15.0.0-canary.a515a2d18.0
+    "@material/elevation": 15.0.0-canary.a515a2d18.0
+    "@material/feature-targeting": 15.0.0-canary.a515a2d18.0
+    "@material/ripple": 15.0.0-canary.a515a2d18.0
+    "@material/rtl": 15.0.0-canary.a515a2d18.0
+    "@material/shape": 15.0.0-canary.a515a2d18.0
+    "@material/theme": 15.0.0-canary.a515a2d18.0
+    "@material/tokens": 15.0.0-canary.a515a2d18.0
+    "@material/typography": 15.0.0-canary.a515a2d18.0
+    tslib: ^2.1.0
+  checksum: 75c02b59adb0fa2c74e5e4936d3f7837a3be7fa52df20176a2709f3a8e04527fdde542ebf1183c0f28a4b8050922c253b92070d8ef2c387632fd85378dc2f5cb
+  languageName: node
+  linkType: hard
+
 "@material/base@npm:15.0.0-canary.10196647d.0":
   version: 15.0.0-canary.10196647d.0
   resolution: "@material/base@npm:15.0.0-canary.10196647d.0"
   dependencies:
     tslib: ^2.1.0
   checksum: 8ed4aecc3f3b99ec58d964673691250a8d35738436e26abab40981a574457e4bdcf0f1e1df725701a1fa437999af583053bbfa27296a93784e925fecb6cb414a
+  languageName: node
+  linkType: hard
+
+"@material/base@npm:15.0.0-canary.a515a2d18.0":
+  version: 15.0.0-canary.a515a2d18.0
+  resolution: "@material/base@npm:15.0.0-canary.a515a2d18.0"
+  dependencies:
+    tslib: ^2.1.0
+  checksum: 7205ea7ed7734ecaacbe678d54ed2b817d5685c543ea4bb09089c2801c994b5110eaa6928c56c6fb7ed0215497e7b03e14770b72c73ea36cc82c778befb7299a
   languageName: node
   linkType: hard
 
@@ -2778,6 +2726,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@material/button@npm:15.0.0-canary.a515a2d18.0":
+  version: 15.0.0-canary.a515a2d18.0
+  resolution: "@material/button@npm:15.0.0-canary.a515a2d18.0"
+  dependencies:
+    "@material/density": 15.0.0-canary.a515a2d18.0
+    "@material/dom": 15.0.0-canary.a515a2d18.0
+    "@material/elevation": 15.0.0-canary.a515a2d18.0
+    "@material/feature-targeting": 15.0.0-canary.a515a2d18.0
+    "@material/focus-ring": 15.0.0-canary.a515a2d18.0
+    "@material/ripple": 15.0.0-canary.a515a2d18.0
+    "@material/rtl": 15.0.0-canary.a515a2d18.0
+    "@material/shape": 15.0.0-canary.a515a2d18.0
+    "@material/theme": 15.0.0-canary.a515a2d18.0
+    "@material/tokens": 15.0.0-canary.a515a2d18.0
+    "@material/touch-target": 15.0.0-canary.a515a2d18.0
+    "@material/typography": 15.0.0-canary.a515a2d18.0
+    tslib: ^2.1.0
+  checksum: e64902ad7d7616a889b9ad354c5fb208c6dce22490e514cbbeea934c6c3c43b6420eadfa6fd1ddff3c47ea5ffb2bfcc814d7de0b8905e1132d602c25a3c42ed4
+  languageName: node
+  linkType: hard
+
 "@material/card@npm:15.0.0-canary.10196647d.0":
   version: 15.0.0-canary.10196647d.0
   resolution: "@material/card@npm:15.0.0-canary.10196647d.0"
@@ -2792,6 +2761,23 @@ __metadata:
     "@material/tokens": 15.0.0-canary.10196647d.0
     tslib: ^2.1.0
   checksum: 1a075259c81ee9d51b517e4135febee2b0ae38ccacf0c7705028302dd2163605406f6a365569e9fbf96d4ea227b45cad9fe48153b2030e5282c4974b1341fd1f
+  languageName: node
+  linkType: hard
+
+"@material/card@npm:15.0.0-canary.a515a2d18.0":
+  version: 15.0.0-canary.a515a2d18.0
+  resolution: "@material/card@npm:15.0.0-canary.a515a2d18.0"
+  dependencies:
+    "@material/dom": 15.0.0-canary.a515a2d18.0
+    "@material/elevation": 15.0.0-canary.a515a2d18.0
+    "@material/feature-targeting": 15.0.0-canary.a515a2d18.0
+    "@material/ripple": 15.0.0-canary.a515a2d18.0
+    "@material/rtl": 15.0.0-canary.a515a2d18.0
+    "@material/shape": 15.0.0-canary.a515a2d18.0
+    "@material/theme": 15.0.0-canary.a515a2d18.0
+    "@material/tokens": 15.0.0-canary.a515a2d18.0
+    tslib: ^2.1.0
+  checksum: b1f48b675f81923c1d23a7837a3486a7e2e7a1cda27dad06064e36223085481151e80879562768690a50253cbcd41aa36a95f376da7914a9087c455cb02dd9d6
   languageName: node
   linkType: hard
 
@@ -2810,6 +2796,24 @@ __metadata:
     "@material/touch-target": 15.0.0-canary.10196647d.0
     tslib: ^2.1.0
   checksum: b1514bddbea745369d8b751bca26bf0b2a2d5b2abf62205832ee14a0c79f1df2a795088b75ef71fecaac3e0b68a38e5940eea9c7a0c606020bb58113689670ab
+  languageName: node
+  linkType: hard
+
+"@material/checkbox@npm:15.0.0-canary.a515a2d18.0":
+  version: 15.0.0-canary.a515a2d18.0
+  resolution: "@material/checkbox@npm:15.0.0-canary.a515a2d18.0"
+  dependencies:
+    "@material/animation": 15.0.0-canary.a515a2d18.0
+    "@material/base": 15.0.0-canary.a515a2d18.0
+    "@material/density": 15.0.0-canary.a515a2d18.0
+    "@material/dom": 15.0.0-canary.a515a2d18.0
+    "@material/feature-targeting": 15.0.0-canary.a515a2d18.0
+    "@material/focus-ring": 15.0.0-canary.a515a2d18.0
+    "@material/ripple": 15.0.0-canary.a515a2d18.0
+    "@material/theme": 15.0.0-canary.a515a2d18.0
+    "@material/touch-target": 15.0.0-canary.a515a2d18.0
+    tslib: ^2.1.0
+  checksum: 07d8b8d68e5eafd8cf045b78d10d595d4cc79d00f29b4aac2bebe4a2fb2233fec3c1fc5724a243fd4835bdd878ee709a1a6bfa07dc7b78cdc2a2c3b941883149
   languageName: node
   linkType: hard
 
@@ -2837,6 +2841,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@material/chips@npm:15.0.0-canary.a515a2d18.0":
+  version: 15.0.0-canary.a515a2d18.0
+  resolution: "@material/chips@npm:15.0.0-canary.a515a2d18.0"
+  dependencies:
+    "@material/animation": 15.0.0-canary.a515a2d18.0
+    "@material/base": 15.0.0-canary.a515a2d18.0
+    "@material/checkbox": 15.0.0-canary.a515a2d18.0
+    "@material/density": 15.0.0-canary.a515a2d18.0
+    "@material/dom": 15.0.0-canary.a515a2d18.0
+    "@material/elevation": 15.0.0-canary.a515a2d18.0
+    "@material/feature-targeting": 15.0.0-canary.a515a2d18.0
+    "@material/focus-ring": 15.0.0-canary.a515a2d18.0
+    "@material/ripple": 15.0.0-canary.a515a2d18.0
+    "@material/rtl": 15.0.0-canary.a515a2d18.0
+    "@material/shape": 15.0.0-canary.a515a2d18.0
+    "@material/theme": 15.0.0-canary.a515a2d18.0
+    "@material/tokens": 15.0.0-canary.a515a2d18.0
+    "@material/touch-target": 15.0.0-canary.a515a2d18.0
+    "@material/typography": 15.0.0-canary.a515a2d18.0
+    tslib: ^2.1.0
+  checksum: aacefde1a7392ece463a576117ff013bdabcb6506ce34d0d5e0b40234f96c28f57858d9307c6826376d5ee8bcc1a3869bbd116abe6b347d1227672dfa2933533
+  languageName: node
+  linkType: hard
+
 "@material/circular-progress@npm:15.0.0-canary.10196647d.0":
   version: 15.0.0-canary.10196647d.0
   resolution: "@material/circular-progress@npm:15.0.0-canary.10196647d.0"
@@ -2849,6 +2877,22 @@ __metadata:
     "@material/theme": 15.0.0-canary.10196647d.0
     tslib: ^2.1.0
   checksum: a02ae4d9ade42413d74a67b9eb538099aba75f027e706712e38e91ac531e00697a514a6a02d1aff4b8091ca0505def05e6b8d9fad076b5a74b378475e48e6d00
+  languageName: node
+  linkType: hard
+
+"@material/circular-progress@npm:15.0.0-canary.a515a2d18.0":
+  version: 15.0.0-canary.a515a2d18.0
+  resolution: "@material/circular-progress@npm:15.0.0-canary.a515a2d18.0"
+  dependencies:
+    "@material/animation": 15.0.0-canary.a515a2d18.0
+    "@material/base": 15.0.0-canary.a515a2d18.0
+    "@material/dom": 15.0.0-canary.a515a2d18.0
+    "@material/feature-targeting": 15.0.0-canary.a515a2d18.0
+    "@material/progress-indicator": 15.0.0-canary.a515a2d18.0
+    "@material/rtl": 15.0.0-canary.a515a2d18.0
+    "@material/theme": 15.0.0-canary.a515a2d18.0
+    tslib: ^2.1.0
+  checksum: 1f4865187fd364d27506e406126b0135e10707aa5d596fe898b9f100905967c48a0c07cde96db9244921c9a8fb5ca3037676be787b70075165c98384de3c4d7e
   languageName: node
   linkType: hard
 
@@ -2878,12 +2922,47 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@material/data-table@npm:15.0.0-canary.a515a2d18.0":
+  version: 15.0.0-canary.a515a2d18.0
+  resolution: "@material/data-table@npm:15.0.0-canary.a515a2d18.0"
+  dependencies:
+    "@material/animation": 15.0.0-canary.a515a2d18.0
+    "@material/base": 15.0.0-canary.a515a2d18.0
+    "@material/checkbox": 15.0.0-canary.a515a2d18.0
+    "@material/density": 15.0.0-canary.a515a2d18.0
+    "@material/dom": 15.0.0-canary.a515a2d18.0
+    "@material/elevation": 15.0.0-canary.a515a2d18.0
+    "@material/feature-targeting": 15.0.0-canary.a515a2d18.0
+    "@material/icon-button": 15.0.0-canary.a515a2d18.0
+    "@material/linear-progress": 15.0.0-canary.a515a2d18.0
+    "@material/list": 15.0.0-canary.a515a2d18.0
+    "@material/menu": 15.0.0-canary.a515a2d18.0
+    "@material/rtl": 15.0.0-canary.a515a2d18.0
+    "@material/select": 15.0.0-canary.a515a2d18.0
+    "@material/shape": 15.0.0-canary.a515a2d18.0
+    "@material/theme": 15.0.0-canary.a515a2d18.0
+    "@material/touch-target": 15.0.0-canary.a515a2d18.0
+    "@material/typography": 15.0.0-canary.a515a2d18.0
+    tslib: ^2.1.0
+  checksum: fe9af8137239060bd2c3d8b959449e8cc280831148b965beaeec21ba7d052db12a083d04ed6aafa51fdc1ca9bf89d0b62450c5adb6befbed1eb6215881ab4838
+  languageName: node
+  linkType: hard
+
 "@material/density@npm:15.0.0-canary.10196647d.0":
   version: 15.0.0-canary.10196647d.0
   resolution: "@material/density@npm:15.0.0-canary.10196647d.0"
   dependencies:
     tslib: ^2.1.0
   checksum: 4792cd99c7b2b8445248a6c700451b40a49385268d85985b515930df0c90140229e027bbe243106c800836535d2295fde7f32c689cc61ed4e1911e2cb4b6de13
+  languageName: node
+  linkType: hard
+
+"@material/density@npm:15.0.0-canary.a515a2d18.0":
+  version: 15.0.0-canary.a515a2d18.0
+  resolution: "@material/density@npm:15.0.0-canary.a515a2d18.0"
+  dependencies:
+    tslib: ^2.1.0
+  checksum: 311eb2eb1daf067263abc21bf2151a7e1aa3645b0a93f0d1c314afb72f7cf1ef5162d133c85a43abd656777be0b0886a3d0d245199dca475f2f32d8b548e0a2a
   languageName: node
   linkType: hard
 
@@ -2910,6 +2989,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@material/dialog@npm:15.0.0-canary.a515a2d18.0":
+  version: 15.0.0-canary.a515a2d18.0
+  resolution: "@material/dialog@npm:15.0.0-canary.a515a2d18.0"
+  dependencies:
+    "@material/animation": 15.0.0-canary.a515a2d18.0
+    "@material/base": 15.0.0-canary.a515a2d18.0
+    "@material/button": 15.0.0-canary.a515a2d18.0
+    "@material/dom": 15.0.0-canary.a515a2d18.0
+    "@material/elevation": 15.0.0-canary.a515a2d18.0
+    "@material/feature-targeting": 15.0.0-canary.a515a2d18.0
+    "@material/icon-button": 15.0.0-canary.a515a2d18.0
+    "@material/ripple": 15.0.0-canary.a515a2d18.0
+    "@material/rtl": 15.0.0-canary.a515a2d18.0
+    "@material/shape": 15.0.0-canary.a515a2d18.0
+    "@material/theme": 15.0.0-canary.a515a2d18.0
+    "@material/tokens": 15.0.0-canary.a515a2d18.0
+    "@material/touch-target": 15.0.0-canary.a515a2d18.0
+    "@material/typography": 15.0.0-canary.a515a2d18.0
+    tslib: ^2.1.0
+  checksum: b0de6ae5fa6f539184325d6fdcdd4f8f5aa8ecc054e1d6f8d3dda9bc60be7673642ec026ce6720661fd6af32e20bc4ab941198705c3ab54303b1fc6e00a9bde7
+  languageName: node
+  linkType: hard
+
 "@material/dom@npm:15.0.0-canary.10196647d.0":
   version: 15.0.0-canary.10196647d.0
   resolution: "@material/dom@npm:15.0.0-canary.10196647d.0"
@@ -2917,6 +3019,16 @@ __metadata:
     "@material/feature-targeting": 15.0.0-canary.10196647d.0
     tslib: ^2.1.0
   checksum: 546f967dae9d283708222788657a8cd851a036cd6ffd42a748f252bf3c2de0055c4248a2dc842ec649b38c4e70a4b1f05f3bfac0e5a8a36dd41f764160ba9bd6
+  languageName: node
+  linkType: hard
+
+"@material/dom@npm:15.0.0-canary.a515a2d18.0":
+  version: 15.0.0-canary.a515a2d18.0
+  resolution: "@material/dom@npm:15.0.0-canary.a515a2d18.0"
+  dependencies:
+    "@material/feature-targeting": 15.0.0-canary.a515a2d18.0
+    tslib: ^2.1.0
+  checksum: a056ec71b0f65662ae6c0534f9ac2eae37f9531722e254a573030e7c39dd8a351b91d12c554fcddaae96d891b04fadf6ec669f99a7e28047e39251c3a0e65a0c
   languageName: node
   linkType: hard
 
@@ -2940,6 +3052,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@material/drawer@npm:15.0.0-canary.a515a2d18.0":
+  version: 15.0.0-canary.a515a2d18.0
+  resolution: "@material/drawer@npm:15.0.0-canary.a515a2d18.0"
+  dependencies:
+    "@material/animation": 15.0.0-canary.a515a2d18.0
+    "@material/base": 15.0.0-canary.a515a2d18.0
+    "@material/dom": 15.0.0-canary.a515a2d18.0
+    "@material/elevation": 15.0.0-canary.a515a2d18.0
+    "@material/feature-targeting": 15.0.0-canary.a515a2d18.0
+    "@material/list": 15.0.0-canary.a515a2d18.0
+    "@material/ripple": 15.0.0-canary.a515a2d18.0
+    "@material/rtl": 15.0.0-canary.a515a2d18.0
+    "@material/shape": 15.0.0-canary.a515a2d18.0
+    "@material/theme": 15.0.0-canary.a515a2d18.0
+    "@material/typography": 15.0.0-canary.a515a2d18.0
+    tslib: ^2.1.0
+  checksum: 648f7a35b02d31b14d31fa31687469bf6370a09dcc345201c015c404be45defccddd486bc3df9a489c4b0b1e3aaef81a911e8087d31c77829e820d39c529b9be
+  languageName: node
+  linkType: hard
+
 "@material/elevation@npm:15.0.0-canary.10196647d.0":
   version: 15.0.0-canary.10196647d.0
   resolution: "@material/elevation@npm:15.0.0-canary.10196647d.0"
@@ -2951,6 +3083,20 @@ __metadata:
     "@material/theme": 15.0.0-canary.10196647d.0
     tslib: ^2.1.0
   checksum: a488a69d0b78e6f521de4731e360d0a8410771f7acc96db4cebee6db1660fcc0e2cedf304a2f60fe8f0cca10333e03916c00da86af6af5cbb91c6d777b4ffb94
+  languageName: node
+  linkType: hard
+
+"@material/elevation@npm:15.0.0-canary.a515a2d18.0":
+  version: 15.0.0-canary.a515a2d18.0
+  resolution: "@material/elevation@npm:15.0.0-canary.a515a2d18.0"
+  dependencies:
+    "@material/animation": 15.0.0-canary.a515a2d18.0
+    "@material/base": 15.0.0-canary.a515a2d18.0
+    "@material/feature-targeting": 15.0.0-canary.a515a2d18.0
+    "@material/rtl": 15.0.0-canary.a515a2d18.0
+    "@material/theme": 15.0.0-canary.a515a2d18.0
+    tslib: ^2.1.0
+  checksum: 78bf5594258d4e17bdeb58f11a23d6328b70109b15c234c61598562b9070e230a4fb4132276fe58ffef0f345d504ea9df0bdb48111e33a5d76fa6db957564ace
   languageName: node
   linkType: hard
 
@@ -2975,12 +3121,42 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@material/fab@npm:15.0.0-canary.a515a2d18.0":
+  version: 15.0.0-canary.a515a2d18.0
+  resolution: "@material/fab@npm:15.0.0-canary.a515a2d18.0"
+  dependencies:
+    "@material/animation": 15.0.0-canary.a515a2d18.0
+    "@material/dom": 15.0.0-canary.a515a2d18.0
+    "@material/elevation": 15.0.0-canary.a515a2d18.0
+    "@material/feature-targeting": 15.0.0-canary.a515a2d18.0
+    "@material/focus-ring": 15.0.0-canary.a515a2d18.0
+    "@material/ripple": 15.0.0-canary.a515a2d18.0
+    "@material/rtl": 15.0.0-canary.a515a2d18.0
+    "@material/shape": 15.0.0-canary.a515a2d18.0
+    "@material/theme": 15.0.0-canary.a515a2d18.0
+    "@material/tokens": 15.0.0-canary.a515a2d18.0
+    "@material/touch-target": 15.0.0-canary.a515a2d18.0
+    "@material/typography": 15.0.0-canary.a515a2d18.0
+    tslib: ^2.1.0
+  checksum: 5e2ee9a44b7016c93a6bb79efa8d46f8f192f268a7e7964b11f83f69e69a0938cf72617dc9a9ccd2ca30b3758002501da02a87e8c2c8e6c3545306113f7ce8e9
+  languageName: node
+  linkType: hard
+
 "@material/feature-targeting@npm:15.0.0-canary.10196647d.0":
   version: 15.0.0-canary.10196647d.0
   resolution: "@material/feature-targeting@npm:15.0.0-canary.10196647d.0"
   dependencies:
     tslib: ^2.1.0
   checksum: 5c34f65a01533c22d9ee5a06ac047a595ecf736bf420420be5021f0fc66606b102769a261ecd03d3b00c59646483cc1c31aa8bdd79cac36bdb90bc2e3a8eb441
+  languageName: node
+  linkType: hard
+
+"@material/feature-targeting@npm:15.0.0-canary.a515a2d18.0":
+  version: 15.0.0-canary.a515a2d18.0
+  resolution: "@material/feature-targeting@npm:15.0.0-canary.a515a2d18.0"
+  dependencies:
+    tslib: ^2.1.0
+  checksum: 33df1b880bf3921b2d85fd461536f73bfdbb2502804e06d6d4a165514dbf24a7c41cc187343222d0e26a152628f23ab744b5ba622089db45e0df1ade25908a03
   languageName: node
   linkType: hard
 
@@ -3000,6 +3176,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@material/floating-label@npm:15.0.0-canary.a515a2d18.0":
+  version: 15.0.0-canary.a515a2d18.0
+  resolution: "@material/floating-label@npm:15.0.0-canary.a515a2d18.0"
+  dependencies:
+    "@material/animation": 15.0.0-canary.a515a2d18.0
+    "@material/base": 15.0.0-canary.a515a2d18.0
+    "@material/dom": 15.0.0-canary.a515a2d18.0
+    "@material/feature-targeting": 15.0.0-canary.a515a2d18.0
+    "@material/rtl": 15.0.0-canary.a515a2d18.0
+    "@material/theme": 15.0.0-canary.a515a2d18.0
+    "@material/typography": 15.0.0-canary.a515a2d18.0
+    tslib: ^2.1.0
+  checksum: 2e277079001189331f41126f3a6eac7df78486937569854a303b171d21012f47ed8e0d556992330b2a5ab3693dac4828f2f3b6e154a2a67ce42e179be22d34b5
+  languageName: node
+  linkType: hard
+
 "@material/focus-ring@npm:15.0.0-canary.10196647d.0":
   version: 15.0.0-canary.10196647d.0
   resolution: "@material/focus-ring@npm:15.0.0-canary.10196647d.0"
@@ -3008,6 +3200,17 @@ __metadata:
     "@material/feature-targeting": 15.0.0-canary.10196647d.0
     "@material/rtl": 15.0.0-canary.10196647d.0
   checksum: 8cad1ad5b06b3033c6d8160629083fa639e7f95747dfd588167726ecb51a84d1a0d6bcf8436851440d9dbeabf67c12a45ba35db381084017d8e8bf06c25f46d7
+  languageName: node
+  linkType: hard
+
+"@material/focus-ring@npm:15.0.0-canary.a515a2d18.0":
+  version: 15.0.0-canary.a515a2d18.0
+  resolution: "@material/focus-ring@npm:15.0.0-canary.a515a2d18.0"
+  dependencies:
+    "@material/dom": 15.0.0-canary.a515a2d18.0
+    "@material/feature-targeting": 15.0.0-canary.a515a2d18.0
+    "@material/rtl": 15.0.0-canary.a515a2d18.0
+  checksum: 31b6610eeffdc2e92f9ede144416cf3e1bb2117f27ac2e321bdf2a75b123d79b7f6bcb567202f45adeebf63a1a4ff75b63d8cbd563e64ecd3fe756e675065dd3
   languageName: node
   linkType: hard
 
@@ -3023,6 +3226,21 @@ __metadata:
     "@material/typography": 15.0.0-canary.10196647d.0
     tslib: ^2.1.0
   checksum: 4f4be0d988291ab18b23e3f98a5c4f8a20dace983c447b9e8a90d1c3ab61f9acb69eb8a39577d30c89cf254bc4eacb971ab8f3ae93573a088fe9a3ce52e87a67
+  languageName: node
+  linkType: hard
+
+"@material/form-field@npm:15.0.0-canary.a515a2d18.0":
+  version: 15.0.0-canary.a515a2d18.0
+  resolution: "@material/form-field@npm:15.0.0-canary.a515a2d18.0"
+  dependencies:
+    "@material/base": 15.0.0-canary.a515a2d18.0
+    "@material/feature-targeting": 15.0.0-canary.a515a2d18.0
+    "@material/ripple": 15.0.0-canary.a515a2d18.0
+    "@material/rtl": 15.0.0-canary.a515a2d18.0
+    "@material/theme": 15.0.0-canary.a515a2d18.0
+    "@material/typography": 15.0.0-canary.a515a2d18.0
+    tslib: ^2.1.0
+  checksum: c484ad325059cab115ebb67fa004e029eb38ef12905cfa8d354cedcb7b1975317051505a2bdbf54c4112dbf2f6253d5d4a462a72878ff545181f20a434a018c9
   languageName: node
   linkType: hard
 
@@ -3045,6 +3263,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@material/icon-button@npm:15.0.0-canary.a515a2d18.0":
+  version: 15.0.0-canary.a515a2d18.0
+  resolution: "@material/icon-button@npm:15.0.0-canary.a515a2d18.0"
+  dependencies:
+    "@material/base": 15.0.0-canary.a515a2d18.0
+    "@material/density": 15.0.0-canary.a515a2d18.0
+    "@material/dom": 15.0.0-canary.a515a2d18.0
+    "@material/elevation": 15.0.0-canary.a515a2d18.0
+    "@material/feature-targeting": 15.0.0-canary.a515a2d18.0
+    "@material/focus-ring": 15.0.0-canary.a515a2d18.0
+    "@material/ripple": 15.0.0-canary.a515a2d18.0
+    "@material/rtl": 15.0.0-canary.a515a2d18.0
+    "@material/theme": 15.0.0-canary.a515a2d18.0
+    "@material/touch-target": 15.0.0-canary.a515a2d18.0
+    tslib: ^2.1.0
+  checksum: 8fcf3a5eda714ec774e836c812b7dec45f4c4e97f4465c0d704ded1a72b40ff08bd1232ec14a5f0f992c27e39589d51e0c42bd7c182b49454ce852af579ba305
+  languageName: node
+  linkType: hard
+
 "@material/image-list@npm:15.0.0-canary.10196647d.0":
   version: 15.0.0-canary.10196647d.0
   resolution: "@material/image-list@npm:15.0.0-canary.10196647d.0"
@@ -3058,12 +3295,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@material/image-list@npm:15.0.0-canary.a515a2d18.0":
+  version: 15.0.0-canary.a515a2d18.0
+  resolution: "@material/image-list@npm:15.0.0-canary.a515a2d18.0"
+  dependencies:
+    "@material/feature-targeting": 15.0.0-canary.a515a2d18.0
+    "@material/shape": 15.0.0-canary.a515a2d18.0
+    "@material/theme": 15.0.0-canary.a515a2d18.0
+    "@material/typography": 15.0.0-canary.a515a2d18.0
+    tslib: ^2.1.0
+  checksum: ee40f07516b3cbceabbee038de4a919d2775f32e474f14d1ba3c3d9ba6c312a4efb3b68eb6d90681f3c97ca4bb0257d9c6493ddb89b9b53323243b8c2f3fa7cb
+  languageName: node
+  linkType: hard
+
 "@material/layout-grid@npm:15.0.0-canary.10196647d.0":
   version: 15.0.0-canary.10196647d.0
   resolution: "@material/layout-grid@npm:15.0.0-canary.10196647d.0"
   dependencies:
     tslib: ^2.1.0
   checksum: c53f744cbbcf7b4ec9cb306983e90b803a4471bab4155093dbb73524afe36646fbf1d7f93e4ce33feb9df5d49ffd8530e4b307ce1f0e7036254cda51a5486c3e
+  languageName: node
+  linkType: hard
+
+"@material/layout-grid@npm:15.0.0-canary.a515a2d18.0":
+  version: 15.0.0-canary.a515a2d18.0
+  resolution: "@material/layout-grid@npm:15.0.0-canary.a515a2d18.0"
+  dependencies:
+    tslib: ^2.1.0
+  checksum: 307eea97415664d6659827a70bc733b0650d9b3595ccffd7e1d89ca54170cad24f7c52ec8f3d7d18f819785b491cb1ab1f4dc4e37f99b1a0ae1ee102aac0c6ca
   languageName: node
   linkType: hard
 
@@ -3080,6 +3339,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@material/line-ripple@npm:15.0.0-canary.a515a2d18.0":
+  version: 15.0.0-canary.a515a2d18.0
+  resolution: "@material/line-ripple@npm:15.0.0-canary.a515a2d18.0"
+  dependencies:
+    "@material/animation": 15.0.0-canary.a515a2d18.0
+    "@material/base": 15.0.0-canary.a515a2d18.0
+    "@material/feature-targeting": 15.0.0-canary.a515a2d18.0
+    "@material/theme": 15.0.0-canary.a515a2d18.0
+    tslib: ^2.1.0
+  checksum: 045e98b7c24250219a5d5c71b9ec4b3d47f250832cf8cc2c1ea8a89a7d41c44f4649c3751d768f5535fe5e3bc1bd0368240276b49b2f013bc7e18398545fa43a
+  languageName: node
+  linkType: hard
+
 "@material/linear-progress@npm:15.0.0-canary.10196647d.0":
   version: 15.0.0-canary.10196647d.0
   resolution: "@material/linear-progress@npm:15.0.0-canary.10196647d.0"
@@ -3093,6 +3365,22 @@ __metadata:
     "@material/theme": 15.0.0-canary.10196647d.0
     tslib: ^2.1.0
   checksum: d3ec9abe35f106fbde194bd770e09ba13e9e5ba530f563f54f15555bb79479df98be489adba6f59c30a87b89b94c0a59a26cb409d65360c1c94149b878ed0054
+  languageName: node
+  linkType: hard
+
+"@material/linear-progress@npm:15.0.0-canary.a515a2d18.0":
+  version: 15.0.0-canary.a515a2d18.0
+  resolution: "@material/linear-progress@npm:15.0.0-canary.a515a2d18.0"
+  dependencies:
+    "@material/animation": 15.0.0-canary.a515a2d18.0
+    "@material/base": 15.0.0-canary.a515a2d18.0
+    "@material/dom": 15.0.0-canary.a515a2d18.0
+    "@material/feature-targeting": 15.0.0-canary.a515a2d18.0
+    "@material/progress-indicator": 15.0.0-canary.a515a2d18.0
+    "@material/rtl": 15.0.0-canary.a515a2d18.0
+    "@material/theme": 15.0.0-canary.a515a2d18.0
+    tslib: ^2.1.0
+  checksum: 78a578fd0887a53346ed6b2d62fadc443a63f26ff7cab33c18fc95cd029223057376ae202ec2a3d2949e67f865cd6349ebc1ebc0fa058b536ad569a50f17139a
   languageName: node
   linkType: hard
 
@@ -3115,6 +3403,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@material/list@npm:15.0.0-canary.a515a2d18.0":
+  version: 15.0.0-canary.a515a2d18.0
+  resolution: "@material/list@npm:15.0.0-canary.a515a2d18.0"
+  dependencies:
+    "@material/base": 15.0.0-canary.a515a2d18.0
+    "@material/density": 15.0.0-canary.a515a2d18.0
+    "@material/dom": 15.0.0-canary.a515a2d18.0
+    "@material/feature-targeting": 15.0.0-canary.a515a2d18.0
+    "@material/ripple": 15.0.0-canary.a515a2d18.0
+    "@material/rtl": 15.0.0-canary.a515a2d18.0
+    "@material/shape": 15.0.0-canary.a515a2d18.0
+    "@material/theme": 15.0.0-canary.a515a2d18.0
+    "@material/tokens": 15.0.0-canary.a515a2d18.0
+    "@material/typography": 15.0.0-canary.a515a2d18.0
+    tslib: ^2.1.0
+  checksum: 8b09f679d4e79ce8cecedadad045b3f5a5a9462a36618d444286e39a3c14651362f8144357549690038ca2220a7e91aff07c8a8b71ceab12c15bca5d41f80501
+  languageName: node
+  linkType: hard
+
 "@material/menu-surface@npm:15.0.0-canary.10196647d.0":
   version: 15.0.0-canary.10196647d.0
   resolution: "@material/menu-surface@npm:15.0.0-canary.10196647d.0"
@@ -3128,6 +3435,22 @@ __metadata:
     "@material/theme": 15.0.0-canary.10196647d.0
     tslib: ^2.1.0
   checksum: 8afe59ce02e77383d0f44f3e4f037cf8d892260be055effdbd3eacad06ba314d59067d9a46ad55d62ea47c7eef3ff5ccaac78d0f9cd48f9cf22877259a387575
+  languageName: node
+  linkType: hard
+
+"@material/menu-surface@npm:15.0.0-canary.a515a2d18.0":
+  version: 15.0.0-canary.a515a2d18.0
+  resolution: "@material/menu-surface@npm:15.0.0-canary.a515a2d18.0"
+  dependencies:
+    "@material/animation": 15.0.0-canary.a515a2d18.0
+    "@material/base": 15.0.0-canary.a515a2d18.0
+    "@material/elevation": 15.0.0-canary.a515a2d18.0
+    "@material/feature-targeting": 15.0.0-canary.a515a2d18.0
+    "@material/rtl": 15.0.0-canary.a515a2d18.0
+    "@material/shape": 15.0.0-canary.a515a2d18.0
+    "@material/theme": 15.0.0-canary.a515a2d18.0
+    tslib: ^2.1.0
+  checksum: 83baf3711fea9e8feb7c30a7c9e9a7c87e1d473500a1e4af6b326879190eca9d46a7a9c62002b6927393fd8589acbd30bb50677b584d2d5a619319b55de85ffb
   languageName: node
   linkType: hard
 
@@ -3149,6 +3472,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@material/menu@npm:15.0.0-canary.a515a2d18.0":
+  version: 15.0.0-canary.a515a2d18.0
+  resolution: "@material/menu@npm:15.0.0-canary.a515a2d18.0"
+  dependencies:
+    "@material/base": 15.0.0-canary.a515a2d18.0
+    "@material/dom": 15.0.0-canary.a515a2d18.0
+    "@material/elevation": 15.0.0-canary.a515a2d18.0
+    "@material/feature-targeting": 15.0.0-canary.a515a2d18.0
+    "@material/list": 15.0.0-canary.a515a2d18.0
+    "@material/menu-surface": 15.0.0-canary.a515a2d18.0
+    "@material/ripple": 15.0.0-canary.a515a2d18.0
+    "@material/rtl": 15.0.0-canary.a515a2d18.0
+    "@material/theme": 15.0.0-canary.a515a2d18.0
+    tslib: ^2.1.0
+  checksum: 5373208ed7ab424ae72984be98ca157ed01e8530eea75b8be56ae4feeb1af8a4bbfc868d9b41a65759b7ccfc70813a3b19f338cb77c40ab27f27a9a2967e1698
+  languageName: node
+  linkType: hard
+
 "@material/notched-outline@npm:15.0.0-canary.10196647d.0":
   version: 15.0.0-canary.10196647d.0
   resolution: "@material/notched-outline@npm:15.0.0-canary.10196647d.0"
@@ -3164,12 +3505,36 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@material/notched-outline@npm:15.0.0-canary.a515a2d18.0":
+  version: 15.0.0-canary.a515a2d18.0
+  resolution: "@material/notched-outline@npm:15.0.0-canary.a515a2d18.0"
+  dependencies:
+    "@material/base": 15.0.0-canary.a515a2d18.0
+    "@material/feature-targeting": 15.0.0-canary.a515a2d18.0
+    "@material/floating-label": 15.0.0-canary.a515a2d18.0
+    "@material/rtl": 15.0.0-canary.a515a2d18.0
+    "@material/shape": 15.0.0-canary.a515a2d18.0
+    "@material/theme": 15.0.0-canary.a515a2d18.0
+    tslib: ^2.1.0
+  checksum: 3b977e1648b8a57193597d0b29db446393572333ad9d9f2c203dbf96957a0d9918f0a57da7951158918dcee57fe547fd8e80beb87a86a28a91b9a6e9490c4048
+  languageName: node
+  linkType: hard
+
 "@material/progress-indicator@npm:15.0.0-canary.10196647d.0":
   version: 15.0.0-canary.10196647d.0
   resolution: "@material/progress-indicator@npm:15.0.0-canary.10196647d.0"
   dependencies:
     tslib: ^2.1.0
   checksum: 55ab330c651be8ab82fcf917c0f7bf2b1b625334756df7e81dea39c5d2616f162d8a17773786ed1b89400e1790561af8b0879108bbd605ee7cb141c5c03465c7
+  languageName: node
+  linkType: hard
+
+"@material/progress-indicator@npm:15.0.0-canary.a515a2d18.0":
+  version: 15.0.0-canary.a515a2d18.0
+  resolution: "@material/progress-indicator@npm:15.0.0-canary.a515a2d18.0"
+  dependencies:
+    tslib: ^2.1.0
+  checksum: 5089a0c90952861af7b0980d499a31fb80895442db9d74911726054fd1e84362744fb434c92fdc65fad519d190f8fd6e9de192f12d6bd2d9f96451be4a514b5a
   languageName: node
   linkType: hard
 
@@ -3191,6 +3556,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@material/radio@npm:15.0.0-canary.a515a2d18.0":
+  version: 15.0.0-canary.a515a2d18.0
+  resolution: "@material/radio@npm:15.0.0-canary.a515a2d18.0"
+  dependencies:
+    "@material/animation": 15.0.0-canary.a515a2d18.0
+    "@material/base": 15.0.0-canary.a515a2d18.0
+    "@material/density": 15.0.0-canary.a515a2d18.0
+    "@material/dom": 15.0.0-canary.a515a2d18.0
+    "@material/feature-targeting": 15.0.0-canary.a515a2d18.0
+    "@material/focus-ring": 15.0.0-canary.a515a2d18.0
+    "@material/ripple": 15.0.0-canary.a515a2d18.0
+    "@material/theme": 15.0.0-canary.a515a2d18.0
+    "@material/touch-target": 15.0.0-canary.a515a2d18.0
+    tslib: ^2.1.0
+  checksum: f2fa63a01ab8da00869c29c43c66efd79a907d5eca9f3fa446bde00c79a2507b78e1e80e68a4b38b7d55fa288d3be73d681c62b23572933001bdcac5bfb21b3d
+  languageName: node
+  linkType: hard
+
 "@material/ripple@npm:15.0.0-canary.10196647d.0":
   version: 15.0.0-canary.10196647d.0
   resolution: "@material/ripple@npm:15.0.0-canary.10196647d.0"
@@ -3206,6 +3589,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@material/ripple@npm:15.0.0-canary.a515a2d18.0":
+  version: 15.0.0-canary.a515a2d18.0
+  resolution: "@material/ripple@npm:15.0.0-canary.a515a2d18.0"
+  dependencies:
+    "@material/animation": 15.0.0-canary.a515a2d18.0
+    "@material/base": 15.0.0-canary.a515a2d18.0
+    "@material/dom": 15.0.0-canary.a515a2d18.0
+    "@material/feature-targeting": 15.0.0-canary.a515a2d18.0
+    "@material/rtl": 15.0.0-canary.a515a2d18.0
+    "@material/theme": 15.0.0-canary.a515a2d18.0
+    tslib: ^2.1.0
+  checksum: 28dc9b66b55a7082dd93c857430f0ed3d94cd8372c6c9b9ee64c273c3ade2ab4d9dedf547807de60bc72f971107541a32664dacf7dd669203c678914bb7e5e7e
+  languageName: node
+  linkType: hard
+
 "@material/rtl@npm:15.0.0-canary.10196647d.0":
   version: 15.0.0-canary.10196647d.0
   resolution: "@material/rtl@npm:15.0.0-canary.10196647d.0"
@@ -3213,6 +3611,16 @@ __metadata:
     "@material/theme": 15.0.0-canary.10196647d.0
     tslib: ^2.1.0
   checksum: 3a32596b009ae182dd97af90f01d1f75351a616af026e35e913aea2ea7bf21afaa2e7bca15e2c7ddf40606e7e51a84cde70f5ab5c5a8c40d9474790a16ca8b83
+  languageName: node
+  linkType: hard
+
+"@material/rtl@npm:15.0.0-canary.a515a2d18.0":
+  version: 15.0.0-canary.a515a2d18.0
+  resolution: "@material/rtl@npm:15.0.0-canary.a515a2d18.0"
+  dependencies:
+    "@material/theme": 15.0.0-canary.a515a2d18.0
+    tslib: ^2.1.0
+  checksum: 4ee53d0015fece363c88ea76f7ba89e26d5f3257bc9daed0bf0d56d0ba11c99967e9e9bad5d6be7cec0d195642cf3a6bb52dd788f70993e5463fe68cc06292ce
   languageName: node
   linkType: hard
 
@@ -3229,6 +3637,22 @@ __metadata:
     "@material/typography": 15.0.0-canary.10196647d.0
     tslib: ^2.1.0
   checksum: 8ba8bd049346972cfcba46e79d2486fafee527cbfd77c8dc425feb723715579d9e5f8ab07505c50ee17a95ce3523e64b326cce142d90dc5f92c79ceb0c6c7814
+  languageName: node
+  linkType: hard
+
+"@material/segmented-button@npm:15.0.0-canary.a515a2d18.0":
+  version: 15.0.0-canary.a515a2d18.0
+  resolution: "@material/segmented-button@npm:15.0.0-canary.a515a2d18.0"
+  dependencies:
+    "@material/base": 15.0.0-canary.a515a2d18.0
+    "@material/elevation": 15.0.0-canary.a515a2d18.0
+    "@material/feature-targeting": 15.0.0-canary.a515a2d18.0
+    "@material/ripple": 15.0.0-canary.a515a2d18.0
+    "@material/theme": 15.0.0-canary.a515a2d18.0
+    "@material/touch-target": 15.0.0-canary.a515a2d18.0
+    "@material/typography": 15.0.0-canary.a515a2d18.0
+    tslib: ^2.1.0
+  checksum: d5dd0a415c5238db29eb27e5950046ebf396644bed27221e934f7126482086d01a7eda22e5c60244c25a095f6237d42de1e524b4fff702776bf6d94bcb063698
   languageName: node
   linkType: hard
 
@@ -3259,6 +3683,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@material/select@npm:15.0.0-canary.a515a2d18.0":
+  version: 15.0.0-canary.a515a2d18.0
+  resolution: "@material/select@npm:15.0.0-canary.a515a2d18.0"
+  dependencies:
+    "@material/animation": 15.0.0-canary.a515a2d18.0
+    "@material/base": 15.0.0-canary.a515a2d18.0
+    "@material/density": 15.0.0-canary.a515a2d18.0
+    "@material/dom": 15.0.0-canary.a515a2d18.0
+    "@material/elevation": 15.0.0-canary.a515a2d18.0
+    "@material/feature-targeting": 15.0.0-canary.a515a2d18.0
+    "@material/floating-label": 15.0.0-canary.a515a2d18.0
+    "@material/line-ripple": 15.0.0-canary.a515a2d18.0
+    "@material/list": 15.0.0-canary.a515a2d18.0
+    "@material/menu": 15.0.0-canary.a515a2d18.0
+    "@material/menu-surface": 15.0.0-canary.a515a2d18.0
+    "@material/notched-outline": 15.0.0-canary.a515a2d18.0
+    "@material/ripple": 15.0.0-canary.a515a2d18.0
+    "@material/rtl": 15.0.0-canary.a515a2d18.0
+    "@material/shape": 15.0.0-canary.a515a2d18.0
+    "@material/theme": 15.0.0-canary.a515a2d18.0
+    "@material/tokens": 15.0.0-canary.a515a2d18.0
+    "@material/typography": 15.0.0-canary.a515a2d18.0
+    tslib: ^2.1.0
+  checksum: d10168a83b6eb4bcd27ca20e38baf9e9d0286f7f565f02f3e46967db702fadafcb07b22a86155bc2030087067cb96417f7a04c52b032a4efd449e54bcaf43c49
+  languageName: node
+  linkType: hard
+
 "@material/shape@npm:15.0.0-canary.10196647d.0":
   version: 15.0.0-canary.10196647d.0
   resolution: "@material/shape@npm:15.0.0-canary.10196647d.0"
@@ -3268,6 +3719,18 @@ __metadata:
     "@material/theme": 15.0.0-canary.10196647d.0
     tslib: ^2.1.0
   checksum: 3e3c4400aea8c5e2ee37d67dc6898d3853fc8aab5b3390df985762db572cbde2b9e093ea1602b481cb25d31770bed90fe690e3cea1d5d2e453d5eaf06450780d
+  languageName: node
+  linkType: hard
+
+"@material/shape@npm:15.0.0-canary.a515a2d18.0":
+  version: 15.0.0-canary.a515a2d18.0
+  resolution: "@material/shape@npm:15.0.0-canary.a515a2d18.0"
+  dependencies:
+    "@material/feature-targeting": 15.0.0-canary.a515a2d18.0
+    "@material/rtl": 15.0.0-canary.a515a2d18.0
+    "@material/theme": 15.0.0-canary.a515a2d18.0
+    tslib: ^2.1.0
+  checksum: 919938608f314649c6f267eaf45314d7959bb2bea3ef0e11c707cad85bd9ba42b3bd630a8fb4f7659f1df6e384bee281896ceeb6d123eda0327320b952f181ab
   languageName: node
   linkType: hard
 
@@ -3286,6 +3749,25 @@ __metadata:
     "@material/typography": 15.0.0-canary.10196647d.0
     tslib: ^2.1.0
   checksum: e853703c3d7d002ee0e8544edcd3d6a31c10d182dafabe343baf752fedff97e0db71b6992b9cc3538e8a9472c3076f42e396509a02793aa3cf240792ddd5926e
+  languageName: node
+  linkType: hard
+
+"@material/slider@npm:15.0.0-canary.a515a2d18.0":
+  version: 15.0.0-canary.a515a2d18.0
+  resolution: "@material/slider@npm:15.0.0-canary.a515a2d18.0"
+  dependencies:
+    "@material/animation": 15.0.0-canary.a515a2d18.0
+    "@material/base": 15.0.0-canary.a515a2d18.0
+    "@material/dom": 15.0.0-canary.a515a2d18.0
+    "@material/elevation": 15.0.0-canary.a515a2d18.0
+    "@material/feature-targeting": 15.0.0-canary.a515a2d18.0
+    "@material/ripple": 15.0.0-canary.a515a2d18.0
+    "@material/rtl": 15.0.0-canary.a515a2d18.0
+    "@material/theme": 15.0.0-canary.a515a2d18.0
+    "@material/tokens": 15.0.0-canary.a515a2d18.0
+    "@material/typography": 15.0.0-canary.a515a2d18.0
+    tslib: ^2.1.0
+  checksum: 764d6ae9b5946516509ee32d9e3d4f356778d3fba09b3e880a3249c4650f47c6c10ed8cbe4d0817c12f750b6faa666b573cf86f20214f186355e064ca0b723fc
   languageName: node
   linkType: hard
 
@@ -3311,6 +3793,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@material/snackbar@npm:15.0.0-canary.a515a2d18.0":
+  version: 15.0.0-canary.a515a2d18.0
+  resolution: "@material/snackbar@npm:15.0.0-canary.a515a2d18.0"
+  dependencies:
+    "@material/animation": 15.0.0-canary.a515a2d18.0
+    "@material/base": 15.0.0-canary.a515a2d18.0
+    "@material/button": 15.0.0-canary.a515a2d18.0
+    "@material/dom": 15.0.0-canary.a515a2d18.0
+    "@material/elevation": 15.0.0-canary.a515a2d18.0
+    "@material/feature-targeting": 15.0.0-canary.a515a2d18.0
+    "@material/icon-button": 15.0.0-canary.a515a2d18.0
+    "@material/ripple": 15.0.0-canary.a515a2d18.0
+    "@material/rtl": 15.0.0-canary.a515a2d18.0
+    "@material/shape": 15.0.0-canary.a515a2d18.0
+    "@material/theme": 15.0.0-canary.a515a2d18.0
+    "@material/tokens": 15.0.0-canary.a515a2d18.0
+    "@material/typography": 15.0.0-canary.a515a2d18.0
+    tslib: ^2.1.0
+  checksum: 31a94ce5999ab49894ee54f4eafe294b470d53bd11148430bc50b247f81cac516825432e1946bb49689d60ed2bb11d3a1b675e2564c4ef19a62784220fd346f2
+  languageName: node
+  linkType: hard
+
 "@material/switch@npm:15.0.0-canary.10196647d.0":
   version: 15.0.0-canary.10196647d.0
   resolution: "@material/switch@npm:15.0.0-canary.10196647d.0"
@@ -3329,6 +3833,27 @@ __metadata:
     "@material/tokens": 15.0.0-canary.10196647d.0
     tslib: ^2.1.0
   checksum: 15ea5f064dd6fc5fdecde389a4a4b412a139de0a5e0cc85d2cd3f6f1182b76a90aa6bf24ae76b3db1da06f87170c9790aa7209e3e9d4c8786995963f9fbc5b3e
+  languageName: node
+  linkType: hard
+
+"@material/switch@npm:15.0.0-canary.a515a2d18.0":
+  version: 15.0.0-canary.a515a2d18.0
+  resolution: "@material/switch@npm:15.0.0-canary.a515a2d18.0"
+  dependencies:
+    "@material/animation": 15.0.0-canary.a515a2d18.0
+    "@material/base": 15.0.0-canary.a515a2d18.0
+    "@material/density": 15.0.0-canary.a515a2d18.0
+    "@material/dom": 15.0.0-canary.a515a2d18.0
+    "@material/elevation": 15.0.0-canary.a515a2d18.0
+    "@material/feature-targeting": 15.0.0-canary.a515a2d18.0
+    "@material/focus-ring": 15.0.0-canary.a515a2d18.0
+    "@material/ripple": 15.0.0-canary.a515a2d18.0
+    "@material/rtl": 15.0.0-canary.a515a2d18.0
+    "@material/shape": 15.0.0-canary.a515a2d18.0
+    "@material/theme": 15.0.0-canary.a515a2d18.0
+    "@material/tokens": 15.0.0-canary.a515a2d18.0
+    tslib: ^2.1.0
+  checksum: 253b2b2c09fdede113d68143e6f3529f9edc970f6e9541963b5fbe8d890d6327b51bfb1cf2bb2f2a688effbc5c7e50178fb84591c6d7c757fffb0fc533464eb9
   languageName: node
   linkType: hard
 
@@ -3351,6 +3876,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@material/tab-bar@npm:15.0.0-canary.a515a2d18.0":
+  version: 15.0.0-canary.a515a2d18.0
+  resolution: "@material/tab-bar@npm:15.0.0-canary.a515a2d18.0"
+  dependencies:
+    "@material/animation": 15.0.0-canary.a515a2d18.0
+    "@material/base": 15.0.0-canary.a515a2d18.0
+    "@material/density": 15.0.0-canary.a515a2d18.0
+    "@material/elevation": 15.0.0-canary.a515a2d18.0
+    "@material/feature-targeting": 15.0.0-canary.a515a2d18.0
+    "@material/tab": 15.0.0-canary.a515a2d18.0
+    "@material/tab-indicator": 15.0.0-canary.a515a2d18.0
+    "@material/tab-scroller": 15.0.0-canary.a515a2d18.0
+    "@material/theme": 15.0.0-canary.a515a2d18.0
+    "@material/typography": 15.0.0-canary.a515a2d18.0
+    tslib: ^2.1.0
+  checksum: fdf3051a9b5fdec31cdf47fbc98b0da33d55f2dbbae1b5e33e9bc4e379688ae9edf27ee96cdfcdcbc4a4a61019d4cdf267c51328292784f5e6a216c329eb8e95
+  languageName: node
+  linkType: hard
+
 "@material/tab-indicator@npm:15.0.0-canary.10196647d.0":
   version: 15.0.0-canary.10196647d.0
   resolution: "@material/tab-indicator@npm:15.0.0-canary.10196647d.0"
@@ -3361,6 +3905,19 @@ __metadata:
     "@material/theme": 15.0.0-canary.10196647d.0
     tslib: ^2.1.0
   checksum: 7a8d0805472712b7859f5dc4420956b9ae79266d30f27cd247c4dba7f500c6f73f7b7e42ac6707ae7090162f4b969fddc53df73c0705663f029bf6e125455978
+  languageName: node
+  linkType: hard
+
+"@material/tab-indicator@npm:15.0.0-canary.a515a2d18.0":
+  version: 15.0.0-canary.a515a2d18.0
+  resolution: "@material/tab-indicator@npm:15.0.0-canary.a515a2d18.0"
+  dependencies:
+    "@material/animation": 15.0.0-canary.a515a2d18.0
+    "@material/base": 15.0.0-canary.a515a2d18.0
+    "@material/feature-targeting": 15.0.0-canary.a515a2d18.0
+    "@material/theme": 15.0.0-canary.a515a2d18.0
+    tslib: ^2.1.0
+  checksum: 5adb35b4b552f50d4b9989407d0c51027ed0ccfd180dcd1ca3427bdfe048e07f1c32578bf04f069dd0ade177298ee60ce47cbd1d89ba41630b30b8d24d1ddd82
   languageName: node
   linkType: hard
 
@@ -3375,6 +3932,20 @@ __metadata:
     "@material/tab": 15.0.0-canary.10196647d.0
     tslib: ^2.1.0
   checksum: a08a2e5e6954c2316138361c331d401e4fb4abb5ad3ca812ddb894a68ed33ee81233e684fb5a57f6ae6f4ec90b1406a58d6e0f7952d2641b55379bc83b68bcd2
+  languageName: node
+  linkType: hard
+
+"@material/tab-scroller@npm:15.0.0-canary.a515a2d18.0":
+  version: 15.0.0-canary.a515a2d18.0
+  resolution: "@material/tab-scroller@npm:15.0.0-canary.a515a2d18.0"
+  dependencies:
+    "@material/animation": 15.0.0-canary.a515a2d18.0
+    "@material/base": 15.0.0-canary.a515a2d18.0
+    "@material/dom": 15.0.0-canary.a515a2d18.0
+    "@material/feature-targeting": 15.0.0-canary.a515a2d18.0
+    "@material/tab": 15.0.0-canary.a515a2d18.0
+    tslib: ^2.1.0
+  checksum: ba678aa7264769823cd46d3c5f5f53b69452809d4d380b3ea9bbcf69c184719cc792e9a629ce5814f7a823745e741a186b5e013c3c2c3a2247a16b95de1bb740
   languageName: node
   linkType: hard
 
@@ -3393,6 +3964,24 @@ __metadata:
     "@material/typography": 15.0.0-canary.10196647d.0
     tslib: ^2.1.0
   checksum: 20e311accf926ea8b8bfb23fd8d9f620bf9a3c115cc14650e2bfbb045571a01d428fad12b173772b90a85fc5d2dd42fb33337e360c7b994e792d1bdddeb22976
+  languageName: node
+  linkType: hard
+
+"@material/tab@npm:15.0.0-canary.a515a2d18.0":
+  version: 15.0.0-canary.a515a2d18.0
+  resolution: "@material/tab@npm:15.0.0-canary.a515a2d18.0"
+  dependencies:
+    "@material/base": 15.0.0-canary.a515a2d18.0
+    "@material/elevation": 15.0.0-canary.a515a2d18.0
+    "@material/feature-targeting": 15.0.0-canary.a515a2d18.0
+    "@material/focus-ring": 15.0.0-canary.a515a2d18.0
+    "@material/ripple": 15.0.0-canary.a515a2d18.0
+    "@material/rtl": 15.0.0-canary.a515a2d18.0
+    "@material/tab-indicator": 15.0.0-canary.a515a2d18.0
+    "@material/theme": 15.0.0-canary.a515a2d18.0
+    "@material/typography": 15.0.0-canary.a515a2d18.0
+    tslib: ^2.1.0
+  checksum: 175715658bc6f03ca26d10f84762934fca97800641565279cd74290ec932f0521d6c268370dc2aced22e40b4803522a2e3bc7f61553f454dd2b386f109b1fe17
   languageName: node
   linkType: hard
 
@@ -3419,6 +4008,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@material/textfield@npm:15.0.0-canary.a515a2d18.0":
+  version: 15.0.0-canary.a515a2d18.0
+  resolution: "@material/textfield@npm:15.0.0-canary.a515a2d18.0"
+  dependencies:
+    "@material/animation": 15.0.0-canary.a515a2d18.0
+    "@material/base": 15.0.0-canary.a515a2d18.0
+    "@material/density": 15.0.0-canary.a515a2d18.0
+    "@material/dom": 15.0.0-canary.a515a2d18.0
+    "@material/feature-targeting": 15.0.0-canary.a515a2d18.0
+    "@material/floating-label": 15.0.0-canary.a515a2d18.0
+    "@material/line-ripple": 15.0.0-canary.a515a2d18.0
+    "@material/notched-outline": 15.0.0-canary.a515a2d18.0
+    "@material/ripple": 15.0.0-canary.a515a2d18.0
+    "@material/rtl": 15.0.0-canary.a515a2d18.0
+    "@material/shape": 15.0.0-canary.a515a2d18.0
+    "@material/theme": 15.0.0-canary.a515a2d18.0
+    "@material/tokens": 15.0.0-canary.a515a2d18.0
+    "@material/typography": 15.0.0-canary.a515a2d18.0
+    tslib: ^2.1.0
+  checksum: 5d361b2b17de770b1203f5a184b1af2a06c1c949f448c39b6895dbeca173e8dde977588cec5b0484f4a3ccd3f32f8e5050314e0f2c0754c9829540222929d74d
+  languageName: node
+  linkType: hard
+
 "@material/theme@npm:15.0.0-canary.10196647d.0":
   version: 15.0.0-canary.10196647d.0
   resolution: "@material/theme@npm:15.0.0-canary.10196647d.0"
@@ -3429,12 +4041,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@material/theme@npm:15.0.0-canary.a515a2d18.0":
+  version: 15.0.0-canary.a515a2d18.0
+  resolution: "@material/theme@npm:15.0.0-canary.a515a2d18.0"
+  dependencies:
+    "@material/feature-targeting": 15.0.0-canary.a515a2d18.0
+    tslib: ^2.1.0
+  checksum: fd6e2d89890532836a1c8719c98ea9c2b436228d2928d596e9d949e56ff922e88ca424b2e0e08f26594746cf1682dbbb4fb9e34848b81073137cd10b3173f6b6
+  languageName: node
+  linkType: hard
+
 "@material/tokens@npm:15.0.0-canary.10196647d.0":
   version: 15.0.0-canary.10196647d.0
   resolution: "@material/tokens@npm:15.0.0-canary.10196647d.0"
   dependencies:
     "@material/elevation": 15.0.0-canary.10196647d.0
   checksum: 80f7c1ea4624d7a775beb690b0ed0c8fa0330efbca9981b8ca9569e90044680e152e14bec9395406ce35c47f4bb3875f1d2bcde1453a09036fcc124f4ac5b257
+  languageName: node
+  linkType: hard
+
+"@material/tokens@npm:15.0.0-canary.a515a2d18.0":
+  version: 15.0.0-canary.a515a2d18.0
+  resolution: "@material/tokens@npm:15.0.0-canary.a515a2d18.0"
+  dependencies:
+    "@material/elevation": 15.0.0-canary.a515a2d18.0
+  checksum: ebdbaa9a6decfde66e305d12aee9eca906a0e05f4a10dfc8fcd7241016d54f2fc99e681fd00120da4a009315d8edc21cc0d687e8d9adedb7a48a92c41478ea44
   languageName: node
   linkType: hard
 
@@ -3458,6 +4089,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@material/tooltip@npm:15.0.0-canary.a515a2d18.0":
+  version: 15.0.0-canary.a515a2d18.0
+  resolution: "@material/tooltip@npm:15.0.0-canary.a515a2d18.0"
+  dependencies:
+    "@material/animation": 15.0.0-canary.a515a2d18.0
+    "@material/base": 15.0.0-canary.a515a2d18.0
+    "@material/button": 15.0.0-canary.a515a2d18.0
+    "@material/dom": 15.0.0-canary.a515a2d18.0
+    "@material/elevation": 15.0.0-canary.a515a2d18.0
+    "@material/feature-targeting": 15.0.0-canary.a515a2d18.0
+    "@material/rtl": 15.0.0-canary.a515a2d18.0
+    "@material/shape": 15.0.0-canary.a515a2d18.0
+    "@material/theme": 15.0.0-canary.a515a2d18.0
+    "@material/tokens": 15.0.0-canary.a515a2d18.0
+    "@material/typography": 15.0.0-canary.a515a2d18.0
+    tslib: ^2.1.0
+  checksum: 296f7b2cbe9069a231ea81ee9a06874ad2f58c0f0bb1ffb9603f5e1fe5de0ba9d60e0f2e028e5250115c3576da8a8d3b978470c1e2d529420884e0259712ecaf
+  languageName: node
+  linkType: hard
+
 "@material/top-app-bar@npm:15.0.0-canary.10196647d.0":
   version: 15.0.0-canary.10196647d.0
   resolution: "@material/top-app-bar@npm:15.0.0-canary.10196647d.0"
@@ -3475,6 +4126,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@material/top-app-bar@npm:15.0.0-canary.a515a2d18.0":
+  version: 15.0.0-canary.a515a2d18.0
+  resolution: "@material/top-app-bar@npm:15.0.0-canary.a515a2d18.0"
+  dependencies:
+    "@material/animation": 15.0.0-canary.a515a2d18.0
+    "@material/base": 15.0.0-canary.a515a2d18.0
+    "@material/elevation": 15.0.0-canary.a515a2d18.0
+    "@material/ripple": 15.0.0-canary.a515a2d18.0
+    "@material/rtl": 15.0.0-canary.a515a2d18.0
+    "@material/shape": 15.0.0-canary.a515a2d18.0
+    "@material/theme": 15.0.0-canary.a515a2d18.0
+    "@material/typography": 15.0.0-canary.a515a2d18.0
+    tslib: ^2.1.0
+  checksum: 40102d49f31febb351df89515a564b3fdaa5a7a54a8899bd7c481305b70bcf23ab6c29233bb953a9ce9d80e73ae725129ca911c9b0c22f67f33998f370deb97e
+  languageName: node
+  linkType: hard
+
 "@material/touch-target@npm:15.0.0-canary.10196647d.0":
   version: 15.0.0-canary.10196647d.0
   resolution: "@material/touch-target@npm:15.0.0-canary.10196647d.0"
@@ -3484,6 +4152,18 @@ __metadata:
     "@material/rtl": 15.0.0-canary.10196647d.0
     tslib: ^2.1.0
   checksum: ba6a568a6c8f98fae62f3e49c0bdc5c712114605d93f52c0b3f353f2d52c9e32e01b613db229a3ccacd4c2a09e6ba9c4b5d4c67fc481d0d4f413a38a03b2b566
+  languageName: node
+  linkType: hard
+
+"@material/touch-target@npm:15.0.0-canary.a515a2d18.0":
+  version: 15.0.0-canary.a515a2d18.0
+  resolution: "@material/touch-target@npm:15.0.0-canary.a515a2d18.0"
+  dependencies:
+    "@material/base": 15.0.0-canary.a515a2d18.0
+    "@material/feature-targeting": 15.0.0-canary.a515a2d18.0
+    "@material/rtl": 15.0.0-canary.a515a2d18.0
+    tslib: ^2.1.0
+  checksum: 52e70764102bdf11eb9e29b7d15e43b300731b5286055453fcde0774102afd912ae576beb9c935e94213308ba5f160d674724d7b4a9865b1eb3f05b75bf4cbac
   languageName: node
   linkType: hard
 
@@ -3498,14 +4178,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ngtools/webpack@npm:15.0.0-next.0":
-  version: 15.0.0-next.0
-  resolution: "@ngtools/webpack@npm:15.0.0-next.0"
+"@material/typography@npm:15.0.0-canary.a515a2d18.0":
+  version: 15.0.0-canary.a515a2d18.0
+  resolution: "@material/typography@npm:15.0.0-canary.a515a2d18.0"
+  dependencies:
+    "@material/feature-targeting": 15.0.0-canary.a515a2d18.0
+    "@material/theme": 15.0.0-canary.a515a2d18.0
+    tslib: ^2.1.0
+  checksum: 665243e99d66c7bd4abd7a965fc5ba166218f6f88afc3b39b23444cd602fad1441616a759486b951af0e2a7d12ae227c53311d2880e532caf676675080c33190
+  languageName: node
+  linkType: hard
+
+"@ngtools/webpack@npm:15.0.0-next.6":
+  version: 15.0.0-next.6
+  resolution: "@ngtools/webpack@npm:15.0.0-next.6"
   peerDependencies:
     "@angular/compiler-cli": ^15.0.0-next
-    typescript: ">=4.6.2 <4.9"
+    typescript: ~4.8.2
     webpack: ^5.54.0
-  checksum: a69d90465d792ce55930306e02a5e6708b43bd06ef419e06cc802d536649e84bfd464d92d06e9d46146709f40bdf669c5d82d035738cceb63cfac3e68019e5ba
+  checksum: ac366a0b078848d52b03a77e7c1de42aca296ee940e4b6c5557a5031f5309e4fc8ca75db158e46b4b243baadb12deb52864952ef39fccbf2c9a5126517ce04a5
   languageName: node
   linkType: hard
 
@@ -3556,6 +4247,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@npmcli/fs@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@npmcli/fs@npm:3.0.0"
+  dependencies:
+    semver: ^7.3.5
+  checksum: a95714f2369ede1fffbcaf2e7ef2db36819316d240ff0cca883ddf243544aee3519c36e4eaaa760cd2721d077a415f71f6808c71382c20a03d0cbb6e753ccd4f
+  languageName: node
+  linkType: hard
+
 "@npmcli/git@npm:^3.0.0":
   version: 3.0.0
   resolution: "@npmcli/git@npm:3.0.0"
@@ -3585,7 +4285,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@npmcli/move-file@npm:^1.0.1, @npmcli/move-file@npm:^1.1.2":
+"@npmcli/move-file@npm:^1.0.1":
   version: 1.1.2
   resolution: "@npmcli/move-file@npm:1.1.2"
   dependencies:
@@ -3643,14 +4343,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@schematics/angular@npm:15.0.0-next.0":
-  version: 15.0.0-next.0
-  resolution: "@schematics/angular@npm:15.0.0-next.0"
+"@schematics/angular@npm:15.0.0-next.6":
+  version: 15.0.0-next.6
+  resolution: "@schematics/angular@npm:15.0.0-next.6"
   dependencies:
-    "@angular-devkit/core": 15.0.0-next.0
-    "@angular-devkit/schematics": 15.0.0-next.0
+    "@angular-devkit/core": 15.0.0-next.6
+    "@angular-devkit/schematics": 15.0.0-next.6
     jsonc-parser: 3.2.0
-  checksum: ea01013a6f9d9b7f6237ec5492b3de2cac71a9b0829cb016b88b5e6344f02cbda302d7f1dc315883c7ccac3a18155da8c4197f8bf955266a37245ea4ba1fd1e8
+  checksum: 9ffb183a2ca2413da07ab9dad3e56bd3c26547ff4bea075597b1d454d862248c1fae6df3f5d1d9aadd78c2de7450592507cff38f0ca735d1b32632e173330616
   languageName: node
   linkType: hard
 
@@ -4361,12 +5061,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"autoprefixer@npm:^10.4.8":
-  version: 10.4.9
-  resolution: "autoprefixer@npm:10.4.9"
+"autoprefixer@npm:10.4.12":
+  version: 10.4.12
+  resolution: "autoprefixer@npm:10.4.12"
   dependencies:
-    browserslist: ^4.21.3
-    caniuse-lite: ^1.0.30001394
+    browserslist: ^4.21.4
+    caniuse-lite: ^1.0.30001407
     fraction.js: ^4.2.0
     normalize-range: ^0.1.2
     picocolors: ^1.0.0
@@ -4375,7 +5075,7 @@ __metadata:
     postcss: ^8.1.0
   bin:
     autoprefixer: bin/autoprefixer
-  checksum: ea5e2067d36ff170af97c68c286ad29cc56640532100a63ebe1464cff2fcb7d7685a1926774141a78faf8bb09f1746edf4918fa1decfd25761e5ccf9ebc0531d
+  checksum: 6ae79cbacd31fb3d464ec64eb6ad2600f4f689c3080bbe62c5536d539b41b472083a2e941ef99d14aa11142370d6c16e8b05a62f077374933ed991aceb5943d2
   languageName: node
   linkType: hard
 
@@ -4416,7 +5116,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-plugin-polyfill-corejs2@npm:^0.3.2":
+"babel-plugin-polyfill-corejs2@npm:^0.3.3":
   version: 0.3.3
   resolution: "babel-plugin-polyfill-corejs2@npm:0.3.3"
   dependencies:
@@ -4429,19 +5129,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-plugin-polyfill-corejs3@npm:^0.5.3":
-  version: 0.5.3
-  resolution: "babel-plugin-polyfill-corejs3@npm:0.5.3"
+"babel-plugin-polyfill-corejs3@npm:^0.6.0":
+  version: 0.6.0
+  resolution: "babel-plugin-polyfill-corejs3@npm:0.6.0"
   dependencies:
-    "@babel/helper-define-polyfill-provider": ^0.3.2
-    core-js-compat: ^3.21.0
+    "@babel/helper-define-polyfill-provider": ^0.3.3
+    core-js-compat: ^3.25.1
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 9c6644a1b0afbe59e402827fdafc6f44994ff92c5b2f258659cbbfd228f7075dea49e95114af10e66d70f36cbde12ff1d81263eb67be749b3ef0e2c18cf3c16d
+  checksum: 470bb8c59f7c0912bd77fe1b5a2e72f349b3f65bbdee1d60d6eb7e1f4a085c6f24b2dd5ab4ac6c2df6444a96b070ef6790eccc9edb6a2668c60d33133bfb62c6
   languageName: node
   linkType: hard
 
-"babel-plugin-polyfill-regenerator@npm:^0.4.0":
+"babel-plugin-polyfill-regenerator@npm:^0.4.1":
   version: 0.4.1
   resolution: "babel-plugin-polyfill-regenerator@npm:0.4.1"
   dependencies:
@@ -4590,7 +5290,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"browserslist@npm:^4.14.5, browserslist@npm:^4.17.5, browserslist@npm:^4.19.1, browserslist@npm:^4.9.1":
+"browserslist@npm:^4.14.5, browserslist@npm:^4.17.5, browserslist@npm:^4.9.1":
   version: 4.19.1
   resolution: "browserslist@npm:4.19.1"
   dependencies:
@@ -4605,7 +5305,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"browserslist@npm:^4.20.2, browserslist@npm:^4.20.3":
+"browserslist@npm:^4.20.2":
   version: 4.20.3
   resolution: "browserslist@npm:4.20.3"
   dependencies:
@@ -4631,6 +5331,20 @@ __metadata:
   bin:
     browserslist: cli.js
   checksum: ff512a7bcca1c530e2854bbdfc7be2791d0fb524097a6340e56e1d5924164c7e4e0a9b070de04cdc4c149d15cb4d4275cb7c626ebbce954278a2823aaad2452a
+  languageName: node
+  linkType: hard
+
+"browserslist@npm:^4.21.4":
+  version: 4.21.4
+  resolution: "browserslist@npm:4.21.4"
+  dependencies:
+    caniuse-lite: ^1.0.30001400
+    electron-to-chromium: ^1.4.251
+    node-releases: ^2.0.6
+    update-browserslist-db: ^1.0.9
+  bin:
+    browserslist: cli.js
+  checksum: 4af3793704dbb4615bcd29059ab472344dc7961c8680aa6c4bb84f05340e14038d06a5aead58724eae69455b8fade8b8c69f1638016e87e5578969d74c078b79
   languageName: node
   linkType: hard
 
@@ -4688,29 +5402,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cacache@npm:16.1.3, cacache@npm:^16.1.0":
-  version: 16.1.3
-  resolution: "cacache@npm:16.1.3"
+"cacache@npm:17.0.0, cacache@npm:^17.0.0":
+  version: 17.0.0
+  resolution: "cacache@npm:17.0.0"
   dependencies:
-    "@npmcli/fs": ^2.1.0
+    "@npmcli/fs": ^3.0.0
     "@npmcli/move-file": ^2.0.0
-    chownr: ^2.0.0
     fs-minipass: ^2.1.0
     glob: ^8.0.1
-    infer-owner: ^1.0.4
     lru-cache: ^7.7.1
     minipass: ^3.1.6
     minipass-collect: ^1.0.2
     minipass-flush: ^1.0.5
     minipass-pipeline: ^1.2.4
-    mkdirp: ^1.0.4
     p-map: ^4.0.0
     promise-inflight: ^1.0.1
-    rimraf: ^3.0.2
     ssri: ^9.0.0
     tar: ^6.1.11
     unique-filename: ^2.0.0
-  checksum: d91409e6e57d7d9a3a25e5dcc589c84e75b178ae8ea7de05cbf6b783f77a5fae938f6e8fda6f5257ed70000be27a681e1e44829251bfffe4c10216002f8f14e6
+  checksum: 0821e15e0c8d50ae9507a42dbfed071e5b4058dfd0d9bccc4fc23606d711889c65d24f2ae14295639231329e505f166f641d8958bfb8ab86c9ad0a6e51dab41d
   languageName: node
   linkType: hard
 
@@ -4740,32 +5450,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cacache@npm:^16.0.0":
-  version: 16.0.0
-  resolution: "cacache@npm:16.0.0"
-  dependencies:
-    "@npmcli/fs": "npm:^1.0.0"
-    "@npmcli/move-file": "npm:^1.1.2"
-    chownr: "npm:^2.0.0"
-    fs-minipass: "npm:^2.1.0"
-    glob: "npm:^7.1.4"
-    infer-owner: "npm:^1.0.4"
-    lru-cache: "npm:^6.0.0"
-    minipass: "npm:^3.1.1"
-    minipass-collect: "npm:^1.0.2"
-    minipass-flush: "npm:^1.0.5"
-    minipass-pipeline: "npm:^1.2.4"
-    mkdirp: "npm:^1.0.4"
-    p-map: "npm:^4.0.0"
-    promise-inflight: "npm:^1.0.1"
-    rimraf: "npm:^3.0.2"
-    ssri: "npm:^8.0.1"
-    tar: "npm:^6.1.11"
-    unique-filename: "npm:^1.1.1"
-  checksum: 1a5404958f60b1dc7c484e00ac5bb0466d8163cda77d20f827875c4fb6043cfedba852340291e96bfbf5995fc5ea8258c31be7a292e92008081d822902ddf22b
-  languageName: node
-  linkType: hard
-
 "cacache@npm:^16.0.2":
   version: 16.0.7
   resolution: "cacache@npm:16.0.7"
@@ -4789,6 +5473,32 @@ __metadata:
     tar: "npm:^6.1.11"
     unique-filename: "npm:^1.1.1"
   checksum: 2155b099b7e0f0369fb1155ca4673532ca7efe2ebdbec63acca8743580b8446b5d4fd7184626b1cb059001af77b981cdc67035c7855544d365d4f048eafca2ca
+  languageName: node
+  linkType: hard
+
+"cacache@npm:^16.1.0":
+  version: 16.1.3
+  resolution: "cacache@npm:16.1.3"
+  dependencies:
+    "@npmcli/fs": ^2.1.0
+    "@npmcli/move-file": ^2.0.0
+    chownr: ^2.0.0
+    fs-minipass: ^2.1.0
+    glob: ^8.0.1
+    infer-owner: ^1.0.4
+    lru-cache: ^7.7.1
+    minipass: ^3.1.6
+    minipass-collect: ^1.0.2
+    minipass-flush: ^1.0.5
+    minipass-pipeline: ^1.2.4
+    mkdirp: ^1.0.4
+    p-map: ^4.0.0
+    promise-inflight: ^1.0.1
+    rimraf: ^3.0.2
+    ssri: ^9.0.0
+    tar: ^6.1.11
+    unique-filename: ^2.0.0
+  checksum: d91409e6e57d7d9a3a25e5dcc589c84e75b178ae8ea7de05cbf6b783f77a5fae938f6e8fda6f5257ed70000be27a681e1e44829251bfffe4c10216002f8f14e6
   languageName: node
   linkType: hard
 
@@ -4837,10 +5547,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.30001394":
-  version: 1.0.30001399
-  resolution: "caniuse-lite@npm:1.0.30001399"
-  checksum: dd105b06fbbdc89867780a2f4debc3ecb184cff82f35b34aaac486628fcc9cf6bacf37573a9cc22dedc661178d460fa8401374a933cb9d2f8ee67316d98b2a8f
+"caniuse-lite@npm:^1.0.30001400, caniuse-lite@npm:^1.0.30001407":
+  version: 1.0.30001418
+  resolution: "caniuse-lite@npm:1.0.30001418"
+  checksum: 03380a9ba50b1abd0081e76bfdf331bfb2c28f2277ce5eead5b83960c4db9f1fbbd84a536efa6f8f1fe2c038bc01129d6c42d17f8323fe99a016a5da3829c4bc
   languageName: node
   linkType: hard
 
@@ -4872,7 +5582,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chokidar@npm:>=3.0.0 <4.0.0, chokidar@npm:^3.0.0, chokidar@npm:^3.5.1, chokidar@npm:^3.5.3":
+"chokidar@npm:3.5.3, chokidar@npm:>=3.0.0 <4.0.0, chokidar@npm:^3.0.0, chokidar@npm:^3.5.1, chokidar@npm:^3.5.3":
   version: 3.5.3
   resolution: "chokidar@npm:3.5.3"
   dependencies:
@@ -4943,6 +5653,17 @@ __metadata:
     strip-ansi: "npm:^6.0.0"
     wrap-ansi: "npm:^7.0.0"
   checksum: ce2e8f578a4813806788ac399b9e866297740eecd4ad1823c27fd344d78b22c5f8597d548adbcc46f0573e43e21e751f39446c5a5e804a12aace402b7a315d7f
+  languageName: node
+  linkType: hard
+
+"cliui@npm:^8.0.1":
+  version: 8.0.1
+  resolution: "cliui@npm:8.0.1"
+  dependencies:
+    string-width: ^4.2.0
+    strip-ansi: ^6.0.1
+    wrap-ansi: ^7.0.0
+  checksum: 79648b3b0045f2e285b76fb2e24e207c6db44323581e421c3acbd0e86454cba1b37aea976ab50195a49e7384b871e6dfb2247ad7dec53c02454ac6497394cb56
   languageName: node
   linkType: hard
 
@@ -5161,23 +5882,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"core-js-compat@npm:^3.21.0":
-  version: 3.21.0
-  resolution: "core-js-compat@npm:3.21.0"
+"core-js-compat@npm:^3.25.1":
+  version: 3.25.5
+  resolution: "core-js-compat@npm:3.25.5"
   dependencies:
-    browserslist: "npm:^4.19.1"
-    semver: "npm:7.0.0"
-  checksum: 7914d2f8a2f7c1b400e1c04c7560f4c96028bf23cec3cea6063ba594e38023cccbd38ad88af41c5d6b65450e97a989eb37598f609e3f7fbc6ebc1856d4195cbb
-  languageName: node
-  linkType: hard
-
-"core-js-compat@npm:^3.22.1":
-  version: 3.22.5
-  resolution: "core-js-compat@npm:3.22.5"
-  dependencies:
-    browserslist: "npm:^4.20.3"
-    semver: "npm:7.0.0"
-  checksum: 5547a51f403faad26f5855ba60e642c51f4acff549becfdd8a327b6db823785b375360f7a03b30978170af2a66f9fbde0fca0f8bb15a28a8c6dbe7df84d8af32
+    browserslist: ^4.21.4
+  checksum: 30686b750d675b685426ee25e41e30b83aa05ff7b79def94b457529d05c1ad123cd4d0b70d9162b077a15dc9f6f177ee997d846d0a3324176dd3c504e917309c
   languageName: node
   linkType: hard
 
@@ -5236,32 +5946,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"css-blank-pseudo@npm:^3.0.3":
-  version: 3.0.3
-  resolution: "css-blank-pseudo@npm:3.0.3"
-  dependencies:
-    postcss-selector-parser: "npm:^6.0.9"
-  peerDependencies:
-    postcss: ^8.4
-  bin:
-    css-blank-pseudo: dist/cli.cjs
-  checksum: 9be0a13885a99d8ba9e1f45ea66e801d4da75b58c1c3c516a40772fa3a93ef9952b15dcac0418acbb6c89daaae0572819647701b8e553a02972826e33d4cd67f
-  languageName: node
-  linkType: hard
-
-"css-has-pseudo@npm:^3.0.4":
-  version: 3.0.4
-  resolution: "css-has-pseudo@npm:3.0.4"
-  dependencies:
-    postcss-selector-parser: "npm:^6.0.9"
-  peerDependencies:
-    postcss: ^8.4
-  bin:
-    css-has-pseudo: dist/cli.cjs
-  checksum: 8f165d68f6621891d9fa1d874794916a52ed8847dfbec591523ad68774650cc1eae062ba08f59514666e04aeba27be72c9b211892f3a187c5ba6e287bd4260e7
-  languageName: node
-  linkType: hard
-
 "css-loader@npm:6.7.1":
   version: 6.7.1
   resolution: "css-loader@npm:6.7.1"
@@ -5277,17 +5961,6 @@ __metadata:
   peerDependencies:
     webpack: ^5.0.0
   checksum: 170fdbc630a05a43679ef60fa97694766b568dbde37adccc0faafa964fc675f08b976bc68837bb73b61d60240e8d2cbcbf51540fe94ebc9dafc56e7c46ba5527
-  languageName: node
-  linkType: hard
-
-"css-prefers-color-scheme@npm:^6.0.3":
-  version: 6.0.3
-  resolution: "css-prefers-color-scheme@npm:6.0.3"
-  peerDependencies:
-    postcss: ^8.4
-  bin:
-    css-prefers-color-scheme: dist/cli.cjs
-  checksum: 3a2b02f0454adda68861cdcaf6a0d11f462eadf165301cba61c5ec7c5f229ac261c5baa54c377d9b811ec5f21b30d72a02bc032cdad2415b3a566f08a0c47b3a
   languageName: node
   linkType: hard
 
@@ -5308,13 +5981,6 @@ __metadata:
   version: 5.1.0
   resolution: "css-what@npm:5.1.0"
   checksum: 0b75d1bac95c885c168573c85744a6c6843d8c33345f54f717218b37ea6296b0e99bb12105930ea170fd4a921990392a7c790c16c585c1d8960c49e2b7ec39f7
-  languageName: node
-  linkType: hard
-
-"cssdb@npm:^7.0.1":
-  version: 7.0.1
-  resolution: "cssdb@npm:7.0.1"
-  checksum: 4b4de59864c8d3adb5f90fad2b97d527714bb7702f317275b43e2d4e91cb68408130e9c8bdef932027feec86bd74beb847509ee931a3338f7a5be7d01c81eac8
   languageName: node
   linkType: hard
 
@@ -5350,7 +6016,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.3, debug@npm:~4.3.1, debug@npm:~4.3.2":
+"debug@npm:4, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.3, debug@npm:~4.3.1, debug@npm:~4.3.2":
   version: 4.3.3
   resolution: "debug@npm:4.3.3"
   dependencies:
@@ -5359,18 +6025,6 @@ __metadata:
     supports-color:
       optional: true
   checksum: 14472d56fe4a94dbcfaa6dbed2dd3849f1d72ba78104a1a328047bb564643ca49df0224c3a17fa63533fd11dd3d4c8636cd861191232a2c6735af00cc2d4de16
-  languageName: node
-  linkType: hard
-
-"debug@npm:4.3.4":
-  version: 4.3.4
-  resolution: "debug@npm:4.3.4"
-  dependencies:
-    ms: "npm:2.1.2"
-  peerDependenciesMeta:
-    supports-color:
-      optional: true
-  checksum: 3dbad3f94ea64f34431a9cbf0bafb61853eda57bff2880036153438f50fb5a84f27683ba0d8e5426bf41a8c6ff03879488120cf5b3a761e77953169c0600a708
   languageName: node
   linkType: hard
 
@@ -5569,6 +6223,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"electron-to-chromium@npm:^1.4.251":
+  version: 1.4.279
+  resolution: "electron-to-chromium@npm:1.4.279"
+  checksum: f98f592ad6acb34a63a7c804b21a14c0f05e85bc2892812e8d20019493b6bd5425c401bfd00363015ca953fb0489136c02cc60140cd9ad59e2b299531faa9d2f
+  languageName: node
+  linkType: hard
+
 "emoji-regex@npm:^8.0.0":
   version: 8.0.0
   resolution: "emoji-regex@npm:8.0.0"
@@ -5691,181 +6352,184 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-android-64@npm:0.15.7":
-  version: 0.15.7
-  resolution: "esbuild-android-64@npm:0.15.7"
+"esbuild-android-64@npm:0.15.10":
+  version: 0.15.10
+  resolution: "esbuild-android-64@npm:0.15.10"
   conditions: os=android & cpu=x64
   languageName: node
   linkType: hard
 
-"esbuild-android-arm64@npm:0.15.7":
-  version: 0.15.7
-  resolution: "esbuild-android-arm64@npm:0.15.7"
+"esbuild-android-arm64@npm:0.15.10":
+  version: 0.15.10
+  resolution: "esbuild-android-arm64@npm:0.15.10"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
 
-"esbuild-darwin-64@npm:0.15.7":
-  version: 0.15.7
-  resolution: "esbuild-darwin-64@npm:0.15.7"
+"esbuild-darwin-64@npm:0.15.10":
+  version: 0.15.10
+  resolution: "esbuild-darwin-64@npm:0.15.10"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"esbuild-darwin-arm64@npm:0.15.7":
-  version: 0.15.7
-  resolution: "esbuild-darwin-arm64@npm:0.15.7"
+"esbuild-darwin-arm64@npm:0.15.10":
+  version: 0.15.10
+  resolution: "esbuild-darwin-arm64@npm:0.15.10"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"esbuild-freebsd-64@npm:0.15.7":
-  version: 0.15.7
-  resolution: "esbuild-freebsd-64@npm:0.15.7"
+"esbuild-freebsd-64@npm:0.15.10":
+  version: 0.15.10
+  resolution: "esbuild-freebsd-64@npm:0.15.10"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
 
-"esbuild-freebsd-arm64@npm:0.15.7":
-  version: 0.15.7
-  resolution: "esbuild-freebsd-arm64@npm:0.15.7"
+"esbuild-freebsd-arm64@npm:0.15.10":
+  version: 0.15.10
+  resolution: "esbuild-freebsd-arm64@npm:0.15.10"
   conditions: os=freebsd & cpu=arm64
   languageName: node
   linkType: hard
 
-"esbuild-linux-32@npm:0.15.7":
-  version: 0.15.7
-  resolution: "esbuild-linux-32@npm:0.15.7"
+"esbuild-linux-32@npm:0.15.10":
+  version: 0.15.10
+  resolution: "esbuild-linux-32@npm:0.15.10"
   conditions: os=linux & cpu=ia32
   languageName: node
   linkType: hard
 
-"esbuild-linux-64@npm:0.15.7":
-  version: 0.15.7
-  resolution: "esbuild-linux-64@npm:0.15.7"
+"esbuild-linux-64@npm:0.15.10":
+  version: 0.15.10
+  resolution: "esbuild-linux-64@npm:0.15.10"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
 
-"esbuild-linux-arm64@npm:0.15.7":
-  version: 0.15.7
-  resolution: "esbuild-linux-arm64@npm:0.15.7"
+"esbuild-linux-arm64@npm:0.15.10":
+  version: 0.15.10
+  resolution: "esbuild-linux-arm64@npm:0.15.10"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
 
-"esbuild-linux-arm@npm:0.15.7":
-  version: 0.15.7
-  resolution: "esbuild-linux-arm@npm:0.15.7"
+"esbuild-linux-arm@npm:0.15.10":
+  version: 0.15.10
+  resolution: "esbuild-linux-arm@npm:0.15.10"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
-"esbuild-linux-mips64le@npm:0.15.7":
-  version: 0.15.7
-  resolution: "esbuild-linux-mips64le@npm:0.15.7"
+"esbuild-linux-mips64le@npm:0.15.10":
+  version: 0.15.10
+  resolution: "esbuild-linux-mips64le@npm:0.15.10"
   conditions: os=linux & cpu=mips64el
   languageName: node
   linkType: hard
 
-"esbuild-linux-ppc64le@npm:0.15.7":
-  version: 0.15.7
-  resolution: "esbuild-linux-ppc64le@npm:0.15.7"
+"esbuild-linux-ppc64le@npm:0.15.10":
+  version: 0.15.10
+  resolution: "esbuild-linux-ppc64le@npm:0.15.10"
   conditions: os=linux & cpu=ppc64
   languageName: node
   linkType: hard
 
-"esbuild-linux-riscv64@npm:0.15.7":
-  version: 0.15.7
-  resolution: "esbuild-linux-riscv64@npm:0.15.7"
+"esbuild-linux-riscv64@npm:0.15.10":
+  version: 0.15.10
+  resolution: "esbuild-linux-riscv64@npm:0.15.10"
   conditions: os=linux & cpu=riscv64
   languageName: node
   linkType: hard
 
-"esbuild-linux-s390x@npm:0.15.7":
-  version: 0.15.7
-  resolution: "esbuild-linux-s390x@npm:0.15.7"
+"esbuild-linux-s390x@npm:0.15.10":
+  version: 0.15.10
+  resolution: "esbuild-linux-s390x@npm:0.15.10"
   conditions: os=linux & cpu=s390x
   languageName: node
   linkType: hard
 
-"esbuild-netbsd-64@npm:0.15.7":
-  version: 0.15.7
-  resolution: "esbuild-netbsd-64@npm:0.15.7"
+"esbuild-netbsd-64@npm:0.15.10":
+  version: 0.15.10
+  resolution: "esbuild-netbsd-64@npm:0.15.10"
   conditions: os=netbsd & cpu=x64
   languageName: node
   linkType: hard
 
-"esbuild-openbsd-64@npm:0.15.7":
-  version: 0.15.7
-  resolution: "esbuild-openbsd-64@npm:0.15.7"
+"esbuild-openbsd-64@npm:0.15.10":
+  version: 0.15.10
+  resolution: "esbuild-openbsd-64@npm:0.15.10"
   conditions: os=openbsd & cpu=x64
   languageName: node
   linkType: hard
 
-"esbuild-sunos-64@npm:0.15.7":
-  version: 0.15.7
-  resolution: "esbuild-sunos-64@npm:0.15.7"
+"esbuild-sunos-64@npm:0.15.10":
+  version: 0.15.10
+  resolution: "esbuild-sunos-64@npm:0.15.10"
   conditions: os=sunos & cpu=x64
   languageName: node
   linkType: hard
 
-"esbuild-wasm@npm:0.15.7":
-  version: 0.15.7
-  resolution: "esbuild-wasm@npm:0.15.7"
+"esbuild-wasm@npm:0.15.10":
+  version: 0.15.10
+  resolution: "esbuild-wasm@npm:0.15.10"
   bin:
     esbuild: bin/esbuild
-  checksum: 559ba4a6ce1ce3cf4493c164d45f651090007978cd9161fcc6b7428524fb61698d88df11d1e9c9f2f9ed3fcaed6b4f6447ddbe9de0d279cd4b866d0579f2e82d
+  checksum: c448d2185e9c475e804704f1fa76e662f1a1aa8d339b556f1957c76bd62e9ce05e45b57677f479f969d9055b82c8b7d1786020c9b7e36d6f2e97960f17b70702
   languageName: node
   linkType: hard
 
-"esbuild-windows-32@npm:0.15.7":
-  version: 0.15.7
-  resolution: "esbuild-windows-32@npm:0.15.7"
+"esbuild-windows-32@npm:0.15.10":
+  version: 0.15.10
+  resolution: "esbuild-windows-32@npm:0.15.10"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
 
-"esbuild-windows-64@npm:0.15.7":
-  version: 0.15.7
-  resolution: "esbuild-windows-64@npm:0.15.7"
+"esbuild-windows-64@npm:0.15.10":
+  version: 0.15.10
+  resolution: "esbuild-windows-64@npm:0.15.10"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
-"esbuild-windows-arm64@npm:0.15.7":
-  version: 0.15.7
-  resolution: "esbuild-windows-arm64@npm:0.15.7"
+"esbuild-windows-arm64@npm:0.15.10":
+  version: 0.15.10
+  resolution: "esbuild-windows-arm64@npm:0.15.10"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"esbuild@npm:0.15.7":
-  version: 0.15.7
-  resolution: "esbuild@npm:0.15.7"
+"esbuild@npm:0.15.10":
+  version: 0.15.10
+  resolution: "esbuild@npm:0.15.10"
   dependencies:
-    "@esbuild/linux-loong64": 0.15.7
-    esbuild-android-64: 0.15.7
-    esbuild-android-arm64: 0.15.7
-    esbuild-darwin-64: 0.15.7
-    esbuild-darwin-arm64: 0.15.7
-    esbuild-freebsd-64: 0.15.7
-    esbuild-freebsd-arm64: 0.15.7
-    esbuild-linux-32: 0.15.7
-    esbuild-linux-64: 0.15.7
-    esbuild-linux-arm: 0.15.7
-    esbuild-linux-arm64: 0.15.7
-    esbuild-linux-mips64le: 0.15.7
-    esbuild-linux-ppc64le: 0.15.7
-    esbuild-linux-riscv64: 0.15.7
-    esbuild-linux-s390x: 0.15.7
-    esbuild-netbsd-64: 0.15.7
-    esbuild-openbsd-64: 0.15.7
-    esbuild-sunos-64: 0.15.7
-    esbuild-windows-32: 0.15.7
-    esbuild-windows-64: 0.15.7
-    esbuild-windows-arm64: 0.15.7
+    "@esbuild/android-arm": 0.15.10
+    "@esbuild/linux-loong64": 0.15.10
+    esbuild-android-64: 0.15.10
+    esbuild-android-arm64: 0.15.10
+    esbuild-darwin-64: 0.15.10
+    esbuild-darwin-arm64: 0.15.10
+    esbuild-freebsd-64: 0.15.10
+    esbuild-freebsd-arm64: 0.15.10
+    esbuild-linux-32: 0.15.10
+    esbuild-linux-64: 0.15.10
+    esbuild-linux-arm: 0.15.10
+    esbuild-linux-arm64: 0.15.10
+    esbuild-linux-mips64le: 0.15.10
+    esbuild-linux-ppc64le: 0.15.10
+    esbuild-linux-riscv64: 0.15.10
+    esbuild-linux-s390x: 0.15.10
+    esbuild-netbsd-64: 0.15.10
+    esbuild-openbsd-64: 0.15.10
+    esbuild-sunos-64: 0.15.10
+    esbuild-windows-32: 0.15.10
+    esbuild-windows-64: 0.15.10
+    esbuild-windows-arm64: 0.15.10
   dependenciesMeta:
+    "@esbuild/android-arm":
+      optional: true
     "@esbuild/linux-loong64":
       optional: true
     esbuild-android-64:
@@ -5910,7 +6574,7 @@ __metadata:
       optional: true
   bin:
     esbuild: bin/esbuild
-  checksum: 54ddaa6cf96798d817861b4f68cb8d176075dc09b6e0ed511c57e5db6fd86d2c673ac2ec631ad9b11678d58ad4a77cd6b7a3853b9c6eac29b7f5c6d38e42f92e
+  checksum: bc2daadb952c527e7ab0a972fd4f79071c9fd3d948cd97290d3de8811b6b7fc0abc43fb20116dffa24dc923550f4fe7b0d930ff6418ae7dfbff3034c1a01d59a
   languageName: node
   linkType: hard
 
@@ -6393,7 +7057,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^7.1.3, glob@npm:^7.1.4, glob@npm:^7.1.6, glob@npm:^7.1.7":
+"glob@npm:^7.1.3, glob@npm:^7.1.4, glob@npm:^7.1.7":
   version: 7.2.0
   resolution: "glob@npm:7.2.0"
   dependencies:
@@ -7173,6 +7837,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"json-parse-even-better-errors@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "json-parse-even-better-errors@npm:3.0.0"
+  checksum: f1970b5220c7fa23d888565510752c3d5e863f93668a202fcaa719739fa41485dfc6a1db212f702ebd3c873851cc067aebc2917e3f79763cae2fdb95046f38f3
+  languageName: node
+  linkType: hard
+
 "json-schema-traverse@npm:^0.4.1":
   version: 0.4.1
   resolution: "json-schema-traverse@npm:0.4.1"
@@ -7336,15 +8007,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"less-loader@npm:11.0.0":
-  version: 11.0.0
-  resolution: "less-loader@npm:11.0.0"
+"less-loader@npm:11.1.0":
+  version: 11.1.0
+  resolution: "less-loader@npm:11.1.0"
   dependencies:
     klona: ^2.0.4
   peerDependencies:
     less: ^3.5.0 || ^4.0.0
     webpack: ^5.0.0
-  checksum: fe5f810549a04c3d1b7fdd838c598e1dd7e6ed35428bdc7ec0caa4e7f2c07abfd1519c477aca713ca1259f88905dae25dd5f0c27b61071d9ce0dfefded86be1a
+  checksum: 041216e0a6d95e24c9724f470719db3eb70b3888c45b1a1e9cd55edabe8ae79709522cd6c6713b466b3e9948544074e2a5b2be50ac3ced5ff41dfa9675f3b182
   languageName: node
   linkType: hard
 
@@ -7498,12 +8169,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"magic-string@npm:0.26.3":
-  version: 0.26.3
-  resolution: "magic-string@npm:0.26.3"
+"magic-string@npm:0.26.7":
+  version: 0.26.7
+  resolution: "magic-string@npm:0.26.7"
   dependencies:
     sourcemap-codec: ^1.4.8
-  checksum: e72c9b3d90ccbde088acc5937109f73fa4be8b6a2c2ea9bf9c3c01974f1ebf09842259a74ff2ba4081008a7d49941d883cfef8c460e6c33a6eb564b58482b750
+  checksum: 89b0d60cbb32bbf3d1e23c46ea93db082d18a8230b972027aecb10a40bba51be519ecce0674f995571e3affe917b76b09f59d8dbc9a1b2c9c4102a2b6e8a2b01
   languageName: node
   linkType: hard
 
@@ -8117,15 +8788,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"npm-bundled@npm:^2.0.0":
-  version: 2.0.1
-  resolution: "npm-bundled@npm:2.0.1"
-  dependencies:
-    npm-normalize-package-bin: ^2.0.0
-  checksum: 7747293985c48c5268871efe691545b03731cb80029692000cbdb0b3344b9617be5187aa36281cabbe6b938e3651b4e87236d1c31f9e645eef391a1a779413e6
-  languageName: node
-  linkType: hard
-
 "npm-install-checks@npm:^4.0.0":
   version: 4.0.0
   resolution: "npm-install-checks@npm:4.0.0"
@@ -8158,15 +8820,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"npm-package-arg@npm:9.1.0":
-  version: 9.1.0
-  resolution: "npm-package-arg@npm:9.1.0"
+"npm-package-arg@npm:9.1.2":
+  version: 9.1.2
+  resolution: "npm-package-arg@npm:9.1.2"
   dependencies:
     hosted-git-info: ^5.0.0
     proc-log: ^2.0.1
     semver: ^7.3.5
     validate-npm-package-name: ^4.0.0
-  checksum: 277c21477731a4f1e31bde36f0db5f5470deb2a008db2aaf1b015d588b23cb225c75f90291ea241235e86682a03de972bbe69fc805c921a786ea9616955990b9
+  checksum: 3793488843985ed71deb14fcba7c068d8ed03a18fd8f6b235c6a64465c9a25f60261598106d5cc8677c0bee9548e405c34c2e3c7a822e3113d3389351c745dfa
   languageName: node
   linkType: hard
 
@@ -8192,17 +8854,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"npm-packlist@npm:^5.1.0":
-  version: 5.1.3
-  resolution: "npm-packlist@npm:5.1.3"
+"npm-packlist@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "npm-packlist@npm:7.0.0"
   dependencies:
-    glob: ^8.0.1
     ignore-walk: ^5.0.1
-    npm-bundled: ^2.0.0
-    npm-normalize-package-bin: ^2.0.0
-  bin:
-    npm-packlist: bin/index.js
-  checksum: 94cc9c66740e8f80243301de85eb0a2cec5bbd570c3f26b6ad7af1a3eca155f7e810580dc7ea4448f12a8fd82f6db307e7132a5fe69e157eb45b325acadeb22a
+  checksum: 43bd3a822c9d68c327b16d595f4a0073af38d49357bcfecfca5999568b61d1e804c6f3ed1720a7b3e41ba0d0053d0b18e3c86922c91a33e7e84d60c33ef7e558
   languageName: node
   linkType: hard
 
@@ -8437,34 +9094,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pacote@npm:13.6.2":
-  version: 13.6.2
-  resolution: "pacote@npm:13.6.2"
+"pacote@npm:15.0.0":
+  version: 15.0.0
+  resolution: "pacote@npm:15.0.0"
   dependencies:
     "@npmcli/git": ^3.0.0
     "@npmcli/installed-package-contents": ^1.0.7
     "@npmcli/promise-spawn": ^3.0.0
     "@npmcli/run-script": ^4.1.0
-    cacache: ^16.0.0
-    chownr: ^2.0.0
+    cacache: ^17.0.0
     fs-minipass: ^2.1.0
-    infer-owner: ^1.0.4
     minipass: ^3.1.6
-    mkdirp: ^1.0.4
     npm-package-arg: ^9.0.0
-    npm-packlist: ^5.1.0
+    npm-packlist: ^7.0.0
     npm-pick-manifest: ^7.0.0
     npm-registry-fetch: ^13.0.1
     proc-log: ^2.0.0
     promise-retry: ^2.0.1
     read-package-json: ^5.0.0
-    read-package-json-fast: ^2.0.3
-    rimraf: ^3.0.2
+    read-package-json-fast: ^3.0.0
     ssri: ^9.0.0
     tar: ^6.1.11
   bin:
     pacote: lib/bin.js
-  checksum: a7b7f97094ab570a23e1c174537e9953a4d53176cc4b18bac77d7728bd89e2b9fa331d0f78fa463add03df79668a918bbdaa2750819504ee39242063abf53c6e
+  checksum: 103928fcb2e42c7837e96ce532cb7f667e2a4be94e30910961c068e1f38b783ca9b0f6cd990c06c136c3712dd5f1e6fb120fa85eb9aed5b67c0c26c5c9edecaf
   languageName: node
   linkType: hard
 
@@ -8608,13 +9261,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pify@npm:^2.3.0":
-  version: 2.3.0
-  resolution: "pify@npm:2.3.0"
-  checksum: 9503aaeaf4577acc58642ad1d25c45c6d90288596238fb68f82811c08104c800e5a7870398e9f015d82b44ecbcbef3dc3d4251a1cbb582f6e5959fe09884b2ba
-  languageName: node
-  linkType: hard
-
 "pify@npm:^4.0.1":
   version: 4.0.1
   resolution: "pify@npm:4.0.1"
@@ -8646,213 +9292,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-attribute-case-insensitive@npm:^5.0.2":
-  version: 5.0.2
-  resolution: "postcss-attribute-case-insensitive@npm:5.0.2"
-  dependencies:
-    postcss-selector-parser: ^6.0.10
-  peerDependencies:
-    postcss: ^8.2
-  checksum: c0b8139f37e68dba372724cba03a53c30716224f0085f98485cada99489beb7c3da9d598ffc1d81519b59d9899291712c9041c250205e6ec0b034bb2c144dcf9
-  languageName: node
-  linkType: hard
-
-"postcss-clamp@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "postcss-clamp@npm:4.1.0"
-  dependencies:
-    postcss-value-parser: "npm:^4.2.0"
-  peerDependencies:
-    postcss: ^8.4.6
-  checksum: 118eec936b3b035dc8d75c89973408f15c5a3de3d1ee210a2b3511e3e431d9c56e6f354b509a90540241e2225ffe3caaa2fdf25919c63348ce4583a28ada642c
-  languageName: node
-  linkType: hard
-
-"postcss-color-functional-notation@npm:^4.2.4":
-  version: 4.2.4
-  resolution: "postcss-color-functional-notation@npm:4.2.4"
-  dependencies:
-    postcss-value-parser: ^4.2.0
-  peerDependencies:
-    postcss: ^8.2
-  checksum: b763e164fe3577a1de96f75e4bf451585c4f80b8ce60799763a51582cc9402d76faed57324a5d5e5556d90ca7ea0ebde565acb820c95e04bee6f36a91b019831
-  languageName: node
-  linkType: hard
-
-"postcss-color-hex-alpha@npm:^8.0.4":
-  version: 8.0.4
-  resolution: "postcss-color-hex-alpha@npm:8.0.4"
-  dependencies:
-    postcss-value-parser: ^4.2.0
-  peerDependencies:
-    postcss: ^8.4
-  checksum: a2f3173a60176cf0aea3b7ebbc799b2cb08229127f0fff708fa31efa14e4ded47ca49aff549d8ed92e74ffe24adee32d5b9d557dbde0524fde5fe389bc520b4e
-  languageName: node
-  linkType: hard
-
-"postcss-color-rebeccapurple@npm:^7.1.1":
-  version: 7.1.1
-  resolution: "postcss-color-rebeccapurple@npm:7.1.1"
-  dependencies:
-    postcss-value-parser: ^4.2.0
-  peerDependencies:
-    postcss: ^8.2
-  checksum: 03482f9b8170da0fa014c41a5d88bce7b987471fb73fc456d397222a2455c89ac7f974dd6ddf40fd31907e768aad158057164b7c5f62cee63a6ecf29d47d7467
-  languageName: node
-  linkType: hard
-
-"postcss-custom-media@npm:^8.0.2":
-  version: 8.0.2
-  resolution: "postcss-custom-media@npm:8.0.2"
-  dependencies:
-    postcss-value-parser: ^4.2.0
-  peerDependencies:
-    postcss: ^8.3
-  checksum: 887bbbacf6f8fab688123796e5dc1e8283b99f21e4c674235bd929dc8018c50df8634ea08932033ec93baaca32670ef2b87e6632863e0b4d84847375dbde9366
-  languageName: node
-  linkType: hard
-
-"postcss-custom-properties@npm:^12.1.8":
-  version: 12.1.8
-  resolution: "postcss-custom-properties@npm:12.1.8"
-  dependencies:
-    postcss-value-parser: ^4.2.0
-  peerDependencies:
-    postcss: ^8.4
-  checksum: 4615b8181fe61c2df9f3a739b3257a9d76d00088c8fc3c502a59de52b25ab90be3d65ece8d372bcd1f9f8ba6bb99da5075707f9f11cb3522826a5d3553265ee5
-  languageName: node
-  linkType: hard
-
-"postcss-custom-selectors@npm:^6.0.3":
-  version: 6.0.3
-  resolution: "postcss-custom-selectors@npm:6.0.3"
-  dependencies:
-    postcss-selector-parser: ^6.0.4
-  peerDependencies:
-    postcss: ^8.3
-  checksum: 18080d60a8a77a76d8ddff185104d65418fffd02bbf9824499f807ced7941509ba63828ab8fe3ec1d6b0d6c72a482bb90a79d79cdef58e5f4b30113cca16e69b
-  languageName: node
-  linkType: hard
-
-"postcss-dir-pseudo-class@npm:^6.0.5":
-  version: 6.0.5
-  resolution: "postcss-dir-pseudo-class@npm:6.0.5"
-  dependencies:
-    postcss-selector-parser: ^6.0.10
-  peerDependencies:
-    postcss: ^8.2
-  checksum: 7810c439d8d1a9072c00f8ab39261a1492873ad170425745bd2819c59767db2f352f906588fc2a7d814e91117900563d7e569ecd640367c7332b26b9829927ef
-  languageName: node
-  linkType: hard
-
-"postcss-double-position-gradients@npm:^3.1.2":
-  version: 3.1.2
-  resolution: "postcss-double-position-gradients@npm:3.1.2"
-  dependencies:
-    "@csstools/postcss-progressive-custom-properties": ^1.1.0
-    postcss-value-parser: ^4.2.0
-  peerDependencies:
-    postcss: ^8.2
-  checksum: ca09bf2aefddc180f1c1413f379eef30d492b8147543413f7251216f23f413c394b2ed10b7cd255e87b18e0c8efe36087ea8b9bfb26a09813f9607a0b8e538b6
-  languageName: node
-  linkType: hard
-
-"postcss-env-function@npm:^4.0.6":
-  version: 4.0.6
-  resolution: "postcss-env-function@npm:4.0.6"
-  dependencies:
-    postcss-value-parser: "npm:^4.2.0"
-  peerDependencies:
-    postcss: ^8.4
-  checksum: 645b2363cfa21be9dcce7fe4a0f172f0af70c00d6a4c1eb3d7ff7e9cfe26d569e291ec2533114d77b12d610023cd168a92d62c38f2fc969fa333b5ae2bff5ffe
-  languageName: node
-  linkType: hard
-
-"postcss-focus-visible@npm:^6.0.4":
-  version: 6.0.4
-  resolution: "postcss-focus-visible@npm:6.0.4"
-  dependencies:
-    postcss-selector-parser: "npm:^6.0.9"
-  peerDependencies:
-    postcss: ^8.4
-  checksum: acd010b9ddef9b86ffb5fa604c13515ba83e18bc5118dad0a1281150f412aa0ece056c2c5ac56b55e2599f53ab0f740f5ebfdc51e1f5cfe43b8130bac0096fcc
-  languageName: node
-  linkType: hard
-
-"postcss-focus-within@npm:^5.0.4":
-  version: 5.0.4
-  resolution: "postcss-focus-within@npm:5.0.4"
-  dependencies:
-    postcss-selector-parser: "npm:^6.0.9"
-  peerDependencies:
-    postcss: ^8.4
-  checksum: f23d8ab757345a6deaa807d76e10c88caf4b771c38b60e1593b24aee161c503b5823620e89302226a6ae5e7afdb6ac31809241291912e4176eb594a7ddcc9521
-  languageName: node
-  linkType: hard
-
-"postcss-font-variant@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "postcss-font-variant@npm:5.0.0"
-  peerDependencies:
-    postcss: ^8.1.0
-  checksum: a19286589261c2bc3e20470486e1ee3b4daf34271c5020167f30856c9b30c26f23264307cb97a184d503814e1b8c5d8a1f9f64a14fd4fd9551c173dca9424695
-  languageName: node
-  linkType: hard
-
-"postcss-gap-properties@npm:^3.0.5":
-  version: 3.0.5
-  resolution: "postcss-gap-properties@npm:3.0.5"
-  peerDependencies:
-    postcss: ^8.2
-  checksum: aed559d6d375203a08a006c9ae8cf5ae90d9edaec5cadd20fe65c1b8ce63c2bc8dfe752d4331880a6e24a300541cde61058be790b7bd9b5d04d470c250fbcd39
-  languageName: node
-  linkType: hard
-
-"postcss-image-set-function@npm:^4.0.7":
-  version: 4.0.7
-  resolution: "postcss-image-set-function@npm:4.0.7"
-  dependencies:
-    postcss-value-parser: ^4.2.0
-  peerDependencies:
-    postcss: ^8.2
-  checksum: 7e509330986de14250ead1a557e8da8baaf66ebe8a40354a5dff60ab40d99a483d92aa57d52713251ca1adbf0055ef476c5702b0d0ba5f85a4f407367cdabac0
-  languageName: node
-  linkType: hard
-
-"postcss-import@npm:15.0.0":
-  version: 15.0.0
-  resolution: "postcss-import@npm:15.0.0"
-  dependencies:
-    postcss-value-parser: ^4.0.0
-    read-cache: ^1.0.0
-    resolve: ^1.1.7
-  peerDependencies:
-    postcss: ^8.0.0
-  checksum: e5048072514f33520348c0c5aaedb5db92da72188e72a7367c26a8d851b9cf92e56aeda30d9c7b4ed1a34f84a58959da1b4b27b4aa23d41fc0ce36efe00bf1d1
-  languageName: node
-  linkType: hard
-
-"postcss-initial@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "postcss-initial@npm:4.0.1"
-  peerDependencies:
-    postcss: ^8.0.0
-  checksum: 6956953853865de79c39d11533a2860e9f38b770bb284d0010d98a00b9469e22de344e4e5fd8208614d797030487e8918dd2f2c37d9e24d4dd59d565d4fc3e12
-  languageName: node
-  linkType: hard
-
-"postcss-lab-function@npm:^4.2.1":
-  version: 4.2.1
-  resolution: "postcss-lab-function@npm:4.2.1"
-  dependencies:
-    "@csstools/postcss-progressive-custom-properties": ^1.1.0
-    postcss-value-parser: ^4.2.0
-  peerDependencies:
-    postcss: ^8.2
-  checksum: 26ac74b430011271b5581beba69b2cd788f56375fcb64c90f6ec1577379af85f6022dc38c410ff471dac520c7ddc289160a6a16cca3c7ff76f5af7e90d31eaa3
-  languageName: node
-  linkType: hard
-
 "postcss-loader@npm:7.0.1":
   version: 7.0.1
   resolution: "postcss-loader@npm:7.0.1"
@@ -8864,24 +9303,6 @@ __metadata:
     postcss: ^7.0.0 || ^8.0.1
     webpack: ^5.0.0
   checksum: 2a3cbcaaade598d4919824d384ae34ffbfc14a9c8db6cc3b154582356f4f44a1c9af9e731b81cf1947b089accf7d0ab7a0c51c717946985f89aa1708d2b4304d
-  languageName: node
-  linkType: hard
-
-"postcss-logical@npm:^5.0.4":
-  version: 5.0.4
-  resolution: "postcss-logical@npm:5.0.4"
-  peerDependencies:
-    postcss: ^8.4
-  checksum: 17c71291ed6a03883a5aa54b9923b874c32710707d041a0f0752e6febdb09dee5d2abf4ef271978d932e4a4c948f349bb23edf633c03e3427ba15e71bfc66ac7
-  languageName: node
-  linkType: hard
-
-"postcss-media-minmax@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "postcss-media-minmax@npm:5.0.0"
-  peerDependencies:
-    postcss: ^8.1.0
-  checksum: 2cd7283e07a1ac1acdcc3ecbaa0e9932f8d1e7647e7aeb14d91845fcb890d60d7257ec70c825cae8d48ae80a08cc77ebc4021a0dfa32360e0cd991e2bc021607
   languageName: node
   linkType: hard
 
@@ -8929,157 +9350,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-nesting@npm:^10.1.10":
-  version: 10.1.10
-  resolution: "postcss-nesting@npm:10.1.10"
-  dependencies:
-    "@csstools/selector-specificity": ^2.0.0
-    postcss-selector-parser: ^6.0.10
-  peerDependencies:
-    postcss: ^8.2
-  checksum: fffaf42aaa1f7cc9c381c6be9c0b6a69a50ed1a5f0fc21a430bdb501ce1eb3767a6b6ed981ea830e62c29ce7c32b5180b91d99b6eeca755309131c95af025eed
-  languageName: node
-  linkType: hard
-
-"postcss-opacity-percentage@npm:^1.1.2":
-  version: 1.1.2
-  resolution: "postcss-opacity-percentage@npm:1.1.2"
-  checksum: b582f6d4efb6a14aa09ba49869774c2f060558a68af8a0c3aa9efc0e01b35a4985e783640806a76d4e26d2ba97556f9b5e88dde91d1664a2e2c24688e4bbcf61
-  languageName: node
-  linkType: hard
-
-"postcss-overflow-shorthand@npm:^3.0.4":
-  version: 3.0.4
-  resolution: "postcss-overflow-shorthand@npm:3.0.4"
-  dependencies:
-    postcss-value-parser: ^4.2.0
-  peerDependencies:
-    postcss: ^8.2
-  checksum: 74009022491e3901263f8f5811630393480323e51f5d23ef17f3fdc7e03bf9c2502a632f3ba8fe6a468b57590f13b2fa3b17a68ef19653589e76277607696743
-  languageName: node
-  linkType: hard
-
-"postcss-page-break@npm:^3.0.4":
-  version: 3.0.4
-  resolution: "postcss-page-break@npm:3.0.4"
-  peerDependencies:
-    postcss: ^8
-  checksum: a7d08c945fc691f62c77ac701e64722218b14ec5c8fc1972b8af9c21553492d40808cf95e61b9697b1dacaf7e6180636876d7fee314f079e6c9e39ac1b1edc6f
-  languageName: node
-  linkType: hard
-
-"postcss-place@npm:^7.0.5":
-  version: 7.0.5
-  resolution: "postcss-place@npm:7.0.5"
-  dependencies:
-    postcss-value-parser: ^4.2.0
-  peerDependencies:
-    postcss: ^8.2
-  checksum: 903fec0c313bb7ec20f2c8f0a125866fb7804aa3186b5b2c7c2d58cb9039ff301461677a060e9db643d1aaffaf80a0ff71e900a6da16705dad6b49c804cb3c73
-  languageName: node
-  linkType: hard
-
-"postcss-preset-env@npm:7.8.1":
-  version: 7.8.1
-  resolution: "postcss-preset-env@npm:7.8.1"
-  dependencies:
-    "@csstools/postcss-cascade-layers": ^1.0.6
-    "@csstools/postcss-color-function": ^1.1.1
-    "@csstools/postcss-font-format-keywords": ^1.0.1
-    "@csstools/postcss-hwb-function": ^1.0.2
-    "@csstools/postcss-ic-unit": ^1.0.1
-    "@csstools/postcss-is-pseudo-class": ^2.0.7
-    "@csstools/postcss-nested-calc": ^1.0.0
-    "@csstools/postcss-normalize-display-values": ^1.0.1
-    "@csstools/postcss-oklab-function": ^1.1.1
-    "@csstools/postcss-progressive-custom-properties": ^1.3.0
-    "@csstools/postcss-stepped-value-functions": ^1.0.1
-    "@csstools/postcss-text-decoration-shorthand": ^1.0.0
-    "@csstools/postcss-trigonometric-functions": ^1.0.2
-    "@csstools/postcss-unset-value": ^1.0.2
-    autoprefixer: ^10.4.8
-    browserslist: ^4.21.3
-    css-blank-pseudo: ^3.0.3
-    css-has-pseudo: ^3.0.4
-    css-prefers-color-scheme: ^6.0.3
-    cssdb: ^7.0.1
-    postcss-attribute-case-insensitive: ^5.0.2
-    postcss-clamp: ^4.1.0
-    postcss-color-functional-notation: ^4.2.4
-    postcss-color-hex-alpha: ^8.0.4
-    postcss-color-rebeccapurple: ^7.1.1
-    postcss-custom-media: ^8.0.2
-    postcss-custom-properties: ^12.1.8
-    postcss-custom-selectors: ^6.0.3
-    postcss-dir-pseudo-class: ^6.0.5
-    postcss-double-position-gradients: ^3.1.2
-    postcss-env-function: ^4.0.6
-    postcss-focus-visible: ^6.0.4
-    postcss-focus-within: ^5.0.4
-    postcss-font-variant: ^5.0.0
-    postcss-gap-properties: ^3.0.5
-    postcss-image-set-function: ^4.0.7
-    postcss-initial: ^4.0.1
-    postcss-lab-function: ^4.2.1
-    postcss-logical: ^5.0.4
-    postcss-media-minmax: ^5.0.0
-    postcss-nesting: ^10.1.10
-    postcss-opacity-percentage: ^1.1.2
-    postcss-overflow-shorthand: ^3.0.4
-    postcss-page-break: ^3.0.4
-    postcss-place: ^7.0.5
-    postcss-pseudo-class-any-link: ^7.1.6
-    postcss-replace-overflow-wrap: ^4.0.0
-    postcss-selector-not: ^6.0.1
-    postcss-value-parser: ^4.2.0
-  peerDependencies:
-    postcss: ^8.2
-  checksum: 5ed4470bfa0bef6d8b5d73c18a822a6a4a5c2da2eb813cb3c286475eb3ce89395da25b306ab80e7356b44445a74e7f63eb4ea5ad42594327cd9626cd579c8f75
-  languageName: node
-  linkType: hard
-
-"postcss-pseudo-class-any-link@npm:^7.1.6":
-  version: 7.1.6
-  resolution: "postcss-pseudo-class-any-link@npm:7.1.6"
-  dependencies:
-    postcss-selector-parser: ^6.0.10
-  peerDependencies:
-    postcss: ^8.2
-  checksum: 43aa18ea1ef1b168f61310856dd92f46ceb3dc60b6cf820e079ca1a849df5cc0f12a1511bdc1811a23f03d60ddcc959200c80c3f9a7b57feebe32bab226afb39
-  languageName: node
-  linkType: hard
-
-"postcss-replace-overflow-wrap@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "postcss-replace-overflow-wrap@npm:4.0.0"
-  peerDependencies:
-    postcss: ^8.0.3
-  checksum: 3ffe20b300a4c377a11c588b142740d8557e03c707474c45234c934190ac374750ddc92c7906c373471d273a20504a429c2062c21fdcaff830fb28e0a81ac1dc
-  languageName: node
-  linkType: hard
-
-"postcss-selector-not@npm:^6.0.1":
-  version: 6.0.1
-  resolution: "postcss-selector-not@npm:6.0.1"
-  dependencies:
-    postcss-selector-parser: ^6.0.10
-  peerDependencies:
-    postcss: ^8.2
-  checksum: fe523a0219e4bd34f04498534bb9e8aec3193f3585eafe4c388d086955b41201cae71fd20980ca465acade7f182029b43dbd5ca7e9d50bf34bbcaf1d19fe3ee6
-  languageName: node
-  linkType: hard
-
-"postcss-selector-parser@npm:^6.0.10":
-  version: 6.0.10
-  resolution: "postcss-selector-parser@npm:6.0.10"
-  dependencies:
-    cssesc: "npm:^3.0.0"
-    util-deprecate: "npm:^1.0.2"
-  checksum: 46afaa60e3d1998bd7adf6caa374baf857cc58d3ff944e29459c9a9e4680a7fe41597bd5b755fc81d7c388357e9bf67c0251d047c640a09f148e13606b8a8608
-  languageName: node
-  linkType: hard
-
-"postcss-selector-parser@npm:^6.0.2, postcss-selector-parser@npm:^6.0.4, postcss-selector-parser@npm:^6.0.9":
+"postcss-selector-parser@npm:^6.0.2, postcss-selector-parser@npm:^6.0.4":
   version: 6.0.9
   resolution: "postcss-selector-parser@npm:6.0.9"
   dependencies:
@@ -9089,21 +9360,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-value-parser@npm:^4.0.0, postcss-value-parser@npm:^4.1.0, postcss-value-parser@npm:^4.2.0":
+"postcss-value-parser@npm:^4.1.0, postcss-value-parser@npm:^4.2.0":
   version: 4.2.0
   resolution: "postcss-value-parser@npm:4.2.0"
   checksum: 819ffab0c9d51cf0acbabf8996dffbfafbafa57afc0e4c98db88b67f2094cb44488758f06e5da95d7036f19556a4a732525e84289a425f4f6fd8e412a9d7442f
   languageName: node
   linkType: hard
 
-"postcss@npm:8.4.16":
-  version: 8.4.16
-  resolution: "postcss@npm:8.4.16"
+"postcss@npm:8.4.18":
+  version: 8.4.18
+  resolution: "postcss@npm:8.4.18"
   dependencies:
     nanoid: ^3.3.4
     picocolors: ^1.0.0
     source-map-js: ^1.0.2
-  checksum: 10eee25efd77868036403858577da0cefaf2e0905feeaba5770d5438ccdddba3d01cba8063e96b8aac4c6daa0ed413dd5ae0554a433a3c4db38df1d134cffc1f
+  checksum: 9349fd99849b2e3d2e134ff949b7770ecb12375f352723ce2bcc06167eba3850ea7844c1b191a85cd915d6a396b4e8ee9a5267e6cc5d8d003d0cbc7a97555d39
   languageName: node
   linkType: hard
 
@@ -9268,15 +9539,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"read-cache@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "read-cache@npm:1.0.0"
-  dependencies:
-    pify: "npm:^2.3.0"
-  checksum: cffc728b9ede1e0667399903f9ecaf3789888b041c46ca53382fa3a06303e5132774dc0a96d0c16aa702dbac1ea0833d5a868d414f5ab2af1e1438e19e6657c6
-  languageName: node
-  linkType: hard
-
 "read-package-json-fast@npm:^2.0.3":
   version: 2.0.3
   resolution: "read-package-json-fast@npm:2.0.3"
@@ -9284,6 +9546,16 @@ __metadata:
     json-parse-even-better-errors: "npm:^2.3.0"
     npm-normalize-package-bin: "npm:^1.0.1"
   checksum: fca37b3b2160b9dda7c5588b767f6a2b8ce68d03a044000e568208e20bea0cf6dd2de17b90740ce8da8b42ea79c0b3859649dadf29510bbe77224ea65326a903
+  languageName: node
+  linkType: hard
+
+"read-package-json-fast@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "read-package-json-fast@npm:3.0.0"
+  dependencies:
+    json-parse-even-better-errors: ^3.0.0
+    npm-normalize-package-bin: ^2.0.0
+  checksum: 025d3a917aacbaa4148b3561acdb208c053235b2dc32768b850ffa30243161d14f74418a8a47fae78f075c458ced88add998c7405b32812948d7efa3c4f1bc07
   languageName: node
   linkType: hard
 
@@ -9357,7 +9629,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"regenerator-runtime@npm:0.13.9, regenerator-runtime@npm:^0.13.4":
+"regenerator-runtime@npm:0.13.10":
+  version: 0.13.10
+  resolution: "regenerator-runtime@npm:0.13.10"
+  checksum: 09893f5a9e82932642d9a999716b6c626dc53ef2a01307c952ebbf8e011802360163a37c304c18a6c358548be5a72b448e37209954a18696f21e438c81cbb4b9
+  languageName: node
+  linkType: hard
+
+"regenerator-runtime@npm:^0.13.4":
   version: 0.13.9
   resolution: "regenerator-runtime@npm:0.13.9"
   checksum: 65ed455fe5afd799e2897baf691ca21c2772e1a969d19bb0c4695757c2d96249eb74ee3553ea34a91062b2a676beedf630b4c1551cc6299afb937be1426ec55e
@@ -9487,7 +9766,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@npm:^1.1.7, resolve@npm:^1.14.2":
+"resolve@npm:^1.14.2":
   version: 1.22.0
   resolution: "resolve@npm:1.22.0"
   dependencies:
@@ -9513,7 +9792,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@patch:resolve@^1.1.7#~builtin<compat/resolve>, resolve@patch:resolve@^1.14.2#~builtin<compat/resolve>":
+"resolve@patch:resolve@^1.14.2#~builtin<compat/resolve>":
   version: 1.22.0
   resolution: "resolve@patch:resolve@npm%3A1.22.0#~builtin<compat/resolve>::version=1.22.0&hash=07638b"
   dependencies:
@@ -9639,9 +9918,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sass-loader@npm:13.0.2":
-  version: 13.0.2
-  resolution: "sass-loader@npm:13.0.2"
+"sass-loader@npm:13.1.0":
+  version: 13.1.0
+  resolution: "sass-loader@npm:13.1.0"
   dependencies:
     klona: ^2.0.4
     neo-async: ^2.6.2
@@ -9660,24 +9939,24 @@ __metadata:
       optional: true
     sass-embedded:
       optional: true
-  checksum: 6306712cc75bd4b4260ce67178778c92110089485f358b5956b6b12aba15a55e5c7287154daaf8b32678891df915b7bcda7356991afe8bf08ca7356ed30eb448
+  checksum: 6b3b6c0e070a32c594001cee98c85a72afb6081c46d56a4283269e6c1802b0e26128bc8363fcd8d8c941abe1f9e441e3efcd401fcf3ef436e1f1fbeb6e0a1374
   languageName: node
   linkType: hard
 
-"sass@npm:1.54.9":
-  version: 1.54.9
-  resolution: "sass@npm:1.54.9"
+"sass@npm:1.55.0":
+  version: 1.55.0
+  resolution: "sass@npm:1.55.0"
   dependencies:
     chokidar: ">=3.0.0 <4.0.0"
     immutable: ^4.0.0
     source-map-js: ">=0.6.2 <2.0.0"
   bin:
     sass: sass.js
-  checksum: 90182b566072b48e2263c5a87229ab85164e13b71b24847ba76a8e68eb952cb69a7dcef815f4ccc0189dd2d0c254311acff6972166603338d33bbc96f6d500c6
+  checksum: 7d769ed08efce4e6134e0f3dc11c4f07e32c413ac8eb43c5855f2686890fdcbd80da34165c91fb4ba407f478ca108e171574b5a60cb9814a5ed09d80f6014f96
   languageName: node
   linkType: hard
 
-"sax@npm:^1.2.4, sax@npm:~1.2.4":
+"sax@npm:^1.2.4":
   version: 1.2.4
   resolution: "sax@npm:1.2.4"
   checksum: d3df7d32b897a2c2f28e941f732c71ba90e27c24f62ee918bd4d9a8cfb3553f2f81e5493c7f0be94a11c1911b643a9108f231dd6f60df3fa9586b5d2e3e9e1fe
@@ -9725,32 +10004,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"selfsigned@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "selfsigned@npm:2.0.1"
+"selfsigned@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "selfsigned@npm:2.1.1"
   dependencies:
-    node-forge: "npm:^1"
-  checksum: 864e65c2f31ca877bce3ccdaa3bdef5e1e992b63b2a03641e00c24cd305bf2acce093431d1fed2e5ae9f526558db4be5e90baa2b3474c0428fcf7e25cc86ac93
+    node-forge: ^1
+  checksum: aa9ce2150a54838978d5c0aee54d7ebe77649a32e4e690eb91775f71fdff773874a4fbafd0ac73d8ec3b702ff8a395c604df4f8e8868528f36fd6c15076fb43a
   languageName: node
   linkType: hard
 
-"semver@npm:7.0.0":
-  version: 7.0.0
-  resolution: "semver@npm:7.0.0"
-  bin:
-    semver: bin/semver.js
-  checksum: 272c11bf8d083274ef79fe40a81c55c184dff84dd58e3c325299d0927ba48cece1f020793d138382b85f89bab5002a35a5ba59a3a68a7eebbb597eb733838778
-  languageName: node
-  linkType: hard
-
-"semver@npm:7.3.7, semver@npm:^7.3.7":
-  version: 7.3.7
-  resolution: "semver@npm:7.3.7"
+"semver@npm:7.3.8":
+  version: 7.3.8
+  resolution: "semver@npm:7.3.8"
   dependencies:
-    lru-cache: "npm:^6.0.0"
+    lru-cache: ^6.0.0
   bin:
     semver: bin/semver.js
-  checksum: 2fa3e877568cd6ce769c75c211beaed1f9fce80b28338cadd9d0b6c40f2e2862bafd62c19a6cff42f3d54292b7c623277bcab8816a2b5521cf15210d43e75232
+  checksum: ba9c7cbbf2b7884696523450a61fee1a09930d888b7a8d7579025ad93d459b2d1949ee5bbfeb188b2be5f4ac163544c5e98491ad6152df34154feebc2cc337c1
   languageName: node
   linkType: hard
 
@@ -9780,6 +10050,17 @@ __metadata:
   bin:
     semver: bin/semver.js
   checksum: 5eafe6102bea2a7439897c1856362e31cc348ccf96efd455c8b5bc2c61e6f7e7b8250dc26b8828c1d76a56f818a7ee907a36ae9fb37a599d3d24609207001d60
+  languageName: node
+  linkType: hard
+
+"semver@npm:^7.3.7":
+  version: 7.3.7
+  resolution: "semver@npm:7.3.7"
+  dependencies:
+    lru-cache: "npm:^6.0.0"
+  bin:
+    semver: bin/semver.js
+  checksum: 2fa3e877568cd6ce769c75c211beaed1f9fce80b28338cadd9d0b6c40f2e2862bafd62c19a6cff42f3d54292b7c623277bcab8816a2b5521cf15210d43e75232
   languageName: node
   linkType: hard
 
@@ -10010,16 +10291,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map-loader@npm:4.0.0":
-  version: 4.0.0
-  resolution: "source-map-loader@npm:4.0.0"
+"source-map-loader@npm:4.0.1":
+  version: 4.0.1
+  resolution: "source-map-loader@npm:4.0.1"
   dependencies:
     abab: ^2.0.6
     iconv-lite: ^0.6.3
     source-map-js: ^1.0.2
   peerDependencies:
     webpack: ^5.72.1
-  checksum: 0b169701735bd6a32d66bff84b7475c31066972d717ebef5a24476cc8678cd19c2b8ebe03a7d62ade9586d4f7ba55c17772fdc8d8bc159dcb9315c757a01046e
+  checksum: 4ddca8b03dc61f406effd4bffe70de4b87fef48bae6f737017b2dabcbc7d609133325be1e73838e9265331de28039111d729fcbb8bce88a6018a816bef510eb1
   languageName: node
   linkType: hard
 
@@ -10054,7 +10335,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map@npm:^0.7.3, source-map@npm:~0.7.2":
+"source-map@npm:~0.7.2":
   version: 0.7.3
   resolution: "source-map@npm:0.7.3"
   checksum: cd24efb3b8fa69b64bf28e3c1b1a500de77e84260c5b7f2b873f88284df17974157cc88d386ee9b6d081f08fdd8242f3fc05c953685a6ad81aad94c7393dedea
@@ -10224,35 +10505,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"stylus-loader@npm:7.0.0":
-  version: 7.0.0
-  resolution: "stylus-loader@npm:7.0.0"
-  dependencies:
-    fast-glob: ^3.2.11
-    klona: ^2.0.5
-    normalize-path: ^3.0.0
-  peerDependencies:
-    stylus: ">=0.52.4"
-    webpack: ^5.0.0
-  checksum: 3bb09d45901865c7414a33d80b36bc32054fef325cd307d3648a7be5f0eca8ad76b7687aacb31d5e36ad216c6af7fcd92d091c8d08542306db7f87821edec10f
-  languageName: node
-  linkType: hard
-
-"stylus@npm:0.59.0":
-  version: 0.59.0
-  resolution: "stylus@npm:0.59.0"
-  dependencies:
-    "@adobe/css-tools": ^4.0.1
-    debug: ^4.3.2
-    glob: ^7.1.6
-    sax: ~1.2.4
-    source-map: ^0.7.3
-  bin:
-    stylus: bin/stylus
-  checksum: 2faf4a5618747c17b7d10854e40efdd43b438a6cf99d197b0231578f5091bfe9313663d846b5666bb37140140420c51606bb127fd877bbf2db46730c01403b01
-  languageName: node
-  linkType: hard
-
 "supports-color@npm:^5.3.0":
   version: 5.5.0
   resolution: "supports-color@npm:5.5.0"
@@ -10337,9 +10589,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"terser@npm:5.15.0":
-  version: 5.15.0
-  resolution: "terser@npm:5.15.0"
+"terser@npm:5.15.1":
+  version: 5.15.1
+  resolution: "terser@npm:5.15.1"
   dependencies:
     "@jridgewell/source-map": ^0.3.2
     acorn: ^8.5.0
@@ -10347,7 +10599,7 @@ __metadata:
     source-map-support: ~0.5.20
   bin:
     terser: bin/terser
-  checksum: b2358c989fcb76b4a1c265f60e175c950d3f776e5f619a9f58f54e8d2d792cd6b4cca86071834075f3b9943556d695357bafdd4ee2390de2fc9fd96ba3efa8c8
+  checksum: 9880a1e0956983a1ce5de204ea35121c0009fa41d582a6904ae850e1953a1a2cc021168439565280c5a8eee67c85a874175627e24989b046c7a72589b81c3979
   languageName: node
   linkType: hard
 
@@ -10498,21 +10750,21 @@ __metadata:
 
 "typescript@file:../../node_modules/typescript::locator=yarn-pnp-compat%40workspace%3A.":
   version: 4.8.2
-  resolution: "typescript@file:../../node_modules/typescript#../../node_modules/typescript::hash=028f88&locator=yarn-pnp-compat%40workspace%3A."
+  resolution: "typescript@file:../../node_modules/typescript#../../node_modules/typescript::hash=4e4245&locator=yarn-pnp-compat%40workspace%3A."
   bin:
     tsc: ./bin/tsc
     tsserver: ./bin/tsserver
-  checksum: 6f49363af8af2fe480da1d5fa68712644438785208b06690a3cbe5e7365fd652c3a0f1e587bc8684d78fb69de3dde4de185c0bad7bb4f3664ddfc813ce8caad6
+  checksum: 9adb2c615840562ecf108b4abc56e23556e8947bd57cd96af5f05ead5e37e548a4cd1ec9af6d69e92b577b2f82dc17f401f424121cecdddd7f8a89f055b96103
   languageName: node
   linkType: hard
 
 "typescript@patch:typescript@file%3A../../node_modules/typescript#~builtin<compat/typescript>":
   version: 4.8.2
-  resolution: "typescript@patch:typescript@file%3A../../node_modules/typescript%23../../node_modules/typescript%3A%3Ahash=028f88&locator=yarn-pnp-compat%2540workspace%253A.#~builtin<compat/typescript>::version=4.8.2&hash=a1c5e5"
+  resolution: "typescript@patch:typescript@file%3A../../node_modules/typescript%23../../node_modules/typescript%3A%3Ahash=4e4245&locator=yarn-pnp-compat%2540workspace%253A.#~builtin<compat/typescript>::version=4.8.2&hash=a1c5e5"
   bin:
     tsc: ./bin/tsc
     tsserver: ./bin/tsserver
-  checksum: 5cb0f02f414f5405f4b0e7ee1fd7fa9177b6a8783c9017b6cad85f56ce4c4f93e0e6f2ce37e863cb597d44227cd009474c9fbd85bf7a50004e5557426cb58079
+  checksum: e4da05a2d65dfe3c87c6734ec39a4fa31b893684ba72650c7440a849f57cf39abf9cff3f6ddf41478b94ed072a4eeab103fccaebe73ee710f41d7016a2be5798
   languageName: node
   linkType: hard
 
@@ -10618,6 +10870,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"update-browserslist-db@npm:^1.0.9":
+  version: 1.0.10
+  resolution: "update-browserslist-db@npm:1.0.10"
+  dependencies:
+    escalade: ^3.1.1
+    picocolors: ^1.0.0
+  peerDependencies:
+    browserslist: ">= 4.21.0"
+  bin:
+    browserslist-lint: cli.js
+  checksum: 12db73b4f63029ac407b153732e7cd69a1ea8206c9100b482b7d12859cd3cd0bc59c602d7ae31e652706189f1acb90d42c53ab24a5ba563ed13aebdddc5561a0
+  languageName: node
+  linkType: hard
+
 "uri-js@npm:^4.2.2":
   version: 4.4.1
   resolution: "uri-js@npm:4.4.1"
@@ -10638,15 +10904,6 @@ __metadata:
   version: 1.0.1
   resolution: "utils-merge@npm:1.0.1"
   checksum: c81095493225ecfc28add49c106ca4f09cdf56bc66731aa8dabc2edbbccb1e1bfe2de6a115e5c6a380d3ea166d1636410b62ef216bb07b3feb1cfde1d95d5080
-  languageName: node
-  linkType: hard
-
-"uuid@npm:9.0.0":
-  version: 9.0.0
-  resolution: "uuid@npm:9.0.0"
-  bin:
-    uuid: dist/bin/uuid
-  checksum: 8dd2c83c43ddc7e1c71e36b60aea40030a6505139af6bee0f382ebcd1a56f6cd3028f7f06ffb07f8cf6ced320b76aea275284b224b002b289f89fe89c389b028
   languageName: node
   linkType: hard
 
@@ -10759,9 +11016,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack-dev-server@npm:4.11.0":
-  version: 4.11.0
-  resolution: "webpack-dev-server@npm:4.11.0"
+"webpack-dev-server@npm:4.11.1":
+  version: 4.11.1
+  resolution: "webpack-dev-server@npm:4.11.1"
   dependencies:
     "@types/bonjour": ^3.5.9
     "@types/connect-history-api-fallback": ^1.3.5
@@ -10786,7 +11043,7 @@ __metadata:
     p-retry: ^4.5.0
     rimraf: ^3.0.2
     schema-utils: ^4.0.0
-    selfsigned: ^2.0.1
+    selfsigned: ^2.1.1
     serve-index: ^1.9.1
     sockjs: ^0.3.24
     spdy: ^4.0.2
@@ -10799,7 +11056,7 @@ __metadata:
       optional: true
   bin:
     webpack-dev-server: bin/webpack-dev-server.js
-  checksum: b2c7e9810138d0c6fa670a890410a74b29d4dd23d428e92e61e0233c542689f57caf9b31c031fbcc772170b6710b0752e81fa9cbc41ac0deefdc32d5749ce08d
+  checksum: b7601a39ee0f413988259e29a36835b0a68522cfaa161de5b7ec99b3399acdd99d44189add4aaf4a5191258bb130f9cf3e68919324a1955c7557f5fe6ab0d96c
   languageName: node
   linkType: hard
 
@@ -11011,18 +11268,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs@npm:17.5.1":
-  version: 17.5.1
-  resolution: "yargs@npm:17.5.1"
+"yargs@npm:17.6.0":
+  version: 17.6.0
+  resolution: "yargs@npm:17.6.0"
   dependencies:
-    cliui: ^7.0.2
+    cliui: ^8.0.1
     escalade: ^3.1.1
     get-caller-file: ^2.0.5
     require-directory: ^2.1.1
     string-width: ^4.2.3
     y18n: ^5.0.5
     yargs-parser: ^21.0.0
-  checksum: 00d58a2c052937fa044834313f07910fd0a115dec5ee35919e857eeee3736b21a4eafa8264535800ba8bac312991ce785ecb8a51f4d2cc8c4676d865af1cfbde
+  checksum: 604bdb4a6395a870540d2f3fea083c8e28441f12da8fd05b172b1e68480f00ed73d76be4a05fac19de9bf55ec7729b41e81cf555cccaed700aa192e4fff64872
   languageName: node
   linkType: hard
 
@@ -11060,10 +11317,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "yarn-pnp-compat@workspace:."
   dependencies:
-    "@angular-devkit/build-angular": ^15.0.0-next.0
+    "@angular-devkit/build-angular": ^15.0.0-next.6
     "@angular/animations": ^15.0.0-next.0
     "@angular/cdk": "file:../../dist/releases/cdk"
-    "@angular/cli": ^15.0.0-next.0
+    "@angular/cli": ^15.0.0-next.6
     "@angular/common": ^15.0.0-next.0
     "@angular/compiler": ^15.0.0-next.0
     "@angular/compiler-cli": ^15.0.0-next.0

--- a/src/material/schematics/ng-add/index.spec.ts
+++ b/src/material/schematics/ng-add/index.spec.ts
@@ -109,10 +109,7 @@ describe('ng-add schematic', () => {
     const workspace = await getWorkspace(tree);
     const project = getProjectFromWorkspace(workspace, baseOptions.project);
 
-    expectProjectStyleFile(
-      project,
-      './node_modules/@angular/material/prebuilt-themes/indigo-pink.css',
-    );
+    expectProjectStyleFile(project, '@angular/material/prebuilt-themes/indigo-pink.css');
   });
 
   it('should support adding a custom theme', async () => {
@@ -393,8 +390,7 @@ describe('ng-add schematic', () => {
 
   describe('theme files', () => {
     /** Path to the default prebuilt theme file that will be added when running ng-add. */
-    const defaultPrebuiltThemePath =
-      './node_modules/@angular/material/prebuilt-themes/indigo-pink.css';
+    const defaultPrebuiltThemePath = '@angular/material/prebuilt-themes/indigo-pink.css';
 
     /** Writes a specific style file to the workspace in the given tree */
     function writeStyleFileToWorkspace(tree: Tree, stylePath: string) {
@@ -430,7 +426,7 @@ describe('ng-add schematic', () => {
     }
 
     it('should replace existing prebuilt theme files', async () => {
-      const existingThemePath = './node_modules/@angular/material/prebuilt-themes/purple-green.css';
+      const existingThemePath = '@angular/material/prebuilt-themes/purple-green.css';
       writeStyleFileToWorkspace(appTree, existingThemePath);
 
       const tree = await runner

--- a/src/material/schematics/ng-add/theming/theming.ts
+++ b/src/material/schematics/ng-add/theming/theming.ts
@@ -109,8 +109,7 @@ async function insertCustomTheme(
 
 /** Insert a pre-built theme into the angular.json file. */
 function insertPrebuiltTheme(project: string, theme: string, logger: logging.LoggerApi): Rule {
-  // Path needs to be always relative to the `package.json` or workspace root.
-  const themePath = `./node_modules/@angular/material/prebuilt-themes/${theme}.css`;
+  const themePath = `@angular/material/prebuilt-themes/${theme}.css`;
 
   return chain([
     addThemeStyleToTarget(project, 'build', themePath, logger),

--- a/yarn.lock
+++ b/yarn.lock
@@ -5742,9 +5742,9 @@ caniuse-lite@^1.0.30001370, caniuse-lite@^1.0.30001373:
   integrity sha512-JVQnfoO7FK7WvU4ZkBRbPjaot4+YqxogSDosHv0Hv5mWpUESmN+UubMU6L/hGz8QlQ2aY5U0vR6MOs6j/CXpNA==
 
 caniuse-lite@^1.0.30001400, caniuse-lite@^1.0.30001407:
-  version "1.0.30001422"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001422.tgz#f2d7c6202c49a8359e6e35add894d88ef93edba1"
-  integrity sha512-hSesn02u1QacQHhaxl/kNMZwqVG35Sz/8DgvmgedxSH8z9UUpcDYSPYgsj3x5dQNRcNp6BwpSfQfVzYUTm+fog==
+  version "1.0.30001419"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001419.tgz#3542722d57d567c8210d5e4d0f9f17336b776457"
+  integrity sha512-aFO1r+g6R7TW+PNQxKzjITwLOyDhVRLjW0LcwS/HCZGUUKTGNp9+IwLC4xyDSZBygVL/mxaFR3HIV6wEKQuSzw==
 
 canonical-path@^1.0.0:
   version "1.0.0"
@@ -7340,9 +7340,9 @@ electron-to-chromium@^1.4.202:
   integrity sha512-ICHvGaCIQR3P88uK8aRtx8gmejbVJyC6bB4LEC3anzBrIzdzC7aiZHY4iFfXhN4st6I7lMO0x4sgBHf/7kBvRw==
 
 electron-to-chromium@^1.4.251:
-  version "1.4.284"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz#61046d1e4cab3a25238f6bf7413795270f125592"
-  integrity sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==
+  version "1.4.282"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.282.tgz#02af3fd6051e97ac3388a4b11d455bc1ca49838f"
+  integrity sha512-Dki0WhHNh/br/Xi1vAkueU5mtIc9XLHcMKB6tNfQKk+kPG0TEUjRh5QEMAUbRp30/rYNMFD1zKKvbVzwq/4wmg==
 
 electron-to-chromium@^1.4.84:
   version "1.4.112"


### PR DESCRIPTION


The Angular CLI supports resolving node modules without the need of specifying `node_modules` directory. This also needed to add support for Yarn PNP which doesn't create a `node_modules` directory.

Closes #25242