### PR TITLE
fix(material/chips): fix state layer interferring with text color

### DIFF
--- a/src/material/chips/chip.scss
+++ b/src/material/chips/chip.scss
@@ -253,6 +253,11 @@
     $offset: calc(#{$border-width} + 2px);
     margin: calc(#{$offset} * -1);
   }
+
+  // Give the text label a higher z-index than the focus overlay to ensure that the focus overlay
+  // does not affect the color of the text. Material spec requires state layer to not interfere with
+  // text color.
+  z-index: 1;
 }
 
 .mat-mdc-chip-remove {


### PR DESCRIPTION
Fixes issue where state layer interfers with color of the text. Give the text label a higher z-index than the focus overlay.