### PR TITLE
fix(cdk/schematics): handle templates with byte order mark

### DIFF
--- a/src/cdk/schematics/update-tool/component-resource-collector.ts
+++ b/src/cdk/schematics/update-tool/component-resource-collector.ts
@@ -155,7 +155,7 @@ export class ComponentResourceCollector {
           return;
         }
 
-        const fileContent = this._fileSystem.read(templatePath);
+        const fileContent = stripBom(this._fileSystem.read(templatePath) || '');
 
         if (fileContent) {
           const lineStartsMap = computeLineStartsMap(fileContent);


### PR DESCRIPTION
Fixes that migrations may throw a "Character out of bounds" error if a template is using BOM.

Fixes #27057.