### PR TITLE
feat(material/badge): warn if used with mat-icon

### DIFF
--- a/src/material/badge/badge.ts
+++ b/src/material/badge/badge.ts
@@ -156,6 +156,20 @@ export class MatBadge extends _MatBadgeBase implements OnInit, OnDestroy, CanDis
       if (nativeElement.nodeType !== nativeElement.ELEMENT_NODE) {
         throw Error('matBadge must be attached to an element node.');
       }
+
+      const badgeTabName: string = 'mat-icon';
+
+      // Heads-up for developers to avoid putting matBadge on MatInput
+      // as it is aria-hidden by default docs mention this at:
+      // https://material.angular.io/components/badge/overview#accessibility
+      if (
+        nativeElement.tagName.toLowerCase() === badgeTabName &&
+        nativeElement.getAttribute('aria-hidden') === 'true'
+      ) {
+        console.warn(
+          `Warning: detected matBadge on a "<mat-icon>" with "aria-hidden="true"\n${nativeElement.outerHTML}`,
+        );
+      }
     }
   }
 


### PR DESCRIPTION
prior this commit there was no warning for matBadge being used with matIcon which means badge content is not visible to screen readers

Closes #27035