### PR TITLE
docs(material/slider): slider docs update for page-up and page-down keyboard interactions

### DIFF
--- a/src/material/slider/slider.md
+++ b/src/material/slider/slider.md
@@ -66,8 +66,8 @@ The slider has the following keyboard bindings:
 | Up arrow    | Increment the slider value by one step.                                            |
 | Left arrow  | Decrement the slider value by one step (increments in RTL).                        |
 | Down arrow  | Decrement the slider value by one step.                                            |
-| Page up     | Increment the slider value by 10 steps.                                            |
-| Page down   | Decrement the slider value by 10 steps.                                            |
+| Page up     | Increment the slider value by 10% of the range.                                    |
+| Page down   | Decrement the slider value by 10% of the range.                                    |
 | End         | Set the value to the maximum possible.                                             |
 | Home        | Set the value to the minimum possible.                                             |
 


### PR DESCRIPTION
docs(material/slider): slider docs update for page-up and page-down keyboard interactions

Fixes wrong documentation for Angular Material `slider` component where page-up and page-down keyboard interactions were listed wrong values as 10 steps instead of 10% of the available slider range.

Fixes #27402