### PR TITLE
fix(material/snackbar): use polite by default

### DIFF
--- a/src/material/snack-bar/snack-bar-config.ts
+++ b/src/material/snack-bar/snack-bar-config.ts
@@ -24,7 +24,7 @@ export type MatSnackBarVerticalPosition = 'top' | 'bottom';
  */
 export class MatSnackBarConfig<D = any> {
   /** The politeness level for the MatAriaLiveAnnouncer announcement. */
-  politeness?: AriaLivePoliteness = 'assertive';
+  politeness?: AriaLivePoliteness = 'polite';
 
   /**
    * Message to be announced by the LiveAnnouncer. When opening a snackbar without a custom


### PR DESCRIPTION
Change the default politeness level of the aria-live in snackbar component. Use "polite" by default.

Existing behavior is to use "assertive" unless specified by developer. That conflicts with our documentation (#27562). It also does not align with how LiveAnnouncer does things.

With this commit applied, use "polite" unless otherwise specified by developers. This aligns with LiveAnnouncer.

Fix #27562