### PR TITLE
refactor(multiple): align letter spacing terminology

### DIFF
--- a/src/material/core/tokens/m2/mat/_slide-toggle.scss
+++ b/src/material/core/tokens/m2/mat/_slide-toggle.scss
@@ -29,7 +29,7 @@ $prefix: (mat, slide-toggle);
   @return (
     label-text-font: typography-utils.font-family($config),
     label-text-size: typography-utils.font-size($config, body-2),
-    label-text-letter-spacing: typography-utils.letter-spacing($config, body-2),
+    label-text-tracking: typography-utils.letter-spacing($config, body-2),
     label-text-line-height: typography-utils.line-height($config, body-2),
     label-text-weight: typography-utils.font-weight($config, body-2),
   );

--- a/src/material/core/tokens/m2/mat/_tab-header.scss
+++ b/src/material/core/tokens/m2/mat/_tab-header.scss
@@ -49,7 +49,7 @@ $prefix: (mat, tab-header);
     label-text-font:
       typography-utils.font-family($config, button) or typography-utils.font-family($config),
     label-text-size: typography-utils.font-size($config, button),
-    label-text-letter-spacing: typography-utils.letter-spacing($config, button),
+    label-text-tracking: typography-utils.letter-spacing($config, button),
     label-text-line-height: typography-utils.line-height($config, button),
     label-text-weight: typography-utils.font-weight($config, button),
   );

--- a/src/material/slide-toggle/slide-toggle.scss
+++ b/src/material/slide-toggle/slide-toggle.scss
@@ -52,7 +52,7 @@
     .mat-mdc-slide-toggle .mdc-label {
       @include token-utils.create-token-slot(font-family, label-text-font);
       @include token-utils.create-token-slot(font-size, label-text-size);
-      @include token-utils.create-token-slot(letter-spacing, label-text-letter-spacing);
+      @include token-utils.create-token-slot(letter-spacing, label-text-tracking);
       @include token-utils.create-token-slot(line-height, label-text-line-height);
       @include token-utils.create-token-slot(font-weight, label-text-weight);
     }

--- a/src/material/tabs/_tabs-common.scss
+++ b/src/material/tabs/_tabs-common.scss
@@ -66,7 +66,7 @@ $mat-tab-animation-duration: 500ms !default;
   ) {
     @include token-utils.create-token-slot(font-family, label-text-font);
     @include token-utils.create-token-slot(font-size, label-text-size);
-    @include token-utils.create-token-slot(letter-spacing, label-text-letter-spacing);
+    @include token-utils.create-token-slot(letter-spacing, label-text-tracking);
     @include token-utils.create-token-slot(line-height, label-text-line-height);
     @include token-utils.create-token-slot(font-weight, label-text-weight);
 


### PR DESCRIPTION
Renames a couple of tokens that were using "letter spacing" instead of "tracking" in order to align them with the rest of the library.