### PR TITLE
refactor(cdk/menu): convert all directives to standalone

### DIFF
--- a/src/cdk/menu/context-menu-trigger.ts
+++ b/src/cdk/menu/context-menu-trigger.ts
@@ -57,6 +57,7 @@ export type ContextMenuCoordinates = {x: number; y: number};
 @Directive({
   selector: '[cdkContextMenuTriggerFor]',
   exportAs: 'cdkContextMenuTriggerFor',
+  standalone: true,
   host: {
     '[attr.data-cdk-menu-stack-id]': 'null',
     '(contextmenu)': '_openOnContextMenu($event)',

--- a/src/cdk/menu/menu-aim.ts
+++ b/src/cdk/menu/menu-aim.ts
@@ -254,6 +254,7 @@ export class TargetMenuAim implements MenuAim, OnDestroy {
 @Directive({
   selector: '[cdkTargetMenuAim]',
   exportAs: 'cdkTargetMenuAim',
+  standalone: true,
   providers: [{provide: MENU_AIM, useClass: TargetMenuAim}],
 })
 export class CdkTargetMenuAim {}

--- a/src/cdk/menu/menu-bar.ts
+++ b/src/cdk/menu/menu-bar.ts
@@ -31,6 +31,7 @@ import {CdkMenuBase} from './menu-base';
 @Directive({
   selector: '[cdkMenuBar]',
   exportAs: 'cdkMenuBar',
+  standalone: true,
   host: {
     'role': 'menubar',
     'class': 'cdk-menu-bar',

--- a/src/cdk/menu/menu-group.ts
+++ b/src/cdk/menu/menu-group.ts
@@ -15,6 +15,7 @@ import {UniqueSelectionDispatcher} from '@angular/cdk/collections';
 @Directive({
   selector: '[cdkMenuGroup]',
   exportAs: 'cdkMenuGroup',
+  standalone: true,
   host: {
     'role': 'group',
     'class': 'cdk-menu-group',

--- a/src/cdk/menu/menu-item-checkbox.ts
+++ b/src/cdk/menu/menu-item-checkbox.ts
@@ -17,6 +17,7 @@ import {CdkMenuItem} from './menu-item';
 @Directive({
   selector: '[cdkMenuItemCheckbox]',
   exportAs: 'cdkMenuItemCheckbox',
+  standalone: true,
   host: {
     'role': 'menuitemcheckbox',
     '[class.cdk-menu-item-checkbox]': 'true',

--- a/src/cdk/menu/menu-item-radio.ts
+++ b/src/cdk/menu/menu-item-radio.ts
@@ -22,6 +22,7 @@ let nextId = 0;
 @Directive({
   selector: '[cdkMenuItemRadio]',
   exportAs: 'cdkMenuItemRadio',
+  standalone: true,
   host: {
     'role': 'menuitemradio',
     '[class.cdk-menu-item-radio]': 'true',

--- a/src/cdk/menu/menu-item.ts
+++ b/src/cdk/menu/menu-item.ts
@@ -36,6 +36,7 @@ import {MENU_AIM, Toggler} from './menu-aim';
 @Directive({
   selector: '[cdkMenuItem]',
   exportAs: 'cdkMenuItem',
+  standalone: true,
   host: {
     'role': 'menuitem',
     'class': 'cdk-menu-item',

--- a/src/cdk/menu/menu-module.ts
+++ b/src/cdk/menu/menu-module.ts
@@ -18,8 +18,7 @@ import {CdkMenuTrigger} from './menu-trigger';
 import {CdkContextMenuTrigger} from './context-menu-trigger';
 import {CdkTargetMenuAim} from './menu-aim';
 
-/** The list of components and directives that should be declared and exported from this module. */
-const EXPORTED_DECLARATIONS = [
+const MENU_DIRECTIVES = [
   CdkMenuBar,
   CdkMenu,
   CdkMenuItem,
@@ -33,8 +32,7 @@ const EXPORTED_DECLARATIONS = [
 
 /** Module that declares components and directives for the CDK menu. */
 @NgModule({
-  imports: [OverlayModule],
-  exports: EXPORTED_DECLARATIONS,
-  declarations: EXPORTED_DECLARATIONS,
+  imports: [OverlayModule, ...MENU_DIRECTIVES],
+  exports: MENU_DIRECTIVES,
 })
 export class CdkMenuModule {}

--- a/src/cdk/menu/menu-trigger.ts
+++ b/src/cdk/menu/menu-trigger.ts
@@ -42,6 +42,7 @@ import {CdkMenuTriggerBase, MENU_TRIGGER} from './menu-trigger-base';
 @Directive({
   selector: '[cdkMenuTriggerFor]',
   exportAs: 'cdkMenuTriggerFor',
+  standalone: true,
   host: {
     'class': 'cdk-menu-trigger',
     'aria-haspopup': 'menu',

--- a/src/cdk/menu/menu.ts
+++ b/src/cdk/menu/menu.ts
@@ -25,6 +25,7 @@ import {CdkMenuBase} from './menu-base';
 @Directive({
   selector: '[cdkMenu]',
   exportAs: 'cdkMenu',
+  standalone: true,
   host: {
     'role': 'menu',
     'class': 'cdk-menu',

--- a/tools/public_api_guard/cdk/menu.md
+++ b/tools/public_api_guard/cdk/menu.md
@@ -14,7 +14,7 @@ import { FocusableOption } from '@angular/cdk/a11y';
 import { FocusKeyManager } from '@angular/cdk/a11y';
 import { FocusOrigin } from '@angular/cdk/a11y';
 import * as i0 from '@angular/core';
-import * as i10 from '@angular/cdk/overlay';
+import * as i1 from '@angular/cdk/overlay';
 import { InjectionToken } from '@angular/core';
 import { Injector } from '@angular/core';
 import { NgZone } from '@angular/core';
@@ -40,7 +40,7 @@ export class CdkContextMenuTrigger extends CdkMenuTriggerBase implements OnDestr
     open(coordinates: ContextMenuCoordinates): void;
     _openOnContextMenu(event: MouseEvent): void;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkContextMenuTrigger, "[cdkContextMenuTriggerFor]", ["cdkContextMenuTriggerFor"], { "menuTemplateRef": "cdkContextMenuTriggerFor"; "menuPosition": "cdkContextMenuPosition"; "menuData": "cdkContextMenuTriggerData"; "disabled": "cdkContextMenuDisabled"; }, { "opened": "cdkContextMenuOpened"; "closed": "cdkContextMenuClosed"; }, never, never, false, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkContextMenuTrigger, "[cdkContextMenuTriggerFor]", ["cdkContextMenuTriggerFor"], { "menuTemplateRef": "cdkContextMenuTriggerFor"; "menuPosition": "cdkContextMenuPosition"; "menuData": "cdkContextMenuTriggerData"; "disabled": "cdkContextMenuDisabled"; }, { "opened": "cdkContextMenuOpened"; "closed": "cdkContextMenuClosed"; }, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<CdkContextMenuTrigger, never>;
 }
@@ -57,7 +57,7 @@ export class CdkMenu extends CdkMenuBase implements AfterContentInit, OnDestroy 
     ngOnDestroy(): void;
     readonly orientation = "vertical";
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkMenu, "[cdkMenu]", ["cdkMenu"], {}, { "closed": "closed"; }, never, never, false, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkMenu, "[cdkMenu]", ["cdkMenu"], {}, { "closed": "closed"; }, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<CdkMenu, never>;
 }
@@ -70,7 +70,7 @@ export class CdkMenuBar extends CdkMenuBase implements AfterContentInit {
     ngAfterContentInit(): void;
     readonly orientation = "horizontal";
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkMenuBar, "[cdkMenuBar]", ["cdkMenuBar"], {}, {}, never, never, false, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkMenuBar, "[cdkMenuBar]", ["cdkMenuBar"], {}, {}, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<CdkMenuBar, never>;
 }
@@ -109,7 +109,7 @@ export abstract class CdkMenuBase extends CdkMenuGroup implements Menu, AfterCon
 // @public
 export class CdkMenuGroup {
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkMenuGroup, "[cdkMenuGroup]", ["cdkMenuGroup"], {}, {}, never, never, false, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkMenuGroup, "[cdkMenuGroup]", ["cdkMenuGroup"], {}, {}, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<CdkMenuGroup, never>;
 }
@@ -142,7 +142,7 @@ export class CdkMenuItem implements FocusableOption, FocusableElement, Toggler, 
     readonly triggered: EventEmitter<void>;
     typeaheadLabel: string | null;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkMenuItem, "[cdkMenuItem]", ["cdkMenuItem"], { "disabled": "cdkMenuItemDisabled"; "typeaheadLabel": "cdkMenuitemTypeaheadLabel"; }, { "triggered": "cdkMenuItemTriggered"; }, never, never, false, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkMenuItem, "[cdkMenuItem]", ["cdkMenuItem"], { "disabled": "cdkMenuItemDisabled"; "typeaheadLabel": "cdkMenuitemTypeaheadLabel"; }, { "triggered": "cdkMenuItemTriggered"; }, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<CdkMenuItem, never>;
 }
@@ -153,7 +153,7 @@ export class CdkMenuItemCheckbox extends CdkMenuItemSelectable {
         keepOpen: boolean;
     }): void;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkMenuItemCheckbox, "[cdkMenuItemCheckbox]", ["cdkMenuItemCheckbox"], {}, {}, never, never, false, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkMenuItemCheckbox, "[cdkMenuItemCheckbox]", ["cdkMenuItemCheckbox"], {}, {}, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<CdkMenuItemCheckbox, never>;
 }
@@ -167,7 +167,7 @@ export class CdkMenuItemRadio extends CdkMenuItemSelectable implements OnDestroy
         keepOpen: boolean;
     }): void;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkMenuItemRadio, "[cdkMenuItemRadio]", ["cdkMenuItemRadio"], {}, {}, never, never, false, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkMenuItemRadio, "[cdkMenuItemRadio]", ["cdkMenuItemRadio"], {}, {}, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<CdkMenuItemRadio, never>;
 }
@@ -190,7 +190,7 @@ export class CdkMenuModule {
     // (undocumented)
     static ɵinj: i0.ɵɵInjectorDeclaration<CdkMenuModule>;
     // (undocumented)
-    static ɵmod: i0.ɵɵNgModuleDeclaration<CdkMenuModule, [typeof i1.CdkMenuBar, typeof i2.CdkMenu, typeof i3.CdkMenuItem, typeof i4.CdkMenuItemRadio, typeof i5.CdkMenuItemCheckbox, typeof i6.CdkMenuTrigger, typeof i7.CdkMenuGroup, typeof i8.CdkContextMenuTrigger, typeof i9.CdkTargetMenuAim], [typeof i10.OverlayModule], [typeof i1.CdkMenuBar, typeof i2.CdkMenu, typeof i3.CdkMenuItem, typeof i4.CdkMenuItemRadio, typeof i5.CdkMenuItemCheckbox, typeof i6.CdkMenuTrigger, typeof i7.CdkMenuGroup, typeof i8.CdkContextMenuTrigger, typeof i9.CdkTargetMenuAim]>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<CdkMenuModule, never, [typeof i1.OverlayModule, typeof i2.CdkMenuBar, typeof i3.CdkMenu, typeof i4.CdkMenuItem, typeof i5.CdkMenuItemRadio, typeof i6.CdkMenuItemCheckbox, typeof i7.CdkMenuTrigger, typeof i8.CdkMenuGroup, typeof i9.CdkContextMenuTrigger, typeof i10.CdkTargetMenuAim], [typeof i2.CdkMenuBar, typeof i3.CdkMenu, typeof i4.CdkMenuItem, typeof i5.CdkMenuItemRadio, typeof i6.CdkMenuItemCheckbox, typeof i7.CdkMenuTrigger, typeof i8.CdkMenuGroup, typeof i9.CdkContextMenuTrigger, typeof i10.CdkTargetMenuAim]>;
 }
 
 // @public
@@ -203,7 +203,7 @@ export class CdkMenuTrigger extends CdkMenuTriggerBase implements OnDestroy {
     toggle(): void;
     _toggleOnKeydown(event: KeyboardEvent): void;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkMenuTrigger, "[cdkMenuTriggerFor]", ["cdkMenuTriggerFor"], { "menuTemplateRef": "cdkMenuTriggerFor"; "menuPosition": "cdkMenuPosition"; "menuData": "cdkMenuTriggerData"; }, { "opened": "cdkMenuOpened"; "closed": "cdkMenuClosed"; }, never, never, false, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkMenuTrigger, "[cdkMenuTriggerFor]", ["cdkMenuTriggerFor"], { "menuTemplateRef": "cdkMenuTriggerFor"; "menuPosition": "cdkMenuPosition"; "menuData": "cdkMenuTriggerData"; }, { "opened": "cdkMenuOpened"; "closed": "cdkMenuClosed"; }, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<CdkMenuTrigger, never>;
 }
@@ -237,7 +237,7 @@ export abstract class CdkMenuTriggerBase implements OnDestroy {
 // @public
 export class CdkTargetMenuAim {
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkTargetMenuAim, "[cdkTargetMenuAim]", ["cdkTargetMenuAim"], {}, {}, never, never, false, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkTargetMenuAim, "[cdkTargetMenuAim]", ["cdkTargetMenuAim"], {}, {}, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<CdkTargetMenuAim, never>;
 }


### PR DESCRIPTION
Converts all of the `@angular/cdk/menu` directives to `standalone` so that they can be used as host directives.

cc @jelbourn 