### PR TITLE
docs: release notes for the v16.1.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+<a name="16.1.3"></a>
+# 16.1.3 "linen-latte" (2023-06-28)
+### cdk
+| Commit | Type | Description |
+| -- | -- | -- |
+| [419528977f](https://github.com/angular/components/commit/419528977fc66928de7e0db544891dd18f7ab5f8) | fix | **schematics:** clean up deep imports of devkit APIs ([#27363](https://github.com/angular/components/pull/27363)) |
+### material
+| Commit | Type | Description |
+| -- | -- | -- |
+| [5c066badba](https://github.com/angular/components/commit/5c066badbaaae48d747f7e99dec16c721584d585) | fix | **badge:** warn if use with mat-icon ([#27368](https://github.com/angular/components/pull/27368)) |
+| [581506145b](https://github.com/angular/components/commit/581506145b994153e430db143b5dbac080540699) | fix | **chips:** remove button role from editable chips ([#27317](https://github.com/angular/components/pull/27317)) |
+| [faccac047b](https://github.com/angular/components/commit/faccac047b56dada0435bf3e414fe4c5607f637a) | fix | **core:** add validation to create-token-slot ([#27357](https://github.com/angular/components/pull/27357)) |
+| [3a846e1ece](https://github.com/angular/components/commit/3a846e1ece7fbfa18ef8dcf42e76ad219c606798) | fix | **dialog:** exit animation duration not being picked up ([#27372](https://github.com/angular/components/pull/27372)) |
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="16.2.0-next.1"></a>
 # 16.2.0-next.1 "plastic-fork" (2023-06-23)
 ### cdk


### PR DESCRIPTION
Cherry-picks the changelog from the "16.1.x" branch to the next branch (main).