### PR TITLE
Expose ComponentRef to dialog components

### DIFF
--- a/src/cdk/dialog/dialog-ref.ts
+++ b/src/cdk/dialog/dialog-ref.ts
@@ -12,6 +12,7 @@ import {Observable, Subject, Subscription} from 'rxjs';
 import {DialogConfig} from './dialog-config';
 import {FocusOrigin} from '@angular/cdk/a11y';
 import {BasePortalOutlet} from '@angular/cdk/portal';
+import {ComponentRef} from '@angular/core';
 
 /** Additional options that can be passed in when closing a dialog. */
 export interface DialogCloseOptions {
@@ -28,6 +29,12 @@ export class DialogRef<R = unknown, C = unknown> {
    * null when the dialog is opened using a `TemplateRef`.
    */
   readonly componentInstance: C | null;
+
+  /**
+   * `ComponentRef` of the component opened into the dialog. Will be
+   * null when the dialog is opened using a `TemplateRef`.
+   */
+  readonly componentRef: ComponentRef<C> | null;
 
   /** Instance of the container that is rendering out the dialog content. */
   readonly containerInstance: BasePortalOutlet & {_closeInteractionType?: FocusOrigin};

--- a/src/cdk/dialog/dialog.spec.ts
+++ b/src/cdk/dialog/dialog.spec.ts
@@ -9,6 +9,7 @@ import {
 import {
   ChangeDetectionStrategy,
   Component,
+  ComponentRef,
   Directive,
   inject,
   Inject,
@@ -89,6 +90,7 @@ describe('Dialog', () => {
 
     expect(overlayContainerElement.textContent).toContain('Pizza');
     expect(dialogRef.componentInstance instanceof PizzaMsg).toBe(true);
+    expect(dialogRef.componentRef instanceof ComponentRef).toBe(true);
     expect(dialogRef.componentInstance!.dialogRef).toBe(dialogRef);
 
     viewContainerFixture.detectChanges();

--- a/src/cdk/dialog/dialog.ts
+++ b/src/cdk/dialog/dialog.ts
@@ -16,6 +16,7 @@ import {
   Inject,
   Optional,
   SkipSelf,
+  ComponentRef,
 } from '@angular/core';
 import {BasePortalOutlet, ComponentPortal, TemplatePortal} from '@angular/cdk/portal';
 import {of as observableOf, Observable, Subject, defer} from 'rxjs';
@@ -290,6 +291,7 @@ export class Dialog implements OnDestroy {
           config.componentFactoryResolver,
         ),
       );
+      (dialogRef as {componentRef: ComponentRef<C>}).componentRef = contentRef;
       (dialogRef as {componentInstance: C}).componentInstance = contentRef.instance;
     }
   }

--- a/src/material/bottom-sheet/bottom-sheet-ref.ts
+++ b/src/material/bottom-sheet/bottom-sheet-ref.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {ComponentRef} from '@angular/core';
 import {DialogRef} from '@angular/cdk/dialog';
 import {ESCAPE, hasModifierKey} from '@angular/cdk/keycodes';
 import {merge, Observable, Subject} from 'rxjs';
@@ -20,6 +21,14 @@ export class MatBottomSheetRef<T = any, R = any> {
   /** Instance of the component making up the content of the bottom sheet. */
   get instance(): T {
     return this._ref.componentInstance!;
+  }
+
+  /**
+   * `ComponentRef` of the component opened into the bottom sheet. Will be
+   * null when the bottom sheet is opened using a `TemplateRef`.
+   */
+  get componentRef(): ComponentRef<T> | null {
+    return this._ref.componentRef;
   }
 
   /**

--- a/src/material/bottom-sheet/bottom-sheet.spec.ts
+++ b/src/material/bottom-sheet/bottom-sheet.spec.ts
@@ -8,6 +8,7 @@ import {Location} from '@angular/common';
 import {SpyLocation} from '@angular/common/testing';
 import {
   Component,
+  ComponentRef,
   Directive,
   Inject,
   Injector,
@@ -83,6 +84,7 @@ describe('MatBottomSheet', () => {
 
     expect(overlayContainerElement.textContent).toContain('Pizza');
     expect(bottomSheetRef.instance instanceof PizzaMsg).toBe(true);
+    expect(bottomSheetRef.componentRef instanceof ComponentRef).toBe(true);
     expect(bottomSheetRef.instance.bottomSheetRef).toBe(bottomSheetRef);
   });
 

--- a/src/material/dialog/dialog-ref.ts
+++ b/src/material/dialog/dialog-ref.ts
@@ -15,6 +15,7 @@ import {_MatDialogContainerBase} from './dialog-container';
 import {filter, take} from 'rxjs/operators';
 import {ESCAPE, hasModifierKey} from '@angular/cdk/keycodes';
 import {GlobalPositionStrategy} from '@angular/cdk/overlay';
+import {ComponentRef} from '@angular/core';
 
 export const enum MatDialogState {
   OPEN,
@@ -28,6 +29,12 @@ export const enum MatDialogState {
 export class MatDialogRef<T, R = any> {
   /** The instance of component opened into the dialog. */
   componentInstance: T;
+
+  /**
+   * `ComponentRef` of the component opened into the dialog. Will be
+   * null when the dialog is opened using a `TemplateRef`.
+   */
+  readonly componentRef: ComponentRef<T> | null;
 
   /** Whether the user is allowed to close the dialog. */
   disableClose: boolean | undefined;

--- a/src/material/dialog/dialog.spec.ts
+++ b/src/material/dialog/dialog.spec.ts
@@ -17,6 +17,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   ComponentFactoryResolver,
+  ComponentRef,
   createNgModuleRef,
   Directive,
   Inject,
@@ -110,6 +111,7 @@ describe('MDC-based MatDialog', () => {
 
     expect(overlayContainerElement.textContent).toContain('Pizza');
     expect(dialogRef.componentInstance instanceof PizzaMsg).toBe(true);
+    expect(dialogRef.componentRef instanceof ComponentRef).toBe(true);
     expect(dialogRef.componentInstance.dialogRef).toBe(dialogRef);
 
     viewContainerFixture.detectChanges();

--- a/src/material/dialog/dialog.ts
+++ b/src/material/dialog/dialog.ts
@@ -10,6 +10,7 @@ import {ComponentType, Overlay, OverlayContainer, ScrollStrategy} from '@angular
 import {Location} from '@angular/common';
 import {
   ANIMATION_MODULE_TYPE,
+  ComponentRef,
   Inject,
   Injectable,
   InjectionToken,
@@ -197,6 +198,7 @@ export abstract class _MatDialogBase<C extends _MatDialogContainerBase> implemen
 
     // This can't be assigned in the `providers` callback, because
     // the instance hasn't been assigned to the CDK ref yet.
+    (dialogRef! as {componentRef: ComponentRef<T>}).componentRef = cdkRef.componentRef!;
     dialogRef!.componentInstance = cdkRef.componentInstance!;
 
     this.openDialogs.push(dialogRef!);

--- a/tools/public_api_guard/cdk/dialog.md
+++ b/tools/public_api_guard/cdk/dialog.md
@@ -175,6 +175,7 @@ export class DialogRef<R = unknown, C = unknown> {
     close(result?: R, options?: DialogCloseOptions): void;
     readonly closed: Observable<R | undefined>;
     readonly componentInstance: C | null;
+    readonly componentRef: ComponentRef<C> | null;
     // (undocumented)
     readonly config: DialogConfig<any, DialogRef<R, C>, BasePortalOutlet>;
     readonly containerInstance: BasePortalOutlet & {

--- a/tools/public_api_guard/material/bottom-sheet.md
+++ b/tools/public_api_guard/material/bottom-sheet.md
@@ -9,6 +9,7 @@ import { AnimationTriggerMetadata } from '@angular/animations';
 import { BreakpointObserver } from '@angular/cdk/layout';
 import { CdkDialogContainer } from '@angular/cdk/dialog';
 import { ChangeDetectorRef } from '@angular/core';
+import { ComponentRef } from '@angular/core';
 import { ComponentType } from '@angular/cdk/portal';
 import { DialogConfig } from '@angular/cdk/dialog';
 import { DialogRef } from '@angular/cdk/dialog';
@@ -117,6 +118,7 @@ export class MatBottomSheetRef<T = any, R = any> {
     afterDismissed(): Observable<R | undefined>;
     afterOpened(): Observable<void>;
     backdropClick(): Observable<MouseEvent>;
+    get componentRef(): ComponentRef<T> | null;
     containerInstance: MatBottomSheetContainer;
     disableClose: boolean | undefined;
     dismiss(result?: R): void;

--- a/tools/public_api_guard/material/dialog.md
+++ b/tools/public_api_guard/material/dialog.md
@@ -7,6 +7,7 @@
 import { AnimationTriggerMetadata } from '@angular/animations';
 import { CdkDialogContainer } from '@angular/cdk/dialog';
 import { ComponentFactoryResolver } from '@angular/core';
+import { ComponentRef } from '@angular/core';
 import { ComponentType } from '@angular/cdk/overlay';
 import { DialogRef } from '@angular/cdk/dialog';
 import { Direction } from '@angular/cdk/bidi';
@@ -250,6 +251,7 @@ export class MatDialogRef<T, R = any> {
     beforeClosed(): Observable<R | undefined>;
     close(dialogResult?: R): void;
     componentInstance: T;
+    readonly componentRef: ComponentRef<T> | null;
     // (undocumented)
     _containerInstance: _MatDialogContainerBase;
     disableClose: boolean | undefined;


### PR DESCRIPTION
Exposes then `ComponentRef` of the components rendered inside the CDK dialog, Material dialog and bottom sheet. Previously we didn't do it, because there wasn't much the user could do with the `ComponentRef`, but as of recently they're able to set the component's inputs which can be useful.

Fixes #27534.