### PR TITLE
WIP: Remove the need for `querySelector`

### DIFF
--- a/src/material/form-field/directives/notched-outline.html
+++ b/src/material/form-field/directives/notched-outline.html
@@ -1,5 +1,5 @@
 <div class="mdc-notched-outline__leading"></div>
-<div class="mdc-notched-outline__notch" [style.width]="_getNotchWidth()">
+<div class="mdc-notched-outline__notch" [style.width]="_getNotchWidth(open, labelWidth)">
   <ng-content></ng-content>
 </div>
 <div class="mdc-notched-outline__trailing"></div>

--- a/src/material/form-field/directives/notched-outline.ts
+++ b/src/material/form-field/directives/notched-outline.ts
@@ -6,15 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {
-  AfterViewInit,
-  ChangeDetectionStrategy,
-  Component,
-  ElementRef,
-  Input,
-  NgZone,
-  ViewEncapsulation,
-} from '@angular/core';
+import {ChangeDetectionStrategy, Component, Input, NgZone, ViewEncapsulation} from '@angular/core';
+
+import {MatFormFieldFloatingLabel} from './floating-label';
 
 /**
  * Internal component that creates an instance of the MDC notched-outline component.
@@ -27,44 +21,49 @@ import {
   templateUrl: './notched-outline.html',
   host: {
     'class': 'mdc-notched-outline',
-    // Besides updating the notch state through the MDC component, we toggle this class through
-    // a host binding in order to ensure that the notched-outline renders correctly on the server.
+    // Besides updating the notch state through the MDC component, we toggle
+    // this class through a host binding in order to ensure that the
+    // notched-outline renders correctly on the server.
     '[class.mdc-notched-outline--notched]': 'open',
+    '[class.mdc-notched-outline--upgraded]': 'label != null',
+    '[class.mdc-notched-outline--no-label]': 'label == null',
   },
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
 })
-export class MatFormFieldNotchedOutline implements AfterViewInit {
+export class MatFormFieldNotchedOutline {
+  _label: MatFormFieldFloatingLabel | undefined;
+
+  get label() {
+    return this._label;
+  }
+  /** Label element */
+  @Input('matFormFieldNotchedOutlineLabel')
+  set label(value: MatFormFieldFloatingLabel | undefined) {
+    this._label = value;
+    const label = this.label?.element;
+    if (label && typeof requestAnimationFrame === 'function') {
+      label.style.transitionDuration = '0s';
+      this._ngZone.runOutsideAngular(() => {
+        requestAnimationFrame(() => (label.style.transitionDuration = ''));
+      });
+    }
+  }
+
   /** Width of the label (original scale) */
   @Input('matFormFieldNotchedOutlineLabelWidth') labelWidth: number = 0;
 
   /** Whether the notch should be opened. */
   @Input('matFormFieldNotchedOutlineOpen') open: boolean = false;
 
-  constructor(private _elementRef: ElementRef<HTMLElement>, private _ngZone: NgZone) {}
+  constructor(private _ngZone: NgZone) {}
 
-  ngAfterViewInit(): void {
-    const label = this._elementRef.nativeElement.querySelector<HTMLElement>('.mdc-floating-label');
-    if (label) {
-      this._elementRef.nativeElement.classList.add('mdc-notched-outline--upgraded');
-
-      if (typeof requestAnimationFrame === 'function') {
-        label.style.transitionDuration = '0s';
-        this._ngZone.runOutsideAngular(() => {
-          requestAnimationFrame(() => (label.style.transitionDuration = ''));
-        });
-      }
-    } else {
-      this._elementRef.nativeElement.classList.add('mdc-notched-outline--no-label');
-    }
-  }
-
-  _getNotchWidth() {
-    if (this.open) {
+  _getNotchWidth(open: boolean, labelWidth: number) {
+    if (open) {
       const NOTCH_ELEMENT_PADDING = 8;
       const NOTCH_ELEMENT_BORDER = 1;
-      return this.labelWidth > 0
-        ? `calc(${this.labelWidth}px * var(--mat-mdc-form-field-floating-label-scale, 0.75) + ${
+      return labelWidth > 0
+        ? `calc(${labelWidth}px * var(--mat-mdc-form-field-floating-label-scale, 0.75) + ${
             NOTCH_ELEMENT_PADDING + NOTCH_ELEMENT_BORDER
           }px)`
         : '0px';

--- a/src/material/form-field/form-field.html
+++ b/src/material/form-field/form-field.html
@@ -45,6 +45,7 @@
   <div class="mat-mdc-form-field-focus-overlay" *ngIf="!_hasOutline() && !_control.disabled"></div>
   <div class="mat-mdc-form-field-flex">
     <div *ngIf="_hasOutline()" matFormFieldNotchedOutline
+         [matFormFieldNotchedOutlineLabel]="_floatingLabel"
          [matFormFieldNotchedOutlineOpen]="_shouldLabelFloat()"
          [matFormFieldNotchedOutlineLabelWidth]="_labelWidth">
       <ng-template [ngIf]="!_forceDisplayInfixLabel()">


### PR DESCRIPTION
Remove the need to use `querySelector` by explicitly passing the floating label down.