### PR TITLE
fix(material/slider): update slider's UI with form control modification

### DIFF
--- a/src/material/slider/slider-input.ts
+++ b/src/material/slider/slider-input.ts
@@ -95,7 +95,9 @@ export class MatSliderThumb implements _MatSliderThumb, OnDestroy, ControlValueA
       this._initialValue = val;
       return;
     }
-    if (this._isActive) {
+    // The control, once initialized via setValue, necessitates a value update.
+    // The _isControlInitialized flag turns true once setValue is executed.
+    if (this._isActive && !this._isControlInitialized) {
       return;
     }
     this._hostElement.value = val;

--- a/src/material/slider/slider.spec.ts
+++ b/src/material/slider/slider.spec.ts
@@ -1357,6 +1357,23 @@ describe('MDC-based MatSlider', () => {
       expect(sliderControl.pristine).toBe(false);
       expect(sliderControl.touched).toBe(true);
     }));
+
+    it('slider responds to form control modifications', () => {
+      // Whenever the starting input is assigned the value 56, it should be adjusted to 55.
+
+      const subscription = startInput.valueChange.subscribe(() => {
+        startInput.value = 55;
+        fixture.detectChanges();
+      });
+
+      // Once the input is manipulated, it gets activated and a value update becomes necessary.
+      startInput._isActive = true;
+      startInput._hostElement.value = `56`;
+      dispatchEvent(startInput._hostElement, new Event('change'));
+
+      subscription.unsubscribe();
+      expect(startInput.value).toBe(55);
+    });
   });
 
   describe('slider with a two-way binding', () => {


### PR DESCRIPTION
This commit rectifies an issue in the setValue function of the MatSliderThumb component where the UI wasn't properly mirroring changes to the form control. The correction involves adjusting the condition for updating the host element value and invoking relevant UI update methods, which are now only bypassed if the control is active `_isActive` and not yet initialized `_isControlInitialized`.

Fixes #27208