### PR TITLE
build: update renovate to not apply `merge safe` label

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,8 +3,8 @@
   "automerge": false,
   "baseBranches": ["main"],
   "enabledManagers": ["npm", "bazel", "github-actions"],
-  "stopUpdatingLabel": "merge ready",
-  "labels": ["target: patch", "merge safe"],
+  "stopUpdatingLabel": "action: merge",
+  "labels": ["target: patch"],
   "lockFileMaintenance": {
     "enabled": false
   },


### PR DESCRIPTION
The `merge safe` label is no longer used in the components repo. Declaring the label in the renovate config results in the label being created all the time.