### PR TITLE
fix(material/tooltip): missing positionAtOrigin documentation

### DIFF
--- a/src/material/tooltip/tooltip.ts
+++ b/src/material/tooltip/tooltip.ts
@@ -200,6 +200,10 @@ export abstract class _MatTooltipBase<T extends _TooltipComponentBase>
     }
   }
 
+  /**
+   * for whether tooltips should be positioned near the click or touch origin
+   * instead of outside the element bounding box.
+   */
   @Input('matTooltipPositionAtOrigin')
   get positionAtOrigin(): boolean {
     return this._positionAtOrigin;

--- a/tools/public_api_guard/material/tooltip.md
+++ b/tools/public_api_guard/material/tooltip.md
@@ -107,7 +107,6 @@ export abstract class _MatTooltipBase<T extends _TooltipComponentBase> implement
     _overlayRef: OverlayRef | null;
     get position(): TooltipPosition;
     set position(value: TooltipPosition);
-    // (undocumented)
     get positionAtOrigin(): boolean;
     set positionAtOrigin(value: BooleanInput);
     show(delay?: number, origin?: {


### PR DESCRIPTION
## Description

The `positionAtOrigin` documentation is missing on Material website: https://material.angular.io/components/tooltip/api

## Current behavior

blank description of the Input.

## New behavior

Comment added on the Input to be rendered on the documentation website.

## Related issue

fixes #26078