### PR TITLE
fix(material/tabs): touch gestures not working on tab nav bar

### DIFF
--- a/src/material/tabs/tab-nav-bar/tab-nav-bar.ts
+++ b/src/material/tabs/tab-nav-bar/tab-nav-bar.ts
@@ -384,6 +384,7 @@ export class MatTabNav extends _MatTabNavBase implements AfterContentInit, After
     if (!this.tabPanel && (typeof ngDevMode === 'undefined' || ngDevMode)) {
       throw new Error('A mat-tab-nav-panel must be specified via [tabPanel].');
     }
+    super.ngAfterViewInit();
   }
 }
 


### PR DESCRIPTION
The touch gestures for holding the pagination buttons weren't working in the tab nav bar, because we were overriding the `ngAfterViewInit` method without invoking the `super` implementation.