### PR TITLE
Fix typo in private-typography-to-2018-config()

### DIFF
--- a/src/material/core/typography/_typography.scss
+++ b/src/material/core/typography/_typography.scss
@@ -324,7 +324,7 @@
         headline-5: map.get($config, headline),
         headline-6: map.get($config, title),
         subtitle-1: map.get($config, subheading-2),
-        font-famiy: map.get($config, font-family),
+        font-family: map.get($config, font-family),
 
         // These mappings are odd, but body-2 in the 2014 system actually looks closer to subtitle-2
         // in the 2018 system, and subeading-1 in the 2014 system looks more like body-1 in the 2018


### PR DESCRIPTION
Currently the `private-typography-to-2018-config` function in `src/material/core/typography/_typography.scss` says `font-famiy`. I fixed it to say `font-family`.