### PR TITLE
build: enable ng-dev auth service

### DIFF
--- a/.ng-dev/github.mts
+++ b/.ng-dev/github.mts
@@ -8,4 +8,5 @@ export const github: GithubConfig = {
   owner: 'angular',
   name: 'components',
   mainBranchName: 'main',
+  useNgDevAuthService: true,
 };


### PR DESCRIPTION
Enable the authentication service for merging rather than using PATs