### PR TITLE
Update next branch to reflect new release-train "v16.1.0-next.0".

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+<a name="16.0.0-next.5"></a>
+# 16.0.0-next.5 "polyester-peach" (2023-04-06)
+### cdk
+| Commit | Type | Description |
+| -- | -- | -- |
+| [5825d4aa59](https://github.com/angular/components/commit/5825d4aa5925466a79c93441fd71a0a62d151d3f) | fix | **menu:** move focus when opening via click ([#26874](https://github.com/angular/components/pull/26874)) |
+### material
+| Commit | Type | Description |
+| -- | -- | -- |
+| [2604f15424](https://github.com/angular/components/commit/2604f1542470d3951fecbe06f6f020d1fd67b775) | feat | **button:** change icon-button to use MDC's token API ([#26824](https://github.com/angular/components/pull/26824)) |
+| [d6d3e3e506](https://github.com/angular/components/commit/d6d3e3e506e03d1ec33e96b786da42570ede9505) | feat | **button:** make button ripples lazy ([#26568](https://github.com/angular/components/pull/26568)) |
+| [b049b8d816](https://github.com/angular/components/commit/b049b8d816eaaf376768af4c6be8c7d9e051d934) | fix | **button:** fix icon button density ([#26877](https://github.com/angular/components/pull/26877)) |
+| [13755056e9](https://github.com/angular/components/commit/13755056e98335890593d227af5a575d082583a7) | fix | **core:** don't use font shorthand property in typography-level ([#26865](https://github.com/angular/components/pull/26865)) |
+### material-luxon-adapter
+| Commit | Type | Description |
+| -- | -- | -- |
+| [00ff979b96](https://github.com/angular/components/commit/00ff979b966e52565df0755570205548f2cc8467) | fix | zone on DateTime ignored ([#26887](https://github.com/angular/components/pull/26887)) |
+## Special Thanks
+Amy Sorto, Andrew Seguin, Joey Perrott, Jonathan Meier, Kristiyan Kostadinov, Paul Gschwendtner, Wagner Maciel and cusher
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="15.2.6"></a>
 # 15.2.6 "chiffon-cardigan" (2023-04-05)
 ### cdk

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "ci-notify-slack-failure": "ts-node --esm --project scripts/tsconfig.json scripts/circleci/notify-slack-job-failure.mts",
     "prepare": "husky install"
   },
-  "version": "16.0.0-next.4",
+  "version": "16.1.0-next.0",
   "dependencies": {
     "@angular/animations": "^16.0.0-next.7",
     "@angular/common": "^16.0.0-next.7",


### PR DESCRIPTION
The previous "next" release-train has moved into the feature-freeze phase. This PR updates the next branch to the subsequent release-train.

Also this PR cherry-picks the changelog for v16.0.0-next.5 into the main branch so that the changelog is up to date.