### PR TITLE
fix(material/list): hover indication blocking interactions

### DIFF
--- a/src/material/list/list.scss
+++ b/src/material/list/list.scss
@@ -61,6 +61,7 @@ a.mdc-list-item--activated {
   @include layout-common.fill();
   content: '';
   opacity: 0;
+  pointer-events: none;
 }
 
 // MDC always sets the cursor to `pointer`. We do not want to show this for non-interactive


### PR DESCRIPTION
Fixes that the overlay we use for focus/hover events was blocking users from interacting with the list item content.

Fixes #26011.