### PR TITLE
fix(material/list): input coercion does not working for `disableRipple` on list items

### DIFF
--- a/src/material/list/list-base.ts
+++ b/src/material/list/list-base.ts
@@ -134,7 +134,7 @@ export abstract class MatListItemBase implements AfterViewInit, OnDestroy, Rippl
       !!this._listBase?.disableRipple
     );
   }
-  set disableRipple(value: boolean) {
+  set disableRipple(value: BooleanInput) {
     this._disableRipple = coerceBooleanProperty(value);
   }
   private _disableRipple: boolean = false;


### PR DESCRIPTION
Fixes a bug that input coercion does not work for the `disableRipple` input on any list item because the setter in `MatListItemBase` still requires a `boolean` and not a `BooleanInput` value.

Fixes #27125