### PR TITLE
Fix missing declaration in README.md

### DIFF
--- a/src/google-maps/google-map/README.md
+++ b/src/google-maps/google-map/README.md
@@ -33,6 +33,7 @@ export class GoogleMapDemo {
 
   center: google.maps.LatLngLiteral = {lat: 24, lng: 12};
   zoom = 4;
+  display: google.maps.LatLngLiteral;
 
   moveMap(event: google.maps.MapMouseEvent) {
     this.center = (event.latLng.toJSON());


### PR DESCRIPTION
Fix missing declaration for display, used type google.maps.LatLngLiteral.