### PR TITLE
fix(material/list): add checkmark to indicate selected option

### DIFF
--- a/src/material/list/BUILD.bazel
+++ b/src/material/list/BUILD.bazel
@@ -31,6 +31,7 @@ ng_module(
         "//src/cdk/observers",
         "//src/material/core",
         "//src/material/divider",
+        "//src/material/icon",
         "@npm//@angular/core",
         "@npm//@angular/forms",
     ],

--- a/src/material/list/list-module.ts
+++ b/src/material/list/list-module.ts
@@ -24,6 +24,7 @@ import {
 import {MatNavList} from './nav-list';
 import {MatSelectionList} from './selection-list';
 import {ObserversModule} from '@angular/cdk/observers';
+import {MatIconModule} from '@angular/material/icon';
 
 @NgModule({
   imports: [
@@ -32,6 +33,7 @@ import {ObserversModule} from '@angular/cdk/observers';
     MatCommonModule,
     MatRippleModule,
     MatPseudoCheckboxModule,
+    MatIconModule,
   ],
   exports: [
     MatList,

--- a/src/material/list/list-option.html
+++ b/src/material/list/list-option.html
@@ -30,6 +30,11 @@
       *ngIf="_hasCheckboxAt('before')">
   <ng-template [ngTemplateOutlet]="checkbox"></ng-template>
 </span>
+<!-- Container for the checkmark at start. -->
+<span class="mdc-list-item__start mat-mdc-list-option-checkbox-before"
+      *ngIf="_hasCheckmarkAt('before')">
+      <mat-icon>check</mat-icon>
+</span>
 <!-- Conditionally renders icons/avatars before the list item text. -->
 <ng-template [ngIf]="_hasIconsOrAvatarsAt('before')">
   <ng-template [ngTemplateOutlet]="icons"></ng-template>
@@ -48,6 +53,11 @@
 <!-- Container for the checkbox at the end. -->
 <span class="mdc-list-item__end" *ngIf="_hasCheckboxAt('after')">
   <ng-template [ngTemplateOutlet]="checkbox"></ng-template>
+</span>
+<!-- Container for the checkmark at end. -->
+<span class="mdc-list-item__start mat-mdc-list-option-checkbox-before"
+      *ngIf="_hasCheckmarkAt('after')">
+      <mat-icon>check</mat-icon>
 </span>
 <!-- Conditionally renders icons/avatars after the list item text. -->
 <ng-template [ngIf]="_hasIconsOrAvatarsAt('after')">

--- a/src/material/list/list-option.ts
+++ b/src/material/list/list-option.ts
@@ -229,6 +229,16 @@ export class MatListOption extends MatListItemBase implements ListOption, OnInit
     return this._selectionList.multiple && this._getCheckboxPosition() === position;
   }
 
+  /** Whether a checkmark is show at the given position. */
+  _hasCheckmarkAt(position: MatListOptionCheckboxPosition): boolean {
+    return (
+      this.selected &&
+      !this._selectionList.multiple &&
+      !this._hasIconsOrAvatarsAt(position) &&
+      this._getCheckboxPosition() === position
+    );
+  }
+
   /** Whether icons or avatars are shown at the given position. */
   _hasIconsOrAvatarsAt(position: 'before' | 'after'): boolean {
     return this._hasProjected('icons', position) || this._hasProjected('avatars', position);


### PR DESCRIPTION
Add a checkmark to indicate the selected option for single-select list. Fix a11y issue where selection option is visually communicated only with color. Communicated selected option with both color and icon to improve a11y.