### PR TITLE
fix(material/tabs): remove background color from tabs

### DIFF
--- a/src/material/tabs/_tabs-common.scss
+++ b/src/material/tabs/_tabs-common.scss
@@ -50,6 +50,9 @@ $mat-tab-animation-duration: 500ms !default;
   -moz-osx-font-smoothing: grayscale;
   text-decoration: none;
 
+  // Tabs might be `button` elements so we have to reset the user agent styling.
+  background: none;
+
   &.mdc-tab {
     // MDC's tabs stretch to fit the header by default, whereas stretching on our current ones
     // is an opt-in behavior. Also technically we don't need to combine the two classes, but


### PR DESCRIPTION
Resolves a recent regression where tabs no longer have a `background: none` which can cause them to be grey when used on a `<button>` element.