### PR TITLE
fix(material/slider): match ios safari slider behavior

### DIFF
--- a/src/material/slider/slider-input.ts
+++ b/src/material/slider/slider-input.ts
@@ -711,7 +711,7 @@ export class MatSliderRangeThumb extends MatSliderThumb implements _MatSliderRan
       this._slider.min < this._slider.max
         ? (this.max - this.min) / (this._slider.max - this._slider.min)
         : 1;
-    let width = maxWidth * percentage + minWidth;
+    const width = maxWidth * percentage + minWidth;
     this._hostElement.style.width = `${width}px`;
     this._hostElement.style.padding = `0 ${this._slider._inputPadding}px`;
   }
@@ -731,8 +731,7 @@ export class MatSliderRangeThumb extends MatSliderThumb implements _MatSliderRan
       : (midValue - this.min) / (this._slider.max - this._slider.min);
 
     const percentage = this._slider.min < this._slider.max ? _percentage : 1;
-    const offset = 24;
-    const width = maxWidth * percentage + offset;
+    const width = maxWidth * percentage + 24;
     this._hostElement.style.width = `${width}px`;
     this._hostElement.style.padding = '0px';
 

--- a/tools/public_api_guard/material/slider.md
+++ b/tools/public_api_guard/material/slider.md
@@ -144,7 +144,7 @@ export class MatSliderModule {
 
 // @public (undocumented)
 export class MatSliderRangeThumb extends MatSliderThumb implements _MatSliderRangeThumb {
-    constructor(_ngZone: NgZone, _slider: _MatSlider, _elementRef: ElementRef<HTMLInputElement>, _cdr: ChangeDetectorRef);
+    constructor(_ngZone: NgZone, _slider: _MatSlider, _elementRef: ElementRef<HTMLInputElement>, _cdr: ChangeDetectorRef, _platform: Platform);
     // (undocumented)
     readonly _cdr: ChangeDetectorRef;
     // (undocumented)
@@ -167,7 +167,9 @@ export class MatSliderRangeThumb extends MatSliderThumb implements _MatSliderRan
     // (undocumented)
     _onPointerMove(event: PointerEvent): void;
     // (undocumented)
-    _onPointerUp(): void;
+    _onPointerUp(event: PointerEvent): void;
+    // (undocumented)
+    readonly _platform: Platform;
     // (undocumented)
     _setIsLeftThumb(): void;
     // (undocumented)
@@ -187,7 +189,7 @@ export class MatSliderRangeThumb extends MatSliderThumb implements _MatSliderRan
 
 // @public
 export class MatSliderThumb implements _MatSliderThumb, OnDestroy, ControlValueAccessor {
-    constructor(_ngZone: NgZone, _elementRef: ElementRef<HTMLInputElement>, _cdr: ChangeDetectorRef, _slider: _MatSlider);
+    constructor(_ngZone: NgZone, _elementRef: ElementRef<HTMLInputElement>, _cdr: ChangeDetectorRef, _slider: _MatSlider, _platform: Platform);
     // (undocumented)
     blur(): void;
     // (undocumented)
@@ -219,6 +221,7 @@ export class MatSliderThumb implements _MatSliderThumb, OnDestroy, ControlValueA
     _initValue(): void;
     _isActive: boolean;
     _isFocused: boolean;
+    protected _isSafariIOS: boolean;
     _knobRadius: number;
     get max(): number;
     set max(v: NumberInput);
@@ -243,8 +246,10 @@ export class MatSliderThumb implements _MatSliderThumb, OnDestroy, ControlValueA
     // (undocumented)
     _onPointerMove(event: PointerEvent): void;
     // (undocumented)
-    _onPointerUp(): void;
+    _onPointerUp(event: PointerEvent): void;
     get percentage(): number;
+    // (undocumented)
+    readonly _platform: Platform;
     registerOnChange(fn: any): void;
     registerOnTouched(fn: any): void;
     setDisabledState(isDisabled: boolean): void;

--- a/tools/public_api_guard/material/slider.md
+++ b/tools/public_api_guard/material/slider.md
@@ -144,7 +144,7 @@ export class MatSliderModule {
 
 // @public (undocumented)
 export class MatSliderRangeThumb extends MatSliderThumb implements _MatSliderRangeThumb {
-    constructor(_ngZone: NgZone, _slider: _MatSlider, _elementRef: ElementRef<HTMLInputElement>, _cdr: ChangeDetectorRef, _platform: Platform);
+    constructor(_ngZone: NgZone, _slider: _MatSlider, _elementRef: ElementRef<HTMLInputElement>, _cdr: ChangeDetectorRef);
     // (undocumented)
     readonly _cdr: ChangeDetectorRef;
     // (undocumented)
@@ -169,8 +169,6 @@ export class MatSliderRangeThumb extends MatSliderThumb implements _MatSliderRan
     // (undocumented)
     _onPointerUp(event: PointerEvent): void;
     // (undocumented)
-    readonly _platform: Platform;
-    // (undocumented)
     _setIsLeftThumb(): void;
     // (undocumented)
     _updateMinMax(): void;
@@ -189,7 +187,7 @@ export class MatSliderRangeThumb extends MatSliderThumb implements _MatSliderRan
 
 // @public
 export class MatSliderThumb implements _MatSliderThumb, OnDestroy, ControlValueAccessor {
-    constructor(_ngZone: NgZone, _elementRef: ElementRef<HTMLInputElement>, _cdr: ChangeDetectorRef, _slider: _MatSlider, _platform: Platform);
+    constructor(_ngZone: NgZone, _elementRef: ElementRef<HTMLInputElement>, _cdr: ChangeDetectorRef, _slider: _MatSlider);
     // (undocumented)
     blur(): void;
     // (undocumented)
@@ -248,8 +246,6 @@ export class MatSliderThumb implements _MatSliderThumb, OnDestroy, ControlValueA
     // (undocumented)
     _onPointerUp(event: PointerEvent): void;
     get percentage(): number;
-    // (undocumented)
-    readonly _platform: Platform;
     registerOnChange(fn: any): void;
     registerOnTouched(fn: any): void;
     setDisabledState(isDisabled: boolean): void;


### PR DESCRIPTION
* On ios, dragging only starts if the slider thumb is pressed. This means pressing the track and dragging does nothing.
* On ios, values are updated on pointer up.
* For some reason, the full width of the slider is off by 2 on ios safari.