### PR TITLE
fix(material/schematics): replace pre-existing attribute values

### DIFF
--- a/src/material/schematics/ng-generate/mdc-migration/rules/tree-traversal.spec.ts
+++ b/src/material/schematics/ng-generate/mdc-migration/rules/tree-traversal.spec.ts
@@ -118,6 +118,14 @@ describe('#visitElements', () => {
       });
       expect(html).toBe('<a attr2="val2" attr1="val1"></a>');
     });
+
+    it('should replace value of existing attribute', async () => {
+      runAddAttributeTest('<a attr="default"></a>', '<a attr="val"></a>');
+    });
+
+    it('should add value to existing attribute that does not have a value', async () => {
+      runAddAttributeTest('<a attr></a>', '<a attr="val"></a>');
+    });
   });
 
   it('should match indentation', async () => {


### PR DESCRIPTION
Fixes that the MDC migration schematic was always adding new attributes, instead of replacing the values of the ones that are already there.