### PR TITLE
fix(cdk/overlay): provide Overlay in root

### DIFF
--- a/src/cdk/overlay/overlay.ts
+++ b/src/cdk/overlay/overlay.ts
@@ -41,7 +41,7 @@ let nextUniqueId = 0;
  *
  * An overlay *is* a PortalOutlet, so any kind of Portal can be loaded into one.
  */
-@Injectable()
+@Injectable({providedIn: 'root'})
 export class Overlay {
   private _appRef: ApplicationRef;
 


### PR DESCRIPTION
Switches the `Overlay` injectable to be provided at the root.