### PR TITLE
docs(material/form-field): custom MatFormFieldControl validation not …

### DIFF
--- a/src/components-examples/material/form-field/form-field-custom-control/form-field-custom-control-example.ts
+++ b/src/components-examples/material/form-field/form-field-custom-control/form-field-custom-control-example.ts
@@ -29,7 +29,7 @@ import {Subject} from 'rxjs';
 })
 export class FormFieldCustomControlExample {
   form: FormGroup = new FormGroup({
-    tel: new FormControl(new MyTel('', '', '')),
+    tel: new FormControl(null),
   });
 }
 


### PR DESCRIPTION
…working unless touched

Fixes a bug in the Angular Material Guide  where form-control remains valid unless touched. This is because MatFormFieldControl emits null value when form is invalid, but default value was not set to null, bypassing required Validators.

Fixes #23352