### PR TITLE
fix(material/dialog): opening animation sometimes being skipped

### DIFF
--- a/src/cdk/dialog/dialog-container.ts
+++ b/src/cdk/dialog/dialog-container.ts
@@ -96,7 +96,7 @@ export class CdkDialogContainer<C extends DialogConfig = DialogConfig>
     @Optional() @Inject(DOCUMENT) _document: any,
     @Inject(DialogConfig) readonly _config: C,
     private _interactivityChecker: InteractivityChecker,
-    private _ngZone: NgZone,
+    protected _ngZone: NgZone,
     private _overlayRef: OverlayRef,
     private _focusMonitor?: FocusMonitor,
   ) {

--- a/src/material/dialog/dialog.spec.ts
+++ b/src/material/dialog/dialog.spec.ts
@@ -2000,6 +2000,8 @@ describe('MDC-based MatDialog with animations enabled', () => {
     expect(spy).not.toHaveBeenCalled();
 
     tick(OPEN_ANIMATION_DURATION);
+    flush();
+
     expect(spy).toHaveBeenCalled();
   }));
 

--- a/tools/public_api_guard/cdk/dialog.md
+++ b/tools/public_api_guard/cdk/dialog.md
@@ -64,6 +64,8 @@ export class CdkDialogContainer<C extends DialogConfig = DialogConfig> extends B
     protected _focusTrapFactory: FocusTrapFactory;
     // (undocumented)
     ngOnDestroy(): void;
+    // (undocumented)
+    protected _ngZone: NgZone;
     _portalOutlet: CdkPortalOutlet;
     _recaptureFocus(): void;
     protected _trapFocus(): void;


### PR DESCRIPTION
When we trigger a dialog animation, we set a CSS variable and a couple of classes to start it, however because we were adding the classes imemdiately after setting the variable, sometimes the animation would be skipped because the browser didn't have time to recalculate the styles.

These changes resolve the issue by adding the classes in a `requestAnimationFrame` which gives the browser enough time to pick up the animation duration.

Fixes #26931.