### PR TITLE
fix(cdk/listbox): remove incorrect usage of validator

### DIFF
--- a/src/cdk/listbox/listbox.spec.ts
+++ b/src/cdk/listbox/listbox.spec.ts
@@ -852,44 +852,28 @@ describe('CdkOption and CdkListbox', () => {
       subscription.unsubscribe();
     });
 
-    it('should have FormControl error when multiple values selected in single-select listbox', () => {
+    it('should throw when multiple values selected in single-select listbox', () => {
       const {testComponent, fixture} = setupComponent(ListboxWithFormControl, [
         ReactiveFormsModule,
       ]);
-      testComponent.formControl.setValue(['orange', 'banana']);
-      fixture.detectChanges();
 
-      expect(testComponent.formControl.hasError('cdkListboxUnexpectedMultipleValues')).toBeTrue();
-      expect(testComponent.formControl.hasError('cdkListboxUnexpectedOptionValues')).toBeFalse();
+      expect(() => {
+        testComponent.formControl.setValue(['orange', 'banana']);
+        fixture.detectChanges();
+      }).toThrowError('Listbox cannot have more than one selected value in multi-selection mode.');
     });
 
-    it('should have FormControl error when non-option value selected', () => {
+    it('should throw when an invalid value is selected', () => {
       const {testComponent, fixture} = setupComponent(ListboxWithFormControl, [
         ReactiveFormsModule,
       ]);
       testComponent.isMultiselectable = true;
-      testComponent.formControl.setValue(['orange', 'dragonfruit', 'mango']);
       fixture.detectChanges();
 
-      expect(testComponent.formControl.hasError('cdkListboxUnexpectedOptionValues')).toBeTrue();
-      expect(testComponent.formControl.hasError('cdkListboxUnexpectedMultipleValues')).toBeFalse();
-      expect(testComponent.formControl.errors?.['cdkListboxUnexpectedOptionValues']).toEqual({
-        'values': ['dragonfruit', 'mango'],
-      });
-    });
-
-    it('should have multiple FormControl errors when multiple non-option values selected in single-select listbox', () => {
-      const {testComponent, fixture} = setupComponent(ListboxWithFormControl, [
-        ReactiveFormsModule,
-      ]);
-      testComponent.formControl.setValue(['dragonfruit', 'mango']);
-      fixture.detectChanges();
-
-      expect(testComponent.formControl.hasError('cdkListboxUnexpectedOptionValues')).toBeTrue();
-      expect(testComponent.formControl.hasError('cdkListboxUnexpectedMultipleValues')).toBeTrue();
-      expect(testComponent.formControl.errors?.['cdkListboxUnexpectedOptionValues']).toEqual({
-        'values': ['dragonfruit', 'mango'],
-      });
+      expect(() => {
+        testComponent.formControl.setValue(['orange', 'dragonfruit', 'mango']);
+        fixture.detectChanges();
+      }).toThrowError('Listbox has selected values that do not match any of its options.');
     });
   });
 });

--- a/tools/public_api_guard/cdk/listbox.md
+++ b/tools/public_api_guard/cdk/listbox.md
@@ -4,7 +4,6 @@
 
 ```ts
 
-import { AbstractControl } from '@angular/forms';
 import { ActiveDescendantKeyManager } from '@angular/cdk/a11y';
 import { AfterContentInit } from '@angular/core';
 import { BooleanInput } from '@angular/cdk/coercion';
@@ -17,11 +16,9 @@ import { OnDestroy } from '@angular/core';
 import { QueryList } from '@angular/core';
 import { SelectionModel } from '@angular/cdk/collections';
 import { Subject } from 'rxjs';
-import { ValidationErrors } from '@angular/forms';
-import { Validator } from '@angular/forms';
 
 // @public (undocumented)
-export class CdkListbox<T = unknown> implements AfterContentInit, OnDestroy, ControlValueAccessor, Validator {
+export class CdkListbox<T = unknown> implements AfterContentInit, OnDestroy, ControlValueAccessor {
     protected readonly changeDetectorRef: ChangeDetectorRef;
     get compareWith(): undefined | ((o1: T, o2: T) => boolean);
     set compareWith(fn: undefined | ((o1: T, o2: T) => boolean));
@@ -59,7 +56,6 @@ export class CdkListbox<T = unknown> implements AfterContentInit, OnDestroy, Con
     set orientation(value: 'horizontal' | 'vertical');
     registerOnChange(fn: (value: readonly T[]) => void): void;
     registerOnTouched(fn: () => {}): void;
-    registerOnValidatorChange(fn: () => void): void;
     select(option: CdkOption<T>): void;
     protected selectionModel: ListboxSelectionModel<T>;
     selectValue(value: T): void;
@@ -72,7 +68,6 @@ export class CdkListbox<T = unknown> implements AfterContentInit, OnDestroy, Con
     protected triggerRange(trigger: CdkOption<T> | null, from: number, to: number, on: boolean): void;
     get useActiveDescendant(): boolean;
     set useActiveDescendant(shouldUseActiveDescendant: BooleanInput);
-    validate(control: AbstractControl<any, any>): ValidationErrors | null;
     get value(): readonly T[];
     set value(value: readonly T[]);
     readonly valueChange: Subject<ListboxValueChangeEvent<T>>;


### PR DESCRIPTION
Currently the CDK listbox is providing itself as a validator so that it can validate that programmatically-assigned values are valid. This is incorrect, because validators are meant to check user-assigned values and the checks that are currently being performed can't happen purely through the UI.

These changes remove the `Validator` implementation and replace the checks with runtime errors.