### PR TITLE
 docs(api-docs/material-table): fixed description for MatHeaderRow

### DIFF
--- a/src/material/table/row.ts
+++ b/src/material/table/row.ts
@@ -52,7 +52,7 @@ export class MatFooterRowDef extends CdkFooterRowDef {}
 })
 export class MatRowDef<T> extends CdkRowDef<T> {}
 
-/** Footer template container that contains the cell outlet. Adds the right class and role. */
+/** Header template container that contains the cell outlet. Adds the right class and role. */
 @Component({
   selector: 'mat-header-row, tr[mat-header-row]',
   template: CDK_ROW_TEMPLATE,


### PR DESCRIPTION
### Documentation Feedback

### Issue :
Description under **MatHeaderRow extends CdkHeaderRow** is

> Footer template container that contains the cell outlet. Adds the right class and role.

However it should be,

> Header template container that contains the cell outlet. Adds the right class and role.

<img width="1685" alt="Screenshot 2023-05-23 at 5 26 51 PM" src="https://github.com/angular/components/assets/24619269/d10d30ed-f2df-40e4-9c7f-faa14c0607aa">


### Fix PR in angular/material2-docs-content : https://github.com/angular/material2-docs-content/pull/20

### Affected documentation page

https://material.angular.io/components/table/api#MatHeaderRowDef