### PR TITLE
fix(cdk/a11y): don't emit blurred events on the server

### DIFF
--- a/src/cdk/a11y/focus-monitor/focus-monitor.ts
+++ b/src/cdk/a11y/focus-monitor/focus-monitor.ts
@@ -197,7 +197,8 @@ export class FocusMonitor implements OnDestroy {
 
     // Do nothing if we're not on the browser platform or the passed in node isn't an element.
     if (!this._platform.isBrowser || nativeElement.nodeType !== 1) {
-      return observableOf(null);
+      // Note: we don't want the observable to emit at all so we don't pass any parameters.
+      return observableOf();
     }
 
     // If the element is inside the shadow DOM, we need to bind our focus/blur listeners to


### PR DESCRIPTION
The `FocusMonitor` is set up to emit `null` when an element is blurred and we have some components that depend on that value to mark themselves as touched. However, it's also set up to return an rxjs observale `of(null)` on the server which means that it'll emit and complete immediately. This is problematic, because it can mark components as touched even though they haven't been.

These changes remove the parameter from `of()` so it never emits.

Fixes #27234.