### PR TITLE
docs(material/chips): require communicating to AT how to edit a chip

### DIFF
--- a/src/material/chips/chips.md
+++ b/src/material/chips/chips.md
@@ -186,8 +186,10 @@ For both MatChipGrid and MatChipListbox, always apply an accessible label to the
 
 Always apply MatChipRemove to a `<button>` element, never a `<mat-icon>` element.
 
-When using `MatChipRemove`, you should always communicate removals for assistive technology. One way to accomplish this is by sending a message with `LiveAnnouncer`. Otherwise, removing a chip may only be communicated visually.
-
 When using MatChipListbox, never nest other interactive controls inside of the `<mat-chip-option>` element. Nesting controls degrades the experience for assistive technology users.
 
 By default, `MatChipListbox` displays a checkmark to identify selected items. While you can hide the checkmark indicator for single-selection via `hideSingleSelectionIndicator`, this makes the component less accessible by making it harder or impossible for users to visually identify selected items.
+
+When using `MatChipRemove`, you should always communicate removals for assistive technology. One way to accomplish this is by sending a message with `LiveAnnouncer`. Otherwise, removing a chip may only be communicated visually.
+
+When a chip is editable, provide instructions to assistive technology how to edit the chip using a keyboard. One way to accomplish this is adding an `aria-description` attribute with instructions to press enter to edit the chip.


### PR DESCRIPTION
Update the accessibility section of chips component to adress editable chips. Require developer to communicate to AT how to edit a chip using a keyboard.

Relates to issue #27106.