### PR TITLE
fix(cdk/schematics): clean up deep imports of devkit APIs

### DIFF
--- a/src/cdk/schematics/ng-update/devkit-migration-rule.ts
+++ b/src/cdk/schematics/ng-update/devkit-migration-rule.ts
@@ -8,7 +8,7 @@
 
 import {Rule, SchematicContext, Tree} from '@angular-devkit/schematics';
 import {NodePackageInstallTask} from '@angular-devkit/schematics/tasks';
-import {ProjectDefinition} from '@angular-devkit/core/src/workspace';
+import {workspaces} from '@angular-devkit/core';
 
 import {UpdateProject} from '../update-tool';
 import {WorkspacePath} from '../update-tool/file-system';
@@ -139,7 +139,7 @@ export function createMigrationSchematicRule(
 
     /** Runs the migrations for the specified workspace project. */
     function runMigrations(
-      project: ProjectDefinition,
+      project: workspaces.ProjectDefinition,
       projectName: string,
       tsconfigPath: WorkspacePath,
       additionalStylesheetPaths: string[],

--- a/src/cdk/schematics/ng-update/devkit-migration.ts
+++ b/src/cdk/schematics/ng-update/devkit-migration.ts
@@ -7,7 +7,7 @@
  */
 
 import {SchematicContext, Tree} from '@angular-devkit/schematics';
-import {ProjectDefinition} from '@angular-devkit/core/src/workspace';
+import {workspaces} from '@angular-devkit/core';
 import {Constructor, Migration, PostMigrationAction} from '../update-tool/migration';
 import {TargetVersion} from '../update-tool/target-version';
 
@@ -17,7 +17,7 @@ export type DevkitContext = {
   /** Name of the project the migrations run against. */
   projectName: string;
   /** Workspace project the migrations run against. */
-  project: ProjectDefinition;
+  project: workspaces.ProjectDefinition;
   /** Whether the migrations run for a test target. */
   isTestTarget: boolean;
 };
@@ -43,5 +43,5 @@ export abstract class DevkitMigration<Data> extends Migration<Data, DevkitContex
 }
 
 export type DevkitMigrationCtor<Data> = Constructor<DevkitMigration<Data>> & {
-  [m in keyof typeof DevkitMigration]: typeof DevkitMigration[m];
+  [m in keyof typeof DevkitMigration]: (typeof DevkitMigration)[m];
 };

--- a/src/cdk/schematics/utils/ast.ts
+++ b/src/cdk/schematics/utils/ast.ts
@@ -13,7 +13,7 @@ import {getWorkspace} from '@schematics/angular/utility/workspace';
 import {findModuleFromOptions as internalFindModule} from '@schematics/angular/utility/find-module';
 import {addImportToModule} from '@schematics/angular/utility/ast-utils';
 import {getAppModulePath} from '@schematics/angular/utility/ng-ast-utils';
-import {ProjectDefinition} from '@angular-devkit/core/src/workspace';
+import {workspaces} from '@angular-devkit/core';
 import * as ts from 'typescript';
 import {getProjectMainFile} from './project-main-file';
 
@@ -31,7 +31,7 @@ export function addModuleImportToRootModule(
   host: Tree,
   moduleName: string,
   src: string,
-  project: ProjectDefinition,
+  project: workspaces.ProjectDefinition,
 ) {
   const modulePath = getAppModulePath(host, getProjectMainFile(project));
   addModuleImportToModule(host, modulePath, moduleName, src);

--- a/src/cdk/schematics/utils/build-component.ts
+++ b/src/cdk/schematics/utils/build-component.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {strings, template as interpolateTemplate} from '@angular-devkit/core';
+import {strings, template as interpolateTemplate, workspaces} from '@angular-devkit/core';
 import {
   apply,
   applyTemplates,
@@ -35,13 +35,12 @@ import {dirname, join, resolve} from 'path';
 import * as ts from 'typescript';
 import {getProjectFromWorkspace} from './get-project';
 import {getDefaultComponentOptions, isStandaloneSchematic} from './schematic-options';
-import {ProjectDefinition} from '@angular-devkit/core/src/workspace';
 
 /**
  * Build a default project path for generating.
  * @param project The project to build the path for.
  */
-function buildDefaultPath(project: ProjectDefinition): string {
+function buildDefaultPath(project: workspaces.ProjectDefinition): string {
   const root = project.sourceRoot ? `/${project.sourceRoot}/` : `/${project.root}/src/`;
 
   const projectDirName = project.extensions.projectType === ProjectType.Application ? 'app' : 'lib';

--- a/src/cdk/schematics/utils/get-project.ts
+++ b/src/cdk/schematics/utils/get-project.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ProjectDefinition, WorkspaceDefinition} from '@angular-devkit/core/src/workspace';
+import {workspaces} from '@angular-devkit/core';
 import {SchematicsException} from '@angular-devkit/schematics';
 
 /**
@@ -14,9 +14,9 @@ import {SchematicsException} from '@angular-devkit/schematics';
  * couldn't be found.
  */
 export function getProjectFromWorkspace(
-  workspace: WorkspaceDefinition,
+  workspace: workspaces.WorkspaceDefinition,
   projectName: string | undefined,
-): ProjectDefinition {
+): workspaces.ProjectDefinition {
   if (!projectName) {
     // TODO(crisbeto): some schematics APIs have the project name as optional so for now it's
     // simpler to allow undefined and checking it at runtime. Eventually we should clean this up.

--- a/src/cdk/schematics/utils/project-index-file.ts
+++ b/src/cdk/schematics/utils/project-index-file.ts
@@ -6,12 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Path} from '@angular-devkit/core';
-import {ProjectDefinition} from '@angular-devkit/core/src/workspace';
+import {Path, workspaces} from '@angular-devkit/core';
 import {defaultTargetBuilders, getTargetsByBuilderName} from './project-targets';
 
 /** Gets the path of the index file in the given project. */
-export function getProjectIndexFiles(project: ProjectDefinition): Path[] {
+export function getProjectIndexFiles(project: workspaces.ProjectDefinition): Path[] {
   const paths = getTargetsByBuilderName(project, defaultTargetBuilders.build)
     .filter(t => t.options?.index)
     .map(t => t.options!.index as Path);

--- a/src/cdk/schematics/utils/project-main-file.ts
+++ b/src/cdk/schematics/utils/project-main-file.ts
@@ -6,13 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Path} from '@angular-devkit/core';
-import {ProjectDefinition} from '@angular-devkit/core/src/workspace';
+import {Path, workspaces} from '@angular-devkit/core';
 import {SchematicsException} from '@angular-devkit/schematics';
 import {getProjectTargetOptions} from './project-targets';
 
 /** Looks for the main TypeScript file in the given project and returns its path. */
-export function getProjectMainFile(project: ProjectDefinition): Path {
+export function getProjectMainFile(project: workspaces.ProjectDefinition): Path {
   const buildOptions = getProjectTargetOptions(project, 'build');
 
   if (!buildOptions.main) {

--- a/src/cdk/schematics/utils/project-style-file.ts
+++ b/src/cdk/schematics/utils/project-style-file.ts
@@ -6,8 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {isJsonArray, normalize} from '@angular-devkit/core';
-import {ProjectDefinition} from '@angular-devkit/core/src/workspace';
+import {isJsonArray, normalize, workspaces} from '@angular-devkit/core';
 import {getProjectTargetOptions} from './project-targets';
 
 /** Regular expression that matches all possible Angular CLI default style files. */
@@ -20,7 +19,10 @@ const validStyleFileRegex = /\.(c|le|sc)ss/;
  * Gets a style file with the given extension in a project and returns its path. If no
  * extension is specified, any style file with a valid extension will be returned.
  */
-export function getProjectStyleFile(project: ProjectDefinition, extension?: string): string | null {
+export function getProjectStyleFile(
+  project: workspaces.ProjectDefinition,
+  extension?: string,
+): string | null {
   const buildOptions = getProjectTargetOptions(project, 'build');
   if (buildOptions.styles && isJsonArray(buildOptions.styles) && buildOptions.styles.length) {
     const styles = buildOptions.styles.map(s =>

--- a/src/cdk/schematics/utils/project-targets.ts
+++ b/src/cdk/schematics/utils/project-targets.ts
@@ -6,8 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ProjectDefinition, TargetDefinition} from '@angular-devkit/core/src/workspace';
-import {JsonValue} from '@angular-devkit/core';
+import {JsonValue, workspaces} from '@angular-devkit/core';
 import {SchematicsException} from '@angular-devkit/schematics';
 
 /** Object that maps a CLI target to its default builder name. */
@@ -18,7 +17,7 @@ export const defaultTargetBuilders = {
 
 /** Resolves the architect options for the build target of the given project. */
 export function getProjectTargetOptions(
-  project: ProjectDefinition,
+  project: workspaces.ProjectDefinition,
   buildTarget: string,
 ): Record<string, JsonValue | undefined> {
   const options = project.targets?.get(buildTarget)?.options;
@@ -34,9 +33,9 @@ export function getProjectTargetOptions(
 
 /** Gets all targets from the given project that match the specified builder name. */
 export function getTargetsByBuilderName(
-  project: ProjectDefinition,
+  project: workspaces.ProjectDefinition,
   builderName: string,
-): TargetDefinition[] {
+): workspaces.TargetDefinition[] {
   return Array.from(project.targets.keys())
     .filter(name => project.targets.get(name)?.builder === builderName)
     .map(name => project.targets.get(name)!);

--- a/src/cdk/schematics/utils/project-tsconfig-paths.ts
+++ b/src/cdk/schematics/utils/project-tsconfig-paths.ts
@@ -6,14 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {normalize} from '@angular-devkit/core';
-import {
-  ProjectDefinition,
-  WorkspaceDefinition,
-  WorkspaceHost,
-} from '@angular-devkit/core/src/workspace';
-import {readJsonWorkspace} from '@angular-devkit/core/src/workspace/json/reader';
+import {normalize, workspaces} from '@angular-devkit/core';
 import {Tree} from '@angular-devkit/schematics';
+import {getWorkspace} from '@schematics/angular/utility/workspace';
 import {WorkspacePath} from '../update-tool/file-system';
 
 /** Name of the default Angular CLI workspace configuration files. */
@@ -21,7 +16,7 @@ const defaultWorkspaceConfigPaths = ['/angular.json', '/.angular.json'];
 
 /** Gets the tsconfig path from the given target within the specified project. */
 export function getTargetTsconfigPath(
-  project: ProjectDefinition,
+  project: workspaces.ProjectDefinition,
   targetName: string,
 ): WorkspacePath | null {
   const tsconfig = project.targets?.get(targetName)?.options?.tsConfig;
@@ -31,18 +26,15 @@ export function getTargetTsconfigPath(
 /** Resolve the workspace configuration of the specified tree gracefully. */
 export async function getWorkspaceConfigGracefully(
   tree: Tree,
-): Promise<WorkspaceDefinition | null> {
+): Promise<workspaces.WorkspaceDefinition | null> {
   const path = defaultWorkspaceConfigPaths.find(filePath => tree.exists(filePath));
-  const configBuffer = tree.read(path!);
 
-  if (!path || !configBuffer) {
+  if (!path) {
     return null;
   }
 
   try {
-    return await readJsonWorkspace(path, {
-      readFile: async filePath => tree.read(filePath)!.toString(),
-    } as WorkspaceHost);
+    return getWorkspace(tree, path);
   } catch {
     return null;
   }

--- a/src/cdk/schematics/utils/schematic-options.ts
+++ b/src/cdk/schematics/utils/schematic-options.ts
@@ -6,8 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ProjectDefinition} from '@angular-devkit/core/src/workspace';
-import {isJsonObject, JsonObject} from '@angular-devkit/core';
+import {isJsonObject, JsonObject, workspaces} from '@angular-devkit/core';
 import {Schema, Style} from '@schematics/angular/component/schema';
 import {isStandaloneApp} from '@schematics/angular/utility/ng-ast-utils';
 import {getProjectMainFile} from './project-main-file';
@@ -22,7 +21,7 @@ import {Tree} from '@angular-devkit/schematics';
  * This is necessary because the Angular CLI only exposes the default values for the "--style",
  * "--inlineStyle", "--skipTests" and "--inlineTemplate" options to the "component" schematic.
  */
-export function getDefaultComponentOptions(project: ProjectDefinition): Partial<Schema> {
+export function getDefaultComponentOptions(project: workspaces.ProjectDefinition): Partial<Schema> {
   // Note: Not all options which are available when running "ng new" will be stored in the
   // workspace config. List of options which will be available in the configuration:
   // angular/angular-cli/blob/main/packages/schematics/angular/application/index.ts#L109-L131
@@ -68,7 +67,7 @@ export async function isStandaloneSchematic(host: Tree, options: Schema): Promis
  * CLI workspace configuration.
  */
 function getDefaultComponentOption<T>(
-  project: ProjectDefinition,
+  project: workspaces.ProjectDefinition,
   optionNames: string[],
   fallbackValue: T,
 ): T {

--- a/src/material/schematics/ng-add/index.spec.ts
+++ b/src/material/schematics/ng-add/index.spec.ts
@@ -1,5 +1,4 @@
-import {normalize} from '@angular-devkit/core';
-import {ProjectDefinition} from '@angular-devkit/core/src/workspace';
+import {normalize, workspaces} from '@angular-devkit/core';
 import {Tree} from '@angular-devkit/schematics';
 import {SchematicTestRunner} from '@angular-devkit/schematics/testing';
 import {
@@ -41,7 +40,7 @@ describe('ng-add schematic', () => {
   });
 
   /** Expects the given file to be in the styles of the specified workspace project. */
-  function expectProjectStyleFile(project: ProjectDefinition, filePath: string) {
+  function expectProjectStyleFile(project: workspaces.ProjectDefinition, filePath: string) {
     expect(getProjectTargetOptions(project, 'build').styles)
       .withContext(`Expected "${filePath}" to be added to the project styles in the workspace.`)
       .toContain(filePath);

--- a/src/material/schematics/ng-add/theming/theming.ts
+++ b/src/material/schematics/ng-add/theming/theming.ts
@@ -6,8 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {normalize, logging} from '@angular-devkit/core';
-import {ProjectDefinition} from '@angular-devkit/core/src/workspace';
+import {normalize, logging, workspaces} from '@angular-devkit/core';
 import {
   chain,
   noop,
@@ -174,7 +173,7 @@ function addThemeStyleToTarget(
  * this function can either throw or just show a warning.
  */
 function validateDefaultTargetBuilder(
-  project: ProjectDefinition,
+  project: workspaces.ProjectDefinition,
   targetName: 'build' | 'test',
   logger: logging.LoggerApi,
 ) {


### PR DESCRIPTION
Removes deep imports for some devkit APIs from the CDK schematics code to avoid potential build issues.

Fixes #27344.