### PR TITLE
fix(material-luxon-adapter): zone on DateTime ignored

### DIFF
--- a/src/material-luxon-adapter/adapter/luxon-date-adapter.spec.ts
+++ b/src/material-luxon-adapter/adapter/luxon-date-adapter.spec.ts
@@ -9,7 +9,7 @@
 import {LOCALE_ID} from '@angular/core';
 import {TestBed, waitForAsync} from '@angular/core/testing';
 import {DateAdapter, MAT_DATE_LOCALE} from '@angular/material/core';
-import {DateTime} from 'luxon';
+import {DateTime, FixedOffsetZone, Settings} from 'luxon';
 import {LuxonDateModule} from './index';
 import {MAT_LUXON_DATE_ADAPTER_OPTIONS} from './luxon-date-adapter';
 
@@ -349,6 +349,16 @@ describe('LuxonDateAdapter', () => {
 
     date = adapter.format(DateTime.local(2017, JAN, 2), 'DD');
     expect(date).toEqual('2. jan. 2017');
+  });
+
+  it('should format with a different timezone', () => {
+    Settings.defaultZone = FixedOffsetZone.parseSpecifier('UTC-12');
+
+    let date = adapter.format(DateTime.local(2017, JAN, 2, {zone: 'UTC-12'}), 'DD');
+    expect(date).toEqual('Jan 2, 2017');
+
+    date = adapter.format(DateTime.local(2017, JAN, 2, {zone: 'UTC+12'}), 'DD');
+    expect(date).toEqual('Jan 2, 2017');
   });
 
   it('should throw when attempting to format invalid date', () => {

--- a/src/material-luxon-adapter/adapter/luxon-date-adapter.ts
+++ b/src/material-luxon-adapter/adapter/luxon-date-adapter.ts
@@ -193,10 +193,11 @@ export class LuxonDateAdapter extends DateAdapter<LuxonDateTime> {
     if (!this.isValid(date)) {
       throw Error('LuxonDateAdapter: Cannot format invalid date.');
     }
-    return date
-      .setLocale(this.locale)
-      .setZone(this._useUTC ? 'utc' : undefined)
-      .toFormat(displayFormat);
+    if (this._useUTC) {
+      return date.setLocale(this.locale).setZone('utc').toFormat(displayFormat);
+    } else {
+      return date.setLocale(this.locale).toFormat(displayFormat);
+    }
   }
 
   addCalendarYears(date: LuxonDateTime, years: number): LuxonDateTime {


### PR DESCRIPTION
Fixes a bug where the timezone on the Luxon DateTime is thrown away during conversion to string, resulting in using the Luxon defaultZone regardless of how the particular DateTime is configured.

Fixes #26869