### PR TITLE
fix(cdk/stepper): set focus origin when navigating with keyboard

### DIFF
--- a/src/cdk/stepper/stepper.ts
+++ b/src/cdk/stepper/stepper.ts
@@ -542,7 +542,7 @@ export class CdkStepper implements AfterContentInit, AfterViewInit, OnDestroy {
       this.selectedIndex = manager.activeItemIndex;
       event.preventDefault();
     } else {
-      manager.onKeydown(event);
+      manager.setFocusOrigin('keyboard').onKeydown(event);
     }
   }
 


### PR DESCRIPTION
Fixes that we weren't setting the focus origin in the stepper when navigating with the keyboard, causing it to be inferred as programmatic focus.

Fixes #26210.