### PR TITLE
perf(material/chips): reduce amount of macro tasks

### DIFF
--- a/src/material/chips/chip-grid.ts
+++ b/src/material/chips/chip-grid.ts
@@ -363,15 +363,7 @@ export class MatChipGrid
     // We must keep this up to date to handle the case where ids are set
     // before the chip input is registered.
     this._ariaDescribedbyIds = ids;
-
-    if (this._chipInput) {
-      // Use a setTimeout in case this is being run during change detection
-      // and the chip input has already determined its host binding for
-      // aria-describedBy.
-      setTimeout(() => {
-        this._chipInput.setDescribedByIds(ids);
-      }, 0);
-    }
+    this._chipInput?.setDescribedByIds(ids);
   }
 
   /**

--- a/src/material/chips/chip-input.ts
+++ b/src/material/chips/chip-input.ts
@@ -65,7 +65,6 @@ let nextUniqueId = 0;
     '[attr.disabled]': 'disabled || null',
     '[attr.placeholder]': 'placeholder || null',
     '[attr.aria-invalid]': '_chipGrid && _chipGrid.ngControl ? _chipGrid.ngControl.invalid : null',
-    '[attr.aria-describedby]': '_ariaDescribedby || null',
     '[attr.aria-required]': '_chipGrid && _chipGrid.required || null',
     '[attr.required]': '_chipGrid && _chipGrid.required || null',
   },
@@ -73,9 +72,6 @@ let nextUniqueId = 0;
 export class MatChipInput implements MatChipTextControl, AfterContentInit, OnChanges, OnDestroy {
   /** Used to prevent focus moving to chips while user is holding backspace */
   private _focusLastChipOnBackspace: boolean;
-
-  /** Value for ariaDescribedby property */
-  _ariaDescribedby?: string;
 
   /** Whether the control is focused. */
   focused: boolean = false;
@@ -241,7 +237,15 @@ export class MatChipInput implements MatChipTextControl, AfterContentInit, OnCha
   }
 
   setDescribedByIds(ids: string[]): void {
-    this._ariaDescribedby = ids.join(' ');
+    const element = this._elementRef.nativeElement;
+
+    // Set the value directly in the DOM since this binding
+    // is prone to "changed after checked" errors.
+    if (ids.length) {
+      element.setAttribute('aria-describedby', ids.join(' '));
+    } else {
+      element.removeAttribute('aria-describedby');
+    }
   }
 
   /** Checks whether a keycode is one of the configured separators. */

--- a/src/material/chips/chip-set.ts
+++ b/src/material/chips/chip-set.ts
@@ -199,7 +199,7 @@ export class MatChipSet
     if (this.tabIndex !== -1) {
       this.tabIndex = -1;
 
-      setTimeout(() => {
+      Promise.resolve().then(() => {
         this.tabIndex = previousTabIndex;
         this._changeDetectorRef.markForCheck();
       });

--- a/tools/public_api_guard/material/chips.md
+++ b/tools/public_api_guard/material/chips.md
@@ -229,7 +229,6 @@ export class MatChipInput implements MatChipTextControl, AfterContentInit, OnCha
     set addOnBlur(value: BooleanInput);
     // (undocumented)
     _addOnBlur: boolean;
-    _ariaDescribedby?: string;
     _blur(): void;
     readonly chipEnd: EventEmitter<MatChipInputEvent>;
     set chipGrid(value: MatChipGrid);


### PR DESCRIPTION
* Fixes that the chip grid was triggering a bunch of change detections on initialization through a `setTimeout` inside `setDescribedByIds`.
* Replaces most of the remaining timeouts in the chips with `Promise.resolve`.

Fixes #25325.