### PR TITLE
fix(material/select): provide horizontal fallback positions

### DIFF
--- a/src/material/select/select.ts
+++ b/src/material/select/select.ts
@@ -1304,9 +1304,22 @@ export class MatSelect extends _MatSelectBase<MatSelectChange> implements OnInit
       overlayY: 'top',
     },
     {
+      originX: 'end',
+      originY: 'bottom',
+      overlayX: 'end',
+      overlayY: 'top',
+    },
+    {
       originX: 'start',
       originY: 'top',
       overlayX: 'start',
+      overlayY: 'bottom',
+      panelClass: 'mat-mdc-select-panel-above',
+    },
+    {
+      originX: 'end',
+      originY: 'top',
+      overlayX: 'end',
       overlayY: 'bottom',
       panelClass: 'mat-mdc-select-panel-above',
     },


### PR DESCRIPTION
The select had configured its positions under the assumption that the dropdown is always as wide as the trigger so it only provided a vertical fallback position. Since users are now able to control the panel width, we also need horizontal fallbacks.

Fixes #27256.