### PR TITLE
docs: mat-chip: add higlighted attribute

### DIFF
--- a/src/components-examples/material/chips/chips-avatar/chips-avatar-example.html
+++ b/src/components-examples/material/chips/chips-avatar/chips-avatar-example.html
@@ -3,11 +3,11 @@
     <img matChipAvatar src="https://material.angular.io/assets/img/examples/shiba1.jpg" alt="Photo of a Shiba Inu"/>
     Dog one
   </mat-chip>
-  <mat-chip color="primary">
+  <mat-chip color="primary" highlighted>
     <img matChipAvatar src="https://material.angular.io/assets/img/examples/shiba1.jpg" alt="Photo of a Shiba Inu"/>
     Dog two
   </mat-chip>
-  <mat-chip color="accent">
+  <mat-chip color="accent" highlighted>
     <img matChipAvatar src="https://material.angular.io/assets/img/examples/shiba1.jpg" alt="Photo of a Shiba Inu"/>
     Dog three
   </mat-chip>


### PR DESCRIPTION
The `color` attribute has not purpose without the `highlighted` attribute, let's add it.