### PR TITLE
feat(material/progress-bar) : add height and border-radius properties in mat-progress-bar widget component. 

### DIFF
--- a/src/material/progress-bar/progress-bar.scss
+++ b/src/material/progress-bar/progress-bar.scss
@@ -4,6 +4,11 @@
 @use '@material/linear-progress/linear-progress-theme' as mdc-linear-progress-theme;
 @use '../core/tokens/m2/mdc/linear-progress' as m2-mdc-linear-progress;
 
+:root {
+  --progressBarHeight: 4px;
+  --progressBarBorderRadius: 0;
+}
+
 @include mdc-custom-properties.configure($emit-fallback-values: false, $emit-fallback-vars: false) {
   $mdc-progress-bar-token-slots: m2-mdc-linear-progress.get-token-slots();
 
@@ -23,6 +28,15 @@
     // Add default values for tokens that aren't outputted by the theming API.
     @include mdc-linear-progress-theme.theme(m2-mdc-linear-progress.get-unthemable-tokens());
   }
+}
+
+.mdc-linear-progress {
+  height: var(--mdc-linear-progress-track-height, --progressBarHeight);
+  border-radius: --progressBarBorderRadius;
+}
+
+.mdc-linear-progress__bar-inner {
+  border-top-width: var(--mdc-linear-progress-track-height, --progressBarHeight);
 }
 
 .mat-mdc-progress-bar {

--- a/src/material/progress-bar/progress-bar.spec.ts
+++ b/src/material/progress-bar/progress-bar.spec.ts
@@ -75,6 +75,84 @@ describe('MDC-based MatProgressBar', () => {
         expect(progressComponent.bufferValue).toBe(100);
       });
 
+      it('expect height of mat-progress-bar to be equal to 10', () => {
+        const fixture = createComponent(BasicProgressBar);
+        fixture.detectChanges();
+
+        const progressElement = fixture.debugElement.query(By.css('mat-progress-bar'))!;
+        const progressElementHTML = progressElement.nativeElement;
+        const progressComponent = progressElement.componentInstance;
+
+        progressComponent.height = 10;
+        expect(progressComponent.height).toBe(10);
+        expect(progressElementHTML.height).toBe(10);
+      });
+
+      it('expect height of mat-progress-bar to be equal to 50', () => {
+        const fixture = createComponent(BasicProgressBar);
+        fixture.detectChanges();
+
+        const progressElement = fixture.debugElement.query(By.css('mat-progress-bar'))!;
+        const progressElementHTML = progressElement.nativeElement;
+        const progressComponent = progressElement.componentInstance;
+
+        progressComponent.height = 50;
+        expect(progressComponent.height).toBe(50);
+        expect(progressElementHTML.height).toBe(50);
+      });
+
+      it('expect height of mat-progress-bar to be equal to 100', () => {
+        const fixture = createComponent(BasicProgressBar);
+        fixture.detectChanges();
+
+        const progressElement = fixture.debugElement.query(By.css('mat-progress-bar'))!;
+        const progressElementHTML = progressElement.nativeElement;
+        const progressComponent = progressElement.componentInstance;
+
+        progressComponent.height = 100;
+        expect(progressComponent.height).toBe(100);
+        expect(progressElementHTML.height).toBe(100);
+      });
+
+      it('expect border-radius of mat-progress-bar to be equal to 2', () => {
+        const fixture = createComponent(BasicProgressBar);
+        fixture.detectChanges();
+
+        const progressElement = fixture.debugElement.query(By.css('mat-progress-bar'))!;
+        const progressElementHTML = progressElement.nativeElement;
+        const progressComponent = progressElement.componentInstance;
+
+        progressComponent.borderRadius = 2;
+        expect(progressComponent.borderRadius).toBe(2);
+        expect(progressElementHTML.borderRadius).toBe(2);
+      });
+
+      it('expect border-radius of mat-progress-bar to be equal to 7', () => {
+        const fixture = createComponent(BasicProgressBar);
+        fixture.detectChanges();
+
+        const progressElement = fixture.debugElement.query(By.css('mat-progress-bar'))!;
+        const progressElementHTML = progressElement.nativeElement;
+        const progressComponent = progressElement.componentInstance;
+
+        progressComponent.borderRadius = 7;
+        expect(progressComponent.borderRadius).toBe(7);
+        expect(progressElementHTML.borderRadius).toBe(7);
+      });
+
+      it('expect border-radius of mat-progress-bar to be equal to 10', () => {
+        const fixture = createComponent(BasicProgressBar);
+        fixture.detectChanges();
+
+        const progressElement = fixture.debugElement.query(By.css('mat-progress-bar'))!;
+        const progressElementHTML = progressElement.nativeElement;
+        const progressComponent = progressElement.componentInstance;
+
+        progressComponent.borderRadius = 10;
+        expect(progressComponent.borderRadius).toBe(10);
+        expect(progressElementHTML.borderRadius).toBe(10);
+      });
+
       it('should set the proper transform based on the current value', () => {
         const fixture = createComponent(BasicProgressBar);
         fixture.detectChanges();

--- a/src/material/progress-bar/progress-bar.ts
+++ b/src/material/progress-bar/progress-bar.ts
@@ -40,6 +40,12 @@ export interface MatProgressBarDefaultOptions {
 
   /** Default mode of the progress bar. */
   mode?: ProgressBarMode;
+
+  /** Default height of the progress bar. */
+  height?: number;
+
+  /** Default border-radius of the progress bar. */
+  borderRadius?: number;
 }
 
 /** Injection token to be used to override the default options for `mat-progress-bar`. */
@@ -134,6 +140,15 @@ export class MatProgressBar
 
       this.mode = defaults.mode || this.mode;
     }
+
+    /** Initialize with defined progress-bar height */
+    document.documentElement.style.setProperty('--progressBarHeigh', defaults?.height + 'px');
+
+    /** Initialize with defined progress-bar border radius  */
+    document.documentElement.style.setProperty(
+      '--progressBarBorderRadius',
+      defaults?.borderRadius + 'px',
+    );
   }
 
   /** Flag that indicates whether NoopAnimations mode is set to true. */
@@ -186,6 +201,28 @@ export class MatProgressBar
     this._changeDetectorRef.markForCheck();
   }
   private _mode: ProgressBarMode = 'determinate';
+
+  /** Height of the progress bar. Defaults to 4px.*/
+  @Input()
+  get height(): number {
+    return this._height;
+  }
+  set height(h: NumberInput) {
+    this._height = clamp(coerceNumberProperty(h));
+    this._changeDetectorRef.markForCheck();
+  }
+  private _height = 0;
+
+  /** Border Radius of the progress bar. Defaults to zero.*/
+  @Input()
+  get borderRadius(): number {
+    return this._borderRadius;
+  }
+  set borderRadius(h: NumberInput) {
+    this._borderRadius = clamp(coerceNumberProperty(h));
+    this._changeDetectorRef.markForCheck();
+  }
+  private _borderRadius = 0;
 
   ngAfterViewInit() {
     // Run outside angular so change detection didn't get triggered on every transition end


### PR DESCRIPTION
I added the height and border-radius parameters to the component, which allows me to have a rendering like this.

![241247875-c7e85726-d411-44fa-9f7a-d22957f130ec](https://github.com/angular/components/assets/40070368/bb35e081-498c-4ba6-bb1c-8639ec4e399b)

![241255258-26aca3e5-5683-4b65-b071-5c1921974b6d](https://github.com/angular/components/assets/40070368/8e29d872-699b-4fd5-9702-5da7a93365f2)
