### PR TITLE
fix(cdk/a11y): live announcer not working with aria-modal element

### DIFF
--- a/src/cdk/a11y/BUILD.bazel
+++ b/src/cdk/a11y/BUILD.bazel
@@ -49,6 +49,7 @@ ng_test_library(
         ":a11y",
         "//src/cdk/keycodes",
         "//src/cdk/observers",
+        "//src/cdk/overlay",
         "//src/cdk/platform",
         "//src/cdk/portal",
         "//src/cdk/testing/private",


### PR DESCRIPTION
When an `aria-modal="true"` element is present, some browsers exclude all the content outside of them from the a11y tree which breaks the `LiveAnnouncer`.

These changes add some logic to set an `aria-owns` on the modals so that the announcement is made.

Fixes #22733.