### PR TITLE
fix(material/menu): add selector for projecting non-Material icons

### DIFF
--- a/src/material/menu/menu-item.html
+++ b/src/material/menu/menu-item.html
@@ -1,4 +1,4 @@
-<ng-content select="mat-icon"></ng-content>
+<ng-content select="mat-icon, [matMenuItemIcon]"></ng-content>
 <span class="mdc-list-item__primary-text"><ng-content></ng-content></span>
 <div class="mat-mdc-menu-ripple" matRipple
      [matRippleDisabled]="disableRipple || disabled"

--- a/tools/public_api_guard/material/menu.md
+++ b/tools/public_api_guard/material/menu.md
@@ -217,7 +217,7 @@ export class MatMenuItem extends _MatMenuItemBase implements FocusableOption, Ca
     _setTriggersSubmenu(triggersSubmenu: boolean): void;
     _triggersSubmenu: boolean;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<MatMenuItem, "[mat-menu-item]", ["matMenuItem"], { "disabled": "disabled"; "disableRipple": "disableRipple"; "role": "role"; }, {}, never, ["mat-icon", "*"], false, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MatMenuItem, "[mat-menu-item]", ["matMenuItem"], { "disabled": "disabled"; "disableRipple": "disableRipple"; "role": "role"; }, {}, never, ["mat-icon, [matMenuItemIcon]", "*"], false, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatMenuItem, [null, null, null, { optional: true; }, null]>;
 }


### PR DESCRIPTION
Adds the `matMenuItemIcon` selector to the `ng-content` so icons that aren't `mat-icon` can be projected in the correct place.

Fixes #26214.