### PR TITLE
fix(material/sort): inconsistency of text alignment in column header

### DIFF
--- a/src/material/sort/sort-header.scss
+++ b/src/material/sort/sort-header.scss
@@ -40,7 +40,6 @@ $header-arrow-hint-opacity: 0.38;
 }
 
 .mat-sort-header-content {
-  text-align: center;
   display: flex;
   align-items: center;
 }


### PR DESCRIPTION
When text breaks onto multiple lines in a mat-table column header, the `text-align:center`style
creates an inconsistency in the way the text is aligned vs other column headers. This issue
only occurs on sortable columns. It appears left aligned in all other scenarios because of how
the containers are nested.
A sample screenshot of the inconsistency:
![5nmnRg6wns2hdXf](https://github.com/angular/components/assets/3590295/29c6f9e3-ef6c-4294-aabf-aa2b7e60fa13)
Live example of the inconsistency: 
https://stackblitz.com/edit/cdpzsf?file=src%2Fexample%2Ftable-basic-example.html