### PR TITLE
fix(material/chips): hide checkmark indicator for multiple selection

### DIFF
--- a/src/material/chips/chip-listbox.ts
+++ b/src/material/chips/chip-listbox.ts
@@ -176,6 +176,18 @@ export class MatChipListbox
   private _hideSingleSelectionIndicator: boolean =
     this._defaultOptions?.hideSingleSelectionIndicator ?? false;
 
+  /** Whether checkmark indicator for multiple-selection options is hidden. */
+  @Input()
+  get hideMultipleSelectionIndicator(): boolean {
+    return this._hideMultipleSelectionIndicator;
+  }
+  set hideMultipleSelectionIndicator(value: BooleanInput) {
+    this._hideMultipleSelectionIndicator = coerceBooleanProperty(value);
+    this._syncListboxProperties();
+  }
+  private _hideMultipleSelectionIndicator: boolean =
+    this._defaultOptions?.hideMultipleSelectionIndicator ?? false;
+
   /** Combined stream of all of the child chips' selection change events. */
   get chipSelectionChanges(): Observable<MatChipSelectionChange> {
     return this._getChipStream<MatChipSelectionChange, MatChipOption>(chip => chip.selectionChange);
@@ -382,6 +394,7 @@ export class MatChipListbox
           chip._chipListMultiple = this.multiple;
           chip.chipListSelectable = this._selectable;
           chip._chipListHideSingleSelectionIndicator = this.hideSingleSelectionIndicator;
+          chip._chipListHideMultipleSelectionIndicator = this.hideMultipleSelectionIndicator;
           chip._changeDetectorRef.markForCheck();
         });
       });

--- a/src/material/chips/chip-option.spec.ts
+++ b/src/material/chips/chip-option.spec.ts
@@ -26,12 +26,14 @@ describe('MDC-based Option Chips', () => {
   let dir = 'ltr';
 
   let hideSingleSelectionIndicator: boolean | undefined;
+  let hideMultipleSelectionIndicator: boolean | undefined;
 
   beforeEach(waitForAsync(() => {
     globalRippleOptions = {};
     const defaultOptions: MatChipsDefaultOptions = {
       separatorKeyCodes: [ENTER, SPACE],
       hideSingleSelectionIndicator,
+      hideMultipleSelectionIndicator,
     };
 
     TestBed.configureTestingModule({
@@ -315,6 +317,15 @@ describe('MDC-based Option Chips', () => {
           )
           .toBeUndefined();
 
+        expect(
+          fixture.debugElement.injector.get(MAT_CHIPS_DEFAULT_OPTIONS)
+            ?.hideMultipleSelectionIndicator,
+        )
+          .withContext(
+            'expected not to have a default value set for `hideMultipleSelectionIndicator`',
+          )
+          .toBeUndefined();
+
         expect(chipNativeElement.querySelector('.mat-mdc-chip-graphic')).toBeTruthy();
         expect(chipNativeElement.classList).toContain('mdc-evolution-chip--with-primary-graphic');
       });
@@ -365,10 +376,12 @@ describe('MDC-based Option Chips', () => {
     describe('with token to hide single-selection checkmark indicator', () => {
       beforeAll(() => {
         hideSingleSelectionIndicator = true;
+        hideMultipleSelectionIndicator = true;
       });
 
       afterAll(() => {
         hideSingleSelectionIndicator = undefined;
+        hideMultipleSelectionIndicator = undefined;
       });
 
       it('does not display checkmark graphic', () => {

--- a/src/material/chips/chip-option.ts
+++ b/src/material/chips/chip-option.ts
@@ -92,6 +92,10 @@ export class MatChipOption extends MatChip implements OnInit {
   _chipListHideSingleSelectionIndicator: boolean =
     this._defaultOptions?.hideSingleSelectionIndicator ?? false;
 
+  /** Whether the chip list hides mutiple-selection indicator. */
+  _chipListHideMultipleSelectionIndicator: boolean =
+    this._defaultOptions?.hideMultipleSelectionIndicator ?? false;
+
   /**
    * Whether or not the chip is selectable.
    *
@@ -181,9 +185,11 @@ export class MatChipOption extends MatChip implements OnInit {
     }
 
     // The checkmark graphic communicates selected state for both single-select and multi-select.
-    // Include checkmark in single-select to fix a11y issue where selected state is communicated
+    // Include checkmark in single-select or multi-select to fix a11y issue where selected state is communicated
     // visually only using color (#25886).
-    return !this._chipListHideSingleSelectionIndicator || this._chipListMultiple;
+    return this._chipListMultiple
+      ? !this._chipListHideMultipleSelectionIndicator
+      : !this._chipListHideSingleSelectionIndicator;
   }
 
   _setSelectedState(isSelected: boolean, isUserInput: boolean, emitEvent: boolean) {

--- a/src/material/chips/chips.md
+++ b/src/material/chips/chips.md
@@ -190,4 +190,4 @@ When using `MatChipRemove`, you should always communicate removals for assistive
 
 When using MatChipListbox, never nest other interactive controls inside of the `<mat-chip-option>` element. Nesting controls degrades the experience for assistive technology users.
 
-By default, `MatChipListbox` displays a checkmark to identify selected items. While you can hide the checkmark indicator for single-selection via `hideSingleSelectionIndicator`, this makes the component less accessible by making it harder or impossible for users to visually identify selected items.
+By default, `MatChipListbox` displays a checkmark to identify selected items. While you can hide the checkmark indicator for single-selection via `hideSingleSelectionIndicator` or `hideMultipleSelectionIndicator` for multiple-selection, although this makes the component less accessible by making it harder or impossible for users to visually identify selected items.

--- a/src/material/chips/tokens.ts
+++ b/src/material/chips/tokens.ts
@@ -15,6 +15,9 @@ export interface MatChipsDefaultOptions {
 
   /** Wheter icon indicators should be hidden for single-selection. */
   hideSingleSelectionIndicator?: boolean;
+
+  /** Wheter icon indicators should be hidden for multiple-selection. */
+  hideMultipleSelectionIndicator?: boolean;
 }
 
 /** Injection token to be used to override the default options for the chips module. */

--- a/tools/public_api_guard/material/chips.md
+++ b/tools/public_api_guard/material/chips.md
@@ -297,6 +297,8 @@ export class MatChipListbox extends MatChipSet implements AfterContentInit, OnDe
     // (undocumented)
     protected _defaultRole: string;
     focus(): void;
+    get hideMultipleSelectionIndicator(): boolean;
+    set hideMultipleSelectionIndicator(value: BooleanInput);
     get hideSingleSelectionIndicator(): boolean;
     set hideSingleSelectionIndicator(value: BooleanInput);
     // (undocumented)
@@ -327,7 +329,7 @@ export class MatChipListbox extends MatChipSet implements AfterContentInit, OnDe
     protected _value: any;
     writeValue(value: any): void;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<MatChipListbox, "mat-chip-listbox", never, { "tabIndex": { "alias": "tabIndex"; "required": false; }; "multiple": { "alias": "multiple"; "required": false; }; "ariaOrientation": { "alias": "aria-orientation"; "required": false; }; "selectable": { "alias": "selectable"; "required": false; }; "compareWith": { "alias": "compareWith"; "required": false; }; "required": { "alias": "required"; "required": false; }; "hideSingleSelectionIndicator": { "alias": "hideSingleSelectionIndicator"; "required": false; }; "value": { "alias": "value"; "required": false; }; }, { "change": "change"; }, ["_chips"], ["*"], false, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MatChipListbox, "mat-chip-listbox", never, { "tabIndex": { "alias": "tabIndex"; "required": false; }; "multiple": { "alias": "multiple"; "required": false; }; "ariaOrientation": { "alias": "aria-orientation"; "required": false; }; "selectable": { "alias": "selectable"; "required": false; }; "compareWith": { "alias": "compareWith"; "required": false; }; "required": { "alias": "required"; "required": false; }; "hideSingleSelectionIndicator": { "alias": "hideSingleSelectionIndicator"; "required": false; }; "hideMultipleSelectionIndicator": { "alias": "hideMultipleSelectionIndicator"; "required": false; }; "value": { "alias": "value"; "required": false; }; }, { "change": "change"; }, ["_chips"], ["*"], false, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatChipListbox, never>;
 }
@@ -345,6 +347,7 @@ export class MatChipListboxChange {
 export class MatChipOption extends MatChip implements OnInit {
     get ariaSelected(): string | null;
     protected basicChipAttrName: string;
+    _chipListHideMultipleSelectionIndicator: boolean;
     _chipListHideSingleSelectionIndicator: boolean;
     _chipListMultiple: boolean;
     chipListSelectable: boolean;
@@ -414,6 +417,7 @@ export class MatChipRow extends MatChip implements AfterViewInit {
 
 // @public
 export interface MatChipsDefaultOptions {
+    hideMultipleSelectionIndicator?: boolean;
     hideSingleSelectionIndicator?: boolean;
     separatorKeyCodes: readonly number[] | ReadonlySet<number>;
 }


### PR DESCRIPTION
adds hideMultipleSelectionIndicator to hide checkmark indicator for multiple selected values in chip-list

fixes #27354