### PR TITLE
fix(material/checkbox): Move unthemable tokens to theme mixin

### DIFF
--- a/src/material/_index.scss
+++ b/src/material/_index.scss
@@ -99,7 +99,7 @@
 @forward './legacy-checkbox/checkbox-theme' as legacy-checkbox-* show
   legacy-checkbox-theme, legacy-checkbox-color, legacy-checkbox-typography;
 @forward './checkbox/checkbox-theme' as checkbox-* show checkbox-theme, checkbox-color,
-  checkbox-typography, checkbox-density;
+  checkbox-typography, checkbox-density, checkbox-base;
 @forward './legacy-chips/chips-theme' as legacy-chips-* show legacy-chips-theme,
   legacy-chips-color, legacy-chips-typography;
 @forward './chips/chips-theme' as chips-* show chips-theme, chips-color, chips-typography,

--- a/src/material/checkbox/_checkbox-theme.scss
+++ b/src/material/checkbox/_checkbox-theme.scss
@@ -7,6 +7,13 @@
 @use '../core/mdc-helpers/mdc-helpers';
 @use '../core/tokens/m2/mdc/checkbox' as tokens-mdc-checkbox;
 
+@mixin base($config-or-theme) {
+  // Add default values for tokens not related to color, typography, or density.
+  @include sass-utils.current-selector-or-root() {
+    @include mdc-checkbox-theme.theme(tokens-mdc-checkbox.get-unthemable-tokens());
+  }
+}
+
 @mixin color($config-or-theme) {
   $config: theming.get-color-config($config-or-theme);
   $primary: map.get($config, primary);
@@ -77,6 +84,7 @@
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);
 
+    @include base($theme);
     @if $color != null {
       @include color($color);
     }

--- a/src/material/checkbox/checkbox.scss
+++ b/src/material/checkbox/checkbox.scss
@@ -141,11 +141,6 @@
       }
     }
   }
-
-  html {
-    // Add default values for MDC checkbox tokens that aren't outputted by the theming API.
-    @include mdc-checkbox-theme.theme(tokens-mdc-checkbox.get-unthemable-tokens());
-  }
 }
 
 .mat-mdc-checkbox {


### PR DESCRIPTION
Though these tokens are not currently affected by the theme, in the future they will be affected by the design system used for theming (M2 or M3)

BREAKING CHANGE:
There are new styles emitted by `mat.checkbox-theme` that are not
emitted by any of: `mat.checkbox-color`, `mat.checkbox-typography`,
`mat.checkbox-density`. If you rely on the partial mixins only and don't
call `mat.checkbox-theme`, you can add `mat.checkbox-base` to get the
missing styles.