### PR TITLE
fix(material/core): use checkmark to indicate selected option

### DIFF
--- a/src/material/core/option/option.html
+++ b/src/material/core/option/option.html
@@ -1,5 +1,6 @@
-<mat-pseudo-checkbox *ngIf="multiple" class="mat-mdc-option-pseudo-checkbox"
-    [state]="selected ? 'checked' : 'unchecked'" [disabled]="disabled"></mat-pseudo-checkbox>
+<mat-pseudo-checkbox *ngIf="multiple || selected" class="mat-mdc-option-pseudo-checkbox"
+    [state]="selected ? 'checked' : 'unchecked'" [disabled]="disabled"
+    [appearance]="multiple ? 'checkbox' : 'checkmark'"></mat-pseudo-checkbox>
 
 <span class="mdc-list-item__primary-text"><ng-content></ng-content></span>
 

--- a/src/material/core/selection/pseudo-checkbox/_pseudo-checkbox-theme.scss
+++ b/src/material/core/selection/pseudo-checkbox/_pseudo-checkbox-theme.scss
@@ -20,7 +20,7 @@
   .mat-pseudo-checkbox {
     color: theming.get-color-from-palette(map.get($config, foreground), secondary-text);
 
-    &::after {
+    &:not(.mat-psuedo-checkbox-checkmark-appearance)::after {
       color: theming.get-color-from-palette($background, background);
     }
   }
@@ -32,6 +32,7 @@
   .mat-primary .mat-pseudo-checkbox-checked,
   .mat-primary .mat-pseudo-checkbox-indeterminate {
     background: theming.get-color-from-palette(map.get($config, primary));
+    color: theming.get-color-from-palette(map.get($config, primary));
   }
 
   // Default to the accent color. Note that the pseudo checkboxes are meant to inherit the
@@ -44,11 +45,13 @@
   .mat-accent .mat-pseudo-checkbox-checked,
   .mat-accent .mat-pseudo-checkbox-indeterminate {
     background: theming.get-color-from-palette(map.get($config, accent));
+    color: theming.get-color-from-palette(map.get($config, accent));
   }
 
   .mat-warn .mat-pseudo-checkbox-checked,
   .mat-warn .mat-pseudo-checkbox-indeterminate {
     background: theming.get-color-from-palette(map.get($config, warn));
+    color: theming.get-color-from-palette(map.get($config, warn));
   }
 
   .mat-pseudo-checkbox-checked,
@@ -56,6 +59,10 @@
     &.mat-pseudo-checkbox-disabled {
       background: $disabled-color;
     }
+  }
+
+  .mat-pseudo-checkbox.mat-psuedo-checkbox-checkmark-appearance {
+    background: transparent;
   }
 }
 

--- a/src/material/core/selection/pseudo-checkbox/pseudo-checkbox.ts
+++ b/src/material/core/selection/pseudo-checkbox/pseudo-checkbox.ts
@@ -46,6 +46,7 @@ export type MatPseudoCheckboxState = 'unchecked' | 'checked' | 'indeterminate';
     '[class.mat-pseudo-checkbox-indeterminate]': 'state === "indeterminate"',
     '[class.mat-pseudo-checkbox-checked]': 'state === "checked"',
     '[class.mat-pseudo-checkbox-disabled]': 'disabled',
+    '[class.mat-psuedo-checkbox-checkmark-appearance]': 'appearance === "checkmark"',
     '[class._mat-animation-noopable]': '_animationMode === "NoopAnimations"',
   },
 })
@@ -55,6 +56,13 @@ export class MatPseudoCheckbox {
 
   /** Whether the checkbox is disabled. */
   @Input() disabled: boolean = false;
+
+  /**
+   * Whether to display a checkbox or a check mark. Use 'checkbox' for multi-select and 'checkmark'
+   * for single-select.
+   */
+  // Use 'checkbox' as default for backwards compatibility
+  @Input() appearance: 'checkmark' | 'checkbox' = 'checkbox';
 
   constructor(@Optional() @Inject(ANIMATION_MODULE_TYPE) public _animationMode?: string) {}
 }

--- a/tools/public_api_guard/material/core.md
+++ b/tools/public_api_guard/material/core.md
@@ -339,10 +339,11 @@ export class MatPseudoCheckbox {
     constructor(_animationMode?: string | undefined);
     // (undocumented)
     _animationMode?: string | undefined;
+    appearance: 'checkmark' | 'checkbox';
     disabled: boolean;
     state: MatPseudoCheckboxState;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<MatPseudoCheckbox, "mat-pseudo-checkbox", never, { "state": "state"; "disabled": "disabled"; }, {}, never, never, false, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MatPseudoCheckbox, "mat-pseudo-checkbox", never, { "state": "state"; "disabled": "disabled"; "appearance": "appearance"; }, {}, never, never, false, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatPseudoCheckbox, [{ optional: true; }]>;
 }


### PR DESCRIPTION
For single-selection, use a checkmark to visually indicate which option is selected. Fix a11y issue where selection option is visually communicated with color alone. Communicate selection with both color and a checkmark.

Add 'checkmark' appearance to mat-option to be used for single-selection.