### PR TITLE
docs(material/snack-bar): fix broken doc example

### DIFF
--- a/src/material/snack-bar/snack-bar.md
+++ b/src/material/snack-bar/snack-bar.md
@@ -84,10 +84,7 @@ snackbars  opened via `snackBar.open`.
 
 If no annotations are used, all the content will be treated as text content.
 
-<!-- example({
-  "example": "snack-bar-annotated-component-example",
-  "file": "snack-bar-annotated-component-example-snack.html"
-}) -->
+<!-- example(snack-bar-annotated-component) -->
 
 ### Setting the global configuration defaults
 If you want to override the default snack bar options, you can do so using the


### PR DESCRIPTION
fixes broken annotated custom component example

fixes #27679

---
Before:
![image](https://github.com/angular/components/assets/54370141/55c8ac43-58fc-404e-828e-5ca901de36d0)


After:
![image](https://github.com/angular/components/assets/54370141/fcc2396c-3dd7-4f80-9eb6-bb451ad53792)


