### PR TITLE
fix(material/chips): fix chip density styles

### DIFF
--- a/src/material/chips/_chips-theme.scss
+++ b/src/material/chips/_chips-theme.scss
@@ -94,7 +94,8 @@
 @mixin density($config-or-theme) {
   $density-scale: theming.get-density-config($config-or-theme);
   $density-scale: theming.clamp-density($density-scale, -2);
-  .mat-mdc-chip {
+  .mat-mdc-chip,
+  .mat-mdc-standard-chip.mat-mdc-standard-chip {
     @include mdc-chip-theme.density($density-scale, $query: mdc-helpers.$mdc-base-styles-query);
   }
 }

--- a/src/material/chips/_chips-theme.scss
+++ b/src/material/chips/_chips-theme.scss
@@ -94,8 +94,7 @@
 @mixin density($config-or-theme) {
   $density-scale: theming.get-density-config($config-or-theme);
   $density-scale: theming.clamp-density($density-scale, -2);
-  .mat-mdc-chip,
-  .mat-mdc-standard-chip.mat-mdc-standard-chip {
+  .mat-mdc-chip.mat-mdc-chip {
     @include mdc-chip-theme.density($density-scale, $query: mdc-helpers.$mdc-base-styles-query);
   }
 }

--- a/src/material/chips/_chips-theme.scss
+++ b/src/material/chips/_chips-theme.scss
@@ -94,7 +94,7 @@
 @mixin density($config-or-theme) {
   $density-scale: theming.get-density-config($config-or-theme);
   $density-scale: theming.clamp-density($density-scale, -2);
-  .mat-mdc-chip.mat-mdc-chip {
+  .mat-mdc-chip.mat-mdc-standard-chip {
     @include mdc-chip-theme.density($density-scale, $query: mdc-helpers.$mdc-base-styles-query);
   }
 }


### PR DESCRIPTION
* Chip density styles were not being applied properly because of specificity issues - [Stackblitz example](https://stackblitz.com/edit/angular-ujvygb?file=src%2Ftheme.scss)