### PR TITLE
fix(material/core): Fix legacy prebuilt themes export

### DIFF
--- a/src/material/package-base.json
+++ b/src/material/package-base.json
@@ -38,16 +38,16 @@
       "style": "./prebuilt-themes/*.css"
     },
     "./legacy-prebuilt-themes/indigo-pink.css": {
-      "style": "./legacy-prebuilt-themes/indigo-pink.css"
+      "style": "./legacy-prebuilt-themes/legacy-indigo-pink.css"
     },
     "./legacy-prebuilt-themes/deeppurple-amber.css": {
-      "style": "./legacy-prebuilt-themes/deeppurple-amber.css"
+      "style": "./legacy-prebuilt-themes/legacy-deeppurple-amber.css"
     },
     "./legacy-prebuilt-themes/pink-bluegrey.css": {
-      "style": "./legacy-prebuilt-themes/pink-bluegrey.css"
+      "style": "./legacy-prebuilt-themes/legacy-pink-bluegrey.css"
     },
     "./legacy-prebuilt-themes/purple-green.css": {
-      "style": "./legacy-prebuilt-themes/purple-green.css"
+      "style": "./legacy-prebuilt-themes/legacy-purple-green.css"
     },
     "./legacy-prebuilt-themes/*": {
       "style": "./legacy-prebuilt-themes/*.css"


### PR DESCRIPTION
Import of the legacy prebuilt-theme in the scss did not work:
`@import '@angular/material/legacy-prebuilt-themes/legacy-indigo-pink.css';` nor the `@import '@angular/material/legacy-prebuilt-themes/indigo-pink.css';`