### PR TITLE
test(cdk/testing): attempt to deflake webdriver tests

### DIFF
--- a/src/cdk/testing/tests/test-main-component.html
+++ b/src/cdk/testing/tests/test-main-component.html
@@ -1,5 +1,6 @@
+<!-- Note that this element is fixed to avoid flakiness if the page has been scrolled down. -->
 <div class="click-test" (click)="onClick($event)" (contextmenu)="onRightClick($event)"
-     style="width: 100px; height: 100px; background: grey"
+     style="width: 100px; height: 100px; background: grey; position: fixed; top: 0; right: 0; z-index: 10;"
      #clickTestElement>
 </div>
 <div class="click-test-result">{{clickResult.x}}-{{clickResult.y}}</div>


### PR DESCRIPTION
The Selenium Webdriver tests for harnesses have been flaky for a while now, because the click coordinates haven't been consistent across test runs. My theory is that it's due to the page being scrolled down on some of them.

These changes attempt to reduce the flakes by making the clicked element fixed.