### PR TITLE
fix(material/tabs): icons not centered inside tab

### DIFF
--- a/src/material/tabs/_tabs-common.scss
+++ b/src/material/tabs/_tabs-common.scss
@@ -51,6 +51,12 @@ $mat-tab-animation-duration: 500ms !default;
     pointer-events: none;
   }
 
+  // We support projecting icons into the tab. These styles ensure that they're centered.
+  .mdc-tab__text-label {
+    display: inline-flex;
+    align-items: center;
+  }
+
   // Required for `fitInkBarToContent` to work. This used to be included with MDC's `without-ripple`
   // mixin, but that no longer appears to be the case with `static-styles`. Since the latter is
   // ~10kb smaller, we include this one extra style ourselves.


### PR DESCRIPTION
Fixes that icons projected into a tab were centered anymore.

Relates to https://github.com/angular/components/issues/26024#issuecomment-1320335400.