### PR TITLE
fix(material/snack-bar): Move unthemable tokens to theme mixin

### DIFF
--- a/src/material/_index.scss
+++ b/src/material/_index.scss
@@ -122,7 +122,7 @@
 @forward './slider/slider-theme' as slider-* show slider-theme, slider-color, slider-typography,
   slider-density, slider-base;
 @forward './snack-bar/snack-bar-theme' as snack-bar-* show snack-bar-theme, snack-bar-color,
-  snack-bar-typography, snack-bar-density;
+  snack-bar-typography, snack-bar-density, snack-bar-base;
 @forward './sort/sort-theme' as sort-* show sort-theme, sort-color, sort-typography, sort-density;
 @forward './stepper/stepper-theme' as stepper-* show stepper-theme, stepper-color,
   stepper-typography, stepper-density;

--- a/src/material/snack-bar/_snack-bar-theme.scss
+++ b/src/material/snack-bar/_snack-bar-theme.scss
@@ -1,10 +1,17 @@
 @use '@material/snackbar/snackbar-theme' as mdc-snackbar-theme;
 @use '../core/theming/theming';
+@use '../core/style/sass-utils';
 @use '../core/typography/typography';
 @use '../core/tokens/token-utils';
 @use '../core/tokens/m2/mdc/snack-bar' as tokens-mdc-snack-bar;
 @use '../core/tokens/m2/mat/snack-bar' as tokens-mat-snack-bar;
 
+@mixin base($config-or-theme) {
+    // Add default values for tokens not related to color, typography, or density.
+  @include sass-utils.current-selector-or-root() {
+    @include mdc-snackbar-theme.theme(tokens-mdc-snack-bar.get-unthemable-tokens());
+  }
+}
 
 @mixin color($config-or-theme) {
   $config: theming.get-color-config($config-or-theme);
@@ -36,6 +43,7 @@
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);
 
+    @include base($theme);
     @if $color != null {
       @include color($color);
     }

--- a/src/material/snack-bar/snack-bar-container.scss
+++ b/src/material/snack-bar/snack-bar-container.scss
@@ -47,7 +47,6 @@
     // surface element.
     @include mdc-snackbar-theme.elevation(mdc-snackbar-theme.$elevation);
     @include mdc-snackbar-theme.theme-styles(tokens-mdc-snack-bar.get-token-slots());
-    @include mdc-snackbar-theme.theme(tokens-mdc-snack-bar.get-unthemable-tokens());
 
     // MDC sets the position as fixed and sets the container on the bottom center of the page (or
     // otherwise can be set to be "leading"). Our overlay handles a more advanced configuration


### PR DESCRIPTION
Though these tokens are not currently affected by the theme, in the future they will be affected by the design system used for theming (M2 or M3)

BREAKING CHANGE:
There are new styles emitted by `mat.snack-bar-theme` that are not emitted by any of: `mat.snack-bar-color`, `mat.snack-bar-typography`, `mat.snack-bar-density`. If you rely on the partial mixins only and don't call `mat.snack-bar-theme`, you can add `mat.snack-bar-base` to get the missing styles.