### PR TITLE
fix(cdk/scrolling): error when querying for CdkVirtualScrollViewport as CdkScrollable

### DIFF
--- a/src/cdk/scrolling/virtual-scroll-viewport.spec.ts
+++ b/src/cdk/scrolling/virtual-scroll-viewport.spec.ts
@@ -1,5 +1,6 @@
 import {ArrayDataSource} from '@angular/cdk/collections';
 import {
+  CdkScrollable,
   CdkVirtualForOf,
   CdkVirtualScrollViewport,
   ScrollDispatcher,
@@ -1175,6 +1176,18 @@ describe('CdkVirtualScrollViewport', () => {
         .toBe(50);
     }));
   });
+
+  it('should be able to query for a virtual scroll viewport as a CdkScrollable', () => {
+    TestBed.configureTestingModule({
+      imports: [ScrollingModule],
+      declarations: [VirtualScrollableQuery],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(VirtualScrollableQuery);
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.scrollable).toBeTruthy();
+  });
 });
 
 /** Finish initializing the virtual scroll component at the beginning of a test. */
@@ -1564,4 +1577,11 @@ class VirtualScrollWithScrollableWindow {
   items = Array(20000)
     .fill(0)
     .map((_, i) => i);
+}
+
+@Component({
+  template: '<cdk-virtual-scroll-viewport itemSize="50"></cdk-virtual-scroll-viewport>',
+})
+class VirtualScrollableQuery {
+  @ViewChild(CdkScrollable) scrollable: CdkScrollable;
 }

--- a/src/cdk/scrolling/virtual-scroll-viewport.ts
+++ b/src/cdk/scrolling/virtual-scroll-viewport.ts
@@ -74,7 +74,7 @@ const SCROLL_SCHEDULER =
         virtualScrollable: CdkVirtualScrollable | null,
         viewport: CdkVirtualScrollViewport,
       ) => virtualScrollable || viewport,
-      deps: [CdkVirtualScrollable, CdkVirtualScrollViewport],
+      deps: [[new Optional(), new Inject(VIRTUAL_SCROLLABLE)], CdkVirtualScrollViewport],
     },
   ],
 })


### PR DESCRIPTION
In an earlier change we started providing the `CdkVirtualScrollable` through the `VIRTUAL_SCROLLABLE` token, but the change wasn't reflected in the `CdkVirtualScrollViewport` which was causing an error.

Fixes #25917.