### PR TITLE
fix(material/core): Fix MacOS Hover feature compatibility with optgroup

### DIFF
--- a/src/material/core/option/optgroup.html
+++ b/src/material/core/option/optgroup.html
@@ -1,6 +1,6 @@
 <span
   class="mat-mdc-optgroup-label"
-  aria-hidden="true"
+  role="presentation"
   [class.mdc-list-item--disabled]="disabled"
   [id]="_labelId">
   <span class="mdc-list-item__primary-text">{{ label }} <ng-content></ng-content></span>


### PR DESCRIPTION
Corrects ARIA semantics for the mat-optgroup component. Add role="presentation" to the label and remove aria-hidden="true" from the label.

Fix compatibility issue with MAC Hover text a11y feature angular#27080. The label of the option group does not need to be aria-hidden, and the Mac Hover text feature seems to rely on it.

Previous PR#27081 fixed this issue for legacy component. This PR fixes it for the non-legacy optgroup component.

Fix angular#27080