### PR TITLE
fix(material/chips): set correct cursor on interactive chips

### DIFF
--- a/src/material/chips/chip-action.ts
+++ b/src/material/chips/chip-action.ts
@@ -28,9 +28,7 @@ const _MatChipActionMixinBase = mixinTabIndex(_MatChipActionBase, -1);
   host: {
     'class': 'mdc-evolution-chip__action mat-mdc-chip-action',
     '[class.mdc-evolution-chip__action--primary]': '_isPrimary',
-    // Note that while our actions are interactive, we have to add the `--presentational` class,
-    // in order to avoid some super-specific `:hover` styles from MDC.
-    '[class.mdc-evolution-chip__action--presentational]': '_isPrimary',
+    '[class.mdc-evolution-chip__action--presentational]': '!isInteractive',
     '[class.mdc-evolution-chip__action--trailing]': '!_isPrimary',
     '[attr.tabindex]': '_getTabindex()',
     '[attr.disabled]': '_getDisabledAttribute()',


### PR DESCRIPTION
We were always setting the `mdc-evolution-chip__action--presentational` class on the primary chip action to avoid some very specific `:hover` styles from MDC, but the side effect was the correct cursor wasn't being applied to the action anymore.

With the new token-based API we don't generate the `:hover` styles at all so we can re-add the class and fix the cursor.

Fixes #26050.