### PR TITLE
docs(material/guides/v15-mdc-migration): Change CSS-Selector-Specificity

### DIFF
--- a/guides/v15-mdc-migration.md
+++ b/guides/v15-mdc-migration.md
@@ -347,7 +347,7 @@ DOM and CSS of the components, you may need to tweak some of your application's 
   following styles:
 
   ```scss
-  .mat-mdc-input-element::-webkit-calendar-picker-indicator {
+  input.mat-mdc-input-element::-webkit-calendar-picker-indicator {
     display: block;
   }
   ```


### PR DESCRIPTION
The specificity of the CSS-Selector is not enough to change the behaviour. I've added the "input"-Type.