### PR TITLE
feat(sort): add manual sort

### DIFF
--- a/src/material/sort/sort.spec.ts
+++ b/src/material/sort/sort.spec.ts
@@ -499,6 +499,56 @@ describe('MatSort', () => {
       expect(containerA.classList.contains('mat-sort-header-position-before')).toBe(true);
       expect(containerB.classList.contains('mat-sort-header-position-before')).toBe(true);
     });
+
+    it('should correctly sort when passing same direction twice to sort method', () => {
+      const matSortWithArrowPositionFixture = TestBed.createComponent(MatSortWithArrowPosition);
+      matSortWithArrowPositionFixture.detectChanges();
+      const matSortWithArrowPositionComponent = matSortWithArrowPositionFixture.componentInstance;
+
+      matSortWithArrowPositionComponent.matSort.sort({
+        id: 'defaultA',
+        direction: 'desc',
+        disableClear: false,
+      });
+
+      matSortWithArrowPositionComponent.matSort.sort({
+        id: 'defaultA',
+        direction: 'desc',
+        disableClear: false,
+      });
+
+      expect(matSortWithArrowPositionComponent.matSort.direction).toBe('desc');
+    });
+
+    it('should correctly sort when passing going desc -> asc -> desc', () => {
+      const matSortWithArrowPositionFixture = TestBed.createComponent(MatSortWithArrowPosition);
+      matSortWithArrowPositionFixture.detectChanges();
+      const matSortWithArrowPositionComponent = matSortWithArrowPositionFixture.componentInstance;
+
+      matSortWithArrowPositionComponent.matSort.sort({
+        id: 'defaultA',
+        direction: 'desc',
+        disableClear: false,
+      });
+
+      expect(matSortWithArrowPositionComponent.matSort.direction).toBe('desc');
+
+      matSortWithArrowPositionComponent.matSort.sort({
+        id: 'defaultA',
+        direction: 'asc',
+        disableClear: false,
+      });
+
+      expect(matSortWithArrowPositionComponent.matSort.direction).toBe('asc');
+
+      matSortWithArrowPositionComponent.matSort.sort({
+        id: 'defaultA',
+        direction: 'desc',
+        disableClear: false,
+      });
+
+      expect(matSortWithArrowPositionComponent.matSort.direction).toBe('desc');
+    });
   });
 
   describe('with default options', () => {

--- a/src/material/sort/sort.ts
+++ b/src/material/sort/sort.ts
@@ -42,6 +42,17 @@ export interface MatSortable {
   /** Whether to disable clearing the sorting state. */
   disableClear: boolean;
 }
+/** Interface for user manual sort. */
+export interface MatManualSort {
+  /** The id of the column being sorted. */
+  id: string;
+
+  /** set direction to exact direction. */
+  direction: SortDirection;
+
+  /** Whether to disable clearing the sorting state. */
+  disableClear: boolean;
+}
 
 /** The current sort state. */
 export interface Sort {
@@ -166,15 +177,27 @@ export class MatSort
   }
 
   /** Sets the active sort id and determines the new sort direction. */
-  sort(sortable: MatSortable): void {
+  sort(sortable: MatSortable | MatManualSort): void {
     if (this.active != sortable.id) {
       this.active = sortable.id;
-      this.direction = sortable.start ? sortable.start : this.start;
+      if (this._isMatManualSort(sortable)) {
+        this.direction = sortable.direction;
+      } else {
+        this.direction = sortable.start ? sortable.start : this.start;
+      }
     } else {
-      this.direction = this.getNextSortDirection(sortable);
+      if (this._isMatManualSort(sortable)) {
+        this.direction = sortable.direction;
+      } else {
+        this.direction = this.getNextSortDirection(sortable);
+      }
     }
 
     this.sortChange.emit({active: this.active, direction: this.direction});
+  }
+
+  private _isMatManualSort(sortable: MatSortable | MatManualSort): sortable is MatManualSort {
+    return (sortable as MatManualSort).direction !== undefined;
   }
 
   /** Returns the next sort direction of the active sortable, checking for potential overrides. */


### PR DESCRIPTION
make the `sort` method of `MatSort` accept new interface `MatManualSort` which has the exact direction the developer wants to be it's fully compatible with the current code
use case that's currently not possible: changing currently set desc to asc using the new interface will make the sort method idempotent

Closes #27515