### PR TITLE
build: prepare for v16 in `main` branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "ci-notify-slack-failure": "ts-node --esm --project scripts/tsconfig.json scripts/circleci/notify-slack-job-failure.mts",
     "prepare": "husky install"
   },
-  "version": "15.3.0-next.0",
+  "version": "16.0.0-next.0",
   "dependencies": {
     "@angular/animations": "^15.2.0-rc.0",
     "@angular/common": "^15.2.0-rc.0",


### PR DESCRIPTION
Main branch should target v16 similar to the framework.