### PR TITLE
fix(material/checkbox): disabled state not distinguishable in high contrast mode

### DIFF
--- a/src/material/checkbox/checkbox.scss
+++ b/src/material/checkbox/checkbox.scss
@@ -1,3 +1,4 @@
+@use '@angular/cdk';
 @use '@material/checkbox/checkbox' as mdc-checkbox;
 @use '@material/checkbox/checkbox-theme' as mdc-checkbox-theme;
 @use '@material/form-field' as mdc-form-field;
@@ -95,6 +96,17 @@
       & ~ .mdc-checkbox__background {
         border-color: var(--mdc-checkbox-unselected-focus-icon-color, black);
       }
+    }
+  }
+
+  @include cdk.high-contrast(active, off) {
+    &.mat-mdc-checkbox-disabled {
+      opacity: 0.5;
+    }
+
+    .mdc-checkbox__checkmark {
+      --mdc-checkbox-selected-checkmark-color: CanvasText;
+      --mdc-checkbox-disabled-selected-checkmark-color: CanvasText;
     }
   }
 


### PR DESCRIPTION
Fixes that disabled checkboxes aren't distinguishable from enabled ones in high contrast mode. I also fixed an issue where the checkmark wasn't visible, but I suspect that it's only a problem when emulating on a Chromium browser.