### PR TITLE
fix(material/schematics): support all potential default builders for ng add

### DIFF
--- a/src/cdk/schematics/utils/project-index-file.ts
+++ b/src/cdk/schematics/utils/project-index-file.ts
@@ -11,7 +11,8 @@ import {defaultTargetBuilders, getTargetsByBuilderName} from './project-targets'
 
 /** Gets the path of the index file in the given project. */
 export function getProjectIndexFiles(project: workspaces.ProjectDefinition): Path[] {
-  const paths = getTargetsByBuilderName(project, defaultTargetBuilders.build)
+  const paths = defaultTargetBuilders.build
+    .flatMap(name => getTargetsByBuilderName(project, name))
     .filter(t => t.options?.index)
     .map(t => t.options!.index as Path);
 

--- a/src/cdk/schematics/utils/project-targets.ts
+++ b/src/cdk/schematics/utils/project-targets.ts
@@ -11,7 +11,11 @@ import {SchematicsException} from '@angular-devkit/schematics';
 
 /** Object that maps a CLI target to its default builder name. */
 export const defaultTargetBuilders = {
-  build: '@angular-devkit/build-angular:browser',
+  build: [
+    '@angular-devkit/build-angular:browser',
+    '@angular-devkit/build-angular:browser-esbuild',
+    '@angular-devkit/build-angular:application',
+  ],
   test: '@angular-devkit/build-angular:karma',
 };
 

--- a/src/material/schematics/ng-add/theming/theming.ts
+++ b/src/material/schematics/ng-add/theming/theming.ts
@@ -177,9 +177,9 @@ function validateDefaultTargetBuilder(
   targetName: 'build' | 'test',
   logger: logging.LoggerApi,
 ) {
-  const defaultBuilder = defaultTargetBuilders[targetName];
+  const defaultBuilders = defaultTargetBuilders[targetName];
   const targetConfig = project.targets && project.targets.get(targetName);
-  const isDefaultBuilder = targetConfig && targetConfig['builder'] === defaultBuilder;
+  const isDefaultBuilder = targetConfig && defaultBuilders.includes(targetConfig['builder']);
 
   // Because the build setup for the Angular CLI can be customized by developers, we can't know
   // where to put the theme file in the workspace configuration if custom builders are being


### PR DESCRIPTION
With the advent of the developer preview for the esbuild-based browser application builder, there are now three potential "default" builders that could be present: browser, browser-esbuild, and application. To ensure that the material add schematics work with CLI generated projects moving forward, all of these potential builders are now checked when running the add schematics.