### PR TITLE
fix(material/chips): create opt-out for single-selection checkmarks

### DIFF
--- a/src/dev-app/theme.scss
+++ b/src/dev-app/theme.scss
@@ -1,5 +1,6 @@
 @use '@angular/material' as mat;
 @use '@angular/material-experimental' as experimental;
+@use '@angular/material/chips/chips-theme';
 
 // Plus imports for other components in your app.
 
@@ -31,6 +32,9 @@ $candy-app-theme: mat.define-light-theme((
 
 @include mat.legacy-typography-hierarchy($candy-app-theme, '.mat-legacy-typography');
 @include mat.typography-hierarchy($candy-app-theme);
+
+// TODO: create a demo with opt-out applied rather than applying opt-out to everything
+@include chips-theme.without-accessible-single-selection-indicators();
 
 .demo-strong-focus {
   // Note: we can theme the indicators directly through `strong-focus-indicators` as well.

--- a/src/material/chips/_chips-theme.scss
+++ b/src/material/chips/_chips-theme.scss
@@ -106,3 +106,10 @@
     }
   }
 }
+
+@mixin without-accessible-single-selection-indicators() {
+  .mat-mdc-chip-listbox[multiple="false"] .mdc-evolution-chip__graphic {
+    width: 0;
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
For mat-chip-listbox, create an opt-out for accessible icon indicators for single-selection. Include the
`withoutAccessibleSingleSelectionIndicators` mixin to remove the checkmarks for single-selection.

PR #25890 added a checkmark for single selection chips. Add an opt-out for the visual changed introduced in that PR.

Does not affect multiple-selection.