### PR TITLE
fix(material/card): Move unthemable tokens to theme mixin

### DIFF
--- a/src/material/_index.scss
+++ b/src/material/_index.scss
@@ -93,7 +93,8 @@
   icon-button-typography, icon-button-density, icon-button-theme;
 @forward './button-toggle/button-toggle-theme' as button-toggle-* show button-toggle-theme,
   button-toggle-color, button-toggle-typography, button-toggle-density;
-@forward './card/card-theme' as card-* show card-theme, card-color, card-typography, card-density;
+@forward './card/card-theme' as card-* show card-theme, card-color, card-typography, card-density,
+  card-base;
 @forward './legacy-card/card-theme' as legacy-card-* show legacy-card-theme, legacy-card-color,
   legacy-card-typography;
 @forward './legacy-checkbox/checkbox-theme' as legacy-checkbox-* show

--- a/src/material/card/_card-theme.scss
+++ b/src/material/card/_card-theme.scss
@@ -8,6 +8,15 @@
 @use '@material/card/elevated-card-theme' as mdc-elevated-card-theme;
 @use '@material/card/outlined-card-theme' as mdc-outlined-card-theme;
 
+@mixin base($config-or-theme) {
+  .mat-mdc-card {
+    @include mdc-elevated-card-theme.theme(tokens-mdc-elevated-card.get-unthemable-tokens());
+    @include mdc-outlined-card-theme.theme(tokens-mdc-outlined-card.get-unthemable-tokens());
+    @include token-utils.create-token-values(
+        tokens-mat-card.$prefix, tokens-mat-card.get-unthemable-tokens());
+  }
+}
+
 @mixin color($config-or-theme) {
   $config: theming.get-color-config($config-or-theme);
   $mdc-elevated-card-color-tokens: token-utils.resolve-elevation(
@@ -66,6 +75,7 @@
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);
 
+    @include base($theme);
     @if $color != null {
       @include color($color);
     }

--- a/src/material/card/card.scss
+++ b/src/material/card/card.scss
@@ -30,12 +30,6 @@
         tokens-mdc-elevated-card.$prefix, $mdc-elevated-card-token-slots) {
       @include token-utils.create-token-slot(box-shadow, container-elevation);
     }
-
-    // Add default values for MDC card tokens that aren't outputted by the theming API.
-    @include mdc-elevated-card-theme.theme(tokens-mdc-elevated-card.get-unthemable-tokens());
-    @include mdc-outlined-card-theme.theme(tokens-mdc-outlined-card.get-unthemable-tokens());
-    @include token-utils.create-token-values(
-            tokens-mat-card.$prefix, tokens-mat-card.get-unthemable-tokens());
   }
 
   .mat-mdc-card-outlined {


### PR DESCRIPTION
Though these tokens are not currently affected by the theme, in the future they will be affected by the design system used for theming (M2 or M3)

BREAKING CHANGE:
There are new styles emitted by `mat.card-theme` that are not emitted by any of: `mat.card-color`, `mat.card-typography`, `mat.card-density`. If you rely on the partial mixins only and don't call `mat.card-theme`, you can add `mat.card-base` to get the missing styles.