### PR TITLE
refactor(cdk/schematics): remove deprecated utility usages

### DIFF
--- a/src/cdk/schematics/testing/test-project.ts
+++ b/src/cdk/schematics/testing/test-project.ts
@@ -16,25 +16,21 @@ export async function createTestProject(
   appOptions = {},
   tree?: Tree,
 ): Promise<UnitTestTree> {
-  const workspaceTree = await runner
-    .runExternalSchematicAsync(
-      '@schematics/angular',
-      'workspace',
-      {
-        name: 'workspace',
-        version: '6.0.0',
-        newProjectRoot: 'projects',
-      },
-      tree,
-    )
-    .toPromise();
+  const workspaceTree = await runner.runExternalSchematic(
+    '@schematics/angular',
+    'workspace',
+    {
+      name: 'workspace',
+      version: '6.0.0',
+      newProjectRoot: 'projects',
+    },
+    tree,
+  );
 
-  return runner
-    .runExternalSchematicAsync(
-      '@schematics/angular',
-      projectType,
-      {name: 'material', ...appOptions},
-      workspaceTree,
-    )
-    .toPromise();
+  return runner.runExternalSchematic(
+    '@schematics/angular',
+    projectType,
+    {name: 'material', ...appOptions},
+    workspaceTree,
+  );
 }


### PR DESCRIPTION
Replaces the usages of `runExternalSchematicAsync` with `runExternalSchematic`.