### PR TITLE
docs(cdk/drag-drop): put back Episode V poster exemple ✨

### DIFF
--- a/src/components-examples/cdk/drag-drop/cdk-drag-drop-custom-preview/cdk-drag-drop-custom-preview-example.ts
+++ b/src/components-examples/cdk/drag-drop/cdk-drag-drop-custom-preview/cdk-drag-drop-custom-preview-example.ts
@@ -32,7 +32,7 @@ export class CdkDragDropCustomPreviewExample {
     },
     {
       title: 'Episode V - The Empire Strikes Back',
-      poster: 'https://upload.wikimedia.org/wikipedia/en/3/3c/SW_-_Empire_Strikes_Back.jpg',
+      poster: 'https://upload.wikimedia.org/wikipedia/en/3/3f/The_Empire_Strikes_Back_%281980_film%29.jpg',
     },
     {
       title: 'Episode VI - Return of the Jedi',

--- a/src/components-examples/cdk/drag-drop/cdk-drag-drop-custom-preview/cdk-drag-drop-custom-preview-example.ts
+++ b/src/components-examples/cdk/drag-drop/cdk-drag-drop-custom-preview/cdk-drag-drop-custom-preview-example.ts
@@ -32,7 +32,8 @@ export class CdkDragDropCustomPreviewExample {
     },
     {
       title: 'Episode V - The Empire Strikes Back',
-      poster: 'https://upload.wikimedia.org/wikipedia/en/3/3f/The_Empire_Strikes_Back_%281980_film%29.jpg',
+      poster:
+        'https://upload.wikimedia.org/wikipedia/en/3/3f/The_Empire_Strikes_Back_%281980_film%29.jpg',
     },
     {
       title: 'Episode VI - Return of the Jedi',


### PR DESCRIPTION
### Documentation update

Missing poster for `Episode V - The Empire Strikes Back`

![Jan-17-2023 14-36-54](https://user-images.githubusercontent.com/3717296/212913122-7245938d-da9d-4aa0-a85c-b274f7595f48.gif)

### Affected documentation page

https://material.angular.io/cdk/drag-drop/overview#customizing-the-drag-preview
