### PR TITLE
fix(cdk/listbox): prevent wrong activeItemIndex after browser tab switch

### DIFF
--- a/tools/public_api_guard/cdk/listbox.md
+++ b/tools/public_api_guard/cdk/listbox.md
@@ -12,6 +12,7 @@ import { ControlValueAccessor } from '@angular/forms';
 import { Highlightable } from '@angular/cdk/a11y';
 import * as i0 from '@angular/core';
 import { ListKeyManagerOption } from '@angular/cdk/a11y';
+import { NgZone } from '@angular/core';
 import { OnDestroy } from '@angular/core';
 import { QueryList } from '@angular/core';
 import { SelectionModel } from '@angular/cdk/collections';
@@ -19,6 +20,7 @@ import { Subject } from 'rxjs';
 
 // @public (undocumented)
 export class CdkListbox<T = unknown> implements AfterContentInit, OnDestroy, ControlValueAccessor {
+    constructor();
     protected readonly changeDetectorRef: ChangeDetectorRef;
     get compareWith(): undefined | ((o1: T, o2: T) => boolean);
     set compareWith(fn: undefined | ((o1: T, o2: T) => boolean));
@@ -53,6 +55,7 @@ export class CdkListbox<T = unknown> implements AfterContentInit, OnDestroy, Con
     ngAfterContentInit(): void;
     // (undocumented)
     ngOnDestroy(): void;
+    protected readonly ngZone: NgZone;
     protected options: QueryList<CdkOption<T>>;
     get orientation(): 'horizontal' | 'vertical';
     set orientation(value: 'horizontal' | 'vertical');


### PR DESCRIPTION
The `activeItemIndex` property of the cdk/listbox component tracks which item in the listbox is currently active or focused. However, some browsers (e.g. Chrome and Firefox) trigger the `focusout` event when the user switches tabs and returns, and set `event.relatedTarget` to null. This causes the `activeItemIndex` to be out of sync with the actual focused element, leading to incorrect behavior and user confusion. To fix this, we use `document.activeElement` as a fallback for `event.relatedTarget`, and update the `activeItemIndex` accordingly.

Fixes #27474.