### PR TITLE
fix(material/input): changes on label detected correctly

### DIFF
--- a/src/dev-app/input/input-demo.html
+++ b/src/dev-app/input/input-demo.html
@@ -709,13 +709,12 @@
   <mat-toolbar color="primary">Appearance toggle</mat-toolbar>
   <mat-card-content>
     <mat-form-field [appearance]="appearance" class="demo-horizontal-spacing">
-      <mat-label *ngIf="appearanceToggleLabelControl.value">{{appearanceToggleLabelControl.value}}</mat-label>
+      <mat-label>{{appearanceToggleLabelControl.value}}</mat-label>
       <input matInput value="Initial">
     </mat-form-field>
     <mat-form-field [appearance]="'outline'" class="demo-horizontal-spacing">
-      <mat-label >{{appearanceToggleLabelControl.value}}</mat-label>
+      <mat-label>{{appearanceToggleLabelControl.value}}</mat-label>
       <input matInput value="Initial">
-      <mat-hint>mat-label not updates correctly with appearance='outline'</mat-hint>
     </mat-form-field>
     <p>
       <mat-button-toggle-group [(ngModel)]="appearance">

--- a/src/dev-app/input/input-demo.html
+++ b/src/dev-app/input/input-demo.html
@@ -709,14 +709,23 @@
   <mat-toolbar color="primary">Appearance toggle</mat-toolbar>
   <mat-card-content>
     <mat-form-field [appearance]="appearance" class="demo-horizontal-spacing">
-      <mat-label>Label</mat-label>
+      <mat-label *ngIf="appearanceToggleLabelControl.value">{{appearanceToggleLabelControl.value}}</mat-label>
       <input matInput value="Initial">
+    </mat-form-field>
+    <mat-form-field [appearance]="'outline'" class="demo-horizontal-spacing">
+      <mat-label >{{appearanceToggleLabelControl.value}}</mat-label>
+      <input matInput value="Initial">
+      <mat-hint>mat-label not updates correctly with appearance='outline'</mat-hint>
     </mat-form-field>
     <p>
       <mat-button-toggle-group [(ngModel)]="appearance">
         <mat-button-toggle value="fill">Fill</mat-button-toggle>
         <mat-button-toggle value="outline">Outline</mat-button-toggle>
       </mat-button-toggle-group>
+      <button
+      mat-raised-button
+      color="primary"
+      (click)="toggleAppearanceToggleLabel()">Toggle Label</button>
     </p>
   </mat-card-content>
 </mat-card>

--- a/src/dev-app/input/input-demo.ts
+++ b/src/dev-app/input/input-demo.ts
@@ -82,6 +82,7 @@ export class InputDemo {
   formControl = new FormControl('hello', Validators.required);
   emailFormControl = new FormControl('', [Validators.required, Validators.pattern(EMAIL_REGEX)]);
   delayedFormControl = new FormControl('');
+  appearanceToggleLabelControl = new FormControl('Label');
   model = 'hello';
   isAutofilled = false;
   customAutofillStyle = true;
@@ -122,6 +123,12 @@ export class InputDemo {
     this.placeholderTestControl.touched
       ? this.placeholderTestControl.markAsUntouched()
       : this.placeholderTestControl.markAsTouched();
+  }
+
+  toggleAppearanceToggleLabel() {
+    this.appearanceToggleLabelControl.setValue(
+      this.appearanceToggleLabelControl.value === '' ? 'Label' : '',
+    );
   }
 
   parseNumber(value: string): number {

--- a/src/material/form-field/directives/notched-outline.ts
+++ b/src/material/form-field/directives/notched-outline.ts
@@ -13,6 +13,8 @@ import {
   ElementRef,
   Input,
   NgZone,
+  OnChanges,
+  SimpleChanges,
   ViewEncapsulation,
 } from '@angular/core';
 
@@ -34,7 +36,7 @@ import {
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
 })
-export class MatFormFieldNotchedOutline implements AfterViewInit {
+export class MatFormFieldNotchedOutline implements AfterViewInit, OnChanges {
   /** Width of the label (original scale) */
   @Input('matFormFieldNotchedOutlineLabelWidth') labelWidth: number = 0;
 
@@ -43,8 +45,22 @@ export class MatFormFieldNotchedOutline implements AfterViewInit {
 
   constructor(private _elementRef: ElementRef<HTMLElement>, private _ngZone: NgZone) {}
 
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes.labelWidth !== undefined) {
+      this._elementRef.nativeElement.classList.remove('mdc-notched-outline--no-label');
+      this._elementRef.nativeElement.classList.remove('mdc-notched-outline--upgraded');
+      if (changes.labelWidth.currentValue > 0) {
+        this._elementRef.nativeElement.classList.add('mdc-notched-outline--upgraded');
+      } else {
+        this._elementRef.nativeElement.classList.add('mdc-notched-outline--no-label');
+      }
+    }
+  }
+
   ngAfterViewInit(): void {
     const label = this._elementRef.nativeElement.querySelector<HTMLElement>('.mdc-floating-label');
+    this._elementRef.nativeElement.classList.remove('mdc-notched-outline--no-label');
+    this._elementRef.nativeElement.classList.remove('mdc-notched-outline--upgraded');
     if (label) {
       this._elementRef.nativeElement.classList.add('mdc-notched-outline--upgraded');
 
@@ -60,6 +76,7 @@ export class MatFormFieldNotchedOutline implements AfterViewInit {
   }
 
   _getNotchWidth() {
+    const NO_PADDING = '0px padding-right: 0px';
     if (this.open) {
       const NOTCH_ELEMENT_PADDING = 8;
       const NOTCH_ELEMENT_BORDER = 1;
@@ -67,9 +84,9 @@ export class MatFormFieldNotchedOutline implements AfterViewInit {
         ? `calc(${this.labelWidth}px * var(--mat-mdc-form-field-floating-label-scale, 0.75) + ${
             NOTCH_ELEMENT_PADDING + NOTCH_ELEMENT_BORDER
           }px)`
-        : '0px';
+        : NO_PADDING;
     }
 
-    return null;
+    return NO_PADDING;
   }
 }

--- a/src/material/form-field/form-field.ts
+++ b/src/material/form-field/form-field.ts
@@ -531,7 +531,7 @@ export class MatFormField
   }
 
   _shouldLabelFloat() {
-    return this._control.shouldLabelFloat || this._shouldAlwaysFloat();
+    return this._control?.shouldLabelFloat || this._shouldAlwaysFloat();
   }
 
   /**
@@ -556,6 +556,10 @@ export class MatFormField
       return;
     }
     this._labelWidth = this._floatingLabel.getWidth();
+
+    // If label changes, subcomponent notched-outline needs to no modify a native element.
+    this._changeDetectorRef.markForCheck();
+    this._changeDetectorRef.detectChanges();
   }
 
   /** Does any extra processing that is required when handling the hints. */


### PR DESCRIPTION
Added an example on dev-app that shows the behaviour of changing an input label with mat-label, in case of a mat-form-field with [appearance]="'outline'" it behaves strangely. See captures:

Initial case:
![label-0](https://user-images.githubusercontent.com/2633254/215062034-c4621d5e-de6d-4a8f-8ba0-02feb9e5abf8.PNG)

After first click on toggle label (it changes label to empty string)
![label-1](https://user-images.githubusercontent.com/2633254/215061659-05e82fc6-feb5-424a-96a5-29a75ba9080f.PNG)
in this case it would be better to remove the white space

After second click on toggle label (it changes label to empty string)
![label-2](https://user-images.githubusercontent.com/2633254/215061666-4f34d946-3027-4fb4-ad11-917a8974ebfe.PNG)
in this case, the expected behavior is to show the label "Label" (like left input)

I think this must be fixed on mat-form-field that is who listen that type of changes.
