### PR TITLE
fix(material/button): fix ripple style for all types of buttons

### DIFF
--- a/src/material/button/_button-base.scss
+++ b/src/material/button/_button-base.scss
@@ -30,6 +30,12 @@
     border-radius: inherit;
   }
 
+  // This style used to be applied by the MatRipple
+  // directive, which is no longer attached to this element.
+  .mat-mdc-button-ripple {
+    overflow: hidden;
+  }
+
   // We use ::before so that we can reuse some of MDC's theming.
   .mat-mdc-button-persistent-ripple::before {
     content: '';

--- a/src/material/button/button.scss
+++ b/src/material/button/button.scss
@@ -92,12 +92,6 @@
   }
 }
 
-// This style used to be applied by the MatRipple
-// directive, which is no longer attached to this element.
-.mat-mdc-button-ripple {
-  overflow: hidden;
-}
-
 // Since the stroked button has has an actual border that reduces the available space for
 // child elements such as the ripple container or focus overlay, an inherited border radius
 // for the absolute-positioned child elements does not work properly. This is because the

--- a/src/material/button/icon-button.scss
+++ b/src/material/button/icon-button.scss
@@ -55,12 +55,6 @@
   @include button-base.mat-private-button-touch-target(true);
   @include private.private-animation-noop();
 
-  // This style used to be applied by the MatRipple
-  // directive, which is no longer attached to this element.
-  .mat-mdc-button-ripple {
-    overflow: hidden;
-  }
-
   .mat-mdc-button-persistent-ripple {
     border-radius: 50%;
   }


### PR DESCRIPTION
The style for ripple were not added for mat-fab and mat-mini-fab buttons in #26568.
Spotting the issue on demo is a little bit tricky, because there are always a button (mat-button, mat-icon-button), which provides the global style for .mat-mdc-button-ripple. But without this components mat-fab button will look as on the screenshot below.

I was considering adding the overflow: hidden into fab.scss, but the _button-base.scss file is more appropriate in my opinion.

The ripple problem without overflow: hidden:
<img width="971" alt="ripple-problem" src="https://user-images.githubusercontent.com/34885331/233551092-f06670c0-0b7e-4bfa-aa65-8169b6c908e7.png">
