### PR TITLE
refactor(cdk/table): convert all directives to standalone

### DIFF
--- a/src/cdk/table/cell.ts
+++ b/src/cdk/table/cell.ts
@@ -28,7 +28,10 @@ export interface CellDef {
  * Cell definition for a CDK table.
  * Captures the template of a column's data row cell as well as cell-specific properties.
  */
-@Directive({selector: '[cdkCellDef]'})
+@Directive({
+  selector: '[cdkCellDef]',
+  standalone: true,
+})
 export class CdkCellDef implements CellDef {
   constructor(/** @docs-private */ public template: TemplateRef<any>) {}
 }
@@ -37,7 +40,10 @@ export class CdkCellDef implements CellDef {
  * Header cell definition for a CDK table.
  * Captures the template of a column's header cell and as well as cell-specific properties.
  */
-@Directive({selector: '[cdkHeaderCellDef]'})
+@Directive({
+  selector: '[cdkHeaderCellDef]',
+  standalone: true,
+})
 export class CdkHeaderCellDef implements CellDef {
   constructor(/** @docs-private */ public template: TemplateRef<any>) {}
 }
@@ -46,7 +52,10 @@ export class CdkHeaderCellDef implements CellDef {
  * Footer cell definition for a CDK table.
  * Captures the template of a column's footer cell and as well as cell-specific properties.
  */
-@Directive({selector: '[cdkFooterCellDef]'})
+@Directive({
+  selector: '[cdkFooterCellDef]',
+  standalone: true,
+})
 export class CdkFooterCellDef implements CellDef {
   constructor(/** @docs-private */ public template: TemplateRef<any>) {}
 }
@@ -63,6 +72,7 @@ const _CdkColumnDefBase: CanStickCtor & typeof CdkColumnDefBase =
  */
 @Directive({
   selector: '[cdkColumnDef]',
+  standalone: true,
   inputs: ['sticky'],
   providers: [{provide: 'MAT_SORT_HEADER_COLUMN_DEF', useExisting: CdkColumnDef}],
 })
@@ -157,6 +167,7 @@ export class BaseCdkCell {
 /** Header cell template container that adds the right classes and role. */
 @Directive({
   selector: 'cdk-header-cell, th[cdk-header-cell]',
+  standalone: true,
   host: {
     'class': 'cdk-header-cell',
     'role': 'columnheader',
@@ -171,6 +182,7 @@ export class CdkHeaderCell extends BaseCdkCell {
 /** Footer cell template container that adds the right classes and role. */
 @Directive({
   selector: 'cdk-footer-cell, td[cdk-footer-cell]',
+  standalone: true,
   host: {
     'class': 'cdk-footer-cell',
   },
@@ -189,6 +201,7 @@ export class CdkFooterCell extends BaseCdkCell {
 /** Cell template container that adds the right classes and role. */
 @Directive({
   selector: 'cdk-cell, td[cdk-cell]',
+  standalone: true,
   host: {
     'class': 'cdk-cell',
   },

--- a/src/cdk/table/row.ts
+++ b/src/cdk/table/row.ts
@@ -92,6 +92,7 @@ const _CdkHeaderRowDefBase: CanStickCtor & typeof CdkHeaderRowDefBase =
  */
 @Directive({
   selector: '[cdkHeaderRowDef]',
+  standalone: true,
   inputs: ['columns: cdkHeaderRowDef', 'sticky: cdkHeaderRowDefSticky'],
 })
 export class CdkHeaderRowDef extends _CdkHeaderRowDefBase implements CanStick, OnChanges {
@@ -122,6 +123,7 @@ const _CdkFooterRowDefBase: CanStickCtor & typeof CdkFooterRowDefBase =
  */
 @Directive({
   selector: '[cdkFooterRowDef]',
+  standalone: true,
   inputs: ['columns: cdkFooterRowDef', 'sticky: cdkFooterRowDefSticky'],
 })
 export class CdkFooterRowDef extends _CdkFooterRowDefBase implements CanStick, OnChanges {
@@ -147,6 +149,7 @@ export class CdkFooterRowDef extends _CdkFooterRowDefBase implements CanStick, O
  */
 @Directive({
   selector: '[cdkRowDef]',
+  standalone: true,
   inputs: ['columns: cdkRowDefColumns', 'when: cdkRowDefWhen'],
 })
 export class CdkRowDef<T> extends BaseRowDef {
@@ -228,7 +231,10 @@ export interface CdkCellOutletMultiRowContext<T> {
  * Outlet for rendering cells inside of a row or header row.
  * @docs-private
  */
-@Directive({selector: '[cdkCellOutlet]'})
+@Directive({
+  selector: '[cdkCellOutlet]',
+  standalone: true,
+})
 export class CdkCellOutlet implements OnDestroy {
   /** The ordered list of cells to render within this outlet's view container */
   cells: CdkCellDef[];
@@ -306,6 +312,7 @@ export class CdkRow {}
 /** Row that can be used to display a message when no data is shown in the table. */
 @Directive({
   selector: 'ng-template[cdkNoDataRow]',
+  standalone: true,
 })
 export class CdkNoDataRow {
   _contentClassName = 'cdk-no-data-row';

--- a/src/cdk/table/table-module.ts
+++ b/src/cdk/table/table-module.ts
@@ -37,34 +37,31 @@ import {
 import {CdkTextColumn} from './text-column';
 import {ScrollingModule} from '@angular/cdk/scrolling';
 
-const EXPORTED_DECLARATIONS = [
-  CdkTable,
-  CdkRowDef,
+const TABLE_DIRECTIVES = [
   CdkCellDef,
-  CdkCellOutlet,
   CdkHeaderCellDef,
   CdkFooterCellDef,
   CdkColumnDef,
-  CdkCell,
-  CdkRow,
   CdkHeaderCell,
   CdkFooterCell,
-  CdkHeaderRow,
+  CdkCell,
   CdkHeaderRowDef,
-  CdkFooterRow,
   CdkFooterRowDef,
+  CdkRowDef,
+  CdkCellOutlet,
+  CdkNoDataRow,
+  CdkRecycleRows,
   DataRowOutlet,
   HeaderRowOutlet,
   FooterRowOutlet,
-  CdkTextColumn,
-  CdkNoDataRow,
-  CdkRecycleRows,
   NoDataRowOutlet,
 ];
 
+const EXPORTED_DECLARATIONS = [CdkTable, CdkRow, CdkHeaderRow, CdkFooterRow, CdkTextColumn];
+
 @NgModule({
-  exports: EXPORTED_DECLARATIONS,
+  exports: [...EXPORTED_DECLARATIONS, ...TABLE_DIRECTIVES],
   declarations: EXPORTED_DECLARATIONS,
-  imports: [ScrollingModule],
+  imports: [ScrollingModule, ...TABLE_DIRECTIVES],
 })
 export class CdkTableModule {}

--- a/src/cdk/table/table.ts
+++ b/src/cdk/table/table.ts
@@ -92,6 +92,7 @@ import {CDK_TABLE} from './tokens';
  */
 @Directive({
   selector: 'cdk-table[recycleRows], table[cdk-table][recycleRows]',
+  standalone: true,
   providers: [{provide: _VIEW_REPEATER_STRATEGY, useClass: _RecycleViewRepeaterStrategy}],
 })
 export class CdkRecycleRows {}
@@ -108,7 +109,10 @@ export type CdkTableDataSourceInput<T> = readonly T[] | DataSource<T> | Observab
  * Provides a handle for the table to grab the view container's ng-container to insert data rows.
  * @docs-private
  */
-@Directive({selector: '[rowOutlet]'})
+@Directive({
+  selector: '[rowOutlet]',
+  standalone: true,
+})
 export class DataRowOutlet implements RowOutlet {
   constructor(public viewContainer: ViewContainerRef, public elementRef: ElementRef) {}
 }
@@ -117,7 +121,10 @@ export class DataRowOutlet implements RowOutlet {
  * Provides a handle for the table to grab the view container's ng-container to insert the header.
  * @docs-private
  */
-@Directive({selector: '[headerRowOutlet]'})
+@Directive({
+  selector: '[headerRowOutlet]',
+  standalone: true,
+})
 export class HeaderRowOutlet implements RowOutlet {
   constructor(public viewContainer: ViewContainerRef, public elementRef: ElementRef) {}
 }
@@ -126,7 +133,10 @@ export class HeaderRowOutlet implements RowOutlet {
  * Provides a handle for the table to grab the view container's ng-container to insert the footer.
  * @docs-private
  */
-@Directive({selector: '[footerRowOutlet]'})
+@Directive({
+  selector: '[footerRowOutlet]',
+  standalone: true,
+})
 export class FooterRowOutlet implements RowOutlet {
   constructor(public viewContainer: ViewContainerRef, public elementRef: ElementRef) {}
 }
@@ -136,7 +146,10 @@ export class FooterRowOutlet implements RowOutlet {
  * container's ng-container to insert the no data row.
  * @docs-private
  */
-@Directive({selector: '[noDataRowOutlet]'})
+@Directive({
+  selector: '[noDataRowOutlet]',
+  standalone: true,
+})
 export class NoDataRowOutlet implements RowOutlet {
   constructor(public viewContainer: ViewContainerRef, public elementRef: ElementRef) {}
 }

--- a/tools/public_api_guard/cdk/table.md
+++ b/tools/public_api_guard/cdk/table.md
@@ -15,7 +15,7 @@ import { Directionality } from '@angular/cdk/bidi';
 import { ElementRef } from '@angular/core';
 import { EventEmitter } from '@angular/core';
 import * as i0 from '@angular/core';
-import * as i5 from '@angular/cdk/scrolling';
+import * as i4 from '@angular/cdk/scrolling';
 import { InjectionToken } from '@angular/core';
 import { IterableChanges } from '@angular/core';
 import { IterableDiffer } from '@angular/core';
@@ -82,7 +82,7 @@ export const CDK_TABLE_TEMPLATE = "\n  <ng-content select=\"caption\"></ng-conte
 export class CdkCell extends BaseCdkCell {
     constructor(columnDef: CdkColumnDef, elementRef: ElementRef);
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkCell, "cdk-cell, td[cdk-cell]", never, {}, {}, never, never, false, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkCell, "cdk-cell, td[cdk-cell]", never, {}, {}, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<CdkCell, never>;
 }
@@ -93,7 +93,7 @@ export class CdkCellDef implements CellDef {
     // (undocumented)
     template: TemplateRef<any>;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkCellDef, "[cdkCellDef]", never, {}, {}, never, never, false, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkCellDef, "[cdkCellDef]", never, {}, {}, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<CdkCellDef, never>;
 }
@@ -109,7 +109,7 @@ export class CdkCellOutlet implements OnDestroy {
     // (undocumented)
     _viewContainer: ViewContainerRef;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkCellOutlet, "[cdkCellOutlet]", never, {}, {}, never, never, false, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkCellOutlet, "[cdkCellOutlet]", never, {}, {}, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<CdkCellOutlet, never>;
 }
@@ -158,7 +158,7 @@ export class CdkColumnDef extends _CdkColumnDefBase implements CanStick {
     _table?: any;
     protected _updateColumnCssClassName(): void;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkColumnDef, "[cdkColumnDef]", never, { "sticky": "sticky"; "name": "cdkColumnDef"; "stickyEnd": "stickyEnd"; }, {}, ["cell", "headerCell", "footerCell"], never, false, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkColumnDef, "[cdkColumnDef]", never, { "sticky": "sticky"; "name": "cdkColumnDef"; "stickyEnd": "stickyEnd"; }, {}, ["cell", "headerCell", "footerCell"], never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<CdkColumnDef, [{ optional: true; }]>;
 }
@@ -167,7 +167,7 @@ export class CdkColumnDef extends _CdkColumnDefBase implements CanStick {
 export class CdkFooterCell extends BaseCdkCell {
     constructor(columnDef: CdkColumnDef, elementRef: ElementRef);
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkFooterCell, "cdk-footer-cell, td[cdk-footer-cell]", never, {}, {}, never, never, false, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkFooterCell, "cdk-footer-cell, td[cdk-footer-cell]", never, {}, {}, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<CdkFooterCell, never>;
 }
@@ -178,7 +178,7 @@ export class CdkFooterCellDef implements CellDef {
     // (undocumented)
     template: TemplateRef<any>;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkFooterCellDef, "[cdkFooterCellDef]", never, {}, {}, never, never, false, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkFooterCellDef, "[cdkFooterCellDef]", never, {}, {}, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<CdkFooterCellDef, never>;
 }
@@ -199,7 +199,7 @@ export class CdkFooterRowDef extends _CdkFooterRowDefBase implements CanStick, O
     // (undocumented)
     _table?: any;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkFooterRowDef, "[cdkFooterRowDef]", never, { "columns": "cdkFooterRowDef"; "sticky": "cdkFooterRowDefSticky"; }, {}, never, never, false, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkFooterRowDef, "[cdkFooterRowDef]", never, { "columns": "cdkFooterRowDef"; "sticky": "cdkFooterRowDefSticky"; }, {}, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<CdkFooterRowDef, [null, null, { optional: true; }]>;
 }
@@ -208,7 +208,7 @@ export class CdkFooterRowDef extends _CdkFooterRowDefBase implements CanStick, O
 export class CdkHeaderCell extends BaseCdkCell {
     constructor(columnDef: CdkColumnDef, elementRef: ElementRef);
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkHeaderCell, "cdk-header-cell, th[cdk-header-cell]", never, {}, {}, never, never, false, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkHeaderCell, "cdk-header-cell, th[cdk-header-cell]", never, {}, {}, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<CdkHeaderCell, never>;
 }
@@ -219,7 +219,7 @@ export class CdkHeaderCellDef implements CellDef {
     // (undocumented)
     template: TemplateRef<any>;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkHeaderCellDef, "[cdkHeaderCellDef]", never, {}, {}, never, never, false, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkHeaderCellDef, "[cdkHeaderCellDef]", never, {}, {}, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<CdkHeaderCellDef, never>;
 }
@@ -240,7 +240,7 @@ export class CdkHeaderRowDef extends _CdkHeaderRowDefBase implements CanStick, O
     // (undocumented)
     _table?: any;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkHeaderRowDef, "[cdkHeaderRowDef]", never, { "columns": "cdkHeaderRowDef"; "sticky": "cdkHeaderRowDefSticky"; }, {}, never, never, false, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkHeaderRowDef, "[cdkHeaderRowDef]", never, { "columns": "cdkHeaderRowDef"; "sticky": "cdkHeaderRowDefSticky"; }, {}, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<CdkHeaderRowDef, [null, null, { optional: true; }]>;
 }
@@ -253,7 +253,7 @@ export class CdkNoDataRow {
     // (undocumented)
     templateRef: TemplateRef<any>;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkNoDataRow, "ng-template[cdkNoDataRow]", never, {}, {}, never, never, false, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkNoDataRow, "ng-template[cdkNoDataRow]", never, {}, {}, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<CdkNoDataRow, never>;
 }
@@ -261,7 +261,7 @@ export class CdkNoDataRow {
 // @public
 export class CdkRecycleRows {
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkRecycleRows, "cdk-table[recycleRows], table[cdk-table][recycleRows]", never, {}, {}, never, never, false, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkRecycleRows, "cdk-table[recycleRows], table[cdk-table][recycleRows]", never, {}, {}, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<CdkRecycleRows, never>;
 }
@@ -281,7 +281,7 @@ export class CdkRowDef<T> extends BaseRowDef {
     _table?: any;
     when: (index: number, rowData: T) => boolean;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkRowDef<any>, "[cdkRowDef]", never, { "columns": "cdkRowDefColumns"; "when": "cdkRowDefWhen"; }, {}, never, never, false, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkRowDef<any>, "[cdkRowDef]", never, { "columns": "cdkRowDefColumns"; "when": "cdkRowDefWhen"; }, {}, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<CdkRowDef<any>, [null, null, { optional: true; }]>;
 }
@@ -376,7 +376,7 @@ export class CdkTableModule {
     // (undocumented)
     static ɵinj: i0.ɵɵInjectorDeclaration<CdkTableModule>;
     // (undocumented)
-    static ɵmod: i0.ɵɵNgModuleDeclaration<CdkTableModule, [typeof i1.CdkTable, typeof i2.CdkRowDef, typeof i3.CdkCellDef, typeof i2.CdkCellOutlet, typeof i3.CdkHeaderCellDef, typeof i3.CdkFooterCellDef, typeof i3.CdkColumnDef, typeof i3.CdkCell, typeof i2.CdkRow, typeof i3.CdkHeaderCell, typeof i3.CdkFooterCell, typeof i2.CdkHeaderRow, typeof i2.CdkHeaderRowDef, typeof i2.CdkFooterRow, typeof i2.CdkFooterRowDef, typeof i1.DataRowOutlet, typeof i1.HeaderRowOutlet, typeof i1.FooterRowOutlet, typeof i4.CdkTextColumn, typeof i2.CdkNoDataRow, typeof i1.CdkRecycleRows, typeof i1.NoDataRowOutlet], [typeof i5.ScrollingModule], [typeof i1.CdkTable, typeof i2.CdkRowDef, typeof i3.CdkCellDef, typeof i2.CdkCellOutlet, typeof i3.CdkHeaderCellDef, typeof i3.CdkFooterCellDef, typeof i3.CdkColumnDef, typeof i3.CdkCell, typeof i2.CdkRow, typeof i3.CdkHeaderCell, typeof i3.CdkFooterCell, typeof i2.CdkHeaderRow, typeof i2.CdkHeaderRowDef, typeof i2.CdkFooterRow, typeof i2.CdkFooterRowDef, typeof i1.DataRowOutlet, typeof i1.HeaderRowOutlet, typeof i1.FooterRowOutlet, typeof i4.CdkTextColumn, typeof i2.CdkNoDataRow, typeof i1.CdkRecycleRows, typeof i1.NoDataRowOutlet]>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<CdkTableModule, [typeof i1.CdkTable, typeof i2.CdkRow, typeof i2.CdkHeaderRow, typeof i2.CdkFooterRow, typeof i3.CdkTextColumn], [typeof i4.ScrollingModule, typeof i5.CdkCellDef, typeof i5.CdkHeaderCellDef, typeof i5.CdkFooterCellDef, typeof i5.CdkColumnDef, typeof i5.CdkHeaderCell, typeof i5.CdkFooterCell, typeof i5.CdkCell, typeof i2.CdkHeaderRowDef, typeof i2.CdkFooterRowDef, typeof i2.CdkRowDef, typeof i2.CdkCellOutlet, typeof i2.CdkNoDataRow, typeof i1.CdkRecycleRows, typeof i1.DataRowOutlet, typeof i1.HeaderRowOutlet, typeof i1.FooterRowOutlet, typeof i1.NoDataRowOutlet], [typeof i1.CdkTable, typeof i2.CdkRow, typeof i2.CdkHeaderRow, typeof i2.CdkFooterRow, typeof i3.CdkTextColumn, typeof i5.CdkCellDef, typeof i5.CdkHeaderCellDef, typeof i5.CdkFooterCellDef, typeof i5.CdkColumnDef, typeof i5.CdkHeaderCell, typeof i5.CdkFooterCell, typeof i5.CdkCell, typeof i2.CdkHeaderRowDef, typeof i2.CdkFooterRowDef, typeof i2.CdkRowDef, typeof i2.CdkCellOutlet, typeof i2.CdkNoDataRow, typeof i1.CdkRecycleRows, typeof i1.DataRowOutlet, typeof i1.HeaderRowOutlet, typeof i1.FooterRowOutlet, typeof i1.NoDataRowOutlet]>;
 }
 
 // @public
@@ -435,7 +435,7 @@ export class DataRowOutlet implements RowOutlet {
     // (undocumented)
     viewContainer: ViewContainerRef;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<DataRowOutlet, "[rowOutlet]", never, {}, {}, never, never, false, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<DataRowOutlet, "[rowOutlet]", never, {}, {}, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<DataRowOutlet, never>;
 }
@@ -450,7 +450,7 @@ export class FooterRowOutlet implements RowOutlet {
     // (undocumented)
     viewContainer: ViewContainerRef;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<FooterRowOutlet, "[footerRowOutlet]", never, {}, {}, never, never, false, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<FooterRowOutlet, "[footerRowOutlet]", never, {}, {}, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<FooterRowOutlet, never>;
 }
@@ -463,7 +463,7 @@ export class HeaderRowOutlet implements RowOutlet {
     // (undocumented)
     viewContainer: ViewContainerRef;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<HeaderRowOutlet, "[headerRowOutlet]", never, {}, {}, never, never, false, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<HeaderRowOutlet, "[headerRowOutlet]", never, {}, {}, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<HeaderRowOutlet, never>;
 }
@@ -479,7 +479,7 @@ export class NoDataRowOutlet implements RowOutlet {
     // (undocumented)
     viewContainer: ViewContainerRef;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<NoDataRowOutlet, "[noDataRowOutlet]", never, {}, {}, never, never, false, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<NoDataRowOutlet, "[noDataRowOutlet]", never, {}, {}, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<NoDataRowOutlet, never>;
 }


### PR DESCRIPTION
This work converts all of the `@angular/cdk/table` directives to `standalone`. With these changes, `table` directives can be used as host directives.