### PR TITLE
fix(cdk/listbox): set initial focus to selected option

### DIFF
--- a/src/cdk/listbox/listbox.spec.ts
+++ b/src/cdk/listbox/listbox.spec.ts
@@ -706,6 +706,38 @@ describe('CdkOption and CdkListbox', () => {
 
       expect(options[options.length - 1].isActive()).toBeTrue();
     });
+
+    it('should focus the selected option when the listbox is focused', () => {
+      const {testComponent, fixture, listbox, listboxEl, options} =
+        setupComponent(ListboxWithOptions);
+      testComponent.selectedValue = 'peach';
+      fixture.detectChanges();
+      listbox.focus();
+      fixture.detectChanges();
+
+      expect(options[3].isActive()).toBeTrue();
+
+      dispatchKeyboardEvent(listboxEl, 'keydown', UP_ARROW);
+      fixture.detectChanges();
+
+      expect(options[2].isActive()).toBeTrue();
+    });
+
+    it('should not move focus to the selected option while the user is navigating', () => {
+      const {testComponent, fixture, listbox, listboxEl, options} =
+        setupComponent(ListboxWithOptions);
+      listbox.focus();
+      fixture.detectChanges();
+      expect(options[0].isActive()).toBeTrue();
+
+      dispatchKeyboardEvent(listboxEl, 'keydown', DOWN_ARROW);
+      fixture.detectChanges();
+      expect(options[1].isActive()).toBeTrue();
+
+      testComponent.selectedValue = 'peach';
+      fixture.detectChanges();
+      expect(options[1].isActive()).toBeTrue();
+    });
   });
 
   describe('with roving tabindex', () => {
@@ -909,6 +941,7 @@ describe('CdkOption and CdkListbox', () => {
          [cdkListboxOrientation]="orientation"
          [cdkListboxNavigationWrapDisabled]="!navigationWraps"
          [cdkListboxNavigatesDisabledOptions]="!navigationSkipsDisabled"
+         [cdkListboxValue]="selectedValue"
          (cdkListboxValueChange)="onSelectionChange($event)">
       <div cdkOption="apple"
            [cdkOptionDisabled]="isAppleDisabled"
@@ -937,6 +970,7 @@ class ListboxWithOptions {
   appleId: string;
   appleTabindex: number;
   orientation: 'horizontal' | 'vertical' = 'vertical';
+  selectedValue: string;
 
   onSelectionChange(event: ListboxValueChangeEvent<unknown>) {
     this.changedOption = event.option;

--- a/tools/public_api_guard/cdk/listbox.md
+++ b/tools/public_api_guard/cdk/listbox.md
@@ -34,10 +34,12 @@ export class CdkListbox<T = unknown> implements AfterContentInit, OnDestroy, Con
     protected _getAriaActiveDescendant(): string | null | undefined;
     protected _getTabIndex(): number | null;
     protected _handleFocus(): void;
+    protected _handleFocusIn(): void;
     protected _handleFocusOut(event: FocusEvent): void;
     protected _handleKeydown(event: KeyboardEvent): void;
     get id(): string;
     set id(value: string);
+    isActive(option: CdkOption<T>): boolean;
     isSelected(option: CdkOption<T>): boolean;
     isValueSelected(value: T): boolean;
     protected listKeyManager: ActiveDescendantKeyManager<CdkOption<T>>;


### PR DESCRIPTION
Fixes that the listbox was setting the initial focus on a deselected option when a selected one was available.

**Note:** this fix is a bit more convoluted than it needs to be. E.g. ideally we would just focus the selected option when the listbox receives focus. We can't do that, because the listbox supports two different focus management modes: focus and `aria-activedescendant`. The former doesn't allow tabbing to the listbox.

Fixes #25833.