### PR TITLE
docs(material/datepicker): Update close calendar label

### DIFF
--- a/src/components-examples/material/datepicker/datepicker-locale/datepicker-locale-example.ts
+++ b/src/components-examples/material/datepicker/datepicker-locale/datepicker-locale-example.ts
@@ -1,4 +1,4 @@
-import {Component, Inject} from '@angular/core';
+import {Component, Inject, OnInit} from '@angular/core';
 import {
   MAT_MOMENT_DATE_FORMATS,
   MomentDateAdapter,
@@ -7,6 +7,7 @@ import {
 import {DateAdapter, MAT_DATE_FORMATS, MAT_DATE_LOCALE} from '@angular/material/core';
 import 'moment/locale/ja';
 import 'moment/locale/fr';
+import {MatDatepickerIntl} from '@angular/material/datepicker';
 
 /** @title Datepicker with different locale */
 @Component({
@@ -29,15 +30,26 @@ import 'moment/locale/fr';
     {provide: MAT_DATE_FORMATS, useValue: MAT_MOMENT_DATE_FORMATS},
   ],
 })
-export class DatepickerLocaleExample {
+export class DatepickerLocaleExample implements OnInit {
   constructor(
     private _adapter: DateAdapter<any>,
+    private _intl: MatDatepickerIntl,
     @Inject(MAT_DATE_LOCALE) private _locale: string,
   ) {}
+
+  ngOnInit() {
+    this.updateCloseButtonLabel('カレンダーを閉じる');
+  }
 
   french() {
     this._locale = 'fr';
     this._adapter.setLocale(this._locale);
+    this.updateCloseButtonLabel('Fermer le calendrier');
+  }
+
+  updateCloseButtonLabel(label: string) {
+    this._intl.closeCalendarLabel = label;
+    this._intl.changes.next();
   }
 
   getDateFormatString(): string {


### PR DESCRIPTION
docs(material/datepicker): Update close calendar label

Previously, the close calendar label was not updating correctly when switching languages. This commit fixes that issue.

Fixes: #25021