### PR TITLE
fix(material/chips): avoid double emit of changed event on blur

### DIFF
--- a/src/material/chips/chip-listbox.ts
+++ b/src/material/chips/chip-listbox.ts
@@ -311,7 +311,6 @@ export class MatChipListbox
       // Wait to see if focus moves to an individual chip.
       setTimeout(() => {
         if (!this.focused) {
-          this._propagateChanges();
           this._markAsTouched();
         }
       });


### PR DESCRIPTION
Fixes that the chips listbox was emitting change events both when a chip is toggled and when the listbox is blurred.

Fixes #26942.