### PR TITLE
docs: release notes for the v16.0.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+<a name="16.0.2"></a>
+# 16.0.2 "plastic-car" (2023-05-25)
+### cdk
+| Commit | Type | Description |
+| -- | -- | -- |
+| [a0aa14fe1a](https://github.com/angular/components/commit/a0aa14fe1ae893202d308ae447a6e3ec73915613) | fix | **schematics:** handle templates with byte order mark ([#27131](https://github.com/angular/components/pull/27131)) |
+### material
+| Commit | Type | Description |
+| -- | -- | -- |
+| [82550af4d7](https://github.com/angular/components/commit/82550af4d7fa432ccc1da07f810cda0f9937ea85) | fix | **checkbox:** set token values on the element where theme is @included ([#27114](https://github.com/angular/components/pull/27114)) |
+| [d2e8a55b3b](https://github.com/angular/components/commit/d2e8a55b3b349c79306ea190f07836c0210fdd55) | fix | **core:** Fix MacOS Hover feature compatibility with optgroup ([#27081](https://github.com/angular/components/pull/27081)) |
+| [6dd2c605b1](https://github.com/angular/components/commit/6dd2c605b1d123c1cf7817a3f02e02f9e91e882c) | fix | **datepicker:** set explicit event options ([#27082](https://github.com/angular/components/pull/27082)) |
+| [5c3107ccc6](https://github.com/angular/components/commit/5c3107ccc66abb4fcf1bfcf186f215c93db9b35d) | fix | **icon:** harness returning wrong name if icon has other content ([#27132](https://github.com/angular/components/pull/27132)) |
+| [9d9ceb2b22](https://github.com/angular/components/commit/9d9ceb2b22482e7f8669eecef9d63679f0b62b46) | fix | **list:** input coercion does not working for `disableRipple` on list items ([#27126](https://github.com/angular/components/pull/27126)) |
+| [5aad5df78e](https://github.com/angular/components/commit/5aad5df78e61d712653d85f8fb23b5a4cd7d810d) | fix | **paginator:** add aria-hidden="true" to decorative svg's ([#27083](https://github.com/angular/components/pull/27083)) |
+### multiple
+| Commit | Type | Description |
+| -- | -- | -- |
+| [12474aafc5](https://github.com/angular/components/commit/12474aafc5d86fa7d5829b5a581138d096b2418b) | fix | set aria-hidden on presentational svgs ([#27116](https://github.com/angular/components/pull/27116)) |
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="16.0.1"></a>
 # 16.0.1 "sulfur-socks" (2023-05-11)
 ### cdk


### PR DESCRIPTION
Cherry-picks the changelog from the "16.0.x" branch to the next branch (main).