### PR TITLE
refactor: replaces `aria-hidden` with `alt=""`

### DIFF
--- a/src/components-examples/material/autocomplete/autocomplete-overview/autocomplete-overview-example.html
+++ b/src/components-examples/material/autocomplete/autocomplete-overview/autocomplete-overview-example.html
@@ -7,7 +7,7 @@
            [formControl]="stateCtrl">
     <mat-autocomplete #auto="matAutocomplete">
       <mat-option *ngFor="let state of filteredStates | async" [value]="state.name">
-        <img class="example-option-img" aria-hidden [src]="state.flag" height="25">
+        <img alt="" class="example-option-img" [src]="state.flag" height="25">
         <span>{{state.name}}</span> |
         <small>Population: {{state.population}}</small>
       </mat-option>


### PR DESCRIPTION
An `alt` attribute is required for an upcoming extended diagnostic, and from my understanding is desirable over `aria-hidden` since it maintains `role="img"` while also indicating that the image is decorative.

See CI failures from: https://app.circleci.com/pipelines/github/angular/angular/52667/workflows/3d58122f-0257-4b79-9ab9-90475590a3f2/jobs/1249004