### PR TITLE
fix(material/schematics): reference correct entrypoint in schematic definition

### DIFF
--- a/src/material/schematics/migration.json
+++ b/src/material/schematics/migration.json
@@ -4,7 +4,7 @@
     "migration-v16": {
       "version": "16.0.0-0",
       "description": "Updates the Angular Material to v16",
-      "factory": "./ng-update/index#updateToV16"
+      "factory": "./ng-update/index_bundled#updateToV16"
     }
   }
 }


### PR DESCRIPTION
Fixes that the Material `ng update` schematic was pointing to a file that doesn't exist.

Fixes #26929.