### PR TITLE
fix(material/snack-bar): prevent override of snack bar action button color

### DIFF
--- a/src/material/snack-bar/snack-bar-container.scss
+++ b/src/material/snack-bar/snack-bar-container.scss
@@ -57,14 +57,16 @@
     // The `mat-mdc-button` and `:not(:disabled)` here are redundant, but we need them to increase
     // the specificity over the button styles that may bleed in from the rest of the app.
     .mat-mdc-button.mat-mdc-snack-bar-action:not(:disabled) {
-      // MDC's `action-label-text-color` should be able to do this, but the button theme has a
-      // higher specificity so it ends up overriding it. Define our own variable that we can
-      // use to control the color instead.
-      @include token-utils.use-tokens(
-        tokens-mat-snack-bar.$prefix,
-        tokens-mat-snack-bar.get-token-slots()
-      ) {
-        @include token-utils.create-token-slot(color, button-color);
+      &.mat-unthemed {
+        // MDC's `action-label-text-color` should be able to do this, but the button theme has a
+        // higher specificity so it ends up overriding it. Define our own variable that we can
+        // use to control the color instead.
+        @include token-utils.use-tokens(
+          tokens-mat-snack-bar.$prefix,
+          tokens-mat-snack-bar.get-token-slots()
+        ) {
+          @include token-utils.create-token-slot(color, button-color);
+        }
       }
 
       // Darken the ripples in the button so they're visible against the dark background.


### PR DESCRIPTION
Prevents the color of the snack bar action button from being overridden to the accent color, when using the `matSnackBarAction` directive.

Closes #27328 