### PR TITLE
feat: add `stretchTabs` to `MatTabsConfig`

### DIFF
--- a/src/material/tabs/tab-config.ts
+++ b/src/material/tabs/tab-config.ts
@@ -36,6 +36,9 @@ export interface MatTabsConfig {
    * like iframes and videos from reloading next time it comes back into the view.
    */
   preserveContent?: boolean;
+  
+  /** Whether tabs should be stretched to fill the header. */
+  stretchTabs?: boolean;
 }
 
 /** Injection token that can be used to provide the default options the tabs module. */


### PR DESCRIPTION
With the new Material component changes, it would be good to allow developers to globally set `stretchTabs` back to it's pre-update default of `false`