### PR TITLE
fix(material/chips): change div to span

### DIFF
--- a/src/material/chips/chip.html
+++ b/src/material/chips/chip.html
@@ -5,7 +5,7 @@
 <span class="mat-mdc-chip-focus-overlay"></span>
 
 <span class="mdc-evolution-chip__cell mdc-evolution-chip__cell--primary">
-  <div matChipAction [isInteractive]="false">
+  <span matChipAction [isInteractive]="false">
     <span class="mdc-evolution-chip__graphic mat-mdc-chip-graphic" *ngIf="leadingIcon">
       <ng-content select="mat-chip-avatar, [matChipAvatar]"></ng-content>
     </span>
@@ -13,7 +13,7 @@
       <ng-content></ng-content>
       <span class="mat-mdc-chip-primary-focus-indicator mat-mdc-focus-indicator"></span>
     </span>
-  </div>
+  </span>
 </span>
 
 <span


### PR DESCRIPTION
For `MatChip` component, change the `<div/>` element for the primary action to a span element. Fix problem where the div is nested inside a span. A span is a container for phrasing content and is not supposed to contain flow content. This could also potentialy cause accessibility issue. Correct the semantics by nesting a span inside another span.