### PR TITLE
fix(material/paginator): not emitting instance of PageEvent

### DIFF
--- a/src/material/paginator/paginator.spec.ts
+++ b/src/material/paginator/paginator.spec.ts
@@ -11,7 +11,7 @@ import {
   MatPaginatorIntl,
   MatPaginatorSelectConfig,
 } from './index';
-import {MAT_PAGINATOR_DEFAULT_OPTIONS, MatPaginatorDefaultOptions} from './paginator';
+import {MAT_PAGINATOR_DEFAULT_OPTIONS, MatPaginatorDefaultOptions, PageEvent} from './paginator';
 
 describe('MDC-based MatPaginator', () => {
   function createComponent<T>(type: Type<T>, providers: Provider[] = []): ComponentFixture<T> {
@@ -157,6 +157,17 @@ describe('MDC-based MatPaginator', () => {
           pageIndex: 0,
         }),
       );
+    });
+
+    it('should emit a PageEvent instance', () => {
+      const fixture = createComponent(MatPaginatorApp);
+      const component = fixture.componentInstance;
+      const paginator = component.paginator;
+
+      dispatchMouseEvent(getNextButton(fixture), 'click');
+
+      expect(paginator.pageIndex).toBe(1);
+      expect(component.pageEvent).toHaveBeenCalledWith(jasmine.any(PageEvent));
     });
   });
 

--- a/src/material/paginator/paginator.ts
+++ b/src/material/paginator/paginator.ts
@@ -359,12 +359,12 @@ export abstract class _MatPaginatorBase<
 
   /** Emits an event notifying that a change of the paginator's properties has been triggered. */
   private _emitPageEvent(previousPageIndex: number) {
-    this.page.emit({
-      previousPageIndex,
-      pageIndex: this.pageIndex,
-      pageSize: this.pageSize,
-      length: this.length,
-    });
+    const event = new PageEvent();
+    event.previousPageIndex = previousPageIndex;
+    event.pageIndex = this.pageIndex;
+    event.pageSize = this.pageSize;
+    event.length = this.length;
+    this.page.emit(event);
   }
 }
 


### PR DESCRIPTION
Fixes that the paginator's `page` event is typed to emit a `PageEvent`, however the value is only an event that matches the `PageEvent` interface, it isn't an actual instance of the class which can throw off `instanceof` checks.

Fixes #26546.