### PR TITLE
fix(material/slider): dragEnd not being emitted

### DIFF
--- a/src/material/slider/slider-input.ts
+++ b/src/material/slider/slider-input.ts
@@ -365,6 +365,7 @@ export class MatSliderThumb implements _MatSliderThumb, OnDestroy, ControlValueA
 
     if (!this.disabled) {
       this._handleValueCorrection(event);
+      this.dragStart.emit({source: this, parent: this._slider, value: this.value});
     }
   }
 
@@ -406,10 +407,7 @@ export class MatSliderThumb implements _MatSliderThumb, OnDestroy, ControlValueA
     const impreciseValue =
       fixedPercentage * (this._slider.max - this._slider.min) + this._slider.min;
     const value = Math.round(impreciseValue / step) * step;
-
     const prevValue = this.value;
-    const dragEvent = {source: this, parent: this._slider, value: value};
-    this._isActive ? this.dragStart.emit(dragEvent) : this.dragEnd.emit(dragEvent);
 
     if (value === prevValue) {
       // Because we prevented UI updates, if it turns out that the race
@@ -440,10 +438,11 @@ export class MatSliderThumb implements _MatSliderThumb, OnDestroy, ControlValueA
   }
 
   _onPointerUp(): void {
-    this._isActive = false;
-    setTimeout(() => {
-      this._updateWidthInactive();
-    });
+    if (this._isActive) {
+      this._isActive = false;
+      this.dragEnd.emit({source: this, parent: this._slider, value: this.value});
+      setTimeout(() => this._updateWidthInactive());
+    }
   }
 
   _clamp(v: number): number {


### PR DESCRIPTION
The `dragStart` and `dragEnd` events were being emitted in the `_fixValue` method, however the call to `_fixValue` was removed from the ending sequence in #26215. This meant that the `dragEnd` event was no longer being emitted.

These changes move the `dragStart` and `dragEnd` events into the pointer down/up handlers instead since emitting them has nothing to do with fixing the value.

Fixes #26285.