### PR TITLE
build: fix snapshot jobs by not updating `@angular/bazel`

### DIFF
--- a/scripts/circleci/setup-angular-snapshots.js
+++ b/scripts/circleci/setup-angular-snapshots.js
@@ -33,6 +33,9 @@ const ignorePackages = [
   // tests for the actual snapshot Angular framework code.
   '@angular/build-tooling',
   '@angular/ng-dev',
+  // TODO(ESM-MIGRATION): Angular Bazel no longer generates dev-mode and relies on `ts_library`
+  //  being patched. Until our setup is compatible with it, we do not update `@angular/bazel`.
+  '@angular/bazel',
 ];
 
 const {writeFileSync} = require('fs');


### PR DESCRIPTION
Angular Bazel has switched to no longer generate devmode outputs but instead be ESM only. These changes are not yet released, and also they rely on `ts_library` being patched.

Until our components setup works with it, we cannot update `@angular/bazel`.