### PR TITLE
fix(material/list): pointer events disabled around content

### DIFF
--- a/src/material/list/list.scss
+++ b/src/material/list/list.scss
@@ -17,6 +17,14 @@ a.mdc-list-item--activated {
 // explicitly set `display: block`
 .mat-mdc-list-base {
   display: block;
+
+  // MDC sets `pointer-events: none` on these elements,
+  // even though we allowed interactive content in them.
+  .mdc-list-item__start,
+  .mdc-list-item__end,
+  .mdc-list-item__content {
+    pointer-events: auto;
+  }
 }
 
 // MDC expects that the list items are always `<li>`, since we actually use `<button>` in some


### PR DESCRIPTION
MDC applies `pointer-events: none` around different sections of the list item which breaks interactivity. As evidenced by the dev app demos, we support interactive content in them so these changes reset the `pointer-events` back to `auto`.

Fixes #26010.