### PR TITLE
docs(material/form-field): remove font size example

### DIFF
--- a/src/components-examples/material/form-field/form-field-theming/form-field-theming-example.html
+++ b/src/components-examples/material/form-field/form-field-theming/form-field-theming-example.html
@@ -1,17 +1,8 @@
-<form class="example-container" [formGroup]="options" [style.fontSize.px]="getFontSize()">
-  <mat-form-field appearance="fill" [color]="options.value.color">
-    <mat-label>Color</mat-label>
-    <mat-select formControlName="color">
-      <mat-option value="primary">Primary</mat-option>
-      <mat-option value="accent">Accent</mat-option>
-      <mat-option value="warn">Warn</mat-option>
-    </mat-select>
-  </mat-form-field>
-
-  <mat-form-field appearance="fill" [color]="options.value.color">
-    <mat-label>Font size</mat-label>
-    <input matInput type="number" placeholder="Ex. 12" formControlName="fontSize" min="10">
-    <span matTextSuffix>px</span>
-    <mat-error *ngIf="options.get('fontSize')?.invalid">Min size: 10px</mat-error>
-  </mat-form-field>
-</form>
+<mat-form-field appearance="fill" [color]="colorControl.value!">
+  <mat-label>Color</mat-label>
+  <mat-select [formControl]="colorControl">
+    <mat-option value="primary">Primary</mat-option>
+    <mat-option value="accent">Accent</mat-option>
+    <mat-option value="warn">Warn</mat-option>
+  </mat-select>
+</mat-form-field>

--- a/src/components-examples/material/form-field/form-field-theming/form-field-theming-example.ts
+++ b/src/components-examples/material/form-field/form-field-theming/form-field-theming-example.ts
@@ -1,5 +1,5 @@
 import {Component} from '@angular/core';
-import {NonNullableFormBuilder, Validators} from '@angular/forms';
+import {FormControl} from '@angular/forms';
 import {ThemePalette} from '@angular/material/core';
 
 /** @title Form field theming */
@@ -9,14 +9,5 @@ import {ThemePalette} from '@angular/material/core';
   styleUrls: ['form-field-theming-example.css'],
 })
 export class FormFieldThemingExample {
-  options = this._formBuilder.group({
-    color: this._formBuilder.control('primary' as ThemePalette),
-    fontSize: this._formBuilder.control(16, Validators.min(10)),
-  });
-
-  constructor(private _formBuilder: NonNullableFormBuilder) {}
-
-  getFontSize() {
-    return Math.max(10, this.options.value.fontSize || 0);
-  }
+  colorControl = new FormControl('primary' as ThemePalette);
 }

--- a/src/material/form-field/form-field.md
+++ b/src/material/form-field/form-field.md
@@ -119,15 +119,6 @@ information on this see the guide on
 will set the color of the form field underline and floating label based on the theme colors
 of your app.
 
-`<mat-form-field>` inherits its `font-size` from its parent element. This can be overridden to an
-explicit size using CSS. We recommend a specificity of at least 1 element + 1 class.
-
-```css
-mat-form-field.mat-form-field {
-  font-size: 16px;
-}
-```
-
 <!-- example(form-field-theming) -->
 
 ### Accessibility


### PR DESCRIPTION
We don't support having the form field inherit the font size with the MDC version. These changes remove the example from the docs.

Fixes #26091.