### PR TITLE
fix(material): update schematics to work with latest UpdateBuffer

### DIFF
--- a/src/material/schematics/ng-update/migrations/legacy-components-v15/index.ts
+++ b/src/material/schematics/ng-update/migrations/legacy-components-v15/index.ts
@@ -409,6 +409,6 @@ export class LegacyComponentsMigration extends Migration<null> {
     str: {old: string; new: string},
   ): void {
     const index = this.fileSystem.read(filePath)!.indexOf(str.old, offset);
-    this.fileSystem.edit(filePath).remove(index, str.old.length).insertRight(index, str.new);
+    this.fileSystem.edit(filePath).remove(index, str.old.length).insertLeft(index, str.new);
   }
 }


### PR DESCRIPTION
With this change we replace the `insertRight` usage with the `insertLeft` to make the update schematic work with the latest changes in `@angular-devkit/schematics`. https://github.com/angular/angular-cli/commit/9b07b469b622e083a9915ed3c24e1d53d8abf38f

Prior to this change the `legacy-components-v15` migration levrage some amgibuites with the `insertRight` method.

In a nutshell, `insertLeft` is append to the right of the string before it, while `insertRight` is prepend to the left of the string after it.