### PR TITLE
refactor(multiple): clean up map-get usages

### DIFF
--- a/src/material/checkbox/_checkbox-private.scss
+++ b/src/material/checkbox/_checkbox-private.scss
@@ -25,7 +25,7 @@ $private-checkbox-theme-config: map.merge(mdc-checkbox-theme.$light-theme, (
 // Mixin that includes the checkbox theme styles with a given palette.
 // By default, the MDC checkbox always uses the `secondary` palette.
 @mixin private-checkbox-styles-with-color($color-config, $color, $mdc-color) {
-  $is-dark: map-get($color-config, is-dark);
+  $is-dark: map.get($color-config, is-dark);
   $on-surface: mdc-theme-color.prop-value(on-surface);
   $border-color: rgba($on-surface, color.opacity(mdc-checkbox-theme.$border-color));
   $disabled-color: rgba($on-surface, color.opacity(mdc-checkbox-theme.$disabled-color));

--- a/src/material/radio/_radio-theme.scss
+++ b/src/material/radio/_radio-theme.scss
@@ -28,7 +28,7 @@
 
   @include mdc-helpers.using-mdc-theme($config) {
     $on-surface: rgba(mdc-theme-color.$on-surface, 0.54);
-    $is-dark: map-get($config, is-dark);
+    $is-dark: map.get($config, is-dark);
     $active-border-color: if(
             $is-dark,
             theming.get-color-from-palette(palette.$gray-palette, 200),


### PR DESCRIPTION
The global `map-get` function is deprecated. We should be using the namespaced `map.get` instead.