### PR TITLE
docs(material/form-field): Use `BooleanInput` for `required` and `disabled` attributes

### DIFF
--- a/guides/creating-a-custom-form-field-control.md
+++ b/guides/creating-a-custom-form-field-control.md
@@ -300,7 +300,7 @@ change detection if the required state changes.
 get required() {
   return this._required;
 }
-set required(req) {
+set required(req: BooleanInput) {
   this._required = coerceBooleanProperty(req);
   this.stateChanges.next();
 }
@@ -316,7 +316,7 @@ make up our component.
 ```ts
 @Input()
 get disabled(): boolean { return this._disabled; }
-set disabled(value: boolean) {
+set disabled(value: BooleanInput) {
   this._disabled = coerceBooleanProperty(value);
   this._disabled ? this.parts.disable() : this.parts.enable();
   this.stateChanges.next();


### PR DESCRIPTION
To be consistent with recent docs, `BooleanInput` is the appropriate type here for `required` and `disabled`