### PR TITLE
fix(material/checkbox): set checkbox checkmark color with default-con…

### DIFF
--- a/src/material-experimental/theming/_checkbox.scss
+++ b/src/material-experimental/theming/_checkbox.scss
@@ -2,26 +2,16 @@
 @use 'sass:map';
 @use 'sass:meta';
 @use '@angular/material' as mat;
-@use '@material/theme/theme-color' as mdc-theme-color;
 @use './token-resolution';
 
 // TODO(mmalerba): This should live under material/checkbox when moving out of experimental.
-
-// Duplicated from core/tokens/m2/mdc/checkbox
-// TODO(mmalerba): Delete duplicated code when this is moved out of experimental.
-@function _contrast-tone($value, $light-color: '#fff', $dark-color: '#000') {
-  @if ($value == 'dark' or $value == 'light' or type-of($value) == 'color') {
-    @return if(mdc-theme-color.contrast-tone($value) == 'dark', $dark-color, $light-color);
-  }
-  @return false;
-}
 
 /// Gets a map of checkbox token values that are derived from the given palette.
 /// @param {Map} $palette An Angular Material palette object.
 /// @return {Map} A map of checkbox token values derived from the given palette.
 @function _get-tokens-for-color-palette($palette) {
   $palette-default-color: mat.get-color-from-palette($palette);
-  $checkmark-color: _contrast-tone($palette-default-color);
+  $checkmark-color: mat.get-color-from-palette($palette, default-contrast);
 
   @return (
     (mdc, checkbox): (

--- a/src/material/core/tokens/m2/mdc/_checkbox.scss
+++ b/src/material/core/tokens/m2/mdc/_checkbox.scss
@@ -3,20 +3,9 @@
 @use '../../../theming/theming';
 @use '../../../style/sass-utils';
 @use '../../token-utils';
-@use '@material/theme/theme-color' as mdc-theme-color;
 
 // The prefix used to generate the fully qualified name for tokens in this file.
 $prefix: (mdc, checkbox);
-
-// MDC logs a warning if the `contrast-tone` function is called with a CSS variable.
-// This function falls back to determining the tone based on whether the theme is light or dark.
-@function _contrast-tone($value, $is-dark, $light-color: '#fff', $dark-color: '#000') {
-  @if ($value == 'dark' or $value == 'light' or type-of($value) == 'color') {
-    @return if(mdc-theme-color.contrast-tone($value) == 'dark', $dark-color, $light-color);
-  }
-
-  @return if($is-dark, $light-color, $dark-color);
-}
 
 // Tokens that can't be configured through Angular Material's current theming API,
 // but may be in a future version of the theming API.
@@ -56,6 +45,7 @@ $prefix: (mdc, checkbox);
   $is-dark: map.get($config, is-dark);
   $foreground-base: theming.get-color-from-palette($foreground, base);
   $accent-default: theming.get-color-from-palette($accent, default);
+  $accent-default-contrast: theming.get-color-from-palette($accent, default-contrast);
   $disabled-color: theming.get-color-from-palette($foreground, base, 0.38);
   $selected-color: theming.get-color-from-palette($accent);
   $border-color: theming.get-color-from-palette($foreground, base, 0.54);
@@ -68,7 +58,7 @@ $prefix: (mdc, checkbox);
     // The color of the checkbox border when the checkbox is unselected and disabled.
     disabled-unselected-icon-color: $disabled-color,
     // The color of the checkmark when the checkbox is selected.
-    selected-checkmark-color: _contrast-tone($selected-color, $is-dark),
+    selected-checkmark-color: $accent-default-contrast,
     // The color of the checkbox fill when the checkbox is selected and focused.
     selected-focus-icon-color: $selected-color,
     // The color of the checkbox fill when the checkbox is selected and hovered.


### PR DESCRIPTION
…trast

Fixes a bug in the Angular Material `checkbox` component where checkmark does not have the right color if theme is set with CSS variables.

Fixes #27204