### PR TITLE
fix(material/tabs): tab header is clickable if its disable

### DIFF
--- a/src/material/tabs/_tabs-common.scss
+++ b/src/material/tabs/_tabs-common.scss
@@ -122,6 +122,11 @@ $mat-tab-animation-duration: 500ms !default;
     // hover and focus selectors.
     pointer-events: none;
 
+    // We also need to prevent content from being clickable.
+    .mdc-tab__content {
+      pointer-events: none;
+    }
+
     @include token-utils.use-tokens(
       tokens-mat-tab-header.$prefix,
       tokens-mat-tab-header.get-token-slots()


### PR DESCRIPTION
Prior this commit disabled tab header content is clickable and causing event when it shouldn't

Fixes #27071