### PR TITLE
fix(material/datepicker): unable to click datepicker toggle when form field is disabled

### DIFF
--- a/src/material/datepicker/datepicker-toggle.scss
+++ b/src/material/datepicker/datepicker-toggle.scss
@@ -1,5 +1,11 @@
 @use '@angular/cdk';
 
+// We support the case where the form field is disabled, but the datepicker is not.
+// MDC sets `pointer-events: none` on disabled form fields which prevents clicks on the toggle.
+.mat-datepicker-toggle {
+  pointer-events: auto;
+}
+
 @include cdk.high-contrast(active, off) {
   .mat-datepicker-toggle-default-icon {
     // On Chromium-based browsers the icon doesn't appear to inherit the text color in high


### PR DESCRIPTION
We support the case where the form field is disabled, but the datepicker isn't. Currently this is broken, because MDC sets `pointer-events: none` on the entire form field when it is disabled. These changes add `pointer-events: auto` only on the toggle to enable clicking.