### PR TITLE
docs(material/datepicker): avoid CalendarView switching

### DIFF
--- a/src/components-examples/material/datepicker/datepicker-views-selection/datepicker-views-selection-example.ts
+++ b/src/components-examples/material/datepicker/datepicker-views-selection/datepicker-views-selection-example.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import {Component, ViewEncapsulation} from '@angular/core';
 import {FormControl} from '@angular/forms';
 import {MomentDateAdapter, MAT_MOMENT_DATE_ADAPTER_OPTIONS} from '@angular/material-moment-adapter';
 import {DateAdapter, MAT_DATE_FORMATS, MAT_DATE_LOCALE} from '@angular/material/core';
@@ -45,6 +45,7 @@ export const MY_FORMATS = {
 
     {provide: MAT_DATE_FORMATS, useValue: MY_FORMATS},
   ],
+  encapsulation: ViewEncapsulation.None,
 })
 export class DatepickerViewsSelectionExample {
   date = new FormControl(moment());


### PR DESCRIPTION
add missing encapsulation  to disable pointer-events for periodButtonLabel.

fixes #24915