### PR TITLE
fix(material/radio): clicking button emit twice

### DIFF
--- a/src/material/radio/radio.html
+++ b/src/material/radio/radio.html
@@ -25,7 +25,7 @@
       <div class="mat-ripple-element mat-radio-persistent-ripple"></div>
     </div>
   </div>
-  <label class="mdc-label" [for]="inputId">
+  <label class="mdc-label" (click)="_onLabelClick($event)" [for]="inputId">
     <ng-content></ng-content>
   </label>
 </div>

--- a/src/material/radio/radio.spec.ts
+++ b/src/material/radio/radio.spec.ts
@@ -484,6 +484,15 @@ describe('MDC-based MatRadio', () => {
       expect(groupInstance.selected).toBe(null);
       expect(groupInstance.value).toBe('fire');
     });
+
+    it('should emit event once on <mat-radio-button> click', () => {
+      const spy = spyOn(fixture.componentInstance, 'WhosThatPokemon');
+
+      radioLabelElements[2].click();
+      fixture.detectChanges();
+
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('group with ngModel', () => {
@@ -1014,7 +1023,7 @@ describe('MatRadioDefaultOverrides', () => {
     <mat-radio-button value="water" [disableRipple]="disableRipple" [color]="color">
       Squirtle
     </mat-radio-button>
-    <mat-radio-button value="leaf" [disableRipple]="disableRipple" [color]="color">
+    <mat-radio-button value="leaf" (click)="WhosThatPokemon()" [disableRipple]="disableRipple" [color]="color">
       Bulbasaur
     </mat-radio-button>
   </mat-radio-group>
@@ -1029,6 +1038,10 @@ class RadiosInsideRadioGroup {
   disableRipple = false;
   color: string | null;
   isFirstShown = true;
+
+  WhosThatPokemon() {
+    console.log("It's bulbasaur");
+  }
 }
 
 @Component({

--- a/src/material/radio/radio.ts
+++ b/src/material/radio/radio.ts
@@ -639,6 +639,15 @@ export class MatRadioButton
     event.stopPropagation();
   }
 
+  _onLabelClick(event: Event) {
+    // If there's a <input type="radio"/> element associated with a <label> element
+    // via [for] attribute, whenever the label gets clicked the input field gets checked
+    // causing another emission of event.
+    // Stopping it would make it that "(click)" binding on MatRadioButton will emit
+    // it once instead of twice.
+    event.stopPropagation();
+  }
+
   /** Triggered when the radio button receives an interaction from the user. */
   _onInputInteraction(event: Event) {
     // We always have to stop propagation on the change event.

--- a/tools/public_api_guard/material/radio.md
+++ b/tools/public_api_guard/material/radio.md
@@ -75,6 +75,8 @@ export class MatRadioButton extends _MatRadioButtonMixinBase implements OnInit, 
     // (undocumented)
     _onInputClick(event: Event): void;
     _onInputInteraction(event: Event): void;
+    // (undocumented)
+    _onLabelClick(event: Event): void;
     _onTouchTargetClick(event: Event): void;
     radioGroup: MatRadioGroup;
     get required(): boolean;


### PR DESCRIPTION
fixes the issue where click binding on MatRadioButton gets emited twice due to label behaviour

fixes #27680