### PR TITLE
refactor(cdk/accordion): convert all directives to standalone

### DIFF
--- a/src/cdk/accordion/accordion-item.ts
+++ b/src/cdk/accordion/accordion-item.ts
@@ -32,6 +32,7 @@ let nextId = 0;
 @Directive({
   selector: 'cdk-accordion-item, [cdkAccordionItem]',
   exportAs: 'cdkAccordionItem',
+  standalone: true,
   providers: [
     // Provide `CDK_ACCORDION` as undefined to prevent nested accordion items from
     // registering to the same accordion.

--- a/src/cdk/accordion/accordion-module.ts
+++ b/src/cdk/accordion/accordion-module.ts
@@ -10,8 +10,10 @@ import {NgModule} from '@angular/core';
 import {CdkAccordion} from './accordion';
 import {CdkAccordionItem} from './accordion-item';
 
+const ACCORDION_DIRECTIVES = [CdkAccordion, CdkAccordionItem];
+
 @NgModule({
-  exports: [CdkAccordion, CdkAccordionItem],
-  declarations: [CdkAccordion, CdkAccordionItem],
+  imports: ACCORDION_DIRECTIVES,
+  exports: ACCORDION_DIRECTIVES,
 })
 export class CdkAccordionModule {}

--- a/src/cdk/accordion/accordion.ts
+++ b/src/cdk/accordion/accordion.ts
@@ -26,6 +26,7 @@ export const CDK_ACCORDION = new InjectionToken<CdkAccordion>('CdkAccordion');
 @Directive({
   selector: 'cdk-accordion, [cdkAccordion]',
   exportAs: 'cdkAccordion',
+  standalone: true,
   providers: [{provide: CDK_ACCORDION, useExisting: CdkAccordion}],
 })
 export class CdkAccordion implements OnDestroy, OnChanges {

--- a/tools/public_api_guard/cdk/accordion.md
+++ b/tools/public_api_guard/cdk/accordion.md
@@ -29,7 +29,7 @@ export class CdkAccordion implements OnDestroy, OnChanges {
     readonly _openCloseAllActions: Subject<boolean>;
     readonly _stateChanges: Subject<SimpleChanges>;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkAccordion, "cdk-accordion, [cdkAccordion]", ["cdkAccordion"], { "multi": "multi"; }, {}, never, never, false, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkAccordion, "cdk-accordion, [cdkAccordion]", ["cdkAccordion"], { "multi": "multi"; }, {}, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<CdkAccordion, never>;
 }
@@ -55,7 +55,7 @@ export class CdkAccordionItem implements OnDestroy {
     readonly opened: EventEmitter<void>;
     toggle(): void;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkAccordionItem, "cdk-accordion-item, [cdkAccordionItem]", ["cdkAccordionItem"], { "expanded": "expanded"; "disabled": "disabled"; }, { "closed": "closed"; "opened": "opened"; "destroyed": "destroyed"; "expandedChange": "expandedChange"; }, never, never, false, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkAccordionItem, "cdk-accordion-item, [cdkAccordionItem]", ["cdkAccordionItem"], { "expanded": "expanded"; "disabled": "disabled"; }, { "closed": "closed"; "opened": "opened"; "destroyed": "destroyed"; "expandedChange": "expandedChange"; }, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<CdkAccordionItem, [{ optional: true; skipSelf: true; }, null, null]>;
 }
@@ -67,7 +67,7 @@ export class CdkAccordionModule {
     // (undocumented)
     static ɵinj: i0.ɵɵInjectorDeclaration<CdkAccordionModule>;
     // (undocumented)
-    static ɵmod: i0.ɵɵNgModuleDeclaration<CdkAccordionModule, [typeof i1.CdkAccordion, typeof i2.CdkAccordionItem], never, [typeof i1.CdkAccordion, typeof i2.CdkAccordionItem]>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<CdkAccordionModule, never, [typeof i1.CdkAccordion, typeof i2.CdkAccordionItem], [typeof i1.CdkAccordion, typeof i2.CdkAccordionItem]>;
 }
 
 // (No @packageDocumentation comment for this package)


### PR DESCRIPTION
This work converts all of the `@angular/cdk/accordion` directives to `standalone`. With these changes, `accordion` directives can be used as host directives.