### PR TITLE
feat(material/core): remove typography styles from core mixin

### DIFF
--- a/src/material/core/_core.scss
+++ b/src/material/core/_core.scss
@@ -3,7 +3,6 @@
 // Core styles that can be used to apply material design treatments to any element.
 @use './ripple/ripple';
 @use './focus-indicators/private';
-@use './typography/all-typography';
 
 // Mixin that renders all of the core styles that are not theme-dependent.
 // TODO: Remove the `$exclude-typography` parameter after all internal clients migrated

--- a/src/material/core/_core.scss
+++ b/src/material/core/_core.scss
@@ -6,12 +6,8 @@
 @use './typography/all-typography';
 
 // Mixin that renders all of the core styles that are not theme-dependent.
-// TODO: Remove the `$exclude-typography` parameter once `ng update` automatically migrates
-// client theme applications to manually include the typography mixin.
+// TODO: Remove the `$exclude-typography` parameter after all internal clients migrated
 @mixin core($typography-config: null, $exclude-typography: false) {
-  @if not $exclude-typography {
-    @include all-typography.all-component-typographies($typography-config);
-  }
   @include ripple.ripple();
   @include cdk.a11y-visually-hidden();
   @include cdk.overlay();

--- a/src/material/core/_core.scss
+++ b/src/material/core/_core.scss
@@ -5,7 +5,7 @@
 @use './focus-indicators/private';
 
 // Mixin that renders all of the core styles that are not theme-dependent.
-// TODO: Remove the `$exclude-typography` parameter after all internal clients migrated
+// TODO: Remove the mixin's parameters after all internal clients migrated
 @mixin core($typography-config: null, $exclude-typography: false) {
   @include ripple.ripple();
   @include cdk.a11y-visually-hidden();

--- a/src/material/legacy-core/_core.scss
+++ b/src/material/legacy-core/_core.scss
@@ -5,7 +5,7 @@
 @use '../core/focus-indicators/private';
 
 // Mixin that renders all of the core styles that are not theme-dependent.
-// TODO: Remove the `$exclude-typography` parameter after all internal clients migrated
+// TODO: Remove the mixin's parameters after all internal clients migrated
 /// @deprecated Use `mat.core` instead. See https://material.angular.io/guide/mdc-migration for information about migrating.
 /// @breaking-change 17.0.0
 @mixin core($typography-config: null, $exclude-typography: false) {

--- a/src/material/legacy-core/_core.scss
+++ b/src/material/legacy-core/_core.scss
@@ -7,14 +7,10 @@
 @use '../core/focus-indicators/private';
 
 // Mixin that renders all of the core styles that are not theme-dependent.
-// TODO: Remove the `$exclude-typography` parameter once `ng update` automatically migrates
-// client theme applications to manually include the typography mixin.
+// TODO: Remove the `$exclude-typography` parameter after all internal clients migrated
 /// @deprecated Use `mat.core` instead. See https://material.angular.io/guide/mdc-migration for information about migrating.
 /// @breaking-change 17.0.0
 @mixin core($typography-config: null, $exclude-typography: false) {
-  @if not $exclude-typography {
-    @include all-typography.all-legacy-component-typographies($typography-config);
-  }
   @include ripple.ripple();
   @include cdk.a11y-visually-hidden();
   @include cdk.overlay();

--- a/src/material/legacy-core/_core.scss
+++ b/src/material/legacy-core/_core.scss
@@ -1,8 +1,6 @@
 @use '@angular/cdk';
 
 // Core styles that can be used to apply material design treatments to any element.
-@use './typography/all-typography';
-
 @use '../core/ripple/ripple';
 @use '../core/focus-indicators/private';
 


### PR DESCRIPTION
All internal clients include typography in their theme files and this can be safely removed. This assumes the `ng update` script will be updated to add `mat.all-component-typographies` before all `mat.core` calls.

The parameter must remain until all cases internally no longer pass the param as an argument

BREAKING CHANGE:
 - `core()` mixin no longer provides typography styles. Applications must call component `typography` mixins to apply typography styles, or call `theme` mixins with a theme config containing typography.