### PR TITLE
refactor(material/form-field): switch notched outline and line ripple to tokens

### DIFF
--- a/src/material/core/tokens/m2/mdc/_filled-text-field.scss
+++ b/src/material/core/tokens/m2/mdc/_filled-text-field.scss
@@ -1,0 +1,161 @@
+@use 'sass:map';
+@use '../../../theming/theming';
+@use '../../../style/sass-utils';
+@use '../../../typography/typography-utils';
+@use '../../token-utils';
+
+// The prefix used to generate the fully qualified name for tokens in this file.
+$prefix: (mdc, filled-text-field);
+
+// Tokens that can't be configured through Angular Material's current theming API,
+// but may be in a future version of the theming API.
+//
+// Tokens that are available in MDC, but not used in Angular Material should be mapped to `null`.
+// `null` indicates that we are intentionally choosing not to emit a slot or value for the token in
+// our CSS.
+@function get-unthemable-tokens() {
+  @return (
+    active-indicator-height: 1px,
+    focus-active-indicator-height: 2px,
+
+    // TODO(crisbeto): distribute the remainder of these tokens
+    container-color: null,
+    container-height: null,
+    container-shape: null,
+    disabled-container-color: null,
+    disabled-container-opacity: null,
+    disabled-input-text-color: null,
+    disabled-input-text-opacity: null,
+    disabled-leading-icon-color: null,
+    disabled-leading-icon-opacity: null,
+    disabled-supporting-text-color: null,
+    disabled-supporting-text-opacity: null,
+    disabled-trailing-icon-color: null,
+    disabled-trailing-icon-opacity: null,
+    error-focus-input-text-color: null,
+    error-focus-leading-icon-color: null,
+    error-focus-supporting-text-color: null,
+    error-focus-trailing-icon-color: null,
+    error-hover-input-text-color: null,
+    error-hover-leading-icon-color: null,
+    error-hover-state-layer-color: null,
+    error-hover-state-layer-opacity: null,
+    error-hover-supporting-text-color: null,
+    error-hover-trailing-icon-color: null,
+    error-input-text-color: null,
+    error-leading-icon-color: null,
+    error-supporting-text-color: null,
+    error-trailing-icon-color: null,
+    focus-input-text-color: null,
+    focus-leading-icon-color: null,
+    focus-supporting-text-color: null,
+    focus-trailing-icon-color: null,
+    hover-input-text-color: null,
+    hover-leading-icon-color: null,
+    hover-state-layer-color: null,
+    hover-state-layer-opacity: null,
+    hover-supporting-text-color: null,
+    hover-trailing-icon-color: null,
+    input-text-color: null,
+    input-text-font: null,
+    input-text-line-height: null,
+    input-text-placeholder-color: null,
+    input-text-prefix-color: null,
+    input-text-size: null,
+    input-text-suffix-color: null,
+    input-text-tracking: null,
+    input-text-type: null,
+    input-text-weight: null,
+    leading-icon-color: null,
+    leading-icon-size: null,
+    supporting-text-color: null,
+    supporting-text-font: null,
+    supporting-text-line-height: null,
+    supporting-text-size: null,
+    supporting-text-tracking: null,
+    supporting-text-weight: null,
+    trailing-icon-color: null,
+    trailing-icon-size: null,
+    label-text-font: null,
+    label-text-line-height: null,
+    label-text-size: null,
+    label-text-tracking: null,
+    label-text-weight: null,
+    disabled-label-text-color: null,
+    disabled-label-text-opacity: null,
+    error-focus-label-text-color: null,
+    error-hover-label-text-color: null,
+    error-label-text-color: null,
+    focus-label-text-color: null,
+    hover-label-text-color: null,
+    label-text-populated-line-height: null,
+    label-text-populated-size: null,
+    label-text-type: null,
+    // =============================================================================================
+    // = TOKENS NOT USED IN ANGULAR MATERIAL                                                       =
+    // =============================================================================================
+    disabled-active-indicator-height: null,
+    hover-active-indicator-height: null,
+    disabled-active-indicator-opacity: null,
+    error-focus-caret-color: null,
+    error-hover-caret-color: null,
+    focus-caret-color: null,
+    hover-caret-color: null,
+  );
+}
+
+// Tokens that can be configured through Angular Material's color theming API.
+@function get-color-tokens($config) {
+  $foreground: map.get($config, foreground);
+  $warn: map.get($config, warn);
+  $is-dark: map.get($config, is-dark);
+  $warn-color: theming.get-color-from-palette($warn);
+  $color-tokens: private-get-color-palette-color-tokens($config, primary);
+
+  @return map.merge($color-tokens, (
+    label-text-color: null,
+    error-caret-color: $warn-color,
+
+    // Line ripple tokens
+    active-indicator-color: theming.get-color-from-palette($foreground, divider, 0.42),
+    disabled-active-indicator-color: theming.get-color-from-palette($foreground, divider, 0.06),
+    hover-active-indicator-color: theming.get-color-from-palette($foreground, divider, 0.87),
+    error-active-indicator-color: $warn-color,
+    error-focus-active-indicator-color: $warn-color,
+    error-hover-active-indicator-color: $warn-color,
+  ));
+}
+
+// Generates the mapping for the properties that change based on the slide toggle color.
+@function private-get-color-palette-color-tokens($config, $palette-name) {
+  $palette: map.get($config, $palette-name);
+  $palette-color: theming.get-color-from-palette($palette);
+
+  @return (
+    caret-color: $palette-color,
+    focus-active-indicator-color: $palette-color,
+  );
+}
+
+// Tokens that can be configured through Angular Material's typography theming API.
+@function get-typography-tokens($config) {
+  $fallback-font-family: typography-utils.font-family($config);
+
+  @return ();
+}
+
+// Tokens that can be configured through Angular Material's density theming API.
+@function get-density-tokens($config) {
+  @return ();
+}
+
+// Combines the tokens generated by the above functions into a single map with placeholder values.
+// This is used to create token slots.
+@function get-token-slots() {
+  @return sass-utils.deep-merge-all(
+      get-unthemable-tokens(),
+      get-color-tokens(token-utils.$placeholder-color-config),
+      get-typography-tokens(token-utils.$placeholder-typography-config),
+      get-density-tokens(token-utils.$placeholder-density-config)
+  );
+}

--- a/src/material/core/tokens/m2/mdc/_outlined-text-field.scss
+++ b/src/material/core/tokens/m2/mdc/_outlined-text-field.scss
@@ -1,0 +1,154 @@
+@use 'sass:map';
+@use '../../../theming/theming';
+@use '../../../style/sass-utils';
+@use '../../token-utils';
+
+// The prefix used to generate the fully qualified name for tokens in this file.
+$prefix: (mdc, outlined-text-field);
+
+// Tokens that can't be configured through Angular Material's current theming API,
+// but may be in a future version of the theming API.
+//
+// Tokens that are available in MDC, but not used in Angular Material should be mapped to `null`.
+// `null` indicates that we are intentionally choosing not to emit a slot or value for the token in
+// our CSS.
+@function get-unthemable-tokens() {
+  @return (
+    outline-width: 1px,
+    focus-outline-width: 2px,
+
+    // TODO(crisbeto): distribute the remainder of these tokens
+    container-height: null,
+    container-shape: null,
+    disabled-input-text-color: null,
+    disabled-input-text-opacity: null,
+    disabled-label-text-color: null,
+    disabled-label-text-opacity: null,
+    disabled-leading-icon-color: null,
+    disabled-leading-icon-opacity: null,
+    disabled-supporting-text-color: null,
+    disabled-supporting-text-opacity: null,
+    disabled-trailing-icon-color: null,
+    disabled-trailing-icon-opacity: null,
+    error-focus-input-text-color: null,
+    error-focus-label-text-color: null,
+    error-focus-leading-icon-color: null,
+    error-focus-supporting-text-color: null,
+    error-focus-trailing-icon-color: null,
+    error-hover-input-text-color: null,
+    error-hover-label-text-color: null,
+    error-hover-leading-icon-color: null,
+    error-hover-supporting-text-color: null,
+    error-hover-trailing-icon-color: null,
+    error-input-text-color: null,
+    error-label-text-color: null,
+    error-leading-icon-color: null,
+    error-supporting-text-color: null,
+    error-trailing-icon-color: null,
+    focus-input-text-color: null,
+    focus-label-text-color: null,
+    focus-leading-icon-color: null,
+    focus-supporting-text-color: null,
+    focus-trailing-icon-color: null,
+    hover-input-text-color: null,
+    hover-label-text-color: null,
+    hover-leading-icon-color: null,
+    hover-supporting-text-color: null,
+    hover-trailing-icon-color: null,
+    input-text-color: null,
+    input-text-font: null,
+    input-text-line-height: null,
+    input-text-placeholder-color: null,
+    input-text-prefix-color: null,
+    input-text-size: null,
+    input-text-suffix-color: null,
+    input-text-tracking: null,
+    input-text-type: null,
+    input-text-weight: null,
+    label-text-color: null,
+    label-text-font: null,
+    label-text-line-height: null,
+    label-text-populated-line-height: null,
+    label-text-populated-size: null,
+    label-text-size: null,
+    label-text-tracking: null,
+    label-text-type: null,
+    label-text-weight: null,
+    leading-icon-color: null,
+    leading-icon-size: null,
+    supporting-text-color: null,
+    supporting-text-font: null,
+    supporting-text-line-height: null,
+    supporting-text-size: null,
+    supporting-text-tracking: null,
+    supporting-text-type: null,
+    supporting-text-weight: null,
+    trailing-icon-color: null,
+    trailing-icon-size: null,
+
+    // =============================================================================================
+    // = TOKENS NOT USED IN ANGULAR MATERIAL                                                       =
+    // =============================================================================================
+    error-focus-caret-color: null,
+    error-hover-caret-color: null,
+    focus-caret-color: null,
+    hover-caret-color: null,
+    disabled-outline-opacity: null,
+    hover-outline-width: null,
+    disabled-outline-width: null,
+  );
+}
+
+// Tokens that can be configured through Angular Material's color theming API.
+@function get-color-tokens($config) {
+  $foreground: map.get($config, foreground);
+  $warn: map.get($config, warn);
+  $is-dark: map.get($config, is-dark);
+  $warn-color: theming.get-color-from-palette($warn);
+  $color-tokens: private-get-color-palette-color-tokens($config, primary);
+
+  @return map.merge($color-tokens, (
+    error-caret-color: $warn-color,
+
+    // Outline tokens
+    outline-color: theming.get-color-from-palette($foreground, divider, 0.38),
+    disabled-outline-color: theming.get-color-from-palette($foreground, divider, 0.06),
+    hover-outline-color: theming.get-color-from-palette($foreground, divider, 0.87),
+    error-focus-outline-color: $warn-color,
+    error-hover-outline-color: $warn-color,
+    error-outline-color: $warn-color,
+  ));
+}
+
+// Generates the mapping for the properties that change based on the slide toggle color.
+@function private-get-color-palette-color-tokens($config, $palette-name) {
+  $palette: map.get($config, $palette-name);
+  $palette-color: theming.get-color-from-palette($palette);
+
+  @return (
+    // focus-outline-color: $palette-color,
+    focus-outline-color: red,
+    caret-color: $palette-color,
+  );
+}
+
+// Tokens that can be configured through Angular Material's typography theming API.
+@function get-typography-tokens($config) {
+  @return ();
+}
+
+// Tokens that can be configured through Angular Material's density theming API.
+@function get-density-tokens($config) {
+  @return ();
+}
+
+// Combines the tokens generated by the above functions into a single map with placeholder values.
+// This is used to create token slots.
+@function get-token-slots() {
+  @return sass-utils.deep-merge-all(
+      get-unthemable-tokens(),
+      get-color-tokens(token-utils.$placeholder-color-config),
+      get-typography-tokens(token-utils.$placeholder-typography-config),
+      get-density-tokens(token-utils.$placeholder-density-config)
+  );
+}

--- a/src/material/form-field/_form-field-theme.scss
+++ b/src/material/form-field/_form-field-theme.scss
@@ -1,13 +1,16 @@
 @use '@material/textfield' as mdc-textfield;
 @use '@material/floating-label' as mdc-floating-label;
-@use '@material/notched-outline' as mdc-notched-outline;
-@use '@material/line-ripple' as mdc-line-ripple;
+@use '@material/textfield/filled-text-field-theme' as mdc-filled-text-field-theme;
+@use '@material/textfield/outlined-text-field-theme' as mdc-outlined-text-field-theme;
 @use '@material/theme/theme-color' as mdc-theme-color;
 @use '@material/typography/typography' as mdc-typography;
 
+@use '../core/tokens/m2/mdc/filled-text-field' as tokens-mdc-filled-text-field;
+@use '../core/tokens/m2/mdc/outlined-text-field' as tokens-mdc-outlined-text-field;
 @use '../core/theming/theming';
 @use '../core/typography/typography';
 @use '../core/mdc-helpers/mdc-helpers';
+@use '../core/style/sass-utils';
 @use './form-field-density';
 @use './form-field-subscript';
 @use './form-field-focus-overlay';
@@ -21,9 +24,6 @@
   $query: mdc-helpers.$mdc-theme-styles-query) {
   $orig-focused-label-color: mdc-textfield.$focused-label-color;
   mdc-textfield.$focused-label-color: rgba(mdc-theme-color.prop-value($palette-name), 0.87);
-
-  @include mdc-textfield.caret-color($palette-name, $query);
-  @include mdc-textfield.line-ripple-color($palette-name, $query);
 
   .mdc-text-field--focused {
     @include mdc-textfield.focused_($query);
@@ -42,22 +42,36 @@
 
 @mixin color($config-or-theme) {
   $config: theming.get-color-config($config-or-theme);
+
+  @include sass-utils.current-selector-or-root() {
+    @include mdc-filled-text-field-theme.theme(
+      tokens-mdc-filled-text-field.get-color-tokens($config));
+    @include mdc-outlined-text-field-theme.theme(
+      tokens-mdc-outlined-text-field.get-color-tokens($config));
+  }
+
   @include mdc-helpers.using-mdc-theme($config) {
     @include mdc-text-field-theme-variable-refresh.private-text-field-refresh-theme-variables() {
       @include mdc-textfield.without-ripple($query: mdc-helpers.$mdc-theme-styles-query);
       @include mdc-floating-label.core-styles($query: mdc-helpers.$mdc-theme-styles-query);
-      @include mdc-notched-outline.core-styles($query: mdc-helpers.$mdc-theme-styles-query);
-      @include mdc-line-ripple.core-styles($query: mdc-helpers.$mdc-theme-styles-query);
       @include form-field-subscript.private-form-field-subscript-color();
       @include form-field-focus-overlay.private-form-field-focus-overlay-color();
       @include form-field-native-select.private-form-field-native-select-color($config);
 
       .mat-mdc-form-field.mat-accent {
         @include _color-styles(secondary);
+        @include mdc-filled-text-field-theme.theme(
+          tokens-mdc-filled-text-field.private-get-color-palette-color-tokens($config, accent));
+        @include mdc-outlined-text-field-theme.theme(
+          tokens-mdc-outlined-text-field.private-get-color-palette-color-tokens($config, accent));
       }
 
       .mat-mdc-form-field.mat-warn {
         @include _color-styles(error);
+        @include mdc-filled-text-field-theme.theme(
+          tokens-mdc-filled-text-field.private-get-color-palette-color-tokens($config, warn));
+        @include mdc-outlined-text-field-theme.theme(
+          tokens-mdc-outlined-text-field.private-get-color-palette-color-tokens($config, warn));
       }
 
       // This fixes an issue where the notch appears to be thicker than the rest of the outline when
@@ -68,15 +82,16 @@
       // Note: class name is repeated to achieve sufficient specificity over the various MDC states.
       // (hover, focus, etc.)
       // TODO(mmalerba): port this fix into MDC
+      // TODO(crisbeto): move this into the structural styles
       .mat-mdc-form-field.mat-mdc-form-field.mat-mdc-form-field.mat-mdc-form-field {
-        &.mat-mdc-form-field .mdc-notched-outline__notch {
+        &.mat-mdc-form-field.mat-mdc-form-field .mdc-notched-outline__notch {
           border-left: 1px solid transparent;
         }
       }
 
       [dir='rtl'] {
         .mat-mdc-form-field.mat-mdc-form-field.mat-mdc-form-field.mat-mdc-form-field {
-          &.mat-mdc-form-field .mdc-notched-outline__notch {
+          &.mat-mdc-form-field.mat-mdc-form-field .mdc-notched-outline__notch {
             border-left: none;
             border-right: 1px solid transparent;
           }
@@ -89,11 +104,16 @@
 @mixin typography($config-or-theme) {
   $config: typography.private-typography-to-2018-config(
       theming.get-typography-config($config-or-theme));
+
+  @include sass-utils.current-selector-or-root() {
+    @include mdc-filled-text-field-theme.theme(
+      tokens-mdc-filled-text-field.get-typography-tokens($config));
+    @include mdc-outlined-text-field-theme.theme(
+      tokens-mdc-outlined-text-field.get-typography-tokens($config));
+  }
+
   @include mdc-helpers.using-mdc-typography($config) {
     @include mdc-textfield.without-ripple($query: mdc-helpers.$mdc-typography-styles-query);
-    @include mdc-floating-label.core-styles($query: mdc-helpers.$mdc-typography-styles-query);
-    @include mdc-notched-outline.core-styles($query: mdc-helpers.$mdc-typography-styles-query);
-    @include mdc-line-ripple.core-styles($query: mdc-helpers.$mdc-typography-styles-query);
     @include form-field-subscript.private-form-field-subscript-typography($config);
 
     // MDC uses `subtitle1` for the input value, placeholder and floating label. The spec
@@ -104,6 +124,7 @@
       @include mdc-typography.typography(body1, $query: mdc-helpers.$mdc-typography-styles-query);
     }
 
+    // TODO(crisbeto): we may be able to set this style with the `label-text-populated-size` token.
     // Above, we updated the floating label to use the `body1` typography level. The MDC notched
     // outline overrides this accidentally (only when the label floats) to a `rem`-based value.
     // This results in different label widths when floated/docked and ultimately breaks the notch

--- a/src/material/form-field/form-field.scss
+++ b/src/material/form-field/form-field.scss
@@ -1,9 +1,18 @@
 @use '@material/textfield' as mdc-textfield;
-@use '@material/floating-label' as mdc-floating-label;
-@use '@material/notched-outline' as mdc-notched-outline;
-@use '@material/line-ripple' as mdc-line-ripple;
+@use '@material/textfield/filled-text-field-theme' as mdc-filled-text-field-theme;
+@use '@material/textfield/outlined-text-field-theme' as mdc-outlined-text-field-theme;
+@use '@material/floating-label/floating-label' as mdc-floating-label;
+@use '@material/floating-label/floating-label-theme' as mdc-floating-label-theme;
+@use '@material/notched-outline/notched-outline' as mdc-notched-outline;
+@use '@material/notched-outline/notched-outline-theme' as mdc-notched-outline-theme;
+@use '@material/line-ripple/line-ripple' as mdc-line-ripple;
+@use '@material/line-ripple/line-ripple-theme' as mdc-line-ripple-theme;
+@use '@material/theme/custom-properties' as mdc-custom-properties;
+@use '../core/tokens/token-utils';
 @use '../core/mdc-helpers/mdc-helpers';
 @use '../core/style/vendor-prefixes';
+@use '../core/tokens/m2/mdc/filled-text-field' as tokens-mdc-filled-text-field;
+@use '../core/tokens/m2/mdc/outlined-text-field' as tokens-mdc-outlined-text-field;
 @use './form-field-sizing';
 @use './form-field-subscript';
 @use './form-field-focus-overlay';
@@ -13,16 +22,42 @@
 @use './mdc-text-field-textarea-overrides';
 @use './mdc-text-field-structure-overrides';
 
+// Includes the structural styles of the components that the form field is composed of.
+@mixin _auxiliary-structural-styles($query) {
+  // Note that while these components have token slots, they're included through the MDC text field.
+  @include mdc-floating-label.static-styles($query);
+  @include mdc-floating-label-theme.theme-styles($query);
+  @include mdc-notched-outline.static-styles($query);
+  @include mdc-notched-outline-theme.theme-styles($query);
+  @include mdc-line-ripple.static-styles($query);
+  @include mdc-line-ripple-theme.theme-styles($query);
+}
+
 // Base styles for MDC text-field, notched-outline, floating label and line-ripple.
 @include mdc-helpers.disable-mdc-fallback-declarations {
+  @include _auxiliary-structural-styles(mdc-helpers.$mdc-base-styles-without-animation-query);
   @include mdc-textfield.without-ripple(
     $query: mdc-helpers.$mdc-base-styles-without-animation-query);
-  @include mdc-floating-label.core-styles(
-    $query: mdc-helpers.$mdc-base-styles-without-animation-query);
-  @include mdc-notched-outline.core-styles(
-    $query: mdc-helpers.$mdc-base-styles-without-animation-query);
-  @include mdc-line-ripple.core-styles(
-    $query: mdc-helpers.$mdc-base-styles-without-animation-query);
+
+  @include mdc-custom-properties.configure(
+    $emit-fallback-values: false, $emit-fallback-vars: false) {
+
+    .mdc-text-field--filled {
+      @include token-utils.create-token-values(
+        tokens-mdc-filled-text-field.$prefix,
+        tokens-mdc-filled-text-field.get-unthemable-tokens());
+      @include mdc-filled-text-field-theme.theme-styles(
+        tokens-mdc-filled-text-field.get-token-slots());
+    }
+
+    .mdc-text-field--outlined {
+      @include token-utils.create-token-values(
+        tokens-mdc-outlined-text-field.$prefix,
+        tokens-mdc-outlined-text-field.get-unthemable-tokens());
+      @include mdc-outlined-text-field-theme.theme-styles(
+        tokens-mdc-outlined-text-field.get-token-slots());
+    }
+  }
 }
 
 // MDC text-field overwrites.
@@ -150,10 +185,8 @@
 // we only activate the animation styles if animations are not explicitly disabled.
 .mat-mdc-form-field:not(.mat-form-field-no-animations) {
   @include mdc-helpers.disable-mdc-fallback-declarations {
+    @include _auxiliary-structural-styles(animation);
     @include mdc-textfield.without-ripple($query: animation);
-    @include mdc-floating-label.core-styles($query: animation);
-    @include mdc-notched-outline.core-styles($query: animation);
-    @include mdc-line-ripple.core-styles($query: animation);
   }
 }
 


### PR DESCRIPTION
Sets up the token boilerplate for the form field and switches the styles associated with the notched outline and the line ripple to use the tokens API. I'll be sending out smaller PRs that switch the different parts of the form field to tokens in order to reduce the amount of breakages.