### PR TITLE
refactor: remove workaround for TS versions earlier than 4.8

### DIFF
--- a/src/cdk/schematics/update-tool/component-resource-collector.ts
+++ b/src/cdk/schematics/update-tool/component-resource-collector.ts
@@ -54,9 +54,7 @@ export class ComponentResourceCollector {
   }
 
   private _visitClassDeclaration(node: ts.ClassDeclaration) {
-    // TODO(crisbeto): in TS 4.8 the `decorators` are combined with the `modifiers` array.
-    // Once we drop support for older versions, we can rely exclusively on `getDecorators`.
-    const decorators = ts.getDecorators?.(node) || node.decorators;
+    const decorators = ts.getDecorators(node);
 
     if (!decorators || !decorators.length) {
       return;

--- a/src/material/schematics/ng-update/migrations/hammer-gestures-v9/hammer-gestures-migration.ts
+++ b/src/material/schematics/ng-update/migrations/hammer-gestures-v9/hammer-gestures-migration.ts
@@ -56,12 +56,6 @@ interface PackageJson {
   dependencies: Record<string, string>;
 }
 
-/**
- * Used to temporarily cast types to `any` to unblock the upgrade to TypeScript 4.8.
- * TODO(crisbeto): Remove this once https://github.com/angular/angular-cli/pull/23764 is released.
- */
-type Ts48MigrationAny = any;
-
 export class HammerGesturesMigration extends DevkitMigration<null> {
   // The migration is enabled when v9 or v10 are targeted, but actual targets are only
   // migrated if they are not test targets. We cannot migrate test targets since they have
@@ -736,7 +730,7 @@ export class HammerGesturesMigration extends DevkitMigration<null> {
 
     const sourceFile = rootModuleSymbol.valueDeclaration.getSourceFile();
     const metadata = getDecoratorMetadata(
-      sourceFile as Ts48MigrationAny,
+      sourceFile,
       'NgModule',
       '@angular/core',
     ) as ts.ObjectLiteralExpression[];
@@ -748,9 +742,9 @@ export class HammerGesturesMigration extends DevkitMigration<null> {
 
     const filePath = this.fileSystem.resolve(sourceFile.fileName);
     const recorder = this.fileSystem.edit(filePath);
-    const providersField = getMetadataField(metadata[0] as Ts48MigrationAny, 'providers')[0];
+    const providersField = getMetadataField(metadata[0], 'providers')[0];
     const providerIdentifiers = providersField
-      ? findMatchingChildNodes(providersField as Ts48MigrationAny, ts.isIdentifier)
+      ? findMatchingChildNodes(providersField, ts.isIdentifier)
       : null;
     const gestureConfigExpr = this._importManager.addImportToSourceFile(
       sourceFile,
@@ -781,7 +775,7 @@ export class HammerGesturesMigration extends DevkitMigration<null> {
     ) {
       const symbolName = this._printNode(newProviderNode, sourceFile);
       addSymbolToNgModuleMetadata(
-        sourceFile as Ts48MigrationAny,
+        sourceFile,
         sourceFile.fileName,
         'providers',
         symbolName,
@@ -834,7 +828,7 @@ export class HammerGesturesMigration extends DevkitMigration<null> {
 
     const sourceFile = rootModuleSymbol.valueDeclaration.getSourceFile();
     const metadata = getDecoratorMetadata(
-      sourceFile as Ts48MigrationAny,
+      sourceFile,
       'NgModule',
       '@angular/core',
     ) as ts.ObjectLiteralExpression[];
@@ -842,9 +836,9 @@ export class HammerGesturesMigration extends DevkitMigration<null> {
       return;
     }
 
-    const importsField = getMetadataField(metadata[0] as Ts48MigrationAny, 'imports')[0];
+    const importsField = getMetadataField(metadata[0], 'imports')[0];
     const importIdentifiers = importsField
-      ? findMatchingChildNodes(importsField as Ts48MigrationAny, ts.isIdentifier)
+      ? findMatchingChildNodes(importsField, ts.isIdentifier)
       : null;
     const recorder = this.fileSystem.edit(this.fileSystem.resolve(sourceFile.fileName));
     const hammerModuleExpr = this._importManager.addImportToSourceFile(
@@ -861,7 +855,7 @@ export class HammerGesturesMigration extends DevkitMigration<null> {
     ) {
       const symbolName = this._printNode(hammerModuleExpr, sourceFile);
       addSymbolToNgModuleMetadata(
-        sourceFile as Ts48MigrationAny,
+        sourceFile,
         sourceFile.fileName,
         'imports',
         symbolName,


### PR DESCRIPTION
Cleans up some workarounds that were put in place to support version of TypeScript earlier than 4.8.