### PR TITLE
Disable toggle for expansion panel 

### DIFF
--- a/src/material/expansion/accordion-base.ts
+++ b/src/material/expansion/accordion-base.ts
@@ -20,6 +20,9 @@ export type MatAccordionTogglePosition = 'before' | 'after';
  * @docs-private
  */
 export interface MatAccordionBase extends CdkAccordion {
+  /** Whether the toggle functionality should be disabled. */
+  disableToggle: MatAccordionBase;
+
   /** Whether the expansion indicator should be hidden. */
   hideToggle: boolean;
 

--- a/src/material/expansion/accordion-base.ts
+++ b/src/material/expansion/accordion-base.ts
@@ -21,7 +21,7 @@ export type MatAccordionTogglePosition = 'before' | 'after';
  */
 export interface MatAccordionBase extends CdkAccordion {
   /** Whether the toggle functionality should be disabled. */
-  disableToggle: MatAccordionBase;
+  disableToggle: boolean;
 
   /** Whether the expansion indicator should be hidden. */
   hideToggle: boolean;

--- a/src/material/expansion/expansion-panel.ts
+++ b/src/material/expansion/expansion-panel.ts
@@ -101,9 +101,9 @@ export class MatExpansionPanel
   extends CdkAccordionItem
   implements AfterContentInit, OnChanges, OnDestroy
 {
+  private _disableToggle = false;
   private _document: Document;
   private _hideToggle = false;
-  private _disableToggle = false;
   private _togglePosition: MatAccordionTogglePosition;
 
   /** Whether the toggle indicator should be hidden. */

--- a/src/material/expansion/expansion-panel.ts
+++ b/src/material/expansion/expansion-panel.ts
@@ -103,6 +103,7 @@ export class MatExpansionPanel
 {
   private _document: Document;
   private _hideToggle = false;
+  private _disableToggle = false;
   private _togglePosition: MatAccordionTogglePosition;
 
   /** Whether the toggle indicator should be hidden. */
@@ -112,6 +113,15 @@ export class MatExpansionPanel
   }
   set hideToggle(value: BooleanInput) {
     this._hideToggle = coerceBooleanProperty(value);
+  }
+
+  /** Whether the toggle functionality should be disabled. */
+  @Input()
+  get disableToggle(): boolean {
+    return this._disableToggle || (this.accordion && this.accordion.disableToggle);
+  }
+  set disableToggle(value: BooleanInput) {
+    this._disableToggle = coerceBooleanProperty(value);
   }
 
   /** The position of the expansion indicator. */
@@ -203,6 +213,7 @@ export class MatExpansionPanel
 
   /** Toggles the expanded state of the expansion panel. */
   override toggle(): void {
+    if (this.disableToggle) return;
     this.expanded = !this.expanded;
   }
 

--- a/src/material/expansion/expansion-panel.ts
+++ b/src/material/expansion/expansion-panel.ts
@@ -213,7 +213,9 @@ export class MatExpansionPanel
 
   /** Toggles the expanded state of the expansion panel. */
   override toggle(): void {
-    if (this.disableToggle) return;
+    if (this.disableToggle) {
+      return;
+    }
     this.expanded = !this.expanded;
   }
 


### PR DESCRIPTION
This feature makes it optional to toggle the expansion panel by parsing in an input.

I have had two situations where I needed this feature of not allowing the user to expand the expansion panel. For instance in a payment card selector where saved cards would appear collapsed as "buttons" and adding a new card would show a credit card iframe in the expanded element.

Also, I've had nested forms that would expand on certain criteria in a search field inside of the panel header. But I needed this workaround to not allow the user to expand it until the search criteria was fulfilled
