### PR TITLE
 fix(material/tabs): update MatTab _scrollToLabel function to always display a label from its start

### DIFF
--- a/src/material/legacy-tabs/tab-header.spec.ts
+++ b/src/material/legacy-tabs/tab-header.spec.ts
@@ -272,9 +272,11 @@ describe('MatTabHeader', () => {
         // Focus on the last tab, expect this to be the maximum scroll distance.
         appComponent.tabHeader.focusIndex = appComponent.tabs.length - 1;
         fixture.detectChanges();
-        expect(appComponent.tabHeader.scrollDistance).toBe(
-          appComponent.tabHeader._getMaxScrollDistance(),
+        const {offsetLeft, offsetWidth} = appComponent.getSelectedLabel(
+          appComponent.tabHeader.focusIndex,
         );
+        const viewLength = appComponent.getViewLength();
+        expect(appComponent.tabHeader.scrollDistance).toBe(offsetLeft + offsetWidth - viewLength);
 
         // Focus on the first tab, expect this to be the maximum scroll distance.
         appComponent.tabHeader.focusIndex = 0;
@@ -331,9 +333,11 @@ describe('MatTabHeader', () => {
         // Focus the last tab so the header scrolls to the end.
         appComponent.tabHeader.focusIndex = appComponent.tabs.length - 1;
         fixture.detectChanges();
-        expect(appComponent.tabHeader.scrollDistance).toBe(
-          appComponent.tabHeader._getMaxScrollDistance(),
+        const {offsetLeft, offsetWidth} = appComponent.getSelectedLabel(
+          appComponent.tabHeader.focusIndex,
         );
+        const viewLength = appComponent.getViewLength();
+        expect(appComponent.tabHeader.scrollDistance).toBe(offsetLeft + offsetWidth - viewLength);
 
         // Remove the first two tabs which includes the selected tab.
         appComponent.tabs = appComponent.tabs.slice(2);
@@ -362,9 +366,8 @@ describe('MatTabHeader', () => {
         // Focus on the last tab, expect this to be the maximum scroll distance.
         appComponent.tabHeader.focusIndex = appComponent.tabs.length - 1;
         fixture.detectChanges();
-        expect(appComponent.tabHeader.scrollDistance).toBe(
-          appComponent.tabHeader._getMaxScrollDistance(),
-        );
+        const {offsetLeft} = appComponent.getSelectedLabel(appComponent.tabHeader.focusIndex);
+        expect(offsetLeft).toBe(0);
 
         // Focus on the first tab, expect this to be the maximum scroll distance.
         appComponent.tabHeader.focusIndex = 0;
@@ -756,5 +759,13 @@ class SimpleTabHeaderApp {
     for (let i = 0; i < amount; i++) {
       this.tabs.push({label: 'new'});
     }
+  }
+
+  getViewLength() {
+    return this.tabHeader._tabListContainer.nativeElement.offsetWidth;
+  }
+
+  getSelectedLabel(index: number) {
+    return this.tabHeader._items.toArray()[this.tabHeader.focusIndex].elementRef.nativeElement;
   }
 }

--- a/src/material/tabs/paginated-tab-header.ts
+++ b/src/material/tabs/paginated-tab-header.ts
@@ -58,12 +58,6 @@ const passiveEventListenerOptions = normalizePassiveListenerOptions({
 export type ScrollDirection = 'after' | 'before';
 
 /**
- * The distance in pixels that will be overshot when scrolling a tab label into view. This helps
- * provide a small affordance to the label next to it.
- */
-const EXAGGERATED_OVERSCROLL = 60;
-
-/**
  * Amount of milliseconds to wait before starting to scroll the header automatically.
  * Set a little conservatively in order to handle fake events dispatched on touch devices.
  */
@@ -524,10 +518,13 @@ export abstract class MatPaginatedTabHeader
 
     if (labelBeforePos < beforeVisiblePos) {
       // Scroll header to move label to the before direction
-      this.scrollDistance -= beforeVisiblePos - labelBeforePos + EXAGGERATED_OVERSCROLL;
+      this.scrollDistance -= beforeVisiblePos - labelBeforePos;
     } else if (labelAfterPos > afterVisiblePos) {
       // Scroll header to move label to the after direction
-      this.scrollDistance += labelAfterPos - afterVisiblePos + EXAGGERATED_OVERSCROLL;
+      this.scrollDistance += Math.min(
+        labelAfterPos - afterVisiblePos,
+        labelBeforePos - beforeVisiblePos,
+      );
     }
   }
 

--- a/src/material/tabs/tab-header.spec.ts
+++ b/src/material/tabs/tab-header.spec.ts
@@ -266,9 +266,11 @@ describe('MDC-based MatTabHeader', () => {
         // Focus on the last tab, expect this to be the maximum scroll distance.
         appComponent.tabHeader.focusIndex = appComponent.tabs.length - 1;
         fixture.detectChanges();
-        expect(appComponent.tabHeader.scrollDistance).toBe(
-          appComponent.tabHeader._getMaxScrollDistance(),
+        const {offsetLeft, offsetWidth} = appComponent.getSelectedLabel(
+          appComponent.tabHeader.focusIndex,
         );
+        const viewLength = appComponent.getViewLength();
+        expect(appComponent.tabHeader.scrollDistance).toBe(offsetLeft + offsetWidth - viewLength);
 
         // Focus on the first tab, expect this to be the maximum scroll distance.
         appComponent.tabHeader.focusIndex = 0;
@@ -329,9 +331,11 @@ describe('MDC-based MatTabHeader', () => {
         // Focus the last tab so the header scrolls to the end.
         appComponent.tabHeader.focusIndex = appComponent.tabs.length - 1;
         fixture.detectChanges();
-        expect(appComponent.tabHeader.scrollDistance).toBe(
-          appComponent.tabHeader._getMaxScrollDistance(),
+        const {offsetLeft, offsetWidth} = appComponent.getSelectedLabel(
+          appComponent.tabHeader.focusIndex,
         );
+        const viewLength = appComponent.getViewLength();
+        expect(appComponent.tabHeader.scrollDistance).toBe(offsetLeft + offsetWidth - viewLength);
 
         // Remove the first two tabs which includes the selected tab.
         appComponent.tabs = appComponent.tabs.slice(2);
@@ -360,9 +364,8 @@ describe('MDC-based MatTabHeader', () => {
         // Focus on the last tab, expect this to be the maximum scroll distance.
         appComponent.tabHeader.focusIndex = appComponent.tabs.length - 1;
         fixture.detectChanges();
-        expect(appComponent.tabHeader.scrollDistance).toBe(
-          appComponent.tabHeader._getMaxScrollDistance(),
-        );
+        const {offsetLeft} = appComponent.getSelectedLabel(appComponent.tabHeader.focusIndex);
+        expect(offsetLeft).toBe(0);
 
         // Focus on the first tab, expect this to be the maximum scroll distance.
         appComponent.tabHeader.focusIndex = 0;
@@ -756,5 +759,13 @@ class SimpleTabHeaderApp {
     for (let i = 0; i < amount; i++) {
       this.tabs.push({label: 'new'});
     }
+  }
+
+  getViewLength() {
+    return this.tabHeader._tabListContainer.nativeElement.offsetWidth;
+  }
+
+  getSelectedLabel(index: number) {
+    return this.tabHeader._items.toArray()[this.tabHeader.focusIndex].elementRef.nativeElement;
   }
 }


### PR DESCRIPTION
<s>_scrollheader() computes the distance to move a tab list. Originally it set the scroll amount to a third of the length of the tab list view window, which did not consider the length of the tab label itself. When the screen size is small, the label might be clipped and not completely readable on its own and users see just the left or right of the tab text.

This PR updates _scrollheader() function to make it smarter on distance calculation. It introduced two variables,
- `minLeftSpace`: the distance from the first fully rendered label to the left border of the viewport.
- `minRightSpace`: the distance from the last fully rendered label to the right border of the viewport. 

Now the new scroll amount is,
- 'before' direction: `MINIMUM(minRightSpace, 1/3 * viewLength)`
- 'after' direction:  `MINIMUM(minLeftSpace, 1/3 * viewLength)`

This way, the moving distance would be guarded by the remaining space on either side of the label and we can make sure the label would not be clipped.</s> 

As discussed offline, it would be hard to display a label fully when it is long without causing any UI regression. A reasonable compromise would be to ensure that the first part of each label is readable and is distinct from other labels.

We update _scrollToLabel function to always display a long label from its start, this way, we at least make sure the first part of it is readable. What the exact changes are,
- set `scrollDistance` so that it will always align the border of the viewport to the head or tail of the focused label
- remove `EXAGGERATED_OVERSCROLL` because that will add disruption to the moving strategy we are using
- update the tab names used in the unit tests to make sure the length of the tabs is always larger than the maximum scroll distance.

> Demo:
![final-demo](https://user-images.githubusercontent.com/20229878/223845656-1c8bbc96-05f6-44ed-87f8-8a8a27c0eb5a.gif)