### PR TITLE
fix(material/datepicker): fix disabled style for datepicker in a legacy form field

### DIFF
--- a/src/material/datepicker/_datepicker-legacy-compat.scss
+++ b/src/material/datepicker/_datepicker-legacy-compat.scss
@@ -6,6 +6,10 @@
     @include button-theme.theme($theme);
     @include icon-button-theme.theme($theme);
   }
+
+  .mat-datepicker-toggle {
+    @include icon-button-theme.theme($theme);
+  }
 }
 
 @mixin legacy-button-compat() {

--- a/src/material/datepicker/_datepicker-legacy-compat.scss
+++ b/src/material/datepicker/_datepicker-legacy-compat.scss
@@ -13,7 +13,9 @@
 }
 
 @mixin legacy-button-compat() {
-  .mat-datepicker-toggle .mat-mdc-button-base {
+  // Class repeated for additional specificity to ensure this takes precedence over styles in
+  // legacy-button-compat-theme
+  .mat-datepicker-toggle.mat-datepicker-toggle .mat-mdc-button-base {
     width: 40px;
     height: 40px;
     padding: 8px 0;


### PR DESCRIPTION
[Reproduction StackBlitz](https://stackblitz.com/edit/angular-1sqlp8?file=src%2Ftheme.scss)

This affects the toggle in the *completely disabled* and *popup disabled* variants when using the legacy Form field component with Datepicker.

![Disabled Datepicker in legacy Form field using `@angular/material@15.0.1`](https://user-images.githubusercontent.com/6364586/205110368-d13e4c5a-0211-4ad6-91fc-29f859d8c0a8.png)

*Disabled Datepicker in legacy Form field using `@angular/material@15.0.1`.*

![Disabled Datepicker in legacy Form field with this bugfix](https://user-images.githubusercontent.com/6364586/205110373-41101733-f2d8-4ee7-b41f-aacf4e27bae7.png)

*Disabled Datepicker in legacy Form field with this bugfix.*

Fixes #26152.