### PR TITLE
fix(material/menu): prevent menu styles from leaking to other components

### DIFF
--- a/src/material/menu/_menu-theme.scss
+++ b/src/material/menu/_menu-theme.scss
@@ -13,7 +13,10 @@
   $config: theming.get-color-config($config-or-theme);
   @include mdc-helpers.using-mdc-theme($config) {
     @include mdc-menu-surface.core-styles(mdc-helpers.$mdc-theme-styles-query);
-    @include mdc-list.without-ripple(mdc-helpers.$mdc-theme-styles-query);
+
+    .mat-mdc-menu-panel-wrapper {
+      @include mdc-list.without-ripple(mdc-helpers.$mdc-theme-styles-query);
+    }
 
     // MDC doesn't appear to have disabled styling for menu
     // items so we have to grey them out ourselves.

--- a/src/material/menu/menu-trigger.ts
+++ b/src/material/menu/menu-trigger.ts
@@ -96,6 +96,7 @@ export abstract class _MatMenuTriggerBase implements AfterContentInit, OnDestroy
   private _menuCloseSubscription = Subscription.EMPTY;
   private _scrollStrategy: () => ScrollStrategy;
   private _changeDetectorRef = inject(ChangeDetectorRef);
+  protected _panelClass: string | null;
 
   /**
    * We're specifically looking for a `MatMenu` here since the generic `MatMenuPanel`
@@ -328,6 +329,10 @@ export abstract class _MatMenuTriggerBase implements AfterContentInit, OnDestroy
 
     this._closingActionsSubscription = this._menuClosingActions().subscribe(() => this.closeMenu());
     this._initMenu(menu);
+
+    if (this._panelClass) {
+      overlayRef.overlayElement.classList.add(this._panelClass);
+    }
 
     if (menu instanceof _MatMenuBase) {
       menu._startAnimation();
@@ -686,4 +691,6 @@ export abstract class _MatMenuTriggerBase implements AfterContentInit, OnDestroy
   },
   exportAs: 'matMenuTrigger',
 })
-export class MatMenuTrigger extends _MatMenuTriggerBase {}
+export class MatMenuTrigger extends _MatMenuTriggerBase {
+  protected override _panelClass = 'mat-mdc-menu-panel-wrapper';
+}

--- a/tools/public_api_guard/material/menu.md
+++ b/tools/public_api_guard/material/menu.md
@@ -275,6 +275,8 @@ export interface MatMenuPanel<T = any> {
 // @public
 export class MatMenuTrigger extends _MatMenuTriggerBase {
     // (undocumented)
+    protected _panelClass: string;
+    // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<MatMenuTrigger, "[mat-menu-trigger-for], [matMenuTriggerFor]", ["matMenuTrigger"], {}, {}, never, never, false, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatMenuTrigger, never>;
@@ -313,6 +315,8 @@ export abstract class _MatMenuTriggerBase implements AfterContentInit, OnDestroy
     // (undocumented)
     _openedBy: Exclude<FocusOrigin, 'program' | null> | undefined;
     openMenu(): void;
+    // (undocumented)
+    protected _panelClass: string | null;
     restoreFocus: boolean;
     toggleMenu(): void;
     triggersSubmenu(): boolean;


### PR DESCRIPTION
The menu theme was including the MDC list styles directly at the root of the theme which caused to leak into other components like `mat-list`.

The mixins will be removed in #27377, however currently the screenshot tests of a lot of internal targets assume that the leaky styles will be there which breaks the presubmit of #27377.

These changes introduce a *temporary* wrapper class around the mixins so that the incorrect screenshots can be approved before trying to land #27377.