### PR TITLE
fix(material/snack-bar): set explicit color on action in dark themes

### DIFF
--- a/src/material/snack-bar/_snack-bar-theme.scss
+++ b/src/material/snack-bar/_snack-bar-theme.scss
@@ -16,8 +16,11 @@
 
   @include mdc-helpers.using-mdc-theme($config) {
     .mat-mdc-snack-bar-container {
-      $button-color:
-          if($is-dark-theme, currentColor, theming.get-color-from-palette($accent, text));
+      $button-color: if(
+        $is-dark-theme,
+        mdc-theme-color.prop-value(text-primary-on-light),
+        theming.get-color-from-palette($accent, text)
+      );
       --mat-mdc-snack-bar-button-color: #{$button-color};
       $on-surface: mdc-theme-color.prop-value(on-surface);
       $surface: mdc-theme-color.prop-value(surface);


### PR DESCRIPTION
We were setting the snack bar action color to `currentColor` on dark themes which might not work as expected if there is a `color` on the `body`. These changes set it to an explicit color.

Fixes #26247.