### PR TITLE
docs(material/chips): remove docs-private from avatar and trailing icon

### DIFF
--- a/src/material/chips/chip-icons.ts
+++ b/src/material/chips/chip-icons.ts
@@ -11,10 +11,7 @@ import {Directive} from '@angular/core';
 import {MatChipAction} from './chip-action';
 import {MAT_CHIP_AVATAR, MAT_CHIP_REMOVE, MAT_CHIP_TRAILING_ICON} from './tokens';
 
-/**
- * Directive to add CSS classes to chip leading icon.
- * @docs-private
- */
+/** Avatar image within a chip. */
 @Directive({
   selector: 'mat-chip-avatar, [matChipAvatar]',
   host: {
@@ -25,10 +22,7 @@ import {MAT_CHIP_AVATAR, MAT_CHIP_REMOVE, MAT_CHIP_TRAILING_ICON} from './tokens
 })
 export class MatChipAvatar {}
 
-/**
- * Directive to add CSS classes to and configure attributes for chip trailing icon.
- * @docs-private
- */
+/** Non-interactive trailing icon in a chip. */
 @Directive({
   selector: 'mat-chip-trailing-icon, [matChipTrailingIcon]',
   host: {


### PR DESCRIPTION
Removes the `@docs-private` tag from the chip avatar and trailing icon since they are public APIs. Internally the tag gets transformed into something which implies that they are private.