### PR TITLE
fix(material/schematics): avoid mutating the AST when traversing

### DIFF
--- a/src/material/schematics/ng-generate/mdc-migration/rules/tree-traversal.ts
+++ b/src/material/schematics/ng-generate/mdc-migration/rules/tree-traversal.ts
@@ -30,8 +30,7 @@ export function visitElements(
   preorderCallback: (node: TmplAstElement) => void = () => {},
   postorderCallback: (node: TmplAstElement) => void = () => {},
 ): void {
-  nodes.reverse();
-  for (let i = 0; i < nodes.length; i++) {
+  for (let i = nodes.length - 1; i > -1; i--) {
     const node = nodes[i];
     const isElement = node instanceof TmplAstElement;
 


### PR DESCRIPTION
The `visitElements` function was calling `reverse` on the node's `children` which reverses it in place. We shouldn't be mutating the AST just to traverse it in reverse order.

These changes switch to using a reverse loop instead.