### PR TITLE
fix(material/form-field): fix duplicate announcement of form controls

### DIFF
--- a/src/material/chips/chip-grid.spec.ts
+++ b/src/material/chips/chip-grid.spec.ts
@@ -526,17 +526,6 @@ describe('MDC-based MatChipGrid', () => {
       expect(spy).toHaveBeenCalled();
       subscription.unsubscribe();
     });
-
-    it('should point the label id to the chip input', () => {
-      const label = fixture.nativeElement.querySelector('label');
-      const input = fixture.nativeElement.querySelector('input');
-
-      fixture.detectChanges();
-
-      expect(label.getAttribute('for')).toBeTruthy();
-      expect(label.getAttribute('for')).toBe(input.getAttribute('id'));
-      expect(label.getAttribute('aria-owns')).toBe(input.getAttribute('id'));
-    });
   });
 
   describe('with chip remove', () => {

--- a/src/material/datepicker/date-range-input.spec.ts
+++ b/src/material/datepicker/date-range-input.spec.ts
@@ -161,16 +161,6 @@ describe('MatDateRangeInput', () => {
     expect(rangeInput.classList).toContain(hideClass);
   });
 
-  it('should point the label aria-owns to the <mat-date-range-input/>', () => {
-    const fixture = createComponent(StandardRangePicker);
-    fixture.detectChanges();
-    const label = fixture.nativeElement.querySelector('label');
-    const rangeInput = fixture.componentInstance.rangeInput;
-
-    expect(rangeInput.id).toBeTruthy();
-    expect(label.getAttribute('aria-owns')).toBe(rangeInput.id);
-  });
-
   it('should point the range input aria-labelledby to the form field label', () => {
     const fixture = createComponent(StandardRangePicker);
     fixture.detectChanges();

--- a/src/material/form-field/form-field.html
+++ b/src/material/form-field/form-field.html
@@ -10,17 +10,13 @@
     as part of the label, and we don't want to spend resources on walking through projected content
     to set `aria-hidden`. Nor do we want to set `aria-labelledby` on every form control if we could
     simply link the label to the control using the label `for` attribute.
-
-    *Note*: We add aria-owns as a workaround for an issue in JAWS & NVDA where the label isn't
-    read if it comes before the control in the DOM.
   -->
   <label matFormFieldFloatingLabel
          [floating]="_shouldLabelFloat()"
          [monitorResize]="_hasOutline()"
          *ngIf="_hasFloatingLabel()"
          [id]="_labelId"
-         [attr.for]="_control.id"
-         [attr.aria-owns]="_control.id">
+         [attr.for]="_control.id">
     <ng-content select="mat-label"></ng-content>
     <!--
       We set the required marker as a separate element, in order to make it easier to target if

--- a/src/material/input/input.spec.ts
+++ b/src/material/input/input.spec.ts
@@ -188,20 +188,6 @@ describe('MatMdcInput without forms', () => {
     expect(inputElement.id).toEqual(labelElement.getAttribute('for')!);
   }));
 
-  it('should add aria-owns to the label for the associated control', fakeAsync(() => {
-    let fixture = createComponent(MatInputTextTestController);
-    fixture.detectChanges();
-
-    const inputElement: HTMLInputElement = fixture.debugElement.query(
-      By.css('input'),
-    )!.nativeElement;
-    const labelElement: HTMLInputElement = fixture.debugElement.query(
-      By.css('label'),
-    )!.nativeElement;
-
-    expect(labelElement.getAttribute('aria-owns')).toBe(inputElement.id);
-  }));
-
   it('should add aria-required reflecting the required state', fakeAsync(() => {
     const fixture = createComponent(MatInputWithRequired);
     fixture.detectChanges();


### PR DESCRIPTION
Fix duplicate screen reader announcement of form controls.

Remove the aria-owns from the form label. Commit
https://github.com/zarend/components/commit/4191b4d66e4dc79fc1dfa446caf48e5d3224d4fa added aria-owns on the label to
work around issue in JAWS and NVDA. That commit is from 2017, and it
appears the JAWS and NVDA issues have been fixed.

Tested on NVDA, JAWS and VoiceOver by verifying that I am able to read
the form field's label using screen reader. Tested on both Windows and
Firefox.

Testing environment:
 - Windows 10 Enterprise Version 22H2
   - Chrome Version 114.0.5735.199 (Official Build) (64-bit)
   - Firefox 115.0 (64-bit)
   - NVDA version 2022.3
   - JAWS Verison 2020.2006.12 ILM
 - MacOS 13.4.1 (22F82)
   - VoiceOver
   - Chrome Version 114.0.5735.198 (Official Build) (arm64)
   - Firefox Version 114.0.2 (64-bit)

Fix https://github.com/angular/components/issues/26583