### PR TITLE
fix(material/schematics): ensure mdc migration compatibility with nx

### DIFF
--- a/src/material/schematics/ng-generate/mdc-migration/schema.json
+++ b/src/material/schematics/ng-generate/mdc-migration/schema.json
@@ -46,6 +46,7 @@
       "x-prompt": {
         "message": "What components do you want to migrate?",
         "type": "list",
+        "multiselect": true,
         "items": [
           {
             "value": "button",


### PR DESCRIPTION
by adding missing `"multiselect": true` in the x-prompt for the `components` property