### PR TITLE
perf(material/button): reduce initialization time

### DIFF
--- a/src/material/button/_button-base.scss
+++ b/src/material/button/_button-base.scss
@@ -14,8 +14,7 @@
 
   // The ripple container should match the bounds of the entire button.
   .mat-mdc-button-ripple,
-  .mat-mdc-button-persistent-ripple,
-  .mat-mdc-button-persistent-ripple::before {
+  .mat-mdc-button-ripple::before {
     @include layout-common.fill;
 
     // Disable pointer events for the ripple container and state overlay because the container
@@ -31,7 +30,7 @@
   }
 
   // We use ::before so that we can reuse some of MDC's theming.
-  .mat-mdc-button-persistent-ripple::before {
+  .mat-mdc-button-ripple::before {
     content: '';
     opacity: 0;
     background-color: var(--mat-mdc-button-persistent-ripple-color);
@@ -77,10 +76,11 @@
   // goes against our rule of not having margins on the host node. Furthermore, having the margin on
   // the button itself would require us to wrap it in another div. See:
   // https://github.com/material-components/material-components-web/tree/master/packages/mdc-button#making-buttons-accessible
-  .mat-mdc-button-touch-target {
+  &::after {
     @include mdc-touch-target.touch-target(
       $set-width: $is-square,
       $query: mdc-helpers.$mdc-base-styles-query);
+    content: '';
   }
 }
 

--- a/src/material/button/_button-theme-private.scss
+++ b/src/material/button/_button-theme-private.scss
@@ -14,18 +14,18 @@
     mdc-ripple-theme.$light-ink-opacities, mdc-ripple-theme.$dark-ink-opacities);
 
   // Ideally these styles would be structural, but MDC bases some of the opacities on the theme.
-  &:hover .mat-mdc-button-persistent-ripple::before {
+  &:hover .mat-mdc-button-ripple::before {
     opacity: map.get($opacities, hover);
   }
 
   &.cdk-program-focused,
   &.cdk-keyboard-focused {
-    .mat-mdc-button-persistent-ripple::before {
+    .mat-mdc-button-ripple::before {
       opacity: map.get($opacities, focus);
     }
   }
 
-  &:active .mat-mdc-button-persistent-ripple::before {
+  &:active .mat-mdc-button-ripple::before {
     opacity: map.get($opacities, press);
   }
 
@@ -59,7 +59,7 @@
 // Hides the touch target on lower densities.
 @mixin touch-target-density($scale) {
   @include mdc-helpers.if-touch-targets-unsupported($scale) {
-    .mat-mdc-button-touch-target {
+    &::after {
       display: none;
     }
   }

--- a/src/material/button/button.html
+++ b/src/material/button/button.html
@@ -1,8 +1,3 @@
-<span
-    class="mat-mdc-button-persistent-ripple"
-    [class.mdc-button__ripple]="!_isFab"
-    [class.mdc-fab__ripple]="_isFab"></span>
-
 <ng-content select=".material-icons:not([iconPositionEnd]), mat-icon:not([iconPositionEnd]), [matButtonIcon]:not([iconPositionEnd])">
 </ng-content>
 
@@ -19,6 +14,7 @@
 
 <span matRipple class="mat-mdc-button-ripple"
      [matRippleDisabled]="_isRippleDisabled()"
-     [matRippleTrigger]="_elementRef.nativeElement"></span>
+     [matRippleTrigger]="_elementRef.nativeElement"
+     [class.mdc-button__ripple]="!_isFab"
+     [class.mdc-fab__ripple]="_isFab"></span>
 
-<span class="mat-mdc-button-touch-target"></span>

--- a/src/material/button/fab.scss
+++ b/src/material/button/fab.scss
@@ -101,6 +101,6 @@
 
 // All FABs are square except the extended ones so we
 // need to set the touch target back to full-width.
-.mat-mdc-extended-fab .mat-mdc-button-touch-target {
+.mat-mdc-extended-fab::after {
   width: 100%;
 }

--- a/src/material/button/icon-button.html
+++ b/src/material/button/icon-button.html
@@ -1,5 +1,3 @@
-<span class="mat-mdc-button-persistent-ripple mdc-icon-button__ripple"></span>
-
 <ng-content></ng-content>
 
 <!--
@@ -8,9 +6,7 @@
 -->
 <span class="mat-mdc-focus-indicator"></span>
 
-<span matRipple class="mat-mdc-button-ripple"
+<span matRipple class="mat-mdc-button-ripple mdc-icon-button__ripple"
       [matRippleDisabled]="_isRippleDisabled()"
       [matRippleCentered]="true"
       [matRippleTrigger]="_elementRef.nativeElement"></span>
-
-<span class="mat-mdc-button-touch-target"></span>

--- a/src/material/button/icon-button.scss
+++ b/src/material/button/icon-button.scss
@@ -48,7 +48,7 @@
   @include button-base.mat-private-button-touch-target(true);
   @include private.private-animation-noop();
 
-  .mat-mdc-button-persistent-ripple {
+  .mat-mdc-button-ripple {
     border-radius: 50%;
   }
 


### PR DESCRIPTION
Reduces the time to initialize a button by reducing the number of DOM nodes that have to be created. Includes:
* Reusing the ripple container for the focus indication.
* Using `::after` for the touch target instead of a separate element.