### PR TITLE
fix(material/snack-bar): misaligned lines on safari for long messages

### DIFF
--- a/src/material/snack-bar/snack-bar-container.scss
+++ b/src/material/snack-bar/snack-bar-container.scss
@@ -90,6 +90,13 @@
       opacity: 0.1;
     }
   }
+
+  // MDC uses this pseudo element to work around an issue with their live announcer, but it
+  // can cause additional space for long snack bar messages (see #26685). Since we don't use
+  // MDC's announcer, we can hide the element.
+  .mdc-snackbar__label::before {
+    display: none;
+  }
 }
 
 // These elements need to have full width using flex layout.


### PR DESCRIPTION
Fixes that multiple lines of text weren't aligned correctly in the snack bar on Safari.

Fixes #26685.