### PR TITLE
fix(material/progress-bar): Move unthemable tokens to theme mixin

### DIFF
--- a/src/material/_index.scss
+++ b/src/material/_index.scss
@@ -139,7 +139,8 @@
 @forward './legacy-progress-bar/progress-bar-theme' as legacy-progress-bar-* show
   legacy-progress-bar-theme, legacy-progress-bar-color, legacy-progress-bar-typography;
 @forward './progress-bar/progress-bar-theme' as progress-bar-* show
-  progress-bar-theme, progress-bar-color, progress-bar-typography, progress-bar-density;
+  progress-bar-theme, progress-bar-color, progress-bar-typography,
+  progress-bar-density, progress-bar-base;
 @forward './progress-spinner/progress-spinner-theme' as progress-spinner-* show
   progress-spinner-theme, progress-spinner-color, progress-spinner-typography,
   progress-spinner-density;

--- a/src/material/progress-bar/_progress-bar-theme.scss
+++ b/src/material/progress-bar/_progress-bar-theme.scss
@@ -1,7 +1,15 @@
+@use '../core/style/sass-utils';
 @use '../core/theming/theming';
 @use '../core/tokens/m2/mdc/linear-progress' as tokens-mdc-linear-progress;
 @use '@material/linear-progress/linear-progress-theme' as mdc-linear-progress-theme;
 @use 'sass:map';
+
+@mixin base($config-or-theme) {
+  // Add default values for tokens not related to color, typography, or density.
+  @include sass-utils.current-selector-or-root() {
+    @include mdc-linear-progress-theme.theme(tokens-mdc-linear-progress.get-unthemable-tokens());
+  }
+}
 
 @mixin _palette-styles($config, $palette-name) {
   $palette-config: map.merge($config, (primary: map.get($config, $palette-name)));
@@ -49,6 +57,7 @@
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);
 
+    @include base($theme);
     @if $color != null {
       @include color($color);
     }

--- a/src/material/progress-bar/progress-bar.scss
+++ b/src/material/progress-bar/progress-bar.scss
@@ -17,12 +17,6 @@
       track-color: null,
     ))
   );
-
-  // Add default values for tokens that aren't outputted by the theming API.
-  .mat-mdc-progress-bar {
-    // Add default values for tokens that aren't outputted by the theming API.
-    @include mdc-linear-progress-theme.theme(m2-mdc-linear-progress.get-unthemable-tokens());
-  }
 }
 
 .mat-mdc-progress-bar {


### PR DESCRIPTION
Though these tokens are not currently affected by the theme, in the future they will be affected by the design system used for theming (M2 or M3)

BREAKING CHANGE:
There are new styles emitted by mat.progress-bar-theme that are not
emitted by any of: mat.progress-bar-color, mat.progress-bar-typography,
mat.progress-bar-density. If you rely on the partial mixins only and don't
call mat.progress-bar-theme, you can add mat.progress-bar-base to get the
missing styles.