### PR TITLE
fix(material/tabs): emit selected index change

### DIFF
--- a/src/material/tabs/tab-group.spec.ts
+++ b/src/material/tabs/tab-group.spec.ts
@@ -639,6 +639,32 @@ describe('MDC-based MatTabGroup', () => {
         fixture.nativeElement.querySelector('.mat-mdc-tab-header-pagination-controls-enabled'),
       ).toBeFalsy();
     }));
+
+    it('should update selected index if the first tab removed while second selected', fakeAsync(() => {
+      const component: MatTabGroup = fixture.debugElement.query(
+        By.css('mat-tab-group'),
+      ).componentInstance;
+
+      // Select second indexed Tab.
+      fixture.componentInstance.selectedIndex = 1;
+      fixture.detectChanges();
+      tick();
+
+      // Remove first indexed Tab, it should fire selectIndexChange to update the selectedIndex.
+      fixture.componentInstance.tabs.shift();
+      fixture.detectChanges();
+      tick();
+
+      const tabs = fixture.componentInstance.tabs;
+      // Make sure there's two Tabs now.
+      expect(tabs.length).toBe(2);
+      // Make sure that component's selectedIndex gets updated.
+      expect(fixture.componentInstance.selectedIndex).toBe(0);
+      // Make sure that next selected Tab is selected.
+      expect(component._tabs.toArray()[fixture.componentInstance.selectedIndex].isActive).toBe(
+        true,
+      );
+    }));
   });
 
   describe('async tabs', () => {

--- a/src/material/tabs/tab-group.ts
+++ b/src/material/tabs/tab-group.ts
@@ -228,6 +228,9 @@ export abstract class _MatTabGroupBase
 
   private _groupId: number;
 
+  /** To check if we should fire SelectIndexChange incase our this._selectedIndex === indexToSelect are equal */
+  private _fireSelectIndexChanged: boolean = false;
+
   constructor(
     elementRef: ElementRef,
     protected _changeDetectorRef: ChangeDetectorRef,
@@ -286,6 +289,17 @@ export abstract class _MatTabGroupBase
       });
     }
 
+    if (this._selectedIndex === indexToSelect && this._fireSelectIndexChanged) {
+      const isFirstRun = this._selectedIndex === null;
+
+      if (!isFirstRun) {
+        Promise.resolve().then(() => {
+          this.selectedIndexChange.emit(indexToSelect);
+          this._fireSelectIndexChanged = false;
+        });
+      }
+    }
+
     // Setup the position for each tab and optionally setup an origin on the next selected tab.
     this._tabs.forEach((tab: MatTab, index: number) => {
       tab.position = index - indexToSelect;
@@ -325,6 +339,9 @@ export abstract class _MatTabGroupBase
             // event, otherwise the consumer may end up in an infinite loop in some edge cases like
             // adding a tab within the `selectedIndexChange` event.
             this._indexToSelect = this._selectedIndex = i;
+            // We need to update that the selectedIndex have changed, setting this true will trigger
+            // selectedIndexChange in ngAfterContentChecked
+            this._fireSelectIndexChanged = true;
             this._lastFocusedTabIndex = null;
             selectedTab = tabs[i];
             break;


### PR DESCRIPTION
Fixes a bug where upon deleting any of the tabs before selected greater index eg. (['one, 'two', 'three']) 0 index gets deleted while 1 index being selected but it doesn't emit that new tab have been selected and return new index, as first index becoming the zeroth index

Fixes #26816

edit: I think I have placed the code at wrong scope in that function. please enlightened me if I did, I will update the code asap if I messed up. ( im sure i kinda did )