### PR TITLE
fix(material/schematics): fix template diagnostic in table schematic

### DIFF
--- a/src/material/schematics/ng-generate/table/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.html.template
+++ b/src/material/schematics/ng-generate/table/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.html.template
@@ -17,7 +17,7 @@
   </table>
 
   <mat-paginator #paginator
-      [length]="dataSource?.data?.length"
+      [length]="dataSource.data.length"
       [pageIndex]="0"
       [pageSize]="10"
       [pageSizeOptions]="[5, 10, 20]"

--- a/src/material/schematics/ng-generate/table/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.ts.template
+++ b/src/material/schematics/ng-generate/table/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.ts.template
@@ -23,14 +23,10 @@ export class <%= classify(name) %>Component implements AfterViewInit {
   @ViewChild(MatPaginator) paginator!: MatPaginator;
   @ViewChild(MatSort) sort!: MatSort;
   @ViewChild(MatTable) table!: MatTable<<%= classify(name) %>Item>;
-  dataSource: <%= classify(name) %>DataSource;
+  dataSource = new <%= classify(name) %>DataSource();
 
   /** Columns displayed in the table. Columns IDs can be added, removed, or reordered. */
   displayedColumns = ['id', 'name'];
-
-  constructor() {
-    this.dataSource = new <%= classify(name) %>DataSource();
-  }
 
   ngAfterViewInit(): void {
     this.dataSource.sort = this.sort;


### PR DESCRIPTION
Fixes that the table schematic was producing a template diagnostic for null checking a value that doesn't need to be null checked. Also removes an unnecessary constructor.

Fixes #27329.