### PR TITLE
fix(material/core): add checkmark for single-select

### DIFF
--- a/src/dev-app/autocomplete/BUILD.bazel
+++ b/src/dev-app/autocomplete/BUILD.bazel
@@ -13,6 +13,7 @@ ng_module(
         "//src/material/autocomplete",
         "//src/material/button",
         "//src/material/card",
+        "//src/material/checkbox",
         "//src/material/form-field",
         "//src/material/input",
         "@npm//@angular/forms",

--- a/src/dev-app/autocomplete/autocomplete-demo.html
+++ b/src/dev-app/autocomplete/autocomplete-demo.html
@@ -10,7 +10,8 @@ Space above cards: <input type="number" [formControl]="topHeightCtrl">
       <mat-label>State</mat-label>
       <input matInput [matAutocomplete]="reactiveAuto" [formControl]="stateCtrl">
     </mat-form-field>
-    <mat-autocomplete #reactiveAuto="matAutocomplete" [displayWith]="displayFn">
+    <mat-autocomplete #reactiveAuto="matAutocomplete" [displayWith]="displayFn"
+      [hideSingleSelectionIndicator]="reactiveHideSingleSelectionIndicator">
       <mat-option *ngFor="let state of tempStates" [value]="state">
         <span>{{ state.name }}</span>
         <span class="demo-secondary-text"> ({{ state.code }}) </span>
@@ -23,11 +24,11 @@ Space above cards: <input type="number" [formControl]="topHeightCtrl">
       <button mat-button (click)="stateCtrl.enabled ? stateCtrl.disable() : stateCtrl.enable()">
         TOGGLE DISABLED
       </button>
-      <select [(ngModel)]="reactiveStatesTheme">
-        <option *ngFor="let theme of availableThemes" [value]="theme.value">
-          {{theme.name}}
-        </option>
-      </select>
+    </mat-card-actions>
+    <mat-card-actions>
+      <mat-checkbox [(ngModel)]="reactiveHideSingleSelectionIndicator">
+        Hide Single-Selection Indicator
+      </mat-checkbox>
     </mat-card-actions>
 
   </mat-card>
@@ -42,7 +43,8 @@ Space above cards: <input type="number" [formControl]="topHeightCtrl">
       <mat-label>State</mat-label>
       <input matInput [matAutocomplete]="tdAuto" [(ngModel)]="currentState"
         (ngModelChange)="tdStates = filterStates(currentState)" [disabled]="tdDisabled">
-      <mat-autocomplete #tdAuto="matAutocomplete">
+      <mat-autocomplete #tdAuto="matAutocomplete"
+        [hideSingleSelectionIndicator]="templateHideSingleSelectionIndicator">
         <mat-option *ngFor="let state of tdStates" [value]="state.name">
           <span>{{ state.name }}</span>
         </mat-option>
@@ -60,6 +62,11 @@ Space above cards: <input type="number" [formControl]="topHeightCtrl">
           {{theme.name}}
         </option>
       </select>
+    </mat-card-actions>
+    <mat-card-actions>
+      <mat-checkbox [(ngModel)]="templateHideSingleSelectionIndicator">
+        Hide Single-Selection Indicator
+      </mat-checkbox>
     </mat-card-actions>
 
   </mat-card>

--- a/src/dev-app/autocomplete/autocomplete-demo.ts
+++ b/src/dev-app/autocomplete/autocomplete-demo.ts
@@ -12,6 +12,7 @@ import {CommonModule} from '@angular/common';
 import {MatAutocompleteModule} from '@angular/material/autocomplete';
 import {MatButtonModule} from '@angular/material/button';
 import {MatCardModule} from '@angular/material/card';
+import {MatCheckboxModule} from '@angular/material/checkbox';
 import {MatInputModule} from '@angular/material/input';
 import {Observable} from 'rxjs';
 import {map, startWith} from 'rxjs/operators';
@@ -38,6 +39,7 @@ export interface StateGroup {
     MatAutocompleteModule,
     MatButtonModule,
     MatCardModule,
+    MatCheckboxModule,
     MatInputModule,
     ReactiveFormsModule,
   ],
@@ -52,6 +54,7 @@ export class AutocompleteDemo {
   tdStates: State[];
 
   tdDisabled = false;
+  hideSingleSelectionIndicators = false;
 
   reactiveStatesTheme: ThemePalette = 'primary';
   templateStatesTheme: ThemePalette = 'primary';
@@ -61,6 +64,9 @@ export class AutocompleteDemo {
     {value: 'accent', name: 'Accent'},
     {value: 'warn', name: 'Warn'},
   ];
+
+  reactiveHideSingleSelectionIndicator = false;
+  templateHideSingleSelectionIndicator = false;
 
   @ViewChild(NgModel) modelDir: NgModel;
 

--- a/src/dev-app/checkbox/checkbox-demo.html
+++ b/src/dev-app/checkbox/checkbox-demo.html
@@ -64,14 +64,29 @@
 </div>
 
 <h1>Pseudo checkboxes</h1>
-<mat-pseudo-checkbox></mat-pseudo-checkbox>
-<mat-pseudo-checkbox [disabled]="true"></mat-pseudo-checkbox>
+<div>
+  <h2>Full appearance</h2>
+  <mat-pseudo-checkbox></mat-pseudo-checkbox>
+  <mat-pseudo-checkbox [disabled]="true"></mat-pseudo-checkbox>
 
-<mat-pseudo-checkbox state="checked"></mat-pseudo-checkbox>
-<mat-pseudo-checkbox state="checked" [disabled]="true"></mat-pseudo-checkbox>
+  <mat-pseudo-checkbox state="checked"></mat-pseudo-checkbox>
+  <mat-pseudo-checkbox state="checked" [disabled]="true"></mat-pseudo-checkbox>
 
-<mat-pseudo-checkbox state="indeterminate"></mat-pseudo-checkbox>
-<mat-pseudo-checkbox state="indeterminate" [disabled]="true"></mat-pseudo-checkbox>
+  <mat-pseudo-checkbox state="indeterminate"></mat-pseudo-checkbox>
+  <mat-pseudo-checkbox state="indeterminate" [disabled]="true"></mat-pseudo-checkbox>
+<div>
+<div>
+  <h2>Minimal appearance</h2>
+  <mat-pseudo-checkbox appearance="minimal"></mat-pseudo-checkbox>
+  <mat-pseudo-checkbox appearance="minimal" [disabled]="true"></mat-pseudo-checkbox>
+
+  <mat-pseudo-checkbox appearance="minimal" state="checked"></mat-pseudo-checkbox>
+  <mat-pseudo-checkbox appearance="minimal" state="checked" [disabled]="true"></mat-pseudo-checkbox>
+
+  <mat-pseudo-checkbox appearance="minimal" state="indeterminate"></mat-pseudo-checkbox>
+  <mat-pseudo-checkbox appearance="minimal" state="indeterminate" [disabled]="true">
+  </mat-pseudo-checkbox>
+<div>
 
 <h1>Nested Checklist</h1>
 <mat-checkbox-demo-nested-checklist></mat-checkbox-demo-nested-checklist>

--- a/src/dev-app/select/BUILD.bazel
+++ b/src/dev-app/select/BUILD.bazel
@@ -12,6 +12,7 @@ ng_module(
     deps = [
         "//src/material/button",
         "//src/material/card",
+        "//src/material/checkbox",
         "//src/material/form-field",
         "//src/material/icon",
         "//src/material/input",

--- a/src/dev-app/select/select-demo.html
+++ b/src/dev-app/select/select-demo.html
@@ -12,8 +12,8 @@ Space above cards: <input type="number" [formControl]="topHeightCtrl">
         <mat-label>Drink</mat-label>
         <mat-select [(ngModel)]="currentDrink" [required]="drinksRequired"
           [disabled]="drinksDisabled" #drinkControl="ngModel">
-          <mat-option>None</mat-option>
-          <mat-option *ngFor="let drink of drinks" [value]="drink.value" [disabled]="drink.disabled">
+          <mat-option [disabled]="drinksOptionsDisabled">None</mat-option>
+          <mat-option *ngFor="let drink of drinks" [value]="drink.value" [disabled]="drinksOptionsDisabled">
             {{ drink.viewValue }}
           </mat-option>
         </mat-select>
@@ -52,6 +52,7 @@ Space above cards: <input type="number" [formControl]="topHeightCtrl">
       <button mat-button (click)="currentDrink='water-2'">SET VALUE</button>
       <button mat-button (click)="drinksRequired=!drinksRequired">TOGGLE REQUIRED</button>
       <button mat-button (click)="drinksDisabled=!drinksDisabled">TOGGLE DISABLED</button>
+      <button mat-button (click)="drinksOptionsDisabled=!drinksOptionsDisabled">TOGGLE DISABLED OPTIONS</button>
       <button mat-button (click)="drinkControl.reset()">RESET</button>
     </mat-card-content>
   </mat-card>
@@ -64,7 +65,7 @@ Space above cards: <input type="number" [formControl]="topHeightCtrl">
         <mat-label>Pokemon</mat-label>
         <mat-select multiple [(ngModel)]="currentPokemon"
           [required]="pokemonRequired" [disabled]="pokemonDisabled" #pokemonControl="ngModel">
-          <mat-option *ngFor="let creature of pokemon" [value]="creature.value">
+          <mat-option *ngFor="let creature of pokemon" [value]="creature.value" [disabled]="pokemonOptionsDisabled">
             {{ creature.viewValue }}
           </mat-option>
         </mat-select>
@@ -82,6 +83,7 @@ Space above cards: <input type="number" [formControl]="topHeightCtrl">
       <button mat-button (click)="setPokemonValue()">SET VALUE</button>
       <button mat-button (click)="pokemonRequired=!pokemonRequired">TOGGLE REQUIRED</button>
       <button mat-button (click)="pokemonDisabled=!pokemonDisabled">TOGGLE DISABLED</button>
+      <button mat-button (click)="pokemonOptionsDisabled=!pokemonOptionsDisabled">TOGGLE DISABLED OPTIONS</button>
       <button mat-button (click)="pokemonControl.reset()">RESET</button>
     </mat-card-content>
   </mat-card>
@@ -354,5 +356,43 @@ Space above cards: <input type="number" [formControl]="topHeightCtrl">
       </mat-form-field>
       <button color="primary" mat-raised-button>Submit</button>
     </form>
+  </mat-card-content>
+</mat-card>
+
+<mat-card class="demo-card demo-narrow">
+  <mat-card-subtitle>Narrow</mat-card-subtitle>
+  <mat-card-content>
+    <p class="demo-narrow-sandwich">
+      <mat-form-field>
+        <mat-label>Bread</mat-label>
+        <mat-select [(ngModel)]="sandwichBread"
+          [hideSingleSelectionIndicator]="sandwichHideSingleSelectionIndicator">
+          <mat-option *ngFor="let bread of breads" [value]="bread.value">
+            {{ bread.viewValue }}
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
+      <mat-form-field>
+        <mat-label>Meat</mat-label>
+        <mat-select [(ngModel)]="sandwichMeat"
+          [hideSingleSelectionIndicator]="sandwichHideSingleSelectionIndicator">
+          <mat-option *ngFor="let meat of meats" [value]="meat.value">
+            {{ meat.viewValue }}
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
+      <mat-form-field>
+        <mat-label>Cheese</mat-label>
+        <mat-select [(ngModel)]="sandwichCheese"
+          [hideSingleSelectionIndicator]="sandwichHideSingleSelectionIndicator">
+          <mat-option *ngFor="let cheese of cheeses" [value]="cheese.value">
+            {{ cheese.viewValue }}
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
+    </p>
+    <mat-checkbox [(ngModel)]="sandwichHideSingleSelectionIndicator">
+      Hide Single-Selection Indicator
+    </mat-checkbox>
   </mat-card-content>
 </mat-card>

--- a/src/dev-app/select/select-demo.scss
+++ b/src/dev-app/select/select-demo.scss
@@ -25,3 +25,12 @@
 .demo-card {
   margin: 30px 0;
 }
+
+.demo-narrow {
+  max-width: 450px;
+
+  .demo-narrow-sandwich {
+    display: flex;
+    gap: 16px;
+  }
+}

--- a/src/dev-app/select/select-demo.ts
+++ b/src/dev-app/select/select-demo.ts
@@ -16,6 +16,7 @@ import {MatCardModule} from '@angular/material/card';
 import {MatIconModule} from '@angular/material/icon';
 import {MatButtonModule} from '@angular/material/button';
 import {MatInputModule} from '@angular/material/input';
+import {MatCheckboxModule} from '@angular/material/checkbox';
 
 /** Error any time control is invalid */
 export class MyErrorStateMatcher implements ErrorStateMatcher {
@@ -37,6 +38,7 @@ export class MyErrorStateMatcher implements ErrorStateMatcher {
     FormsModule,
     MatButtonModule,
     MatCardModule,
+    MatCheckboxModule,
     MatIconModule,
     MatInputModule,
     MatSelectModule,
@@ -48,7 +50,9 @@ export class SelectDemo {
   drinkObjectRequired = false;
   pokemonRequired = false;
   drinksDisabled = false;
+  drinksOptionsDisabled = false;
   pokemonDisabled = false;
+  pokemonOptionsDisabled = false;
   showSelect = false;
   currentDrink: string;
   currentDrinkObject: {} | undefined = {value: 'tea-5', viewValue: 'Tea'};
@@ -66,6 +70,12 @@ export class SelectDemo {
   compareByValue = true;
   selectFormControl = new FormControl('', Validators.required);
 
+  sandwichBread = '';
+  sandwichMeat = '';
+  sandwichCheese = '';
+
+  sandwichHideSingleSelectionIndicator = false;
+
   foods = [
     {value: null, viewValue: 'None'},
     {value: 'steak-0', viewValue: 'Steak'},
@@ -74,19 +84,19 @@ export class SelectDemo {
   ];
 
   drinks = [
-    {value: 'coke-0', viewValue: 'Coke', disabled: false},
+    {value: 'coke-0', viewValue: 'Coke'},
     {
       value: 'long-name-1',
       viewValue: 'Decaf Chocolate Brownie Vanilla Gingerbread Frappuccino',
       disabled: false,
     },
-    {value: 'water-2', viewValue: 'Water', disabled: false},
-    {value: 'pepper-3', viewValue: 'Dr. Pepper', disabled: false},
-    {value: 'coffee-4', viewValue: 'Coffee', disabled: false},
-    {value: 'tea-5', viewValue: 'Tea', disabled: false},
-    {value: 'juice-6', viewValue: 'Orange juice', disabled: false},
-    {value: 'wine-7', viewValue: 'Wine', disabled: false},
-    {value: 'milk-8', viewValue: 'Milk', disabled: true},
+    {value: 'water-2', viewValue: 'Water'},
+    {value: 'pepper-3', viewValue: 'Dr. Pepper'},
+    {value: 'coffee-4', viewValue: 'Coffee'},
+    {value: 'tea-5', viewValue: 'Tea'},
+    {value: 'juice-6', viewValue: 'Orange juice'},
+    {value: 'wine-7', viewValue: 'Wine'},
+    {value: 'milk-8', viewValue: 'Milk'},
   ];
 
   pokemon = [
@@ -147,6 +157,26 @@ export class SelectDemo {
     {value: 'pajiramon-3', viewValue: 'Pajiramon'},
     {value: 'vajiramon-4', viewValue: 'Vajiramon'},
     {value: 'indramon-5', viewValue: 'Indramon'},
+  ];
+
+  breads = [
+    {value: 'white', viewValue: 'White'},
+    {value: 'white', viewValue: 'Wheat'},
+    {value: 'white', viewValue: 'Sourdough'},
+  ];
+
+  meats = [
+    {value: 'turkey', viewValue: 'Turkey'},
+    {value: 'bacon', viewValue: 'Bacon'},
+    {value: 'veggiePatty', viewValue: 'Veggie Patty'},
+    {value: 'tuna', viewValue: 'Tuna'},
+  ];
+
+  cheeses = [
+    {value: 'none', viewValue: 'None'},
+    {value: 'swiss', viewValue: 'Swiss'},
+    {value: 'american', viewValue: 'American'},
+    {value: 'cheddar', viewValue: 'Cheddar'},
   ];
 
   toggleDisabled() {

--- a/src/material/autocomplete/autocomplete.spec.ts
+++ b/src/material/autocomplete/autocomplete.spec.ts
@@ -46,6 +46,7 @@ import {map, startWith} from 'rxjs/operators';
 import {
   getMatAutocompleteMissingPanelError,
   MatAutocomplete,
+  MatAutocompleteDefaultOptions,
   MatAutocompleteModule,
   MatAutocompleteOrigin,
   MatAutocompleteSelectedEvent,
@@ -3412,6 +3413,50 @@ describe('MDC-based MatAutocomplete', () => {
 
     subscription.unsubscribe();
   }));
+
+  describe('a11y', () => {
+    it('should display checkmark for selection by default', () => {
+      const fixture = createComponent(AutocompleteWithNgModel);
+      fixture.componentInstance.selectedState = 'New York';
+      fixture.detectChanges();
+
+      fixture.componentInstance.trigger.openPanel();
+      fixture.detectChanges();
+
+      dispatchFakeEvent(document.querySelector('mat-option')!, 'click');
+      fixture.detectChanges();
+
+      const selectedOption = document.querySelector('mat-option[aria-selected="true"');
+      expect(selectedOption).withContext('Expected an option to be selected.').not.toBeNull();
+      expect(selectedOption?.querySelector('.mat-pseudo-checkbox.mat-pseudo-checkbox-minimal'))
+        .withContext(
+          'Expected selection option to have a pseudo-checkbox with "minimal" appearance.',
+        )
+        .toBeTruthy();
+    });
+  });
+
+  describe('with token to hide single selection indicator', () => {
+    it('should not display checkmark', () => {
+      const defaultOptions: MatAutocompleteDefaultOptions = {
+        hideSingleSelectionIndicator: true,
+      };
+      const fixture = createComponent(AutocompleteWithNgModel, [
+        {provide: MAT_AUTOCOMPLETE_DEFAULT_OPTIONS, useValue: defaultOptions},
+      ]);
+      fixture.detectChanges();
+
+      fixture.componentInstance.trigger.openPanel();
+      fixture.detectChanges();
+
+      dispatchFakeEvent(document.querySelector('mat-option')!, 'click');
+      fixture.detectChanges();
+
+      const selectedOption = document.querySelector('mat-option[aria-selected="true"');
+      expect(selectedOption).withContext('Expected an option to be selected.').not.toBeNull();
+      expect(document.querySelectorAll('.mat-pseudo-checkbox').length).toBe(0);
+    });
+  });
 });
 
 const SIMPLE_AUTOCOMPLETE_TEMPLATE = `
@@ -3575,6 +3620,8 @@ class AutocompleteWithNgModel {
   filteredStates: any[];
   selectedState: string;
   states = ['New York', 'Washington', 'Oregon'];
+
+  @ViewChild(MatAutocompleteTrigger, {static: true}) trigger: MatAutocompleteTrigger;
 
   constructor() {
     this.filteredStates = this.states.slice();

--- a/src/material/core/option/option-parent.ts
+++ b/src/material/core/option/option-parent.ts
@@ -17,6 +17,7 @@ export interface MatOptionParentComponent {
   disableRipple?: boolean;
   multiple?: boolean;
   inertGroups?: boolean;
+  hideSingleSelectionIndicator?: boolean;
 }
 
 /**

--- a/src/material/core/option/option.html
+++ b/src/material/core/option/option.html
@@ -5,6 +5,11 @@
 
 <span class="mdc-list-item__primary-text" #text><ng-content></ng-content></span>
 
+<!-- Render checkmark at the end for single-selection. -->
+<mat-pseudo-checkbox *ngIf="!multiple && selected && !hideSingleSelectionIndicator"
+    class="mat-mdc-option-pseudo-checkbox" state="checked" [disabled]="disabled"
+    appearance="minimal"></mat-pseudo-checkbox>
+
 <!-- See a11y notes inside optgroup.ts for context behind this element. -->
 <span class="cdk-visually-hidden" *ngIf="group && group._inert">({{ group.label }})</span>
 

--- a/src/material/core/option/option.scss
+++ b/src/material/core/option/option.scss
@@ -48,13 +48,23 @@
   }
 
   .mat-icon,
-  .mat-pseudo-checkbox {
+  .mat-pseudo-checkbox-full {
     margin-right: mdc-list-variables.$side-padding;
     flex-shrink: 0;
 
     [dir='rtl'] & {
       margin-right: 0;
       margin-left: mdc-list-variables.$side-padding;
+    }
+  }
+
+  .mat-pseudo-checkbox-minimal {
+    margin-left: mdc-list-variables.$side-padding;
+    flex-shrink: 0;
+
+    [dir='rtl'] & {
+      margin-right: mdc-list-variables.$side-padding;
+      margin-left: 0;
     }
   }
 
@@ -84,6 +94,13 @@
     font-family: inherit;
     text-decoration: inherit;
     text-transform: inherit;
+
+    margin-right: auto;
+
+    [dir='rtl'] & {
+      margin-right: 0;
+      margin-left: auto;
+    }
   }
 
   @include cdk.high-contrast(active, off) {

--- a/src/material/core/option/option.ts
+++ b/src/material/core/option/option.ts
@@ -83,6 +83,11 @@ export class _MatOptionBase<T = any> implements FocusableOption, AfterViewChecke
     return !!(this._parent && this._parent.disableRipple);
   }
 
+  /** Whether to display checkmark for single-selection. */
+  get hideSingleSelectionIndicator(): boolean {
+    return !!(this._parent && this._parent.hideSingleSelectionIndicator);
+  }
+
   /** Event emitted when the option is selected or deselected. */
   // tslint:disable-next-line:no-output-on-prefix
   @Output() readonly onSelectionChange = new EventEmitter<MatOptionSelectionChange<T>>();
@@ -95,7 +100,7 @@ export class _MatOptionBase<T = any> implements FocusableOption, AfterViewChecke
 
   constructor(
     private _element: ElementRef<HTMLElement>,
-    private _changeDetectorRef: ChangeDetectorRef,
+    public _changeDetectorRef: ChangeDetectorRef,
     private _parent: MatOptionParentComponent,
     readonly group: _MatOptgroupBase,
   ) {}

--- a/src/material/core/selection/pseudo-checkbox/_pseudo-checkbox-common.scss
+++ b/src/material/core/selection/pseudo-checkbox/_pseudo-checkbox-common.scss
@@ -4,26 +4,79 @@
 // Padding inside of a pseudo checkbox.
 $padding: checkbox-common.$border-width * 2;
 
+// Center a checkmark indicator inside the checkbox.
+//
+// `$box-size`: size of the checkbox
+// `$mark-size`: size of the checkmark indicator
+@mixin _checkbox-checked-styles-with-size($box-size, $mark-size) {
+  // Center a checkmark. `$checkbox-cmmon.$border-width` is the width of the line of the checkmark.
+  $width: $mark-size;
+  $height: math.div($mark-size - checkbox-common.$border-width, 2);
+
+  // The rendered length of the short-side of the checkmark graphic when rendered. Add length of
+  // the border-width since this element is content-box.
+  $short-side: $height + checkbox-common.$border-width;
+
+  width: $width;
+  height: $height;
+
+  // Rotate on the center of the element. This makes it easier to center the checkmark graphic.
+  transform-origin: center;
+
+  // Take negative one times the distance from the top corner of the checkmark graphic to the top
+  // of the element in its rotated position. This accounts for the top corner of the elemant being
+  // blank since we only use the left and bottom borders to draw the checkmark graphic.
+  top: -1 * math.div($short-side - checkbox-common.$border-width, math.sqrt(2));
+
+  left: 0;
+  bottom: 0;
+  right: 0;
+
+  // center the checkmark graphic with margin auto
+  margin: auto;
+}
+
+// Center a horizontal line placed in the vertical and horizontal center of the checkbox. It does
+// not touch the border of the checkbox.
+//
+// `$box-size`: size of the checkbox.
+// `$border-size`: size of the checkbox's border.
+@mixin _checkbox-indeterminate-styles-with-size($box-size, $border-size) {
+  // Center the line in the the checkbox. `$checkbox-common.$border-width` is the width of the line.
+  top: math.div($box-size - checkbox-common.$border-width, 2) - $border-size;
+  width: $box-size - checkbox-common.$border-width - (2 * $border-size);
+}
+
 /// Applies the styles that set the size of the pseudo checkbox
 @mixin size($box-size) {
-  $mark-size: $box-size - (2 * $padding);
 
   .mat-pseudo-checkbox {
     width: $box-size;
     height: $box-size;
   }
 
-  .mat-pseudo-checkbox-indeterminate::after {
-    top: math.div($box-size - checkbox-common.$border-width, 2) -
-      checkbox-common.$border-width;
-    width: $box-size - 6px;
+  .mat-pseudo-checkbox-minimal {
+    $mark-size: $box-size - $padding;
+    $border-size: 0; // Minimal appearance does not have a border.
+
+    &.mat-pseudo-checkbox-checked::after {
+      @include _checkbox-checked-styles-with-size($box-size, $mark-size);
+    }
+    &.mat-pseudo-checkbox-indeterminate::after {
+      @include _checkbox-indeterminate-styles-with-size($box-size, $border-size);
+    }
   }
 
-  .mat-pseudo-checkbox-checked::after {
-    top: math.div($box-size, 2) - math.div($mark-size, 4) -
-       math.div($box-size, 10) - checkbox-common.$border-width;
-    width: $mark-size;
-    height: math.div($mark-size - checkbox-common.$border-width, 2);
+  .mat-pseudo-checkbox-full {
+    $mark-size: $box-size - (2 * $padding); // Apply a smaller mark to account for the border.
+    $border-size: checkbox-common.$border-width;
+
+    &.mat-pseudo-checkbox-checked::after {
+      @include _checkbox-checked-styles-with-size($box-size, $mark-size);
+    }
+    &.mat-pseudo-checkbox-indeterminate::after {
+      @include _checkbox-indeterminate-styles-with-size($box-size, $border-size);
+    }
   }
 }
 

--- a/src/material/core/selection/pseudo-checkbox/_pseudo-checkbox-theme.scss
+++ b/src/material/core/selection/pseudo-checkbox/_pseudo-checkbox-theme.scss
@@ -1,13 +1,33 @@
 @use 'sass:map';
 @use '../../theming/theming';
 
+@mixin _psuedo-checkbox-styles-with-color($text-color, $background) {
+  .mat-pseudo-checkbox-checked,
+  .mat-pseudo-checkbox-indeterminate {
+    &.mat-pseudo-checkbox-minimal::after {
+      color: $text-color;
+    }
+
+    // Full (checkbox) appearance inverts colors of text and background.
+    &.mat-pseudo-checkbox-full {
+      &::after {
+        color: $background;
+      }
+
+      background: $text-color;
+    }
+  }
+}
+
 @mixin color($config-or-theme) {
   $config: theming.get-color-config($config-or-theme);
   $is-dark-theme: map.get($config, is-dark);
-  $primary: map.get($config, primary);
-  $accent: map.get($config, accent);
-  $warn: map.get($config, warn);
-  $background: map.get($config, background);
+
+  $primary: theming.get-color-from-palette(map.get($config, primary));
+  $accent: theming.get-color-from-palette(map.get($config, accent));
+  $warn: theming.get-color-from-palette(map.get($config, warn));
+  $background: theming.get-color-from-palette(map.get($config, background), background);
+  $secondary-text: theming.get-color-from-palette(map.get($config, foreground), secondary-text);
 
   // NOTE(traviskaufman): While the spec calls for translucent blacks/whites for disabled colors,
   // this does not work well with elements layered on top of one another. To get around this we
@@ -17,21 +37,15 @@
   $disabled-color: if($is-dark-theme, $white-30pct-opacity-on-dark, $black-26pct-opacity-on-light);
   $colored-box-selector: '.mat-pseudo-checkbox-checked, .mat-pseudo-checkbox-indeterminate';
 
-  .mat-pseudo-checkbox {
-    color: theming.get-color-from-palette(map.get($config, foreground), secondary-text);
-
-    &::after {
-      color: theming.get-color-from-palette($background, background);
+  .mat-pseudo-checkbox-full {
+    color: $secondary-text;
+    &.mat-pseudo-checkbox-disabled {
+      color: $disabled-color;
     }
   }
 
-  .mat-pseudo-checkbox-disabled {
-    color: $disabled-color;
-  }
-
-  .mat-primary .mat-pseudo-checkbox-checked,
-  .mat-primary .mat-pseudo-checkbox-indeterminate {
-    background: theming.get-color-from-palette(map.get($config, primary));
+  .mat-primary {
+    @include _psuedo-checkbox-styles-with-color($primary, $background);
   }
 
   // Default to the accent color. Note that the pseudo checkboxes are meant to inherit the
@@ -39,21 +53,22 @@
   // don't attach to the `mat-*` classes. Also note that this needs to be below `.mat-primary`
   // in order to allow for the color to be overwritten if the checkbox is inside a parent that
   // has `mat-accent` and is placed inside another parent that has `mat-primary`.
-  .mat-pseudo-checkbox-checked,
-  .mat-pseudo-checkbox-indeterminate,
-  .mat-accent .mat-pseudo-checkbox-checked,
-  .mat-accent .mat-pseudo-checkbox-indeterminate {
-    background: theming.get-color-from-palette(map.get($config, accent));
+  @include _psuedo-checkbox-styles-with-color($accent, $background);
+  .mat-accent {
+    @include _psuedo-checkbox-styles-with-color($accent, $background);
   }
 
-  .mat-warn .mat-pseudo-checkbox-checked,
-  .mat-warn .mat-pseudo-checkbox-indeterminate {
-    background: theming.get-color-from-palette(map.get($config, warn));
+  .mat-warn {
+    @include _psuedo-checkbox-styles-with-color($warn, $background);
   }
 
-  .mat-pseudo-checkbox-checked,
-  .mat-pseudo-checkbox-indeterminate {
-    &.mat-pseudo-checkbox-disabled {
+  .mat-pseudo-checkbox-disabled.mat-pseudo-checkbox-checked,
+  .mat-pseudo-checkbox-disabled.mat-pseudo-checkbox-indeterminate {
+    &.mat-pseudo-checkbox-minimal::after {
+      color: $disabled-color;
+    }
+
+    &.mat-pseudo-checkbox-full {
       background: $disabled-color;
     }
   }

--- a/src/material/core/selection/pseudo-checkbox/pseudo-checkbox.scss
+++ b/src/material/core/selection/pseudo-checkbox/pseudo-checkbox.scss
@@ -5,7 +5,6 @@
 @use './pseudo-checkbox-common';
 
 .mat-pseudo-checkbox {
-  border: checkbox-common.$border-width solid;
   border-radius: 2px;
   cursor: pointer;
   display: inline-block;
@@ -25,10 +24,6 @@
     border-bottom: checkbox-common.$border-width solid currentColor;
     transition: opacity checkbox-common.$transition-duration
       variables.$linear-out-slow-in-timing-function;
-  }
-
-  &.mat-pseudo-checkbox-checked, &.mat-pseudo-checkbox-indeterminate {
-    border-color: transparent;
   }
 
   @include private.private-animation-noop {
@@ -54,6 +49,13 @@
   transform: rotate(-45deg);
   opacity: 1;
   box-sizing: content-box;
+}
+
+.mat-pseudo-checkbox-full {
+  border: checkbox-common.$border-width solid;
+  &.mat-pseudo-checkbox-checked, &.mat-pseudo-checkbox-indeterminate {
+    border-color: transparent;
+  }
 }
 
 @include pseudo-checkbox-common.size(checkbox-common.$size);

--- a/src/material/core/selection/pseudo-checkbox/pseudo-checkbox.ts
+++ b/src/material/core/selection/pseudo-checkbox/pseudo-checkbox.ts
@@ -46,6 +46,8 @@ export type MatPseudoCheckboxState = 'unchecked' | 'checked' | 'indeterminate';
     '[class.mat-pseudo-checkbox-indeterminate]': 'state === "indeterminate"',
     '[class.mat-pseudo-checkbox-checked]': 'state === "checked"',
     '[class.mat-pseudo-checkbox-disabled]': 'disabled',
+    '[class.mat-pseudo-checkbox-minimal]': 'appearance === "minimal"',
+    '[class.mat-pseudo-checkbox-full]': 'appearance === "full"',
     '[class._mat-animation-noopable]': '_animationMode === "NoopAnimations"',
   },
 })
@@ -55,6 +57,12 @@ export class MatPseudoCheckbox {
 
   /** Whether the checkbox is disabled. */
   @Input() disabled: boolean = false;
+
+  /**
+   * Appearance of the pseudo checkbox. Default appearance of 'full' renders a checkmark/mixedmark
+   * indicator inside a square box. 'minimal' appearance only renders the checkmark/mixedmark.
+   */
+  @Input() appearance: 'minimal' | 'full' = 'full';
 
   constructor(@Optional() @Inject(ANIMATION_MODULE_TYPE) public _animationMode?: string) {}
 }

--- a/src/material/select/select.spec.ts
+++ b/src/material/select/select.spec.ts
@@ -1321,6 +1321,56 @@ describe('MDC-based MatSelect', () => {
             )
             .toEqual([options[7]]);
         }));
+
+        it('should render a checkmark on selected option', fakeAsync(() => {
+          fixture.componentInstance.control.setValue(fixture.componentInstance.foods[2].value);
+          fixture.detectChanges();
+
+          trigger.click();
+          fixture.detectChanges();
+          flush();
+
+          const pseudoCheckboxes = options
+            .map(option => option.querySelector('.mat-pseudo-checkbox-minimal'))
+            .filter((x): x is HTMLElement => !!x);
+          const selectedOption = options[2];
+
+          expect(selectedOption.querySelector('.mat-pseudo-checkbox-minimal')).not.toBeNull();
+          expect(pseudoCheckboxes.length).toBe(1);
+        }));
+
+        it('should render checkboxes for multi-select', fakeAsync(() => {
+          fixture.destroy();
+
+          const multiFixture = TestBed.createComponent(MultiSelect);
+          multiFixture.detectChanges();
+
+          multiFixture.componentInstance.control.setValue([
+            multiFixture.componentInstance.foods[2].value,
+          ]);
+          multiFixture.detectChanges();
+
+          trigger = multiFixture.debugElement.query(
+            By.css('.mat-mdc-select-trigger'),
+          )!.nativeElement;
+
+          trigger.click();
+          multiFixture.detectChanges();
+          flush();
+
+          options = Array.from(overlayContainerElement.querySelectorAll('mat-option'));
+          const pseudoCheckboxes = options
+            .map(option => option.querySelector('.mat-pseudo-checkbox.mat-pseudo-checkbox-full'))
+            .filter((x): x is HTMLElement => !!x);
+          const selectedPseudoCheckbox = pseudoCheckboxes[2];
+
+          expect(pseudoCheckboxes.length)
+            .withContext('expecting each option to have a pseudo-checkbox with "full" appearance')
+            .toEqual(options.length);
+          expect(selectedPseudoCheckbox.classList)
+            .withContext('expecting selected pseudo-checkbox to be checked')
+            .toContain('mat-pseudo-checkbox-checked');
+        }));
       });
 
       describe('for option groups', () => {
@@ -4376,6 +4426,39 @@ describe('MDC-based MatSelect', () => {
     expect(select.typeaheadDebounceInterval).toBe(1337);
     expect(document.querySelector('.cdk-overlay-pane')?.classList).toContain('test-panel-class');
   }));
+
+  it('should be able to hide checkmark icon through an injection token', () => {
+    const matSelectConfig: MatSelectConfig = {hideSingleSelectionIndicator: true};
+    configureMatSelectTestingModule(
+      [NgModelSelect],
+      [
+        {
+          provide: MAT_SELECT_CONFIG,
+          useValue: matSelectConfig,
+        },
+      ],
+    );
+    const fixture = TestBed.createComponent(NgModelSelect);
+    fixture.detectChanges();
+    const select = fixture.componentInstance.select;
+
+    fixture.componentInstance.select.value = fixture.componentInstance.foods[0].value;
+    select.open();
+    fixture.detectChanges();
+
+    // Select the first value to ensure selection state is displayed. That way this test ensures
+    // that the selection state hides the checkmark icon, rather than hiding the checkmark icon
+    // because nothing is selected.
+    expect(document.querySelector('mat-option[aria-selected="true"]'))
+      .withContext('expecting selection state to be displayed')
+      .not.toBeNull();
+
+    const pseudoCheckboxes = document.querySelectorAll('.mat-pseudo-checkbox');
+
+    expect(pseudoCheckboxes.length)
+      .withContext('expecting not to display a pseudo-checkbox')
+      .toBe(0);
+  });
 
   it('should not not throw if the select is inside an ng-container with ngIf', fakeAsync(() => {
     configureMatSelectTestingModule([SelectInNgContainer]);

--- a/src/material/select/select.ts
+++ b/src/material/select/select.ts
@@ -130,6 +130,9 @@ export interface MatSelectConfig {
 
   /** Class or list of classes to be applied to the menu's overlay panel. */
   overlayPanelClass?: string | string[];
+
+  /** Wheter icon indicators should be hidden for single-selection. */
+  hideSingleSelectionIndicator?: boolean;
 }
 
 /** Injection token that can be used to provide the default options the select module. */
@@ -483,7 +486,7 @@ export abstract class _MatSelectBase<C>
     @Attribute('tabindex') tabIndex: string,
     @Inject(MAT_SELECT_SCROLL_STRATEGY) scrollStrategyFactory: any,
     private _liveAnnouncer: LiveAnnouncer,
-    @Optional() @Inject(MAT_SELECT_CONFIG) private _defaultOptions?: MatSelectConfig,
+    @Optional() @Inject(MAT_SELECT_CONFIG) protected _defaultOptions?: MatSelectConfig,
   ) {
     super(elementRef, _defaultErrorStateMatcher, _parentForm, _parentFormGroup, ngControl);
 
@@ -1290,5 +1293,26 @@ export class MatSelect extends _MatSelectBase<MatSelectChange> implements OnInit
         ? this._preferredOverlayOrigin.elementRef
         : this._preferredOverlayOrigin || this._elementRef;
     return refToMeasure.nativeElement.getBoundingClientRect().width;
+  }
+
+  /** Whether checkmark indicator for single-selection options is hidden. */
+  @Input()
+  get hideSingleSelectionIndicator(): boolean {
+    return this._hideSingleSelectionIndicator;
+  }
+  set hideSingleSelectionIndicator(value: BooleanInput) {
+    this._hideSingleSelectionIndicator = coerceBooleanProperty(value);
+    this._syncParentProperties();
+  }
+  private _hideSingleSelectionIndicator: boolean =
+    this._defaultOptions?.hideSingleSelectionIndicator ?? false;
+
+  /** Syncs the parent state with the individual options. */
+  _syncParentProperties(): void {
+    if (this.options) {
+      for (const option of this.options) {
+        option._changeDetectorRef.markForCheck();
+      }
+    }
   }
 }

--- a/tools/public_api_guard/material/autocomplete.md
+++ b/tools/public_api_guard/material/autocomplete.md
@@ -71,12 +71,15 @@ export const MAT_AUTOCOMPLETE_VALUE_ACCESSOR: any;
 export class MatAutocomplete extends _MatAutocompleteBase {
     // (undocumented)
     protected _hiddenClass: string;
+    get hideSingleSelectionIndicator(): boolean;
+    set hideSingleSelectionIndicator(value: BooleanInput);
     optionGroups: QueryList<MatOptgroup>;
     options: QueryList<MatOption>;
+    _syncParentProperties(): void;
     // (undocumented)
     protected _visibleClass: string;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<MatAutocomplete, "mat-autocomplete", ["matAutocomplete"], { "disableRipple": "disableRipple"; }, {}, ["optionGroups", "options"], ["*"], false, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MatAutocomplete, "mat-autocomplete", ["matAutocomplete"], { "disableRipple": "disableRipple"; "hideSingleSelectionIndicator": "hideSingleSelectionIndicator"; }, {}, ["optionGroups", "options"], ["*"], false, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatAutocomplete, never>;
 }
@@ -89,7 +92,7 @@ export interface MatAutocompleteActivatedEvent {
 
 // @public
 export abstract class _MatAutocompleteBase extends _MatAutocompleteMixinBase implements AfterContentInit, CanDisableRipple, OnDestroy {
-    constructor(_changeDetectorRef: ChangeDetectorRef, _elementRef: ElementRef<HTMLElement>, defaults: MatAutocompleteDefaultOptions, platform?: Platform);
+    constructor(_changeDetectorRef: ChangeDetectorRef, _elementRef: ElementRef<HTMLElement>, _defaults: MatAutocompleteDefaultOptions, platform?: Platform);
     ariaLabel: string;
     ariaLabelledby: string;
     get autoActiveFirstOption(): boolean;
@@ -102,6 +105,8 @@ export abstract class _MatAutocompleteBase extends _MatAutocompleteMixinBase imp
         [key: string]: boolean;
     };
     readonly closed: EventEmitter<void>;
+    // (undocumented)
+    protected _defaults: MatAutocompleteDefaultOptions;
     displayWith: ((value: any) => string) | null;
     _emitSelectEvent(option: _MatOptionBase): void;
     _getPanelAriaLabelledby(labelId: string | null): string | null;
@@ -140,6 +145,7 @@ export abstract class _MatAutocompleteBase extends _MatAutocompleteMixinBase imp
 export interface MatAutocompleteDefaultOptions {
     autoActiveFirstOption?: boolean;
     autoSelectActiveOption?: boolean;
+    hideSingleSelectionIndicator?: boolean;
     overlayPanelClass?: string | string[];
 }
 

--- a/tools/public_api_guard/material/core.md
+++ b/tools/public_api_guard/material/core.md
@@ -272,6 +272,8 @@ export class MatOption<T = any> extends _MatOptionBase<T> {
 export class _MatOptionBase<T = any> implements FocusableOption, AfterViewChecked, OnDestroy {
     constructor(_element: ElementRef<HTMLElement>, _changeDetectorRef: ChangeDetectorRef, _parent: MatOptionParentComponent, group: _MatOptgroupBase);
     get active(): boolean;
+    // (undocumented)
+    _changeDetectorRef: ChangeDetectorRef;
     deselect(): void;
     get disabled(): boolean;
     set disabled(value: BooleanInput);
@@ -284,6 +286,7 @@ export class _MatOptionBase<T = any> implements FocusableOption, AfterViewChecke
     // (undocumented)
     readonly group: _MatOptgroupBase;
     _handleKeydown(event: KeyboardEvent): void;
+    get hideSingleSelectionIndicator(): boolean;
     id: string;
     get multiple(): boolean | undefined;
     // (undocumented)
@@ -321,6 +324,8 @@ export interface MatOptionParentComponent {
     // (undocumented)
     disableRipple?: boolean;
     // (undocumented)
+    hideSingleSelectionIndicator?: boolean;
+    // (undocumented)
     inertGroups?: boolean;
     // (undocumented)
     multiple?: boolean;
@@ -340,10 +345,11 @@ export class MatPseudoCheckbox {
     constructor(_animationMode?: string | undefined);
     // (undocumented)
     _animationMode?: string | undefined;
+    appearance: 'minimal' | 'full';
     disabled: boolean;
     state: MatPseudoCheckboxState;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<MatPseudoCheckbox, "mat-pseudo-checkbox", never, { "state": "state"; "disabled": "disabled"; }, {}, never, never, false, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MatPseudoCheckbox, "mat-pseudo-checkbox", never, { "state": "state"; "disabled": "disabled"; "appearance": "appearance"; }, {}, never, never, false, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatPseudoCheckbox, [{ optional: true; }]>;
 }

--- a/tools/public_api_guard/material/select.md
+++ b/tools/public_api_guard/material/select.md
@@ -83,6 +83,8 @@ export class MatSelect extends _MatSelectBase<MatSelectChange> implements OnInit
     customTrigger: MatSelectTrigger;
     // (undocumented)
     protected _getChangeEvent(value: any): MatSelectChange;
+    get hideSingleSelectionIndicator(): boolean;
+    set hideSingleSelectionIndicator(value: BooleanInput);
     // (undocumented)
     ngAfterViewInit(): void;
     // (undocumented)
@@ -102,8 +104,9 @@ export class MatSelect extends _MatSelectBase<MatSelectChange> implements OnInit
     protected _scrollOptionIntoView(index: number): void;
     // (undocumented)
     get shouldLabelFloat(): boolean;
+    _syncParentProperties(): void;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<MatSelect, "mat-select", ["matSelect"], { "disabled": "disabled"; "disableRipple": "disableRipple"; "tabIndex": "tabIndex"; }, {}, ["customTrigger", "options", "optionGroups"], ["mat-select-trigger", "*"], false, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MatSelect, "mat-select", ["matSelect"], { "disabled": "disabled"; "disableRipple": "disableRipple"; "tabIndex": "tabIndex"; "hideSingleSelectionIndicator": "hideSingleSelectionIndicator"; }, {}, ["customTrigger", "options", "optionGroups"], ["mat-select-trigger", "*"], false, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatSelect, never>;
 }
@@ -128,6 +131,8 @@ export abstract class _MatSelectBase<C> extends _MatSelectMixinBase implements A
     set compareWith(fn: (o1: any, o2: any) => boolean);
     controlType: string;
     abstract customTrigger: {};
+    // (undocumented)
+    protected _defaultOptions?: MatSelectConfig | undefined;
     protected readonly _destroy: Subject<void>;
     get disableOptionCentering(): boolean;
     set disableOptionCentering(value: BooleanInput);
@@ -231,6 +236,7 @@ export class MatSelectChange {
 // @public
 export interface MatSelectConfig {
     disableOptionCentering?: boolean;
+    hideSingleSelectionIndicator?: boolean;
     overlayPanelClass?: string | string[];
     typeaheadDebounceInterval?: number;
 }


### PR DESCRIPTION
Add checkmark to mat-option for single-select. Fix a11y issues where selected state is visually communicated with color alone. Communicate selection with both color and a checkmark indicator. Affect components that use mat-option for single-selection, which include select and autocomplete.

Add an `appearance` Input to mat-pseudo-checkbox. "full" appearance renders a checkbox, which is the current behavior. Render "full" appearance by default. "minimal" apperance renders only a checkmark.

Summary of API and behavior changes:
 - Add an `@Input appearance` to pseudo-checkbox with options for "full" and "minimal".
 - mat-option renders "minimal" appearance for single-select, which looks like a checkmark.
 - Select and autocomplete components display checkmark on selected option.

What's not changing:
 - does not affect multiple selection
 - mat-option renders "full" apperance by default, which is same as existing behavior

Fixes: #25961

<img width="330" alt="image" src="https://user-images.githubusercontent.com/7720245/201437429-ca42bcf5-76e2-4cf2-8d1f-5cd3731eede9.png">
<img width="295" alt="image" src="https://user-images.githubusercontent.com/7720245/201437451-06f7a2ca-2890-4e27-b69f-6c0316fcde98.png">
<img width="447" alt="image" src="https://user-images.githubusercontent.com/7720245/201437482-b970a31a-48b3-405c-a802-cf89ceb0b166.png">
