### PR TITLE
fix(cdk/drag-drop): receiving class not updated in OnPush component

### DIFF
--- a/src/cdk/drag-drop/directives/drag.spec.ts
+++ b/src/cdk/drag-drop/directives/drag.spec.ts
@@ -5838,6 +5838,33 @@ describe('CdkDrag', () => {
       }),
     );
 
+    it('should set the receiving class when the list is wrapped in an OnPush component', fakeAsync(() => {
+      const fixture = createComponent(ConnectedDropListsInOnPush, undefined, undefined, [
+        DraggableInOnPushDropZone,
+      ]);
+      fixture.detectChanges();
+
+      const dropZones = Array.from<HTMLElement>(
+        fixture.nativeElement.querySelectorAll('.cdk-drop-list'),
+      );
+      const item = dropZones[0].querySelector('.cdk-drag')!;
+
+      expect(dropZones.every(c => !c.classList.contains('cdk-drop-list-receiving')))
+        .withContext('Expected neither of the containers to have the class.')
+        .toBe(true);
+
+      startDraggingViaMouse(fixture, item);
+      fixture.detectChanges();
+
+      expect(dropZones[0].classList)
+        .withContext('Expected source container not to have the receiving class.')
+        .not.toContain('cdk-drop-list-receiving');
+
+      expect(dropZones[1].classList)
+        .withContext('Expected target container to have the receiving class.')
+        .toContain('cdk-drop-list-receiving');
+    }));
+
     it(
       'should be able to move the item over an intermediate container before ' +
         'dropping it into the final one',
@@ -6763,10 +6790,21 @@ class DraggableInDropZone implements AfterViewInit {
 }
 
 @Component({
+  selector: 'draggable-in-on-push-zone',
   template: DROP_ZONE_FIXTURE_TEMPLATE,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 class DraggableInOnPushDropZone extends DraggableInDropZone {}
+
+@Component({
+  template: `
+    <div cdkDropListGroup>
+      <draggable-in-on-push-zone></draggable-in-on-push-zone>
+      <draggable-in-on-push-zone></draggable-in-on-push-zone>
+    </div>
+  `,
+})
+class ConnectedDropListsInOnPush {}
 
 @Component({
   template: DROP_ZONE_FIXTURE_TEMPLATE,

--- a/src/cdk/drag-drop/directives/drop-list.ts
+++ b/src/cdk/drag-drop/directives/drop-list.ts
@@ -35,7 +35,7 @@ import {DropListRef} from '../drop-list-ref';
 import {DragRef} from '../drag-ref';
 import {DragDrop} from '../drag-drop';
 import {DropListOrientation, DragAxis, DragDropConfig, CDK_DRAG_CONFIG} from './config';
-import {Subject} from 'rxjs';
+import {merge, Subject} from 'rxjs';
 import {startWith, takeUntil} from 'rxjs/operators';
 import {assertElementNode} from './assertions';
 
@@ -375,6 +375,10 @@ export class CdkDropList<T = any> implements OnDestroy {
       // detection and we're not guaranteed for something else to have triggered it.
       this._changeDetectorRef.markForCheck();
     });
+
+    merge(ref.receivingStarted, ref.receivingStopped).subscribe(() =>
+      this._changeDetectorRef.markForCheck(),
+    );
   }
 
   /** Assigns the default input values based on a provided config object. */

--- a/tools/public_api_guard/cdk/drag-drop.md
+++ b/tools/public_api_guard/cdk/drag-drop.md
@@ -494,6 +494,15 @@ export class DropListRef<T = any> {
     _isOverContainer(x: number, y: number): boolean;
     isReceiving(): boolean;
     lockAxis: 'x' | 'y';
+    readonly receivingStarted: Subject<{
+        receiver: DropListRef;
+        initiator: DropListRef;
+        items: DragRefInternal[];
+    }>;
+    readonly receivingStopped: Subject<{
+        receiver: DropListRef;
+        initiator: DropListRef;
+    }>;
     readonly sorted: Subject<{
         previousIndex: number;
         currentIndex: number;


### PR DESCRIPTION
Fixes that the `cdk-drop-list-receiving` class wasn't being updated when two lists are connected across components boundaries that are using OnPush change detection.

Fixes #26362.