### PR TITLE
fix(material/form-field): don't toggle hover state over subscript

### DIFF
--- a/src/material/form-field/_form-field-focus-overlay.scss
+++ b/src/material/form-field/_form-field-focus-overlay.scss
@@ -19,7 +19,7 @@
       tokens-mat-form-field.$prefix, tokens-mat-form-field.get-token-slots()) {
       @include token-utils.create-token-slot(background-color, state-layer-color);
 
-      .mat-mdc-form-field:hover & {
+      .mat-mdc-text-field-wrapper:hover & {
         @include token-utils.create-token-slot(opacity, hover-state-layer-opacity);
       }
 


### PR DESCRIPTION
Fixes that the form field was showing its hover state when hovering over the hint/error area. This looked off, because while these elements are connected to the form field, they aren't part of the main container.