### PR TITLE
fix(material/table): Simultaneous Row Expansion Issue in MatTab with Nested MatTable Component

### DIFF
--- a/src/components-examples/material/table/table-expandable-rows/table-expandable-rows-example.ts
+++ b/src/components-examples/material/table/table-expandable-rows/table-expandable-rows-example.ts
@@ -14,7 +14,7 @@ import {MatTableModule} from '@angular/material/table';
   templateUrl: 'table-expandable-rows-example.html',
   animations: [
     trigger('detailExpand', [
-      state('collapsed', style({height: '0px', minHeight: '0'})),
+      state('collapsed,void', style({height: '0px', minHeight: '0'})),
       state('expanded', style({height: '*'})),
       transition('expanded <=> collapsed', animate('225ms cubic-bezier(0.4, 0.0, 0.2, 1)')),
     ]),


### PR DESCRIPTION
Resolved a bug causing simultaneous row expansion in a MatTab when a nested MatTable component with expandable rows was used. The problem stemmed from animations triggered by the parent's visibility set to 'hidden.'

Solution: Incorporated void state within animations to reset them after eraseStyles function execution, ensuring consistent row expansion behavior within MatTabs.

Fix #27560