### PR TITLE
fix(material/core): add validation to create-token-slot

### DIFF
--- a/src/material/core/tokens/_token-utils.scss
+++ b/src/material/core/tokens/_token-utils.scss
@@ -75,6 +75,9 @@ $_component-prefix: null;
   @if $_component-prefix == null or $_tokens == null {
     @error '`create-token-slot` must be used within `use-tokens`';
   }
+  @if not map.has-key($_tokens, $token) {
+    @error 'Token #{$token} does not exist. Configured tokens are: #{map.keys($_tokens)}';
+  }
   @if map.get($_tokens, $token) != null {
     $fallback: null;
 


### PR DESCRIPTION
Currently we look up if a token is set to null in the token map, and if it is, we don't emit the slot at all. The problem is that `null` is also returned if the token doesn't exist at all which may mask some bugs.

These changes add a check to verify that the token exists before trying to look it up.