### PR TITLE
docs(material/select, material/autocomplete): update a11y docs on che…

### DIFF
--- a/src/material/autocomplete/autocomplete.md
+++ b/src/material/autocomplete/autocomplete.md
@@ -129,3 +129,7 @@ attribute, or the `aria-labelledby` attribute.
 
 `MatAutocomplete` preserves focus on the text trigger, using `aria-activedescendant` to support
 navigation though the autocomplete options.
+
+By default, `MatAutocomplete` displays a checkmark to identify the selected item. While you can hide
+the checkmark indicator via `hideSingleSelectionIndicator`, this makes the component less accessible
+by making it harder or impossible for users to visually identify selected items.

--- a/src/material/select/select.md
+++ b/src/material/select/select.md
@@ -165,6 +165,11 @@ this interferes with most assistive technology.
 Always provide an accessible label for the select. This can be done by adding a `<mat-label>`
 inside of `<mat-form-field>`, the `aria-label` attribute, or the `aria-labelledby` attribute.
 
+By default, `MatSelect` displays a checkmark to identify selected items. While you can hide the
+checkmark indicator for single-selection via `hideSingleSelectionIndicator`, this makes the
+component less accessible by making it harder or impossible for users to visually identify selected
+items.
+
 ### Troubleshooting
 
 #### Error: Cannot change `multiple` mode of select after initialization


### PR DESCRIPTION
…ckmark indicators

Update the accessibility section on checkmark indicators for single-selection. Add instructions to always communicate selection with icon indicators. Fulfill documentation needs as follow-up for #25962.