### PR TITLE
fix(material/form-field): change selector to allow density class on form field

### DIFF
--- a/src/material/form-field/_form-field-density.scss
+++ b/src/material/form-field/_form-field-density.scss
@@ -78,7 +78,7 @@
   // on whether a textarea is used. This is not possible in our implementation of the
   // form-field because we do not know what type of form-field control is set up. Hence
   // we always use a fixed position for the label. This does not have any implications.
-  .mat-mdc-form-field .mat-mdc-text-field-wrapper .mat-mdc-floating-label {
+  .mat-mdc-text-field-wrapper .mat-mdc-form-field-flex .mat-mdc-floating-label {
     top: math.div($height, 2);
   }
 


### PR DESCRIPTION
Fixes that one of the form field density selectors was targeting `.mat-mdc-form-field` which prevents users from setting density classes directly on the form field.

Fixes #26062.