### PR TITLE
Chip harness editing support

### DIFF
--- a/src/cdk/testing/protractor/protractor-element.ts
+++ b/src/cdk/testing/protractor/protractor-element.ts
@@ -199,6 +199,20 @@ export class ProtractorElement implements TestElement {
     return browser.executeScript(`return (arguments[0].textContent || '').trim()`, this.element);
   }
 
+  /**
+   * Sets the value of a `contenteditable` element.
+   * @param value Value to be set on the element.
+   */
+  async setContenteditableValue(value: string): Promise<void> {
+    const contenteditableAttr = await this.getAttribute('contenteditable');
+
+    if (contenteditableAttr !== '' && contenteditableAttr !== 'true') {
+      throw new Error('setContenteditableValue can only be called on a `contenteditable` element.');
+    }
+
+    return browser.executeScript(`arguments[0].textContent = arguments[1];`, this.element, value);
+  }
+
   /** Gets the value for the given attribute from the element. */
   async getAttribute(name: string): Promise<string | null> {
     return browser.executeScript(

--- a/src/cdk/testing/selenium-webdriver/selenium-web-driver-element.ts
+++ b/src/cdk/testing/selenium-webdriver/selenium-web-driver-element.ts
@@ -154,6 +154,25 @@ export class SeleniumWebDriverElement implements TestElement {
     );
   }
 
+  /**
+   * Sets the value of a `contenteditable` element.
+   * @param value Value to be set on the element.
+   */
+  async setContenteditableValue(value: string): Promise<void> {
+    const contenteditableAttr = await this.getAttribute('contenteditable');
+
+    if (contenteditableAttr !== '' && contenteditableAttr !== 'true') {
+      throw new Error('setContenteditableValue can only be called on a `contenteditable` element.');
+    }
+
+    await this._stabilize();
+    return this._executeScript(
+      (element: Element, valueToSet: string) => (element.textContent = valueToSet),
+      this.element(),
+      value,
+    );
+  }
+
   /** Gets the value for the given attribute from the element. */
   async getAttribute(name: string): Promise<string | null> {
     await this._stabilize();

--- a/src/cdk/testing/test-element.ts
+++ b/src/cdk/testing/test-element.ts
@@ -137,6 +137,13 @@ export interface TestElement {
    */
   text(options?: TextOptions): Promise<string>;
 
+  /**
+   * Sets the value of a `contenteditable` element.
+   * @param value Value to be set on the element.
+   * @breaking-change 16.0.0 Will become a required method.
+   */
+  setContenteditableValue?(value: string): Promise<void>;
+
   /** Gets the value for the given attribute from the element. */
   getAttribute(name: string): Promise<string | null>;
 

--- a/src/cdk/testing/testbed/unit-test-element.ts
+++ b/src/cdk/testing/testbed/unit-test-element.ts
@@ -185,6 +185,21 @@ export class UnitTestElement implements TestElement {
     return (this.element.textContent || '').trim();
   }
 
+  /**
+   * Sets the value of a `contenteditable` element.
+   * @param value Value to be set on the element.
+   */
+  async setContenteditableValue(value: string): Promise<void> {
+    const contenteditableAttr = await this.getAttribute('contenteditable');
+
+    if (contenteditableAttr !== '' && contenteditableAttr !== 'true') {
+      throw new Error('setContenteditableValue can only be called on a `contenteditable` element.');
+    }
+
+    await this._stabilize();
+    this.element.textContent = value;
+  }
+
   /** Gets the value for the given attribute from the element. */
   async getAttribute(name: string): Promise<string | null> {
     await this._stabilize();

--- a/src/cdk/testing/tests/cross-environment.spec.ts
+++ b/src/cdk/testing/tests/cross-environment.spec.ts
@@ -716,6 +716,17 @@ export function crossEnvironmentSpecs(
       const hiddenElement = await harness.hidden();
       expect(await hiddenElement.text()).toBe('Hello');
     });
+
+    it('should be able to set the value of a contenteditable element', async () => {
+      const element = await harness.contenteditable();
+      expect(await element.text()).not.toBe('hello');
+
+      // @breaking-change 16.0.0 Remove non-null assertion once `setContenteditableValue`
+      // becomes a required method.
+      await element.setContenteditableValue!('hello');
+
+      expect(await element.text()).toBe('hello');
+    });
   });
 }
 

--- a/src/cdk/testing/tests/harnesses/main-component-harness.ts
+++ b/src/cdk/testing/tests/harnesses/main-component-harness.ts
@@ -40,6 +40,7 @@ export class MainComponentHarness extends ComponentHarness {
   readonly numberInput = this.locatorFor('#number-input');
   readonly numberInputValue = this.locatorFor('#number-input-value');
   readonly contextmenuTestResult = this.locatorFor('.contextmenu-test-result');
+  readonly contenteditable = this.locatorFor('#contenteditable');
   // Allow null for element
   readonly nullItem = this.locatorForOptional('wrong locator');
   // Allow null for component harness

--- a/src/cdk/testing/tests/test-main-component.html
+++ b/src/cdk/testing/tests/test-main-component.html
@@ -14,6 +14,7 @@
   <label>AsyncCounter:</label>
   <div id="asyncCounter">{{asyncCounter}}</div>
 </div>
+<span id="contenteditable" contenteditable>initial value</span>
 <div class="inputs">
   <input [(ngModel)]="input" id="input" aria-label="input" (keydown)="onKeyDown($event)">
   <span class="special-key">{{specialKey}}</span>

--- a/src/material/chips/testing/chip-edit-input-harness.ts
+++ b/src/material/chips/testing/chip-edit-input-harness.ts
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {
+  ComponentHarness,
+  ComponentHarnessConstructor,
+  HarnessPredicate,
+} from '@angular/cdk/testing';
+import {ChipEditInputHarnessFilters} from './chip-harness-filters';
+
+/** Harness for interacting with an editable chip's input in tests. */
+export class MatChipEditInputHarness extends ComponentHarness {
+  static hostSelector = '.mat-chip-edit-input';
+
+  /**
+   * Gets a `HarnessPredicate` that can be used to search for a chip edit input with specific
+   * attributes.
+   * @param options Options for filtering which input instances are considered a match.
+   * @return a `HarnessPredicate` configured with the given options.
+   */
+  static with<T extends MatChipEditInputHarness>(
+    this: ComponentHarnessConstructor<T>,
+    options: ChipEditInputHarnessFilters = {},
+  ): HarnessPredicate<T> {
+    return new HarnessPredicate(this, options);
+  }
+
+  /** Sets the value of the input. */
+  async setValue(value: string): Promise<void> {
+    const host = await this.host();
+
+    // @breaking-change 16.0.0 Remove this null check once `setContenteditableValue`
+    // becomes a required method.
+    if (!host.setContenteditableValue) {
+      throw new Error(
+        'Cannot set chip edit input value, because test ' +
+          'element does not implement the `setContenteditableValue` method.',
+      );
+    }
+
+    return host.setContenteditableValue(value);
+  }
+}

--- a/src/material/chips/testing/chip-harness-filters.ts
+++ b/src/material/chips/testing/chip-harness-filters.ts
@@ -46,3 +46,5 @@ export interface ChipSetHarnessFilters extends BaseHarnessFilters {}
 export interface ChipRemoveHarnessFilters extends BaseHarnessFilters {}
 
 export interface ChipAvatarHarnessFilters extends BaseHarnessFilters {}
+
+export interface ChipEditInputHarnessFilters extends BaseHarnessFilters {}

--- a/src/material/chips/testing/chip-row-harness.ts
+++ b/src/material/chips/testing/chip-row-harness.ts
@@ -6,9 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {TestKey} from '@angular/cdk/testing';
+import {MatChipEditInputHarness} from './chip-edit-input-harness';
 import {MatChipHarness} from './chip-harness';
-
-// TODO(crisbeto): add harness for the chip edit input inside the row.
+import {ChipEditInputHarnessFilters} from './chip-harness-filters';
 
 /** Harness for interacting with a mat-chip-row in tests. */
 export class MatChipRowHarness extends MatChipHarness {
@@ -22,5 +23,25 @@ export class MatChipRowHarness extends MatChipHarness {
   /** Whether the chip is currently being edited. */
   async isEditing(): Promise<boolean> {
     return (await this.host()).hasClass('mat-mdc-chip-editing');
+  }
+
+  /** Sets the chip row into an editing state, if it is editable. */
+  async startEditing(): Promise<void> {
+    if (!(await this.isEditable())) {
+      throw new Error('Cannot begin editing a chip that is not editable.');
+    }
+    return (await this.host()).dispatchEvent('dblclick');
+  }
+
+  /** Stops editing the chip, if it was in the editing state. */
+  async finishEditing(): Promise<void> {
+    if (await this.isEditing()) {
+      await (await this.host()).sendKeys(TestKey.ENTER);
+    }
+  }
+
+  /** Gets the edit input inside the chip row. */
+  async getEditInput(filter: ChipEditInputHarnessFilters = {}): Promise<MatChipEditInputHarness> {
+    return this.locatorFor(MatChipEditInputHarness.with(filter))();
   }
 }

--- a/src/material/chips/testing/public-api.ts
+++ b/src/material/chips/testing/public-api.ts
@@ -16,3 +16,4 @@ export * from './chip-listbox-harness';
 export * from './chip-grid-harness';
 export * from './chip-row-harness';
 export * from './chip-set-harness';
+export * from './chip-edit-input-harness';

--- a/tools/public_api_guard/cdk/testing-selenium-webdriver.md
+++ b/tools/public_api_guard/cdk/testing-selenium-webdriver.md
@@ -39,6 +39,7 @@ export class SeleniumWebDriverElement implements TestElement {
     selectOptions(...optionIndexes: number[]): Promise<void>;
     sendKeys(...keys: (string | TestKey)[]): Promise<void>;
     sendKeys(modifiers: ModifierKeys, ...keys: (string | TestKey)[]): Promise<void>;
+    setContenteditableValue(value: string): Promise<void>;
     setInputValue(newValue: string): Promise<void>;
     text(options?: TextOptions): Promise<string>;
 }

--- a/tools/public_api_guard/cdk/testing-testbed.md
+++ b/tools/public_api_guard/cdk/testing-testbed.md
@@ -61,6 +61,7 @@ export class UnitTestElement implements TestElement {
     selectOptions(...optionIndexes: number[]): Promise<void>;
     sendKeys(...keys: (string | TestKey)[]): Promise<void>;
     sendKeys(modifiers: ModifierKeys, ...keys: (string | TestKey)[]): Promise<void>;
+    setContenteditableValue(value: string): Promise<void>;
     setInputValue(value: string): Promise<void>;
     text(options?: TextOptions): Promise<string>;
 }

--- a/tools/public_api_guard/cdk/testing.md
+++ b/tools/public_api_guard/cdk/testing.md
@@ -251,6 +251,7 @@ export interface TestElement {
     selectOptions(...optionIndexes: number[]): Promise<void>;
     sendKeys(...keys: (string | TestKey)[]): Promise<void>;
     sendKeys(modifiers: ModifierKeys, ...keys: (string | TestKey)[]): Promise<void>;
+    setContenteditableValue?(value: string): Promise<void>;
     setInputValue(value: string): Promise<void>;
     text(options?: TextOptions): Promise<string>;
 }

--- a/tools/public_api_guard/material/chips-testing.md
+++ b/tools/public_api_guard/material/chips-testing.md
@@ -18,6 +18,10 @@ export interface ChipAvatarHarnessFilters extends BaseHarnessFilters {
 }
 
 // @public (undocumented)
+export interface ChipEditInputHarnessFilters extends BaseHarnessFilters {
+}
+
+// @public (undocumented)
 export interface ChipGridHarnessFilters extends BaseHarnessFilters {
     disabled?: boolean;
 }
@@ -62,6 +66,14 @@ export class MatChipAvatarHarness extends ComponentHarness {
     // (undocumented)
     static hostSelector: string;
     static with<T extends MatChipAvatarHarness>(this: ComponentHarnessConstructor<T>, options?: ChipAvatarHarnessFilters): HarnessPredicate<T>;
+}
+
+// @public
+export class MatChipEditInputHarness extends ComponentHarness {
+    // (undocumented)
+    static hostSelector: string;
+    setValue(value: string): Promise<void>;
+    static with<T extends MatChipEditInputHarness>(this: ComponentHarnessConstructor<T>, options?: ChipEditInputHarnessFilters): HarnessPredicate<T>;
 }
 
 // @public
@@ -140,10 +152,13 @@ export class MatChipRemoveHarness extends ComponentHarness {
 
 // @public
 export class MatChipRowHarness extends MatChipHarness {
+    finishEditing(): Promise<void>;
+    getEditInput(filter?: ChipEditInputHarnessFilters): Promise<MatChipEditInputHarness>;
     // (undocumented)
     static hostSelector: string;
     isEditable(): Promise<boolean>;
     isEditing(): Promise<boolean>;
+    startEditing(): Promise<void>;
 }
 
 // @public


### PR DESCRIPTION
Includes a couple of commits necessary to support editing a chip row through harnesses.

The first commit adds a `setText` method to `TestElement`. It is required, because the chip's edit input is a `contenteditable` span and we currently don't have a way of setting its text.

The second commit adds `startEditing` and `finishEditing` methods to the chip row harness, as well as a `MatChipEditInputHarness` to support the entire editing flow in a test.

Fixes https://github.com/angular/components/issues/26419.