### PR TITLE
build: improve dev app appearance toggles

### DIFF
--- a/src/dev-app/dev-app.ts
+++ b/src/dev-app/dev-app.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, inject, ViewEncapsulation} from '@angular/core';
-import {ActivatedRoute, RouterModule} from '@angular/router';
+import {Component, ViewEncapsulation} from '@angular/core';
+import {RouterModule} from '@angular/router';
 import {DevAppLayout} from './dev-app/dev-app-layout';
 
 /** Root component for the dev-app demos. */
@@ -18,14 +18,4 @@ import {DevAppLayout} from './dev-app/dev-app-layout';
   standalone: true,
   imports: [DevAppLayout, RouterModule],
 })
-export class DevApp {
-  route = inject(ActivatedRoute);
-
-  constructor() {
-    this.route.queryParams.subscribe(q => {
-      (document.querySelector('#theme-styles') as any).href = q.hasOwnProperty('tokenapi')
-        ? 'theme-token-api.css'
-        : 'theme.css';
-    });
-  }
-}
+export class DevApp {}

--- a/src/dev-app/dev-app/BUILD.bazel
+++ b/src/dev-app/dev-app/BUILD.bazel
@@ -18,6 +18,7 @@ ng_module(
         "//src/material/list",
         "//src/material/sidenav",
         "//src/material/toolbar",
+        "//src/material/tooltip",
         "@npm//@angular/router",
     ],
 )

--- a/src/dev-app/dev-app/dev-app-layout.html
+++ b/src/dev-app/dev-app/dev-app-layout.html
@@ -43,7 +43,7 @@
     be one level above the density class in the DOM. At the same time, we want the density to apply
     to the toolbar while always keeping it in LTR at the same time.
    -->
-  <main [attr.dir]="dir.value" [ngClass]="getDensityClass()" class="demo-main">
+  <main [attr.dir]="state.direction" [ngClass]="getDensityClass()" class="demo-main">
     <!-- The toolbar should always be in the LTR direction -->
     <mat-toolbar color="primary" dir="ltr">
       <button mat-icon-button (click)="navigation.open('mouse')">
@@ -52,28 +52,53 @@
       <div class="demo-toolbar">
         <h1>Angular Material Demos</h1>
         <div class="demo-config-buttons">
-          <button mat-icon-button (click)="toggleFullscreen()" title="Toggle fullscreen">
+          <button
+            mat-icon-button
+            (click)="toggleFullscreen()"
+            matTooltip="Toggle fullscreen">
             <mat-icon>fullscreen</mat-icon>
           </button>
-          <button mat-button (click)="toggleAnimations()">
-            {{animationsDisabled ? 'Enable' : 'Disable'}} animations
+          <button
+            mat-icon-button
+            (click)="toggleTokens()"
+            [matTooltip]="state.tokensEnabled ? 'Disable tokens' : 'Enable tokens'">
+            <mat-icon>brush</mat-icon>
           </button>
-          <button mat-button (click)="isDark = !isDark">
-            {{isDark ? 'Light' : 'Dark'}} theme
+          <button
+            mat-icon-button
+            (click)="toggleAnimations()"
+            [matTooltip]="state.animations ? 'Disable animations' : 'Enable animations'">
+            <mat-icon>animation</mat-icon>
           </button>
-          <button mat-button (click)="rippleOptions.disabled = !rippleOptions.disabled">
-            {{rippleOptions.disabled ? 'Enable' : 'Disable'}} ripples
+          <button
+            mat-icon-button
+            (click)="toggleTheme()"
+            [matTooltip]="state.darkTheme ? 'Switch to light theme' : 'Switch to dark theme'">
+            <mat-icon>dark_mode</mat-icon>
           </button>
-          <button mat-button (click)="toggleStrongFocus()">
-            {{strongFocus ? 'Disable strong focus' : 'Enable strong focus'}}
+          <button
+            mat-icon-button
+            (click)="toggleRippleDisabled()"
+            [matTooltip]="state.rippleDisabled ? 'Enable ripples' : 'Disable ripples'">
+            <mat-icon>waves</mat-icon>
           </button>
-          <button mat-button (click)="dir.value = (dir.value === 'rtl' ? 'ltr' : 'rtl')"
-                  title="Toggle between RTL and LTR">
-            {{dir.value.toUpperCase()}}
+          <button
+            mat-icon-button
+            (click)="toggleStrongFocus()"
+            [matTooltip]="state.strongFocusEnabled ? 'Disable strong focus' : 'Enable strong focus'">
+            <mat-icon>accessibility</mat-icon>
           </button>
-          <button mat-button (click)="selectNextDensity()"
-                  title="Use next density scale: {{densityScales[getNextDensityIndex()]}}">
-            Density scale: {{densityScales[this.currentDensityIndex]}}
+          <button
+            mat-icon-button
+            (click)="toggleDirection()"
+            [matTooltip]="state.direction === 'rtl' ? 'Switch to LTR' : 'Switch to RTL'">
+            <mat-icon>keyboard_tab_rtl</mat-icon>
+          </button>
+          <button
+            mat-icon-button
+            (click)="toggleDensity()"
+            [matTooltip]="'Density: ' + state.density">
+            <mat-icon>grid_on</mat-icon>
           </button>
         </div>
       </div>

--- a/src/dev-app/dev-app/dev-app-state.ts
+++ b/src/dev-app/dev-app/dev-app-state.ts
@@ -1,0 +1,73 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Direction} from '@angular/cdk/bidi';
+
+const KEY = 'MAT_DEV_APP_STATE';
+
+/** State of the appearance of the dev app. */
+export interface DevAppState {
+  density: string | number;
+  animations: boolean;
+  darkTheme: boolean;
+  rippleDisabled: boolean;
+  strongFocusEnabled: boolean;
+  tokensEnabled: boolean;
+  direction: Direction;
+}
+
+/** Gets the current appearance state of the dev app. */
+export function getAppState(): DevAppState {
+  let value: DevAppState | null = null;
+
+  // Needs a try/catch since some browsers throw an error when accessing in incognito.
+  try {
+    const storageValue = localStorage.getItem(KEY);
+
+    if (storageValue) {
+      value = JSON.parse(storageValue);
+    }
+  } catch {}
+
+  if (!value) {
+    value = {
+      density: 0,
+      animations: true,
+      darkTheme: false,
+      rippleDisabled: false,
+      strongFocusEnabled: false,
+      tokensEnabled: false,
+      direction: 'ltr',
+    };
+
+    saveToStorage(value);
+  }
+
+  return value;
+}
+
+/** Saves the state of the dev app apperance in local storage. */
+export function setAppState(newState: DevAppState): void {
+  const currentState = getAppState();
+  const keys = Object.keys(currentState) as (keyof DevAppState)[];
+
+  // Only write to storage if something actually changed.
+  for (const key of keys) {
+    if (currentState[key] !== newState[key]) {
+      saveToStorage(newState);
+      break;
+    }
+  }
+}
+
+function saveToStorage(value: DevAppState): void {
+  // Needs a try/catch since some browsers throw an error when accessing in incognito.
+  try {
+    localStorage.setItem(KEY, JSON.stringify(value));
+  } catch {}
+}

--- a/src/dev-app/index.html
+++ b/src/dev-app/index.html
@@ -10,7 +10,6 @@
   <link rel="preconnect" href="https://fonts.gstatic.com">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
-  <link href="theme.css" rel="stylesheet" id="theme-styles">
 
   <!-- FontAwesome for mat-icon demo. -->
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">

--- a/src/dev-app/main.ts
+++ b/src/dev-app/main.ts
@@ -22,14 +22,23 @@ import {OverlayContainer, FullscreenOverlayContainer} from '@angular/cdk/overlay
 import {DevApp} from './dev-app';
 import {DevAppDirectionality} from './dev-app/dev-app-directionality';
 import {DevAppRippleOptions} from './dev-app/ripple-options';
-import {ANIMATIONS_STORAGE_KEY} from './dev-app/dev-app-layout';
 import {DEV_APP_ROUTES} from './routes';
+import {getAppState} from './dev-app/dev-app-state';
+
+// We need to insert this stylesheet manually since it depends on the value from the app state.
+// It uses a different file, instead of toggling a class, to avoid other styles from bleeding in.
+const cachedAppState = getAppState();
+const theme = document.createElement('link');
+theme.href = cachedAppState.tokensEnabled ? 'theme-token-api.css' : 'theme.css';
+theme.id = 'theme-styles';
+theme.rel = 'stylesheet';
+document.head.appendChild(theme);
 
 bootstrapApplication(DevApp, {
   providers: [
     importProvidersFrom(
       BrowserAnimationsModule.withConfig({
-        disableAnimations: localStorage.getItem(ANIMATIONS_STORAGE_KEY) === 'true',
+        disableAnimations: !cachedAppState.animations,
       }),
       RouterModule.forRoot(DEV_APP_ROUTES),
       HttpClientModule,


### PR DESCRIPTION
Currently we have some toggles to change the appearance of the dev app (e.g. changing the theme, updating the direction). It has a few problems:
1. We have a lot of toggles so we're starting to run out of space in the toolbar.
2. The state of some of the toggles is saved in `localStorage` while for others it isn't.
3. The code is a bit messy since we were adding these toggles ad-hoc.

These changes address the issues by:
1. Switching all the buttons to icons which take up less space.
2. Having a centralized way to save the state to `localStorage` so we don't need to do it on a case-by-case basis.
3. Cleaning up the logic a bit.

I've also added a dedicated button for toggling the tokens theming API, because currently it's done through a query parameter which isn't easy to discover.