### PR TITLE
feat(material/datepicker): deprecate unused i18n string

### DIFF
--- a/src/material/datepicker/datepicker-intl.ts
+++ b/src/material/datepicker/datepicker-intl.ts
@@ -51,10 +51,18 @@ export class MatDatepickerIntl {
   /** A label for the 'switch to year view' button (used by screen readers). */
   switchToMultiYearViewLabel = 'Choose month and year';
 
-  /** A label for the first date of a range of dates (used by screen readers). */
+  /**
+   * A label for the first date of a range of dates (used by screen readers).
+   * @deprecated Provide your own internationalization string.
+   * @breaking-change 17.0.0
+   */
   startDateLabel = 'Start date';
 
-  /** A label for the last date of a range of dates (used by screen readers). */
+  /**
+   * A label for the last date of a range of dates (used by screen readers).
+   * @deprecated Provide your own internationalization string.
+   * @breaking-change 17.0.0
+   */
   endDateLabel = 'End date';
 
   /** Formats a range of years (used for visuals). */

--- a/tools/public_api_guard/material/datepicker.md
+++ b/tools/public_api_guard/material/datepicker.md
@@ -471,6 +471,7 @@ export class MatDatepickerIntl {
     calendarLabel: string;
     readonly changes: Subject<void>;
     closeCalendarLabel: string;
+    // @deprecated
     endDateLabel: string;
     formatYearRange(start: string, end: string): string;
     formatYearRangeLabel(start: string, end: string): string;
@@ -481,6 +482,7 @@ export class MatDatepickerIntl {
     prevMonthLabel: string;
     prevMultiYearLabel: string;
     prevYearLabel: string;
+    // @deprecated
     startDateLabel: string;
     switchToMonthViewLabel: string;
     switchToMultiYearViewLabel: string;


### PR DESCRIPTION
Remove two unused i18n strings from datepicker. Remove `startDateLabel` and `endDateLabel`.

DEPRECATED
 * startDateLabel is deprecated because it is not used
 * endDateLabel is deprecated because it is not used