### PR TITLE
fix(cdk/menu): not closing when inside shadow DOM

### DIFF
--- a/src/cdk/menu/context-menu-trigger.ts
+++ b/src/cdk/menu/context-menu-trigger.ts
@@ -15,6 +15,7 @@ import {
   STANDARD_DROPDOWN_BELOW_POSITIONS,
 } from '@angular/cdk/overlay';
 import {BooleanInput, coerceBooleanProperty} from '@angular/cdk/coercion';
+import {_getEventTarget} from '@angular/cdk/platform';
 import {merge, partition} from 'rxjs';
 import {skip, takeUntil} from 'rxjs/operators';
 import {MENU_STACK, MenuStack} from './menu-stack';
@@ -191,7 +192,7 @@ export class CdkContextMenuTrigger extends CdkMenuTriggerBase implements OnDestr
         outsideClicks = merge(nonAuxClicks, auxClicks.pipe(skip(1)));
       }
       outsideClicks.pipe(takeUntil(this.stopOutsideClicksListener)).subscribe(event => {
-        if (!this.isElementInsideMenuStack(event.target as Element)) {
+        if (!this.isElementInsideMenuStack(_getEventTarget(event)!)) {
           this.menuStack.closeAll();
         }
       });


### PR DESCRIPTION
Fixes that the CDK menu wasn't closing on outside clicks when the trigger is inside the shadow DOM. The problem is that reading the `Event.target` doesn't work as expected in the shadow DOM and we have to go through a helper.

Fixes #26107.