### PR TITLE
fix(datepicker): intl provider not being picked up in lazy-loaded modules.

### DIFF
--- a/src/components-examples/material/datepicker/datepicker-locale/datepicker-locale-example.ts
+++ b/src/components-examples/material/datepicker/datepicker-locale/datepicker-locale-example.ts
@@ -1,4 +1,4 @@
-import {Component, Inject} from '@angular/core';
+import {Component, Inject, Injectable} from '@angular/core';
 import {
   MAT_MOMENT_DATE_FORMATS,
   MomentDateAdapter,
@@ -7,6 +7,12 @@ import {
 import {DateAdapter, MAT_DATE_FORMATS, MAT_DATE_LOCALE} from '@angular/material/core';
 import 'moment/locale/ja';
 import 'moment/locale/fr';
+import {MatDatepickerIntl} from '@angular/material/datepicker';
+
+@Injectable()
+export class DatepickerIntl extends MatDatepickerIntl {
+  override closeCalendarLabel = 'カレンダーを閉じる';
+}
 
 /** @title Datepicker with different locale */
 @Component({
@@ -26,18 +32,23 @@ import 'moment/locale/fr';
       useClass: MomentDateAdapter,
       deps: [MAT_DATE_LOCALE, MAT_MOMENT_DATE_ADAPTER_OPTIONS],
     },
+    {provide: MatDatepickerIntl, useClass: DatepickerIntl},
     {provide: MAT_DATE_FORMATS, useValue: MAT_MOMENT_DATE_FORMATS},
   ],
 })
 export class DatepickerLocaleExample {
   constructor(
     private _adapter: DateAdapter<any>,
+    private _intl: MatDatepickerIntl,
     @Inject(MAT_DATE_LOCALE) private _locale: string,
   ) {}
 
   french() {
     this._locale = 'fr';
     this._adapter.setLocale(this._locale);
+
+    this._intl.closeCalendarLabel = 'Fermer le calendrier';
+    this._intl.changes.next();
   }
 
   getDateFormatString(): string {

--- a/src/material/datepicker/datepicker-intl.ts
+++ b/src/material/datepicker/datepicker-intl.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Injectable} from '@angular/core';
+import {Injectable, Optional, SkipSelf} from '@angular/core';
 import {Subject} from 'rxjs';
 
 /** Datepicker data that requires internationalization. */
@@ -75,3 +75,15 @@ export class MatDatepickerIntl {
     return `${start} to ${end}`;
   }
 }
+
+/** @docs-private */
+export function MAT_DATEPICKER_INTL_PROVIDER_FACTORY(parentIntl: MatDatepickerIntl) {
+  return parentIntl || new MatDatepickerIntl();
+}
+
+/** @docs-private */
+export const MAT_DATEPICKER_INTL_PROVIDER = {
+  provide: MatDatepickerIntl,
+  deps: [[new Optional(), new SkipSelf(), MatDatepickerIntl]],
+  useFactory: MAT_DATEPICKER_INTL_PROVIDER_FACTORY,
+};

--- a/src/material/datepicker/datepicker-module.ts
+++ b/src/material/datepicker/datepicker-module.ts
@@ -22,7 +22,7 @@ import {
   MAT_DATEPICKER_SCROLL_STRATEGY_FACTORY_PROVIDER,
 } from './datepicker-base';
 import {MatDatepickerInput} from './datepicker-input';
-import {MatDatepickerIntl} from './datepicker-intl';
+import {MAT_DATEPICKER_INTL_PROVIDER} from './datepicker-intl';
 import {MatDatepickerToggle, MatDatepickerToggleIcon} from './datepicker-toggle';
 import {MatMonthView} from './month-view';
 import {MatMultiYearView} from './multi-year-view';
@@ -82,6 +82,6 @@ import {MatDatepickerActions, MatDatepickerApply, MatDatepickerCancel} from './d
     MatDatepickerCancel,
     MatDatepickerApply,
   ],
-  providers: [MatDatepickerIntl, MAT_DATEPICKER_SCROLL_STRATEGY_FACTORY_PROVIDER],
+  providers: [MAT_DATEPICKER_INTL_PROVIDER, MAT_DATEPICKER_SCROLL_STRATEGY_FACTORY_PROVIDER],
 })
 export class MatDatepickerModule {}


### PR DESCRIPTION
fix(datepicker): Resolve issue with MatDatepickerIntl not being picked up in lazy-loaded modules

Along the same lines as #12934, where the consumer-provided  instance was not being picked up within lazy-loaded modules. The fix also resolves an issue with the close button text when switching to French language in components-examples.

fixes #25021