### PR TITLE
docs(material/chips): communicate to AT that Enter will edit a chip

### DIFF
--- a/src/material/chips/chips.md
+++ b/src/material/chips/chips.md
@@ -40,6 +40,13 @@ Use `<mat-chip-grid>` and `<mat-chip-row>` for assisting users with text entry.
 
 Chips are always used inside a container. To create chips connected to an input field, start by creating a `<mat-chip-grid>` as the container. Add an `<input/>` element, and register it to the `<mat-chip-grid>` by passing the `matChipInputFor` Input. Always use an `<input/>` elemnt with `<mat-chip-grid>`. Nest a `<mat-chip-row>` element inside the `<mat-chip-grid>` for each piece of data entered by the user. An example of of using chips for text input.
 
+Editable chips change to the edit state on Enter key press or double click. Always add an accessible label or description to communicate that Enter key will begin editing.
+
+``` html
+<mat-chip-row [editable]="true" ariaDescription="press Enter to edit ketchup" ...
+
+```
+
 <!-- example(chips-input) -->
 
 #### Disabled `<mat-chip-row>`


### PR DESCRIPTION
Update a11y documentation for chips. Add instructions for editable chips to communicate to AT how to enter the editing state. Require putting an aria label or description that communicates that pressing Enter key will switch to the editing state.