### PR TITLE
fix(material/legacy-tabs): Programmatically indicate tab-nav-bar chevron icons are disabled for screen reader users.

### DIFF
--- a/src/material/legacy-tabs/tab-nav-bar/tab-nav-bar.html
+++ b/src/material/legacy-tabs/tab-nav-bar/tab-nav-bar.html
@@ -7,6 +7,7 @@
      [matRippleDisabled]="_disableScrollBefore || disableRipple"
      [class.mat-tab-header-pagination-disabled]="_disableScrollBefore"
      [disabled]="_disableScrollBefore || null"
+     [attr.aria-disabled]="_disableScrollBefore || null"
      (click)="_handlePaginatorClick('before')"
      (mousedown)="_handlePaginatorPress('before', $event)"
      (touchend)="_stopInterval()">
@@ -34,6 +35,7 @@
      [matRippleDisabled]="_disableScrollAfter || disableRipple"
      [class.mat-tab-header-pagination-disabled]="_disableScrollAfter"
      [disabled]="_disableScrollAfter || null"
+     [attr.aria-disabled]="_disableScrollAfter || null"
      tabindex="-1"
      (mousedown)="_handlePaginatorPress('after', $event)"
      (click)="_handlePaginatorClick('after')"

--- a/src/material/legacy-tabs/tab-nav-bar/tab-nav-bar.spec.ts
+++ b/src/material/legacy-tabs/tab-nav-bar/tab-nav-bar.spec.ts
@@ -29,6 +29,7 @@ describe('MatTabNavBar', () => {
         TabBarWithoutPanelWithNativeTabindexAttr,
         TabBarWithInactiveTabsOnInit,
         TabBarWithoutPanel,
+        TabLinkWithLotsOfTabs,
       ],
       providers: [
         {provide: MAT_RIPPLE_GLOBAL_OPTIONS, useFactory: () => globalRippleOptions},
@@ -333,6 +334,55 @@ describe('MatTabNavBar', () => {
     expect(tabLinks[1].classList.contains('mat-tab-label-active')).toBe(true);
   });
 
+  describe('paginator', () => {
+    it('should aria-disable left paginator when paginator is disabled', () => {
+      const fixture = TestBed.createComponent(TabLinkWithLotsOfTabs);
+      fixture.detectChanges();
+
+      const leftPaginator = fixture.nativeElement.querySelector(
+        '.mat-tab-header-pagination-before',
+      );
+      expect(leftPaginator.getAttribute('aria-disabled')).toBe('true');
+    });
+    it('should not set aria-disabled attribute when left paginator is enabled', () => {
+      const fixture = TestBed.createComponent(TabLinkWithLotsOfTabs);
+      fixture.detectChanges();
+
+      const rightPaginator = fixture.nativeElement.querySelector(
+        '.mat-tab-header-pagination-after',
+      );
+      rightPaginator.click();
+      fixture.detectChanges();
+
+      const leftPaginator = fixture.nativeElement.querySelector(
+        '.mat-tab-header-pagination-before',
+      );
+      expect(leftPaginator.getAttribute('aria-disabled')).toBe(null);
+    });
+    it('should aria-disable right paginator when paginator is disabled', () => {
+      const fixture = TestBed.createComponent(TabLinkWithLotsOfTabs);
+      fixture.detectChanges();
+
+      const rightPaginator = fixture.nativeElement.querySelector(
+        '.mat-tab-header-pagination-after',
+      );
+      rightPaginator.click();
+      rightPaginator.click();
+      fixture.detectChanges();
+
+      expect(rightPaginator.getAttribute('aria-disabled')).toBe('true');
+    });
+    it('should not set aria-disabled attribute when right paginator is enabled', () => {
+      const fixture = TestBed.createComponent(TabLinkWithLotsOfTabs);
+      fixture.detectChanges();
+
+      const rightPaginator = fixture.nativeElement.querySelector(
+        '.mat-tab-header-pagination-after',
+      );
+      expect(rightPaginator.getAttribute('aria-disabled')).toBe(null);
+    });
+  });
+
   describe('ripples', () => {
     let fixture: ComponentFixture<SimpleTabNavBarTestApp>;
 
@@ -608,3 +658,20 @@ class TabBarWithoutPanelWithTabIndexBinding {
   `,
 })
 class TabBarWithoutPanelWithNativeTabindexAttr {}
+
+@Component({
+  template: `
+    <nav mat-tab-nav-bar [tabPanel]="tabPanel">
+      <a mat-tab-link
+          *ngFor="let tab of tabs; let index = index"
+          [active]="activeIndex === index">
+        Tab link {{label}}
+      </a>
+    </nav>
+    <mat-tab-nav-panel #tabPanel >Tab panel</mat-tab-nav-panel>
+  `,
+})
+class TabLinkWithLotsOfTabs {
+  activeIndex = 0;
+  tabs = [0, 1, 2, 3, 4, 5, 6];
+}


### PR DESCRIPTION
Screen reader users are not informed of when the left and right chevron icons are disabled. Added aria-disabled to inform them.

BREAKING CHANGE: No breaking changes.

This is an accessibility change that should have no effect on builds.