### PR TITLE
fix(material/dialog): take dialog background from theme palette

### DIFF
--- a/src/material/dialog/_dialog-theme.scss
+++ b/src/material/dialog/_dialog-theme.scss
@@ -9,16 +9,16 @@
 
 @mixin color($config-or-theme) {
   $config: theming.get-color-config($config-or-theme);
+  $background: map.get($config, background);
 
   @include mdc-helpers.using-mdc-theme($config) {
     .mat-mdc-dialog-container {
-      $surface: mdc-theme-color.$surface;
       $on-surface: mdc-theme-color.$on-surface;
       $text-emphasis-high: mdc-theme-color.text-emphasis(high);
       $text-emphasis-medium: mdc-theme-color.text-emphasis(medium);
 
       @include mdc-dialog-theme.theme((
-        container-color: $surface,
+        container-color: theming.get-color-from-palette($background, dialog),
         with-divider-divider-color: rgba($on-surface, mdc-dialog.$scroll-divider-opacity),
         subhead-color: rgba($on-surface, $text-emphasis-high),
         supporting-text-color: rgba($on-surface, $text-emphasis-medium),


### PR DESCRIPTION
We were using MDC's `surface` variable to set the background of the dialog, however the `surface` was being mapped to our `card` variable. In practice the values for both are the same, but the new behavior breaks apps with custom palettes.

Fixes #26272.