### PR TITLE
fix(material/toolbar): inherit toolbar color in flat buttons

### DIFF
--- a/src/dev-app/dev-app/dev-app-layout.scss
+++ b/src/dev-app/dev-app/dev-app-layout.scss
@@ -73,8 +73,4 @@ body {
 .demo-config-buttons {
   display: flex;
   align-items: center;
-
-  .mat-mdc-button-base {
-    --mdc-text-button-label-text-color: inherit;
-  }
 }

--- a/src/material/toolbar/toolbar.scss
+++ b/src/material/toolbar/toolbar.scss
@@ -10,6 +10,11 @@ $height-mobile-portrait: 56px !default;
   @include cdk.high-contrast(active, off) {
     outline: solid 1px;
   }
+
+  .mat-mdc-button-base {
+    --mdc-text-button-label-text-color: inherit;
+    --mdc-outlined-button-label-text-color: inherit;
+  }
 }
 
 .mat-toolbar-row, .mat-toolbar-single-row {


### PR DESCRIPTION
Fixes that MDC-based buttons placed inside a toolbar weren't inheriting its text color like the non-MDC buttons.

Fixes #26063.