### PR TITLE
fix(material/schematics): getWorkspace should receive the project parameter from options

### DIFF
--- a/src/material/schematics/ng-add/setup-project.ts
+++ b/src/material/schematics/ng-add/setup-project.ts
@@ -39,7 +39,7 @@ const noopAnimationsModuleName = 'NoopAnimationsModule';
  */
 export default function (options: Schema): Rule {
   return async (host: Tree, context: SchematicContext) => {
-    const workspace = await getWorkspace(host);
+    const workspace = await getWorkspace(host, options.project);
     const project = getProjectFromWorkspace(workspace, options.project);
 
     if (project.extensions.projectType === ProjectType.Application) {


### PR DESCRIPTION
For some reason, when I use the ng new with the --collection argument, the getWorkspace is unable to find the angular.json file and throws an error with the following message:

- Exception has occurred: Error: Path "/angular.json" does not exist.

The reason I'm requesting this change inside angular/material source, is because I can't use the "ng add @angular/material" right after using the "ng new" inside a collection I'm developing.