### PR TITLE
fix(material/list): validation using wrong variable

### DIFF
--- a/src/components-examples/material/datepicker/datepicker-locale/datepicker-locale-example.ts
+++ b/src/components-examples/material/datepicker/datepicker-locale/datepicker-locale-example.ts
@@ -6,12 +6,11 @@ import {
 } from '@angular/material-moment-adapter';
 import {DateAdapter, MAT_DATE_FORMATS, MAT_DATE_LOCALE} from '@angular/material/core';
 import {MatButtonModule} from '@angular/material/button';
-import {MatDatepickerModule} from '@angular/material/datepicker';
+import {MatDatepickerModule, MatDatepickerIntl} from '@angular/material/datepicker';
 import {MatInputModule} from '@angular/material/input';
 import {MatFormFieldModule} from '@angular/material/form-field';
 import 'moment/locale/ja';
 import 'moment/locale/fr';
-import {MatDatepickerIntl} from '@angular/material/datepicker';
 
 /** @title Datepicker with different locale */
 @Component({

--- a/src/material/list/list-base.ts
+++ b/src/material/list/list-base.ts
@@ -326,13 +326,13 @@ export abstract class MatListItemBase implements AfterViewInit, OnDestroy, Rippl
  */
 function sanityCheckListItemContent(item: MatListItemBase) {
   const numTitles = item._titles!.length;
-  const numLines = item._titles!.length;
+  const numLines = item._lines!.length;
 
   if (numTitles > 1) {
-    throw Error('A list item cannot have multiple titles.');
+    console.warn('A list item cannot have multiple titles.');
   }
   if (numTitles === 0 && numLines > 0) {
-    throw Error('A list item line can only be used if there is a list item title.');
+    console.warn('A list item line can only be used if there is a list item title.');
   }
   if (
     numTitles === 0 &&
@@ -340,9 +340,9 @@ function sanityCheckListItemContent(item: MatListItemBase) {
     item._explicitLines !== null &&
     item._explicitLines > 1
   ) {
-    throw Error('A list item cannot have wrapping content without a title.');
+    console.warn('A list item cannot have wrapping content without a title.');
   }
   if (numLines > 2 || (numLines === 2 && item._hasUnscopedTextContent)) {
-    throw Error('A list item can have at maximum three lines.');
+    console.warn('A list item can have at maximum three lines.');
   }
 }

--- a/src/material/list/list.spec.ts
+++ b/src/material/list/list.spec.ts
@@ -17,7 +17,6 @@ describe('MDC-based MatList', () => {
         ListWithItemWithCssClass,
         ListWithDynamicNumberOfLines,
         ListWithMultipleItems,
-        ListWithManyLines,
         NavListWithOneAnchorItem,
         NavListWithActivatedItem,
         ActionListWithoutType,
@@ -69,7 +68,7 @@ describe('MDC-based MatList', () => {
   });
 
   it('should have a strong focus indicator configured for all list-items', () => {
-    const fixture = TestBed.createComponent(ListWithManyLines);
+    const fixture = TestBed.createComponent(ListWithThreeLineItem);
     fixture.detectChanges();
     const listItems = fixture.debugElement.children[0]
       .queryAll(By.css('mat-list-item'))
@@ -554,21 +553,6 @@ class ListWithTwoLineItem extends BaseTestList {}
   </mat-list>`,
 })
 class ListWithThreeLineItem extends BaseTestList {}
-
-@Component({
-  template: `
-  <mat-list>
-    @for (item of items; track item) {
-      <mat-list-item>
-        <h3 matListItemTitle>Line 1</h3>
-        <p matListItemLine>Line 2</p>
-        <p matListItemLine>Line 3</p>
-        <p matListItemLine>Line 4</p>
-      </mat-list-item>
-    }
-  </mat-list>`,
-})
-class ListWithManyLines extends BaseTestList {}
 
 @Component({
   template: `


### PR DESCRIPTION
Fixes that the list was using the wrong variable to verify that it has the correct number of lines.

Fixes #27582.