### PR TITLE
fix(material/core): add typography hierarchy to prebuilt

### DIFF
--- a/src/material/core/theming/prebuilt/deeppurple-amber.scss
+++ b/src/material/core/theming/prebuilt/deeppurple-amber.scss
@@ -3,6 +3,7 @@
 @use '../palette';
 @use '../theming';
 @use '../../typography/all-typography';
+@use '../../typography/typography';
 
 // Include non-theme styles for core.
 @include core.core();
@@ -22,3 +23,5 @@ $theme: theming.define-light-theme((
 
 // Include all theme styles for the components.
 @include all-theme.all-component-themes($theme);
+
+@include typography.typography-hierarchy($theme);

--- a/src/material/core/theming/prebuilt/indigo-pink.scss
+++ b/src/material/core/theming/prebuilt/indigo-pink.scss
@@ -3,6 +3,7 @@
 @use '../palette';
 @use '../theming';
 @use '../../typography/all-typography';
+@use '../../typography/typography';
 
 
 // Include non-theme styles for core.
@@ -23,3 +24,5 @@ $theme: theming.define-light-theme((
 
 // Include all theme styles for the components.
 @include all-theme.all-component-themes($theme);
+
+@include typography.typography-hierarchy($theme);

--- a/src/material/core/theming/prebuilt/pink-bluegrey.scss
+++ b/src/material/core/theming/prebuilt/pink-bluegrey.scss
@@ -3,6 +3,7 @@
 @use '../palette';
 @use '../theming';
 @use '../../typography/all-typography';
+@use '../../typography/typography';
 
 
 // Include non-theme styles for core.
@@ -23,3 +24,5 @@ $theme: theming.define-dark-theme((
 
 // Include all theme styles for the components.
 @include all-theme.all-component-themes($theme);
+
+@include typography.typography-hierarchy($theme);

--- a/src/material/core/theming/prebuilt/purple-green.scss
+++ b/src/material/core/theming/prebuilt/purple-green.scss
@@ -3,6 +3,7 @@
 @use '../palette';
 @use '../theming';
 @use '../../typography/all-typography';
+@use '../../typography/typography';
 
 
 // Include non-theme styles for core.
@@ -23,3 +24,5 @@ $theme: theming.define-dark-theme((
 
 // Include all theme styles for the components.
 @include all-theme.all-component-themes($theme);
+
+@include typography.typography-hierarchy($theme);

--- a/src/material/legacy-core/theming/prebuilt/deeppurple-amber.scss
+++ b/src/material/legacy-core/theming/prebuilt/deeppurple-amber.scss
@@ -2,6 +2,7 @@
 @use '../../core';
 @use '../../../core/theming/palette';
 @use '../../../core/theming/theming';
+@use '../../../core/typography/typography';
 @use '../../../core/typography/all-typography';
 
 
@@ -23,3 +24,5 @@ $theme: theming.define-light-theme((
 
 // Include all theme styles for the components.
 @include all-theme.all-legacy-component-themes($theme);
+
+@include typography.typography-hierarchy($theme);

--- a/src/material/legacy-core/theming/prebuilt/indigo-pink.scss
+++ b/src/material/legacy-core/theming/prebuilt/indigo-pink.scss
@@ -2,6 +2,7 @@
 @use '../../core';
 @use '../../../core/theming/palette';
 @use '../../../core/theming/theming';
+@use '../../../core/typography/typography';
 @use '../../../core/typography/all-typography';
 
 
@@ -23,3 +24,5 @@ $theme: theming.define-light-theme((
 
 // Include all theme styles for the components.
 @include all-theme.all-legacy-component-themes($theme);
+
+@include typography.typography-hierarchy($theme);

--- a/src/material/legacy-core/theming/prebuilt/pink-bluegrey.scss
+++ b/src/material/legacy-core/theming/prebuilt/pink-bluegrey.scss
@@ -2,6 +2,7 @@
 @use '../../core';
 @use '../../../core/theming/palette';
 @use '../../../core/theming/theming';
+@use '../../../core/typography/typography';
 @use '../../../core/typography/all-typography';
 
 
@@ -23,3 +24,5 @@ $theme: theming.define-dark-theme((
 
 // Include all theme styles for the components.
 @include all-theme.all-legacy-component-themes($theme);
+
+@include typography.typography-hierarchy($theme);

--- a/src/material/legacy-core/theming/prebuilt/purple-green.scss
+++ b/src/material/legacy-core/theming/prebuilt/purple-green.scss
@@ -2,6 +2,7 @@
 @use '../../core';
 @use '../../../core/theming/palette';
 @use '../../../core/theming/theming';
+@use '../../../core/typography/typography';
 @use '../../../core/typography/all-typography';
 
 
@@ -23,3 +24,5 @@ $theme: theming.define-dark-theme((
 
 // Include all theme styles for the components.
 @include all-theme.all-legacy-component-themes($theme);
+
+@include typography.typography-hierarchy($theme);


### PR DESCRIPTION
Add typography hierarchy back to the prebuilt themes. 

They used to rely on `mat.core` calling `all-component-typographies`, which is equal to `all-component-themes` (with typography in the config) + `typography-hierarchy`.  