### PR TITLE
fix(material/chips): increase specificity of chip ripple selector

### DIFF
--- a/src/material/chips/chip.scss
+++ b/src/material/chips/chip.scss
@@ -184,7 +184,7 @@
 }
 
 // The ripple container should match the bounds of the entire chip.
-.mat-mdc-chip-ripple {
+.mat-ripple.mat-mdc-chip-ripple {
   @include layout-common.fill;
 
   // Disable pointer events for the ripple container and state overlay because the container


### PR DESCRIPTION
* avoids issues where chip ripple styles are overriden by mat-ripple styles