### PR TITLE
build: update peer dependency to angular framework

### DIFF
--- a/packages.bzl
+++ b/packages.bzl
@@ -1,7 +1,7 @@
 # Each individual package uses a placeholder for the version of Angular to ensure they're
 # all in-sync. This map is passed to each ng_package rule to stamp out the appropriate
 # version for the placeholders.
-ANGULAR_PACKAGE_VERSION = "^15.0.0-0 || ^16.0.0"
+ANGULAR_PACKAGE_VERSION = "^15.0.0 || ^16.0.0"
 MDC_PACKAGE_VERSION = "15.0.0-canary.ecfee946f.0"
 TSLIB_PACKAGE_VERSION = "^2.3.0"
 RXJS_PACKAGE_VERSION = "^6.5.3 || ^7.4.0"


### PR DESCRIPTION
Before being able to cut v15 stable, the peer dependency needs to be updates so that Angular
framework v15 stable can be used.