### PR TITLE
Fix(material/paginator): Table data does not get updated when paginat…

### DIFF
--- a/src/material/paginator/paginator.ts
+++ b/src/material/paginator/paginator.ts
@@ -130,8 +130,10 @@ export abstract class _MatPaginatorBase<
     return this._pageIndex;
   }
   set pageIndex(value: NumberInput) {
+    const previousPageIndex = this._pageIndex;
     this._pageIndex = Math.max(coerceNumberProperty(value), 0);
     this._changeDetectorRef.markForCheck();
+    this._emitPageEvent(previousPageIndex);
   }
   private _pageIndex = 0;
 
@@ -242,9 +244,7 @@ export abstract class _MatPaginatorBase<
       return;
     }
 
-    const previousPageIndex = this.pageIndex;
     this.pageIndex = this.pageIndex + 1;
-    this._emitPageEvent(previousPageIndex);
   }
 
   /** Move back to the previous page if it exists. */
@@ -253,9 +253,7 @@ export abstract class _MatPaginatorBase<
       return;
     }
 
-    const previousPageIndex = this.pageIndex;
     this.pageIndex = this.pageIndex - 1;
-    this._emitPageEvent(previousPageIndex);
   }
 
   /** Move to the first page if not already there. */
@@ -277,9 +275,7 @@ export abstract class _MatPaginatorBase<
       return;
     }
 
-    const previousPageIndex = this.pageIndex;
     this.pageIndex = this.getNumberOfPages() - 1;
-    this._emitPageEvent(previousPageIndex);
   }
 
   /** Whether there is a previous page. */

--- a/src/material/table/table.spec.ts
+++ b/src/material/table/table.spec.ts
@@ -558,6 +558,18 @@ describe('MDC-based MatTable', () => {
         ['a_10', 'b_10', 'c_10'],
         ['Footer A', 'Footer B', 'Footer C'],
       ]);
+
+      component.paginator.pageIndex = 0;
+      fixture.detectChanges();
+      expectTableToMatchContent(tableElement, [
+        ['Column A', 'Column B', 'Column C'],
+        ['a_1', 'b_1', 'c_1'],
+        ['a_2', 'b_2', 'c_2'],
+        ['a_3', 'b_3', 'c_3'],
+        ['a_4', 'b_4', 'c_4'],
+        ['a_5', 'b_5', 'c_5'],
+        ['Footer A', 'Footer B', 'Footer C'],
+      ]);
     }));
 
     it('should sort strings with numbers larger than MAX_SAFE_INTEGER correctly', () => {


### PR DESCRIPTION
Fixes a bug in the Angular Material `paginator` component where table data does not get updated when paginator pageIndex is modified via Input. This is because pageEvent is not fired when pageIndex changes.

Fixes #26890 