### PR TITLE
docs(material/chips): fix chip input examples

### DIFF
--- a/src/components-examples/material/chips/chips-autocomplete/chips-autocomplete-example.html
+++ b/src/components-examples/material/chips/chips-autocomplete/chips-autocomplete-example.html
@@ -1,5 +1,5 @@
 <form>
-  <mat-form-field class="example-chip-list" appearance="fill">
+  <mat-form-field class="example-chip-list" appearance="fill" floatLabel="always">
     <mat-label>Favorite Fruits</mat-label>
     <mat-chip-grid #chipGrid aria-label="Fruit selection">
       <mat-chip-row *ngFor="let fruit of fruits" (removed)="remove(fruit)">

--- a/src/components-examples/material/chips/chips-form-control/chips-form-control-example.html
+++ b/src/components-examples/material/chips/chips-form-control/chips-form-control-example.html
@@ -5,7 +5,7 @@
 <p>
   <i>Enter video keywords</i>
 </p>
-<mat-form-field appearance="fill" class="example-form-field">
+<mat-form-field appearance="fill" class="example-form-field" floatLabel="always">
   <mat-label>Video keywords</mat-label>
   <mat-chip-grid #chipGrid aria-label="Enter keywords" [formControl]="formControl" >
     <mat-chip-row *ngFor="let keyword of keywords" (removed)="removeKeyword(keyword)">

--- a/src/components-examples/material/chips/chips-input/chips-input-example.html
+++ b/src/components-examples/material/chips/chips-input/chips-input-example.html
@@ -1,4 +1,4 @@
-<mat-form-field class="example-chip-list" appearance="fill">
+<mat-form-field class="example-chip-list" appearance="fill" floatLabel="always">
   <mat-label>Favorite Fruits</mat-label>
   <mat-chip-grid #chipGrid aria-label="Enter fruits">
     <mat-chip-row *ngFor="let fruit of fruits"


### PR DESCRIPTION
Fixes not showing the placeholder by default in examples where chips are contained within form fields.

Fixes https://github.com/angular/components/issues/26883