### PR TITLE
fix(material/progress-spinner): Move unthemable tokens to theme mixin

### DIFF
--- a/src/material/_index.scss
+++ b/src/material/_index.scss
@@ -142,7 +142,7 @@
   progress-bar-theme, progress-bar-color, progress-bar-typography, progress-bar-density;
 @forward './progress-spinner/progress-spinner-theme' as progress-spinner-* show
   progress-spinner-theme, progress-spinner-color, progress-spinner-typography,
-  progress-spinner-density;
+  progress-spinner-density, progress-spinner-base;
 @forward './legacy-progress-spinner/progress-spinner-theme' as legacy-progress-spinner-* show
   legacy-progress-spinner-theme, legacy-progress-spinner-color, legacy-progress-spinner-typography;
 @forward './radio/radio-theme' as radio-* show radio-theme, radio-color, radio-typography,

--- a/src/material/progress-spinner/_progress-spinner-theme.scss
+++ b/src/material/progress-spinner/_progress-spinner-theme.scss
@@ -1,7 +1,17 @@
 @use 'sass:map';
+@use '../core/style/sass-utils';
 @use '../core/theming/theming';
 @use '../core/tokens/m2/mdc/circular-progress' as tokens-mdc-circular-progress;
 @use '@material/circular-progress/circular-progress-theme' as mdc-circular-progress-theme;
+
+@mixin base($config-or-theme) {
+  // Add default values for tokens not related to color, typography, or density.
+  @include sass-utils.current-selector-or-root() {
+    @include mdc-circular-progress-theme.theme(
+      tokens-mdc-circular-progress.get-unthemable-tokens()
+    );
+  }
+}
 
 @mixin color($config-or-theme) {
   $config: theming.get-color-config($config-or-theme);
@@ -33,6 +43,7 @@
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);
 
+    @include base($theme);
     @if $color != null {
       @include color($color);
     }

--- a/src/material/progress-spinner/progress-spinner.scss
+++ b/src/material/progress-spinner/progress-spinner.scss
@@ -14,9 +14,6 @@
   .mat-mdc-progress-spinner {
     // Add the official slots for the MDC circular progress.
     @include mdc-circular-progress-theme.theme-styles($mdc-circular-progress-token-slots);
-
-    // Add default values for tokens that aren't outputted by the theming API.
-    @include mdc-circular-progress-theme.theme(m2-mdc-circular-progress.get-unthemable-tokens());
   }
 }
 


### PR DESCRIPTION
Though these tokens are not currently affected by the theme, in the future they will be affected by the design system used for theming (M2 or M3)

BREAKING CHANGE:
There are new styles emitted by mat.progress-spinner-theme that are not
emitted by any of: mat.progress-spinner-color, mat.progress-spinner-typography,
mat.progress-spinner-density. If you rely on the partial mixins only and don't
call mat.progress-spinner-theme, you can add mat.progress-spinner-base to get the
missing styles.