### PR TITLE
fix(material/chips): unable to add space when editing chip

### DIFF
--- a/src/material/chips/chip-action.ts
+++ b/src/material/chips/chip-action.ts
@@ -85,6 +85,7 @@ export class MatChipAction extends _MatChipActionMixinBase implements HasTabInde
       _handlePrimaryActionInteraction(): void;
       remove(): void;
       disabled: boolean;
+      _isEditing?: boolean;
     },
   ) {
     super();
@@ -110,7 +111,8 @@ export class MatChipAction extends _MatChipActionMixinBase implements HasTabInde
       (event.keyCode === ENTER || event.keyCode === SPACE) &&
       !this.disabled &&
       this.isInteractive &&
-      this._isPrimary
+      this._isPrimary &&
+      !this._parentChip._isEditing
     ) {
       event.preventDefault();
       this._parentChip._handlePrimaryActionInteraction();

--- a/src/material/chips/chip-row.spec.ts
+++ b/src/material/chips/chip-row.spec.ts
@@ -1,5 +1,5 @@
 import {Directionality} from '@angular/cdk/bidi';
-import {BACKSPACE, DELETE, ENTER} from '@angular/cdk/keycodes';
+import {BACKSPACE, DELETE, ENTER, SPACE} from '@angular/cdk/keycodes';
 import {
   createKeyboardEvent,
   dispatchEvent,
@@ -330,6 +330,14 @@ describe('MDC-based Row Chips', () => {
         keyDownOnPrimaryAction(ENTER, 'Enter');
         flush();
         expect(document.activeElement).not.toBe(primaryAction);
+      }));
+
+      it('should not prevent SPACE events when editing', fakeAsync(() => {
+        const event = dispatchKeyboardEvent(getEditInput(), 'keydown', SPACE);
+        fixture.detectChanges();
+        flush();
+
+        expect(event.defaultPrevented).toBe(false);
       }));
     });
 


### PR DESCRIPTION
Fixes that the default action of the spacebar was being prevented while the chip is in its editing state, not allowing users to enter whitespace.