### PR TITLE
fix(material/list): remove previously removed API

### DIFF
--- a/src/material/list/selection-list.ts
+++ b/src/material/list/selection-list.ts
@@ -46,12 +46,6 @@ export class MatSelectionListChange {
   constructor(
     /** Reference to the selection list that emitted the event. */
     public source: MatSelectionList,
-    /**
-     * Reference to the option that has been changed.
-     * @deprecated Use `options` instead, because some events may change more than one option.
-     * @breaking-change 12.0.0
-     */
-    public option: MatListOption,
     /** Reference to the options that have been changed. */
     public options: MatListOption[],
   ) {}
@@ -213,7 +207,7 @@ export class MatSelectionList
 
   /** Emits a change event if the selected state of an option changed. */
   _emitChangeEvent(options: MatListOption[]) {
-    this.selectionChange.emit(new MatSelectionListChange(this, options[0], options));
+    this.selectionChange.emit(new MatSelectionListChange(this, options));
   }
 
   /** Implemented as part of ControlValueAccessor. */

--- a/tools/public_api_guard/material/list.md
+++ b/tools/public_api_guard/material/list.md
@@ -260,10 +260,7 @@ export class MatSelectionList extends MatListBase implements SelectionList, Cont
 export class MatSelectionListChange {
     constructor(
     source: MatSelectionList,
-    option: MatListOption,
     options: MatListOption[]);
-    // @deprecated
-    option: MatListOption;
     options: MatListOption[];
     source: MatSelectionList;
 }


### PR DESCRIPTION
In #21974 the `MatSelectionChange.option` property was removed, but we accidentally re-added it during the MDC switch. These changes re-remove the property.

Fixes #26005.