### PR TITLE
fix(material/snack-bar): live region not working when modal is open

### DIFF
--- a/src/material/legacy-snack-bar/snack-bar-container.html
+++ b/src/material/legacy-snack-bar/snack-bar-container.html
@@ -4,4 +4,4 @@
 </div>
 
 <!-- Will receive the snack bar content from the non-live div, move will happen a short delay after opening -->
-<div [attr.aria-live]="_live" [attr.role]="_role"></div>
+<div [attr.aria-live]="_live" [attr.role]="_role" [attr.id]="_liveElementId"></div>

--- a/src/material/snack-bar/snack-bar-container.html
+++ b/src/material/snack-bar/snack-bar-container.html
@@ -10,6 +10,6 @@
     </div>
 
     <!-- Will receive the snack bar content from the non-live div, move will happen a short delay after opening -->
-    <div [attr.aria-live]="_live" [attr.role]="_role"></div>
+    <div [attr.aria-live]="_live" [attr.role]="_role" [attr.id]="_liveElementId"></div>
   </div>
 </div>

--- a/tools/public_api_guard/material/snack-bar.md
+++ b/tools/public_api_guard/material/snack-bar.md
@@ -142,6 +142,7 @@ export abstract class _MatSnackBarContainerBase extends BasePortalOutlet impleme
     enter(): void;
     exit(): Observable<void>;
     _live: AriaLivePoliteness;
+    readonly _liveElementId: string;
     ngOnDestroy(): void;
     onAnimationEnd(event: AnimationEvent_2): void;
     readonly _onAnnounce: Subject<void>;


### PR DESCRIPTION
Implements a workaround to the issue where some browsers don't expose live elements to the accessibility tree if there's an `aria-modal` on the page.

Fixes #26708.