### PR TITLE
refactor: update schematics to work with new UpdateBuffer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -582,6 +582,9 @@ jobs:
       # Setup the components repository to use the MDC snapshot builds.
       # Run project tests with the MDC canary builds.
       - run: bazel test --build_tag_filters=-docs-package,-e2e --test_tag_filters=-e2e --build_tests_only -- src/...
+      # The below tests should be removed when consuming Angular CLI version 16 which should contain
+      # https://github.com/angular/angular-cli/pull/24211
+      - run: bazel test //src/cdk/schematics/... //src/material/schematics/... --build_tests_only --test_env=NG_UPDATE_BUFFER_V2=1
       - *slack_notify_on_failure
 
 # ----------------------------------------------------------------------------------------


### PR DESCRIPTION
This change is needed for the upcoming changes in Angular CLI version 16 where the default `UpdateBuffer` is replaced with the `UpdateBuffer2`.

This commits changes how certain updates are applied to avoid overlapping changes which would otherwise result in broken output due to the offset would be out of sync.

