### PR TITLE
refactor(material/chips): Use tokens for state layer

### DIFF
--- a/src/material/chips/_chips-theme.scss
+++ b/src/material/chips/_chips-theme.scss
@@ -58,10 +58,6 @@
       }
     }
   }
-
-  .mat-mdc-chip-focus-overlay {
-    background: map.get(map.get($config, foreground), base);
-  }
 }
 
 @mixin typography($config-or-theme) {

--- a/src/material/chips/chip.scss
+++ b/src/material/chips/chip.scss
@@ -5,6 +5,7 @@
 @use '../core/style/layout-common';
 @use '../core/focus-indicators/private' as focus-indicators-private;
 @use '../core/tokens/m2/mdc/chip' as m2-mdc-chip;
+@use '../core/tokens/token-utils';
 @use '@material/theme/custom-properties' as mdc-custom-properties;
 
 // The slots for tokens that will be configured in the theme can be emitted with no fallback.
@@ -20,6 +21,14 @@
 
     // Add default values for tokens that aren't outputted by the theming API.
     @include mdc-chip-theme.theme(m2-mdc-chip.get-unthemable-tokens());
+  }
+
+  // Add additional slots for the MDC chip tokens, needed in Angular Material.
+  @include token-utils.use-tokens(m2-mdc-chip.$prefix, $token-slots) {
+    .mat-mdc-chip-focus-overlay {
+      @include token-utils.create-token-slot(background, focus-state-layer-color);
+      @include token-utils.create-token-slot(opacity, focus-state-layer-opacity);
+    }
   }
 }
 

--- a/src/material/core/tokens/m2/mdc/_chip.scss
+++ b/src/material/core/tokens/m2/mdc/_chip.scss
@@ -135,10 +135,6 @@ $prefix: (mdc, chip);
     // Unused.
     focus-outline-color: null,
     // Unused.
-    focus-state-layer-color: null,
-    // Unused.
-    focus-state-layer-opacity: null,
-    // Unused.
     hover-label-text-color: null,
     // Unused.
     hover-state-layer-color: null,
@@ -234,8 +230,12 @@ $prefix: (mdc, chip);
 // Tokens that can be configured through Angular Material's color theming API.
 @function get-color-tokens($config) {
   $palette: map.get($config, primary);
+
   $background: theming.get-color-from-palette($palette);
   $foreground: theming.get-color-from-palette($palette, default-contrast);
+
+  $state-layer-color: theming.get-color-from-palette(map.get($config, foreground), base);
+  $state-layer-opacity: 0.12; // 0.12 is a common value in Material Design for opacity.
 
   @return (
     // The text color of a disabled chip.
@@ -244,6 +244,10 @@ $prefix: (mdc, chip);
     elevated-container-color: $background,
     // The background-color of a disabled chip.
     elevated-disabled-container-color: $background,
+    // The color of the focus state layer.
+    focus-state-layer-color: $state-layer-color,
+    // The opacity of the focus state layer.
+    focus-state-layer-opacity: $state-layer-opacity,
     // The chip text color.
     label-text-color: $foreground,
     // The icon color of a chip.


### PR DESCRIPTION
[refactor(material/chips): Use tokens for state layer](https://github.com/angular/components/pull/27245/commits/9d6bfd6822150addd2d136213ca7cf80a3f21deb) 

Refactors how the state layer for chips components is styled. Use the
`focus-state-layer-color` and `focus-state-layer-opacity` to style the
focus state layer.

Does not make visual changes.

Googlers: see also http://cl/538867829