### PR TITLE
fix(material/chips): chips erasing values when focusing out of input 

### DIFF
--- a/src/dev-app/chips/chips-demo.html
+++ b/src/dev-app/chips/chips-demo.html
@@ -50,17 +50,15 @@
           </button>
         </mat-chip>
 
-        <mat-chip>
-          Razzle
-        </mat-chip>
+        <mat-chip> Razzle </mat-chip>
 
         <mat-chip>
-          <img src="https://material.angular.io/assets/img/examples/shiba2.jpg" matChipAvatar>
+          <img src="https://material.angular.io/assets/img/examples/shiba2.jpg" matChipAvatar />
           Mal
         </mat-chip>
 
         <mat-chip highlighted="true" color="warn">
-          <img src="https://material.angular.io/assets/img/examples/shiba2.jpg" matChipAvatar>
+          <img src="https://material.angular.io/assets/img/examples/shiba2.jpg" matChipAvatar />
           Husi
           <button matChipRemove>
             <mat-icon>cancel</mat-icon>
@@ -76,14 +74,18 @@
           Bad
           <mat-icon matChipTrailingIcon>star_border</mat-icon>
         </mat-chip>
-
       </mat-chip-set>
 
       <h4>With Events</h4>
 
       <mat-chip-set>
-        <mat-chip highlighted="true" color="warn" *ngIf="visible"
-                 (destroyed)="displayMessage('chip destroyed')" (removed)="toggleVisible()">
+        <mat-chip
+          highlighted="true"
+          color="warn"
+          *ngIf="visible"
+          (destroyed)="displayMessage('chip destroyed')"
+          (removed)="toggleVisible()"
+        >
           With Events
           <button matChipRemove aria-label="Remove chip">
             <mat-icon>cancel</mat-icon>
@@ -91,7 +93,6 @@
         </mat-chip>
       </mat-chip-set>
       <div>{{message}}</div>
-
     </mat-card-content>
   </mat-card>
 
@@ -100,7 +101,7 @@
 
     <mat-card-content>
       <button mat-button (click)="disabledListboxes = !disabledListboxes">
-       {{disabledListboxes ? "Enable" : "Disable"}}
+        {{disabledListboxes ? "Enable" : "Disable"}}
       </button>
       <button mat-button (click)="listboxesWithAvatar = !listboxesWithAvatar">
        {{listboxesWithAvatar ? "Hide Avatar" : "Show Avatar"}}
@@ -123,7 +124,6 @@
           {{hint.label}}
         </mat-chip-option>
       </mat-chip-listbox>
-
     </mat-card-content>
   </mat-card>
 
@@ -132,13 +132,13 @@
 
     <mat-card-content>
       <p>
-        The <code>&lt;mat-chip-grid&gt;</code> component pairs with the <code>matChipInputFor</code> directive
-        to convert user input text into chips.
-        They can be used inside a <code>&lt;mat-form-field&gt;</code>.
+        The <code>&lt;mat-chip-grid&gt;</code> component pairs with the
+        <code>matChipInputFor</code> directive to convert user input text into chips. They can be
+        used inside a <code>&lt;mat-form-field&gt;</code>.
       </p>
 
       <button mat-button (click)="disableInputs = !disableInputs">
-       {{disableInputs ? "Enable" : "Disable"}}
+        {{disableInputs ? "Enable" : "Disable"}}
       </button>
 
       <button mat-button (click)="editable = !editable">
@@ -146,24 +146,27 @@
       </button>
 
       <h4>Input is last child of chip grid</h4>
-
       <mat-form-field class="demo-has-chip-list">
         <mat-label>New Contributor...</mat-label>
         <mat-chip-grid #chipGrid1 [(ngModel)]="selectedPeople" required [disabled]="disableInputs">
-          <mat-chip-row *ngFor="let person of people"
-                   [editable]="editable"
-                   (removed)="remove(person)"
-                   (edited)="edit(person, $event)">
+          <mat-chip-row
+            *ngFor="let person of people"
+            [editable]="true"
+            (removed)="remove(person)"
+            (edited)="edit(person, $event)"
+          >
             {{person.name}}
             <button matChipRemove aria-label="Remove contributor">
               <mat-icon>cancel</mat-icon>
             </button>
           </mat-chip-row>
-          <input [disabled]="disableInputs"
-                 [matChipInputFor]="chipGrid1"
-                 [matChipInputSeparatorKeyCodes]="separatorKeysCodes"
-                 [matChipInputAddOnBlur]="addOnBlur"
-                 (matChipInputTokenEnd)="add($event)" />
+          <input
+            [disabled]="disableInputs"
+            [matChipInputFor]="chipGrid1"
+            [matChipInputSeparatorKeyCodes]="separatorKeysCodes"
+            [matChipInputAddOnBlur]="addOnBlur"
+            (matChipInputTokenEnd)="add($event)"
+          />
         </mat-chip-grid>
       </mat-form-field>
 
@@ -172,17 +175,47 @@
       <mat-form-field>
         <mat-label>New Contributor...</mat-label>
         <mat-chip-grid #chipGrid2 [(ngModel)]="selectedPeople" required [disabled]="disableInputs">
-          <mat-chip-row *ngFor="let person of people" (removed)="remove(person)">
+          <mat-chip-row *ngFor="let person of people" [editable]="true" (removed)="remove(person)">
             {{person.name}}
             <button matChipRemove aria-label="Remove contributor">
               <mat-icon>cancel</mat-icon>
             </button>
           </mat-chip-row>
         </mat-chip-grid>
-        <input [matChipInputFor]="chipGrid2"
-               [matChipInputSeparatorKeyCodes]="separatorKeysCodes"
-               [matChipInputAddOnBlur]="addOnBlur"
-               (matChipInputTokenEnd)="add($event)" />
+        <input
+          [matChipInputFor]="chipGrid2"
+          [matChipInputSeparatorKeyCodes]="separatorKeysCodes"
+          [matChipInputAddOnBlur]="addOnBlur"
+          (matChipInputTokenEnd)="add($event)"
+        />
+      </mat-form-field>
+
+      <h4>Input is last child of chip grid with Reactive Forms</h4>
+      Form Control value: {{control.value | json}}
+      <mat-form-field class="demo-has-chip-list">
+        <mat-label>New Contributor...</mat-label>
+        <mat-chip-grid #chipGrid3 [formControl]="control">
+          <mat-chip-row
+            *ngFor="let person of control.value; let index = index"
+            [editable]="true"
+            [displayWith]="displayFn"
+            [value]="person"
+            (removed)="removeControl(index)"
+            (edited)="editControl($event, index)"
+          >
+            {{person.name}}
+            <button matChipRemove aria-label="Remove contributor">
+              <mat-icon>cancel</mat-icon>
+            </button>
+          </mat-chip-row>
+          <input
+            [disabled]="disableInputs"
+            [matChipInputFor]="chipGrid3"
+            [matChipInputSeparatorKeyCodes]="separatorKeysCodes"
+            [matChipInputAddOnBlur]="addOnBlur"
+            (matChipInputTokenEnd)="add($event, true)"
+          />
+        </mat-chip-grid>
       </mat-form-field>
 
       <p>
@@ -194,7 +227,6 @@
       <p>
         <mat-checkbox name="addOnBlur" [(ngModel)]="addOnBlur">Add on Blur</mat-checkbox>
       </p>
-
     </mat-card-content>
   </mat-card>
 
@@ -203,13 +235,10 @@
     <mat-card-content>
       <h4>Stacked</h4>
 
-      <p>
-        You can also stack the chips if you want them on top of each other.
-      </p>
+      <p>You can also stack the chips if you want them on top of each other.</p>
 
       <mat-chip-set class="mat-mdc-chip-set-stacked">
-        <mat-chip *ngFor="let aColor of availableColors" highlighted="true"
-                  [color]="aColor.color">
+        <mat-chip *ngFor="let aColor of availableColors" highlighted="true" [color]="aColor.color">
           {{aColor.name}}
         </mat-chip>
       </mat-chip-set>
@@ -217,21 +246,28 @@
       <h4>NgModel with multi selection</h4>
 
       <mat-chip-listbox [multiple]="true" [(ngModel)]="selectedColors">
-        <mat-chip-option *ngFor="let aColor of availableColors" [color]="aColor.color"
-                 [value]="aColor.name">
+        <mat-chip-option
+          *ngFor="let aColor of availableColors"
+          [color]="aColor.color"
+          [value]="aColor.name"
+        >
           {{aColor.name}}
         </mat-chip-option>
       </mat-chip-listbox>
 
       The selected colors are
       <span *ngFor="let color of selectedColors; let isLast=last">
-        {{color}}{{isLast ? '' : ', '}}</span>.
+        {{color}}{{isLast ? '' : ', '}}</span
+      >.
 
       <h4>NgModel with single selection</h4>
 
       <mat-chip-listbox [(ngModel)]="selectedColor">
-        <mat-chip-option *ngFor="let aColor of availableColors" [color]="aColor.color"
-                 [value]="aColor.name">
+        <mat-chip-option
+          *ngFor="let aColor of availableColors"
+          [color]="aColor.color"
+          [value]="aColor.name"
+        >
           {{aColor.name}}
         </mat-chip-option>
       </mat-chip-listbox>

--- a/src/material/chips/chip-row.ts
+++ b/src/material/chips/chip-row.ts
@@ -88,6 +88,9 @@ export class MatChipRow extends MatChip implements AfterViewInit {
 
   @Input() editable: boolean = false;
 
+  /** Function that maps option's control value to its display value. Used in case of editable="true" and having an object as value */
+  @Input() displayWith: ((value: any) => string) | null = null;
+
   /** Emitted when the chip is edited. */
   @Output() readonly edited: EventEmitter<MatChipEditedEvent> =
     new EventEmitter<MatChipEditedEvent>();
@@ -178,7 +181,12 @@ export class MatChipRow extends MatChip implements AfterViewInit {
     }
 
     // The value depends on the DOM so we need to extract it before we flip the flag.
-    const value = this.value;
+    let value: any;
+    if (this.displayWith) {
+      value = this.displayWith(this.value);
+    } else {
+      value = this.value;
+    }
 
     this._isEditing = true;
     this._editStartPending = true;

--- a/tools/public_api_guard/material/chips.md
+++ b/tools/public_api_guard/material/chips.md
@@ -386,6 +386,7 @@ export class MatChipRow extends MatChip implements AfterViewInit {
     protected basicChipAttrName: string;
     contentEditInput?: MatChipEditInput;
     defaultEditInput?: MatChipEditInput;
+    displayWith: ((value: any) => string) | null;
     // (undocumented)
     _doubleclick(event: MouseEvent): void;
     // (undocumented)
@@ -399,7 +400,7 @@ export class MatChipRow extends MatChip implements AfterViewInit {
     _isEditing: boolean;
     _mousedown(event: MouseEvent): void;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<MatChipRow, "mat-chip-row, mat-basic-chip-row", never, { "color": "color"; "disabled": "disabled"; "disableRipple": "disableRipple"; "tabIndex": "tabIndex"; "editable": "editable"; }, { "edited": "edited"; }, ["contentEditInput"], ["mat-chip-avatar, [matChipAvatar]", "*", "[matChipEditInput]", "mat-chip-trailing-icon,[matChipRemove],[matChipTrailingIcon]"], false, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MatChipRow, "mat-chip-row, mat-basic-chip-row", never, { "color": "color"; "disabled": "disabled"; "disableRipple": "disableRipple"; "tabIndex": "tabIndex"; "editable": "editable"; "displayWith": "displayWith"; }, { "edited": "edited"; }, ["contentEditInput"], ["mat-chip-avatar, [matChipAvatar]", "*", "[matChipEditInput]", "mat-chip-trailing-icon,[matChipRemove],[matChipTrailingIcon]"], false, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatChipRow, [null, null, null, null, null, { optional: true; }, { optional: true; }, { attribute: "tabindex"; }]>;
 }


### PR DESCRIPTION
Fixes https://github.com/angular/components/issues/26358
1. Fix chips erasing values when focusing out of input bound to reactive forms
2. Add integration tests for edit mode with Reactive Forms approach
3. Add scenario with Reactive forms in Chips Demo and enable edit mode