### PR TITLE
fix(cdk/listbox): prevent form submission on click

### DIFF
--- a/src/cdk/listbox/listbox.spec.ts
+++ b/src/cdk/listbox/listbox.spec.ts
@@ -2,7 +2,7 @@ import {fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {Component, Type} from '@angular/core';
 import {By} from '@angular/platform-browser';
 import {CdkListbox, CdkListboxModule, CdkOption, ListboxValueChangeEvent} from './index';
-import {dispatchKeyboardEvent, dispatchMouseEvent} from '../testing/private';
+import {dispatchFakeEvent, dispatchKeyboardEvent, dispatchMouseEvent} from '../testing/private';
 import {
   A,
   B,
@@ -137,6 +137,14 @@ describe('CdkOption and CdkListbox', () => {
       expect(options[0].isSelected()).toBeTrue();
       expect(optionEls[0].getAttribute('aria-selected')).toBe('true');
       expect(fixture.componentInstance.changedOption?.id).toBe(options[0].id);
+    });
+
+    it('should prevent the default click action', () => {
+      const {fixture, optionEls} = setupComponent(ListboxWithOptions);
+      const event = dispatchFakeEvent(optionEls[1], 'click');
+      fixture.detectChanges();
+
+      expect(event.defaultPrevented).toBe(true);
     });
 
     it('should select and deselect range on option SHIFT + click', () => {

--- a/src/cdk/listbox/listbox.ts
+++ b/src/cdk/listbox/listbox.ts
@@ -931,6 +931,7 @@ export class CdkListbox<T = unknown>
    * @param option The option that was clicked.
    */
   private _handleOptionClicked(option: CdkOption<T>, event: MouseEvent) {
+    event.preventDefault();
     this.listKeyManager.setActiveItem(option);
     if (event.shiftKey && this.multiple) {
       this.triggerRange(


### PR DESCRIPTION
`CdkOption` can be placed on any element which means that it could cause a `form` to be submitted if it's placed on a `button`. These changes add a `preventDefault` to avoid the submission.