### PR TITLE
docs(material/list): description for disableRipple

### DIFF
--- a/src/material/list/list-base.ts
+++ b/src/material/list/list-base.ts
@@ -125,6 +125,7 @@ export abstract class MatListItemBase implements AfterViewInit, OnDestroy, Rippl
   }
   _explicitLines: number | null = null;
 
+  /** Whether ripples for list items are disabled. */
   @Input()
   get disableRipple(): boolean {
     return (


### PR DESCRIPTION
prior this commit on properties table disableRipple had no description showing table cell to be empty