### PR TITLE
fix(cdk/menu): control + option + space not working on VoiceOver

### DIFF
--- a/src/cdk/menu/event-detection.ts
+++ b/src/cdk/menu/event-detection.ts
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ElementRef} from '@angular/core';
+import {ENTER, SPACE} from '@angular/cdk/keycodes';
+
+/** Checks whether a keyboard event will trigger a native `click` event on an element. */
+export function eventDispatchesNativeClick(
+  elementRef: ElementRef<HTMLElement>,
+  event: KeyboardEvent,
+): boolean {
+  // Synthetic events won't trigger clicks.
+  if (!event.isTrusted) {
+    return false;
+  }
+
+  const el = elementRef.nativeElement;
+  const keyCode = event.keyCode;
+
+  // Buttons trigger clicks both on space and enter events.
+  if (el.nodeName === 'BUTTON' && !(el as HTMLButtonElement).disabled) {
+    return keyCode === ENTER || keyCode === SPACE;
+  }
+
+  // Links only trigger clicks on enter.
+  if (el.nodeName === 'A') {
+    return keyCode === ENTER;
+  }
+
+  // Any other elements won't dispatch clicks from keyboard events.
+  return false;
+}

--- a/tools/public_api_guard/cdk/menu.md
+++ b/tools/public_api_guard/cdk/menu.md
@@ -129,7 +129,6 @@ export class CdkMenuItem implements FocusableOption, FocusableElement, Toggler, 
     getLabel(): string;
     getMenu(): Menu | undefined;
     getMenuTrigger(): CdkMenuTrigger | null;
-    _handleClick(): void;
     get hasMenu(): boolean;
     isMenuOpen(): boolean;
     // (undocumented)


### PR DESCRIPTION
In #26296 I added a condition in the click handler for menu triggers and menu items to skip clicks dispatched by the keyboard so that they don't trigger the menu twice. The problem is that this also ends up ignoring the default keyboard shortcut that VoiceOver mentions should be used to trigger the menu (Control + Option + Space), because it ends up being dispatched as a plain `click` event and it doesn't trigger the `keydown` event at all.

These changes address the issue by removing the previous condition and inferring whether the event will trigger a click by looking at it and the element it's coming from.

Fixes #27376.