### PR TITLE
fix(material/tabs): wrong disabled class on tab pagination button

### DIFF
--- a/src/material/tabs/tab-header.html
+++ b/src/material/tabs/tab-header.html
@@ -37,7 +37,7 @@
      type="button"
      mat-ripple
      [matRippleDisabled]="_disableScrollAfter || disableRipple"
-     [class.mat-mdc-header-pagination-disabled]="_disableScrollAfter"
+     [class.mat-mdc-tab-header-pagination-disabled]="_disableScrollAfter"
      [disabled]="_disableScrollAfter || null"
      tabindex="-1"
      (mousedown)="_handlePaginatorPress('after', $event)"


### PR DESCRIPTION
Fixes that there was a typo on the disabled class for the "Next" button in the tab header.