### PR TITLE
fix(material/chips): aria-selected not reflecting selection state

### DIFF
--- a/src/material/chips/chip-option.ts
+++ b/src/material/chips/chip-option.ts
@@ -92,6 +92,7 @@ export class MatChipOption extends MatChip implements OnInit {
   }
   set selectable(value: BooleanInput) {
     this._selectable = coerceBooleanProperty(value);
+    this._changeDetectorRef.markForCheck();
   }
   protected _selectable: boolean = true;
 
@@ -168,6 +169,8 @@ export class MatChipOption extends MatChip implements OnInit {
           selected: this.selected,
         });
       }
+
+      this._changeDetectorRef.markForCheck();
     }
   }
 }


### PR DESCRIPTION
When the chip listbox is in single selection mode, it needs to remove `aria-selected` from the selected option and move it to the newly-selected one. The listbox was doing this already, but change detection wasn't being triggered which meant that the DOM was out of date.