### PR TITLE
docs(material/theming): add missing theme variable to theming guide docs

### DIFF
--- a/guides/theming-your-components.md
+++ b/guides/theming-your-components.md
@@ -19,6 +19,14 @@ indicating whether dark mode is set.
 @use 'sass:map';
 @use '@angular/material' as mat;
 
+$primary: mat.define-palette(mat.$indigo-palette);
+$accent: mat.define-palette(mat.$pink-palette);
+$warn: mat.define-palette(mat.$red-palette);
+
+$theme: mat.define-light-theme((
+  color: (primary: $primary, accent: $accent, warn: $warn),
+));
+
 $color-config:    mat.get-color-config($theme);
 $primary-palette: map.get($color-config, 'primary');
 $accent-palette:  map.get($color-config, 'accent');


### PR DESCRIPTION
Fixes missing $theme variable in [Reading color values](https://material.angular.io/guide/theming-your-components#reading-color-values) in [Theme your own components](https://material.angular.io/guide/theming-your-components)

Fixes https://github.com/angular/components/issues/24405