### PR TITLE
feat(cdk/menu): Allow setting cdkMenuTriggerFor null

### DIFF
--- a/src/cdk/menu/menu-item.ts
+++ b/src/cdk/menu/menu-item.ts
@@ -93,7 +93,13 @@ export class CdkMenuItem implements FocusableOption, FocusableElement, Toggler, 
   @Output('cdkMenuItemTriggered') readonly triggered: EventEmitter<void> = new EventEmitter();
 
   /** Whether the menu item opens a menu. */
-  readonly hasMenu = !!this._menuTrigger;
+  get hasMenu() {
+    if (this._menuTrigger?.menuTemplateRef == null) {
+      return false;
+    }
+
+    return true;
+  }
 
   /**
    * The tabindex for this menu item managed internally and used for implementing roving a

--- a/src/cdk/menu/menu-item.ts
+++ b/src/cdk/menu/menu-item.ts
@@ -94,11 +94,7 @@ export class CdkMenuItem implements FocusableOption, FocusableElement, Toggler, 
 
   /** Whether the menu item opens a menu. */
   get hasMenu() {
-    if (this._menuTrigger?.menuTemplateRef == null) {
-      return false;
-    }
-
-    return true;
+    return this._menuTrigger?.menuTemplateRef != null;
   }
 
   /**

--- a/src/cdk/menu/menu-trigger-base.ts
+++ b/src/cdk/menu/menu-trigger-base.ts
@@ -58,7 +58,7 @@ export abstract class CdkMenuTriggerBase implements OnDestroy {
   readonly closed: EventEmitter<void> = new EventEmitter();
 
   /** Template reference variable to the menu this trigger opens */
-  menuTemplateRef: TemplateRef<unknown>;
+  menuTemplateRef: TemplateRef<unknown> | null;
 
   /** Context data to be passed along to the menu template */
   menuData: unknown;

--- a/src/cdk/menu/menu-trigger.spec.ts
+++ b/src/cdk/menu/menu-trigger.spec.ts
@@ -1,4 +1,3 @@
-import {CdkContextMenuTrigger} from './context-menu-trigger';
 import {Component, ViewChildren, QueryList, ElementRef, ViewChild, Type} from '@angular/core';
 import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';

--- a/src/cdk/menu/menu-trigger.spec.ts
+++ b/src/cdk/menu/menu-trigger.spec.ts
@@ -48,12 +48,36 @@ describe('MenuTrigger', () => {
       expect(menuItemElement.getAttribute('aria-disabled')).toBe('true');
     });
 
-    it('should set aria-haspopup to menu', () => {
+    it('should set aria-haspopup based on whether a menu is assigned', () => {
       expect(menuItemElement.getAttribute('aria-haspopup')).toEqual('menu');
+
+      fixture.componentInstance.trigger.menuTemplateRef = null;
+      fixture.detectChanges();
+
+      expect(menuItemElement.hasAttribute('aria-haspopup')).toBe(false);
     });
 
-    it('should  have a menu', () => {
+    it('should have a menu based on whether a menu is assigned', () => {
       expect(menuItem.hasMenu).toBeTrue();
+
+      fixture.componentInstance.trigger.menuTemplateRef = null;
+      fixture.detectChanges();
+
+      expect(menuItem.hasMenu).toBeFalse();
+    });
+
+    it('should set aria-controls based on whether a menu is assigned', () => {
+      expect(menuItemElement.hasAttribute('aria-controls')).toBeFalse();
+    });
+
+    it('should set aria-expanded based on whether a menu is assigned', () => {
+        expect(menuItemElement.hasAttribute('aria-expanded')).toBeTrue();
+        expect(menuItemElement.getAttribute('aria-expanded')).toBe('false');
+
+        fixture.componentInstance.trigger.menuTemplateRef = null;
+        fixture.detectChanges();
+
+        expect(menuItemElement.hasAttribute('aria-expanded')).toBeFalse();
     });
   });
 
@@ -471,21 +495,10 @@ describe('MenuTrigger', () => {
     expect(document.querySelector('.test-menu')?.textContent).toBe('Hello!');
   });
 
-  describe('null triggerFor', () => {
+  xdescribe('null triggerFor', () => {
     let fixture: ComponentFixture<TriggerWithNullValue>;
 
     let nativeTrigger: HTMLElement;
-    let contextNativeTrigger: HTMLElement;
-
-    const grabElementsForTesting = () => {
-      nativeTrigger = fixture.componentInstance.nativeTrigger.nativeElement;
-    };
-
-    /** run change detection and, extract and set the rendered elements */
-    const detectChanges = () => {
-      fixture.detectChanges();
-      grabElementsForTesting();
-    };
 
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
@@ -496,7 +509,7 @@ describe('MenuTrigger', () => {
 
     beforeEach(() => {
       fixture = TestBed.createComponent(TriggerWithNullValue);
-      detectChanges();
+      nativeTrigger = fixture.componentInstance.nativeTrigger.nativeElement
     });
 
     it('should not set aria-haspopup', () => {
@@ -511,7 +524,8 @@ describe('MenuTrigger', () => {
       expect(fixture.componentInstance.trigger.isOpen()).toBeFalse();
 
       nativeTrigger.click();
-      detectChanges();
+      fixture.detectChanges();
+
       expect(fixture.componentInstance.trigger.isOpen()).toBeFalse();
     });
 
@@ -519,7 +533,8 @@ describe('MenuTrigger', () => {
       expect(fixture.componentInstance.trigger.isOpen()).toBeFalse();
 
       dispatchKeyboardEvent(nativeTrigger, 'keydown', SPACE);
-      detectChanges();
+      fixture.detectChanges();
+
       expect(fixture.componentInstance.trigger.isOpen()).toBeFalse();
     });
   });
@@ -531,7 +546,10 @@ describe('MenuTrigger', () => {
     <ng-template #noop><div cdkMenu></div></ng-template>
   `,
 })
-class TriggerForEmptyMenu {}
+class TriggerForEmptyMenu {
+    @ViewChild(CdkMenuTrigger) trigger: CdkMenuTrigger;
+    @ViewChild(CdkMenuTrigger, { read: ElementRef }) nativeTrigger: ElementRef;
+}
 
 @Component({
   template: `

--- a/src/cdk/menu/menu-trigger.spec.ts
+++ b/src/cdk/menu/menu-trigger.spec.ts
@@ -71,13 +71,13 @@ describe('MenuTrigger', () => {
     });
 
     it('should set aria-expanded based on whether a menu is assigned', () => {
-        expect(menuItemElement.hasAttribute('aria-expanded')).toBeTrue();
-        expect(menuItemElement.getAttribute('aria-expanded')).toBe('false');
+      expect(menuItemElement.hasAttribute('aria-expanded')).toBeTrue();
+      expect(menuItemElement.getAttribute('aria-expanded')).toBe('false');
 
-        fixture.componentInstance.trigger.menuTemplateRef = null;
-        fixture.detectChanges();
+      fixture.componentInstance.trigger.menuTemplateRef = null;
+      fixture.detectChanges();
 
-        expect(menuItemElement.hasAttribute('aria-expanded')).toBeFalse();
+      expect(menuItemElement.hasAttribute('aria-expanded')).toBeFalse();
     });
   });
 
@@ -495,7 +495,7 @@ describe('MenuTrigger', () => {
     expect(document.querySelector('.test-menu')?.textContent).toBe('Hello!');
   });
 
-  xdescribe('null triggerFor', () => {
+  describe('null triggerFor', () => {
     let fixture: ComponentFixture<TriggerWithNullValue>;
 
     let nativeTrigger: HTMLElement;
@@ -509,7 +509,7 @@ describe('MenuTrigger', () => {
 
     beforeEach(() => {
       fixture = TestBed.createComponent(TriggerWithNullValue);
-      nativeTrigger = fixture.componentInstance.nativeTrigger.nativeElement
+      nativeTrigger = fixture.componentInstance.nativeTrigger.nativeElement;
     });
 
     it('should not set aria-haspopup', () => {
@@ -547,8 +547,8 @@ describe('MenuTrigger', () => {
   `,
 })
 class TriggerForEmptyMenu {
-    @ViewChild(CdkMenuTrigger) trigger: CdkMenuTrigger;
-    @ViewChild(CdkMenuTrigger, { read: ElementRef }) nativeTrigger: ElementRef;
+  @ViewChild(CdkMenuTrigger) trigger: CdkMenuTrigger;
+  @ViewChild(CdkMenuTrigger, {read: ElementRef}) nativeTrigger: ElementRef;
 }
 
 @Component({
@@ -678,16 +678,12 @@ class TriggerWithData {
 @Component({
   template: `
     <button [cdkMenuTriggerFor]="null">First</button>
-    <button [cdkContextMenuTriggerFor]="null">First</button>
   `,
 })
 class TriggerWithNullValue {
-  @ViewChild(CdkMenuTrigger)
+  @ViewChild(CdkMenuTrigger, {static: true})
   trigger: CdkMenuTrigger;
 
-  @ViewChild(CdkMenuTrigger, {read: ElementRef})
+  @ViewChild(CdkMenuTrigger, {static: true, read: ElementRef})
   nativeTrigger: ElementRef<HTMLElement>;
-
-  @ViewChild(CdkContextMenuTrigger, {read: ElementRef})
-  contextMenuNativeTrigger: ElementRef<HTMLElement>;
 }

--- a/src/cdk/menu/menu-trigger.spec.ts
+++ b/src/cdk/menu/menu-trigger.spec.ts
@@ -1,3 +1,4 @@
+import {CdkContextMenuTrigger} from './context-menu-trigger';
 import {Component, ViewChildren, QueryList, ElementRef, ViewChild, Type} from '@angular/core';
 import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
@@ -469,6 +470,59 @@ describe('MenuTrigger', () => {
 
     expect(document.querySelector('.test-menu')?.textContent).toBe('Hello!');
   });
+
+  describe('null triggerFor', () => {
+    let fixture: ComponentFixture<TriggerWithNullValue>;
+
+    let nativeTrigger: HTMLElement;
+    let contextNativeTrigger: HTMLElement;
+
+    const grabElementsForTesting = () => {
+      nativeTrigger = fixture.componentInstance.nativeTrigger.nativeElement;
+    };
+
+    /** run change detection and, extract and set the rendered elements */
+    const detectChanges = () => {
+      fixture.detectChanges();
+      grabElementsForTesting();
+    };
+
+    beforeEach(waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [CdkMenuModule],
+        declarations: [TriggerWithNullValue],
+      }).compileComponents();
+    }));
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(TriggerWithNullValue);
+      detectChanges();
+    });
+
+    it('should not set aria-haspopup', () => {
+      expect(nativeTrigger.hasAttribute('aria-haspopup')).toBeFalse();
+    });
+
+    it('should not set aria-controls', () => {
+      expect(nativeTrigger.hasAttribute('aria-controls')).toBeFalse();
+    });
+
+    it('should not toggle the menu on trigger', () => {
+      expect(fixture.componentInstance.trigger.isOpen()).toBeFalse();
+
+      nativeTrigger.click();
+      detectChanges();
+      expect(fixture.componentInstance.trigger.isOpen()).toBeFalse();
+    });
+
+    it('should not toggle the menu on keyboard events', () => {
+      expect(fixture.componentInstance.trigger.isOpen()).toBeFalse();
+
+      dispatchKeyboardEvent(nativeTrigger, 'keydown', SPACE);
+      detectChanges();
+      expect(fixture.componentInstance.trigger.isOpen()).toBeFalse();
+    });
+  });
 });
 
 @Component({
@@ -601,4 +655,21 @@ class StandaloneTriggerWithInlineMenu {
 })
 class TriggerWithData {
   menuData: unknown;
+}
+
+@Component({
+  template: `
+    <button [cdkMenuTriggerFor]="null">First</button>
+    <button [cdkContextMenuTriggerFor]="null">First</button>
+  `,
+})
+class TriggerWithNullValue {
+  @ViewChild(CdkMenuTrigger)
+  trigger: CdkMenuTrigger;
+
+  @ViewChild(CdkMenuTrigger, {read: ElementRef})
+  nativeTrigger: ElementRef<HTMLElement>;
+
+  @ViewChild(CdkContextMenuTrigger, {read: ElementRef})
+  contextMenuNativeTrigger: ElementRef<HTMLElement>;
 }

--- a/src/cdk/menu/menu-trigger.ts
+++ b/src/cdk/menu/menu-trigger.ts
@@ -45,7 +45,7 @@ import {CdkMenuTriggerBase, MENU_TRIGGER} from './menu-trigger-base';
   standalone: true,
   host: {
     'class': 'cdk-menu-trigger',
-    'aria-haspopup': 'menu',
+    '[attr.aria-haspopup]': 'menuTemplateRef ? "menu" : null',
     '[attr.aria-expanded]': 'isOpen()',
     '(focusin)': '_setHasFocus(true)',
     '(focusout)': '_setHasFocus(false)',
@@ -99,7 +99,7 @@ export class CdkMenuTrigger extends CdkMenuTriggerBase implements OnDestroy {
 
   /** Open the attached menu. */
   open() {
-    if (!this.isOpen()) {
+    if (!this.isOpen() && this.menuTemplateRef != null) {
       this.opened.next();
 
       this.overlayRef = this.overlayRef || this._overlay.create(this._getOverlayConfig());

--- a/src/cdk/menu/menu-trigger.ts
+++ b/src/cdk/menu/menu-trigger.ts
@@ -46,7 +46,7 @@ import {CdkMenuTriggerBase, MENU_TRIGGER} from './menu-trigger-base';
   host: {
     'class': 'cdk-menu-trigger',
     '[attr.aria-haspopup]': 'menuTemplateRef ? "menu" : null',
-    '[attr.aria-expanded]': 'isOpen()',
+    '[attr.aria-expanded]': 'menuTemplateRef == null ? null : isOpen()',
     '(focusin)': '_setHasFocus(true)',
     '(focusout)': '_setHasFocus(false)',
     '(keydown)': '_toggleOnKeydown($event)',

--- a/tools/public_api_guard/cdk/menu.md
+++ b/tools/public_api_guard/cdk/menu.md
@@ -127,7 +127,7 @@ export class CdkMenuItem implements FocusableOption, FocusableElement, Toggler, 
     getLabel(): string;
     getMenu(): Menu | undefined;
     getMenuTrigger(): CdkMenuTrigger | null;
-    readonly hasMenu: boolean;
+    get hasMenu(): boolean;
     isMenuOpen(): boolean;
     // (undocumented)
     ngOnDestroy(): void;
@@ -220,7 +220,7 @@ export abstract class CdkMenuTriggerBase implements OnDestroy {
     menuData: unknown;
     menuPosition: ConnectedPosition[];
     protected readonly menuStack: MenuStack;
-    menuTemplateRef: TemplateRef<unknown>;
+    menuTemplateRef: TemplateRef<unknown> | null;
     // (undocumented)
     ngOnDestroy(): void;
     readonly opened: EventEmitter<void>;


### PR DESCRIPTION
This PR fixes issue #25782 and allows to set `[cdkMenuTriggerFor]='null'`