### PR TITLE
fix(material/button): use token API for typography

### DIFF
--- a/src/material/button/_button-base.scss
+++ b/src/material/button/_button-base.scss
@@ -4,14 +4,20 @@
 @use '../core/style/layout-common';
 @use '../core/mdc-helpers/mdc-helpers';
 
+// Styles to ensure consistent rendering of buttons across browsers.
+@mixin mat-private-button-reset() {
+  text-decoration: none;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  -webkit-tap-highlight-color: transparent;
+}
+
 // Adds styles necessary to provide stateful interactions with the button. This includes providing
 // content for the state container's ::before and ::after so that they can be given a background
 // color and opacity for states like hover, active, and focus. Additionally, adds styles to the
 // ripple and state container so that they fill the button, match the border radius, and avoid
 // pointer events.
 @mixin mat-private-button-interactive() {
-  -webkit-tap-highlight-color: transparent;
-
   // The ripple container should match the bounds of the entire button.
   .mat-mdc-button-ripple,
   .mat-mdc-button-persistent-ripple,

--- a/src/material/button/_button-theme.scss
+++ b/src/material/button/_button-theme.scss
@@ -1,11 +1,11 @@
 @use 'sass:map';
-@use '@material/button/button' as mdc-button;
 @use '@material/button/button-theme' as mdc-button-theme;
 @use '@material/button/button-text-theme' as mdc-button-text-theme;
 @use '@material/button/button-filled-theme' as mdc-button-filled-theme;
 @use '@material/button/button-protected-theme' as mdc-button-protected-theme;
 @use '@material/button/button-outlined-theme' as mdc-button-outlined-theme;
 @use '@material/theme/theme-color' as mdc-theme-color;
+@use '@material/typography/typography' as mdc-typography;
 
 @use './button-theme-private';
 @use '../core/mdc-helpers/mdc-helpers';
@@ -187,7 +187,28 @@
   $config: typography.private-typography-to-2018-config(
     theming.get-typography-config($config-or-theme));
   @include mdc-helpers.using-mdc-typography($config) {
-    @include mdc-button.without-ripple($query: mdc-helpers.$mdc-typography-styles-query);
+    $tokens: (
+      label-text-font: mdc-typography.get-font(button),
+      label-text-size: mdc-typography.get-size(button),
+      label-text-tracking: mdc-typography.get-tracking(button),
+      label-text-weight: mdc-typography.get-weight(button),
+    );
+
+    .mat-mdc-button {
+      @include mdc-button-text-theme.theme($tokens);
+    }
+
+    .mat-mdc-unelevated-button {
+      @include mdc-button-filled-theme.theme($tokens);
+    }
+
+    .mat-mdc-raised-button {
+      @include mdc-button-protected-theme.theme($tokens);
+    }
+
+    .mat-mdc-outlined-button {
+      @include mdc-button-outlined-theme.theme($tokens);
+    }
   }
 }
 

--- a/src/material/button/_fab-theme.scss
+++ b/src/material/button/_fab-theme.scss
@@ -65,6 +65,7 @@
   $config: typography.private-typography-to-2018-config(
     theming.get-typography-config($config-or-theme));
   @include mdc-helpers.using-mdc-typography($config) {
+    // TODO(crisbeto): the FAB typography isn't supported through the theming API yet.
     @include mdc-fab.without-ripple($query: mdc-helpers.$mdc-typography-styles-query);
   }
 }

--- a/src/material/button/_icon-button-theme.scss
+++ b/src/material/button/_icon-button-theme.scss
@@ -6,7 +6,6 @@
 @use './button-theme-private';
 @use '../core/mdc-helpers/mdc-helpers';
 @use '../core/theming/theming';
-@use '../core/typography/typography';
 
 @mixin color($config-or-theme) {
   $config: theming.get-color-config($config-or-theme);
@@ -40,13 +39,7 @@
   }
 }
 
-@mixin typography($config-or-theme) {
-  $config: typography.private-typography-to-2018-config(
-    theming.get-typography-config($config-or-theme));
-  @include mdc-helpers.using-mdc-typography($config) {
-    @include mdc-icon-button.without-ripple($query: mdc-helpers.$mdc-typography-styles-query);
-  }
-}
+@mixin typography($config-or-theme) {}
 
 @mixin density($config-or-theme) {
   $density-scale: theming.get-density-config($config-or-theme);

--- a/src/material/button/button.scss
+++ b/src/material/button/button.scss
@@ -17,11 +17,7 @@
 
   // Keys to exclude from the MDC theme config, allowing us to drop styles we don't need.
   $override-keys: button-base.mat-private-button-remove-ripple((
-    label-text-font: null,
-    label-text-size: null,
-    label-text-tracking: null,
     label-text-transform: null,
-    label-text-weight: null,
     with-icon-icon-size: null,
     label-text-color: inherit,
   ));
@@ -58,6 +54,7 @@
 .mat-mdc-raised-button,
 .mat-mdc-outlined-button {
   @include button-base.mat-private-button-interactive();
+  @include button-base.mat-private-button-reset();
   @include button-base.mat-private-button-disabled();
   @include button-base.mat-private-button-touch-target(false);
   @include style-private.private-animation-noop();

--- a/src/material/button/fab.scss
+++ b/src/material/button/fab.scss
@@ -12,6 +12,7 @@
 
 .mat-mdc-fab, .mat-mdc-mini-fab {
   @include button-base.mat-private-button-interactive();
+  @include button-base.mat-private-button-reset();
   @include button-base.mat-private-button-touch-target(true);
   @include style-private.private-animation-noop();
 

--- a/src/material/button/icon-button.scss
+++ b/src/material/button/icon-button.scss
@@ -45,6 +45,7 @@
   };
 
   @include button-base.mat-private-button-interactive();
+  @include button-base.mat-private-button-reset();
   @include button-base.mat-private-button-touch-target(true);
   @include private.private-animation-noop();
 


### PR DESCRIPTION
Fixes that the buttons were going through the `without-ripple` mixins for their typography, instead of the token API. Note that the FAB isn't included here, because it doesn't support typography through tokens yet.