### PR TITLE
refactor(material/core): clean up temporary mixins from MDC migration

### DIFF
--- a/src/material/core/density/private/_all-density.scss
+++ b/src/material/core/density/private/_all-density.scss
@@ -29,14 +29,6 @@
 @use '../../../snack-bar/snack-bar-theme';
 @use '../../../table/table-theme';
 
-@mixin private-all-unmigrated-component-densities($config) {
-  @include expansion-theme.density($config);
-  @include stepper-theme.density($config);
-  @include toolbar-theme.density($config);
-  @include tree-theme.density($config);
-  @include button-toggle-theme.density($config);
-}
-
 // Includes all of the density styles.
 @mixin all-component-densities($config-or-theme) {
   // In case a theme object has been passed instead of a configuration for
@@ -77,7 +69,11 @@
   @include icon-button-theme.density($config);
   @include fab-theme.density($config);
   @include table-theme.density($config);
-  @include private-all-unmigrated-component-densities($config);
+  @include expansion-theme.density($config);
+  @include stepper-theme.density($config);
+  @include toolbar-theme.density($config);
+  @include tree-theme.density($config);
+  @include button-toggle-theme.density($config);
 }
 
 

--- a/src/material/core/theming/_all-theme.scss
+++ b/src/material/core/theming/_all-theme.scss
@@ -38,23 +38,6 @@
 @use '../../form-field/form-field-theme';
 @use './theming';
 
-@mixin private-all-unmigrated-component-themes($theme-or-color-config) {
-  @include badge-theme.theme($theme-or-color-config);
-  @include bottom-sheet-theme.theme($theme-or-color-config);
-  @include button-toggle-theme.theme($theme-or-color-config);
-  @include datepicker-theme.theme($theme-or-color-config);
-  @include divider-theme.theme($theme-or-color-config);
-  @include expansion-theme.theme($theme-or-color-config);
-  @include grid-list-theme.theme($theme-or-color-config);
-  @include icon-theme.theme($theme-or-color-config);
-  @include progress-spinner-theme.theme($theme-or-color-config);
-  @include sidenav-theme.theme($theme-or-color-config);
-  @include stepper-theme.theme($theme-or-color-config);
-  @include sort-theme.theme($theme-or-color-config);
-  @include toolbar-theme.theme($theme-or-color-config);
-  @include tree-theme.theme($theme-or-color-config);
-}
-
 // Create a theme.
 @mixin all-component-themes($theme-or-color-config) {
   $dedupe-key: 'angular-material-theme';
@@ -82,7 +65,20 @@
     @include fab-theme.theme($theme-or-color-config);
     @include snack-bar-theme.theme($theme-or-color-config);
     @include table-theme.theme($theme-or-color-config);
-    @include private-all-unmigrated-component-themes($theme-or-color-config);
+    @include progress-spinner-theme.theme($theme-or-color-config);
+    @include badge-theme.theme($theme-or-color-config);
+    @include bottom-sheet-theme.theme($theme-or-color-config);
+    @include button-toggle-theme.theme($theme-or-color-config);
+    @include datepicker-theme.theme($theme-or-color-config);
+    @include divider-theme.theme($theme-or-color-config);
+    @include expansion-theme.theme($theme-or-color-config);
+    @include grid-list-theme.theme($theme-or-color-config);
+    @include icon-theme.theme($theme-or-color-config);
+    @include sidenav-theme.theme($theme-or-color-config);
+    @include stepper-theme.theme($theme-or-color-config);
+    @include sort-theme.theme($theme-or-color-config);
+    @include toolbar-theme.theme($theme-or-color-config);
+    @include tree-theme.theme($theme-or-color-config);
   }
 }
 

--- a/src/material/core/theming/tests/test-css-variables-theme.scss
+++ b/src/material/core/theming/tests/test-css-variables-theme.scss
@@ -3,20 +3,6 @@
 @use '../all-theme';
 @use '../palette';
 @use '../theming';
-@use '../../../badge/badge-theme';
-@use '../../../bottom-sheet/bottom-sheet-theme';
-@use '../../../button-toggle/button-toggle-theme';
-@use '../../../datepicker/datepicker-theme';
-@use '../../../divider/divider-theme';
-@use '../../../expansion/expansion-theme';
-@use '../../../grid-list/grid-list-theme';
-@use '../../../icon/icon-theme';
-@use '../../../legacy-progress-spinner/progress-spinner-theme';
-@use '../../../sidenav/sidenav-theme';
-@use '../../../stepper/stepper-theme';
-@use '../../../sort/sort-theme';
-@use '../../../toolbar/toolbar-theme';
-@use '../../../tree/tree-theme';
 @use '../../../legacy-core/theming/all-theme' as legacy-all-theme;
 
 // Recursively replaces all of the values inside a Sass map with a different value.
@@ -46,19 +32,5 @@
     )
   ));
   $css-var-theme: replace-all-values($theme, var(--test-var));
-  @include badge-theme.theme($css-var-theme);
-  @include bottom-sheet-theme.theme($css-var-theme);
-  @include button-toggle-theme.theme($css-var-theme);
-  @include datepicker-theme.theme($css-var-theme);
-  @include divider-theme.theme($css-var-theme);
-  @include expansion-theme.theme($css-var-theme);
-  @include grid-list-theme.theme($css-var-theme);
-  @include icon-theme.theme($css-var-theme);
-  @include progress-spinner-theme.theme($css-var-theme);
-  @include sidenav-theme.theme($css-var-theme);
-  @include stepper-theme.theme($css-var-theme);
-  @include sort-theme.theme($css-var-theme);
-  @include toolbar-theme.theme($css-var-theme);
-  @include tree-theme.theme($css-var-theme);
   @include legacy-all-theme.all-legacy-component-themes($css-var-theme);
 }

--- a/src/material/core/typography/_all-typography.scss
+++ b/src/material/core/typography/_all-typography.scss
@@ -195,24 +195,6 @@
   );
 }
 
-@mixin private-all-unmigrated-component-typographies($config) {
-  @include badge-theme.typography($config);
-  @include typography.typography-hierarchy($config);
-  @include bottom-sheet-theme.typography($config);
-  @include button-toggle-theme.typography($config);
-  @include divider-theme.typography($config);
-  @include datepicker-theme.typography($config);
-  @include expansion-theme.typography($config);
-  @include grid-list-theme.typography($config);
-  @include icon-theme.typography($config);
-  @include progress-spinner-theme.typography($config);
-  @include sidenav-theme.typography($config);
-  @include stepper-theme.typography($config);
-  @include sort-theme.typography($config);
-  @include toolbar-theme.typography($config);
-  @include tree-theme.typography($config);
-}
-
 // Includes all of the typographic styles.
 @mixin all-component-typographies($config-or-theme: null) {
   $config: if(theming.private-is-theme-object($config-or-theme),
@@ -228,7 +210,21 @@
   // not possible as it would introduce a circular dependency for typography because the `mat-core`
   // mixin that is transitively loaded by the `all-theme` file, imports `all-typography` which
   // would then load `all-theme` again. This ultimately results a circular dependency.
-  @include private-all-unmigrated-component-typographies($config);
+  @include badge-theme.typography($config);
+  @include typography.typography-hierarchy($config);
+  @include bottom-sheet-theme.typography($config);
+  @include button-toggle-theme.typography($config);
+  @include divider-theme.typography($config);
+  @include datepicker-theme.typography($config);
+  @include expansion-theme.typography($config);
+  @include grid-list-theme.typography($config);
+  @include icon-theme.typography($config);
+  @include progress-spinner-theme.typography($config);
+  @include sidenav-theme.typography($config);
+  @include stepper-theme.typography($config);
+  @include sort-theme.typography($config);
+  @include toolbar-theme.typography($config);
+  @include tree-theme.typography($config);
   @include core-theme.typography($config);
   @include card-theme.typography($config);
   @include progress-bar-theme.typography($config);

--- a/src/material/legacy-core/density/private/_all-density.scss
+++ b/src/material/legacy-core/density/private/_all-density.scss
@@ -1,6 +1,10 @@
 @use '../../../core/theming/theming';
-@use '../../../core/density/private/all-density';
 @use '../../../legacy-form-field/form-field-theme';
+@use '../../../expansion/expansion-theme';
+@use '../../../stepper/stepper-theme';
+@use '../../../toolbar/toolbar-theme';
+@use '../../../tree/tree-theme';
+@use '../../../button-toggle/button-toggle-theme';
 
 // Add legacy theme imports here, e.g.:
 // @use '../../../<legacy-component>/<legacy-component>-theme';
@@ -27,7 +31,11 @@
   // Add legacy density includes here, e.g.:
   // @include <legacy-component>-theme.density($config);
   @include form-field-theme.density($config);
-  @include all-density.private-all-unmigrated-component-densities($config);
+  @include expansion-theme.density($config);
+  @include stepper-theme.density($config);
+  @include toolbar-theme.density($config);
+  @include tree-theme.density($config);
+  @include button-toggle-theme.density($config);
 }
 
 

--- a/src/material/legacy-core/theming/_all-theme.scss
+++ b/src/material/legacy-core/theming/_all-theme.scss
@@ -1,5 +1,4 @@
 @use '../../core/theming/theming';
-@use '../../core/theming/all-theme';
 @use '../core-theme';
 @use '../../legacy-button/button-theme';
 @use '../../legacy-card/card-theme';
@@ -22,6 +21,19 @@
 @use '../../legacy-tabs/tabs-theme';
 @use '../../legacy-snack-bar/snack-bar-theme';
 @use '../../legacy-table/table-theme';
+@use '../../badge/badge-theme';
+@use '../../bottom-sheet/bottom-sheet-theme';
+@use '../../button-toggle/button-toggle-theme';
+@use '../../datepicker/datepicker-theme';
+@use '../../divider/divider-theme';
+@use '../../expansion/expansion-theme';
+@use '../../grid-list/grid-list-theme';
+@use '../../icon/icon-theme';
+@use '../../sidenav/sidenav-theme';
+@use '../../stepper/stepper-theme';
+@use '../../sort/sort-theme';
+@use '../../toolbar/toolbar-theme';
+@use '../../tree/tree-theme';
 
 // Create a theme.
 /// @deprecated Use `mat.all-component-themes` instead. See https://material.angular.io/guide/mdc-migration for information about migrating.
@@ -29,6 +41,7 @@
 @mixin all-legacy-component-themes($theme-or-color-config) {
   $dedupe-key: 'angular-material-legacy-theme';
   @include theming.private-check-duplicate-theme-styles($theme-or-color-config, $dedupe-key) {
+    // Legacy components.
     @include button-theme.theme($theme-or-color-config);
     @include core-theme.theme($theme-or-color-config);
     @include card-theme.theme($theme-or-color-config);
@@ -51,7 +64,21 @@
     @include tabs-theme.theme($theme-or-color-config);
     @include snack-bar-theme.theme($theme-or-color-config);
     @include table-theme.theme($theme-or-color-config);
-    @include all-theme.private-all-unmigrated-component-themes($theme-or-color-config);
+
+    // Components without MDC versions.
+    @include badge-theme.theme($theme-or-color-config);
+    @include bottom-sheet-theme.theme($theme-or-color-config);
+    @include button-toggle-theme.theme($theme-or-color-config);
+    @include datepicker-theme.theme($theme-or-color-config);
+    @include divider-theme.theme($theme-or-color-config);
+    @include expansion-theme.theme($theme-or-color-config);
+    @include grid-list-theme.theme($theme-or-color-config);
+    @include icon-theme.theme($theme-or-color-config);
+    @include sidenav-theme.theme($theme-or-color-config);
+    @include stepper-theme.theme($theme-or-color-config);
+    @include sort-theme.theme($theme-or-color-config);
+    @include toolbar-theme.theme($theme-or-color-config);
+    @include tree-theme.theme($theme-or-color-config);
   }
 }
 

--- a/src/material/legacy-core/typography/_all-typography.scss
+++ b/src/material/legacy-core/typography/_all-typography.scss
@@ -1,5 +1,4 @@
 @use '../../core/typography/typography';
-@use '../../core/typography/all-typography';
 @use '../../core/theming/theming';
 @use '../option/option-theme';
 @use '../option/optgroup-theme';
@@ -24,6 +23,19 @@
 @use '../../legacy-tabs/tabs-theme';
 @use '../../legacy-snack-bar/snack-bar-theme';
 @use '../../legacy-table/table-theme';
+@use '../../badge/badge-theme';
+@use '../../bottom-sheet/bottom-sheet-theme';
+@use '../../button-toggle/button-toggle-theme';
+@use '../../divider/divider-theme';
+@use '../../datepicker/datepicker-theme';
+@use '../../expansion/expansion-theme';
+@use '../../grid-list/grid-list-theme';
+@use '../../icon/icon-theme';
+@use '../../sidenav/sidenav-theme';
+@use '../../stepper/stepper-theme';
+@use '../../sort/sort-theme';
+@use '../../toolbar/toolbar-theme';
+@use '../../tree/tree-theme';
 
 // Includes all of the typographic styles.
 /// @deprecated Use `mat.all-component-typographies` instead. See https://material.angular.io/guide/mdc-migration for information about migrating.
@@ -43,7 +55,24 @@
   // mixin that is transitively loaded by the `all-theme` file, imports `all-typography` which
   // would then load `all-theme` again. This ultimately results a circular dependency.
 
-  @include all-typography.private-all-unmigrated-component-typographies($config);
+
+  // Components without MDC versions.
+  @include typography.typography-hierarchy($config);
+  @include badge-theme.typography($config);
+  @include bottom-sheet-theme.typography($config);
+  @include button-toggle-theme.typography($config);
+  @include divider-theme.typography($config);
+  @include datepicker-theme.typography($config);
+  @include expansion-theme.typography($config);
+  @include grid-list-theme.typography($config);
+  @include icon-theme.typography($config);
+  @include sidenav-theme.typography($config);
+  @include stepper-theme.typography($config);
+  @include sort-theme.typography($config);
+  @include toolbar-theme.typography($config);
+  @include tree-theme.typography($config);
+
+  // Legacy components.
   @include option-theme.typography($config);
   @include optgroup-theme.typography($config);
   @include button-theme.typography($config);


### PR DESCRIPTION
Some mixins were introduced during the MDC migration to make it easier to distinguish which components were migrated and which ones were pending. These changes remove the mixins now that the migration is finished.