### PR TITLE
fix(material/toolbar): don't override colors of themed buttons

### DIFF
--- a/src/material/toolbar/toolbar.scss
+++ b/src/material/toolbar/toolbar.scss
@@ -11,7 +11,7 @@ $height-mobile-portrait: 56px !default;
     outline: solid 1px;
   }
 
-  .mat-mdc-button-base {
+  .mat-mdc-button-base.mat-unthemed {
     --mdc-text-button-label-text-color: inherit;
     --mdc-outlined-button-label-text-color: inherit;
   }


### PR DESCRIPTION
Fixes a regression caused by #26089 where the colors of all buttons in the toolbar were being overridden, instead of only the unthemed ones.

Fixes #26192.