### PR TITLE
fix(material/button): propogation inner handler from `mat-icon`

### DIFF
--- a/src/material/button/_button-base.scss
+++ b/src/material/button/_button-base.scss
@@ -43,8 +43,10 @@
 
   // The content should appear over the state and ripple layers, otherwise they may adversely affect
   // the accessibility of the text content.
-  .mdc-button__label {
+  .mdc-button__label,
+  .mat-icon {
     z-index: 1;
+    position: relative;
   }
 
   // The focus indicator should match the bounds of the entire button.


### PR DESCRIPTION
Fix propogation inner handler from `mat-icon`.

Fixes #26309.