### PR TITLE
fix(cdk/menu): don't prevent default selection key actions

### DIFF
--- a/src/cdk/menu/menu-item.spec.ts
+++ b/src/cdk/menu/menu-item.spec.ts
@@ -67,10 +67,10 @@ describe('MenuItem', () => {
       expect(menuItem.hasMenu).toBeFalse();
     });
 
-    it('should prevent the default selection key action', () => {
+    it('should not prevent the default selection key action', () => {
       const event = dispatchKeyboardEvent(nativeButton, 'keydown', ENTER);
       fixture.detectChanges();
-      expect(event.defaultPrevented).toBe(true);
+      expect(event.defaultPrevented).toBe(false);
     });
   });
 

--- a/src/cdk/menu/menu-trigger.spec.ts
+++ b/src/cdk/menu/menu-trigger.spec.ts
@@ -438,7 +438,7 @@ describe('MenuTrigger', () => {
       expect(nativeMenus.length).toBe(2);
     });
 
-    it('should toggle the menu on trigger', () => {
+    it('should toggle the menu on clicks', () => {
       nativeTrigger.click();
       detectChanges();
       expect(nativeMenus.length).toBe(2);
@@ -451,13 +451,13 @@ describe('MenuTrigger', () => {
     it('should toggle the menu on keyboard events', () => {
       const firstEvent = dispatchKeyboardEvent(nativeTrigger, 'keydown', ENTER);
       detectChanges();
-      expect(firstEvent.defaultPrevented).toBe(true);
+      expect(firstEvent.defaultPrevented).toBe(false);
       expect(nativeMenus.length).toBe(2);
 
       const secondEvent = dispatchKeyboardEvent(nativeTrigger, 'keydown', ENTER);
       detectChanges();
       expect(nativeMenus.length).toBe(1);
-      expect(secondEvent.defaultPrevented).toBe(true);
+      expect(secondEvent.defaultPrevented).toBe(false);
     });
 
     it('should close the open menu on background click', () => {

--- a/tools/public_api_guard/cdk/menu.md
+++ b/tools/public_api_guard/cdk/menu.md
@@ -119,18 +119,22 @@ export class CdkMenuItem implements FocusableOption, FocusableElement, Toggler, 
     constructor();
     protected closeOnSpacebarTrigger: boolean;
     protected readonly destroyed: Subject<void>;
+    // (undocumented)
     protected readonly _dir: Directionality | null;
     get disabled(): boolean;
     set disabled(value: BooleanInput);
+    // (undocumented)
     readonly _elementRef: ElementRef<HTMLElement>;
     focus(): void;
     getLabel(): string;
     getMenu(): Menu | undefined;
     getMenuTrigger(): CdkMenuTrigger | null;
+    _handleClick(): void;
     get hasMenu(): boolean;
     isMenuOpen(): boolean;
     // (undocumented)
     ngOnDestroy(): void;
+    // (undocumented)
     protected _ngZone: NgZone;
     _onKeydown(event: KeyboardEvent): void;
     _resetTabIndex(): void;
@@ -198,6 +202,7 @@ export class CdkMenuTrigger extends CdkMenuTriggerBase implements OnDestroy {
     constructor();
     close(): void;
     getMenu(): Menu | undefined;
+    _handleClick(): void;
     open(): void;
     _setHasFocus(hasFocus: boolean): void;
     toggle(): void;


### PR DESCRIPTION
In #26051 a couple of `preventDefault` calls were added, because we were moving focus within an enter key `keydown` event which was causing the menu to close immediately after it opens. The problem is that the calls also prevent links from navigating.

These changes remove the `preventDefault` calls and resolve the initial issue by ignoring clicks initiated by the keyboard.

Fixes #26291.