### PR TITLE
docs: fix blue-grey palette name in theming

### DIFF
--- a/guides/theming.md
+++ b/guides/theming.md
@@ -244,7 +244,7 @@ You can use one of these pre-built themes if you don't want to define a custom t
 |------------------------|----------------|----------------------------------|
 | `deeppurple-amber.css` | Light          | deep-purple, amber, red          |
 | `indigo-pink.css`      | Light          | indigo, pink, red                |
-| `pink-bluegrey.css`    | Dark           | pink, bluegrey, red              |
+| `pink-bluegrey.css`    | Dark           | pink, blue-grey, red              |
 | `purple-green.css`     | Dark           | purple, green, red               |
 
 These files include the CSS for every component in the library. To include only the CSS for a subset


### PR DESCRIPTION
updates pre-built theme doc using incorrect name for blue-grey variable name

fixes #25768