### PR TITLE
docs: clean up explicit form field appearance

### DIFF
--- a/src/components-examples/cdk/a11y/focus-monitor-focus-via/focus-monitor-focus-via-example.html
+++ b/src/components-examples/cdk/a11y/focus-monitor-focus-via/focus-monitor-focus-via-example.html
@@ -3,7 +3,7 @@
   <button #unmonitored>2. Not Monitored</button>
 </div>
 
-<mat-form-field appearance="fill">
+<mat-form-field>
   <mat-label>Simulated focus origin</mat-label>
   <mat-select #simulatedOrigin value="mouse">
     <mat-option value="mouse">Mouse</mat-option>

--- a/src/components-examples/cdk/text-field/text-field-autofill-directive/text-field-autofill-directive-example.html
+++ b/src/components-examples/cdk/text-field/text-field-autofill-directive/text-field-autofill-directive-example.html
@@ -1,10 +1,10 @@
 <form (submit)="$event.preventDefault()">
-  <mat-form-field appearance="fill">
+  <mat-form-field>
     <mat-label>First name</mat-label>
     <input matInput (cdkAutofill)="firstNameAutofilled = $event.isAutofilled">
     <mat-hint *ngIf="firstNameAutofilled">Autofilled!</mat-hint>
   </mat-form-field>
-  <mat-form-field appearance="fill">
+  <mat-form-field>
     <mat-label>Last name</mat-label>
     <input matInput (cdkAutofill)="lastNameAutofilled = $event.isAutofilled">
     <mat-hint *ngIf="lastNameAutofilled">Autofilled!</mat-hint>

--- a/src/components-examples/cdk/text-field/text-field-autofill-monitor/text-field-autofill-monitor-example.html
+++ b/src/components-examples/cdk/text-field/text-field-autofill-monitor/text-field-autofill-monitor-example.html
@@ -1,10 +1,10 @@
 <form (submit)="$event.preventDefault()">
-  <mat-form-field appearance="fill">
+  <mat-form-field>
     <mat-label>First name</mat-label>
     <input matInput #first>
     <mat-hint *ngIf="firstNameAutofilled">Autofilled!</mat-hint>
   </mat-form-field>
-  <mat-form-field appearance="fill">
+  <mat-form-field>
     <mat-label>Last name</mat-label>
     <input matInput #last>
     <mat-hint *ngIf="lastNameAutofilled">Autofilled!</mat-hint>

--- a/src/components-examples/cdk/text-field/text-field-autosize-textarea/text-field-autosize-textarea-example.html
+++ b/src/components-examples/cdk/text-field/text-field-autosize-textarea/text-field-autosize-textarea-example.html
@@ -1,4 +1,4 @@
-<mat-form-field appearance="fill">
+<mat-form-field>
   <mat-label>Font size</mat-label>
   <mat-select #fontSize value="16px" (selectionChange)="triggerResize()">
     <mat-option value="10px">10px</mat-option>
@@ -10,7 +10,7 @@
   </mat-select>
 </mat-form-field>
 
-<mat-form-field [style.fontSize]="fontSize.value" appearance="fill">
+<mat-form-field [style.fontSize]="fontSize.value">
   <mat-label>Autosize textarea</mat-label>
   <textarea matInput
             cdkTextareaAutosize

--- a/src/components-examples/material-experimental/popover-edit/popover-edit-cell-span-mat-table/popover-edit-cell-span-mat-table-example.html
+++ b/src/components-examples/material-experimental/popover-edit/popover-edit-cell-span-mat-table/popover-edit-cell-span-mat-table-example.html
@@ -7,15 +7,15 @@
           [matEditLensPreservedFormValue]="preservedValues.get(ctx.person)"
           (matEditLensPreservedFormValueChange)="preservedValues.set(ctx.person, $event)">
         <div mat-edit-content class="example-input-container">
-          <mat-form-field appearance="fill">
+          <mat-form-field>
             <input matInput [ngModel]="ctx.person.firstName" name="firstName" required
                 [attr.cdkFocusInitial]="ctx.focus === 'firstName' || null">
           </mat-form-field>
-          <mat-form-field appearance="fill">
+          <mat-form-field>
             <input matInput [ngModel]="ctx.person.middleName" name="middleName"
                 [attr.cdkFocusInitial]="ctx.focus === 'middleName' || null">
           </mat-form-field>
-          <mat-form-field appearance="fill">
+          <mat-form-field>
             <input matInput [ngModel]="ctx.person.lastName" name="lastName" required
                 [attr.cdkFocusInitial]="ctx.focus === 'lastName' || null">
           </mat-form-field>

--- a/src/components-examples/material-experimental/popover-edit/popover-edit-mat-table-flex/popover-edit-mat-table-flex-example.html
+++ b/src/components-examples/material-experimental/popover-edit/popover-edit-mat-table-flex/popover-edit-mat-table-flex-example.html
@@ -11,7 +11,7 @@
           [matEditLensPreservedFormValue]="preservedWeightValues.get(element)"
           (matEditLensPreservedFormValueChange)="preservedWeightValues.set(element, $event)">
         <div mat-edit-content>
-          <mat-form-field appearance="fill">
+          <mat-form-field>
             <input matInput type="number" [ngModel]="element.weight" name="weight" required>
           </mat-form-field>
         </div>
@@ -42,7 +42,7 @@
               (matEditLensPreservedFormValueChange)="preservedNameValues.set(element, $event)">
             <h2 mat-edit-title>Name</h2>
             <div mat-edit-content>
-              <mat-form-field appearance="fill">
+              <mat-form-field>
                 <input matInput [ngModel]="element.name" name="name" required>
               </mat-form-field>
             </div>

--- a/src/components-examples/material-experimental/popover-edit/popover-edit-mat-table/popover-edit-mat-table-example.html
+++ b/src/components-examples/material-experimental/popover-edit/popover-edit-mat-table/popover-edit-mat-table-example.html
@@ -10,7 +10,7 @@
           (ngSubmit)="onSubmitWeight(element, f)"
           [(matEditLensPreservedFormValue)]="weightValues.for(element).value">
         <div mat-edit-content>
-          <mat-form-field appearance="fill">
+          <mat-form-field>
             <input matInput type="number" [ngModel]="element.weight" name="weight" required>
           </mat-form-field>
         </div>
@@ -57,7 +57,7 @@
               [(matEditLensPreservedFormValue)]="nameValues.for(element).value">
             <h2 mat-edit-title>Name</h2>
             <div mat-edit-content>
-              <mat-form-field appearance="fill">
+              <mat-form-field>
                 <input matInput [ngModel]="element.name" name="name" required>
               </mat-form-field>
             </div>

--- a/src/components-examples/material-experimental/popover-edit/popover-edit-tab-out-mat-table/popover-edit-tab-out-mat-table-example.html
+++ b/src/components-examples/material-experimental/popover-edit/popover-edit-tab-out-mat-table/popover-edit-tab-out-mat-table-example.html
@@ -12,7 +12,7 @@
           [matEditLensPreservedFormValue]="preservedWeightValues.get(element)"
           (matEditLensPreservedFormValueChange)="preservedWeightValues.set(element, $event)">
         <div mat-edit-content>
-          <mat-form-field appearance="fill">
+          <mat-form-field>
             <input matInput type="number" [ngModel]="element.weight" name="weight" required>
           </mat-form-field>
         </div>
@@ -44,7 +44,7 @@
               [matEditLensPreservedFormValue]="preservedNameValues.get(element)"
               (matEditLensPreservedFormValueChange)="preservedNameValues.set(element, $event)">
             <div mat-edit-content>
-              <mat-form-field appearance="fill">
+              <mat-form-field>
                 <input matInput [ngModel]="element.name" name="name" required>
               </mat-form-field>
             </div>

--- a/src/components-examples/material/autocomplete/autocomplete-auto-active-first-option/autocomplete-auto-active-first-option-example.html
+++ b/src/components-examples/material/autocomplete/autocomplete-auto-active-first-option/autocomplete-auto-active-first-option-example.html
@@ -1,5 +1,5 @@
 <form class="example-form">
-  <mat-form-field class="example-full-width" appearance="fill">
+  <mat-form-field class="example-full-width">
     <mat-label>Number</mat-label>
     <input type="text"
            placeholder="Pick one"

--- a/src/components-examples/material/autocomplete/autocomplete-display/autocomplete-display-example.html
+++ b/src/components-examples/material/autocomplete/autocomplete-display/autocomplete-display-example.html
@@ -1,5 +1,5 @@
 <form class="example-form">
-  <mat-form-field class="example-full-width" appearance="fill">
+  <mat-form-field class="example-full-width">
     <mat-label>Assignee</mat-label>
     <input type="text" matInput [formControl]="myControl" [matAutocomplete]="auto">
     <mat-autocomplete #auto="matAutocomplete" [displayWith]="displayFn">

--- a/src/components-examples/material/autocomplete/autocomplete-filter/autocomplete-filter-example.html
+++ b/src/components-examples/material/autocomplete/autocomplete-filter/autocomplete-filter-example.html
@@ -1,5 +1,5 @@
 <form class="example-form">
-  <mat-form-field class="example-full-width" appearance="fill">
+  <mat-form-field class="example-full-width">
     <mat-label>Number</mat-label>
     <input type="text"
            placeholder="Pick one"

--- a/src/components-examples/material/autocomplete/autocomplete-optgroup/autocomplete-optgroup-example.html
+++ b/src/components-examples/material/autocomplete/autocomplete-optgroup/autocomplete-optgroup-example.html
@@ -1,5 +1,5 @@
 <form [formGroup]="stateForm">
-  <mat-form-field appearance="fill">
+  <mat-form-field>
     <mat-label>States Group</mat-label>
     <input type="text"
            matInput

--- a/src/components-examples/material/autocomplete/autocomplete-overview/autocomplete-overview-example.html
+++ b/src/components-examples/material/autocomplete/autocomplete-overview/autocomplete-overview-example.html
@@ -1,5 +1,5 @@
 <form class="example-form">
-  <mat-form-field class="example-full-width" appearance="fill">
+  <mat-form-field class="example-full-width">
     <mat-label>State</mat-label>
     <input matInput
            aria-label="State"

--- a/src/components-examples/material/autocomplete/autocomplete-simple/autocomplete-simple-example.html
+++ b/src/components-examples/material/autocomplete/autocomplete-simple/autocomplete-simple-example.html
@@ -1,5 +1,5 @@
 <form class="example-form">
-  <mat-form-field class="example-full-width" appearance="fill">
+  <mat-form-field class="example-full-width">
     <mat-label>Number</mat-label>
 <!-- #docregion input -->
     <input type="text"

--- a/src/components-examples/material/chips/chips-autocomplete/chips-autocomplete-example.html
+++ b/src/components-examples/material/chips/chips-autocomplete/chips-autocomplete-example.html
@@ -1,5 +1,5 @@
 <form>
-  <mat-form-field class="example-chip-list" appearance="fill">
+  <mat-form-field class="example-chip-list">
     <mat-label>Favorite Fruits</mat-label>
     <mat-chip-grid #chipGrid aria-label="Fruit selection">
       <mat-chip-row *ngFor="let fruit of fruits" (removed)="remove(fruit)">

--- a/src/components-examples/material/chips/chips-form-control/chips-form-control-example.html
+++ b/src/components-examples/material/chips/chips-form-control/chips-form-control-example.html
@@ -5,7 +5,7 @@
 <p>
   <i>Enter video keywords</i>
 </p>
-<mat-form-field appearance="fill" class="example-form-field">
+<mat-form-field class="example-form-field">
   <mat-label>Video keywords</mat-label>
   <mat-chip-grid #chipGrid aria-label="Enter keywords" [formControl]="formControl" >
     <mat-chip-row *ngFor="let keyword of keywords" (removed)="removeKeyword(keyword)">

--- a/src/components-examples/material/chips/chips-input/chips-input-example.html
+++ b/src/components-examples/material/chips/chips-input/chips-input-example.html
@@ -1,4 +1,4 @@
-<mat-form-field class="example-chip-list" appearance="fill">
+<mat-form-field class="example-chip-list">
   <mat-label>Favorite Fruits</mat-label>
   <mat-chip-grid #chipGrid aria-label="Enter fruits">
     <mat-chip-row *ngFor="let fruit of fruits"

--- a/src/components-examples/material/core/ripple-overview/ripple-overview-example.html
+++ b/src/components-examples/material/core/ripple-overview/ripple-overview-example.html
@@ -2,11 +2,11 @@
 <mat-checkbox [(ngModel)]="disabled" class="example-ripple-checkbox">Disabled</mat-checkbox>
 <mat-checkbox [(ngModel)]="unbounded" class="example-ripple-checkbox">Unbounded</mat-checkbox>
 
-<mat-form-field class="example-ripple-form-field" appearance="fill">
+<mat-form-field class="example-ripple-form-field">
   <mat-label>Radius</mat-label>
   <input matInput [(ngModel)]="radius" type="number">
 </mat-form-field>
-<mat-form-field class="example-ripple-form-field" appearance="fill">
+<mat-form-field class="example-ripple-form-field">
   <mat-label>Color</mat-label>
   <input matInput [(ngModel)]="color" type="text">
 </mat-form-field>

--- a/src/components-examples/material/datepicker/date-range-picker-comparison/date-range-picker-comparison-example.html
+++ b/src/components-examples/material/datepicker/date-range-picker-comparison/date-range-picker-comparison-example.html
@@ -1,4 +1,4 @@
-<mat-form-field class="example-form-field" appearance="fill">
+<mat-form-field class="example-form-field">
   <mat-label>First campaign</mat-label>
   <mat-date-range-input
     [formGroup]="campaignOne"
@@ -13,7 +13,7 @@
   <mat-date-range-picker #campaignOnePicker></mat-date-range-picker>
 </mat-form-field>
 
-<mat-form-field class="example-form-field" appearance="fill">
+<mat-form-field class="example-form-field">
   <mat-label>Second campaign</mat-label>
   <mat-date-range-input
     [formGroup]="campaignTwo"

--- a/src/components-examples/material/datepicker/date-range-picker-forms/date-range-picker-forms-example.html
+++ b/src/components-examples/material/datepicker/date-range-picker-forms/date-range-picker-forms-example.html
@@ -1,4 +1,4 @@
-<mat-form-field appearance="fill">
+<mat-form-field>
   <mat-label>Enter a date range</mat-label>
   <mat-date-range-input [formGroup]="range" [rangePicker]="picker">
     <input matStartDate formControlName="start" placeholder="Start date">

--- a/src/components-examples/material/datepicker/date-range-picker-overview/date-range-picker-overview-example.html
+++ b/src/components-examples/material/datepicker/date-range-picker-overview/date-range-picker-overview-example.html
@@ -1,4 +1,4 @@
-<mat-form-field appearance="fill">
+<mat-form-field>
   <mat-label>Enter a date range</mat-label>
   <mat-date-range-input [rangePicker]="picker">
     <input matStartDate placeholder="Start date">

--- a/src/components-examples/material/datepicker/date-range-picker-selection-strategy/date-range-picker-selection-strategy-example.html
+++ b/src/components-examples/material/datepicker/date-range-picker-selection-strategy/date-range-picker-selection-strategy-example.html
@@ -1,4 +1,4 @@
-<mat-form-field appearance="fill">
+<mat-form-field>
   <mat-label>Enter a date range</mat-label>
   <mat-date-range-input [rangePicker]="picker">
     <input matStartDate placeholder="Start date">

--- a/src/components-examples/material/datepicker/datepicker-actions/datepicker-actions-example.html
+++ b/src/components-examples/material/datepicker/datepicker-actions/datepicker-actions-example.html
@@ -1,4 +1,4 @@
-<mat-form-field appearance="fill" class="example-form-field">
+<mat-form-field class="example-form-field">
   <mat-label>Choose a date</mat-label>
   <input matInput [matDatepicker]="datepicker">
   <mat-hint>MM/DD/YYYY</mat-hint>
@@ -13,7 +13,7 @@
 <!-- #enddocregion datepicker-actions -->
 </mat-form-field>
 
-<mat-form-field appearance="fill" class="example-form-field">
+<mat-form-field class="example-form-field">
   <mat-label>Enter a date range</mat-label>
   <mat-date-range-input [rangePicker]="rangePicker">
     <input matStartDate placeholder="Start date">

--- a/src/components-examples/material/datepicker/datepicker-api/datepicker-api-example.html
+++ b/src/components-examples/material/datepicker/datepicker-api/datepicker-api-example.html
@@ -1,4 +1,4 @@
-<mat-form-field class="example-full-width" appearance="fill">
+<mat-form-field class="example-full-width">
   <mat-label>Choose a date</mat-label>
   <input matInput [matDatepicker]="picker">
   <mat-hint>MM/DD/YYYY</mat-hint>

--- a/src/components-examples/material/datepicker/datepicker-color/datepicker-color-example.html
+++ b/src/components-examples/material/datepicker/datepicker-color/datepicker-color-example.html
@@ -1,4 +1,4 @@
-<mat-form-field color="accent" appearance="fill">
+<mat-form-field color="accent">
   <mat-label>Inherited calendar color</mat-label>
   <input matInput [matDatepicker]="picker1">
   <mat-hint>MM/DD/YYYY</mat-hint>
@@ -6,7 +6,7 @@
   <mat-datepicker #picker1></mat-datepicker>
 </mat-form-field>
 
-<mat-form-field color="accent" appearance="fill">
+<mat-form-field color="accent">
   <mat-label>Custom calendar color</mat-label>
   <input matInput [matDatepicker]="picker2">
   <mat-hint>MM/DD/YYYY</mat-hint>

--- a/src/components-examples/material/datepicker/datepicker-custom-header/datepicker-custom-header-example.html
+++ b/src/components-examples/material/datepicker/datepicker-custom-header/datepicker-custom-header-example.html
@@ -1,4 +1,4 @@
-<mat-form-field appearance="fill">
+<mat-form-field>
   <mat-label>Custom calendar header</mat-label>
   <input matInput [matDatepicker]="picker">
   <mat-hint>MM/DD/YYYY</mat-hint>

--- a/src/components-examples/material/datepicker/datepicker-custom-icon/datepicker-custom-icon-example.html
+++ b/src/components-examples/material/datepicker/datepicker-custom-icon/datepicker-custom-icon-example.html
@@ -1,4 +1,4 @@
-<mat-form-field class="example-full-width" appearance="fill">
+<mat-form-field class="example-full-width">
   <mat-label>Choose a date</mat-label>
   <input matInput [matDatepicker]="picker">
   <mat-hint>MM/DD/YYYY</mat-hint>

--- a/src/components-examples/material/datepicker/datepicker-date-class/datepicker-date-class-example.html
+++ b/src/components-examples/material/datepicker/datepicker-date-class/datepicker-date-class-example.html
@@ -1,4 +1,4 @@
-<mat-form-field class="example-full-width" appearance="fill">
+<mat-form-field class="example-full-width">
   <mat-label>Choose a date</mat-label>
   <input matInput [matDatepicker]="picker">
   <mat-hint>MM/DD/YYYY</mat-hint>

--- a/src/components-examples/material/datepicker/datepicker-disabled/datepicker-disabled-example.html
+++ b/src/components-examples/material/datepicker/datepicker-disabled/datepicker-disabled-example.html
@@ -1,5 +1,5 @@
 <p>
-  <mat-form-field appearance="fill">
+  <mat-form-field>
     <mat-label>Completely disabled</mat-label>
     <input matInput [matDatepicker]="dp1" disabled>
     <mat-hint>MM/DD/YYYY</mat-hint>
@@ -9,7 +9,7 @@
 </p>
 
 <p>
-  <mat-form-field appearance="fill">
+  <mat-form-field>
     <mat-label>Popup disabled</mat-label>
     <input matInput [matDatepicker]="dp2">
     <mat-hint>MM/DD/YYYY</mat-hint>
@@ -19,7 +19,7 @@
 </p>
 
 <p>
-  <mat-form-field appearance="fill">
+  <mat-form-field>
     <mat-label>Input disabled</mat-label>
     <input matInput [matDatepicker]="dp3" disabled>
     <mat-hint>MM/DD/YYYY</mat-hint>

--- a/src/components-examples/material/datepicker/datepicker-events/datepicker-events-example.html
+++ b/src/components-examples/material/datepicker/datepicker-events/datepicker-events-example.html
@@ -1,4 +1,4 @@
-<mat-form-field appearance="fill">
+<mat-form-field>
   <mat-label>Input & change events</mat-label>
   <input matInput [matDatepicker]="picker"
          (dateInput)="addEvent('input', $event)" (dateChange)="addEvent('change', $event)">

--- a/src/components-examples/material/datepicker/datepicker-filter/datepicker-filter-example.html
+++ b/src/components-examples/material/datepicker/datepicker-filter/datepicker-filter-example.html
@@ -1,4 +1,4 @@
-<mat-form-field class="example-full-width" appearance="fill">
+<mat-form-field class="example-full-width">
   <mat-label>Choose a date</mat-label>
   <input matInput [matDatepickerFilter]="myFilter" [matDatepicker]="picker">
   <mat-hint>MM/DD/YYYY</mat-hint>

--- a/src/components-examples/material/datepicker/datepicker-formats/datepicker-formats-example.html
+++ b/src/components-examples/material/datepicker/datepicker-formats/datepicker-formats-example.html
@@ -1,4 +1,4 @@
-<mat-form-field appearance="fill">
+<mat-form-field>
   <mat-label>Verbose datepicker</mat-label>
   <input matInput [matDatepicker]="dp" [formControl]="date">
   <mat-hint>MMMM DD, YYYY</mat-hint>

--- a/src/components-examples/material/datepicker/datepicker-locale/datepicker-locale-example.html
+++ b/src/components-examples/material/datepicker/datepicker-locale/datepicker-locale-example.html
@@ -1,4 +1,4 @@
-<mat-form-field appearance="fill">
+<mat-form-field>
   <mat-label>Different locale</mat-label>
   <input matInput [matDatepicker]="dp">
   <mat-hint>{{getDateFormatString()}}</mat-hint>

--- a/src/components-examples/material/datepicker/datepicker-min-max/datepicker-min-max-example.html
+++ b/src/components-examples/material/datepicker/datepicker-min-max/datepicker-min-max-example.html
@@ -1,4 +1,4 @@
-<mat-form-field class="example-full-width" appearance="fill">
+<mat-form-field class="example-full-width">
   <mat-label>Choose a date</mat-label>
   <input matInput [min]="minDate" [max]="maxDate" [matDatepicker]="picker">
   <mat-hint>MM/DD/YYYY</mat-hint>

--- a/src/components-examples/material/datepicker/datepicker-moment/datepicker-moment-example.html
+++ b/src/components-examples/material/datepicker/datepicker-moment/datepicker-moment-example.html
@@ -1,4 +1,4 @@
-<mat-form-field appearance="fill">
+<mat-form-field>
   <mat-label>Moment.js datepicker</mat-label>
   <input matInput [matDatepicker]="dp" [formControl]="date">
   <mat-hint>MM/DD/YYYY</mat-hint>

--- a/src/components-examples/material/datepicker/datepicker-overview/datepicker-overview-example.html
+++ b/src/components-examples/material/datepicker/datepicker-overview/datepicker-overview-example.html
@@ -1,4 +1,4 @@
-<mat-form-field appearance="fill">
+<mat-form-field>
   <mat-label>Choose a date</mat-label>
 <!-- #docregion toggle -->
   <input matInput [matDatepicker]="picker">

--- a/src/components-examples/material/datepicker/datepicker-start-view/datepicker-start-view-example.html
+++ b/src/components-examples/material/datepicker/datepicker-start-view/datepicker-start-view-example.html
@@ -1,4 +1,4 @@
-<mat-form-field appearance="fill">
+<mat-form-field>
   <mat-label>Choose a date</mat-label>
   <input matInput [matDatepicker]="picker">
   <mat-hint>MM/DD/YYYY</mat-hint>

--- a/src/components-examples/material/datepicker/datepicker-touch/datepicker-touch-example.html
+++ b/src/components-examples/material/datepicker/datepicker-touch/datepicker-touch-example.html
@@ -1,4 +1,4 @@
-<mat-form-field class="example-full-width" appearance="fill">
+<mat-form-field class="example-full-width">
   <mat-label>Choose a date</mat-label>
   <input matInput [matDatepicker]="picker">
   <mat-hint>MM/DD/YYYY</mat-hint>

--- a/src/components-examples/material/datepicker/datepicker-value/datepicker-value-example.html
+++ b/src/components-examples/material/datepicker/datepicker-value/datepicker-value-example.html
@@ -1,4 +1,4 @@
-<mat-form-field appearance="fill">
+<mat-form-field>
   <mat-label>Angular forms</mat-label>
   <input matInput [matDatepicker]="picker1" [formControl]="date">
   <mat-hint>MM/DD/YYYY</mat-hint>
@@ -6,7 +6,7 @@
   <mat-datepicker #picker1></mat-datepicker>
 </mat-form-field>
 
-<mat-form-field appearance="fill">
+<mat-form-field>
   <mat-label>Angular forms (w/ deserialization)</mat-label>
   <input matInput [matDatepicker]="picker2"
          [formControl]="serializedDate">
@@ -15,7 +15,7 @@
   <mat-datepicker #picker2></mat-datepicker>
 </mat-form-field>
 
-<mat-form-field appearance="fill">
+<mat-form-field>
   <mat-label>Value binding</mat-label>
   <input matInput [matDatepicker]="picker3" [value]="date.value">
   <mat-hint>MM/DD/YYYY</mat-hint>

--- a/src/components-examples/material/datepicker/datepicker-views-selection/datepicker-views-selection-example.html
+++ b/src/components-examples/material/datepicker/datepicker-views-selection/datepicker-views-selection-example.html
@@ -1,4 +1,4 @@
-<mat-form-field appearance="fill">
+<mat-form-field>
   <mat-label>Month and Year</mat-label>
   <input matInput [matDatepicker]="dp" [formControl]="date">
   <mat-hint>MM/YYYY</mat-hint>

--- a/src/components-examples/material/dialog/dialog-overview/dialog-overview-example-dialog.html
+++ b/src/components-examples/material/dialog/dialog-overview/dialog-overview-example-dialog.html
@@ -1,7 +1,7 @@
 <h1 mat-dialog-title>Hi {{data.name}}</h1>
 <div mat-dialog-content>
   <p>What's your favorite animal?</p>
-  <mat-form-field appearance="fill">
+  <mat-form-field>
     <mat-label>Favorite Animal</mat-label>
     <input matInput [(ngModel)]="data.animal">
   </mat-form-field>

--- a/src/components-examples/material/dialog/dialog-overview/dialog-overview-example.html
+++ b/src/components-examples/material/dialog/dialog-overview/dialog-overview-example.html
@@ -1,6 +1,6 @@
 <ol>
   <li>
-    <mat-form-field appearance="fill">
+    <mat-form-field>
       <mat-label>What's your name?</mat-label>
       <input matInput [(ngModel)]="name">
     </mat-form-field>

--- a/src/components-examples/material/expansion/expansion-expand-collapse-all/expansion-expand-collapse-all-example.html
+++ b/src/components-examples/material/expansion/expansion-expand-collapse-all/expansion-expand-collapse-all-example.html
@@ -16,12 +16,12 @@
       </mat-panel-description>
     </mat-expansion-panel-header>
 
-    <mat-form-field appearance="fill">
+    <mat-form-field>
       <mat-label>First name</mat-label>
       <input matInput>
     </mat-form-field>
 
-    <mat-form-field appearance="fill">
+    <mat-form-field>
       <mat-label>Age</mat-label>
       <input matInput type="number" min="1">
     </mat-form-field>
@@ -40,7 +40,7 @@
       </mat-panel-description>
     </mat-expansion-panel-header>
 
-    <mat-form-field appearance="fill">
+    <mat-form-field>
       <mat-label>Country</mat-label>
       <input matInput>
     </mat-form-field>
@@ -57,7 +57,7 @@
       </mat-panel-description>
     </mat-expansion-panel-header>
 
-    <mat-form-field appearance="fill">
+    <mat-form-field>
       <mat-label>Date</mat-label>
       <input matInput [matDatepicker]="picker" (focus)="picker.open()" readonly>
     </mat-form-field>

--- a/src/components-examples/material/expansion/expansion-steps/expansion-steps-example.html
+++ b/src/components-examples/material/expansion/expansion-steps/expansion-steps-example.html
@@ -10,12 +10,12 @@
       </mat-panel-description>
     </mat-expansion-panel-header>
 
-    <mat-form-field appearance="fill">
+    <mat-form-field>
       <mat-label>First name</mat-label>
       <input matInput>
     </mat-form-field>
 
-    <mat-form-field appearance="fill">
+    <mat-form-field>
       <mat-label>Age</mat-label>
       <input matInput type="number" min="1">
     </mat-form-field>
@@ -37,7 +37,7 @@
       </mat-panel-description>
     </mat-expansion-panel-header>
 
-    <mat-form-field appearance="fill">
+    <mat-form-field>
       <mat-label>Country</mat-label>
       <input matInput>
     </mat-form-field>
@@ -59,7 +59,7 @@
       </mat-panel-description>
     </mat-expansion-panel-header>
 
-    <mat-form-field appearance="fill">
+    <mat-form-field>
       <mat-label>Date</mat-label>
       <input matInput [matDatepicker]="picker" (focus)="picker.open()" readonly>
     </mat-form-field>

--- a/src/components-examples/material/form-field/form-field-custom-control/form-field-custom-control-example.html
+++ b/src/components-examples/material/form-field/form-field-custom-control/form-field-custom-control-example.html
@@ -1,5 +1,5 @@
 <div [formGroup]="form">
-  <mat-form-field appearance="fill">
+  <mat-form-field>
     <mat-label>Phone number</mat-label>
     <example-tel-input formControlName="tel" required></example-tel-input>
     <mat-icon matSuffix>phone</mat-icon>

--- a/src/components-examples/material/form-field/form-field-error/form-field-error-example.html
+++ b/src/components-examples/material/form-field/form-field-error/form-field-error-example.html
@@ -1,5 +1,5 @@
 <div class="example-container">
-  <mat-form-field appearance="fill">
+  <mat-form-field>
     <mat-label>Enter your email</mat-label>
     <input matInput placeholder="pat@example.com" [formControl]="email" required>
     <mat-error *ngIf="email.invalid">{{getErrorMessage()}}</mat-error>

--- a/src/components-examples/material/form-field/form-field-harness/form-field-harness-example.html
+++ b/src/components-examples/material/form-field/form-field-harness/form-field-harness-example.html
@@ -1,4 +1,4 @@
-<mat-form-field id="with-errors" appearance="fill">
+<mat-form-field id="with-errors">
   <span class="custom-control">Custom control harness</span>
   <input matInput [formControl]="requiredControl">
 

--- a/src/components-examples/material/form-field/form-field-hint/form-field-hint-example.html
+++ b/src/components-examples/material/form-field/form-field-hint/form-field-hint-example.html
@@ -1,11 +1,11 @@
 <div class="example-container">
-  <mat-form-field hintLabel="Max 10 characters" appearance="fill">
+  <mat-form-field hintLabel="Max 10 characters">
     <mat-label>Enter some input</mat-label>
     <input matInput #input maxlength="10" placeholder="Ex. Nougat">
     <mat-hint align="end">{{input.value.length}}/10</mat-hint>
   </mat-form-field>
 
-  <mat-form-field appearance="fill">
+  <mat-form-field>
     <mat-label>Select me</mat-label>
     <mat-select>
       <mat-option value="option">Option</mat-option>

--- a/src/components-examples/material/form-field/form-field-label/form-field-label-example.html
+++ b/src/components-examples/material/form-field/form-field-label/form-field-label-example.html
@@ -10,18 +10,18 @@
     </div>
 
     <div class="example-form-fields">
-      <mat-form-field appearance="fill"
+      <mat-form-field
           [hideRequiredMarker]="hideRequiredControl.value"
           [floatLabel]="getFloatLabelValue()">
         <input matInput placeholder="Simple placeholder" required>
       </mat-form-field>
 
-      <mat-form-field appearance="fill" [floatLabel]="getFloatLabelValue()">
+      <mat-form-field [floatLabel]="getFloatLabelValue()">
         <mat-label>Both a label and a placeholder</mat-label>
         <input matInput placeholder="Simple placeholder">
       </mat-form-field>
 
-      <mat-form-field appearance="fill"
+      <mat-form-field
           [hideRequiredMarker]="hideRequiredControl.value"
           [floatLabel]="getFloatLabelValue()">
         <mat-select required>

--- a/src/components-examples/material/form-field/form-field-overview/form-field-overview-example.html
+++ b/src/components-examples/material/form-field/form-field-overview/form-field-overview-example.html
@@ -1,15 +1,15 @@
-<mat-form-field appearance="fill">
+<mat-form-field>
   <mat-label>Input</mat-label>
   <input matInput>
 </mat-form-field>
-<mat-form-field appearance="fill">
+<mat-form-field>
   <mat-label>Select</mat-label>
   <mat-select>
     <mat-option value="one">First option</mat-option>
     <mat-option value="two">Second option</mat-option>
   </mat-select>
 </mat-form-field>
-<mat-form-field appearance="fill">
+<mat-form-field>
   <mat-label>Textarea</mat-label>
   <textarea matInput></textarea>
 </mat-form-field>

--- a/src/components-examples/material/form-field/form-field-prefix-suffix/form-field-prefix-suffix-example.html
+++ b/src/components-examples/material/form-field/form-field-prefix-suffix/form-field-prefix-suffix-example.html
@@ -1,5 +1,5 @@
 <div class="example-container">
-  <mat-form-field appearance="fill">
+  <mat-form-field>
     <mat-label>Enter your password</mat-label>
     <input matInput [type]="hide ? 'password' : 'text'">
     <button mat-icon-button matSuffix (click)="hide = !hide" [attr.aria-label]="'Hide password'" [attr.aria-pressed]="hide">
@@ -7,7 +7,7 @@
     </button>
   </mat-form-field>
 
-  <mat-form-field appearance="fill" floatLabel="always">
+  <mat-form-field floatLabel="always">
     <mat-label>Amount</mat-label>
     <input matInput type="number" class="example-right-align" placeholder="0">
     <span matTextPrefix>$&nbsp;</span>

--- a/src/components-examples/material/form-field/form-field-theming/form-field-theming-example.html
+++ b/src/components-examples/material/form-field/form-field-theming/form-field-theming-example.html
@@ -1,4 +1,4 @@
-<mat-form-field appearance="fill" [color]="colorControl.value!">
+<mat-form-field [color]="colorControl.value!">
   <mat-label>Color</mat-label>
   <mat-select [formControl]="colorControl">
     <mat-option value="primary">Primary</mat-option>

--- a/src/components-examples/material/select/select-custom-trigger/select-custom-trigger-example.html
+++ b/src/components-examples/material/select/select-custom-trigger/select-custom-trigger-example.html
@@ -1,4 +1,4 @@
-<mat-form-field appearance="fill">
+<mat-form-field>
   <mat-label>Toppings</mat-label>
   <mat-select [formControl]="toppings" multiple>
     <mat-select-trigger>

--- a/src/components-examples/material/select/select-disabled/select-disabled-example.html
+++ b/src/components-examples/material/select/select-disabled/select-disabled-example.html
@@ -3,7 +3,7 @@
 </p>
 
 <h4>mat-select</h4>
-<mat-form-field appearance="fill">
+<mat-form-field>
   <mat-label>Choose an option</mat-label>
   <mat-select [disabled]="disableSelect.value">
     <mat-option value="option1">Option 1</mat-option>
@@ -13,7 +13,7 @@
 </mat-form-field>
 
 <h4>native html select</h4>
-<mat-form-field appearance="fill">
+<mat-form-field>
   <mat-label>Choose an option</mat-label>
   <select matNativeControl [disabled]="disableSelect.value">
     <option value="" selected></option>

--- a/src/components-examples/material/select/select-error-state-matcher/select-error-state-matcher-example.html
+++ b/src/components-examples/material/select/select-error-state-matcher/select-error-state-matcher-example.html
@@ -1,5 +1,5 @@
 <h4>mat-select</h4>
-<mat-form-field appearance="fill">
+<mat-form-field>
   <mat-label>Choose one</mat-label>
   <mat-select [formControl]="selected" [errorStateMatcher]="matcher">
     <mat-option>Clear</mat-option>
@@ -14,7 +14,7 @@
 </mat-form-field>
 
 <h4>native html select</h4>
-<mat-form-field class="demo-full-width" appearance="fill">
+<mat-form-field class="demo-full-width">
   <mat-label>Choose one</mat-label>
   <select matNativeControl [formControl]="nativeSelectFormControl" [errorStateMatcher]="matcher">
     <option value=""></option>

--- a/src/components-examples/material/select/select-form/select-form-example.html
+++ b/src/components-examples/material/select/select-form/select-form-example.html
@@ -1,6 +1,6 @@
 <form>
   <h4>mat-select</h4>
-  <mat-form-field appearance="fill">
+  <mat-form-field>
     <mat-label>Favorite food</mat-label>
     <mat-select [(ngModel)]="selectedValue" name="food">
       <mat-option *ngFor="let food of foods" [value]="food.value">
@@ -10,7 +10,7 @@
   </mat-form-field>
   <p> Selected food: {{selectedValue}} </p>
   <h4>native html select</h4>
-  <mat-form-field appearance="fill">
+  <mat-form-field>
     <mat-label>Favorite car</mat-label>
     <select matNativeControl [(ngModel)]="selectedCar" name="car">
       <option value="" selected></option>

--- a/src/components-examples/material/select/select-harness/select-harness-example.html
+++ b/src/components-examples/material/select/select-harness/select-harness-example.html
@@ -1,4 +1,4 @@
-<mat-form-field appearance="fill">
+<mat-form-field>
   <mat-label>Favorite food</mat-label>
   <mat-select>
     <mat-option *ngFor="let food of foods" [value]="food.value">

--- a/src/components-examples/material/select/select-hint-error/select-hint-error-example.html
+++ b/src/components-examples/material/select/select-hint-error/select-hint-error-example.html
@@ -1,5 +1,5 @@
 <h4>mat select</h4>
-<mat-form-field appearance="fill">
+<mat-form-field>
   <mat-label>Favorite animal</mat-label>
   <mat-select [formControl]="animalControl" required>
     <mat-option>--</mat-option>
@@ -12,7 +12,7 @@
 </mat-form-field>
 
 <h4>native html select</h4>
-<mat-form-field appearance="fill">
+<mat-form-field>
   <mat-label>Select your car (required)</mat-label>
   <select matNativeControl required [formControl]="selectFormControl">
     <option label="--select something --"></option>

--- a/src/components-examples/material/select/select-initial-value/select-initial-value-example.html
+++ b/src/components-examples/material/select/select-initial-value/select-initial-value-example.html
@@ -1,5 +1,5 @@
 <h4>Basic mat-select with initial value</h4>
-<mat-form-field appearance="fill">
+<mat-form-field>
   <mat-label>Favorite Food</mat-label>
   <mat-select [(value)]="selectedFood">
     <mat-option></mat-option>
@@ -9,7 +9,7 @@
 <p>You selected: {{selectedFood}}</p>
 
 <h4>Basic native select with initial value</h4>
-<mat-form-field appearance="fill">
+<mat-form-field>
   <mat-label>Favorite Car</mat-label>
   <select matNativeControl (change)="selectCar($event)">
     <option value=""></option>

--- a/src/components-examples/material/select/select-multiple/select-multiple-example.html
+++ b/src/components-examples/material/select/select-multiple/select-multiple-example.html
@@ -1,4 +1,4 @@
-<mat-form-field appearance="fill">
+<mat-form-field>
   <mat-label>Toppings</mat-label>
   <mat-select [formControl]="toppings" multiple>
     <mat-option *ngFor="let topping of toppingList" [value]="topping">{{topping}}</mat-option>

--- a/src/components-examples/material/select/select-no-ripple/select-no-ripple-example.html
+++ b/src/components-examples/material/select/select-no-ripple/select-no-ripple-example.html
@@ -1,4 +1,4 @@
-<mat-form-field appearance="fill">
+<mat-form-field>
   <mat-label>Select an option</mat-label>
   <mat-select disableRipple>
     <mat-option value="1">Option 1</mat-option>

--- a/src/components-examples/material/select/select-optgroup/select-optgroup-example.html
+++ b/src/components-examples/material/select/select-optgroup/select-optgroup-example.html
@@ -1,5 +1,5 @@
 <h4>mat-select</h4>
-<mat-form-field appearance="fill">
+<mat-form-field>
   <mat-label>Pokemon</mat-label>
   <mat-select [formControl]="pokemonControl">
     <mat-option>-- None --</mat-option>
@@ -13,7 +13,7 @@
 </mat-form-field>
 
 <h4>native html select</h4>
-<mat-form-field appearance="fill">
+<mat-form-field>
   <mat-label>Cars</mat-label>
   <select matNativeControl>
     <optgroup label="Swedish Cars">

--- a/src/components-examples/material/select/select-overview/select-overview-example.html
+++ b/src/components-examples/material/select/select-overview/select-overview-example.html
@@ -1,5 +1,5 @@
 <h4>Basic mat-select</h4>
-<mat-form-field appearance="fill">
+<mat-form-field>
   <mat-label>Favorite food</mat-label>
   <mat-select>
     <mat-option *ngFor="let food of foods" [value]="food.value">
@@ -9,7 +9,7 @@
 </mat-form-field>
 
 <h4>Basic native select</h4>
-<mat-form-field appearance="fill">
+<mat-form-field>
   <mat-label>Cars</mat-label>
   <select matNativeControl required>
     <option value="volvo">Volvo</option>

--- a/src/components-examples/material/select/select-panel-class/select-panel-class-example.html
+++ b/src/components-examples/material/select/select-panel-class/select-panel-class-example.html
@@ -1,4 +1,4 @@
-<mat-form-field appearance="fill">
+<mat-form-field>
   <mat-label>Panel color</mat-label>
   <mat-select [formControl]="panelColor"
               panelClass="example-panel-{{panelColor.value}}">

--- a/src/components-examples/material/select/select-reactive-form/select-reactive-form-example.html
+++ b/src/components-examples/material/select/select-reactive-form/select-reactive-form-example.html
@@ -1,6 +1,6 @@
 <form [formGroup]="form">
   <h4>mat-select</h4>
-  <mat-form-field appearance="fill">
+  <mat-form-field>
     <mat-label>Favorite Food</mat-label>
     <mat-select [formControl]="foodControl" name="food">
       <mat-option>None</mat-option>
@@ -11,7 +11,7 @@
   </mat-form-field>
   <p>Selected: {{foodControl.value}}</p>
   <h4>Native select</h4>
-  <mat-form-field appearance="fill">
+  <mat-form-field>
     <mat-label>Favorite Car</mat-label>
     <select matNativeControl [formControl]="carControl" name="car">
       <option value="">None</option>

--- a/src/components-examples/material/select/select-reset/select-reset-example.html
+++ b/src/components-examples/material/select/select-reset/select-reset-example.html
@@ -1,5 +1,5 @@
 <h4>mat-select</h4>
-<mat-form-field appearance="fill">
+<mat-form-field>
   <mat-label>State</mat-label>
   <mat-select>
     <mat-option>None</mat-option>
@@ -8,7 +8,7 @@
 </mat-form-field>
 
 <h4>native html select</h4>
-<mat-form-field appearance="fill">
+<mat-form-field>
   <mat-label>Select your car</mat-label>
   <select matNativeControl id="mySelectId">
     <option value="" disabled selected></option>

--- a/src/components-examples/material/select/select-value-binding/select-value-binding-example.html
+++ b/src/components-examples/material/select/select-value-binding/select-value-binding-example.html
@@ -1,4 +1,4 @@
-<mat-form-field appearance="fill">
+<mat-form-field>
   <mat-label>Select an option</mat-label>
   <mat-select [(value)]="selected">
     <mat-option>None</mat-option>

--- a/src/components-examples/material/sidenav/sidenav-backdrop/sidenav-backdrop-example.html
+++ b/src/components-examples/material/sidenav/sidenav-backdrop/sidenav-backdrop-example.html
@@ -1,7 +1,7 @@
 <mat-drawer-container class="example-container" [hasBackdrop]="hasBackdrop.value">
   <mat-drawer #drawer [mode]="mode.value">I'm a drawer</mat-drawer>
   <mat-drawer-content>
-    <mat-form-field appearance="fill">
+    <mat-form-field>
       <mat-label>Sidenav mode</mat-label>
       <mat-select #mode value="side">
         <mat-option value="side">Side</mat-option>
@@ -9,7 +9,7 @@
         <mat-option value="push">Push</mat-option>
       </mat-select>
     </mat-form-field>
-    <mat-form-field appearance="fill">
+    <mat-form-field>
       <mat-label>Has backdrop</mat-label>
       <mat-select #hasBackdrop>
         <mat-option>Unset</mat-option>

--- a/src/components-examples/material/sidenav/sidenav-fixed/sidenav-fixed-example.html
+++ b/src/components-examples/material/sidenav/sidenav-fixed/sidenav-fixed-example.html
@@ -10,11 +10,11 @@
 
     <mat-sidenav-content [formGroup]="options">
       <p><mat-checkbox formControlName="fixed">Fixed</mat-checkbox></p>
-      <p><mat-form-field appearance="fill">
+      <p><mat-form-field>
         <mat-label>Top gap</mat-label>
         <input matInput type="number" formControlName="top">
       </mat-form-field></p>
-      <p><mat-form-field appearance="fill">
+      <p><mat-form-field>
         <mat-label>Bottom gap</mat-label>
         <input matInput type="number" formControlName="bottom">
       </mat-form-field></p>

--- a/src/components-examples/material/slider/slider-configurable/slider-configurable-example.html
+++ b/src/components-examples/material/slider/slider-configurable/slider-configurable-example.html
@@ -3,19 +3,19 @@
     <h2 class="example-h2">Slider configuration</h2>
 
     <section class="example-section">
-      <mat-form-field class="example-margin example-width" appearance="fill">
+      <mat-form-field class="example-margin example-width">
         <mat-label>Value</mat-label>
         <input matInput type="number" [(ngModel)]="value">
       </mat-form-field>
-      <mat-form-field class="example-margin example-width" appearance="fill">
+      <mat-form-field class="example-margin example-width">
         <mat-label>Min value</mat-label>
         <input matInput type="number" [(ngModel)]="min">
       </mat-form-field>
-      <mat-form-field class="example-margin example-width" appearance="fill">
+      <mat-form-field class="example-margin example-width">
         <mat-label>Max value</mat-label>
         <input matInput type="number" [(ngModel)]="max">
       </mat-form-field>
-      <mat-form-field class="example-margin example-width" appearance="fill">
+      <mat-form-field class="example-margin example-width">
         <mat-label>Step size</mat-label>
         <input matInput type="number" [(ngModel)]="step">
       </mat-form-field>

--- a/src/components-examples/material/snack-bar/snack-bar-annotated-component/snack-bar-annotated-component-example.html
+++ b/src/components-examples/material/snack-bar/snack-bar-annotated-component/snack-bar-annotated-component-example.html
@@ -1,4 +1,4 @@
-<mat-form-field appearance="fill">
+<mat-form-field>
   <mat-label>Snack bar duration (seconds)</mat-label>
   <input type="number" [(ngModel)]="durationInSeconds" matInput>
 </mat-form-field>

--- a/src/components-examples/material/snack-bar/snack-bar-component/snack-bar-component-example.html
+++ b/src/components-examples/material/snack-bar/snack-bar-component/snack-bar-component-example.html
@@ -1,4 +1,4 @@
-<mat-form-field appearance="fill">
+<mat-form-field>
   <mat-label>Snack bar duration (seconds)</mat-label>
   <input type="number" [(ngModel)]="durationInSeconds" matInput>
 </mat-form-field>

--- a/src/components-examples/material/snack-bar/snack-bar-overview/snack-bar-overview-example.html
+++ b/src/components-examples/material/snack-bar/snack-bar-overview/snack-bar-overview-example.html
@@ -1,9 +1,9 @@
-<mat-form-field appearance="fill">
+<mat-form-field>
   <mat-label>Message</mat-label>
   <input matInput value="Disco party!" #message>
 </mat-form-field>
 
-<mat-form-field appearance="fill">
+<mat-form-field>
   <mat-label>Action</mat-label>
   <input matInput value="Dance" #action>
 </mat-form-field>

--- a/src/components-examples/material/snack-bar/snack-bar-position/snack-bar-position-example.html
+++ b/src/components-examples/material/snack-bar/snack-bar-position/snack-bar-position-example.html
@@ -1,4 +1,4 @@
-<mat-form-field appearance="fill">
+<mat-form-field>
   <mat-label>Horizontal position</mat-label>
   <mat-select [(value)]="horizontalPosition">
     <mat-option value="start">Start</mat-option>
@@ -8,7 +8,7 @@
     <mat-option value="right">Right</mat-option>
   </mat-select>
 </mat-form-field>
-<mat-form-field appearance="fill">
+<mat-form-field>
   <mat-label>Vertical position</mat-label>
   <mat-select [(value)]="verticalPosition">
     <mat-option value="top">Top</mat-option>

--- a/src/components-examples/material/stepper/stepper-editable/stepper-editable-example.html
+++ b/src/components-examples/material/stepper/stepper-editable/stepper-editable-example.html
@@ -10,7 +10,7 @@
 <!-- #docregion step-label -->
       <ng-template matStepLabel>Fill out your name</ng-template>
 <!-- #enddocregion step-label -->
-      <mat-form-field appearance="fill">
+      <mat-form-field>
         <mat-label>Name</mat-label>
         <input matInput formControlName="firstCtrl" placeholder="Last name, First name" required>
       </mat-form-field>
@@ -22,7 +22,7 @@
   <mat-step [stepControl]="secondFormGroup" [editable]="isEditable">
     <form [formGroup]="secondFormGroup">
       <ng-template matStepLabel>Fill out your address</ng-template>
-      <mat-form-field appearance="fill">
+      <mat-form-field>
         <mat-label>Address</mat-label>
         <input matInput formControlName="secondCtrl" placeholder="Ex. 1 Main St, New York, NY"
                required>

--- a/src/components-examples/material/stepper/stepper-errors/stepper-errors-example.html
+++ b/src/components-examples/material/stepper/stepper-errors/stepper-errors-example.html
@@ -2,7 +2,7 @@
   <mat-step [stepControl]="firstFormGroup" errorMessage="Name is required.">
     <form [formGroup]="firstFormGroup">
       <ng-template matStepLabel>Fill out your name</ng-template>
-      <mat-form-field appearance="fill">
+      <mat-form-field>
         <mat-label>Name</mat-label>
         <input matInput placeholder="Last name, First name" formControlName="firstCtrl" required>
       </mat-form-field>
@@ -15,7 +15,7 @@
   <mat-step [stepControl]="secondFormGroup" errorMessage="Address is required.">
     <form [formGroup]="secondFormGroup">
       <ng-template matStepLabel>Fill out your address</ng-template>
-      <mat-form-field appearance="fill">
+      <mat-form-field>
         <mat-label>Address</mat-label>
         <input matInput placeholder="Ex. 1 Main St, New York, NY" formControlName="secondCtrl"
                required>

--- a/src/components-examples/material/stepper/stepper-intl/stepper-intl-example.html
+++ b/src/components-examples/material/stepper/stepper-intl/stepper-intl-example.html
@@ -15,7 +15,7 @@
   <mat-step [stepControl]="firstFormGroup">
     <form [formGroup]="firstFormGroup">
       <ng-template matStepLabel>Fill out your name</ng-template>
-      <mat-form-field class="demo-form-field" appearance="fill">
+      <mat-form-field class="demo-form-field">
         <mat-label>Name</mat-label>
         <input
           matInput
@@ -34,7 +34,7 @@
     label="Fill out your address"
     optional>
     <form [formGroup]="secondFormGroup">
-      <mat-form-field appearance="fill">
+      <mat-form-field>
         <mat-label>Address</mat-label>
         <input
           matInput

--- a/src/components-examples/material/stepper/stepper-label-position-bottom/stepper-label-position-bottom-example.html
+++ b/src/components-examples/material/stepper/stepper-label-position-bottom/stepper-label-position-bottom-example.html
@@ -4,7 +4,7 @@
   <mat-step [stepControl]="firstFormGroup">
     <form [formGroup]="firstFormGroup">
       <ng-template matStepLabel>Fill out your name</ng-template>
-      <mat-form-field appearance="fill">
+      <mat-form-field>
         <mat-label>Name</mat-label>
         <input matInput placeholder="Last name, First name" formControlName="firstCtrl" required>
       </mat-form-field>
@@ -16,7 +16,7 @@
   <mat-step [stepControl]="secondFormGroup" optional>
     <form [formGroup]="secondFormGroup">
       <ng-template matStepLabel>Fill out your address</ng-template>
-      <mat-form-field appearance="fill">
+      <mat-form-field>
         <mat-label>Address</mat-label>
         <input matInput formControlName="secondCtrl" placeholder="Ex. 1 Main St, New York, NY"
                required>

--- a/src/components-examples/material/stepper/stepper-optional/stepper-optional-example.html
+++ b/src/components-examples/material/stepper/stepper-optional/stepper-optional-example.html
@@ -6,7 +6,7 @@
   <mat-step [stepControl]="firstFormGroup">
     <form [formGroup]="firstFormGroup">
       <ng-template matStepLabel>Fill out your name</ng-template>
-      <mat-form-field appearance="fill">
+      <mat-form-field>
         <mat-label>Name</mat-label>
         <input matInput placeholder="Last name, First name" formControlName="firstCtrl" required>
       </mat-form-field>
@@ -20,7 +20,7 @@
   <!-- #enddocregion optional -->
     <form [formGroup]="secondFormGroup">
       <ng-template matStepLabel>Fill out your address</ng-template>
-      <mat-form-field appearance="fill">
+      <mat-form-field>
         <mat-label>Address</mat-label>
         <input matInput formControlName="secondCtrl" placeholder="Ex. 1 Main St, New York, NY"
                required>

--- a/src/components-examples/material/stepper/stepper-overview/stepper-overview-example.html
+++ b/src/components-examples/material/stepper/stepper-overview/stepper-overview-example.html
@@ -5,7 +5,7 @@
   <mat-step [stepControl]="firstFormGroup">
     <form [formGroup]="firstFormGroup">
       <ng-template matStepLabel>Fill out your name</ng-template>
-      <mat-form-field appearance="fill">
+      <mat-form-field>
         <mat-label>Name</mat-label>
         <input matInput placeholder="Last name, First name" formControlName="firstCtrl" required>
       </mat-form-field>
@@ -18,7 +18,7 @@
   <mat-step [stepControl]="secondFormGroup" label="Fill out your address">
   <!-- #enddocregion label -->
     <form [formGroup]="secondFormGroup">
-      <mat-form-field appearance="fill">
+      <mat-form-field>
         <mat-label>Address</mat-label>
         <input matInput formControlName="secondCtrl" placeholder="Ex. 1 Main St, New York, NY"
                required>

--- a/src/components-examples/material/stepper/stepper-responsive/stepper-responsive-example.html
+++ b/src/components-examples/material/stepper/stepper-responsive/stepper-responsive-example.html
@@ -8,7 +8,7 @@
   [orientation]="(stepperOrientation | async)!">
   <mat-step [stepControl]="firstFormGroup" label="Fill out your name">
     <form [formGroup]="firstFormGroup">
-      <mat-form-field appearance="fill">
+      <mat-form-field>
         <mat-label>Name</mat-label>
         <input matInput placeholder="Last name, First name" formControlName="firstCtrl" required>
       </mat-form-field>
@@ -19,7 +19,7 @@
   </mat-step>
   <mat-step [stepControl]="secondFormGroup" label="Fill out your address">
     <form [formGroup]="secondFormGroup">
-      <mat-form-field appearance="fill">
+      <mat-form-field>
         <mat-label>Address</mat-label>
         <input matInput formControlName="secondCtrl" placeholder="Ex. 1 Main St, New York, NY"
                required>
@@ -32,7 +32,7 @@
   </mat-step>
   <mat-step [stepControl]="thirdFormGroup" label="Fill out your phone number">
     <form [formGroup]="thirdFormGroup">
-      <mat-form-field appearance="fill">
+      <mat-form-field>
         <mat-label>Phone number</mat-label>
         <input matInput formControlName="thirdCtrl" placeholder="Ex. 12345678" required>
       </mat-form-field>

--- a/src/components-examples/material/stepper/stepper-states/stepper-states-example.html
+++ b/src/components-examples/material/stepper/stepper-states/stepper-states-example.html
@@ -2,7 +2,7 @@
   <mat-step [stepControl]="firstFormGroup">
     <form [formGroup]="firstFormGroup">
       <ng-template matStepLabel>Fill out your name</ng-template>
-      <mat-form-field appearance="fill">
+      <mat-form-field>
         <mat-label>Name</mat-label>
         <input matInput placeholder="Last name, First name" formControlName="firstCtrl" required>
       </mat-form-field>
@@ -14,7 +14,7 @@
   <mat-step [stepControl]="secondFormGroup">
     <form [formGroup]="secondFormGroup">
       <ng-template matStepLabel>Fill out your address</ng-template>
-      <mat-form-field appearance="fill">
+      <mat-form-field>
         <mat-label>Address</mat-label>
         <input matInput formControlName="secondCtrl" placeholder="Ex. 1 Main St, New York, NY"
                required>

--- a/src/components-examples/material/stepper/stepper-vertical/stepper-vertical-example.html
+++ b/src/components-examples/material/stepper/stepper-vertical/stepper-vertical-example.html
@@ -5,7 +5,7 @@
   <mat-step [stepControl]="firstFormGroup">
     <form [formGroup]="firstFormGroup">
       <ng-template matStepLabel>Fill out your name</ng-template>
-      <mat-form-field appearance="fill">
+      <mat-form-field>
         <mat-label>Name</mat-label>
         <input matInput placeholder="Last name, First name" formControlName="firstCtrl" required>
       </mat-form-field>
@@ -17,7 +17,7 @@
   <mat-step [stepControl]="secondFormGroup">
     <form [formGroup]="secondFormGroup">
       <ng-template matStepLabel>Fill out your address</ng-template>
-      <mat-form-field appearance="fill">
+      <mat-form-field>
         <mat-label>Address</mat-label>
         <input matInput formControlName="secondCtrl" placeholder="Ex. 1 Main St, New York, NY"
                required>

--- a/src/components-examples/material/tabs/tab-group-dynamic/tab-group-dynamic-example.html
+++ b/src/components-examples/material/tabs/tab-group-dynamic/tab-group-dynamic-example.html
@@ -1,4 +1,4 @@
-<mat-form-field appearance="fill">
+<mat-form-field>
   <mat-label>Selected tab index</mat-label>
   <input matInput type="number" [formControl]="selected">
 </mat-form-field>

--- a/src/components-examples/material/tooltip/tooltip-auto-hide/tooltip-auto-hide-example.html
+++ b/src/components-examples/material/tooltip/tooltip-auto-hide/tooltip-auto-hide-example.html
@@ -1,4 +1,4 @@
-<mat-form-field appearance="fill">
+<mat-form-field>
   <mat-label>Tooltip position</mat-label>
   <mat-select [formControl]="position">
     <mat-option *ngFor="let positionOption of positionOptions" [value]="positionOption">

--- a/src/components-examples/material/tooltip/tooltip-delay/tooltip-delay-example.html
+++ b/src/components-examples/material/tooltip/tooltip-delay/tooltip-delay-example.html
@@ -1,11 +1,11 @@
-<mat-form-field class="example-user-input" appearance="fill">
+<mat-form-field class="example-user-input">
   <mat-label>Show delay</mat-label>
   <input matInput type="number" [formControl]="showDelay"
          aria-label="Adds a delay between hovering over the button and displaying the tooltip">
   <mat-hint>milliseconds</mat-hint>
 </mat-form-field>
 
-<mat-form-field class="example-user-input" appearance="fill">
+<mat-form-field class="example-user-input">
   <mat-label>Hide delay</mat-label>
   <input matInput type="number" [formControl]="hideDelay"
          aria-label="Adds a delay between hovering away from the button and hiding the tooltip">

--- a/src/components-examples/material/tooltip/tooltip-message/tooltip-message-example.html
+++ b/src/components-examples/material/tooltip/tooltip-message/tooltip-message-example.html
@@ -1,4 +1,4 @@
-<mat-form-field class="example-user-input" appearance="fill">
+<mat-form-field class="example-user-input">
   <mat-label>Tooltip message</mat-label>
   <input matInput [formControl]="message">
 </mat-form-field>

--- a/src/components-examples/material/tooltip/tooltip-position/tooltip-position-example.html
+++ b/src/components-examples/material/tooltip/tooltip-position/tooltip-position-example.html
@@ -1,4 +1,4 @@
-<mat-form-field class="example-user-input" appearance="fill">
+<mat-form-field class="example-user-input">
   <mat-label>Tooltip position</mat-label>
   <mat-select [formControl]="position">
     <mat-option *ngFor="let positionOption of positionOptions" [value]="positionOption">

--- a/src/components-examples/material/tree/tree-checklist/tree-checklist-example.html
+++ b/src/components-examples/material/tree/tree-checklist/tree-checklist-example.html
@@ -8,7 +8,7 @@
 
   <mat-tree-node *matTreeNodeDef="let node; when: hasNoContent" matTreeNodePadding>
     <button mat-icon-button disabled></button>
-    <mat-form-field appearance="fill">
+    <mat-form-field>
       <mat-label>New item...</mat-label>
       <input matInput #itemValue placeholder="Ex. Lettuce">
     </mat-form-field>


### PR DESCRIPTION
In #22837 we had to add `appearance="fill"` to all the examples to ensure a consistent appearance between the docs site and Stackblitz during the MDC transition. Now that the MDC components are the default, we don't need the explicit `appearance` anymore since `fill` is the default.