### PR TITLE
docs: fix invalid SCSS in migration guide

### DIFF
--- a/guides/v15-mdc-migration.md
+++ b/guides/v15-mdc-migration.md
@@ -168,7 +168,7 @@ DOM and CSS of the components, you may need to tweak some of your application's 
   included by default when you include a theme mixin.
 
   ```scss
-  @import '@angular/material' as mat;
+  @use '@angular/material' as mat;
 
   $theme: mat.define-light-theme((
     color: ...


### PR DESCRIPTION
Fixes an invalid usage of the legacy SCSS module system in the migration guide.