### PR TITLE
feat(material/tooltip): be able to customize the longpress delay

### DIFF
--- a/src/material/tooltip/tooltip.ts
+++ b/src/material/tooltip/tooltip.ts
@@ -128,6 +128,9 @@ export interface MatTooltipDefaultOptions {
   /** Default delay when hiding the tooltip on a touch device. */
   touchendHideDelay: number;
 
+  /** Time between the user putting the pointer on a tooltip trigger and the long press event being fired on a touch device. */
+  touchLongPressShowDelay?: number;
+
   /** Default touch gesture handling for tooltips. */
   touchGestures?: TooltipTouchGestures;
 
@@ -155,12 +158,6 @@ const PANEL_CLASS = 'tooltip-panel';
 
 /** Options used to bind passive event listeners. */
 const passiveListenerOptions = normalizePassiveListenerOptions({passive: true});
-
-/**
- * Time between the user putting the pointer on a tooltip
- * trigger and the long press event being fired.
- */
-const LONGPRESS_DELAY = 500;
 
 // These constants were taken from MDC's `numbers` object. We can't import them from MDC,
 // because they have some top-level references to `window` which break during SSR.
@@ -787,7 +784,12 @@ export class MatTooltip implements OnDestroy, AfterViewInit {
           // because it can prevent click events from firing on the element.
           this._setupPointerExitEventsIfNeeded();
           clearTimeout(this._touchstartTimeout);
-          this._touchstartTimeout = setTimeout(() => this.show(undefined, origin), LONGPRESS_DELAY);
+
+          const DEFAULT_LONGPRESS_DELAY = 500;
+          this._touchstartTimeout = setTimeout(
+            () => this.show(undefined, origin),
+            this._defaultOptions.touchLongPressShowDelay ?? DEFAULT_LONGPRESS_DELAY,
+          );
         },
       ]);
     }

--- a/tools/public_api_guard/material/tooltip.md
+++ b/tools/public_api_guard/material/tooltip.md
@@ -125,6 +125,7 @@ export interface MatTooltipDefaultOptions {
     showDelay: number;
     touchendHideDelay: number;
     touchGestures?: TooltipTouchGestures;
+    touchLongPressShowDelay?: number;
 }
 
 // @public (undocumented)


### PR DESCRIPTION
Right now it is not possible to customize the delay for the longpress on touch devices. Sometimesit might be desirable to use other value than 500ms, adding this as a `touchLongPressShowDelay` option for `MAT_TOOLTIP_DEFAULT_OPTIONS`