### PR TITLE
fix(material/slider): Move unthemable tokens to theme mixin

### DIFF
--- a/src/material/_index.scss
+++ b/src/material/_index.scss
@@ -163,7 +163,7 @@
 @forward './legacy-slider/slider-theme' as legacy-slider-* show legacy-slider-theme,
   legacy-slider-color, legacy-slider-typography;
 @forward './slider/slider-theme' as slider-* show slider-theme, slider-color, slider-typography,
-  slider-density;
+  slider-density, slider-base;
 @forward './snack-bar/snack-bar-theme' as snack-bar-* show snack-bar-theme, snack-bar-color,
   snack-bar-typography, snack-bar-density;
 @forward './legacy-snack-bar/snack-bar-theme' as legacy-snack-bar-* show legacy-snack-bar-theme,

--- a/src/material/slider/_slider-theme.scss
+++ b/src/material/slider/_slider-theme.scss
@@ -3,9 +3,17 @@
 @use '@material/slider/slider-theme' as mdc-slider-theme;
 @use '../core/theming/theming';
 @use '../core/typography/typography';
+@use '../core/style/sass-utils';
 @use '../core/tokens/token-utils';
 @use '../core/tokens/m2/mat/slider' as m2-mat-slider;
 @use '../core/tokens/m2/mdc/slider' as m2-mdc-slider;
+
+@mixin base($config-or-theme) {
+  // Add default values for tokens not related to color, typography, or density.
+  @include sass-utils.current-selector-or-root() {
+    @include mdc-slider-theme.theme(m2-mdc-slider.get-unthemable-tokens());
+  }
+}
 
 @mixin color($config-or-theme) {
   $config: theming.get-color-config($config-or-theme);
@@ -74,6 +82,7 @@
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);
 
+    @include base($theme);
     @if $color != null {
       @include color($color);
     }

--- a/src/material/slider/slider.scss
+++ b/src/material/slider/slider.scss
@@ -32,9 +32,6 @@ $mat-slider-horizontal-margin: 8px !default;
       }
     }
 
-    // Add default values for MDC slider tokens that aren't outputted by the theming API.
-    @include mdc-slider-theme.theme(m2-mdc-slider.get-unthemable-tokens());
-
     display: inline-block;
     box-sizing: border-box;
     outline: none;


### PR DESCRIPTION
Though these tokens are not currently affected by the theme, in the future they will be affected by the design system used for theming (M2 or M3)

BREAKING CHANGE:
There are new styles emitted by `mat.slider-theme` that are not emitted by any of: `mat.slider-color`, `mat.slider-typography`, `mat.slider-density`. If you rely on the partial mixins only and don't call `mat.slider-theme`, you can add `mat.slider-base` to get the missing styles.