### PR TITLE
fix(material/chips): error if empty getter is accessed too early

### DIFF
--- a/src/material/chips/chip-set.spec.ts
+++ b/src/material/chips/chip-set.spec.ts
@@ -98,6 +98,12 @@ describe('MDC-based MatChipSet', () => {
 
     expect(chips.toArray().every(chip => chip.disabled)).toBe(false);
   });
+
+  it('should be able to access the `empty` getter before the chips are initialized', () => {
+    const fixture = TestBed.createComponent(BasicChipSet);
+    const chipSet = fixture.debugElement.query(By.directive(MatChipSet))!;
+    expect(chipSet.componentInstance.empty).toBe(true);
+  });
 });
 
 @Component({

--- a/src/material/chips/chip-set.ts
+++ b/src/material/chips/chip-set.ts
@@ -98,7 +98,7 @@ export class MatChipSet
 
   /** Whether the chip list contains chips or not. */
   get empty(): boolean {
-    return this._chips.length === 0;
+    return !this._chips || this._chips.length === 0;
   }
 
   /** The ARIA role applied to the chip set. */


### PR DESCRIPTION
Fixes that the `empty` getter wasn't null checking the `chips` field and would throw an error if it is accessed before `ngAfterContentInit`.

Fixes #27404.