### PR TITLE
fix(material/tabs): default stretchTabs value not picked up by nav bar

### DIFF
--- a/src/material/tabs/tab-nav-bar/tab-nav-bar.ts
+++ b/src/material/tabs/tab-nav-bar/tab-nav-bar.ts
@@ -385,6 +385,8 @@ export class MatTabNav extends _MatTabNavBase implements AfterContentInit, After
       defaultConfig && defaultConfig.fitInkBarToContent != null
         ? defaultConfig.fitInkBarToContent
         : false;
+    this.stretchTabs =
+      defaultConfig && defaultConfig.stretchTabs != null ? defaultConfig.stretchTabs : true;
   }
 
   override ngAfterContentInit() {


### PR DESCRIPTION
Fixes that the tab nav bar wasn't picking up the default value for `stretchTabs` from the config.

Fixes #27211.