### PR TITLE
fix(material/core): top-level font family not copied when converting between typography formats

### DIFF
--- a/src/material/core/typography/_typography.scss
+++ b/src/material/core/typography/_typography.scss
@@ -132,6 +132,7 @@
         body-1: map.get($config, body-2),
         button: map.get($config, button),
         caption: map.get($config, caption),
+        font-family: map.get($config, font-family),
     );
     $non-null-args: ();
     @each $key, $value in $args {
@@ -161,6 +162,7 @@
         headline-5: map.get($config, headline),
         headline-6: map.get($config, title),
         subtitle-1: map.get($config, subheading-2),
+        font-famiy: map.get($config, font-family),
 
         // These mappings are odd, but body-2 in the 2014 system actually looks closer to subtitle-2
         // in the 2018 system, and subeading-1 in the 2014 system looks more like body-1 in the 2018


### PR DESCRIPTION
Fixes that our functions for converting between the 2014 and 2018 typography formats weren't copying over the top-level font family.

Fixes #26446.