### PR TITLE
refactor(material/chips): Use variant `theme-styles` instead of `chip-theme.theme-styles`

### DIFF
--- a/src/material/chips/chip.scss
+++ b/src/material/chips/chip.scss
@@ -1,6 +1,11 @@
+@use 'sass:map';
 @use '@angular/cdk';
 @use '@material/chips/chip' as mdc-chip;
 @use '@material/chips/chip-theme' as mdc-chip-theme;
+@use '@material/chips/assist-chip-theme' as mdc-assist-chip-theme;
+@use '@material/chips/filter-chip-theme' as mdc-filter-chip-theme;
+@use '@material/chips/input-chip-theme' as mdc-input-chip-theme;
+@use '@material/chips/suggestion-chip-theme' as mdc-suggestion-chip-theme;
 @use '../core/mdc-helpers/mdc-helpers';
 @use '../core/style/layout-common';
 @use '../core/focus-indicators/private' as focus-indicators-private;
@@ -62,34 +67,21 @@
   -webkit-tap-highlight-color: transparent;
 
   @include mdc-helpers.disable-mdc-fallback-declarations {
-    @include mdc-chip-theme.theme-styles((
-      // Static tokens
-      with-avatar-avatar-shape: (
-        family: 'rounded',
-        radius: (14px, 14px, 14px, 14px)
-      ),
-      with-icon-icon-size: 18px,
-      with-leading-icon-disabled-leading-icon-opacity: 0.38,
-      with-leading-icon-leading-icon-size: 20px,
-      with-trailing-icon-disabled-trailing-icon-opacity: 0.38,
-      with-avatar-avatar-size: 28px,
-      with-avatar-disabled-avatar-opacity: 0.38,
-      with-icon-disabled-icon-opacity: 0.38,
-      with-trailing-icon-trailing-icon-size: 18px,
-      flat-disabled-outline-opacity: 0.12,
-      flat-disabled-unselected-outline-opacity: 0.12,
-      flat-selected-outline-width: 0,
-      outline-width: 1px,
-      flat-unselected-outline-width: 1px,
-      flat-outline-width: 1px,
+    $_base-theme: (
       disabled-label-text-opacity: 0.38,
-      disabled-outline-opacity: 0.12,
-      elevated-disabled-container-opacity: 0.12,
       container-height: 32px,
       container-shape: (
         family: 'rounded',
         radius: (16px, 16px, 16px, 16px)
       ),
+    );
+    @include mdc-assist-chip-theme.theme-styles(map.merge($_base-theme, (
+      // Static tokens
+      with-icon-icon-size: 18px,
+      with-icon-disabled-icon-opacity: 0.38,
+      flat-disabled-outline-opacity: 0.12,
+      flat-outline-width: 1px,
+      elevated-disabled-container-opacity: 0.12,
 
       // Tokens that will be overwritten in the theme
       elevated-container-color: transparent,
@@ -98,10 +90,57 @@
       disabled-label-text-color: currentColor,
       with-icon-icon-color: currentColor,
       with-icon-disabled-icon-color: currentColor,
+    )));
+    @include mdc-filter-chip-theme.theme-styles(map.merge($_base-theme, (
+      // Static tokens
+      with-icon-icon-size: 18px,
+      with-icon-disabled-icon-opacity: 0.38,
+      flat-disabled-unselected-outline-opacity: 0.12,
+      flat-selected-outline-width: 0,
+      flat-unselected-outline-width: 1px,
+      elevated-disabled-container-opacity: 0.12,
+
+      // Tokens that will be overwritten in the theme
+      elevated-disabled-container-color: transparent,
+      disabled-label-text-color: currentColor,
+      with-icon-disabled-icon-color: currentColor,
+      with-icon-selected-icon-color: currentColor,
+    )));
+    @include mdc-input-chip-theme.theme-styles(map.merge($_base-theme, (
+      // Static tokens
+      with-avatar-avatar-shape: (
+        family: 'rounded',
+        radius: (14px, 14px, 14px, 14px)
+      ),
+      with-leading-icon-disabled-leading-icon-opacity: 0.38,
+      with-leading-icon-leading-icon-size: 20px,
+      with-trailing-icon-disabled-trailing-icon-opacity: 0.38,
+      with-avatar-avatar-size: 28px,
+      with-avatar-disabled-avatar-opacity: 0.38,
+      with-trailing-icon-trailing-icon-size: 18px,
+      outline-width: 1px,
+      disabled-outline-opacity: 0.12,
+
+      // Tokens that will be overwritten in the theme
+      label-text-color: currentColor,
+      disabled-label-text-color: currentColor,
       with-trailing-icon-disabled-trailing-icon-color: currentColor,
       with-trailing-icon-trailing-icon-color: currentColor,
-      with-icon-selected-icon-color: currentColor,
-    ));
+    )));
+    @include mdc-suggestion-chip-theme.theme-styles(map.merge($_base-theme, (
+      // Static tokens
+      with-leading-icon-disabled-leading-icon-opacity: 0.38,
+      with-leading-icon-leading-icon-size: 20px,
+      flat-disabled-outline-opacity: 0.12,
+      flat-outline-width: 1px,
+      elevated-disabled-container-opacity: 0.12,
+
+      // Tokens that will be overwritten in the theme
+      elevated-container-color: transparent,
+      elevated-disabled-container-color: transparent,
+      label-text-color: currentColor,
+      disabled-label-text-color: currentColor,
+    )));
   }
 
   @include cdk.high-contrast(active, off) {


### PR DESCRIPTION
This is Step 1 of the effort to migrate off MDC Chips `chip-theme`.