### PR TITLE
fix(material/slider): value jumping after drag with box-sizing: border-box

### DIFF
--- a/src/material/slider/slider.scss
+++ b/src/material/slider/slider.scss
@@ -34,6 +34,9 @@ $mat-slider-horizontal-margin: 8px !default;
   -webkit-tap-highlight-color: transparent;
 
   .mdc-slider__input {
+    // It's common for apps to globally set `box-sizing: border-box` which messes up our
+    // measurements. Explicitly set `content-box` to avoid issues like #26246.
+    box-sizing: content-box;
     pointer-events: auto;
 
     &.mat-mdc-slider-input-no-pointer-events {


### PR DESCRIPTION
It's common for apps to set `box-sizing: border-box` on all elements to make layouts more consistent, however this ended up offsetting the native slider inside `mat-slider` which was causing the value to jump after dragging and the 100% value to happen around the 95% mark.

Fixes #26246.