### PR TITLE
fix(material/paginator): opt-out of single-selection indicator

### DIFF
--- a/src/material/paginator/paginator.html
+++ b/src/material/paginator/paginator.html
@@ -16,7 +16,8 @@
           [aria-labelledby]="_pageSizeLabelId"
           [panelClass]="selectConfig.panelClass || ''"
           [disableOptionCentering]="selectConfig.disableOptionCentering"
-          (selectionChange)="_changePageSize($event.value)">
+          (selectionChange)="_changePageSize($event.value)"
+          hideSingleSelectionIndicator>
           <mat-option *ngFor="let pageSizeOption of _displayedPageSizeOptions" [value]="pageSizeOption">
             {{pageSizeOption}}
           </mat-option>


### PR DESCRIPTION
Opt-out of the single-selection indicator for mat-select. Fix bug where text is truncated when there are 10 or more items per page.