### PR TITLE
fix(multiple): fix VoiceOver confused by Select/Autocomplete's ARIA semantics

### DIFF
--- a/src/cdk/a11y/live-announcer/live-announcer.ts
+++ b/src/cdk/a11y/live-announcer/live-announcer.ts
@@ -190,6 +190,9 @@ export class LiveAnnouncer implements OnDestroy {
    * pointing the `aria-owns` of all modals to the live announcer element.
    */
   private _exposeAnnouncerToModals(id: string) {
+    // TODO(http://github.com/angular/components/issues/26853): consider de-duplicating this with
+    // the `SnakBarContainer` and other usages.
+    //
     // Note that the selector here is limited to CDK overlays at the moment in order to reduce the
     // section of the DOM we need to look through. This should cover all the cases we support, but
     // the selector can be expanded if it turns out to be too narrow.

--- a/src/cdk/a11y/public-api.ts
+++ b/src/cdk/a11y/public-api.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 export * from './aria-describer/aria-describer';
+export * from './aria-describer/aria-reference';
 export * from './key-manager/activedescendant-key-manager';
 export * from './key-manager/focus-key-manager';
 export * from './key-manager/list-key-manager';

--- a/src/dev-app/autocomplete/BUILD.bazel
+++ b/src/dev-app/autocomplete/BUILD.bazel
@@ -14,6 +14,7 @@ ng_module(
         "//src/material/button",
         "//src/material/card",
         "//src/material/checkbox",
+        "//src/material/dialog",
         "//src/material/form-field",
         "//src/material/input",
         "@npm//@angular/forms",

--- a/src/dev-app/autocomplete/autocomplete-demo.html
+++ b/src/dev-app/autocomplete/autocomplete-demo.html
@@ -112,6 +112,13 @@ Space above cards: <input type="number" [formControl]="topHeightCtrl">
         (ngModelChange)="filteredGroupedStates = filterStateGroups(currentGroupedState)">
     </mat-form-field>
   </mat-card>
+
+  <mat-card>
+    <mat-card-subtitle>Autocomplete inside a Dialog</mat-card-subtitle>
+    <mat-card-content>
+      <button mat-button (click)="openDialog()">Open dialog</button>
+    </mat-card-content>
+  </mat-card>
 </div>
 
 <mat-autocomplete #groupedAuto="matAutocomplete">

--- a/src/dev-app/autocomplete/autocomplete-demo.ts
+++ b/src/dev-app/autocomplete/autocomplete-demo.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, ViewChild} from '@angular/core';
+import {Component, inject, ViewChild} from '@angular/core';
 import {FormControl, NgModel, FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {CommonModule} from '@angular/common';
 import {MatAutocompleteModule} from '@angular/material/autocomplete';
@@ -17,6 +17,7 @@ import {MatInputModule} from '@angular/material/input';
 import {Observable} from 'rxjs';
 import {map, startWith} from 'rxjs/operators';
 import {ThemePalette} from '@angular/material/core';
+import {MatDialog, MatDialogModule, MatDialogRef} from '@angular/material/dialog';
 
 export interface State {
   code: string;
@@ -43,6 +44,7 @@ type DisableStateOption = 'none' | 'first-middle-last' | 'all';
     MatButtonModule,
     MatCardModule,
     MatCheckboxModule,
+    MatDialogModule,
     MatInputModule,
     ReactiveFormsModule,
   ],
@@ -201,5 +203,65 @@ export class AutocompleteDemo {
       );
     }
     return false;
+  }
+
+  dialog = inject(MatDialog);
+  dialogRef: MatDialogRef<AutocompleteDemoExampleDialog> | null;
+
+  openDialog() {
+    this.dialogRef = this.dialog.open(AutocompleteDemoExampleDialog, {width: '400px'});
+  }
+}
+
+@Component({
+  selector: 'autocomplete-demo-example-dialog',
+  template: `
+    <form (submit)="close()">
+      <p>Choose a T-shirt size.</p>
+      <mat-form-field>
+        <mat-label>T-Shirt Size</mat-label>
+        <input matInput [matAutocomplete]="tdAuto" [(ngModel)]="currentSize" name="size">
+        <mat-autocomplete #tdAuto="matAutocomplete">
+          <mat-option *ngFor="let size of sizes" [value]="size">
+            {{size}}
+          </mat-option>
+        </mat-autocomplete>
+      </mat-form-field>
+
+      <button type="submit" mat-button>Close</button>
+    </form>
+  `,
+  styles: [
+    `
+    :host {
+      display: block;
+      padding: 20px;
+    }
+
+    form {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+    }
+  `,
+  ],
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    MatAutocompleteModule,
+    MatButtonModule,
+    MatDialogModule,
+    MatInputModule,
+  ],
+})
+export class AutocompleteDemoExampleDialog {
+  constructor(public dialogRef: MatDialogRef<AutocompleteDemoExampleDialog>) {}
+
+  currentSize = '';
+  sizes = ['S', 'M', 'L'];
+
+  close() {
+    this.dialogRef.close();
   }
 }

--- a/src/dev-app/dialog/dialog-demo.html
+++ b/src/dev-app/dialog/dialog-demo.html
@@ -116,18 +116,30 @@
 <p>Last beforeClose result: {{lastBeforeCloseResult}}</p>
 
 <ng-template let-data let-dialogRef="dialogRef">
-  I'm a template dialog. I've been opened {{numTemplateOpens}} times!
-
-  <p>It's Jazz!</p>
+  <p>Order printer ink refills.</p>
 
   <mat-form-field>
-    <mat-label>How much?</mat-label>
+    <mat-label>How many?</mat-label>
     <input matInput #howMuch>
   </mat-form-field>
 
+  <mat-form-field>
+    <mat-label>What color?</mat-label>
+    <mat-select #whatColor>
+      <mat-option></mat-option>
+      <mat-option value="black">Black</mat-option>
+      <mat-option value="cyan">Cyan</mat-option>
+      <mat-option value="magenta">Magenta</mat-option>
+      <mat-option value="yellow">Yellow</mat-option>
+    </mat-select>
+  </mat-form-field>
+
   <p> {{ data.message }} </p>
-  <button type="button" (click)="dialogRef.close(howMuch.value)" class="demo-dialog-button"
-          cdkFocusInitial>
+
+  <p>I'm a template dialog. I've been opened {{numTemplateOpens}} times!</p>
+
+  <button type="button" class="demo-dialog-button" cdkFocusInitial
+          (click)="dialogRef.close({ quantity: howMuch.value, color: whatColor.value })">
     Close dialog
   </button>
   <button (click)="dialogRef.updateSize('500px', '500px').updatePosition({top: '25px', left: '25px'});"

--- a/src/dev-app/dialog/dialog-demo.ts
+++ b/src/dev-app/dialog/dialog-demo.ts
@@ -125,15 +125,30 @@ export class DialogDemo {
   selector: 'demo-jazz-dialog',
   template: `
     <div cdkDrag cdkDragRootElement=".cdk-overlay-pane">
-      <p>It's Jazz!</p>
+      <p>Order printer ink refills.</p>
 
       <mat-form-field>
-        <mat-label>How much?</mat-label>
+        <mat-label>How many?</mat-label>
         <input matInput #howMuch>
       </mat-form-field>
 
+      <mat-form-field>
+        <mat-label>What color?</mat-label>
+        <mat-select #whatColor>
+          <mat-option></mat-option>
+          <mat-option value="black">Black</mat-option>
+          <mat-option value="cyan">Cyan</mat-option>
+          <mat-option value="magenta">Magenta</mat-option>
+          <mat-option value="yellow">Yellow</mat-option>
+        </mat-select>
+      </mat-form-field>
+
       <p cdkDragHandle> {{ data.message }} </p>
-      <button type="button" (click)="dialogRef.close(howMuch.value)">Close dialog</button>
+      <button type="button" class="demo-dialog-button"
+              (click)="dialogRef.close({ quantity: howMuch.value, color: whatColor.value })">
+
+        Close dialog
+      </button>
       <button (click)="togglePosition()">Change dimensions</button>
       <button (click)="temporarilyHide()">Hide for 2 seconds</button>
     </div>
@@ -141,7 +156,7 @@ export class DialogDemo {
   encapsulation: ViewEncapsulation.None,
   styles: [`.hidden-dialog { opacity: 0; }`],
   standalone: true,
-  imports: [MatInputModule, DragDropModule],
+  imports: [DragDropModule, MatInputModule, MatSelectModule],
 })
 export class JazzDialog {
   private _dimensionToggle = false;

--- a/src/material/autocomplete/BUILD.bazel
+++ b/src/material/autocomplete/BUILD.bazel
@@ -14,6 +14,7 @@ ng_module(
         ":autocomplete_scss",
     ] + glob(["**/*.html"]),
     deps = [
+        "//src/cdk/a11y",
         "//src/cdk/coercion",
         "//src/cdk/overlay",
         "//src/cdk/scrolling",

--- a/src/material/autocomplete/testing/autocomplete-harness.ts
+++ b/src/material/autocomplete/testing/autocomplete-harness.ts
@@ -129,7 +129,7 @@ export abstract class _MatAutocompleteHarnessBase<
   }
 
   /** Gets the selector that can be used to find the autocomplete trigger's panel. */
-  private async _getPanelSelector(): Promise<string> {
+  protected async _getPanelSelector(): Promise<string> {
     return `#${await (await this.host()).getAttribute('aria-owns')}`;
   }
 }
@@ -167,5 +167,10 @@ export class MatAutocompleteHarness extends _MatAutocompleteHarnessBase<
       .addOption('disabled', options.disabled, async (harness, disabled) => {
         return (await harness.isDisabled()) === disabled;
       });
+  }
+
+  /** Gets the selector that can be used to find the autocomplete trigger's panel. */
+  protected override async _getPanelSelector(): Promise<string> {
+    return `#${await (await this.host()).getAttribute('aria-controls')}`;
   }
 }

--- a/src/material/core/option/option.html
+++ b/src/material/core/option/option.html
@@ -1,5 +1,9 @@
-<mat-pseudo-checkbox *ngIf="multiple" class="mat-mdc-option-pseudo-checkbox"
-    [state]="selected ? 'checked' : 'unchecked'" [disabled]="disabled"></mat-pseudo-checkbox>
+<!-- Set aria-hidden="true" to this DOM node and other decorative nodes in this file. This might
+ be contributing to issue where sometimes VoiceOver focuses on a TextNode in the a11y tree instead
+ of the Option node (#23202). Most assistive technology will generally ignore non-role,
+ non-text-content elements. Adding aria-hidden seems to make VoiceOver behave more consistently. -->
+<mat-pseudo-checkbox *ngIf="multiple" class="mat-mdc-option-pseudo-checkbox" [disabled]="disabled"
+    [state]="selected ? 'checked' : 'unchecked'" aria-hidden="true"></mat-pseudo-checkbox>
 
 <ng-content select="mat-icon"></ng-content>
 
@@ -7,13 +11,12 @@
 
 <!-- Render checkmark at the end for single-selection. -->
 <mat-pseudo-checkbox *ngIf="!multiple && selected && !hideSingleSelectionIndicator"
-    class="mat-mdc-option-pseudo-checkbox" state="checked" [disabled]="disabled"
-    appearance="minimal"></mat-pseudo-checkbox>
+    class="mat-mdc-option-pseudo-checkbox" [disabled]="disabled" state="checked"
+    aria-hidden="true" appearance="minimal"></mat-pseudo-checkbox>
 
 <!-- See a11y notes inside optgroup.ts for context behind this element. -->
 <span class="cdk-visually-hidden" *ngIf="group && group._inert">({{ group.label }})</span>
 
-<div class="mat-mdc-option-ripple mat-mdc-focus-indicator" mat-ripple
-     [matRippleTrigger]="_getHostElement()"
-     [matRippleDisabled]="disabled || disableRipple">
+<div class="mat-mdc-option-ripple mat-mdc-focus-indicator" aria-hidden="true" mat-ripple
+     [matRippleTrigger]="_getHostElement()" [matRippleDisabled]="disabled || disableRipple">
 </div>

--- a/src/material/select/select.html
+++ b/src/material/select/select.html
@@ -1,14 +1,4 @@
-<!--
- Note that the select trigger element specifies `aria-owns` pointing to the listbox overlay.
- While aria-owns is not required for the ARIA 1.2 `role="combobox"` interaction pattern,
- it fixes an issue with VoiceOver when the select appears inside of an `aria-model="true"`
- element (e.g. a dialog). Without this `aria-owns`, the `aria-modal` on a dialog prevents
- VoiceOver from "seeing" the select's listbox overlay for aria-activedescendant.
- Using `aria-owns` re-parents the select overlay so that it works again.
- See https://github.com/angular/components/issues/20694
--->
 <div cdk-overlay-origin
-     [attr.aria-owns]="panelOpen ? id + '-panel' : null"
      class="mat-mdc-select-trigger"
      (click)="toggle()"
      #fallbackOverlayOrigin="cdkOverlayOrigin"

--- a/src/material/select/select.spec.ts
+++ b/src/material/select/select.spec.ts
@@ -14,7 +14,7 @@ import {
   PAGE_DOWN,
   PAGE_UP,
 } from '@angular/cdk/keycodes';
-import {OverlayContainer} from '@angular/cdk/overlay';
+import {OverlayContainer, OverlayModule} from '@angular/cdk/overlay';
 import {ScrollDispatcher} from '@angular/cdk/scrolling';
 import {
   createKeyboardEvent,
@@ -27,6 +27,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   DebugElement,
+  ElementRef,
   OnInit,
   QueryList,
   ViewChild,
@@ -96,6 +97,7 @@ describe('MDC-based MatSelect', () => {
         ReactiveFormsModule,
         FormsModule,
         NoopAnimationsModule,
+        OverlayModule,
       ],
       declarations: declarations,
       providers: [
@@ -117,6 +119,7 @@ describe('MDC-based MatSelect', () => {
     beforeEach(waitForAsync(() => {
       configureMatSelectTestingModule([
         BasicSelect,
+        SelectInsideAModal,
         MultiSelect,
         SelectWithGroups,
         SelectWithGroupsAndNgContainer,
@@ -153,19 +156,6 @@ describe('MDC-based MatSelect', () => {
           const ariaControls = select.getAttribute('aria-controls');
           expect(ariaControls).toBeTruthy();
           expect(ariaControls).toBe(document.querySelector('.mat-mdc-select-panel')!.id);
-        }));
-
-        it('should point the aria-owns attribute to the listbox on the trigger', fakeAsync(() => {
-          const trigger = select.querySelector('.mat-mdc-select-trigger')!;
-          expect(trigger.hasAttribute('aria-owns')).toBe(false);
-
-          fixture.componentInstance.select.open();
-          fixture.detectChanges();
-          flush();
-
-          const ariaOwns = trigger.getAttribute('aria-owns');
-          expect(ariaOwns).toBeTruthy();
-          expect(ariaOwns).toBe(document.querySelector('.mat-mdc-select-panel')!.id);
         }));
 
         it('should set aria-expanded based on the select open state', fakeAsync(() => {
@@ -1169,6 +1159,27 @@ describe('MDC-based MatSelect', () => {
           const panel = document.querySelector('.mat-mdc-select-panel')!;
           expect(panel.getAttribute('aria-label')).toBe('My label');
           expect(panel.hasAttribute('aria-labelledby')).toBe(false);
+        }));
+      });
+
+      describe('for select inside a modal', () => {
+        let fixture: ComponentFixture<SelectInsideAModal>;
+
+        beforeEach(fakeAsync(() => {
+          fixture = TestBed.createComponent(SelectInsideAModal);
+          fixture.detectChanges();
+        }));
+
+        it('should add the id of the select panel to the aria-owns of the modal', fakeAsync(() => {
+          fixture.componentInstance.select.open();
+          fixture.detectChanges();
+
+          const panelId = `${fixture.componentInstance.select.id}-panel`;
+          const modalElement = fixture.componentInstance.modal.nativeElement;
+
+          expect(modalElement.getAttribute('aria-owns')?.split(' '))
+            .withContext('expecting modal to own the select panel')
+            .toContain(panelId);
         }));
       });
 
@@ -5449,4 +5460,35 @@ class BasicSelectWithFirstAndLastOptionDisabled {
 
   @ViewChild(MatSelect, {static: true}) select: MatSelect;
   @ViewChildren(MatOption) options: QueryList<MatOption>;
+}
+
+@Component({
+  selector: 'select-inside-a-modal',
+  template: `
+    <button cdkOverlayOrigin #trigger="cdkOverlayOrigin">open dialog</button>
+    <ng-template cdkConnectedOverlay [cdkConnectedOverlayOpen]="true"
+      [cdkConnectedOverlayOrigin]="trigger">
+      <div role="dialog" [attr.aria-modal]="'true'" #modal>
+        <mat-form-field>
+          <mat-label>Select a food</mat-label>
+          <mat-select placeholder="Food" ngModel>
+            <mat-option *ngFor="let food of foods"
+                        [value]="food.value">{{ food.viewValue }}
+            </mat-option>
+          </mat-select>
+        </mat-form-field>
+      </div>
+    </ng-template>
+  `,
+})
+class SelectInsideAModal {
+  foods = [
+    {value: 'steak-0', viewValue: 'Steak'},
+    {value: 'pizza-1', viewValue: 'Pizza'},
+    {value: 'tacos-2', viewValue: 'Tacos'},
+  ];
+
+  @ViewChild(MatSelect) select: MatSelect;
+  @ViewChildren(MatOption) options: QueryList<MatOption>;
+  @ViewChild('modal') modal: ElementRef;
 }

--- a/src/material/select/select.ts
+++ b/src/material/select/select.ts
@@ -6,7 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ActiveDescendantKeyManager, LiveAnnouncer} from '@angular/cdk/a11y';
+import {
+  ActiveDescendantKeyManager,
+  LiveAnnouncer,
+  addAriaReferencedId,
+  removeAriaReferencedId,
+} from '@angular/cdk/a11y';
 import {Directionality} from '@angular/cdk/bidi';
 import {
   BooleanInput,
@@ -588,6 +593,7 @@ export abstract class _MatSelectBase<C>
     this._destroy.next();
     this._destroy.complete();
     this.stateChanges.complete();
+    this._clearFromModal();
   }
 
   /** Toggles the overlay panel open or closed. */
@@ -598,11 +604,78 @@ export abstract class _MatSelectBase<C>
   /** Opens the overlay panel. */
   open(): void {
     if (this._canOpen()) {
+      this._applyModalPanelOwnership();
+
       this._panelOpen = true;
       this._keyManager.withHorizontalOrientation(null);
       this._highlightCorrectOption();
       this._changeDetectorRef.markForCheck();
     }
+  }
+
+  /**
+   * Track which modal we have modified the `aria-owns` attribute of. When the combobox trigger is
+   * inside an aria-modal, we apply aria-owns to the parent modal with the `id` of the options
+   * panel. Track the modal we have changed so we can undo the changes on destroy.
+   */
+  private _trackedModal: Element | null = null;
+
+  /**
+   * If the autocomplete trigger is inside of an `aria-modal` element, connect
+   * that modal to the options panel with `aria-owns`.
+   *
+   * For some browser + screen reader combinations, when navigation is inside
+   * of an `aria-modal` element, the screen reader treats everything outside
+   * of that modal as hidden or invisible.
+   *
+   * This causes a problem when the combobox trigger is _inside_ of a modal, because the
+   * options panel is rendered _outside_ of that modal, preventing screen reader navigation
+   * from reaching the panel.
+   *
+   * We can work around this issue by applying `aria-owns` to the modal with the `id` of
+   * the options panel. This effectively communicates to assistive technology that the
+   * options panel is part of the same interaction as the modal.
+   *
+   * At time of this writing, this issue is present in VoiceOver.
+   * See https://github.com/angular/components/issues/20694
+   */
+  private _applyModalPanelOwnership() {
+    // TODO(http://github.com/angular/components/issues/26853): consider de-duplicating this with
+    // the `LiveAnnouncer` and any other usages.
+    //
+    // Note that the selector here is limited to CDK overlays at the moment in order to reduce the
+    // section of the DOM we need to look through. This should cover all the cases we support, but
+    // the selector can be expanded if it turns out to be too narrow.
+    const modal = this._elementRef.nativeElement.closest(
+      'body > .cdk-overlay-container [aria-modal="true"]',
+    );
+
+    if (!modal) {
+      // Most commonly, the autocomplete trigger is not inside a modal.
+      return;
+    }
+
+    const panelId = `${this.id}-panel`;
+
+    if (this._trackedModal) {
+      removeAriaReferencedId(this._trackedModal, 'aria-owns', panelId);
+    }
+
+    addAriaReferencedId(modal, 'aria-owns', panelId);
+    this._trackedModal = modal;
+  }
+
+  /** Clears the reference to the listbox overlay element from the modal it was added to. */
+  private _clearFromModal() {
+    if (!this._trackedModal) {
+      // Most commonly, the autocomplete trigger is not used inside a modal.
+      return;
+    }
+
+    const panelId = `${this.id}-panel`;
+
+    removeAriaReferencedId(this._trackedModal, 'aria-owns', panelId);
+    this._trackedModal = null;
   }
 
   /** Closes the overlay panel and focuses the host element. */

--- a/src/material/snack-bar/snack-bar-container.ts
+++ b/src/material/snack-bar/snack-bar-container.ts
@@ -241,7 +241,9 @@ export abstract class _MatSnackBarContainerBase extends BasePortalOutlet impleme
    * pointing the `aria-owns` of all modals to the live element.
    */
   private _exposeToModals() {
-    // TODO(crisbeto): consider de-duplicating this with the `LiveAnnouncer`.
+    // TODO(http://github.com/angular/components/issues/26853): consider de-duplicating this with the
+    // `LiveAnnouncer` and any other usages.
+    //
     // Note that the selector here is limited to CDK overlays at the moment in order to reduce the
     // section of the DOM we need to look through. This should cover all the cases we support, but
     // the selector can be expanded if it turns out to be too narrow.

--- a/tools/public_api_guard/cdk/a11y.md
+++ b/tools/public_api_guard/cdk/a11y.md
@@ -41,6 +41,9 @@ export class ActiveDescendantKeyManager<T> extends ListKeyManager<Highlightable 
 }
 
 // @public
+export function addAriaReferencedId(el: Element, attr: `aria-${string}`, id: string): void;
+
+// @public
 export class AriaDescriber implements OnDestroy {
     constructor(_document: any,
     _platform?: Platform | undefined);
@@ -256,6 +259,9 @@ export interface FocusTrapInertStrategy {
 }
 
 // @public
+export function getAriaReferenceIds(el: Element, attr: string): string[];
+
+// @public
 export const enum HighContrastMode {
     // (undocumented)
     BLACK_ON_WHITE = 1,
@@ -414,6 +420,9 @@ export interface RegisteredMessage {
     messageElement: Element;
     referenceCount: number;
 }
+
+// @public
+export function removeAriaReferencedId(el: Element, attr: `aria-${string}`, id: string): void;
 
 // (No @packageDocumentation comment for this package)
 

--- a/tools/public_api_guard/material/autocomplete-testing.md
+++ b/tools/public_api_guard/material/autocomplete-testing.md
@@ -21,6 +21,7 @@ export interface AutocompleteHarnessFilters extends BaseHarnessFilters {
 
 // @public
 export class MatAutocompleteHarness extends _MatAutocompleteHarnessBase<typeof MatOptionHarness, MatOptionHarness, OptionHarnessFilters, typeof MatOptgroupHarness, MatOptgroupHarness, OptgroupHarnessFilters> {
+    protected _getPanelSelector(): Promise<string>;
     static hostSelector: string;
     // (undocumented)
     protected _optionClass: typeof MatOptionHarness;
@@ -45,6 +46,7 @@ export abstract class _MatAutocompleteHarnessBase<OptionType extends ComponentHa
     focus(): Promise<void>;
     getOptionGroups(filters?: Omit<OptionGroupFilters, 'ancestor'>): Promise<OptionGroup[]>;
     getOptions(filters?: Omit<OptionFilters, 'ancestor'>): Promise<Option[]>;
+    protected _getPanelSelector(): Promise<string>;
     getValue(): Promise<string>;
     isDisabled(): Promise<boolean>;
     isFocused(): Promise<boolean>;


### PR DESCRIPTION
For Select and Autcomplete components, fix issues where VoiceOver was confused
by the ARIA semantics of the combobox. Fix multiple behaviors:

 - Fix VoiceOver focus ring stuck on the combobox while navigating
   options.
 - Fix VoiceOver would sometimes reading option as a TextNode and not
   communicating the selected state and position in set.
 - Fix VoiceOver "flickering" behavior where VoiceOver would display one
   announcement then quickly change to another annoucement.

Fix the same issues for both Select and Autocomplete component.

Implement fix by correcting the combobox element and also invidual
options.

First, move the aria-owns reference to the overlay from the child of the
combobox to the parent modal of the comobobx. Having an aria-owns
reference inside the combobox element seemed to confuse VoiceOver.

Second, apply `aria-hidden="true"` to the ripple element and pseudo
checkboxes on mat-option. These DOM nodes are only used for visual
purposes, so it is most appropriate to remove them from the
accessibility tree. This seemed to make VoiceOver's behavior more
consistent.

Fix https://github.com/angular/components/issues/23202, https://github.com/angular/components/issues/19798