### PR TITLE
docs: use correct syntax for getting color from palette

### DIFF
--- a/guides/theming.md
+++ b/guides/theming.md
@@ -363,7 +363,7 @@ hue's number identifier with `-contrast`.
 $my-palette: mat.define-palette(mat.$indigo-palette);
 
 .my-custom-style {
- background: mat.get-color-from-palette($my-palette, '500');
+ background: mat.get-color-from-palette($my-palette, 500);
  color: mat.get-color-from-palette($my-palette, '500-contrast');
 }
 ```


### PR DESCRIPTION
Currently the Theming guide contains code which is supposed to get a color from a palette, that doesn't work due to usage of quotes. This PR fixes it. I also checked the following line, for `500-contrast` both quoted and unquoted syntax work, so nothing needs to be changed there.

Closes #27630