### PR TITLE
build: remove no longer available export

### DIFF
--- a/src/components-examples/package.json
+++ b/src/components-examples/package.json
@@ -14,8 +14,8 @@
     "components"
   ],
   "exports": {
-    "./fesm2020": {
-      "default": "./fesm2020"
+    "./fesm2022": {
+      "default": "./fesm2022"
     }
   },
   "license": "MIT",


### PR DESCRIPTION
build: update no longer available export

`fesm2020` was replaced with `fesm2020` no longer available. This is needed to fix https://app.circleci.com/pipelines/github/angular/components/52235/workflows/84d2aaf9-f235-4c55-a63d-d712619d1f50/jobs/469364