### PR TITLE
build: add Zach to chips codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,7 +7,7 @@
 /src/material/button/**                                     @andrewseguin
 /src/material/card/**                                       @mmalerba
 /src/material/checkbox/**                                   @mmalerba
-/src/material/chips/**                                      @mmalerba @crisbeto
+/src/material/chips/**                                      @mmalerba @crisbeto @zarend
 /src/material/datepicker/**                                 @mmalerba @crisbeto @zarend
 /src/material/dialog/**                                     @devversion
 /src/material/divider/**                                    @andrewseguin @crisbeto


### PR DESCRIPTION
Add Zach (zarend) to code owners for chips.