### PR TITLE
docs(multiple): remove unecessary async/await from docs

### DIFF
--- a/src/components-examples/material/autocomplete/autocomplete-harness/autocomplete-harness-example.spec.ts
+++ b/src/components-examples/material/autocomplete/autocomplete-harness/autocomplete-harness-example.spec.ts
@@ -10,8 +10,8 @@ describe('AutocompleteHarnessExample', () => {
   let fixture: ComponentFixture<AutocompleteHarnessExample>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatAutocompleteModule, NoopAnimationsModule],
       declarations: [AutocompleteHarnessExample],
     }).compileComponents();

--- a/src/components-examples/material/badge/badge-harness/badge-harness-example.spec.ts
+++ b/src/components-examples/material/badge/badge-harness/badge-harness-example.spec.ts
@@ -9,8 +9,8 @@ describe('BadgeHarnessExample', () => {
   let fixture: ComponentFixture<BadgeHarnessExample>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatBadgeModule],
       declarations: [BadgeHarnessExample],
     }).compileComponents();

--- a/src/components-examples/material/bottom-sheet/bottom-sheet-harness/bottom-sheet-harness-example.spec.ts
+++ b/src/components-examples/material/bottom-sheet/bottom-sheet-harness/bottom-sheet-harness-example.spec.ts
@@ -10,8 +10,8 @@ describe('BottomSheetHarnessExample', () => {
   let fixture: ComponentFixture<BottomSheetHarnessExample>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatBottomSheetModule, NoopAnimationsModule],
       declarations: [BottomSheetHarnessExample],
     }).compileComponents();

--- a/src/components-examples/material/button-toggle/button-toggle-harness/button-toggle-harness-example.spec.ts
+++ b/src/components-examples/material/button-toggle/button-toggle-harness/button-toggle-harness-example.spec.ts
@@ -9,8 +9,8 @@ describe('ButtonToggleHarnessExample', () => {
   let fixture: ComponentFixture<ButtonToggleHarnessExample>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatButtonToggleModule],
       declarations: [ButtonToggleHarnessExample],
     }).compileComponents();

--- a/src/components-examples/material/button/button-harness/button-harness-example.spec.ts
+++ b/src/components-examples/material/button/button-harness/button-harness-example.spec.ts
@@ -9,8 +9,8 @@ describe('ButtonHarnessExample', () => {
   let fixture: ComponentFixture<ButtonHarnessExample>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatButtonModule],
       declarations: [ButtonHarnessExample],
     }).compileComponents();

--- a/src/components-examples/material/card/card-harness/card-harness-example.spec.ts
+++ b/src/components-examples/material/card/card-harness/card-harness-example.spec.ts
@@ -10,8 +10,8 @@ describe('CardHarnessExample', () => {
   let fixture: ComponentFixture<CardHarnessExample>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatCardModule],
       declarations: [CardHarnessExample],
     }).compileComponents();

--- a/src/components-examples/material/checkbox/checkbox-harness/checkbox-harness-example.spec.ts
+++ b/src/components-examples/material/checkbox/checkbox-harness/checkbox-harness-example.spec.ts
@@ -10,8 +10,8 @@ describe('CheckboxHarnessExample', () => {
   let fixture: ComponentFixture<CheckboxHarnessExample>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatCheckboxModule, ReactiveFormsModule],
       declarations: [CheckboxHarnessExample],
     }).compileComponents();

--- a/src/components-examples/material/chips/chips-harness/chips-harness-example.spec.ts
+++ b/src/components-examples/material/chips/chips-harness/chips-harness-example.spec.ts
@@ -10,8 +10,8 @@ describe('ChipsHarnessExample', () => {
   let fixture: ComponentFixture<ChipsHarnessExample>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatChipsModule, NoopAnimationsModule],
       declarations: [ChipsHarnessExample],
     }).compileComponents();

--- a/src/components-examples/material/datepicker/datepicker-harness/datepicker-harness-example.spec.ts
+++ b/src/components-examples/material/datepicker/datepicker-harness/datepicker-harness-example.spec.ts
@@ -12,8 +12,8 @@ describe('DatepickerHarnessExample', () => {
   let fixture: ComponentFixture<DatepickerHarnessExample>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatDatepickerModule, NoopAnimationsModule, MatNativeDateModule, FormsModule],
       declarations: [DatepickerHarnessExample],
     }).compileComponents();

--- a/src/components-examples/material/dialog/dialog-harness/dialog-harness-example.spec.ts
+++ b/src/components-examples/material/dialog/dialog-harness/dialog-harness-example.spec.ts
@@ -1,4 +1,4 @@
-import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatDialogHarness} from '@angular/material/dialog/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
@@ -10,15 +10,15 @@ describe('DialogHarnessExample', () => {
   let fixture: ComponentFixture<DialogHarnessExample>;
   let loader: HarnessLoader;
 
-  beforeEach(waitForAsync(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatDialogModule, NoopAnimationsModule],
       declarations: [DialogHarnessExample],
     }).compileComponents();
     fixture = TestBed.createComponent(DialogHarnessExample);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.documentRootLoader(fixture);
-  }));
+  });
 
   it('should load harness for dialog', async () => {
     fixture.componentInstance.open();

--- a/src/components-examples/material/divider/divider-harness/divider-harness-example.spec.ts
+++ b/src/components-examples/material/divider/divider-harness/divider-harness-example.spec.ts
@@ -9,8 +9,8 @@ describe('DividerHarnessExample', () => {
   let fixture: ComponentFixture<DividerHarnessExample>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatDividerModule],
       declarations: [DividerHarnessExample],
     }).compileComponents();

--- a/src/components-examples/material/expansion/expansion-harness/expansion-harness-example.spec.ts
+++ b/src/components-examples/material/expansion/expansion-harness/expansion-harness-example.spec.ts
@@ -10,8 +10,8 @@ describe('ExpansionHarnessExample', () => {
   let fixture: ComponentFixture<ExpansionHarnessExample>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatExpansionModule, NoopAnimationsModule],
       declarations: [ExpansionHarnessExample],
     }).compileComponents();

--- a/src/components-examples/material/form-field/form-field-harness/form-field-harness-example.spec.ts
+++ b/src/components-examples/material/form-field/form-field-harness/form-field-harness-example.spec.ts
@@ -13,8 +13,8 @@ describe('FormFieldHarnessExample', () => {
   let fixture: ComponentFixture<FormFieldHarnessExample>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatFormFieldModule, MatInputModule, ReactiveFormsModule, NoopAnimationsModule],
       declarations: [FormFieldHarnessExample],
     }).compileComponents();

--- a/src/components-examples/material/grid-list/grid-list-harness/grid-list-harness-example.spec.ts
+++ b/src/components-examples/material/grid-list/grid-list-harness/grid-list-harness-example.spec.ts
@@ -9,8 +9,8 @@ describe('GridListHarnessExample', () => {
   let fixture: ComponentFixture<GridListHarnessExample>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatGridListModule],
       declarations: [GridListHarnessExample],
     }).compileComponents();

--- a/src/components-examples/material/icon/icon-harness/icon-harness-example.spec.ts
+++ b/src/components-examples/material/icon/icon-harness/icon-harness-example.spec.ts
@@ -10,8 +10,8 @@ describe('IconHarnessExample', () => {
   let fixture: ComponentFixture<IconHarnessExample>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatIconModule],
       declarations: [IconHarnessExample],
     }).compileComponents();

--- a/src/components-examples/material/input/input-harness/input-harness-example.spec.ts
+++ b/src/components-examples/material/input/input-harness/input-harness-example.spec.ts
@@ -11,8 +11,8 @@ describe('InputHarnessExample', () => {
   let fixture: ComponentFixture<InputHarnessExample>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatInputModule, NoopAnimationsModule, ReactiveFormsModule],
       declarations: [InputHarnessExample],
     }).compileComponents();

--- a/src/components-examples/material/list/list-harness/list-harness-example.spec.ts
+++ b/src/components-examples/material/list/list-harness/list-harness-example.spec.ts
@@ -9,8 +9,8 @@ describe('ListHarnessExample', () => {
   let fixture: ComponentFixture<ListHarnessExample>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatListModule],
       declarations: [ListHarnessExample],
     }).compileComponents();

--- a/src/components-examples/material/menu/menu-harness/menu-harness-example.spec.ts
+++ b/src/components-examples/material/menu/menu-harness/menu-harness-example.spec.ts
@@ -10,8 +10,8 @@ describe('MenuHarnessExample', () => {
   let fixture: ComponentFixture<MenuHarnessExample>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatMenuModule, NoopAnimationsModule],
       declarations: [MenuHarnessExample],
     }).compileComponents();

--- a/src/components-examples/material/paginator/paginator-harness/paginator-harness-example.spec.ts
+++ b/src/components-examples/material/paginator/paginator-harness/paginator-harness-example.spec.ts
@@ -11,8 +11,8 @@ describe('PaginatorHarnessExample', () => {
   let loader: HarnessLoader;
   let instance: PaginatorHarnessExample;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatPaginatorModule, NoopAnimationsModule],
       declarations: [PaginatorHarnessExample],
     }).compileComponents();

--- a/src/components-examples/material/progress-bar/progress-bar-harness/progress-bar-harness-example.spec.ts
+++ b/src/components-examples/material/progress-bar/progress-bar-harness/progress-bar-harness-example.spec.ts
@@ -9,8 +9,8 @@ describe('ProgressBarHarnessExample', () => {
   let fixture: ComponentFixture<ProgressBarHarnessExample>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatProgressBarModule],
       declarations: [ProgressBarHarnessExample],
     }).compileComponents();

--- a/src/components-examples/material/progress-spinner/progress-spinner-harness/progress-spinner-harness-example.spec.ts
+++ b/src/components-examples/material/progress-spinner/progress-spinner-harness/progress-spinner-harness-example.spec.ts
@@ -9,8 +9,8 @@ describe('ProgressSpinnerHarnessExample', () => {
   let fixture: ComponentFixture<ProgressSpinnerHarnessExample>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatProgressSpinnerModule],
       declarations: [ProgressSpinnerHarnessExample],
     }).compileComponents();

--- a/src/components-examples/material/radio/radio-harness/radio-harness-example.spec.ts
+++ b/src/components-examples/material/radio/radio-harness/radio-harness-example.spec.ts
@@ -10,8 +10,8 @@ describe('RadioHarnessExample', () => {
   let fixture: ComponentFixture<RadioHarnessExample>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatRadioModule, ReactiveFormsModule],
       declarations: [RadioHarnessExample],
     }).compileComponents();

--- a/src/components-examples/material/select/select-harness/select-harness-example.spec.ts
+++ b/src/components-examples/material/select/select-harness/select-harness-example.spec.ts
@@ -10,8 +10,8 @@ describe('SelectHarnessExample', () => {
   let fixture: ComponentFixture<SelectHarnessExample>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatSelectModule, NoopAnimationsModule],
       declarations: [SelectHarnessExample],
     }).compileComponents();

--- a/src/components-examples/material/sidenav/sidenav-harness/sidenav-harness-example.spec.ts
+++ b/src/components-examples/material/sidenav/sidenav-harness/sidenav-harness-example.spec.ts
@@ -14,8 +14,8 @@ describe('SidenavHarnessExample', () => {
   let fixture: ComponentFixture<SidenavHarnessExample>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatSidenavModule, NoopAnimationsModule],
       declarations: [SidenavHarnessExample],
     }).compileComponents();

--- a/src/components-examples/material/slide-toggle/slide-toggle-harness/slide-toggle-harness-example.spec.ts
+++ b/src/components-examples/material/slide-toggle/slide-toggle-harness/slide-toggle-harness-example.spec.ts
@@ -10,8 +10,8 @@ describe('SlideToggleHarnessExample', () => {
   let fixture: ComponentFixture<SlideToggleHarnessExample>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatSlideToggleModule, ReactiveFormsModule],
       declarations: [SlideToggleHarnessExample],
     }).compileComponents();

--- a/src/components-examples/material/slider/slider-harness/slider-harness-example.spec.ts
+++ b/src/components-examples/material/slider/slider-harness/slider-harness-example.spec.ts
@@ -9,8 +9,8 @@ describe('SliderHarnessExample', () => {
   let fixture: ComponentFixture<SliderHarnessExample>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatSliderModule],
       declarations: [SliderHarnessExample],
     }).compileComponents();

--- a/src/components-examples/material/snack-bar/snack-bar-harness/snack-bar-harness-example.spec.ts
+++ b/src/components-examples/material/snack-bar/snack-bar-harness/snack-bar-harness-example.spec.ts
@@ -10,8 +10,8 @@ describe('SnackBarHarnessExample', () => {
   let fixture: ComponentFixture<SnackBarHarnessExample>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatSnackBarModule, NoopAnimationsModule],
       declarations: [SnackBarHarnessExample],
     }).compileComponents();

--- a/src/components-examples/material/sort/sort-harness/sort-harness-example.spec.ts
+++ b/src/components-examples/material/sort/sort-harness/sort-harness-example.spec.ts
@@ -10,8 +10,8 @@ describe('SortHarnessExample', () => {
   let fixture: ComponentFixture<SortHarnessExample>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatSortModule, NoopAnimationsModule],
       declarations: [SortHarnessExample],
     }).compileComponents();

--- a/src/components-examples/material/stepper/stepper-harness/stepper-harness-example.spec.ts
+++ b/src/components-examples/material/stepper/stepper-harness/stepper-harness-example.spec.ts
@@ -11,8 +11,8 @@ describe('StepperHarnessExample', () => {
   let fixture: ComponentFixture<StepperHarnessExample>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatStepperModule, NoopAnimationsModule, ReactiveFormsModule],
       declarations: [StepperHarnessExample],
     }).compileComponents();

--- a/src/components-examples/material/table/table-harness/table-harness-example.spec.ts
+++ b/src/components-examples/material/table/table-harness/table-harness-example.spec.ts
@@ -9,8 +9,8 @@ describe('TableHarnessExample', () => {
   let fixture: ComponentFixture<TableHarnessExample>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatTableModule],
       declarations: [TableHarnessExample],
     }).compileComponents();

--- a/src/components-examples/material/tabs/tab-group-harness/tab-group-harness-example.spec.ts
+++ b/src/components-examples/material/tabs/tab-group-harness/tab-group-harness-example.spec.ts
@@ -10,8 +10,8 @@ describe('TabGroupHarnessExample', () => {
   let fixture: ComponentFixture<TabGroupHarnessExample>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatTabsModule, NoopAnimationsModule],
       declarations: [TabGroupHarnessExample],
     }).compileComponents();

--- a/src/components-examples/material/toolbar/toolbar-harness/toolbar-harness-example.spec.ts
+++ b/src/components-examples/material/toolbar/toolbar-harness/toolbar-harness-example.spec.ts
@@ -10,8 +10,8 @@ describe('ToolbarHarnessExample', () => {
   let fixture: ComponentFixture<ToolbarHarnessExample>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatToolbarModule, MatIconModule],
       declarations: [ToolbarHarnessExample],
     }).compileComponents();

--- a/src/components-examples/material/tooltip/tooltip-harness/tooltip-harness-example.spec.ts
+++ b/src/components-examples/material/tooltip/tooltip-harness/tooltip-harness-example.spec.ts
@@ -10,8 +10,8 @@ describe('TooltipHarnessExample', () => {
   let fixture: ComponentFixture<TooltipHarnessExample>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatTooltipModule, NoopAnimationsModule],
       declarations: [TooltipHarnessExample],
     }).compileComponents();

--- a/src/components-examples/material/tree/tree-harness/tree-harness-example.spec.ts
+++ b/src/components-examples/material/tree/tree-harness/tree-harness-example.spec.ts
@@ -10,8 +10,8 @@ describe('TreeHarnessExample', () => {
   let fixture: ComponentFixture<TreeHarnessExample>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatTreeModule, MatIconModule],
       declarations: [TreeHarnessExample],
     }).compileComponents();


### PR DESCRIPTION
We don't need to `await` the `TestBed.compileComponents` call. It can only be async if the tests have external templates or stylesheets which we don't use in our tests.