### PR TITLE
fix(cdk/drag-drop): native event not passed as parameter to drop container

### DIFF
--- a/src/cdk/drag-drop/drag-ref.ts
+++ b/src/cdk/drag-drop/drag-ref.ts
@@ -971,7 +971,7 @@ export class DragRef<T = any> {
         isPointerOverContainer,
         distance,
         pointerPosition,
-        event
+        event,
       );
       this._dropContainer = this._initialContainer;
     });

--- a/src/cdk/drag-drop/drag-ref.ts
+++ b/src/cdk/drag-drop/drag-ref.ts
@@ -971,6 +971,7 @@ export class DragRef<T = any> {
         isPointerOverContainer,
         distance,
         pointerPosition,
+        event
       );
       this._dropContainer = this._initialContainer;
     });


### PR DESCRIPTION
Fixes a bug where native event was always an empty object because it was not passed to the container drop function and the default `{}` object was always used.