### PR TITLE
refactor(material/sort): Remove unnecessary ngSkipHydration attribute

### DIFF
--- a/src/material/sort/sort.ts
+++ b/src/material/sort/sort.ts
@@ -75,7 +75,6 @@ const _MatSortBase = mixinInitialized(mixinDisabled(class {}));
   exportAs: 'matSort',
   host: {
     'class': 'mat-sort',
-    'ngSkipHydration': 'true',
   },
   inputs: ['disabled: matSortDisabled'],
 })


### PR DESCRIPTION
This attribute was inadvertently added and would cause hydration errors due to being applied on a plain table and not a component.