### PR TITLE
fix(material/schematics): don't migrate unknown stylesheet formats

### DIFF
--- a/src/material/schematics/ng-generate/mdc-migration/rules/ts-migration/runtime-migration.ts
+++ b/src/material/schematics/ng-generate/mdc-migration/rules/ts-migration/runtime-migration.ts
@@ -225,10 +225,10 @@ export class RuntimeCodeMigration extends Migration<ComponentMigrator[], Schemat
   }
 
   private _migratePropertyAssignment(
-    node: ts.StringLiteralLike | ts.Identifier,
+    node: ts.StringLiteralLike,
     migration: TemplateMigration | ThemingStylesMigration,
   ) {
-    let migratedText = migration.migrate(node.text, node.getSourceFile().fileName);
+    let migratedText = migration.migrate(node.text, node.getSourceFile().fileName, true);
     let migratedTextLines = migratedText.split('\n');
 
     // Update quotes based on if its multiline or not to avoid compilation errors

--- a/src/material/schematics/ng-update/migrations/legacy-components-v15/index.ts
+++ b/src/material/schematics/ng-update/migrations/legacy-components-v15/index.ts
@@ -19,11 +19,18 @@ import {
   MIGRATED_CORE_SYMBOLS,
 } from './constants';
 import {Migration, ResolvedResource, TargetVersion, WorkspacePath} from '@angular/cdk/schematics';
+import {extname} from 'path';
 
 export class LegacyComponentsMigration extends Migration<null> {
   enabled = this.targetVersion === TargetVersion.V15;
 
   override visitStylesheet(stylesheet: ResolvedResource): void {
+    const extension = extname(stylesheet.filePath).toLowerCase();
+
+    if (!stylesheet.inline && extension && extension !== '.css' && extension !== '.scss') {
+      return;
+    }
+
     let namespace: string | undefined = undefined;
     const processor = new postcss.Processor([
       {


### PR DESCRIPTION
Fixes that we were trying to parse stylesheets that we don't support (e.g. `.sass`).

Fixes #26396.