### PR TITLE
fix(material/slide-toggle): focus indication not showing inside OnPush parent

### DIFF
--- a/src/material/slide-toggle/slide-toggle.ts
+++ b/src/material/slide-toggle/slide-toggle.ts
@@ -180,6 +180,7 @@ export abstract class _MatSlideToggleBase<T>
     this._focusMonitor.monitor(this._elementRef, true).subscribe(focusOrigin => {
       if (focusOrigin === 'keyboard' || focusOrigin === 'program') {
         this._focused = true;
+        this._changeDetectorRef.markForCheck();
       } else if (!focusOrigin) {
         // When a focused element becomes disabled, the browser *immediately* fires a blur event.
         // Angular does not expect events to be raised during change detection, so any state


### PR DESCRIPTION
Fixes that the focus indication wasn't showing up when the slide toggle is placed inside of an `OnPush` component.