### PR TITLE
fix(material/core): ripples not being removed if container is hidden

### DIFF
--- a/src/material/core/ripple/ripple-renderer.ts
+++ b/src/material/core/ripple/ripple-renderer.ts
@@ -153,16 +153,19 @@ export class RippleRenderer implements EventListenerObject {
     const userTransitionProperty = computedStyles.transitionProperty;
     const userTransitionDuration = computedStyles.transitionDuration;
 
-    // Note: We detect whether animation is forcibly disabled through CSS by the use of
-    // `transition: none`. This is technically unexpected since animations are controlled
-    // through the animation config, but this exists for backwards compatibility. This logic does
-    // not need to be super accurate since it covers some edge cases which can be easily avoided by users.
+    // Note: We detect whether animation is forcibly disabled through CSS (e.g. through
+    // `transition: none` or `display: none`). This is technically unexpected since animations are
+    // controlled through the animation config, but this exists for backwards compatibility. This
+    // logic does not need to be super accurate since it covers some edge cases which can be easily
+    // avoided by users.
     const animationForciblyDisabledThroughCss =
       userTransitionProperty === 'none' ||
       // Note: The canonical unit for serialized CSS `<time>` properties is seconds. Additionally
       // some browsers expand the duration for every property (in our case `opacity` and `transform`).
       userTransitionDuration === '0s' ||
-      userTransitionDuration === '0s, 0s';
+      userTransitionDuration === '0s, 0s' ||
+      // If the container is 0x0, it's likely `display: none`.
+      (containerRect.width === 0 && containerRect.height === 0);
 
     // Exposed reference to the ripple that will be returned.
     const rippleRef = new RippleRef(this, ripple, config, animationForciblyDisabledThroughCss);


### PR DESCRIPTION
Fixes that the ripples weren't being removed if the ripple container has `display: none` on it. This is a bit of an edge case that I hit while working on a different task, but it's easy to guard against since we have all the information to know when it happens.