### PR TITLE
fix(material/dialog): Move unthemable tokens to theme mixin

### DIFF
--- a/src/material/_index.scss
+++ b/src/material/_index.scss
@@ -111,7 +111,7 @@
 @forward './legacy-dialog/dialog-theme' as legacy-dialog-* show legacy-dialog-theme,
   legacy-dialog-color, legacy-dialog-typography;
 @forward './dialog/dialog-theme' as dialog-* show dialog-theme, dialog-color, dialog-typography,
-  dialog-density;
+  dialog-density, dialog-base;
 @forward './dialog/dialog-legacy-padding' as dialog-* show dialog-legacy-padding;
 @forward './divider/divider-theme' as divider-* show divider-theme, divider-color,
   divider-typography, divider-density;

--- a/src/material/dialog/_dialog-theme.scss
+++ b/src/material/dialog/_dialog-theme.scss
@@ -1,7 +1,16 @@
 @use '@material/dialog/dialog-theme' as mdc-dialog-theme;
+@use '../core/style/sass-utils';
 @use '../core/tokens/m2/mdc/dialog' as tokens-mdc-dialog;
 @use '../core/theming/theming';
 @use '../core/typography/typography';
+
+
+@mixin base($config-or-theme) {
+  // Add default values for tokens not related to color, typography, or density.
+  @include sass-utils.current-selector-or-root() {
+    @include mdc-dialog-theme.theme(tokens-mdc-dialog.get-unthemable-tokens());
+  }
+}
 
 @mixin color($config-or-theme) {
   $config: theming.get-color-config($config-or-theme);
@@ -31,6 +40,7 @@
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);
 
+    @include base($theme);
     @if $color != null {
       @include color($color);
     }

--- a/src/material/dialog/dialog.scss
+++ b/src/material/dialog/dialog.scss
@@ -20,9 +20,6 @@ $mat-dialog-button-horizontal-margin: 8px !default;
     $mat-dialog-content-max-height);
 
   .mat-mdc-dialog-container {
-    // Add default values for MDC dialog tokens that aren't outputted by the theming API.
-    @include mdc-dialog-theme.theme(tokens-mdc-dialog.get-unthemable-tokens());
-
     // Apply the theming slots to the container using an initial set of
     // values that will be overridden in the theme styles.
     @include mdc-dialog-theme.theme-styles(tokens-mdc-dialog.get-token-slots());


### PR DESCRIPTION
Though these tokens are not currently affected by the theme, in the future they will be affected by the design system used for theming (M2 or M3)

BREAKING CHANGE:
There are new styles emitted by `mat.dialog-theme` that are not emitted by any of: `mat.dialog-color`, `mat.dialog-typography`, `mat.dialog-density`. If you rely on the partial mixins only and don't call `mat.dialog-theme`, you can add `mat.dialog-base` to get the missing styles.