### PR TITLE
fix(material/chips): remove form-field focus overlay for mat-chip-grid

### DIFF
--- a/src/material/chips/chip-grid.ts
+++ b/src/material/chips/chip-grid.ts
@@ -130,6 +130,12 @@ export class MatChipGrid
    */
   readonly controlType: string = 'mat-chip-grid';
 
+  /**
+   * Implemented as part of MatFormFieldControl.
+   * @docs-private
+   */
+  readonly shouldHaveFocusOverlay = false;
+
   /** The chip input to add more chips */
   protected _chipInput: MatChipTextControl;
 

--- a/src/material/form-field/form-field-control.ts
+++ b/src/material/form-field/form-field-control.ts
@@ -73,4 +73,10 @@ export abstract class MatFormFieldControl<T> {
 
   /** Handles a click on the control's container. */
   abstract onContainerClick(event: MouseEvent): void;
+
+  /**
+   * Whether the `MatFormField` should have a focus overlay. If property is not present on the
+   * control it is assumed to be true.
+   */
+  readonly shouldHaveFocusOverlay?: boolean;
 }

--- a/src/material/form-field/form-field.html
+++ b/src/material/form-field/form-field.html
@@ -37,7 +37,7 @@
      [class.mdc-text-field--disabled]="_control.disabled"
      [class.mdc-text-field--invalid]="_control.errorState"
      (click)="_control.onContainerClick($event)">
-  <div class="mat-mdc-form-field-focus-overlay" *ngIf="!_hasOutline() && !_control.disabled"></div>
+  <div class="mat-mdc-form-field-focus-overlay" *ngIf="_shouldHaveFocusOverlay()"></div>
   <div class="mat-mdc-form-field-flex">
     <div *ngIf="_hasOutline()" matFormFieldNotchedOutline
          [matFormFieldNotchedOutlineOpen]="_shouldLabelFloat()">

--- a/src/material/form-field/form-field.ts
+++ b/src/material/form-field/form-field.ts
@@ -503,6 +503,15 @@ export class MatFormField
     return this.appearance === 'outline';
   }
 
+  _shouldHaveFocusOverlay() {
+    // TODO(zarend): add a unit test to cover `shouldHaveFocusOverlay`.
+    if (this._control.shouldHaveFocusOverlay === false) {
+      return false;
+    }
+
+    return !this._hasOutline() && !this._control.disabled;
+  }
+
   /**
    * Whether the label should display in the infix. Labels in the outline appearance are
    * displayed as part of the notched-outline and are horizontally offset to account for

--- a/tools/public_api_guard/material/chips.md
+++ b/tools/public_api_guard/material/chips.md
@@ -213,6 +213,7 @@ export class MatChipGrid extends _MatChipGridMixinBase implements AfterContentIn
     protected _required: boolean | undefined;
     setDescribedByIds(ids: string[]): void;
     setDisabledState(isDisabled: boolean): void;
+    readonly shouldHaveFocusOverlay = false;
     get shouldLabelFloat(): boolean;
     get value(): any;
     set value(value: any);

--- a/tools/public_api_guard/material/form-field.md
+++ b/tools/public_api_guard/material/form-field.md
@@ -137,6 +137,8 @@ export class MatFormField implements FloatingLabelParent, AfterContentInit, Afte
     _shouldAlwaysFloat(): boolean;
     _shouldForward(prop: keyof AbstractControlDirective): boolean;
     // (undocumented)
+    _shouldHaveFocusOverlay(): boolean;
+    // (undocumented)
     _shouldLabelFloat(): boolean;
     _subscriptAnimationState: string;
     get subscriptSizing(): SubscriptSizing;
@@ -175,6 +177,7 @@ export abstract class MatFormFieldControl<T> {
     readonly placeholder: string;
     readonly required: boolean;
     abstract setDescribedByIds(ids: string[]): void;
+    readonly shouldHaveFocusOverlay?: boolean;
     readonly shouldLabelFloat: boolean;
     readonly stateChanges: Observable<void>;
     readonly userAriaDescribedBy?: string;


### PR DESCRIPTION
Remove the focus overlay on mat-form-field component when it's control is a mat-chip-grid. Fix accessibility issue where label has insufficient contrast when mat-chip-grid is focused (#27505).

Removing the focus overlay increases the text contrast and aligns closer to the Material Design specification.

Fix #27505