### PR TITLE
docs: fix outdated wai-aria-practices dialog_modal url

### DIFF
--- a/src/cdk/a11y/a11y.md
+++ b/src/cdk/a11y/a11y.md
@@ -60,7 +60,7 @@ Each item must also have an ID bound to the listbox's or menu's `aria-activedesc
 
 The `cdkTrapFocus` directive traps <kbd>Tab</kbd> key focus within an element. This is intended to
 be used to create accessible experience for components like
-[modal dialogs](https://www.w3.org/TR/wai-aria-practices-1.1/#dialog_modal), where focus must be
+[modal dialogs](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/), where focus must be
 constrained.
 
 This directive is declared in `A11yModule`.

--- a/src/cdk/a11y/focus-trap/focus-trap.md
+++ b/src/cdk/a11y/focus-trap/focus-trap.md
@@ -2,7 +2,7 @@
 
 The `cdkTrapFocus` directive traps <kbd>Tab</kbd> key focus within an element. This is intended to
 be used to create accessible experience for components like
-[modal dialogs](https://www.w3.org/TR/wai-aria-practices-1.1/#dialog_modal), where focus must be
+[modal dialogs](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/), where focus must be
 constrained.
 
 This directive is declared in `A11yModule`.


### PR DESCRIPTION
I am not sure if the new URL is the correct one, but the old one https://www.w3.org/TR/wai-aria-practices-1.1/#dialog_modal seems outdated since it gets redirected to https://www.w3.org/WAI/ARIA/apg/ and the page contains nothing about modal dialogs. So I suggest changing it to https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/ .