### PR TITLE
refactor(material/schematics): remove usage of deprecated function

### DIFF
--- a/src/material/schematics/ng-update/migrations/hammer-gestures-v9/hammer-gestures-migration.ts
+++ b/src/material/schematics/ng-update/migrations/hammer-gestures-v9/hammer-gestures-migration.ts
@@ -1001,7 +1001,7 @@ function unwrapExpression(node: ts.Node): ts.Node {
     return unwrapExpression(node.expression);
   } else if (ts.isAsExpression(node)) {
     return unwrapExpression(node.expression);
-  } else if (ts.isTypeAssertion(node)) {
+  } else if (ts.isTypeAssertionExpression(node)) {
     return unwrapExpression(node.expression);
   }
   return node;


### PR DESCRIPTION
Replaces a call to a deprecated function that was logging a warning.