### PR TITLE
fix(google-maps): error if API is initialized incorrectly

### DIFF
--- a/src/google-maps/map-event-manager.spec.ts
+++ b/src/google-maps/map-event-manager.spec.ts
@@ -141,6 +141,20 @@ describe('MapEventManager', () => {
     alternateTarget.triggerListeners('click');
     expect(spy).toHaveBeenCalledTimes(2);
   });
+
+  it('should not throw with an invalid target', () => {
+    manager.setTarget({
+      addListener: () => undefined,
+    });
+    const stream = manager.getLazyEmitter('click');
+    const completeSpy = jasmine.createSpy('completeSpy');
+    const errorSpy = jasmine.createSpy('errorSpy');
+    stream.subscribe({complete: completeSpy, error: errorSpy});
+
+    expect(() => manager.destroy()).not.toThrow();
+    expect(completeSpy).toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
 });
 
 /** Imitates a Google Maps event target and keeps track of the registered events. */

--- a/src/google-maps/map-event-manager.ts
+++ b/src/google-maps/map-event-manager.ts
@@ -15,7 +15,7 @@ type MapEventManagerTarget =
       addListener: (
         name: string,
         callback: (...args: any[]) => void,
-      ) => google.maps.MapsEventListener;
+      ) => google.maps.MapsEventListener | undefined;
     }
   | undefined;
 
@@ -51,6 +51,14 @@ export class MapEventManager {
           const listener = target.addListener(name, (event: T) => {
             this._ngZone.run(() => observer.next(event));
           });
+
+          // If there's an error when initializing the Maps API (e.g. a wrong API key), it will
+          // return a dummy object that returns `undefined` from `addListener` (see #26514).
+          if (!listener) {
+            observer.complete();
+            return undefined;
+          }
+
           this._listeners.push(listener);
           return () => listener.remove();
         });


### PR DESCRIPTION
When the Google Maps API fails to initialize (e.g. when the API key is invalid), it returns dummy objects which return `undefined` from `addListener`, causing an error when the `MapEventManager` is destroyed.

These changes add a check to guard against those errors.

Fixes #26514.