### PR TITLE
fix(material/datepicker): add hideHeader

### DIFF
--- a/src/material/datepicker/calendar.html
+++ b/src/material/datepicker/calendar.html
@@ -1,4 +1,4 @@
-<ng-template [cdkPortalOutlet]="_calendarHeaderPortal"></ng-template>
+<ng-template *ngIf="!hideHeader" [cdkPortalOutlet]="_calendarHeaderPortal"></ng-template>
 
 <div class="mat-calendar-content" [ngSwitch]="currentView" cdkMonitorSubtreeFocus tabindex="-1">
   <mat-month-view
@@ -17,6 +17,7 @@
       (dragStarted)="_dragStarted($event)"
       (dragEnded)="_dragEnded($event)"
       [activeDrag]="_activeDrag"
+      [hideHeader]="hideHeader"
       >
   </mat-month-view>
 

--- a/src/material/datepicker/calendar.scss
+++ b/src/material/datepicker/calendar.scss
@@ -139,6 +139,17 @@ $_tokens: tokens-mat-datepicker.$prefix, tokens-mat-datepicker.get-token-slots()
   }
 }
 
+.mat-calendar-table-no-header th {
+  text-align: center;
+  padding: $calendar-padding 0 $calendar-padding 0;
+
+  @include token-utils.use-tokens($_tokens...) {
+    @include token-utils.create-token-slot(color, calendar-header-text-color);
+    @include token-utils.create-token-slot(font-size, calendar-header-text-size);
+    @include token-utils.create-token-slot(font-weight, calendar-header-text-weight);
+  }
+}
+
 .mat-calendar-table-header-divider {
   position: relative;
   height: $calendar-header-divider-width;

--- a/src/material/datepicker/calendar.ts
+++ b/src/material/datepicker/calendar.ts
@@ -316,6 +316,9 @@ export class MatCalendar<D> implements AfterContentInit, AfterViewChecked, OnDes
   /** ARIA Accessible name of the `<input matEndDate/>` */
   @Input() endDateAccessibleName: string | null;
 
+  /** Whether the header in calendar should be rendered.  */
+  @Input() hideHeader: boolean = false;
+
   /** Emits when the currently selected date changes. */
   @Output() readonly selectedChange: EventEmitter<D | null> = new EventEmitter<D | null>();
 

--- a/src/material/datepicker/datepicker-base.ts
+++ b/src/material/datepicker/datepicker-base.ts
@@ -333,10 +333,11 @@ export interface MatDatepickerPanel<
 /** Base class for a datepicker. */
 @Directive()
 export abstract class MatDatepickerBase<
-  C extends MatDatepickerControl<D>,
-  S,
-  D = ExtractDateTypeFromSelection<S>,
-> implements MatDatepickerPanel<C, S, D>, OnDestroy, OnChanges
+    C extends MatDatepickerControl<D>,
+    S,
+    D = ExtractDateTypeFromSelection<S>,
+  >
+  implements MatDatepickerPanel<C, S, D>, OnDestroy, OnChanges
 {
   private _scrollStrategy: () => ScrollStrategy;
   private _inputStateChanges = Subscription.EMPTY;
@@ -423,6 +424,18 @@ export abstract class MatDatepickerBase<
     this._restoreFocus = coerceBooleanProperty(value);
   }
   private _restoreFocus = true;
+
+  /**
+   * Whether the header should be rendered.
+   */
+  @Input()
+  get hideHeader(): boolean {
+    return this._hideHeader;
+  }
+  set hideHeader(value: BooleanInput) {
+    this._hideHeader = coerceBooleanProperty(value);
+  }
+  private _hideHeader = false;
 
   /**
    * Emits selected year in multiyear view.

--- a/src/material/datepicker/datepicker-content.html
+++ b/src/material/datepicker/datepicker-content.html
@@ -5,6 +5,7 @@
   [attr.aria-labelledby]="_dialogLabelId ?? undefined"
   class="mat-datepicker-content-container"
   [class.mat-datepicker-content-container-with-custom-header]="datepicker.calendarHeaderComponent"
+  [class.mat-datepicker-content-container-with-no-header]="datepicker.hideHeader"
   [class.mat-datepicker-content-container-with-actions]="_actionsPortal">
   <mat-calendar
     [id]="datepicker.id"
@@ -22,6 +23,7 @@
     [@fadeInCalendar]="'enter'"
     [startDateAccessibleName]="startDateAccessibleName"
     [endDateAccessibleName]="endDateAccessibleName"
+    [hideHeader]="datepicker.hideHeader"
     (yearSelected)="datepicker._selectYear($event)"
     (monthSelected)="datepicker._selectMonth($event)"
     (viewChanged)="datepicker._viewChanged($event)"

--- a/src/material/datepicker/datepicker-content.scss
+++ b/src/material/datepicker/datepicker-content.scss
@@ -49,6 +49,14 @@ $touch-max-height: 788px;
     height: auto;
   }
 
+
+  // Height should be auto, when theres no header for calendar,
+  // if we don't set it to auto, it will render the hardcoded height
+  // for non-touch showing some extra space at the end of calendar.
+  .mat-datepicker-content-container-with-no-header .mat-calendar {
+    height: auto;
+  }
+
   // Note that this selector doesn't technically have to be nested, but we want the slightly
   // higher specificity, or it can be overridden based on the CSS insertion order (see #21043).
   .mat-datepicker-close-button {

--- a/src/material/datepicker/datepicker.spec.ts
+++ b/src/material/datepicker/datepicker.spec.ts
@@ -2465,6 +2465,37 @@ describe('MatDatepicker', () => {
       expect(actualClasses.contains('bar')).toBe(true);
     }));
   });
+
+  describe('datepicker with toggleable header', () => {
+    let fixture: ComponentFixture<DatepickerWithNoHeader>;
+    let testComponent: DatepickerWithNoHeader;
+
+    beforeEach(fakeAsync(() => {
+      fixture = createComponent(DatepickerWithNoHeader, [MatNativeDateModule]);
+      fixture.detectChanges();
+      testComponent = fixture.componentInstance;
+    }));
+
+    it('should find the header element', fakeAsync(() => {
+      testComponent.datepicker.open();
+      fixture.detectChanges();
+      tick();
+
+      expect(document.querySelector('.mat-calendar-header')).toBeTruthy();
+    }));
+
+    it('should not find the header element', fakeAsync(() => {
+      fixture.componentInstance.hide = true;
+      fixture.detectChanges();
+      tick();
+
+      testComponent.datepicker.open();
+      fixture.detectChanges();
+      tick();
+
+      expect(document.querySelector('.mat-calendar-header')).toBeFalsy();
+    }));
+  });
 });
 
 /**
@@ -2833,4 +2864,15 @@ class PanelClassDatepicker {
   date = new Date(0);
   panelClass: any;
   @ViewChild('d') datepicker: MatDatepicker<Date>;
+}
+
+@Component({
+  template: `
+  <input [matDatepicker]="dp"/>
+  <mat-datepicker #dp [hideHeader]="hide"></mat-datepicker>
+  `,
+})
+class DatepickerWithNoHeader {
+  @ViewChild('dp') datepicker: MatDatepicker<Date>;
+  hide: boolean = false;
 }

--- a/src/material/datepicker/month-view.html
+++ b/src/material/datepicker/month-view.html
@@ -1,5 +1,5 @@
 <table class="mat-calendar-table" role="grid">
-  <thead class="mat-calendar-table-header">
+  <thead [class.mat-calendar-table-header]="!hideHeader" [class.mat-calendar-table-no-header]="hideHeader">
     <tr>
       <th scope="col" *ngFor="let day of _weekdays">
         <span class="cdk-visually-hidden">{{day.long}}</span>

--- a/src/material/datepicker/month-view.ts
+++ b/src/material/datepicker/month-view.ts
@@ -148,6 +148,11 @@ export class MatMonthView<D> implements AfterContentInit, OnChanges, OnDestroy {
   /** Origin of active drag, or null when dragging is not active. */
   @Input() activeDrag: MatCalendarUserEvent<D> | null = null;
 
+  /**
+   * Whether the header should be rendered. If its hidden we might wanna add extra space on top of header.
+   */
+  @Input() hideHeader: boolean = false;
+
   /** Emits when a new date is selected. */
   @Output() readonly selectedChange: EventEmitter<D | null> = new EventEmitter<D | null>();
 

--- a/tools/public_api_guard/material/datepicker.md
+++ b/tools/public_api_guard/material/datepicker.md
@@ -158,6 +158,7 @@ export class MatCalendar<D> implements AfterContentInit, AfterViewChecked, OnDes
     focusActiveCell(): void;
     _goToDateInView(date: D, view: 'month' | 'year' | 'multi-year'): void;
     headerComponent: ComponentType<any>;
+    hideHeader: boolean;
     get maxDate(): D | null;
     set maxDate(value: D | null);
     get minDate(): D | null;
@@ -190,7 +191,7 @@ export class MatCalendar<D> implements AfterContentInit, AfterViewChecked, OnDes
     _yearSelectedInMultiYearView(normalizedYear: D): void;
     yearView: MatYearView<D>;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<MatCalendar<any>, "mat-calendar", ["matCalendar"], { "headerComponent": { "alias": "headerComponent"; "required": false; }; "startAt": { "alias": "startAt"; "required": false; }; "startView": { "alias": "startView"; "required": false; }; "selected": { "alias": "selected"; "required": false; }; "minDate": { "alias": "minDate"; "required": false; }; "maxDate": { "alias": "maxDate"; "required": false; }; "dateFilter": { "alias": "dateFilter"; "required": false; }; "dateClass": { "alias": "dateClass"; "required": false; }; "comparisonStart": { "alias": "comparisonStart"; "required": false; }; "comparisonEnd": { "alias": "comparisonEnd"; "required": false; }; "startDateAccessibleName": { "alias": "startDateAccessibleName"; "required": false; }; "endDateAccessibleName": { "alias": "endDateAccessibleName"; "required": false; }; }, { "selectedChange": "selectedChange"; "yearSelected": "yearSelected"; "monthSelected": "monthSelected"; "viewChanged": "viewChanged"; "_userSelection": "_userSelection"; "_userDragDrop": "_userDragDrop"; }, never, never, false, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MatCalendar<any>, "mat-calendar", ["matCalendar"], { "headerComponent": { "alias": "headerComponent"; "required": false; }; "startAt": { "alias": "startAt"; "required": false; }; "startView": { "alias": "startView"; "required": false; }; "selected": { "alias": "selected"; "required": false; }; "minDate": { "alias": "minDate"; "required": false; }; "maxDate": { "alias": "maxDate"; "required": false; }; "dateFilter": { "alias": "dateFilter"; "required": false; }; "dateClass": { "alias": "dateClass"; "required": false; }; "comparisonStart": { "alias": "comparisonStart"; "required": false; }; "comparisonEnd": { "alias": "comparisonEnd"; "required": false; }; "startDateAccessibleName": { "alias": "startDateAccessibleName"; "required": false; }; "endDateAccessibleName": { "alias": "endDateAccessibleName"; "required": false; }; "hideHeader": { "alias": "hideHeader"; "required": false; }; }, { "selectedChange": "selectedChange"; "yearSelected": "yearSelected"; "monthSelected": "monthSelected"; "viewChanged": "viewChanged"; "_userSelection": "_userSelection"; "_userDragDrop": "_userDragDrop"; }, never, never, false, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatCalendar<any>, [null, { optional: true; }, { optional: true; }, null]>;
 }
@@ -714,6 +715,7 @@ export class MatMonthView<D> implements AfterContentInit, OnChanges, OnDestroy {
     _focusActiveCellAfterViewChecked(): void;
     _handleCalendarBodyKeydown(event: KeyboardEvent): void;
     _handleCalendarBodyKeyup(event: KeyboardEvent): void;
+    hideHeader: boolean;
     _init(): void;
     _isRange: boolean;
     _matCalendarBody: MatCalendarBody;
@@ -746,7 +748,7 @@ export class MatMonthView<D> implements AfterContentInit, OnChanges, OnDestroy {
     }[];
     _weeks: MatCalendarCell[][];
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<MatMonthView<any>, "mat-month-view", ["matMonthView"], { "activeDate": { "alias": "activeDate"; "required": false; }; "selected": { "alias": "selected"; "required": false; }; "minDate": { "alias": "minDate"; "required": false; }; "maxDate": { "alias": "maxDate"; "required": false; }; "dateFilter": { "alias": "dateFilter"; "required": false; }; "dateClass": { "alias": "dateClass"; "required": false; }; "comparisonStart": { "alias": "comparisonStart"; "required": false; }; "comparisonEnd": { "alias": "comparisonEnd"; "required": false; }; "startDateAccessibleName": { "alias": "startDateAccessibleName"; "required": false; }; "endDateAccessibleName": { "alias": "endDateAccessibleName"; "required": false; }; "activeDrag": { "alias": "activeDrag"; "required": false; }; }, { "selectedChange": "selectedChange"; "_userSelection": "_userSelection"; "dragStarted": "dragStarted"; "dragEnded": "dragEnded"; "activeDateChange": "activeDateChange"; }, never, never, false, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MatMonthView<any>, "mat-month-view", ["matMonthView"], { "activeDate": { "alias": "activeDate"; "required": false; }; "selected": { "alias": "selected"; "required": false; }; "minDate": { "alias": "minDate"; "required": false; }; "maxDate": { "alias": "maxDate"; "required": false; }; "dateFilter": { "alias": "dateFilter"; "required": false; }; "dateClass": { "alias": "dateClass"; "required": false; }; "comparisonStart": { "alias": "comparisonStart"; "required": false; }; "comparisonEnd": { "alias": "comparisonEnd"; "required": false; }; "startDateAccessibleName": { "alias": "startDateAccessibleName"; "required": false; }; "endDateAccessibleName": { "alias": "endDateAccessibleName"; "required": false; }; "activeDrag": { "alias": "activeDrag"; "required": false; }; "hideHeader": { "alias": "hideHeader"; "required": false; }; }, { "selectedChange": "selectedChange"; "_userSelection": "_userSelection"; "dragStarted": "dragStarted"; "dragEnded": "dragEnded"; "activeDateChange": "activeDateChange"; }, never, never, false, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatMonthView<any>, [null, { optional: true; }, { optional: true; }, { optional: true; }, { optional: true; }]>;
 }


### PR DESCRIPTION
adds a boolean Input for mat-datepicker to hide header so the users dont have to pass empty component to remove it

fixes #24337