### PR TITLE
fix(material/form-field): outline not updated if required state changes

### DIFF
--- a/src/material/form-field/form-field.html
+++ b/src/material/form-field/form-field.html
@@ -17,8 +17,8 @@
   <label matFormFieldFloatingLabel
          [floating]="_shouldLabelFloat()"
          *ngIf="_hasFloatingLabel()"
-         (cdkObserveContent)="_refreshOutlineNotchWidth()"
-         [cdkObserveContentDisabled]="!_hasOutline()"
+         (cdkObserveContent)="_labelContentChanged()"
+         [cdkObserveContentDisabled]="!_shouldObserveLabelContentChanges()"
          [id]="_labelId"
          [attr.for]="_control.id"
          [attr.aria-owns]="_control.id">

--- a/tools/public_api_guard/material/form-field.md
+++ b/tools/public_api_guard/material/form-field.md
@@ -115,6 +115,7 @@ export class MatFormField implements AfterContentInit, AfterContentChecked, Afte
     _labelChildNonStatic: MatLabel | undefined;
     // (undocumented)
     _labelChildStatic: MatLabel | undefined;
+    _labelContentChanged(): void;
     // (undocumented)
     readonly _labelId: string;
     _labelWidth: number;
@@ -137,6 +138,7 @@ export class MatFormField implements AfterContentInit, AfterContentChecked, Afte
     _shouldForward(prop: keyof AbstractControlDirective): boolean;
     // (undocumented)
     _shouldLabelFloat(): boolean;
+    _shouldObserveLabelContentChanges(): boolean;
     _subscriptAnimationState: string;
     get subscriptSizing(): SubscriptSizing;
     set subscriptSizing(value: SubscriptSizing);


### PR DESCRIPTION
Fixes that the form field outline wasn't being updated when the `required` state of the underlying control changes. Also adds some logic to reduce the amount of times we measure the label on init.

Fixes #26848.