### PR TITLE
fix(material/schematics): replace legacy typography config function transformation with a TODO comment in ng generate

### DIFF
--- a/integration/mdc-migration/golden/src/styles.scss
+++ b/integration/mdc-migration/golden/src/styles.scss
@@ -7,7 +7,7 @@
 // Include the common styles for Angular Material. We include this here so that you only
 // have to load a single css file for Angular Material in your app.
 // Be sure that you only ever include this mixin once!
-@include mat.all-component-typographies(mat.define-typography-config());
+@include mat.all-component-typographies(mat.define-legacy-typography-config());
 @include mat.core();
 
 // Define the palettes for your theme using the Material Design palettes available in palette.scss
@@ -27,7 +27,7 @@ $sample-project-theme: mat.define-light-theme((
     accent: $sample-project-accent,
     warn: $sample-project-warn,
   ),
-  typography: mat.define-typography-config(),
+  typography: mat.define-legacy-typography-config(),
 ));
 
 @include mat.core-theme($sample-project-theme);

--- a/src/material/schematics/ng-generate/mdc-migration/rules/components/multiple-components-styles.spec.ts
+++ b/src/material/schematics/ng-generate/mdc-migration/rules/components/multiple-components-styles.spec.ts
@@ -201,5 +201,38 @@ describe('multiple component styles', () => {
       `,
       );
     });
+
+    it('should add TODO comment for instance of define-legacy-typography-config sass function', async () => {
+      await runMigrationTest(
+        ['checkbox', 'radio'],
+        `
+        $sample-project-theme: mat.define-light-theme((
+          color: (
+            primary: $sample-project-primary,
+            accent: $sample-project-accent,
+            warn: $sample-project-warn,
+          ),
+          typography: mat.define-legacy-typography-config(
+            $display-1: mat.define-typography-level(34px, 40px, 400),
+            $headline:  mat.define-typography-level(24px, 32px, 400),
+          ),
+        ));
+      `,
+        `
+        /* TODO(mdc-migration): Use define-typography-config with updated typography levels instead of legacy function */
+        $sample-project-theme: mat.define-light-theme((
+          color: (
+            primary: $sample-project-primary,
+            accent: $sample-project-accent,
+            warn: $sample-project-warn,
+          ),
+          typography: mat.define-legacy-typography-config(
+            $display-1: mat.define-typography-level(34px, 40px, 400),
+            $headline:  mat.define-typography-level(24px, 32px, 400),
+          ),
+        ));
+      `,
+      );
+    });
   });
 });


### PR DESCRIPTION
In the ng update schematic, the sass function is being transformed from `define-typography-config` to `define-legacy-typography-config`. The ng generate schematic did the opposite, although since the typography levels have changed for MDC, this would show an error in the console and break the typography configurations when overriding. This change just leaves the `define-legacy-typography-config` function call and adds a TODO comment to update the typography levels when values are being overriden. We should do the mappings automatically if possible as well in a future PR.