### PR TITLE
fix(material/chips): conform to ARIA button spec for chip-row

### DIFF
--- a/src/material/chips/chip-row.spec.ts
+++ b/src/material/chips/chip-row.spec.ts
@@ -96,13 +96,6 @@ describe('MDC-based Row Chips', () => {
         expect(testComponent.chipRemove).toHaveBeenCalledWith({chip: chipInstance});
       });
 
-      it('should prevent the default click action', () => {
-        const event = dispatchFakeEvent(chipNativeElement, 'mousedown');
-        fixture.detectChanges();
-
-        expect(event.defaultPrevented).toBe(true);
-      });
-
       it('should have the correct role', () => {
         expect(chipNativeElement.getAttribute('role')).toBe('row');
       });
@@ -189,13 +182,6 @@ describe('MDC-based Row Chips', () => {
       });
 
       describe('focus management', () => {
-        it('sends focus to first grid cell on mousedown', () => {
-          dispatchFakeEvent(chipNativeElement, 'mousedown');
-          fixture.detectChanges();
-
-          expect(document.activeElement).toHaveClass('mdc-evolution-chip__action--primary');
-        });
-
         it('emits focus only once for multiple focus() calls', () => {
           let counter = 0;
           chipInstance._onFocus.subscribe(() => {
@@ -217,9 +203,9 @@ describe('MDC-based Row Chips', () => {
         fixture.detectChanges();
       });
 
-      it('should begin editing on double click', () => {
+      it('should begin editing on click', () => {
         expect(chipNativeElement.querySelector('.mat-chip-edit-input')).toBeFalsy();
-        dispatchFakeEvent(chipNativeElement, 'dblclick');
+        dispatchFakeEvent(chipNativeElement, 'click');
         fixture.detectChanges();
         expect(chipNativeElement.querySelector('.mat-chip-edit-input')).toBeTruthy();
       });
@@ -239,7 +225,7 @@ describe('MDC-based Row Chips', () => {
       beforeEach(fakeAsync(() => {
         testComponent.editable = true;
         fixture.detectChanges();
-        dispatchFakeEvent(chipNativeElement, 'dblclick');
+        dispatchFakeEvent(chipNativeElement, 'click');
         fixture.detectChanges();
         flush();
 
@@ -306,7 +292,7 @@ describe('MDC-based Row Chips', () => {
         keyDownOnPrimaryAction(ENTER, 'Enter');
         testComponent.useCustomEditInput = false;
         fixture.detectChanges();
-        dispatchFakeEvent(chipNativeElement, 'dblclick');
+        dispatchFakeEvent(chipNativeElement, 'click');
         fixture.detectChanges();
         const editInputDebugElement = fixture.debugElement.query(By.directive(MatChipEditInput))!;
         const editInputNoProject =

--- a/src/material/chips/chip-row.ts
+++ b/src/material/chips/chip-row.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ENTER} from '@angular/cdk/keycodes';
+import {ENTER, SPACE} from '@angular/cdk/keycodes';
 import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 import {
   AfterViewInit,
@@ -66,8 +66,7 @@ export interface MatChipEditedEvent extends MatChipEvent {
     '[attr.aria-label]': 'null',
     '[attr.aria-description]': 'null',
     '[attr.role]': 'role',
-    '(mousedown)': '_mousedown($event)',
-    '(dblclick)': '_doubleclick($event)',
+    '(click)': '_click($event)',
   },
   providers: [
     {provide: MatChip, useExisting: MatChipRow},
@@ -136,19 +135,8 @@ export class MatChipRow extends MatChip implements AfterViewInit {
     return !this._isEditing && super._hasTrailingIcon();
   }
 
-  /** Sends focus to the first gridcell when the user clicks anywhere inside the chip. */
-  _mousedown(event: MouseEvent) {
-    if (!this._isEditing) {
-      if (!this.disabled) {
-        this.focus();
-      }
-
-      event.preventDefault();
-    }
-  }
-
   override _handleKeydown(event: KeyboardEvent): void {
-    if (event.keyCode === ENTER && !this.disabled) {
+    if ((event.keyCode === ENTER || event.keyCode === SPACE) && !this.disabled) {
       if (this._isEditing) {
         event.preventDefault();
         this._onEditFinish();
@@ -163,7 +151,7 @@ export class MatChipRow extends MatChip implements AfterViewInit {
     }
   }
 
-  _doubleclick(event: MouseEvent) {
+  _click(event: MouseEvent) {
     if (!this.disabled && this.editable) {
       this._startEditing(event);
     }

--- a/tools/public_api_guard/material/chips.md
+++ b/tools/public_api_guard/material/chips.md
@@ -379,10 +379,10 @@ export class MatChipRow extends MatChip implements AfterViewInit {
     constructor(changeDetectorRef: ChangeDetectorRef, elementRef: ElementRef, ngZone: NgZone, focusMonitor: FocusMonitor, _document: any, animationMode?: string, globalRippleOptions?: RippleGlobalOptions, tabIndex?: string);
     // (undocumented)
     protected basicChipAttrName: string;
+    // (undocumented)
+    _click(event: MouseEvent): void;
     contentEditInput?: MatChipEditInput;
     defaultEditInput?: MatChipEditInput;
-    // (undocumented)
-    _doubleclick(event: MouseEvent): void;
     // (undocumented)
     editable: boolean;
     readonly edited: EventEmitter<MatChipEditedEvent>;
@@ -392,7 +392,6 @@ export class MatChipRow extends MatChip implements AfterViewInit {
     _hasTrailingIcon(): boolean;
     // (undocumented)
     _isEditing: boolean;
-    _mousedown(event: MouseEvent): void;
     // (undocumented)
     static ɵcmp: i0.ɵɵComponentDeclaration<MatChipRow, "mat-chip-row, mat-basic-chip-row", never, { "color": "color"; "disabled": "disabled"; "disableRipple": "disableRipple"; "tabIndex": "tabIndex"; "editable": "editable"; }, { "edited": "edited"; }, ["contentEditInput"], ["mat-chip-avatar, [matChipAvatar]", "*", "[matChipEditInput]", "mat-chip-trailing-icon,[matChipRemove],[matChipTrailingIcon]"], false, never>;
     // (undocumented)


### PR DESCRIPTION
Correct the keyboard event and click handling event in chip-row to meet ARIA spec for button interaction pattern.

Removes the dblclick handler because screen readers do not have a way to doubleclick. Also removes the mousedown handler because screen readers also do not have a way to trigger mousedown.

Meets ARIA spec for button interaction pattern which requires action to be performed on click event and enter/space to trigger action.

Summary of behavior changes
 - on click, start editing chip if it's editable and not disabled
 - on enter key or space, perform same action as click event
 - do not handle dblclick event. Screen readers and other AT do not have a way to double click on things.