### PR TITLE
fix(material/sort): sort header not updated when active column or direction change

### DIFF
--- a/src/material/sort/sort-header.ts
+++ b/src/material/sort/sort-header.ts
@@ -394,10 +394,8 @@ export class MatSortHeader
 
         this._setAnimationTransitionState({fromState: this._arrowDirection, toState: 'active'});
         this._showIndicatorHint = false;
-      }
-
-      // If this header was recently active and now no longer sorted, animate away the arrow.
-      if (!this._isSorted() && this._viewState && this._viewState.toState === 'active') {
+      } else if (this._viewState && this._viewState.toState === 'active') {
+        // If this header was recently active and now no longer sorted, animate away the arrow.
         this._disableViewStateAnimation = false;
         this._setAnimationTransitionState({fromState: 'active', toState: this._arrowDirection});
       }

--- a/src/material/sort/sort.spec.ts
+++ b/src/material/sort/sort.spec.ts
@@ -148,7 +148,7 @@ describe('MatSort', () => {
       it('should be correct when cycling through a default sort header', () => {
         // Sort the header to set it to the active start state
         component.sort('defaultA');
-        expectedStates.set('defaultA', {viewState: 'asc-to-active', arrowDirection: 'active-asc'});
+        expectedStates.set('defaultA', {viewState: 'active', arrowDirection: 'active-asc'});
         component.expectViewAndDirectionStates(expectedStates);
 
         // Sorting again will reverse its direction
@@ -179,13 +179,13 @@ describe('MatSort', () => {
       it('should be correct when sort has changed while a header is active', () => {
         // Sort the first header to set up
         component.sort('defaultA');
-        expectedStates.set('defaultA', {viewState: 'asc-to-active', arrowDirection: 'active-asc'});
+        expectedStates.set('defaultA', {viewState: 'active', arrowDirection: 'active-asc'});
         component.expectViewAndDirectionStates(expectedStates);
 
         // Sort the second header and verify that the first header animated away
         component.dispatchMouseEvent('defaultB', 'click');
         expectedStates.set('defaultA', {viewState: 'active-to-asc', arrowDirection: 'asc'});
-        expectedStates.set('defaultB', {viewState: 'asc-to-active', arrowDirection: 'active-asc'});
+        expectedStates.set('defaultB', {viewState: 'active', arrowDirection: 'active-asc'});
         component.expectViewAndDirectionStates(expectedStates);
       });
 
@@ -203,7 +203,7 @@ describe('MatSort', () => {
         component.direction = 'asc';
         fixture.detectChanges();
 
-        expectedStates.set('defaultB', {viewState: 'asc-to-active', arrowDirection: 'active-asc'});
+        expectedStates.set('defaultB', {viewState: 'active', arrowDirection: 'active-asc'});
         component.expectViewAndDirectionStates(expectedStates);
       });
     });
@@ -498,6 +498,25 @@ describe('MatSort', () => {
 
       expect(containerA.classList.contains('mat-sort-header-position-before')).toBe(true);
       expect(containerB.classList.contains('mat-sort-header-position-before')).toBe(true);
+    });
+
+    it('should emit to sortChange when the active column changes', () => {
+      expect(component.latestSortEvent).toBeFalsy();
+
+      component.active = 'defaultB';
+      fixture.detectChanges();
+
+      expect(component.latestSortEvent).toEqual({active: 'defaultB', direction: ''});
+    });
+
+    it('should emit to sortChange when the direction changes', () => {
+      expect(component.latestSortEvent).toBeFalsy();
+
+      component.active = 'defaultA';
+      component.direction = 'desc';
+      fixture.detectChanges();
+
+      expect(component.latestSortEvent).toEqual({active: 'defaultA', direction: 'desc'});
     });
   });
 

--- a/src/material/sort/sort.ts
+++ b/src/material/sort/sort.ts
@@ -89,7 +89,22 @@ export class MatSort
   readonly _stateChanges = new Subject<void>();
 
   /** The id of the most recently sorted MatSortable. */
-  @Input('matSortActive') active: string;
+  @Input('matSortActive')
+  get active(): string {
+    return this._active;
+  }
+  set active(active: string) {
+    if (active !== this._active) {
+      this._active = active;
+
+      // Needs to emit to `sortChange` in order for the table to update.
+      // Skip the initial value since it is picked up automatically.
+      if (this.initialized) {
+        this.sortChange.emit({active, direction: this.direction});
+      }
+    }
+  }
+  private _active: string;
 
   /**
    * The direction to set when an MatSortable is initially sorted.
@@ -111,7 +126,16 @@ export class MatSort
     ) {
       throw getSortInvalidDirectionError(direction);
     }
-    this._direction = direction;
+
+    if (direction !== this._direction) {
+      this._direction = direction;
+
+      // Needs to emit to `sortChange` in order for the table to update.
+      // Skip the initial value since it is picked up automatically.
+      if (this.initialized) {
+        this.sortChange.emit({active: this.active, direction});
+      }
+    }
   }
   private _direction: SortDirection = '';
 

--- a/tools/public_api_guard/material/sort.md
+++ b/tools/public_api_guard/material/sort.md
@@ -53,7 +53,8 @@ export function MAT_SORT_HEADER_INTL_PROVIDER_FACTORY(parentIntl: MatSortHeaderI
 // @public
 export class MatSort extends _MatSortBase implements CanDisable, HasInitialized, OnChanges, OnDestroy, OnInit {
     constructor(_defaultOptions?: MatSortDefaultOptions | undefined);
-    active: string;
+    get active(): string;
+    set active(active: string);
     deregister(sortable: MatSortable): void;
     get direction(): SortDirection;
     set direction(direction: SortDirection);


### PR DESCRIPTION
Fixes that the sort header's state wasn't updating the when active column or the direction changed automatically.

Fixes #10242.