### PR TITLE
fix(material/core): throw better error messages from typography utils

### DIFF
--- a/src/material/core/typography/_typography-utils.scss
+++ b/src/material/core/typography/_typography-utils.scss
@@ -7,6 +7,15 @@
 
 // Utility for fetching a nested value from a typography config.
 @function _mat-get-type-value($config, $level, $name) {
+  @if meta.type-of($config) != 'map' {
+    @error 'Typography config must be a map. Received #{meta.type-of($config)}.';
+  }
+
+  @if not map.has-key($config, $level) {
+    @error 'Typography config does not have a level called "#{$level}". ' +
+           'Available levels are: #{map.keys($config)}.';
+  }
+
   @return map.get(map.get($config, $level), $name);
 }
 
@@ -42,6 +51,10 @@
 /// @param {Map} $config A typography config.
 /// @param {Map} $level A typography level.
 @function font-family($config, $level: null) {
+  @if meta.type-of($config) != 'map' {
+    @error 'Typography config must be a map. Received #{meta.type-of($config)}.';
+  }
+
   $font-family: map.get($config, font-family);
 
   @if $level != null {


### PR DESCRIPTION
Currently the typography functions assume that a config and the level being looked up will exist, but that's not necessarily the case which leads to some cryptic error messages that take a while to parse.

These changes add some validations so that it's easier to figure out what's wrong.