### PR TITLE
fix(material/tabs): tabgroup update selectedIndex

### DIFF
--- a/src/material/tabs/tab-group.spec.ts
+++ b/src/material/tabs/tab-group.spec.ts
@@ -603,6 +603,20 @@ describe('MDC-based MatTabGroup', () => {
       expect(fixture.componentInstance.handleSelection).not.toHaveBeenCalled();
     }));
 
+    it('should update selectedIndex when the amount of tabs changes', fakeAsync(() => {
+      fixture.detectChanges();
+      fixture.componentInstance.selectedIndex = 1;
+      fixture.detectChanges();
+
+      // Remove the first tab
+      fixture.componentInstance.tabs.shift();
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.selectedIndex).toBe(0);
+    }));
+
     it('should update the newly-selected tab if the previously-selected tab is replaced', fakeAsync(() => {
       const component: MatTabGroup = fixture.debugElement.query(
         By.css('mat-tab-group'),

--- a/src/material/tabs/tab-group.ts
+++ b/src/material/tabs/tab-group.ts
@@ -327,6 +327,11 @@ export abstract class _MatTabGroupBase
             this._indexToSelect = this._selectedIndex = i;
             this._lastFocusedTabIndex = null;
             selectedTab = tabs[i];
+            // Since we don't fire a changed event, we need to emit the `selectedIndexChange`
+            // here to maintain a correct selected index
+            Promise.resolve().then(() => {
+              this.selectedIndexChange.emit(i);
+            });
             break;
           }
         }


### PR DESCRIPTION
Fixes an issue with the tab group where the selectedIndex was not properly maintained when the number of tabs changed.

Fixes #26816