### PR TITLE
fix(material/chips): use checkmark graphic for single-selection

### DIFF
--- a/src/material/chips/chip-option.ts
+++ b/src/material/chips/chip-option.ts
@@ -164,8 +164,10 @@ export class MatChipOption extends MatChip implements OnInit {
   }
 
   _hasLeadingGraphic() {
-    // The checkmark graphic is built in for multi-select chip lists.
-    return this.leadingIcon || (this._chipListMultiple && this.selectable);
+    // The checkmark graphic communicates selected state for both single-select and multi-select.
+    // Include checkmark in single-select to fix a11y issue where selected state is communicated
+    // visually only using color (#25886).
+    return this.leadingIcon || this.selectable;
   }
 
   _setSelectedState(isSelected: boolean, isUserInput: boolean, emitEvent: boolean) {


### PR DESCRIPTION
For mat-chip-listbox, use the checkmark component for single-selection. Fixes issue where selected state is communicated visually only using color (#25886).