### PR TITLE
refactor(material/autocomplete): declare injected properties as nullable

### DIFF
--- a/src/material/autocomplete/autocomplete-trigger.ts
+++ b/src/material/autocomplete/autocomplete-trigger.ts
@@ -201,13 +201,13 @@ export abstract class _MatAutocompleteTriggerBase
     private _zone: NgZone,
     private _changeDetectorRef: ChangeDetectorRef,
     @Inject(MAT_AUTOCOMPLETE_SCROLL_STRATEGY) scrollStrategy: any,
-    @Optional() private _dir: Directionality,
-    @Optional() @Inject(MAT_FORM_FIELD) @Host() private _formField: MatFormField,
+    @Optional() private _dir: Directionality | null,
+    @Optional() @Inject(MAT_FORM_FIELD) @Host() private _formField: MatFormField | null,
     @Optional() @Inject(DOCUMENT) private _document: any,
     private _viewportRuler: ViewportRuler,
     @Optional()
     @Inject(MAT_AUTOCOMPLETE_DEFAULT_OPTIONS)
-    private _defaults?: MatAutocompleteDefaultOptions,
+    private _defaults?: MatAutocompleteDefaultOptions | null,
   ) {
     this._scrollStrategy = scrollStrategy;
   }
@@ -506,7 +506,9 @@ export abstract class _MatAutocompleteTriggerBase
   /** If the label has been manually elevated, return it to its normal state. */
   private _resetLabel(): void {
     if (this._manuallyFloatingLabel) {
-      this._formField.floatLabel = 'auto';
+      if (this._formField) {
+        this._formField.floatLabel = 'auto';
+      }
       this._manuallyFloatingLabel = false;
     }
   }
@@ -679,7 +681,7 @@ export abstract class _MatAutocompleteTriggerBase
       positionStrategy: this._getOverlayPosition(),
       scrollStrategy: this._scrollStrategy(),
       width: this._getPanelWidth(),
-      direction: this._dir,
+      direction: this._dir ?? undefined,
       panelClass: this._defaults?.overlayPanelClass,
     });
   }

--- a/tools/public_api_guard/material/autocomplete.md
+++ b/tools/public_api_guard/material/autocomplete.md
@@ -191,7 +191,7 @@ export class MatAutocompleteTrigger extends _MatAutocompleteTriggerBase {
 
 // @public
 export abstract class _MatAutocompleteTriggerBase implements ControlValueAccessor, AfterViewInit, OnChanges, OnDestroy {
-    constructor(_element: ElementRef<HTMLInputElement>, _overlay: Overlay, _viewContainerRef: ViewContainerRef, _zone: NgZone, _changeDetectorRef: ChangeDetectorRef, scrollStrategy: any, _dir: Directionality, _formField: MatFormField, _document: any, _viewportRuler: ViewportRuler, _defaults?: MatAutocompleteDefaultOptions | undefined);
+    constructor(_element: ElementRef<HTMLInputElement>, _overlay: Overlay, _viewContainerRef: ViewContainerRef, _zone: NgZone, _changeDetectorRef: ChangeDetectorRef, scrollStrategy: any, _dir: Directionality | null, _formField: MatFormField | null, _document: any, _viewportRuler: ViewportRuler, _defaults?: MatAutocompleteDefaultOptions | null | undefined);
     protected abstract _aboveClass: string;
     get activeOption(): _MatOptionBase | null;
     autocomplete: _MatAutocompleteBase;


### PR DESCRIPTION
In autocomplete-trigger.ts, add `| null` to the typing of optionally injected properties. This improves code health because the compiler can detect possible type errors with `null`.