### PR TITLE
test(material/schematics): clean up deprecated API usage

### DIFF
--- a/src/cdk/schematics/ng-add/index.spec.ts
+++ b/src/cdk/schematics/ng-add/index.spec.ts
@@ -18,7 +18,7 @@ describe('CDK ng-add', () => {
   });
 
   it('should update the package.json', async () => {
-    const tree = await runner.runSchematicAsync('ng-add', {}, appTree).toPromise();
+    const tree = await runner.runSchematic('ng-add', {}, appTree);
     const packageJson = JSON.parse(getFileContent(tree, '/package.json')) as PackageJson;
     const dependencies = packageJson.dependencies;
 
@@ -36,7 +36,7 @@ describe('CDK ng-add', () => {
     // requested package version into the `package.json` before the actual schematic runs.
     addPackageToPackageJson(appTree, '@angular/cdk', '^9.0.0');
 
-    const tree = await runner.runSchematicAsync('ng-add', {}, appTree).toPromise();
+    const tree = await runner.runSchematic('ng-add', {}, appTree);
     const packageJson = JSON.parse(getFileContent(tree, '/package.json')) as PackageJson;
     const dependencies = packageJson.dependencies;
 

--- a/src/cdk/schematics/ng-generate/drag-drop/index.spec.ts
+++ b/src/cdk/schematics/ng-generate/drag-drop/index.spec.ts
@@ -20,7 +20,7 @@ describe('CDK drag-drop schematic', () => {
 
   it('should create drag-drop files and add them to module', async () => {
     const app = await createTestApp(runner);
-    const tree = await runner.runSchematicAsync('drag-drop', baseOptions, app).toPromise();
+    const tree = await runner.runSchematic('drag-drop', baseOptions, app);
     const moduleContent = getFileContent(tree, '/projects/material/src/app/app.module.ts');
     const files = tree.files;
 
@@ -35,7 +35,7 @@ describe('CDK drag-drop schematic', () => {
 
   it('should add drag-drop module', async () => {
     const app = await createTestApp(runner);
-    const tree = await runner.runSchematicAsync('drag-drop', baseOptions, app).toPromise();
+    const tree = await runner.runSchematic('drag-drop', baseOptions, app);
     const moduleContent = getFileContent(tree, '/projects/material/src/app/app.module.ts');
 
     expect(moduleContent).toContain('DragDropModule');
@@ -43,14 +43,11 @@ describe('CDK drag-drop schematic', () => {
 
   describe('style option', () => {
     it('should respect the option value', async () => {
-      const tree = await runner
-        .runSchematicAsync(
-          'drag-drop',
-          {style: 'scss', ...baseOptions},
-          await createTestApp(runner),
-        )
-        .toPromise();
-
+      const tree = await runner.runSchematic(
+        'drag-drop',
+        {style: 'scss', ...baseOptions},
+        await createTestApp(runner),
+      );
       expect(tree.files).toContain('/projects/material/src/app/foo/foo.component.scss');
     });
 
@@ -75,20 +72,17 @@ describe('CDK drag-drop schematic', () => {
           },
         }),
       );
-      tree = await runner.runSchematicAsync('drag-drop', baseOptions, tree).toPromise();
+      tree = await runner.runSchematic('drag-drop', baseOptions, tree);
 
       expect(tree.files).toContain('/projects/material/src/app/foo/foo.component.scss');
     });
 
     it('should not generate invalid stylesheets', async () => {
-      const tree = await runner
-        .runSchematicAsync(
-          'drag-drop',
-          {style: 'styl', ...baseOptions},
-          await createTestApp(runner),
-        )
-        .toPromise();
-
+      const tree = await runner.runSchematic(
+        'drag-drop',
+        {style: 'styl', ...baseOptions},
+        await createTestApp(runner),
+      );
       // In this case we expect the schematic to generate a plain "css" file because
       // the component schematics are using CSS style templates which are not compatible
       // with all CLI supported styles (e.g. Stylus or Sass)
@@ -104,10 +98,11 @@ describe('CDK drag-drop schematic', () => {
     });
 
     it('should fall back to the @schematics/angular:component option value', async () => {
-      const tree = await runner
-        .runSchematicAsync('drag-drop', baseOptions, await createTestApp(runner, {style: 'less'}))
-        .toPromise();
-
+      const tree = await runner.runSchematic(
+        'drag-drop',
+        baseOptions,
+        await createTestApp(runner, {style: 'less'}),
+      );
       expect(tree.files).toContain('/projects/material/src/app/foo/foo.component.less');
     });
   });
@@ -115,22 +110,16 @@ describe('CDK drag-drop schematic', () => {
   describe('inlineStyle option', () => {
     it('should respect the option value', async () => {
       const app = await createTestApp(runner);
-      const tree = await runner
-        .runSchematicAsync('drag-drop', {inlineStyle: true, ...baseOptions}, app)
-        .toPromise();
-
+      const tree = await runner.runSchematic('drag-drop', {inlineStyle: true, ...baseOptions}, app);
       expect(tree.files).not.toContain('/projects/material/src/app/foo/foo.component.css');
     });
 
     it('should fall back to the @schematics/angular:component option value', async () => {
-      const tree = await runner
-        .runSchematicAsync(
-          'drag-drop',
-          baseOptions,
-          await createTestApp(runner, {inlineStyle: true}),
-        )
-        .toPromise();
-
+      const tree = await runner.runSchematic(
+        'drag-drop',
+        baseOptions,
+        await createTestApp(runner, {inlineStyle: true}),
+      );
       expect(tree.files).not.toContain('/projects/material/src/app/foo/foo.component.css');
     });
   });
@@ -138,16 +127,17 @@ describe('CDK drag-drop schematic', () => {
   describe('inlineTemplate option', () => {
     it('should respect the option value', async () => {
       const app = await createTestApp(runner);
-      const tree = await runner
-        .runSchematicAsync('drag-drop', {inlineTemplate: true, ...baseOptions}, app)
-        .toPromise();
-
+      const tree = await runner.runSchematic(
+        'drag-drop',
+        {inlineTemplate: true, ...baseOptions},
+        app,
+      );
       expect(tree.files).not.toContain('/projects/material/src/app/foo/foo.component.html');
     });
 
     it('should fall back to the @schematics/angular:component option value', async () => {
       const app = await createTestApp(runner, {inlineTemplate: true});
-      const tree = await runner.runSchematicAsync('drag-drop', baseOptions, app).toPromise();
+      const tree = await runner.runSchematic('drag-drop', baseOptions, app);
 
       expect(tree.files).not.toContain('/projects/material/src/app/foo/foo.component.html');
     });
@@ -155,14 +145,11 @@ describe('CDK drag-drop schematic', () => {
 
   describe('skipTests option', () => {
     it('should respect the option value', async () => {
-      const tree = await runner
-        .runSchematicAsync(
-          'drag-drop',
-          {skipTests: true, ...baseOptions},
-          await createTestApp(runner),
-        )
-        .toPromise();
-
+      const tree = await runner.runSchematic(
+        'drag-drop',
+        {skipTests: true, ...baseOptions},
+        await createTestApp(runner),
+      );
       expect(tree.files).not.toContain('/projects/material/src/app/foo/foo.component.spec.ts');
     });
 
@@ -187,16 +174,17 @@ describe('CDK drag-drop schematic', () => {
           },
         }),
       );
-      tree = await runner.runSchematicAsync('drag-drop', baseOptions, tree).toPromise();
+      tree = await runner.runSchematic('drag-drop', baseOptions, tree);
 
       expect(tree.files).not.toContain('/projects/material/src/app/foo/foo.component.spec.ts');
     });
 
     it('should fall back to the @schematics/angular:component option value', async () => {
-      const tree = await runner
-        .runSchematicAsync('drag-drop', baseOptions, await createTestApp(runner, {skipTests: true}))
-        .toPromise();
-
+      const tree = await runner.runSchematic(
+        'drag-drop',
+        baseOptions,
+        await createTestApp(runner, {skipTests: true}),
+      );
       expect(tree.files).not.toContain('/projects/material/src/app/foo/foo.component.spec.ts');
     });
   });

--- a/src/cdk/schematics/testing/test-case-setup.ts
+++ b/src/cdk/schematics/testing/test-case-setup.ts
@@ -105,7 +105,7 @@ export async function createTestCaseSetup(
     // TODO(devversion): RxJS version conflicts between angular-devkit and our dev deps.
     runner.engine.executePostTasks = () => EMPTY as any;
 
-    await runner.runSchematicAsync(migrationName, {}, appTree).toPromise();
+    await runner.runSchematic(migrationName, {}, appTree);
 
     return {logOutput};
   };

--- a/src/material/schematics/ng-add/index.spec.ts
+++ b/src/material/schematics/ng-add/index.spec.ts
@@ -60,7 +60,7 @@ describe('ng-add schematic', () => {
     // animations installed already, we remove the animations dependency explicitly.
     removePackageJsonDependency(appTree, '@angular/animations');
 
-    const tree = await runner.runSchematicAsync('ng-add', baseOptions, appTree).toPromise();
+    const tree = await runner.runSchematic('ng-add', baseOptions, appTree);
     const packageJson = JSON.parse(getFileContent(tree, '/package.json')) as PackageJson;
     const dependencies = packageJson.dependencies;
     const angularCoreVersion = dependencies['@angular/core'];
@@ -93,7 +93,7 @@ describe('ng-add schematic', () => {
     // requested package version into the `package.json` before the actual schematic runs.
     addPackageToPackageJson(appTree, '@angular/material', '^9.0.0');
 
-    const tree = await runner.runSchematicAsync('ng-add', baseOptions, appTree).toPromise();
+    const tree = await runner.runSchematic('ng-add', baseOptions, appTree);
     const packageJson = JSON.parse(getFileContent(tree, '/package.json')) as PackageJson;
     const dependencies = packageJson.dependencies;
 
@@ -102,10 +102,7 @@ describe('ng-add schematic', () => {
   });
 
   it('should add default theme', async () => {
-    const tree = await runner
-      .runSchematicAsync('ng-add-setup-project', baseOptions, appTree)
-      .toPromise();
-
+    const tree = await runner.runSchematic('ng-add-setup-project', baseOptions, appTree);
     const workspace = await getWorkspace(tree);
     const project = getProjectFromWorkspace(workspace, baseOptions.project);
 
@@ -116,10 +113,11 @@ describe('ng-add schematic', () => {
     // TODO(devversion): do not re-create test app here.
     appTree = await createTestApp(runner, {style: 'scss'});
 
-    const tree = await runner
-      .runSchematicAsync('ng-add-setup-project', {...baseOptions, theme: 'custom'}, appTree)
-      .toPromise();
-
+    const tree = await runner.runSchematic(
+      'ng-add-setup-project',
+      {...baseOptions, theme: 'custom'},
+      appTree,
+    );
     const workspace = await getWorkspace(tree);
     const project = getProjectFromWorkspace(workspace, baseOptions.project);
     const expectedStylesPath = normalize(`/${project.root}/src/styles.scss`);
@@ -135,9 +133,11 @@ describe('ng-add schematic', () => {
     // TODO(devversion): do not re-create test app here.
     appTree = await createTestApp(runner, {style: 'css'});
 
-    const tree = await runner
-      .runSchematicAsync('ng-add-setup-project', {...baseOptions, theme: 'custom'}, appTree)
-      .toPromise();
+    const tree = await runner.runSchematic(
+      'ng-add-setup-project',
+      {...baseOptions, theme: 'custom'},
+      appTree,
+    );
     const workspace = await getWorkspace(tree);
     const project = getProjectFromWorkspace(workspace, baseOptions.project);
     const expectedStylesPath = normalize(`/${project.root}/src/custom-theme.scss`);
@@ -149,9 +149,7 @@ describe('ng-add schematic', () => {
   });
 
   it('should add font links', async () => {
-    const tree = await runner
-      .runSchematicAsync('ng-add-setup-project', baseOptions, appTree)
-      .toPromise();
+    const tree = await runner.runSchematic('ng-add-setup-project', baseOptions, appTree);
     const workspace = await getWorkspace(tree);
     const project = getProjectFromWorkspace(workspace, baseOptions.project);
 
@@ -177,9 +175,7 @@ describe('ng-add schematic', () => {
   });
 
   it('should add material app styles', async () => {
-    const tree = await runner
-      .runSchematicAsync('ng-add-setup-project', baseOptions, appTree)
-      .toPromise();
+    const tree = await runner.runSchematic('ng-add-setup-project', baseOptions, appTree);
     const workspace = await getWorkspace(tree);
     const project = getProjectFromWorkspace(workspace, baseOptions.project);
 
@@ -194,9 +190,7 @@ describe('ng-add schematic', () => {
 
   describe('animations enabled', () => {
     it('should add the BrowserAnimationsModule to the project module', async () => {
-      const tree = await runner
-        .runSchematicAsync('ng-add-setup-project', baseOptions, appTree)
-        .toPromise();
+      const tree = await runner.runSchematic('ng-add-setup-project', baseOptions, appTree);
       const fileContent = getFileContent(tree, '/projects/material/src/app/app.module.ts');
 
       expect(fileContent)
@@ -219,7 +213,7 @@ describe('ng-add schematic', () => {
         project,
       );
 
-      await runner.runSchematicAsync('ng-add-setup-project', baseOptions, appTree).toPromise();
+      await runner.runSchematic('ng-add-setup-project', baseOptions, appTree);
 
       expect(errorOutput.length).toBe(1);
       expect(errorOutput[0]).toMatch(/Could not set up "BrowserAnimationsModule"/);
@@ -240,9 +234,7 @@ describe('ng-add schematic', () => {
         `,
       );
 
-      const tree = await runner
-        .runSchematicAsync('ng-add-setup-project', baseOptions, appTree)
-        .toPromise();
+      const tree = await runner.runSchematic('ng-add-setup-project', baseOptions, appTree);
       const fileContent = getFileContent(tree, '/projects/material/src/main.ts');
       expect(fileContent).toContain('importProvidersFrom(BrowserModule, BrowserAnimationsModule)');
     });
@@ -263,7 +255,7 @@ describe('ng-add schematic', () => {
         `,
       );
 
-      await runner.runSchematicAsync('ng-add-setup-project', baseOptions, appTree).toPromise();
+      await runner.runSchematic('ng-add-setup-project', baseOptions, appTree);
 
       expect(errorOutput.length).toBe(1);
       expect(errorOutput[0]).toMatch(
@@ -274,13 +266,11 @@ describe('ng-add schematic', () => {
 
   describe('animations disabled', () => {
     it('should add the NoopAnimationsModule to the project module', async () => {
-      const tree = await runner
-        .runSchematicAsync(
-          'ng-add-setup-project',
-          {...baseOptions, animations: 'disabled'},
-          appTree,
-        )
-        .toPromise();
+      const tree = await runner.runSchematic(
+        'ng-add-setup-project',
+        {...baseOptions, animations: 'disabled'},
+        appTree,
+      );
       const fileContent = getFileContent(tree, '/projects/material/src/app/app.module.ts');
 
       expect(fileContent)
@@ -314,13 +304,11 @@ describe('ng-add schematic', () => {
 
   describe('animations excluded', () => {
     it('should not add any animations code if animations are excluded', async () => {
-      const tree = await runner
-        .runSchematicAsync(
-          'ng-add-setup-project',
-          {...baseOptions, animations: 'excluded'},
-          appTree,
-        )
-        .toPromise();
+      const tree = await runner.runSchematic(
+        'ng-add-setup-project',
+        {...baseOptions, animations: 'excluded'},
+        appTree,
+      );
       const fileContent = getFileContent(tree, '/projects/material/src/app/app.module.ts');
 
       expect(fileContent).not.toContain('NoopAnimationsModule');
@@ -372,13 +360,13 @@ describe('ng-add schematic', () => {
     it('should throw an error if the "build" target has been changed', async () => {
       overwriteTargetBuilder(appTree, 'build', 'thirdparty-builder');
       await expectAsync(
-        runner.runSchematicAsync('ng-add-setup-project', baseOptions, appTree).toPromise(),
+        runner.runSchematic('ng-add-setup-project', baseOptions, appTree),
       ).toBeRejectedWithError(/not using the default builders.*build/);
     });
 
     it('should warn if the "test" target has been changed', async () => {
       overwriteTargetBuilder(appTree, 'test', 'thirdparty-test-builder');
-      await runner.runSchematicAsync('ng-add-setup-project', baseOptions, appTree).toPromise();
+      await runner.runSchematic('ng-add-setup-project', baseOptions, appTree);
 
       expect(errorOutput.length).toBe(0);
       expect(warnOutput.length).toBe(1);
@@ -429,9 +417,7 @@ describe('ng-add schematic', () => {
       const existingThemePath = '@angular/material/prebuilt-themes/purple-green.css';
       writeStyleFileToWorkspace(appTree, existingThemePath);
 
-      const tree = await runner
-        .runSchematicAsync('ng-add-setup-project', baseOptions, appTree)
-        .toPromise();
+      const tree = await runner.runSchematic('ng-add-setup-project', baseOptions, appTree);
       const workspace = await getWorkspace(tree);
       const project = getProjectFromWorkspace(workspace, baseOptions.project);
       const styles = getProjectTargetOptions(project, 'build').styles;
@@ -447,9 +433,7 @@ describe('ng-add schematic', () => {
     it('should not replace existing custom theme files', async () => {
       writeStyleFileToWorkspace(appTree, './projects/material/custom-theme.scss');
 
-      const tree = await runner
-        .runSchematicAsync('ng-add-setup-project', baseOptions, appTree)
-        .toPromise();
+      const tree = await runner.runSchematic('ng-add-setup-project', baseOptions, appTree);
       const workspace = await getWorkspace(tree);
       const project = getProjectFromWorkspace(workspace, baseOptions.project);
       const styles = getProjectTargetOptions(project, 'build').styles;
@@ -464,9 +448,7 @@ describe('ng-add schematic', () => {
     it('should not add a theme file multiple times', async () => {
       writeStyleFileToWorkspace(appTree, defaultPrebuiltThemePath);
 
-      const tree = await runner
-        .runSchematicAsync('ng-add-setup-project', baseOptions, appTree)
-        .toPromise();
+      const tree = await runner.runSchematic('ng-add-setup-project', baseOptions, appTree);
       const workspace = await getWorkspace(tree);
       const project = getProjectFromWorkspace(workspace, baseOptions.project);
       const styles = getProjectTargetOptions(project, 'build').styles;
@@ -480,10 +462,11 @@ describe('ng-add schematic', () => {
 
     it('should not overwrite existing custom theme files', async () => {
       appTree.create('/projects/material/custom-theme.scss', 'custom-theme');
-      const tree = await runner
-        .runSchematicAsync('ng-add-setup-project', {...baseOptions, theme: 'custom'}, appTree)
-        .toPromise();
-
+      const tree = await runner.runSchematic(
+        'ng-add-setup-project',
+        {...baseOptions, theme: 'custom'},
+        appTree,
+      );
       expect(tree.readContent('/projects/material/custom-theme.scss'))
         .withContext('Expected the old custom theme content to be unchanged.')
         .toBe('custom-theme');
@@ -491,16 +474,14 @@ describe('ng-add schematic', () => {
   });
 
   it('should add the global typography class if the body has no classes', async () => {
-    const tree = await runner
-      .runSchematicAsync(
-        'ng-add-setup-project',
-        {
-          ...baseOptions,
-          typography: true,
-        },
-        appTree,
-      )
-      .toPromise();
+    const tree = await runner.runSchematic(
+      'ng-add-setup-project',
+      {
+        ...baseOptions,
+        typography: true,
+      },
+      appTree,
+    );
     const workspace = await getWorkspace(tree);
     const project = getProjectFromWorkspace(workspace, baseOptions.project);
 
@@ -524,17 +505,14 @@ describe('ng-add schematic', () => {
     `,
     );
 
-    const tree = await runner
-      .runSchematicAsync(
-        'ng-add-setup-project',
-        {
-          ...baseOptions,
-          typography: true,
-        },
-        appTree,
-      )
-      .toPromise();
-
+    const tree = await runner.runSchematic(
+      'ng-add-setup-project',
+      {
+        ...baseOptions,
+        typography: true,
+      },
+      appTree,
+    );
     const workspace = await getWorkspace(tree);
     const project = getProjectFromWorkspace(workspace, baseOptions.project);
     const indexFiles = getProjectIndexFiles(project);
@@ -557,17 +535,14 @@ describe('ng-add schematic', () => {
     `,
     );
 
-    const tree = await runner
-      .runSchematicAsync(
-        'ng-add-setup-project',
-        {
-          ...baseOptions,
-          typography: true,
-        },
-        appTree,
-      )
-      .toPromise();
-
+    const tree = await runner.runSchematic(
+      'ng-add-setup-project',
+      {
+        ...baseOptions,
+        typography: true,
+      },
+      appTree,
+    );
     const workspace = await getWorkspace(tree);
     const project = getProjectFromWorkspace(workspace, baseOptions.project);
     const indexFiles = getProjectIndexFiles(project);
@@ -590,17 +565,14 @@ describe('ng-add schematic', () => {
     `,
     );
 
-    const tree = await runner
-      .runSchematicAsync(
-        'ng-add-setup-project',
-        {
-          ...baseOptions,
-          typography: false,
-        },
-        appTree,
-      )
-      .toPromise();
-
+    const tree = await runner.runSchematic(
+      'ng-add-setup-project',
+      {
+        ...baseOptions,
+        typography: false,
+      },
+      appTree,
+    );
     const workspace = await getWorkspace(tree);
     const project = getProjectFromWorkspace(workspace, baseOptions.project);
     const indexFiles = getProjectIndexFiles(project);
@@ -635,9 +607,7 @@ describe('ng-add schematic - library project', () => {
   });
 
   it('should warn if a library project is targeted', async () => {
-    await runner
-      .runSchematicAsync('ng-add-setup-project', {project: 'material'}, libraryTree)
-      .toPromise();
+    await runner.runSchematic('ng-add-setup-project', {project: 'material'}, libraryTree);
 
     expect(errorOutput.length).toBe(0);
     expect(warnOutput.length).toBe(1);

--- a/src/material/schematics/ng-generate/address-form/index.spec.ts
+++ b/src/material/schematics/ng-generate/address-form/index.spec.ts
@@ -17,7 +17,7 @@ describe('Material address-form schematic', () => {
 
   it('should create address-form files and add them to module', async () => {
     const app = await createTestApp(runner);
-    const tree = await runner.runSchematicAsync('address-form', baseOptions, app).toPromise();
+    const tree = await runner.runSchematic('address-form', baseOptions, app);
     const files = tree.files;
 
     expect(files).toContain('/projects/material/src/app/foo/foo.component.css');
@@ -32,7 +32,7 @@ describe('Material address-form schematic', () => {
 
   it('should add address-form imports to module', async () => {
     const app = await createTestApp(runner);
-    const tree = await runner.runSchematicAsync('address-form', baseOptions, app).toPromise();
+    const tree = await runner.runSchematic('address-form', baseOptions, app);
     const moduleContent = getFileContent(tree, '/projects/material/src/app/app.module.ts');
 
     expect(moduleContent).toContain('MatInputModule');
@@ -46,32 +46,26 @@ describe('Material address-form schematic', () => {
     const appTree = await createTestApp(runner);
 
     await expectAsync(
-      runner.runSchematicAsync('address-form', {project: 'material'}, appTree).toPromise(),
+      runner.runSchematic('address-form', {project: 'material'}, appTree),
     ).toBeRejectedWithError(/required property 'name'/);
   });
 
   describe('style option', () => {
     it('should respect the option value', async () => {
-      const tree = await runner
-        .runSchematicAsync(
-          'address-form',
-          {style: 'scss', ...baseOptions},
-          await createTestApp(runner),
-        )
-        .toPromise();
-
+      const tree = await runner.runSchematic(
+        'address-form',
+        {style: 'scss', ...baseOptions},
+        await createTestApp(runner),
+      );
       expect(tree.files).toContain('/projects/material/src/app/foo/foo.component.scss');
     });
 
     it('should fall back to the @schematics/angular:component option value', async () => {
-      const tree = await runner
-        .runSchematicAsync(
-          'address-form',
-          baseOptions,
-          await createTestApp(runner, {style: 'less'}),
-        )
-        .toPromise();
-
+      const tree = await runner.runSchematic(
+        'address-form',
+        baseOptions,
+        await createTestApp(runner, {style: 'less'}),
+      );
       expect(tree.files).toContain('/projects/material/src/app/foo/foo.component.less');
     });
   });
@@ -79,10 +73,11 @@ describe('Material address-form schematic', () => {
   describe('inlineStyle option', () => {
     it('should respect the option value', async () => {
       const app = await createTestApp(runner);
-      const tree = await runner
-        .runSchematicAsync('address-form', {inlineStyle: true, ...baseOptions}, app)
-        .toPromise();
-
+      const tree = await runner.runSchematic(
+        'address-form',
+        {inlineStyle: true, ...baseOptions},
+        app,
+      );
       expect(tree.files).not.toContain('/projects/material/src/app/foo/foo.component.css');
       expect(tree.readContent('/projects/material/src/app/foo/foo.component.ts')).toContain(
         'styles: [`',
@@ -91,7 +86,7 @@ describe('Material address-form schematic', () => {
 
     it('should fall back to the @schematics/angular:component option value', async () => {
       const app = await createTestApp(runner, {inlineStyle: true});
-      const tree = await runner.runSchematicAsync('address-form', baseOptions, app).toPromise();
+      const tree = await runner.runSchematic('address-form', baseOptions, app);
 
       expect(tree.files).not.toContain('/projects/material/src/app/foo/foo.component.css');
     });
@@ -100,10 +95,11 @@ describe('Material address-form schematic', () => {
   describe('inlineTemplate option', () => {
     it('should respect the option value', async () => {
       const app = await createTestApp(runner);
-      const tree = await runner
-        .runSchematicAsync('address-form', {inlineTemplate: true, ...baseOptions}, app)
-        .toPromise();
-
+      const tree = await runner.runSchematic(
+        'address-form',
+        {inlineTemplate: true, ...baseOptions},
+        app,
+      );
       expect(tree.files).not.toContain('/projects/material/src/app/foo/foo.component.html');
       expect(tree.readContent('/projects/material/src/app/foo/foo.component.ts')).toContain(
         'template: `',
@@ -112,7 +108,7 @@ describe('Material address-form schematic', () => {
 
     it('should fall back to the @schematics/angular:component option value', async () => {
       const app = await createTestApp(runner, {inlineTemplate: true});
-      const tree = await runner.runSchematicAsync('address-form', baseOptions, app).toPromise();
+      const tree = await runner.runSchematic('address-form', baseOptions, app);
 
       expect(tree.files).not.toContain('/projects/material/src/app/foo/foo.component.html');
     });
@@ -121,22 +117,20 @@ describe('Material address-form schematic', () => {
   describe('skipTests option', () => {
     it('should respect the option value', async () => {
       const app = await createTestApp(runner);
-      const tree = await runner
-        .runSchematicAsync('address-form', {skipTests: true, ...baseOptions}, app)
-        .toPromise();
-
+      const tree = await runner.runSchematic(
+        'address-form',
+        {skipTests: true, ...baseOptions},
+        app,
+      );
       expect(tree.files).not.toContain('/projects/material/src/app/foo/foo.component.spec.ts');
     });
 
     it('should fall back to the @schematics/angular:component option value', async () => {
-      const tree = await runner
-        .runSchematicAsync(
-          'address-form',
-          baseOptions,
-          await createTestApp(runner, {skipTests: true}),
-        )
-        .toPromise();
-
+      const tree = await runner.runSchematic(
+        'address-form',
+        baseOptions,
+        await createTestApp(runner, {skipTests: true}),
+      );
       expect(tree.files).not.toContain('/projects/material/src/app/foo/foo.component.spec.ts');
     });
   });

--- a/src/material/schematics/ng-generate/dashboard/index.spec.ts
+++ b/src/material/schematics/ng-generate/dashboard/index.spec.ts
@@ -17,7 +17,7 @@ describe('material-dashboard-schematic', () => {
 
   it('should create dashboard files and add them to module', async () => {
     const app = await createTestApp(runner);
-    const tree = await runner.runSchematicAsync('dashboard', baseOptions, app).toPromise();
+    const tree = await runner.runSchematic('dashboard', baseOptions, app);
     const files = tree.files;
 
     expect(files).toContain('/projects/material/src/app/foo/foo.component.css');
@@ -32,7 +32,7 @@ describe('material-dashboard-schematic', () => {
 
   it('should add dashboard imports to module', async () => {
     const app = await createTestApp(runner);
-    const tree = await runner.runSchematicAsync('dashboard', baseOptions, app).toPromise();
+    const tree = await runner.runSchematic('dashboard', baseOptions, app);
     const moduleContent = getFileContent(tree, '/projects/material/src/app/app.module.ts');
 
     expect(moduleContent).toContain('MatGridListModule');
@@ -54,28 +54,26 @@ describe('material-dashboard-schematic', () => {
     const appTree = await createTestApp(runner);
 
     await expectAsync(
-      runner.runSchematicAsync('dashboard', {project: 'material'}, appTree).toPromise(),
+      runner.runSchematic('dashboard', {project: 'material'}, appTree),
     ).toBeRejectedWithError(/required property 'name'/);
   });
 
   describe('style option', () => {
     it('should respect the option value', async () => {
-      const tree = await runner
-        .runSchematicAsync(
-          'dashboard',
-          {style: 'scss', ...baseOptions},
-          await createTestApp(runner),
-        )
-        .toPromise();
-
+      const tree = await runner.runSchematic(
+        'dashboard',
+        {style: 'scss', ...baseOptions},
+        await createTestApp(runner),
+      );
       expect(tree.files).toContain('/projects/material/src/app/foo/foo.component.scss');
     });
 
     it('should fall back to the @schematics/angular:component option value', async () => {
-      const tree = await runner
-        .runSchematicAsync('dashboard', baseOptions, await createTestApp(runner, {style: 'less'}))
-        .toPromise();
-
+      const tree = await runner.runSchematic(
+        'dashboard',
+        baseOptions,
+        await createTestApp(runner, {style: 'less'}),
+      );
       expect(tree.files).toContain('/projects/material/src/app/foo/foo.component.less');
     });
   });
@@ -83,22 +81,16 @@ describe('material-dashboard-schematic', () => {
   describe('inlineStyle option', () => {
     it('should respect the option value', async () => {
       const app = await createTestApp(runner);
-      const tree = await runner
-        .runSchematicAsync('dashboard', {inlineStyle: true, ...baseOptions}, app)
-        .toPromise();
-
+      const tree = await runner.runSchematic('dashboard', {inlineStyle: true, ...baseOptions}, app);
       expect(tree.files).not.toContain('/projects/material/src/app/foo/foo.component.css');
     });
 
     it('should fall back to the @schematics/angular:component option value', async () => {
-      const tree = await runner
-        .runSchematicAsync(
-          'dashboard',
-          baseOptions,
-          await createTestApp(runner, {inlineStyle: true}),
-        )
-        .toPromise();
-
+      const tree = await runner.runSchematic(
+        'dashboard',
+        baseOptions,
+        await createTestApp(runner, {inlineStyle: true}),
+      );
       expect(tree.files).not.toContain('/projects/material/src/app/foo/foo.component.css');
     });
   });
@@ -106,16 +98,17 @@ describe('material-dashboard-schematic', () => {
   describe('inlineTemplate option', () => {
     it('should respect the option value', async () => {
       const app = await createTestApp(runner);
-      const tree = await runner
-        .runSchematicAsync('dashboard', {inlineTemplate: true, ...baseOptions}, app)
-        .toPromise();
-
+      const tree = await runner.runSchematic(
+        'dashboard',
+        {inlineTemplate: true, ...baseOptions},
+        app,
+      );
       expect(tree.files).not.toContain('/projects/material/src/app/foo/foo.component.html');
     });
 
     it('should fall back to the @schematics/angular:component option value', async () => {
       const app = await createTestApp(runner, {inlineTemplate: true});
-      const tree = await runner.runSchematicAsync('dashboard', baseOptions, app).toPromise();
+      const tree = await runner.runSchematic('dashboard', baseOptions, app);
 
       expect(tree.files).not.toContain('/projects/material/src/app/foo/foo.component.html');
     });
@@ -123,22 +116,20 @@ describe('material-dashboard-schematic', () => {
 
   describe('skipTests option', () => {
     it('should respect the option value', async () => {
-      const tree = await runner
-        .runSchematicAsync(
-          'dashboard',
-          {skipTests: true, ...baseOptions},
-          await createTestApp(runner),
-        )
-        .toPromise();
-
+      const tree = await runner.runSchematic(
+        'dashboard',
+        {skipTests: true, ...baseOptions},
+        await createTestApp(runner),
+      );
       expect(tree.files).not.toContain('/projects/material/src/app/foo/foo.component.spec.ts');
     });
 
     it('should fall back to the @schematics/angular:component option value', async () => {
-      const tree = await runner
-        .runSchematicAsync('dashboard', baseOptions, await createTestApp(runner, {skipTests: true}))
-        .toPromise();
-
+      const tree = await runner.runSchematic(
+        'dashboard',
+        baseOptions,
+        await createTestApp(runner, {skipTests: true}),
+      );
       expect(tree.files).not.toContain('/projects/material/src/app/foo/foo.component.spec.ts');
     });
   });

--- a/src/material/schematics/ng-generate/mdc-migration/rules/components/test-setup-helper.ts
+++ b/src/material/schematics/ng-generate/mdc-migration/rules/components/test-setup-helper.ts
@@ -32,7 +32,9 @@ export async function migrateComponents(
   runner: SchematicTestRunner,
   tree: UnitTestTree,
 ): Promise<UnitTestTree> {
-  return await runner
-    .runSchematicAsync('mdcMigration', {tsconfig: TS_CONFIG, components: components}, tree)
-    .toPromise();
+  return await runner.runSchematic(
+    'mdcMigration',
+    {tsconfig: TS_CONFIG, components: components},
+    tree,
+  );
 }

--- a/src/material/schematics/ng-generate/navigation/index.spec.ts
+++ b/src/material/schematics/ng-generate/navigation/index.spec.ts
@@ -38,7 +38,7 @@ describe('material-navigation-schematic', () => {
 
   it('should create navigation files and add them to module', async () => {
     const app = await createTestApp(runner);
-    const tree = await runner.runSchematicAsync('navigation', baseOptions, app).toPromise();
+    const tree = await runner.runSchematic('navigation', baseOptions, app);
     const files = tree.files;
 
     expect(files).toContain('/projects/material/src/app/foo/foo.component.css');
@@ -53,13 +53,13 @@ describe('material-navigation-schematic', () => {
 
   it('should add navigation imports to module', async () => {
     const app = await createTestApp(runner);
-    const tree = await runner.runSchematicAsync('navigation', baseOptions, app).toPromise();
+    const tree = await runner.runSchematic('navigation', baseOptions, app);
     expectNavigationSchematicModuleImports(tree);
   });
 
   it('should support `nav` as schematic alias', async () => {
     const app = await createTestApp(runner);
-    const tree = await runner.runSchematicAsync('nav', baseOptions, app).toPromise();
+    const tree = await runner.runSchematic('nav', baseOptions, app);
     expectNavigationSchematicModuleImports(tree);
   });
 
@@ -67,129 +67,105 @@ describe('material-navigation-schematic', () => {
     const appTree = await createTestApp(runner);
 
     await expectAsync(
-      runner.runSchematicAsync('navigation', {project: 'material'}, appTree).toPromise(),
+      runner.runSchematic('navigation', {project: 'material'}, appTree),
     ).toBeRejectedWithError(/required property 'name'/);
   });
 
   describe('style option', () => {
     it('should respect the option value', async () => {
-      const tree = await runner
-        .runSchematicAsync(
-          'navigation',
-          {style: 'scss', ...baseOptions},
-          await createTestApp(runner),
-        )
-        .toPromise();
-
+      const tree = await runner.runSchematic(
+        'navigation',
+        {style: 'scss', ...baseOptions},
+        await createTestApp(runner),
+      );
       expect(tree.files).toContain('/projects/material/src/app/foo/foo.component.scss');
     });
 
     it('should fall back to the @schematics/angular:component option value', async () => {
-      const tree = await runner
-        .runSchematicAsync('navigation', baseOptions, await createTestApp(runner, {style: 'less'}))
-        .toPromise();
-
+      const tree = await runner.runSchematic(
+        'navigation',
+        baseOptions,
+        await createTestApp(runner, {style: 'less'}),
+      );
       expect(tree.files).toContain('/projects/material/src/app/foo/foo.component.less');
     });
   });
 
   describe('inlineStyle option', () => {
     it('should respect the option value', async () => {
-      const tree = await runner
-        .runSchematicAsync(
-          'navigation',
-          {inlineStyle: true, ...baseOptions},
-          await createTestApp(runner),
-        )
-        .toPromise();
-
+      const tree = await runner.runSchematic(
+        'navigation',
+        {inlineStyle: true, ...baseOptions},
+        await createTestApp(runner),
+      );
       expect(tree.files).not.toContain('/projects/material/src/app/foo/foo.component.css');
     });
 
     it('should fall back to the @schematics/angular:component option value', async () => {
-      const tree = await runner
-        .runSchematicAsync(
-          'navigation',
-          baseOptions,
-          await createTestApp(runner, {inlineStyle: true}),
-        )
-        .toPromise();
-
+      const tree = await runner.runSchematic(
+        'navigation',
+        baseOptions,
+        await createTestApp(runner, {inlineStyle: true}),
+      );
       expect(tree.files).not.toContain('/projects/material/src/app/foo/foo.component.css');
     });
   });
 
   describe('inlineTemplate option', () => {
     it('should respect the option value', async () => {
-      const tree = await runner
-        .runSchematicAsync(
-          'navigation',
-          {inlineTemplate: true, ...baseOptions},
-          await createTestApp(runner),
-        )
-        .toPromise();
-
+      const tree = await runner.runSchematic(
+        'navigation',
+        {inlineTemplate: true, ...baseOptions},
+        await createTestApp(runner),
+      );
       expect(tree.files).not.toContain('/projects/material/src/app/foo/foo.component.html');
     });
 
     it('should fall back to the @schematics/angular:component option value', async () => {
-      const tree = await runner
-        .runSchematicAsync(
-          'navigation',
-          baseOptions,
-          await createTestApp(runner, {inlineTemplate: true}),
-        )
-        .toPromise();
-
+      const tree = await runner.runSchematic(
+        'navigation',
+        baseOptions,
+        await createTestApp(runner, {inlineTemplate: true}),
+      );
       expect(tree.files).not.toContain('/projects/material/src/app/foo/foo.component.html');
     });
   });
 
   describe('skipTests option', () => {
     it('should respect the option value', async () => {
-      const tree = await runner
-        .runSchematicAsync(
-          'navigation',
-          {skipTests: true, ...baseOptions},
-          await createTestApp(runner),
-        )
-        .toPromise();
-
+      const tree = await runner.runSchematic(
+        'navigation',
+        {skipTests: true, ...baseOptions},
+        await createTestApp(runner),
+      );
       expect(tree.files).not.toContain('/projects/material/src/app/foo/foo.component.spec.ts');
     });
 
     it('should fall back to the @schematics/angular:component option value', async () => {
-      const tree = await runner
-        .runSchematicAsync(
-          'navigation',
-          baseOptions,
-          await createTestApp(runner, {skipTests: true}),
-        )
-        .toPromise();
-
+      const tree = await runner.runSchematic(
+        'navigation',
+        baseOptions,
+        await createTestApp(runner, {skipTests: true}),
+      );
       expect(tree.files).not.toContain('/projects/material/src/app/foo/foo.component.spec.ts');
     });
   });
   describe('router option', () => {
     it('should respect the option value if routing true', async () => {
-      const tree = await runner
-        .runSchematicAsync(
-          'navigation',
-          {routing: true, ...baseOptions},
-          await createTestApp(runner),
-        )
-        .toPromise();
+      const tree = await runner.runSchematic(
+        'navigation',
+        {routing: true, ...baseOptions},
+        await createTestApp(runner),
+      );
       const template = tree.readContent('/projects/material/src/app/foo/foo.component.html');
       expect(template).toContain('<a mat-list-item routerLink="/">Link 1</a>');
     });
     it('should respect the option value if routing false', async () => {
-      const tree = await runner
-        .runSchematicAsync(
-          'navigation',
-          {routing: false, ...baseOptions},
-          await createTestApp(runner),
-        )
-        .toPromise();
+      const tree = await runner.runSchematic(
+        'navigation',
+        {routing: false, ...baseOptions},
+        await createTestApp(runner),
+      );
       const template = tree.readContent('/projects/material/src/app/foo/foo.component.html');
       expect(template).toContain('<a mat-list-item href="#">Link 1</a>');
     });

--- a/src/material/schematics/ng-generate/table/index.spec.ts
+++ b/src/material/schematics/ng-generate/table/index.spec.ts
@@ -17,7 +17,7 @@ describe('material-table-schematic', () => {
 
   it('should create table files and add them to module', async () => {
     const app = await createTestApp(runner);
-    const tree = await runner.runSchematicAsync('table', baseOptions, app).toPromise();
+    const tree = await runner.runSchematic('table', baseOptions, app);
     const files = tree.files;
 
     expect(files).toContain('/projects/material/src/app/foo/foo.component.css');
@@ -48,7 +48,7 @@ describe('material-table-schematic', () => {
 
   it('should add table imports to module', async () => {
     const app = await createTestApp(runner);
-    const tree = await runner.runSchematicAsync('table', baseOptions, app).toPromise();
+    const tree = await runner.runSchematic('table', baseOptions, app);
     const moduleContent = getFileContent(tree, '/projects/material/src/app/app.module.ts');
 
     expect(moduleContent).toContain('MatTableModule');
@@ -66,90 +66,86 @@ describe('material-table-schematic', () => {
     const appTree = await createTestApp(runner);
 
     await expectAsync(
-      runner.runSchematicAsync('table', {project: 'material'}, appTree).toPromise(),
+      runner.runSchematic('table', {project: 'material'}, appTree),
     ).toBeRejectedWithError(/required property 'name'/);
   });
 
   describe('style option', () => {
     it('should respect the option value', async () => {
-      const tree = await runner
-        .runSchematicAsync('table', {style: 'scss', ...baseOptions}, await createTestApp(runner))
-        .toPromise();
-
+      const tree = await runner.runSchematic(
+        'table',
+        {style: 'scss', ...baseOptions},
+        await createTestApp(runner),
+      );
       expect(tree.files).toContain('/projects/material/src/app/foo/foo.component.scss');
     });
 
     it('should fall back to the @schematics/angular:component option value', async () => {
-      const tree = await runner
-        .runSchematicAsync('table', baseOptions, await createTestApp(runner, {style: 'less'}))
-        .toPromise();
-
+      const tree = await runner.runSchematic(
+        'table',
+        baseOptions,
+        await createTestApp(runner, {style: 'less'}),
+      );
       expect(tree.files).toContain('/projects/material/src/app/foo/foo.component.less');
     });
   });
 
   describe('inlineStyle option', () => {
     it('should respect the option value', async () => {
-      const tree = await runner
-        .runSchematicAsync(
-          'table',
-          {inlineStyle: true, ...baseOptions},
-          await createTestApp(runner),
-        )
-        .toPromise();
-
+      const tree = await runner.runSchematic(
+        'table',
+        {inlineStyle: true, ...baseOptions},
+        await createTestApp(runner),
+      );
       expect(tree.files).not.toContain('/projects/material/src/app/foo/foo.component.css');
     });
 
     it('should fall back to the @schematics/angular:component option value', async () => {
-      const tree = await runner
-        .runSchematicAsync('table', baseOptions, await createTestApp(runner, {inlineStyle: true}))
-        .toPromise();
-
+      const tree = await runner.runSchematic(
+        'table',
+        baseOptions,
+        await createTestApp(runner, {inlineStyle: true}),
+      );
       expect(tree.files).not.toContain('/projects/material/src/app/foo/foo.component.css');
     });
   });
 
   describe('inlineTemplate option', () => {
     it('should respect the option value', async () => {
-      const tree = await runner
-        .runSchematicAsync(
-          'table',
-          {inlineTemplate: true, ...baseOptions},
-          await createTestApp(runner),
-        )
-        .toPromise();
-
+      const tree = await runner.runSchematic(
+        'table',
+        {inlineTemplate: true, ...baseOptions},
+        await createTestApp(runner),
+      );
       expect(tree.files).not.toContain('/projects/material/src/app/foo/foo.component.html');
     });
 
     it('should fall back to the @schematics/angular:component option value', async () => {
-      const tree = await runner
-        .runSchematicAsync(
-          'table',
-          baseOptions,
-          await createTestApp(runner, {inlineTemplate: true}),
-        )
-        .toPromise();
-
+      const tree = await runner.runSchematic(
+        'table',
+        baseOptions,
+        await createTestApp(runner, {inlineTemplate: true}),
+      );
       expect(tree.files).not.toContain('/projects/material/src/app/foo/foo.component.html');
     });
   });
 
   describe('skipTests option', () => {
     it('should respect the option value', async () => {
-      const tree = await runner
-        .runSchematicAsync('table', {skipTests: true, ...baseOptions}, await createTestApp(runner))
-        .toPromise();
-
+      const tree = await runner.runSchematic(
+        'table',
+        {skipTests: true, ...baseOptions},
+        await createTestApp(runner),
+      );
       expect(tree.files).not.toContain('/projects/material/src/app/foo/foo.component.spec.ts');
     });
 
     it('should fall back to the @schematics/angular:component option value', async () => {
-      const tree = await runner
-        .runSchematicAsync('table', baseOptions, await createTestApp(runner, {skipTests: true}))
-        .toPromise();
-
+      const tree = await runner.runSchematic(
+        'table',
+        baseOptions,
+        await createTestApp(runner, {skipTests: true}),
+      );
       expect(tree.files).not.toContain('/projects/material/src/app/foo/foo.component.spec.ts');
     });
   });

--- a/src/material/schematics/ng-generate/tree/index.spec.ts
+++ b/src/material/schematics/ng-generate/tree/index.spec.ts
@@ -17,7 +17,7 @@ describe('Material tree schematic', () => {
 
   it('should create tree component files and add them to module', async () => {
     const app = await createTestApp(runner);
-    const tree = await runner.runSchematicAsync('tree', baseOptions, app).toPromise();
+    const tree = await runner.runSchematic('tree', baseOptions, app);
     const files = tree.files;
 
     expect(files).toContain('/projects/material/src/app/foo/foo.component.css');
@@ -32,7 +32,7 @@ describe('Material tree schematic', () => {
 
   it('should add tree imports to module', async () => {
     const app = await createTestApp(runner);
-    const tree = await runner.runSchematicAsync('tree', baseOptions, app).toPromise();
+    const tree = await runner.runSchematic('tree', baseOptions, app);
     const moduleContent = getFileContent(tree, '/projects/material/src/app/app.module.ts');
 
     expect(moduleContent).toContain('MatTreeModule');
@@ -44,82 +44,86 @@ describe('Material tree schematic', () => {
     const appTree = await createTestApp(runner);
 
     await expectAsync(
-      runner.runSchematicAsync('tree', {project: 'material'}, appTree).toPromise(),
+      runner.runSchematic('tree', {project: 'material'}, appTree),
     ).toBeRejectedWithError(/required property 'name'/);
   });
 
   describe('style option', () => {
     it('should respect the option value', async () => {
-      const tree = await runner
-        .runSchematicAsync('tree', {style: 'scss', ...baseOptions}, await createTestApp(runner))
-        .toPromise();
-
+      const tree = await runner.runSchematic(
+        'tree',
+        {style: 'scss', ...baseOptions},
+        await createTestApp(runner),
+      );
       expect(tree.files).toContain('/projects/material/src/app/foo/foo.component.scss');
     });
 
     it('should fall back to the @schematics/angular:component option value', async () => {
-      const tree = await runner
-        .runSchematicAsync('tree', baseOptions, await createTestApp(runner, {style: 'less'}))
-        .toPromise();
-
+      const tree = await runner.runSchematic(
+        'tree',
+        baseOptions,
+        await createTestApp(runner, {style: 'less'}),
+      );
       expect(tree.files).toContain('/projects/material/src/app/foo/foo.component.less');
     });
   });
 
   describe('inlineStyle option', () => {
     it('should respect the option value', async () => {
-      const tree = await runner
-        .runSchematicAsync('tree', {inlineStyle: true, ...baseOptions}, await createTestApp(runner))
-        .toPromise();
-
+      const tree = await runner.runSchematic(
+        'tree',
+        {inlineStyle: true, ...baseOptions},
+        await createTestApp(runner),
+      );
       expect(tree.files).not.toContain('/projects/material/src/app/foo/foo.component.css');
     });
 
     it('should fall back to the @schematics/angular:component option value', async () => {
-      const tree = await runner
-        .runSchematicAsync('tree', baseOptions, await createTestApp(runner, {inlineStyle: true}))
-        .toPromise();
-
+      const tree = await runner.runSchematic(
+        'tree',
+        baseOptions,
+        await createTestApp(runner, {inlineStyle: true}),
+      );
       expect(tree.files).not.toContain('/projects/material/src/app/foo/foo.component.css');
     });
   });
 
   describe('inlineTemplate option', () => {
     it('should respect the option value', async () => {
-      const tree = await runner
-        .runSchematicAsync(
-          'tree',
-          {inlineTemplate: true, ...baseOptions},
-          await createTestApp(runner),
-        )
-        .toPromise();
-
+      const tree = await runner.runSchematic(
+        'tree',
+        {inlineTemplate: true, ...baseOptions},
+        await createTestApp(runner),
+      );
       expect(tree.files).not.toContain('/projects/material/src/app/foo/foo.component.html');
     });
 
     it('should fall back to the @schematics/angular:component option value', async () => {
-      const tree = await runner
-        .runSchematicAsync('tree', baseOptions, await createTestApp(runner, {inlineTemplate: true}))
-        .toPromise();
-
+      const tree = await runner.runSchematic(
+        'tree',
+        baseOptions,
+        await createTestApp(runner, {inlineTemplate: true}),
+      );
       expect(tree.files).not.toContain('/projects/material/src/app/foo/foo.component.html');
     });
   });
 
   describe('skipTests option', () => {
     it('should respect the option value', async () => {
-      const tree = await runner
-        .runSchematicAsync('tree', {skipTests: true, ...baseOptions}, await createTestApp(runner))
-        .toPromise();
-
+      const tree = await runner.runSchematic(
+        'tree',
+        {skipTests: true, ...baseOptions},
+        await createTestApp(runner),
+      );
       expect(tree.files).not.toContain('/projects/material/src/app/foo/foo.component.spec.ts');
     });
 
     it('should fall back to the @schematics/angular:component option value', async () => {
-      const tree = await runner
-        .runSchematicAsync('tree', baseOptions, await createTestApp(runner, {skipTests: true}))
-        .toPromise();
-
+      const tree = await runner.runSchematic(
+        'tree',
+        baseOptions,
+        await createTestApp(runner, {skipTests: true}),
+      );
       expect(tree.files).not.toContain('/projects/material/src/app/foo/foo.component.spec.ts');
     });
   });


### PR DESCRIPTION
The `runSchematicAsync` API has been replaced by `runSchematic`. These changes clean up all of our usages.