### PR TITLE
refactor(material/menu): expose MenuCloseReason type

### DIFF
--- a/src/material/menu/public-api.ts
+++ b/src/material/menu/public-api.ts
@@ -6,7 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-export {MatMenu, _MatMenuBase, MAT_MENU_DEFAULT_OPTIONS, MatMenuDefaultOptions} from './menu';
+export {
+  MatMenu,
+  _MatMenuBase,
+  MAT_MENU_DEFAULT_OPTIONS,
+  MatMenuDefaultOptions,
+  MenuCloseReason,
+} from './menu';
 export * from './menu-item';
 export * from './menu-content';
 export {

--- a/tools/public_api_guard/material/menu.md
+++ b/tools/public_api_guard/material/menu.md
@@ -327,6 +327,9 @@ export abstract class _MatMenuTriggerBase implements AfterContentInit, OnDestroy
 export const MENU_PANEL_TOP_PADDING = 8;
 
 // @public
+export type MenuCloseReason = void | 'click' | 'keydown' | 'tab';
+
+// @public
 export type MenuPositionX = 'before' | 'after';
 
 // @public (undocumented)


### PR DESCRIPTION
Exposes the `MenuCloseReason` type since it's used in the `closed` event of `MatMenu` which is a public API.

Fixes #26416.