### PR TITLE
test(material/legacy-chips): fix selectable chips tests

### DIFF
--- a/src/material/legacy-chips/chip-list.spec.ts
+++ b/src/material/legacy-chips/chip-list.spec.ts
@@ -792,6 +792,7 @@ describe('MatChipList', () => {
       });
 
       it('should take an initial view value with reactive forms', () => {
+        fixture.componentInstance.selectable = true;
         fixture.componentInstance.control = new FormControl('pizza-1');
         fixture.detectChanges();
 
@@ -995,6 +996,7 @@ describe('MatChipList', () => {
       });
 
       it('should take an initial view value with reactive forms', () => {
+        fixture.componentInstance.selectable = true;
         fixture.componentInstance.control = new FormControl(['pizza-1']);
         fixture.detectChanges();
 


### PR DESCRIPTION
Fixes that we had some tests where we were testing user selection of a chip, but the chip wasn't set as selectable.

Setting this as a P2, because it's blocking https://github.com/angular/angular/pull/47576.