### PR TITLE
fix(material/legacy-tabs): Remove ara-hidden from interactive chevron elements in tab-nav-bar

### DIFF
--- a/src/material/legacy-tabs/tab-nav-bar/tab-nav-bar.html
+++ b/src/material/legacy-tabs/tab-nav-bar/tab-nav-bar.html
@@ -1,7 +1,7 @@
 <button class="mat-tab-header-pagination mat-tab-header-pagination-before mat-elevation-z4"
      #previousPaginator
-     aria-hidden="true"
      type="button"
+     aria-label="previous page"
      mat-ripple
      tabindex="-1"
      [matRippleDisabled]="_disableScrollBefore || disableRipple"
@@ -28,8 +28,8 @@
 
 <button class="mat-tab-header-pagination mat-tab-header-pagination-after mat-elevation-z4"
      #nextPaginator
-     aria-hidden="true"
      type="button"
+     aria-label="next page"
      mat-ripple
      [matRippleDisabled]="_disableScrollAfter || disableRipple"
      [class.mat-tab-header-pagination-disabled]="_disableScrollAfter"

--- a/src/material/legacy-tabs/tab-nav-bar/tab-nav-bar.spec.ts
+++ b/src/material/legacy-tabs/tab-nav-bar/tab-nav-bar.spec.ts
@@ -333,6 +333,45 @@ describe('MatTabNavBar', () => {
     expect(tabLinks[1].classList.contains('mat-tab-label-active')).toBe(true);
   });
 
+  describe('paginator', () => {
+    it('should not hide left paginator from screen readers', () => {
+      const fixture = TestBed.createComponent(SimpleTabNavBarTestApp);
+      fixture.detectChanges();
+
+      const leftPaginator = fixture.nativeElement.querySelector(
+        '.mat-tab-header-pagination-before',
+      );
+      expect(leftPaginator.getAttribute('aria-hidden')).toBe(null);
+    });
+    it('should have a aria label on the left paginator', () => {
+      const fixture = TestBed.createComponent(SimpleTabNavBarTestApp);
+      fixture.detectChanges();
+
+      const leftPaginator = fixture.nativeElement.querySelector(
+        '.mat-tab-header-pagination-before',
+      );
+      expect(leftPaginator.getAttribute('aria-label')).toBe('previous page');
+    });
+    it('should not hide the right paginator from screen reader users', () => {
+      const fixture = TestBed.createComponent(SimpleTabNavBarTestApp);
+      fixture.detectChanges();
+
+      const rightPaginator = fixture.nativeElement.querySelector(
+        '.mat-tab-header-pagination-after',
+      );
+      expect(rightPaginator.getAttribute('aria-hidden')).toBe(null);
+    });
+    it('should have a aria label on the right paginator', () => {
+      const fixture = TestBed.createComponent(SimpleTabNavBarTestApp);
+      fixture.detectChanges();
+
+      const rightPaginator = fixture.nativeElement.querySelector(
+        '.mat-tab-header-pagination-after',
+      );
+      expect(rightPaginator.getAttribute('aria-label')).toBe('next page');
+    });
+  });
+
   describe('ripples', () => {
     let fixture: ComponentFixture<SimpleTabNavBarTestApp>;
 


### PR DESCRIPTION
Screen reader users are not informed of whe nthe left and right chevron icons are disabled since the icons are aria-hidden from them. Removing aria-hidden so they are informed of the button's disabled state.

BREAKING CHANGE: No breaking changes.

This is an accessibility change that should have no effect on builds.