### PR TITLE
feat(material/core/option): allow set role for MatOption

### DIFF
--- a/src/material/core/option/option.spec.ts
+++ b/src/material/core/option/option.spec.ts
@@ -14,7 +14,7 @@ describe('MatOption component', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [MatOptionModule],
-      declarations: [BasicOption],
+      declarations: [BasicOption, CheckboxOption],
     }).compileComponents();
   }));
 
@@ -149,6 +149,22 @@ describe('MatOption component', () => {
     subscription.unsubscribe();
   });
 
+  it("should set ARIA check status when role='checkbox'", () => {
+    const fixture = TestBed.createComponent(CheckboxOption);
+    fixture.detectChanges();
+
+    const optionInstance: MatOption = fixture.debugElement.query(
+      By.directive(MatOption),
+    )!.componentInstance;
+
+    optionInstance.select();
+    fixture.detectChanges();
+
+    expect(optionInstance.role).toBe('checkbox');
+    expect(optionInstance._getHostElement().getAttribute('aria-selected')).toBeNull();
+    expect(optionInstance._getHostElement().getAttribute('aria-checked')).toBe('true');
+  });
+
   describe('ripples', () => {
     let fixture: ComponentFixture<BasicOption>;
     let optionDebugElement: DebugElement;
@@ -259,3 +275,8 @@ class BasicOption {
   `,
 })
 class InsideGroup {}
+
+@Component({
+  template: `<mat-option role="checkbox"></mat-option>`,
+})
+class CheckboxOption {}

--- a/src/material/core/option/option.ts
+++ b/src/material/core/option/option.ts
@@ -10,6 +10,7 @@ import {FocusableOption, FocusOrigin} from '@angular/cdk/a11y';
 import {BooleanInput, coerceBooleanProperty} from '@angular/cdk/coercion';
 import {ENTER, hasModifierKey, SPACE} from '@angular/cdk/keycodes';
 import {
+  Attribute,
   Component,
   ViewEncapsulation,
   ChangeDetectionStrategy,
@@ -52,6 +53,9 @@ export class _MatOptionBase<T = any> implements FocusableOption, AfterViewChecke
   private _active = false;
   private _disabled = false;
   private _mostRecentViewValue = '';
+
+  /** The role of the option. */
+  role: string = 'option';
 
   /** Whether the wrapping component is in multiple selection mode. */
   get multiple() {
@@ -253,7 +257,6 @@ export class _MatOptionBase<T = any> implements FocusableOption, AfterViewChecke
   selector: 'mat-option',
   exportAs: 'matOption',
   host: {
-    'role': 'option',
     '[class.mdc-list-item--selected]': 'selected',
     '[class.mat-mdc-option-multiple]': 'multiple',
     '[class.mat-mdc-option-active]': 'active',
@@ -268,7 +271,11 @@ export class _MatOptionBase<T = any> implements FocusableOption, AfterViewChecke
     //
     // Set `aria-selected="false"` on not-selected listbox options to fix VoiceOver announcing
     // every option as "selected" (#21491).
-    '[attr.aria-selected]': 'selected',
+    //
+    // When role="checkbox", the aria-checked attribute should be used instead of aria-selected
+    // to ensure that all screen readers announce the selection status.
+    '[attr.aria-selected]': "role === 'option' ? selected : null",
+    '[attr.aria-checked]': "role === 'checkbox' ? selected : null",
     '[attr.aria-disabled]': 'disabled.toString()',
     '(click)': '_selectViaInteraction()',
     '(keydown)': '_handleKeydown($event)',
@@ -285,8 +292,11 @@ export class MatOption<T = any> extends _MatOptionBase<T> {
     changeDetectorRef: ChangeDetectorRef,
     @Optional() @Inject(MAT_OPTION_PARENT_COMPONENT) parent: MatOptionParentComponent,
     @Optional() @Inject(MAT_OPTGROUP) group: MatOptgroup,
+    @Attribute('role') role: string,
   ) {
     super(element, changeDetectorRef, parent, group);
+    this.role = role || 'option';
+    this._getHostElement().setAttribute('role', this.role);
   }
 }
 

--- a/src/material/legacy-core/option/option.spec.ts
+++ b/src/material/legacy-core/option/option.spec.ts
@@ -14,7 +14,7 @@ describe('MatLegacyOption component', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [MatLegacyOptionModule],
-      declarations: [BasicOption],
+      declarations: [BasicOption, CheckboxOption],
     }).compileComponents();
   }));
 
@@ -150,6 +150,22 @@ describe('MatLegacyOption component', () => {
     subscription.unsubscribe();
   });
 
+  it("should set ARIA check status when role='checkbox'", () => {
+    const fixture = TestBed.createComponent(CheckboxOption);
+    fixture.detectChanges();
+
+    const optionInstance: MatLegacyOption = fixture.debugElement.query(
+      By.directive(MatLegacyOption),
+    )!.componentInstance;
+
+    optionInstance.select();
+    fixture.detectChanges();
+
+    expect(optionInstance.role).toBe('checkbox');
+    expect(optionInstance._getHostElement().getAttribute('aria-selected')).toBeNull();
+    expect(optionInstance._getHostElement().getAttribute('aria-checked')).toBe('true');
+  });
+
   describe('ripples', () => {
     let fixture: ComponentFixture<BasicOption>;
     let optionDebugElement: DebugElement;
@@ -257,3 +273,8 @@ class BasicOption {
   `,
 })
 class InsideGroup {}
+
+@Component({
+  template: `<mat-option role="checkbox"></mat-option>`,
+})
+class CheckboxOption {}

--- a/src/material/legacy-core/option/option.ts
+++ b/src/material/legacy-core/option/option.ts
@@ -7,6 +7,7 @@
  */
 
 import {
+  Attribute,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
@@ -38,7 +39,8 @@ import {MatLegacyOptgroup} from './optgroup';
     '[class.mat-option-multiple]': 'multiple',
     '[class.mat-active]': 'active',
     '[id]': 'id',
-    '[attr.aria-selected]': 'selected',
+    '[attr.aria-selected]': "role === 'option' ? selected : null",
+    '[attr.aria-checked]': "role === 'checkbox' ? selected : null",
     '[attr.aria-disabled]': 'disabled.toString()',
     '[class.mat-option-disabled]': 'disabled',
     '(click)': '_selectViaInteraction()',
@@ -56,7 +58,10 @@ export class MatLegacyOption<T = any> extends _MatOptionBase<T> {
     changeDetectorRef: ChangeDetectorRef,
     @Optional() @Inject(MAT_OPTION_PARENT_COMPONENT) parent: MatOptionParentComponent,
     @Optional() @Inject(MAT_OPTGROUP) group: MatLegacyOptgroup,
+    @Attribute('role') role: string,
   ) {
     super(element, changeDetectorRef, parent, group);
+    this.role = role || 'option';
+    this._getHostElement().setAttribute('role', this.role);
   }
 }

--- a/tools/public_api_guard/material/core.md
+++ b/tools/public_api_guard/material/core.md
@@ -261,11 +261,11 @@ export class _MatOptgroupBase extends _MatOptgroupMixinBase implements CanDisabl
 
 // @public
 export class MatOption<T = any> extends _MatOptionBase<T> {
-    constructor(element: ElementRef<HTMLElement>, changeDetectorRef: ChangeDetectorRef, parent: MatOptionParentComponent, group: MatOptgroup);
+    constructor(element: ElementRef<HTMLElement>, changeDetectorRef: ChangeDetectorRef, parent: MatOptionParentComponent, group: MatOptgroup, role: string);
     // (undocumented)
     static ɵcmp: i0.ɵɵComponentDeclaration<MatOption<any>, "mat-option", ["matOption"], {}, {}, never, ["mat-icon", "*"], false, never>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<MatOption<any>, [null, null, { optional: true; }, { optional: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MatOption<any>, [null, null, { optional: true; }, { optional: true; }, { attribute: "role"; }]>;
 }
 
 // @public (undocumented)
@@ -293,6 +293,7 @@ export class _MatOptionBase<T = any> implements FocusableOption, AfterViewChecke
     // (undocumented)
     ngOnDestroy(): void;
     readonly onSelectionChange: EventEmitter<MatOptionSelectionChange<T>>;
+    role: string;
     select(): void;
     get selected(): boolean;
     _selectViaInteraction(): void;

--- a/tools/public_api_guard/material/legacy-core.md
+++ b/tools/public_api_guard/material/legacy-core.md
@@ -172,11 +172,11 @@ export { _MatLegacyOptgroupBase }
 
 // @public @deprecated
 export class MatLegacyOption<T = any> extends _MatLegacyOptionBase<T> {
-    constructor(element: ElementRef<HTMLElement>, changeDetectorRef: ChangeDetectorRef, parent: MatLegacyOptionParentComponent, group: MatLegacyOptgroup);
+    constructor(element: ElementRef<HTMLElement>, changeDetectorRef: ChangeDetectorRef, parent: MatLegacyOptionParentComponent, group: MatLegacyOptgroup, role: string);
     // (undocumented)
     static ɵcmp: i0.ɵɵComponentDeclaration<MatLegacyOption<any>, "mat-option", ["matOption"], {}, {}, never, ["*"], false, never>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<MatLegacyOption<any>, [null, null, { optional: true; }, { optional: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MatLegacyOption<any>, [null, null, { optional: true; }, { optional: true; }, { attribute: "role"; }]>;
 }
 
 export { _MatLegacyOptionBase }


### PR DESCRIPTION
This change enables clients to pass a role value to MatOption. This provides clients with the flexibility to make options behave like checkboxes to assertive technologies, and could be used to resolve the A11y issue of selection status not being conveyed by some screen readers.

This change will not have a negative impact on existing use cases, as the role value will default to "option," which was previously used. Clients must explicitly pass in the role value in order to use it, e.g., 

`<mat-option role="checkbox"></mat-option>`.