### PR TITLE
fix(material/slide-toggle): animations not disabled with NoopAnimationsModule

### DIFF
--- a/src/material/slide-toggle/slide-toggle.scss
+++ b/src/material/slide-toggle/slide-toggle.scss
@@ -76,4 +76,16 @@
   .mat-mdc-focus-indicator::before {
     border-radius: 50%;
   }
+
+  &._mat-animation-noopable {
+    .mdc-switch__handle-track,
+    .mdc-elevation-overlay,
+    .mdc-switch__icon,
+    .mdc-switch__handle::before,
+    .mdc-switch__handle::after,
+    .mdc-switch__track::before,
+    .mdc-switch__track::after {
+      transition: none;
+    }
+  }
 }


### PR DESCRIPTION
Fixes that the animations of the slide toggle weren't disabled when using the `NoopAnimationsModule`.