### PR TITLE
refactor(material/select): rename some tokens for more clarity

### DIFF
--- a/src/material/core/tokens/m2/mat/_select.scss
+++ b/src/material/core/tokens/m2/mat/_select.scss
@@ -25,9 +25,9 @@ $prefix: (mat, select);
 
   @return (
     panel-background-color: theming.get-color-from-palette($background, card),
-    enabled-trigger-color: rgba($on-surface, 0.87),
-    disabled-trigger-color: rgba($on-surface, 0.38),
-    placeholder-color: rgba($on-surface, 0.6),
+    enabled-trigger-text-color: rgba($on-surface, 0.87),
+    disabled-trigger-text-color: rgba($on-surface, 0.38),
+    placeholder-text-color: rgba($on-surface, 0.6),
     enabled-arrow-color: rgba($on-surface, 0.54),
     disabled-arrow-color: rgba($on-surface, 0.38),
     focused-arrow-color: theming.get-color-from-palette($primary, default, 0.87),
@@ -46,12 +46,12 @@ $prefix: (mat, select);
   }
 
   @return (
-    trigger-font: typography-utils.font-family($config, body-1) or
+    trigger-text-font: typography-utils.font-family($config, body-1) or
       typography-utils.font-family($config),
-    trigger-line-height: typography-utils.line-height($config, body-1),
-    trigger-size: typography-utils.font-size($config, body-1),
-    trigger-tracking: typography-utils.letter-spacing($config, body-1),
-    trigger-weight: typography-utils.font-weight($config, body-1)
+    trigger-text-line-height: typography-utils.line-height($config, body-1),
+    trigger-text-size: typography-utils.font-size($config, body-1),
+    trigger-text-tracking: typography-utils.letter-spacing($config, body-1),
+    trigger-text-weight: typography-utils.font-weight($config, body-1)
   );
 }
 

--- a/src/material/select/select.scss
+++ b/src/material/select/select.scss
@@ -24,19 +24,19 @@ $scale: 0.75 !default;
   @include token-utils.use-tokens(
     tokens-mat-select.$prefix, tokens-mat-select.get-token-slots()) {
     @include mdc-typography.smooth-font();
-    @include token-utils.create-token-slot(color, enabled-trigger-color);
-    @include token-utils.create-token-slot(font-family, trigger-font);
-    @include token-utils.create-token-slot(line-height, trigger-line-height);
-    @include token-utils.create-token-slot(font-size, trigger-size);
-    @include token-utils.create-token-slot(font-weight, trigger-weight);
-    @include token-utils.create-token-slot(letter-spacing, trigger-tracking);
+    @include token-utils.create-token-slot(color, enabled-trigger-text-color);
+    @include token-utils.create-token-slot(font-family, trigger-text-font);
+    @include token-utils.create-token-slot(line-height, trigger-text-line-height);
+    @include token-utils.create-token-slot(font-size, trigger-text-size);
+    @include token-utils.create-token-slot(font-weight, trigger-text-weight);
+    @include token-utils.create-token-slot(letter-spacing, trigger-text-tracking);
   }
 }
 
 .mat-mdc-select-disabled {
   @include token-utils.use-tokens(
     tokens-mat-select.$prefix, tokens-mat-select.get-token-slots()) {
-    @include token-utils.create-token-slot(color, disabled-trigger-color);
+    @include token-utils.create-token-slot(color, disabled-trigger-text-color);
   }
 }
 
@@ -171,7 +171,7 @@ div.mat-mdc-select-panel {
 
   @include token-utils.use-tokens(
     tokens-mat-select.$prefix, tokens-mat-select.get-token-slots()) {
-    @include token-utils.create-token-slot(color, placeholder-color);
+    @include token-utils.create-token-slot(color, placeholder-text-color);
   }
 
   ._mat-animation-noopable & {


### PR DESCRIPTION
Renames some of the `mat-select` tokens to make it clearer what they're referring to.