### PR TITLE
Truncate long words in menu and option

### DIFF
--- a/src/material/autocomplete/autocomplete.spec.ts
+++ b/src/material/autocomplete/autocomplete.spec.ts
@@ -1597,7 +1597,7 @@ describe('MDC-based MatAutocomplete', () => {
 
       fixture.componentInstance.trigger.openPanel();
       fixture.detectChanges();
-      tick();
+      zone.simulateZoneExit();
       fixture.detectChanges();
       const container = document.querySelector('.mat-mdc-autocomplete-panel') as HTMLElement;
 

--- a/src/material/core/option/optgroup.scss
+++ b/src/material/core/option/optgroup.scss
@@ -24,5 +24,8 @@
   // leak in from the list and cause the text to truncate.
   .mdc-list-item__primary-text {
     white-space: normal;
+
+    // In case the label is one long string that doesn't break into multiple lines.
+    word-break: break-word;
   }
 }

--- a/src/material/core/option/option.scss
+++ b/src/material/core/option/option.scss
@@ -84,6 +84,9 @@
   .mdc-list-item__primary-text {
     white-space: normal;
 
+    // In case the label is one long string that doesn't break into multiple lines.
+    word-break: break-word;
+
     // MDC assigns the typography to this element, rather than the option itself, which will break
     // existing overrides. Set all of the typography-related properties to `inherit` so that any
     // styles set on the host can propagate down.

--- a/src/material/menu/menu.scss
+++ b/src/material/menu/menu.scss
@@ -124,6 +124,9 @@ mat-menu {
   // leak in from the list and cause the text to truncate.
   .mdc-list-item__primary-text {
     white-space: normal;
+
+    // In case the label is one long string that doesn't break into multiple lines.
+    word-break: break-word;
   }
 
   &.mat-mdc-menu-item-submenu-trigger {


### PR DESCRIPTION
Fixes that the menu items and `mat-option` weren't truncating or wrapping really long single words.

Fixes #26807.