### PR TITLE
fix(material/button): use correct mixin for icon button and FAB structural styles

### DIFF
--- a/src/material/button/fab.scss
+++ b/src/material/button/fab.scss
@@ -7,7 +7,7 @@
 @use '../core/focus-indicators/private' as focus-indicators-private;
 
 @include mdc-helpers.disable-mdc-fallback-declarations {
-  @include mdc-fab.without-ripple($query: mdc-helpers.$mdc-base-styles-query);
+  @include mdc-fab.static-styles($query: mdc-helpers.$mdc-base-styles-query);
 }
 
 .mat-mdc-fab, .mat-mdc-mini-fab {

--- a/src/material/button/icon-button.scss
+++ b/src/material/button/icon-button.scss
@@ -7,7 +7,7 @@
 @use '../core/style/private';
 
 @include mdc-helpers.disable-mdc-fallback-declarations {
-  @include mdc-icon-button.without-ripple($query: mdc-helpers.$mdc-base-styles-query);
+  @include mdc-icon-button.static-styles($query: mdc-helpers.$mdc-base-styles-query);
 }
 
 .mat-mdc-icon-button {
@@ -24,6 +24,9 @@
     @include mdc-icon-button-theme.theme-styles(
       map.merge(mdc-icon-button-theme.$light-theme, $theme-overrides));
   }
+
+  // MDC requires a class to be placed on font-based icons which we don't have control over.
+  font-size: var(--mdc-icon-button-icon-size, #{mdc-icon-button-theme.$icon-size});
 
   // Border radius is inherited by ripple to know its shape. Set to 50% so the ripple is round.
   border-radius: 50%;


### PR DESCRIPTION
Uses the `static-styles` mixin for the icon button and FAB structural styles, instead of `without-ripple`. This removes a few duplicated styles.