### PR TITLE
feat(material/formfield): Add `mdc-label` class to `<label>`

### DIFF
--- a/src/material/checkbox/checkbox.html
+++ b/src/material/checkbox/checkbox.html
@@ -44,7 +44,8 @@
     (#14385). Putting a click handler on the <label/> caused this bug because the browser produced
     an unnecessary accessibility tree node.
   -->
-  <label #label
+  <label class="mdc-label"
+         #label
          [for]="inputId">
     <ng-content></ng-content>
   </label>

--- a/src/material/radio/radio.html
+++ b/src/material/radio/radio.html
@@ -25,7 +25,7 @@
       <div class="mat-ripple-element mat-radio-persistent-ripple"></div>
     </div>
   </div>
-  <label [for]="inputId">
+  <label class="mdc-label" [for]="inputId">
     <ng-content></ng-content>
   </label>
 </div>

--- a/src/material/slide-toggle/slide-toggle.html
+++ b/src/material/slide-toggle/slide-toggle.html
@@ -47,7 +47,7 @@
     Clicking on the label will trigger another click event from the button.
     Stop propagation here so other listeners further up in the DOM don't execute twice.
   -->
-  <label [for]="buttonId" [attr.id]="_labelId" (click)="$event.stopPropagation()">
+  <label class="mdc-label" [for]="buttonId" [attr.id]="_labelId" (click)="$event.stopPropagation()">
     <ng-content></ng-content>
   </label>
 </div>


### PR DESCRIPTION
This is added to prevent a bug with the upcoming Theming API for Form Field.