### PR TITLE
fix(material/form-field): missing ellipsis for input with long text

### DIFF
--- a/src/material/form-field/form-field.scss
+++ b/src/material/form-field/form-field.scss
@@ -226,3 +226,9 @@
 .mdc-notched-outline--upgraded .mdc-floating-label--float-above {
   max-width: calc(100% * 4 / 3 + 1px);
 }
+
+.mat-mdc-form-field.mat-form-field-appearance-fill {
+  .mat-mdc-floating-label {
+    max-width: 100%;
+  }
+}


### PR DESCRIPTION
Fixes missing ellipsis for input when text is long in mat-label  

Fixes #26721