### PR TITLE
refactor(material/core): deprecate initialized mixin

### DIFF
--- a/src/material/core/common-behaviors/initialized.ts
+++ b/src/material/core/common-behaviors/initialized.ts
@@ -15,6 +15,8 @@ import {Constructor} from './constructor';
  * If the subscription is made after it has already been marked as initialized, then it will trigger
  * an emit immediately.
  * @docs-private
+ * @deprecated No longer in use. To be removed.
+ * @breaking-change 17.0.0
  */
 export interface HasInitialized {
   /** Stream that emits once during the directive/component's ngOnInit. */
@@ -30,7 +32,11 @@ export interface HasInitialized {
 
 type HasInitializedCtor = Constructor<HasInitialized>;
 
-/** Mixin to augment a directive with an initialized property that will emits when ngOnInit ends. */
+/**
+ * Mixin to augment a directive with an initialized property that will emits when ngOnInit ends.
+ * @deprecated No longer in use. To be removed.
+ * @breaking-change 17.0.0
+ */
 export function mixinInitialized<T extends Constructor<{}>>(base: T): HasInitializedCtor & T {
   return class extends base {
     /** Whether this directive has been marked as initialized. */

--- a/src/material/paginator/paginator.ts
+++ b/src/material/paginator/paginator.ts
@@ -22,14 +22,8 @@ import {
   ViewEncapsulation,
 } from '@angular/core';
 import {MatFormFieldAppearance} from '@angular/material/form-field';
-import {
-  CanDisable,
-  HasInitialized,
-  mixinDisabled,
-  mixinInitialized,
-  ThemePalette,
-} from '@angular/material/core';
-import {Subscription} from 'rxjs';
+import {CanDisable, mixinDisabled, ThemePalette} from '@angular/material/core';
+import {Subscription, ReplaySubject} from 'rxjs';
 import {
   BooleanInput,
   coerceBooleanProperty,
@@ -100,7 +94,7 @@ export const MAT_PAGINATOR_DEFAULT_OPTIONS = new InjectionToken<MatPaginatorDefa
 
 // Boilerplate for applying mixins to _MatPaginatorBase.
 /** @docs-private */
-const _MatPaginatorMixinBase = mixinDisabled(mixinInitialized(class {}));
+const _MatPaginatorMixinBase = mixinDisabled(class {});
 
 /**
  * Base class with all of the `MatPaginator` functionality.
@@ -116,7 +110,7 @@ export abstract class _MatPaginatorBase<
     },
   >
   extends _MatPaginatorMixinBase
-  implements OnInit, OnDestroy, CanDisable, HasInitialized
+  implements OnInit, OnDestroy, CanDisable
 {
   private _initialized: boolean;
   private _intlChanges: Subscription;
@@ -197,6 +191,9 @@ export abstract class _MatPaginatorBase<
   /** Displayed set of page size options. Will be sorted and include current page size. */
   _displayedPageSizeOptions: number[];
 
+  /** Emits when the paginator has been initialized. */
+  initialized = new ReplaySubject<void>(1);
+
   constructor(
     public _intl: MatPaginatorIntl,
     private _changeDetectorRef: ChangeDetectorRef,
@@ -228,11 +225,12 @@ export abstract class _MatPaginatorBase<
 
   ngOnInit() {
     this._initialized = true;
+    this.initialized.next();
     this._updateDisplayedPageSizeOptions();
-    this._markInitialized();
   }
 
   ngOnDestroy() {
+    this.initialized.complete();
     this._intlChanges.unsubscribe();
   }
 

--- a/src/material/sort/sort.ts
+++ b/src/material/sort/sort.ts
@@ -19,8 +19,8 @@ import {
   Optional,
   Output,
 } from '@angular/core';
-import {CanDisable, HasInitialized, mixinDisabled, mixinInitialized} from '@angular/material/core';
-import {Subject} from 'rxjs';
+import {CanDisable, mixinDisabled} from '@angular/material/core';
+import {ReplaySubject, Subject} from 'rxjs';
 import {SortDirection} from './sort-direction';
 import {
   getSortDuplicateSortableIdError,
@@ -67,7 +67,7 @@ export const MAT_SORT_DEFAULT_OPTIONS = new InjectionToken<MatSortDefaultOptions
 
 // Boilerplate for applying mixins to MatSort.
 /** @docs-private */
-const _MatSortBase = mixinInitialized(mixinDisabled(class {}));
+const _MatSortBase = mixinDisabled(class {});
 
 /** Container for MatSortables to manage the sort state and provide default sort parameters. */
 @Directive({
@@ -76,12 +76,12 @@ const _MatSortBase = mixinInitialized(mixinDisabled(class {}));
   host: {'class': 'mat-sort'},
   inputs: ['disabled: matSortDisabled'],
 })
-export class MatSort
-  extends _MatSortBase
-  implements CanDisable, HasInitialized, OnChanges, OnDestroy, OnInit
-{
+export class MatSort extends _MatSortBase implements CanDisable, OnChanges, OnInit, OnDestroy {
   /** Collection of all registered sortables that this directive manages. */
   sortables = new Map<string, MatSortable>();
+
+  /** Emits when the directive has been initialized. */
+  initialized = new ReplaySubject<void>(1);
 
   /** Used to notify any child components listening to state changes. */
   readonly _stateChanges = new Subject<void>();
@@ -194,8 +194,8 @@ export class MatSort
     return sortDirectionCycle[nextDirectionIndex];
   }
 
-  ngOnInit() {
-    this._markInitialized();
+  ngOnInit(): void {
+    this.initialized.next();
   }
 
   ngOnChanges() {
@@ -203,6 +203,7 @@ export class MatSort
   }
 
   ngOnDestroy() {
+    this.initialized.complete();
     this._stateChanges.complete();
   }
 }

--- a/tools/public_api_guard/material/core.md
+++ b/tools/public_api_guard/material/core.md
@@ -150,7 +150,7 @@ export interface GranularSanityChecks {
     version: boolean;
 }
 
-// @public
+// @public @deprecated
 export interface HasInitialized {
     initialized: Observable<void>;
     _markInitialized: () => void;
@@ -410,7 +410,7 @@ export function mixinDisableRipple<T extends _AbstractConstructor<{}>>(base: T):
 // @public
 export function mixinErrorState<T extends _AbstractConstructor<HasErrorState>>(base: T): CanUpdateErrorStateCtor & T;
 
-// @public
+// @public @deprecated
 export function mixinInitialized<T extends _Constructor<{}>>(base: T): HasInitializedCtor & T;
 
 // @public

--- a/tools/public_api_guard/material/paginator.md
+++ b/tools/public_api_guard/material/paginator.md
@@ -10,7 +10,6 @@ import { CanDisable } from '@angular/material/core';
 import { ChangeDetectorRef } from '@angular/core';
 import { _Constructor } from '@angular/material/core';
 import { EventEmitter } from '@angular/core';
-import { HasInitialized } from '@angular/material/core';
 import * as i0 from '@angular/core';
 import * as i2 from '@angular/common';
 import * as i3 from '@angular/material/button';
@@ -22,6 +21,7 @@ import { NumberInput } from '@angular/cdk/coercion';
 import { OnDestroy } from '@angular/core';
 import { OnInit } from '@angular/core';
 import { Optional } from '@angular/core';
+import { ReplaySubject } from 'rxjs';
 import { Subject } from 'rxjs';
 import { ThemePalette } from '@angular/material/core';
 
@@ -55,7 +55,7 @@ export abstract class _MatPaginatorBase<O extends {
     pageSizeOptions?: number[];
     hidePageSize?: boolean;
     showFirstLastButtons?: boolean;
-}> extends _MatPaginatorMixinBase implements OnInit, OnDestroy, CanDisable, HasInitialized {
+}> extends _MatPaginatorMixinBase implements OnInit, OnDestroy, CanDisable {
     constructor(_intl: MatPaginatorIntl, _changeDetectorRef: ChangeDetectorRef, defaults?: O);
     _changePageSize(pageSize: number): void;
     color: ThemePalette;
@@ -66,6 +66,7 @@ export abstract class _MatPaginatorBase<O extends {
     hasPreviousPage(): boolean;
     get hidePageSize(): boolean;
     set hidePageSize(value: BooleanInput);
+    initialized: ReplaySubject<void>;
     // (undocumented)
     _intl: MatPaginatorIntl;
     lastPage(): void;

--- a/tools/public_api_guard/material/sort.md
+++ b/tools/public_api_guard/material/sort.md
@@ -15,7 +15,6 @@ import { _Constructor } from '@angular/material/core';
 import { ElementRef } from '@angular/core';
 import { EventEmitter } from '@angular/core';
 import { FocusMonitor } from '@angular/cdk/a11y';
-import { HasInitialized } from '@angular/material/core';
 import * as i0 from '@angular/core';
 import * as i3 from '@angular/common';
 import * as i4 from '@angular/material/core';
@@ -24,6 +23,7 @@ import { OnChanges } from '@angular/core';
 import { OnDestroy } from '@angular/core';
 import { OnInit } from '@angular/core';
 import { Optional } from '@angular/core';
+import { ReplaySubject } from 'rxjs';
 import { Subject } from 'rxjs';
 
 // @public
@@ -51,7 +51,7 @@ export const MAT_SORT_HEADER_INTL_PROVIDER: {
 export function MAT_SORT_HEADER_INTL_PROVIDER_FACTORY(parentIntl: MatSortHeaderIntl): MatSortHeaderIntl;
 
 // @public
-export class MatSort extends _MatSortBase implements CanDisable, HasInitialized, OnChanges, OnDestroy, OnInit {
+export class MatSort extends _MatSortBase implements CanDisable, OnChanges, OnInit, OnDestroy {
     constructor(_defaultOptions?: MatSortDefaultOptions | undefined);
     active: string;
     deregister(sortable: MatSortable): void;
@@ -60,6 +60,7 @@ export class MatSort extends _MatSortBase implements CanDisable, HasInitialized,
     get disableClear(): boolean;
     set disableClear(v: BooleanInput);
     getNextSortDirection(sortable: MatSortable): SortDirection;
+    initialized: ReplaySubject<void>;
     // (undocumented)
     ngOnChanges(): void;
     // (undocumented)


### PR DESCRIPTION
The `mixinInitialized` is only used in a couple of places and it takes more boilerplate code to consume than to recreate its functionality. It also basically recreates the implementation of `ReplaySubject`.

These changes deprecate the mixin and remove its usages from our code so that we can eventually drop it in version 17.