### PR TITLE
docs(material/menu): require only static content and MenuItems in popup

### DIFF
--- a/src/material/menu/menu.md
+++ b/src/material/menu/menu.md
@@ -115,3 +115,5 @@ Angular Material does not support the `menuitemcheckbox` or `menuitemradio` role
 
 Always provide an accessible label via `aria-label` or `aria-labelledby` for any menu
 triggers or menu items without descriptive text content.
+
+MatMenu should not contain any interactive controls aside from MatMenuItem.


### PR DESCRIPTION
Update a11y documentation for MatMenu. REquest that MatMenu should not contain interactive controls, aside from MatMenuItem.

Add clarification for the supported configurations of MatMenu. A common accessibility mistake is to nest interactive controls inside of a menu popup.

Addresses #27426