### PR TITLE
fix(material/progress-bar): alignment affected by parent text-align

### DIFF
--- a/src/material/progress-bar/progress-bar.scss
+++ b/src/material/progress-bar/progress-bar.scss
@@ -23,6 +23,13 @@
   // Explicitly set to `block` since the browser defaults custom elements to `inline`.
   display: block;
 
+  // Explicitly set a `text-align` so that the content isn't affected by the parent (see #27613).
+  text-align: left;
+
+  [dir='rtl'] & {
+    text-align: right;
+  }
+
   // Inverts the progress bar horizontally in `query` mode.
   &[mode='query'] {
     transform: scaleX(-1);


### PR DESCRIPTION
Fixes that the progress bar's alignment was affected by the parent's element's `text-align`.

Fixes #27613.