### PR TITLE
refactor(multiple): remove usages of the deprecated signature of inject

### DIFF
--- a/src/cdk/listbox/listbox.ts
+++ b/src/cdk/listbox/listbox.ts
@@ -14,7 +14,6 @@ import {
   ElementRef,
   forwardRef,
   inject,
-  InjectFlags,
   Input,
   OnDestroy,
   Output,
@@ -431,7 +430,7 @@ export class CdkListbox<T = unknown>
   );
 
   /** The directionality of the page. */
-  private readonly _dir = inject(Directionality, InjectFlags.Optional);
+  private readonly _dir = inject(Directionality, {optional: true});
 
   /** A predicate that skips disabled options. */
   private readonly _skipDisabledPredicate = (option: CdkOption<T>) => option.disabled;

--- a/src/cdk/menu/context-menu-trigger.ts
+++ b/src/cdk/menu/context-menu-trigger.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, inject, Injectable, InjectFlags, Input, OnDestroy} from '@angular/core';
+import {Directive, inject, Injectable, Input, OnDestroy} from '@angular/core';
 import {Directionality} from '@angular/cdk/bidi';
 import {
   FlexibleConnectedPositionStrategy,
@@ -77,7 +77,7 @@ export class CdkContextMenuTrigger extends CdkMenuTriggerBase implements OnDestr
   private readonly _overlay = inject(Overlay);
 
   /** The directionality of the page. */
-  private readonly _directionality = inject(Directionality, InjectFlags.Optional);
+  private readonly _directionality = inject(Directionality, {optional: true});
 
   /** The app's context menu tracking registry */
   private readonly _contextMenuTracker = inject(ContextMenuTracker);

--- a/src/cdk/menu/menu-base.ts
+++ b/src/cdk/menu/menu-base.ts
@@ -13,7 +13,6 @@ import {
   Directive,
   ElementRef,
   inject,
-  InjectFlags,
   Input,
   NgZone,
   OnDestroy,
@@ -63,10 +62,10 @@ export abstract class CdkMenuBase
   readonly menuStack: MenuStack = inject(MENU_STACK);
 
   /** The menu aim service used by this menu. */
-  protected readonly menuAim = inject(MENU_AIM, InjectFlags.Optional | InjectFlags.Self);
+  protected readonly menuAim = inject(MENU_AIM, {optional: true, self: true});
 
   /** The directionality (text direction) of the current page. */
-  protected readonly dir = inject(Directionality, InjectFlags.Optional);
+  protected readonly dir = inject(Directionality, {optional: true});
 
   /** The id of the menu's host element. */
   @Input() id = `cdk-menu-${nextId++}`;

--- a/src/cdk/menu/menu-item.ts
+++ b/src/cdk/menu/menu-item.ts
@@ -11,7 +11,6 @@ import {
   ElementRef,
   EventEmitter,
   inject,
-  InjectFlags,
   Input,
   NgZone,
   OnDestroy,
@@ -50,7 +49,7 @@ import {MENU_AIM, Toggler} from './menu-aim';
 })
 export class CdkMenuItem implements FocusableOption, FocusableElement, Toggler, OnDestroy {
   /** The directionality (text direction) of the current page. */
-  protected readonly _dir = inject(Directionality, InjectFlags.Optional);
+  protected readonly _dir = inject(Directionality, {optional: true});
 
   /** The menu's native DOM host element. */
   readonly _elementRef: ElementRef<HTMLElement> = inject(ElementRef);
@@ -59,16 +58,16 @@ export class CdkMenuItem implements FocusableOption, FocusableElement, Toggler, 
   protected _ngZone = inject(NgZone);
 
   /** The menu aim service used by this menu. */
-  private readonly _menuAim = inject(MENU_AIM, InjectFlags.Optional);
+  private readonly _menuAim = inject(MENU_AIM, {optional: true});
 
   /** The stack of menus this menu belongs to. */
   private readonly _menuStack = inject(MENU_STACK);
 
   /** The parent menu in which this menuitem resides. */
-  private readonly _parentMenu = inject(CDK_MENU, InjectFlags.Optional);
+  private readonly _parentMenu = inject(CDK_MENU, {optional: true});
 
   /** Reference to the CdkMenuItemTrigger directive if one is added to the same element */
-  private readonly _menuTrigger = inject(CdkMenuTrigger, InjectFlags.Optional | InjectFlags.Self);
+  private readonly _menuTrigger = inject(CdkMenuTrigger, {optional: true, self: true});
 
   /**  Whether the CdkMenuItem is disabled - defaults to false */
   @Input('cdkMenuItemDisabled')

--- a/src/cdk/menu/menu-trigger.ts
+++ b/src/cdk/menu/menu-trigger.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, ElementRef, inject, InjectFlags, NgZone, OnDestroy} from '@angular/core';
+import {Directive, ElementRef, inject, NgZone, OnDestroy} from '@angular/core';
 import {Directionality} from '@angular/cdk/bidi';
 import {
   ConnectedPosition,
@@ -73,13 +73,13 @@ export class CdkMenuTrigger extends CdkMenuTriggerBase implements OnDestroy {
   private readonly _ngZone = inject(NgZone);
 
   /** The parent menu this trigger belongs to. */
-  private readonly _parentMenu = inject(CDK_MENU, InjectFlags.Optional);
+  private readonly _parentMenu = inject(CDK_MENU, {optional: true});
 
   /** The menu aim service used by this menu. */
-  private readonly _menuAim = inject(MENU_AIM, InjectFlags.Optional);
+  private readonly _menuAim = inject(MENU_AIM, {optional: true});
 
   /** The directionality of the page. */
-  private readonly _directionality = inject(Directionality, InjectFlags.Optional);
+  private readonly _directionality = inject(Directionality, {optional: true});
 
   constructor() {
     super();

--- a/src/cdk/menu/menu.ts
+++ b/src/cdk/menu/menu.ts
@@ -6,15 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {
-  AfterContentInit,
-  Directive,
-  EventEmitter,
-  inject,
-  InjectFlags,
-  OnDestroy,
-  Output,
-} from '@angular/core';
+import {AfterContentInit, Directive, EventEmitter, inject, OnDestroy, Output} from '@angular/core';
 import {ESCAPE, hasModifierKey, LEFT_ARROW, RIGHT_ARROW, TAB} from '@angular/cdk/keycodes';
 import {takeUntil} from 'rxjs/operators';
 import {CdkMenuGroup} from './menu-group';
@@ -46,7 +38,7 @@ import {CdkMenuBase} from './menu-base';
   ],
 })
 export class CdkMenu extends CdkMenuBase implements AfterContentInit, OnDestroy {
-  private _parentTrigger = inject(MENU_TRIGGER, InjectFlags.Optional);
+  private _parentTrigger = inject(MENU_TRIGGER, {optional: true});
 
   /** Event emitted when the menu is closed. */
   @Output() readonly closed: EventEmitter<void> = new EventEmitter();

--- a/src/material/datepicker/date-range-input-parts.ts
+++ b/src/material/datepicker/date-range-input-parts.ts
@@ -89,7 +89,7 @@ abstract class MatDateRangeInputPartBase<D>
   protected abstract override _assignValueToModel(value: D | null): void;
   protected abstract override _getValueFromModel(modelValue: DateRange<D>): D | null;
 
-  protected readonly _dir = inject(Directionality, InjectFlags.Optional);
+  protected readonly _dir = inject(Directionality, {optional: true});
 
   constructor(
     @Inject(MAT_DATE_RANGE_INPUT_PARENT) public _rangeInput: MatDateRangeInputParent<D>,

--- a/src/material/legacy-input/input.ts
+++ b/src/material/legacy-input/input.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, inject, InjectFlags} from '@angular/core';
+import {Directive, inject} from '@angular/core';
 import {MatInput as BaseMatInput} from '@angular/material/input';
 import {
   MatLegacyFormFieldControl,
@@ -44,10 +44,7 @@ import {
   providers: [{provide: MatLegacyFormFieldControl, useExisting: MatLegacyInput}],
 })
 export class MatLegacyInput extends BaseMatInput {
-  private _legacyFormField = inject<MatLegacyFormField>(
-    MAT_LEGACY_FORM_FIELD,
-    InjectFlags.Optional,
-  );
+  private _legacyFormField = inject<MatLegacyFormField>(MAT_LEGACY_FORM_FIELD, {optional: true});
 
   protected override _getPlaceholder() {
     // If we're hiding the native placeholder, it should also be cleared from the DOM, otherwise


### PR DESCRIPTION
Cleans up the usages of the deprecated signature of the `inject` function that were passing in `InjectFlags` instead of an object literal.