### PR TITLE
docs(material/chips): fix stacked chips example

### DIFF
--- a/src/components-examples/material/chips/chips-stacked/chips-stacked-example.css
+++ b/src/components-examples/material/chips/chips-stacked/chips-stacked-example.css
@@ -1,3 +1,3 @@
-mat-chip {
+.mat-mdc-chip-set {
   max-width: 200px;
 }


### PR DESCRIPTION
Fixes that the stacked chips example was using the wrong selector so the chips were too wide.

Fixes #26589.