### PR TITLE
fix(material/schematics): handle input level in typography migration

### DIFF
--- a/src/material/schematics/ng-generate/mdc-migration/rules/components/typography-config.spec.ts
+++ b/src/material/schematics/ng-generate/mdc-migration/rules/components/typography-config.spec.ts
@@ -103,7 +103,6 @@ describe('typography migrations', () => {
             $body-1: $body-1,
             $caption: $caption,
             $button: $button,
-            $input: $input,
           ),
         ));
       `,
@@ -130,7 +129,6 @@ describe('typography migrations', () => {
             $body-2: $body-1,
             $caption: $caption,
             $button: $button,
-            $input: $input,
           ),
         ));
       `,
@@ -193,6 +191,114 @@ describe('typography migrations', () => {
             $subtitle-1: $subheading-2,
           ),
         ));
+      `,
+    );
+  });
+
+  it('should migrate a typography config with a mixture of positional and named arguments', async () => {
+    await runMigrationTest(
+      THEME_FILE,
+      `
+      @use '@angular/material' as mat;
+
+      $sample-project-theme: mat.define-light-theme((
+        color: (
+          primary: $sample-project-primary,
+          accent: $sample-project-accent,
+          warn: $sample-project-warn,
+        ),
+        typography: mat.define-legacy-typography-config($font-family, $display-4: $custom-display-4, $display-3),
+      ));
+      `,
+      `
+      @use '@angular/material' as mat;
+
+      $sample-project-theme: mat.define-light-theme((
+        color: (
+          primary: $sample-project-primary,
+          accent: $sample-project-accent,
+          warn: $sample-project-warn,
+        ),
+        typography: mat.define-typography-config($font-family, $headline-1: $custom-display-4, $display-3),
+      ));
+      `,
+    );
+  });
+
+  it('should replace the `input` level with `body-1` if there is no `body-1` in the config', async () => {
+    await runMigrationTest(
+      THEME_FILE,
+      `
+      @use '@angular/material' as mat;
+
+      $sample-project-theme: mat.define-light-theme((
+        color: (
+          primary: $sample-project-primary,
+          accent: $sample-project-accent,
+          warn: $sample-project-warn,
+        ),
+        typography: mat.define-legacy-typography-config(
+          $display-4: $display-4,
+          $display-3: $display-3,
+          $input: $input,
+        ),
+      ));
+      `,
+      `
+      @use '@angular/material' as mat;
+
+      $sample-project-theme: mat.define-light-theme((
+        color: (
+          primary: $sample-project-primary,
+          accent: $sample-project-accent,
+          warn: $sample-project-warn,
+        ),
+        typography: mat.define-typography-config(
+          $headline-1: $display-4,
+          $headline-2: $display-3,
+          $body-1: $input,
+        ),
+      ));
+      `,
+    );
+  });
+
+  it('should comment out the `input` level if a `body-1` already exists', async () => {
+    await runMigrationTest(
+      THEME_FILE,
+      `
+      @use '@angular/material' as mat;
+
+      $sample-project-theme: mat.define-light-theme((
+        color: (
+          primary: $sample-project-primary,
+          accent: $sample-project-accent,
+          warn: $sample-project-warn,
+        ),
+        typography: mat.define-legacy-typography-config(
+          $display-4: $display-4,
+          $display-3: $display-3,
+          $input: $input,
+          $subheading-1: $subheading-1,
+        ),
+      ));
+      `,
+      `
+      @use '@angular/material' as mat;
+
+      $sample-project-theme: mat.define-light-theme((
+        color: (
+          primary: $sample-project-primary,
+          accent: $sample-project-accent,
+          warn: $sample-project-warn,
+        ),
+        typography: mat.define-typography-config(
+          $headline-1: $display-4,
+          $headline-2: $display-3,
+          /* TODO(mdc-migration): No longer supported. Use \`body-1\` instead. $input: $input, */
+          $body-1: $subheading-1,
+        ),
+      ));
       `,
     );
   });

--- a/src/material/schematics/ng-generate/mdc-migration/rules/components/typography-hierarchy/constants.ts
+++ b/src/material/schematics/ng-generate/mdc-migration/rules/components/typography-hierarchy/constants.ts
@@ -29,3 +29,6 @@ export const RENAMED_TYPOGRAPHY_LEVELS = new Map(mappings);
 export const RENAMED_TYPOGRAPHY_CLASSES = new Map(
   mappings.map(m => ['mat-' + m[0], 'mat-' + m[1]]),
 );
+
+/** Typography levels that have been combined into other levels with no replacement. */
+export const COMBINED_TYPOGRAPHY_LEVELS = new Map([['input', 'body-1']]);


### PR DESCRIPTION
Expands the logic in the MDC theming migration to be able to discern both keys and values of named Sass function parameters. The new logic is used to correctly migrate users away from the `input` typography level which doesn't have an equivalent in the new system.