### PR TITLE
refactor(multiple): remove final usages of InjectFlags

### DIFF
--- a/src/cdk/dialog/dialog.ts
+++ b/src/cdk/dialog/dialog.ts
@@ -13,7 +13,6 @@ import {
   OnDestroy,
   Type,
   StaticProvider,
-  InjectFlags,
   Inject,
   Optional,
   SkipSelf,
@@ -328,7 +327,7 @@ export class Dialog implements OnDestroy {
     if (
       config.direction &&
       (!userInjector ||
-        !userInjector.get<Directionality | null>(Directionality, null, InjectFlags.Optional))
+        !userInjector.get<Directionality | null>(Directionality, null, {optional: true}))
     ) {
       providers.push({
         provide: Directionality,

--- a/src/material/datepicker/date-range-input-parts.ts
+++ b/src/material/datepicker/date-range-input-parts.ts
@@ -15,7 +15,6 @@ import {
   Inject,
   OnInit,
   Injector,
-  InjectFlags,
   DoCheck,
 } from '@angular/core';
 import {
@@ -112,7 +111,7 @@ abstract class MatDateRangeInputPartBase<D>
     // validator. We work around it here by injecting the `NgControl` in `ngOnInit`, after
     // everything has been resolved.
     // tslint:disable-next-line:no-bitwise
-    const ngControl = this._injector.get(NgControl, null, InjectFlags.Self | InjectFlags.Optional);
+    const ngControl = this._injector.get(NgControl, null, {optional: true, self: true});
 
     if (ngControl) {
       this.ngControl = ngControl;


### PR DESCRIPTION
Removes all of the remaining usages of the deprecated `InjectFlags` symbol.