### PR TITLE
fix(material/slide-toggle): add cursor pointer for label

### DIFF
--- a/src/material/slide-toggle/slide-toggle.scss
+++ b/src/material/slide-toggle/slide-toggle.scss
@@ -127,4 +127,9 @@
       transition: none;
     }
   }
+
+  // If our slide-toggle is enabled the cursor on label should appear as a pointer.
+  .mdc-switch:enabled + .mdc-label {
+    cursor: pointer;
+  }
 }


### PR DESCRIPTION
our label in slider doesn't contain cursor pointer style as we can still click on label and toggle slider

fixes #26490