### PR TITLE
fix(material/tabs): avoid unnecessary updates of tab ink bar

### DIFF
--- a/src/material/tabs/ink-bar.ts
+++ b/src/material/tabs/ink-bar.ts
@@ -46,6 +46,10 @@ export class MatInkBar {
     const correspondingItem = this._items.find(item => item.elementRef.nativeElement === element);
     const currentItem = this._currentItem;
 
+    if (correspondingItem === currentItem) {
+      return;
+    }
+
     currentItem?.deactivateInkBar();
 
     if (correspondingItem) {


### PR DESCRIPTION
There's a resize observer in the `paginated-tab-header`, that calls `_alignInkBarToSelectedTab` method here https://github.com/angular/components/blob/946cc6743c4d0f46c943fca7fdb2ed07148535d9/src/material/tabs/paginated-tab-header.ts#L206 

This causes the ink bar to be updated each time there's any size change. Sometimes it can cause additional problems. For example, in our case we are slightly customizing the UI so that selected tab has larger font weight than others. And this actually triggers the resize observer, which attempts to redraw the ink bar twice and breaks the ink bar animation

https://user-images.githubusercontent.com/33101123/236193271-2e37a5c6-a267-4846-b680-554e944c554c.mp4

