### PR TITLE
fix(material/form-field): lay out content horizontally in prefix/suffix

### DIFF
--- a/src/material/form-field/form-field.scss
+++ b/src/material/form-field/form-field.scss
@@ -71,6 +71,8 @@
 
 .mat-mdc-form-field-icon-prefix,
 .mat-mdc-form-field-icon-suffix {
+  // Allow content to flow horizontally if multiple elements are projected in.
+  display: inline-flex;
   // Vertically center icons.
   align-self: center;
   // The line-height can cause the prefix/suffix container to be taller than the actual icons,


### PR DESCRIPTION
Fixes that if there are multiple elements inside the prefix or suffix, they would stack vertically instead of horizontally.

Fixes #26758.