### PR TITLE
docs(material/autocomplete): reset template driven autocomplete example

### DIFF
--- a/src/dev-app/autocomplete/autocomplete-demo.html
+++ b/src/dev-app/autocomplete/autocomplete-demo.html
@@ -83,7 +83,7 @@ Space above cards: <input type="number" [formControl]="topHeightCtrl">
     </mat-form-field>
 
     <p>
-      <button mat-button (click)="modelDir.reset()">RESET</button>
+      <button mat-button (click)="clearTemplateState()">RESET</button>
       <button mat-button (click)="currentState='California'">SET VALUE</button>
       <button mat-button (click)="tdDisabled=!tdDisabled">
         TOGGLE DISABLED

--- a/src/dev-app/autocomplete/autocomplete-demo.ts
+++ b/src/dev-app/autocomplete/autocomplete-demo.ts
@@ -187,6 +187,12 @@ export class AutocompleteDemo {
     return this._isStateDisabled(index, this.templateDisableStateOption);
   }
 
+  clearTemplateState() {
+    this.modelDir.reset();
+    this.currentState = '';
+    this.tdStates = this.states.slice();
+  }
+
   private _isStateDisabled(stateIndex: number, disableStateOption: DisableStateOption) {
     if (disableStateOption === 'all') {
       return true;


### PR DESCRIPTION
Make a bug fix to the template-driven autocomplete example. Fix demo issue where clicking the reset button doesn't reset the autocomplete options and the value in the input to the original state. Reset the form field by resetting the value of the input and the tdStates to the value when the demo is first rendered.