### PR TITLE
fix(material/tooltip): animation not cancelled when mouseleave goes through tooltip

### DIFF
--- a/tools/public_api_guard/material/tooltip.md
+++ b/tools/public_api_guard/material/tooltip.md
@@ -188,7 +188,7 @@ export class TooltipComponent extends _TooltipComponentBase {
 export abstract class _TooltipComponentBase implements OnDestroy {
     constructor(_changeDetectorRef: ChangeDetectorRef, animationMode?: string);
     afterHidden(): Observable<void>;
-    _cancelPendingHide(): void;
+    _cancelPendingAnimations(): void;
     _handleAnimationEnd({ animationName }: AnimationEvent): void;
     _handleBodyInteraction(): void;
     // (undocumented)


### PR DESCRIPTION
We ignore `mouseleave` events that go into the tooltip which meant that some animations weren't being cancelled correctly after the fix in #25699. These changes resolve the issue by skipping all animations if the tooltip isn't fully shown yet.

Fixes #24614.