### PR TITLE
refactor(multiple): convert components to theme inspection API 

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -148,7 +148,6 @@
     {
       "files": [
         "**/_card-theme.scss",
-        "**/_checkbox-theme.scss",
         "**/_core-theme.scss",
         "**/_form-field-theme.scss",
         "**/_optgroup-theme.scss",

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -143,5 +143,23 @@
         "resolveNestedSelectors": true
       }
     ]
-  }
+  },
+  "overrides": [
+    {
+      "files": [
+        "**/_card-theme.scss",
+        "**/_checkbox-theme.scss",
+        "**/_core-theme.scss",
+        "**/_form-field-theme.scss",
+        "**/_optgroup-theme.scss",
+        "**/_option-theme.scss",
+        "**/_progress-bar-theme.scss",
+        "**/_pseudo-checkbox-theme.scss",
+        "**/_ripple-theme.scss"
+      ],
+      "rules": {
+        "material/theme-mixin-api": false
+      }
+    }
+  ]
 }

--- a/src/dev-app/theme.scss
+++ b/src/dev-app/theme.scss
@@ -3,6 +3,10 @@
 
 // Plus imports for other components in your app.
 
+// Disable legacy API compatibility.
+// TODO: uncomment once conversion to inspection API is complete.
+//mat.$theme-legacy-inspection-api-compatibility: false;
+
 // Define the default (light) theme.
 $candy-app-primary: mat.define-palette(mat.$indigo-palette);
 $candy-app-accent: mat.define-palette(mat.$pink-palette, A200, A100, A400);

--- a/src/material/card/_card-theme.scss
+++ b/src/material/card/_card-theme.scss
@@ -10,9 +10,9 @@
 @use '@material/card/elevated-card-theme' as mdc-elevated-card-theme;
 @use '@material/card/outlined-card-theme' as mdc-outlined-card-theme;
 
-@mixin base($config-or-theme) {
-  @if inspection.get-theme-version($config-or-theme) == 1 {
-    @include _theme-from-tokens(inspection.get-theme-tokens($config-or-theme, base));
+@mixin base($theme) {
+  @if inspection.get-theme-version($theme) == 1 {
+    @include _theme-from-tokens(inspection.get-theme-tokens($theme, base));
   }
   @else {
     @include sass-utils.current-selector-or-root() {
@@ -24,24 +24,22 @@
   }
 }
 
-@mixin color($config-or-theme) {
-  $config: theming.get-color-config($config-or-theme);
-
-  @if inspection.get-theme-version($config-or-theme) == 1 {
-    @include _theme-from-tokens(inspection.get-theme-tokens($config-or-theme, color));
+@mixin color($theme) {
+  @if inspection.get-theme-version($theme) == 1 {
+    @include _theme-from-tokens(inspection.get-theme-tokens($theme, color));
   }
   @else {
     $mdc-elevated-card-color-tokens: token-utils.resolve-elevation(
-        tokens-mdc-elevated-card.get-color-tokens($config),
+        tokens-mdc-elevated-card.get-color-tokens($theme),
         container-elevation,
         container-shadow-color
     );
     $mdc-outlined-card-color-tokens: token-utils.resolve-elevation(
-        tokens-mdc-outlined-card.get-color-tokens($config),
+        tokens-mdc-outlined-card.get-color-tokens($theme),
         container-elevation,
         container-shadow-color,
     );
-    $mat-card-color-tokens: tokens-mat-card.get-color-tokens($config);
+    $mat-card-color-tokens: tokens-mat-card.get-color-tokens($theme);
 
     // Add values for card tokens.
     @include sass-utils.current-selector-or-root() {
@@ -52,17 +50,14 @@
   }
 }
 
-@mixin typography($config-or-theme) {
-  $config: typography.private-typography-to-2018-config(
-      theming.get-typography-config($config-or-theme));
-
-  @if inspection.get-theme-version($config-or-theme) == 1 {
-    @include _theme-from-tokens(inspection.get-theme-tokens($config-or-theme, typography));
+@mixin typography($theme) {
+  @if inspection.get-theme-version($theme) == 1 {
+    @include _theme-from-tokens(inspection.get-theme-tokens($theme, typography));
   }
   @else {
-    $mdc-elevated-card-typography-tokens: tokens-mdc-elevated-card.get-typography-tokens($config);
-    $mdc-outlined-card-typography-tokens: tokens-mdc-outlined-card.get-typography-tokens($config);
-    $mat-card-typography-tokens: tokens-mat-card.get-typography-tokens($config);
+    $mdc-elevated-card-typography-tokens: tokens-mdc-elevated-card.get-typography-tokens($theme);
+    $mdc-outlined-card-typography-tokens: tokens-mdc-outlined-card.get-typography-tokens($theme);
+    $mat-card-typography-tokens: tokens-mat-card.get-typography-tokens($theme);
 
     // Add values for card tokens.
     @include sass-utils.current-selector-or-root() {
@@ -74,16 +69,14 @@
   }
 }
 
-@mixin density($config-or-theme) {
-  $density-scale: theming.get-density-config($config-or-theme);
-
-  @if inspection.get-theme-version($config-or-theme) == 1 {
-    @include _theme-from-tokens(inspection.get-theme-tokens($config-or-theme, density));
+@mixin density($theme) {
+  @if inspection.get-theme-version($theme) == 1 {
+    @include _theme-from-tokens(inspection.get-theme-tokens($theme, density));
   }
   @else {
-    $mdc-elevated-card-density-tokens: tokens-mdc-elevated-card.get-density-tokens($density-scale);
-    $mdc-outlined-card-density-tokens: tokens-mdc-outlined-card.get-density-tokens($density-scale);
-    $mat-card-density-tokens: tokens-mat-card.get-density-tokens($density-scale);
+    $mdc-elevated-card-density-tokens: tokens-mdc-elevated-card.get-density-tokens($theme);
+    $mdc-outlined-card-density-tokens: tokens-mdc-outlined-card.get-density-tokens($theme);
+    $mat-card-density-tokens: tokens-mat-card.get-density-tokens($theme);
 
     // Add values for card tokens.
     @include sass-utils.current-selector-or-root() {
@@ -102,19 +95,15 @@
       @include _theme-from-tokens(inspection.get-theme-tokens($theme));
     }
     @else {
-      $color: theming.get-color-config($theme);
-      $density: theming.get-density-config($theme);
-      $typography: theming.get-typography-config($theme);
-
       @include base($theme);
-      @if $color != null {
-        @include color($color);
+      @if inspection.theme-has($theme, color) {
+        @include color($theme);
       }
-      @if $density != null {
-        @include density($density);
+      @if inspection.theme-has($theme, density) {
+        @include density($theme);
       }
-      @if $typography != null {
-        @include typography($typography);
+      @if inspection.theme-has($theme, typography) {
+        @include typography($theme);
       }
     }
   }

--- a/src/material/card/_card-theme.scss
+++ b/src/material/card/_card-theme.scss
@@ -24,7 +24,7 @@
   }
 }
 
-@mixin color($config-or-theme) {
+@mixin color($theme) {
   @if inspection.get-theme-version($theme) == 1 {
     @include _theme-from-tokens(inspection.get-theme-tokens($theme, color));
   }
@@ -50,7 +50,7 @@
   }
 }
 
-@mixin typography($config-or-theme) {
+@mixin typography($theme) {
   @if inspection.get-theme-version($theme) == 1 {
     @include _theme-from-tokens(inspection.get-theme-tokens($theme, typography));
   }
@@ -69,7 +69,7 @@
   }
 }
 
-@mixin density($config-or-theme) {
+@mixin density($theme) {
   @if inspection.get-theme-version($theme) == 1 {
     @include _theme-from-tokens(inspection.get-theme-tokens($theme, density));
   }

--- a/src/material/card/_card-theme.scss
+++ b/src/material/card/_card-theme.scss
@@ -24,7 +24,7 @@
   }
 }
 
-@mixin color($theme) {
+@mixin color($config-or-theme) {
   @if inspection.get-theme-version($theme) == 1 {
     @include _theme-from-tokens(inspection.get-theme-tokens($theme, color));
   }
@@ -50,7 +50,7 @@
   }
 }
 
-@mixin typography($theme) {
+@mixin typography($config-or-theme) {
   @if inspection.get-theme-version($theme) == 1 {
     @include _theme-from-tokens(inspection.get-theme-tokens($theme, typography));
   }
@@ -69,7 +69,7 @@
   }
 }
 
-@mixin density($theme) {
+@mixin density($config-or-theme) {
   @if inspection.get-theme-version($theme) == 1 {
     @include _theme-from-tokens(inspection.get-theme-tokens($theme, density));
   }

--- a/src/material/checkbox/_checkbox-theme.scss
+++ b/src/material/checkbox/_checkbox-theme.scss
@@ -8,7 +8,7 @@
 @use '../core/mdc-helpers/mdc-helpers';
 @use '../core/tokens/m2/mdc/checkbox' as tokens-mdc-checkbox;
 
-@mixin base($theme) {
+@mixin base($config-or-theme) {
   @if inspection.get-theme-version($config-or-theme) == 1 {
     @include _theme-from-tokens(inspection.get-theme-tokens($config-or-theme, base));
   }
@@ -19,7 +19,7 @@
   }
 }
 
-@mixin color($theme) {
+@mixin color($config-or-theme) {
   $config: theming.get-color-config($config-or-theme);
 
   @if inspection.get-theme-version($config-or-theme) == 1 {
@@ -58,7 +58,7 @@
   }
 }
 
-@mixin typography($theme) {
+@mixin typography($config-or-theme) {
   $config: typography.private-typography-to-2018-config(
           theming.get-typography-config($config-or-theme));
 
@@ -79,7 +79,7 @@
   }
 }
 
-@mixin density($theme) {
+@mixin density($config-or-theme) {
   $density-scale: theming.get-density-config($config-or-theme);
 
   @if inspection.get-theme-version($config-or-theme) == 1 {

--- a/src/material/checkbox/_checkbox-theme.scss
+++ b/src/material/checkbox/_checkbox-theme.scss
@@ -8,7 +8,7 @@
 @use '../core/mdc-helpers/mdc-helpers';
 @use '../core/tokens/m2/mdc/checkbox' as tokens-mdc-checkbox;
 
-@mixin base($config-or-theme) {
+@mixin base($theme) {
   @if inspection.get-theme-version($config-or-theme) == 1 {
     @include _theme-from-tokens(inspection.get-theme-tokens($config-or-theme, base));
   }
@@ -19,7 +19,7 @@
   }
 }
 
-@mixin color($config-or-theme) {
+@mixin color($theme) {
   $config: theming.get-color-config($config-or-theme);
 
   @if inspection.get-theme-version($config-or-theme) == 1 {
@@ -58,7 +58,7 @@
   }
 }
 
-@mixin typography($config-or-theme) {
+@mixin typography($theme) {
   $config: typography.private-typography-to-2018-config(
           theming.get-typography-config($config-or-theme));
 
@@ -79,7 +79,7 @@
   }
 }
 
-@mixin density($config-or-theme) {
+@mixin density($theme) {
   $density-scale: theming.get-density-config($config-or-theme);
 
   @if inspection.get-theme-version($config-or-theme) == 1 {

--- a/src/material/core/_core-theme.scss
+++ b/src/material/core/_core-theme.scss
@@ -1,4 +1,3 @@
-@use 'sass:map';
 @use './theming/theming';
 @use './theming/inspection';
 @use './style/private';
@@ -9,7 +8,7 @@
 @use './style/elevation';
 @use './typography/typography';
 
-@mixin color($theme) {
+@mixin color($config-or-theme) {
   @include ripple-theme.color($theme);
   @include option-theme.color($theme);
   @include optgroup-theme.color($theme);
@@ -43,7 +42,7 @@
   }
 }
 
-@mixin typography($theme) {
+@mixin typography($config-or-theme) {
   @include option-theme.typography($theme);
   @include optgroup-theme.typography($theme);
   @include pseudo-checkbox-theme.typography($theme);
@@ -51,7 +50,7 @@
   // @include ripple-theme.typography($config);
 }
 
-@mixin density($theme) {
+@mixin density($config-or-theme) {
   @include option-theme.density($theme);
   @include optgroup-theme.density($theme);
   // TODO(mmalerba): add density mixins for these.

--- a/src/material/core/_core-theme.scss
+++ b/src/material/core/_core-theme.scss
@@ -8,7 +8,7 @@
 @use './style/elevation';
 @use './typography/typography';
 
-@mixin color($config-or-theme) {
+@mixin color($theme) {
   @include ripple-theme.color($theme);
   @include option-theme.color($theme);
   @include optgroup-theme.color($theme);
@@ -42,7 +42,7 @@
   }
 }
 
-@mixin typography($config-or-theme) {
+@mixin typography($theme) {
   @include option-theme.typography($theme);
   @include optgroup-theme.typography($theme);
   @include pseudo-checkbox-theme.typography($theme);
@@ -50,7 +50,7 @@
   // @include ripple-theme.typography($config);
 }
 
-@mixin density($config-or-theme) {
+@mixin density($theme) {
   @include option-theme.density($theme);
   @include optgroup-theme.density($theme);
   // TODO(mmalerba): add density mixins for these.

--- a/src/material/core/_core-theme.scss
+++ b/src/material/core/_core-theme.scss
@@ -1,5 +1,6 @@
 @use 'sass:map';
-@use 'theming/theming';
+@use './theming/theming';
+@use './theming/inspection';
 @use './style/private';
 @use './ripple/ripple-theme';
 @use './option/option-theme';
@@ -8,23 +9,18 @@
 @use './style/elevation';
 @use './typography/typography';
 
-@mixin color($config-or-theme) {
-  $config: theming.get-color-config($config-or-theme);
-
-  @include ripple-theme.color($config);
-  @include option-theme.color($config);
-  @include optgroup-theme.color($config);
-  @include pseudo-checkbox-theme.color($config);
+@mixin color($theme) {
+  @include ripple-theme.color($theme);
+  @include option-theme.color($theme);
+  @include optgroup-theme.color($theme);
+  @include pseudo-checkbox-theme.color($theme);
 
   // Wrapper element that provides the theme background when the user's content isn't
   // inside of a `mat-sidenav-container`. Note that we need to exclude the ampersand
   // selector in case the mixin is included at the top level.
   .mat-app-background#{if(&, ', &.mat-app-background', '')} {
-    $background: map.get($config, background);
-    $foreground: map.get($config, foreground);
-
-    background-color: theming.get-color-from-palette($background, background);
-    color: theming.get-color-from-palette($foreground, text);
+    background-color: inspection.get-theme-color($theme, background, background);
+    color: inspection.get-theme-color($theme, foreground, text);
   }
 
   // Provides external CSS classes for each elevation value. Each CSS class is formatted as
@@ -35,7 +31,7 @@
     // We need the `mat-mdc-elevation-specific`, because some MDC mixins
     // come with elevation baked in and we don't have a way of removing it.
     .#{$selector}, .mat-mdc-elevation-specific.#{$selector} {
-      @include private.private-theme-elevation($zValue, $config);
+      @include private.private-theme-elevation($zValue, $theme);
     }
   }
 
@@ -47,22 +43,17 @@
   }
 }
 
-@mixin typography($config-or-theme) {
-  $config: typography.private-typography-to-2018-config(
-          theming.get-typography-config($config-or-theme));
-
-  @include option-theme.typography($config);
-  @include optgroup-theme.typography($config);
-  @include pseudo-checkbox-theme.typography($config);
+@mixin typography($theme) {
+  @include option-theme.typography($theme);
+  @include optgroup-theme.typography($theme);
+  @include pseudo-checkbox-theme.typography($theme);
   // TODO(mmalerba): add typography mixin for this.
   // @include ripple-theme.typography($config);
 }
 
-@mixin density($config-or-theme) {
-  $density-scale: theming.get-density-config($config-or-theme);
-
-  @include option-theme.density($density-scale);
-  @include optgroup-theme.density($density-scale);
+@mixin density($theme) {
+  @include option-theme.density($theme);
+  @include optgroup-theme.density($theme);
   // TODO(mmalerba): add density mixins for these.
   // @include ripple-theme.density($density-scale);
   // @include pseudo-checkbox-theme.density($density-scale);
@@ -75,18 +66,14 @@
   // there won't be multiple warnings. e.g. if `mat-core-theme` reports a warning, then
   // the imported themes (such as `mat-ripple-theme`) should not report again.
   @include theming.private-check-duplicate-theme-styles($theme, 'mat-core') {
-    $color: theming.get-color-config($theme);
-    $density: theming.get-density-config($theme);
-    $typography: theming.get-typography-config($theme);
-
-    @if $color != null {
-      @include color($color);
+    @if inspection.theme-has($theme, color) {
+      @include color($theme);
     }
-    @if $density != null {
-      @include density($density);
+    @if inspection.theme-has($theme, density) {
+      @include density($theme);
     }
-    @if $typography != null {
-      @include typography($typography);
+    @if inspection.theme-has($theme, typography) {
+      @include typography($theme);
     }
   }
 }

--- a/src/material/core/_core-theme.scss
+++ b/src/material/core/_core-theme.scss
@@ -59,8 +59,7 @@
 }
 
 // Mixin that renders all of the core styles that depend on the theme.
-@mixin theme($theme-or-color-config) {
-  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+@mixin theme($theme) {
   // Wrap the sub-theme includes in the duplicate theme styles mixin. This ensures that
   // there won't be multiple warnings. e.g. if `mat-core-theme` reports a warning, then
   // the imported themes (such as `mat-ripple-theme`) should not report again.

--- a/src/material/core/option/_optgroup-theme.scss
+++ b/src/material/core/option/_optgroup-theme.scss
@@ -23,8 +23,7 @@
 @mixin density($theme) {
 }
 
-@mixin theme($theme-or-color-config) {
-  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+@mixin theme($theme) {
   @include theming.private-check-duplicate-theme-styles($theme, 'mat-optgroup') {
     @if inspection.theme-has($theme, color) {
       @include color($theme);

--- a/src/material/core/option/_optgroup-theme.scss
+++ b/src/material/core/option/_optgroup-theme.scss
@@ -3,46 +3,37 @@
 @use '../style/sass-utils';
 
 @use '../theming/theming';
+@use '../theming/inspection';
 @use '../typography/typography';
 
-@mixin color($config-or-theme) {
-  $config: theming.get-color-config($config-or-theme);
-
+@mixin color($theme) {
   @include sass-utils.current-selector-or-root() {
     @include token-utils.create-token-values(tokens-mat-optgroup.$prefix,
-      tokens-mat-optgroup.get-color-tokens($config));
+      tokens-mat-optgroup.get-color-tokens($theme));
   }
 }
 
-@mixin typography($config-or-theme) {
-  $config: typography.private-typography-to-2018-config(
-      theming.get-typography-config($config-or-theme));
-
+@mixin typography($theme) {
   @include sass-utils.current-selector-or-root() {
     @include token-utils.create-token-values(tokens-mat-optgroup.$prefix,
-      tokens-mat-optgroup.get-typography-tokens($config));
+      tokens-mat-optgroup.get-typography-tokens($theme));
   }
 }
 
-@mixin density($config-or-theme) {
-  $density-scale: theming.get-density-config($config-or-theme);
+@mixin density($theme) {
 }
 
 @mixin theme($theme-or-color-config) {
   $theme: theming.private-legacy-get-theme($theme-or-color-config);
   @include theming.private-check-duplicate-theme-styles($theme, 'mat-optgroup') {
-    $color: theming.get-color-config($theme);
-    $density: theming.get-density-config($theme);
-    $typography: theming.get-typography-config($theme);
-
-    @if $color != null {
-      @include color($color);
+    @if inspection.theme-has($theme, color) {
+      @include color($theme);
     }
-    @if $density != null {
-      @include density($density);
+    @if inspection.theme-has($theme, density) {
+      @include density($theme);
     }
-    @if $typography != null {
-      @include typography($typography);
+    @if inspection.theme-has($theme, typography) {
+      @include typography($theme);
     }
   }
 }

--- a/src/material/core/option/_optgroup-theme.scss
+++ b/src/material/core/option/_optgroup-theme.scss
@@ -6,21 +6,21 @@
 @use '../theming/inspection';
 @use '../typography/typography';
 
-@mixin color($config-or-theme) {
+@mixin color($theme) {
   @include sass-utils.current-selector-or-root() {
     @include token-utils.create-token-values(tokens-mat-optgroup.$prefix,
       tokens-mat-optgroup.get-color-tokens($theme));
   }
 }
 
-@mixin typography($config-or-theme) {
+@mixin typography($theme) {
   @include sass-utils.current-selector-or-root() {
     @include token-utils.create-token-values(tokens-mat-optgroup.$prefix,
       tokens-mat-optgroup.get-typography-tokens($theme));
   }
 }
 
-@mixin density($config-or-theme) {
+@mixin density($theme) {
 }
 
 @mixin theme($theme-or-color-config) {

--- a/src/material/core/option/_optgroup-theme.scss
+++ b/src/material/core/option/_optgroup-theme.scss
@@ -6,21 +6,21 @@
 @use '../theming/inspection';
 @use '../typography/typography';
 
-@mixin color($theme) {
+@mixin color($config-or-theme) {
   @include sass-utils.current-selector-or-root() {
     @include token-utils.create-token-values(tokens-mat-optgroup.$prefix,
       tokens-mat-optgroup.get-color-tokens($theme));
   }
 }
 
-@mixin typography($theme) {
+@mixin typography($config-or-theme) {
   @include sass-utils.current-selector-or-root() {
     @include token-utils.create-token-values(tokens-mat-optgroup.$prefix,
       tokens-mat-optgroup.get-typography-tokens($theme));
   }
 }
 
-@mixin density($theme) {
+@mixin density($config-or-theme) {
 }
 
 @mixin theme($theme-or-color-config) {

--- a/src/material/core/option/_option-theme.scss
+++ b/src/material/core/option/_option-theme.scss
@@ -6,7 +6,7 @@
 @use '../theming/inspection';
 @use '../typography/typography';
 
-@mixin color($config-or-theme) {
+@mixin color($theme) {
   @include sass-utils.current-selector-or-root() {
     @include token-utils.create-token-values(tokens-mat-option.$prefix,
       tokens-mat-option.get-color-tokens($theme));
@@ -23,14 +23,14 @@
   }
 }
 
-@mixin typography($config-or-theme) {
+@mixin typography($theme) {
   @include sass-utils.current-selector-or-root() {
     @include token-utils.create-token-values(tokens-mat-option.$prefix,
       tokens-mat-option.get-typography-tokens($theme));
   }
 }
 
-@mixin density($config-or-theme) {
+@mixin density($theme) {
 }
 
 @mixin theme($theme-or-color-config) {

--- a/src/material/core/option/_option-theme.scss
+++ b/src/material/core/option/_option-theme.scss
@@ -1,4 +1,3 @@
-@use 'sass:map';
 @use '../tokens/m2/mat/option' as tokens-mat-option;
 @use '../tokens/token-utils';
 @use '../style/sass-utils';
@@ -6,9 +5,8 @@
 @use '../theming/theming';
 @use '../theming/inspection';
 @use '../typography/typography';
-@use '../mdc-helpers/mdc-helpers';
 
-@mixin color($theme) {
+@mixin color($config-or-theme) {
   @include sass-utils.current-selector-or-root() {
     @include token-utils.create-token-values(tokens-mat-option.$prefix,
       tokens-mat-option.get-color-tokens($theme));
@@ -25,14 +23,14 @@
   }
 }
 
-@mixin typography($theme) {
+@mixin typography($config-or-theme) {
   @include sass-utils.current-selector-or-root() {
     @include token-utils.create-token-values(tokens-mat-option.$prefix,
       tokens-mat-option.get-typography-tokens($theme));
   }
 }
 
-@mixin density($theme) {
+@mixin density($config-or-theme) {
 }
 
 @mixin theme($theme-or-color-config) {

--- a/src/material/core/option/_option-theme.scss
+++ b/src/material/core/option/_option-theme.scss
@@ -4,42 +4,35 @@
 @use '../style/sass-utils';
 
 @use '../theming/theming';
+@use '../theming/inspection';
 @use '../typography/typography';
 @use '../mdc-helpers/mdc-helpers';
 
-@mixin color($config-or-theme) {
-  $config: theming.get-color-config($config-or-theme);
-
-  @include mdc-helpers.using-mdc-theme($config) {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values(tokens-mat-option.$prefix,
-        tokens-mat-option.get-color-tokens($config));
-    }
-
-    .mat-accent {
-      @include token-utils.create-token-values(tokens-mat-option.$prefix,
-        tokens-mat-option.private-get-color-palette-color-tokens(map.get($config, accent)));
-    }
-
-    .mat-warn {
-      @include token-utils.create-token-values(tokens-mat-option.$prefix,
-        tokens-mat-option.private-get-color-palette-color-tokens(map.get($config, warn)));
-    }
-  }
-}
-
-@mixin typography($config-or-theme) {
-  $config: typography.private-typography-to-2018-config(
-      theming.get-typography-config($config-or-theme));
-
+@mixin color($theme) {
   @include sass-utils.current-selector-or-root() {
     @include token-utils.create-token-values(tokens-mat-option.$prefix,
-      tokens-mat-option.get-typography-tokens($config));
+      tokens-mat-option.get-color-tokens($theme));
+  }
+
+  .mat-accent {
+    @include token-utils.create-token-values(tokens-mat-option.$prefix,
+      tokens-mat-option.get-color-tokens($theme, accent));
+  }
+
+  .mat-warn {
+    @include token-utils.create-token-values(tokens-mat-option.$prefix,
+      tokens-mat-option.get-color-tokens($theme, warn));
   }
 }
 
-@mixin density($config-or-theme) {
-  $density-scale: theming.get-density-config($config-or-theme);
+@mixin typography($theme) {
+  @include sass-utils.current-selector-or-root() {
+    @include token-utils.create-token-values(tokens-mat-option.$prefix,
+      tokens-mat-option.get-typography-tokens($theme));
+  }
+}
+
+@mixin density($theme) {
 }
 
 @mixin theme($theme-or-color-config) {
@@ -49,13 +42,13 @@
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);
 
-    @if $color != null {
-      @include color($color);
+    @if inspection.theme-has($theme, color) {
+      @include color($theme);
     }
-    @if $density != null {
+    @if inspection.theme-has($theme, density) {
       @include density($density);
     }
-    @if $typography != null {
+    @if inspection.theme-has($theme, typography) {
       @include typography($typography);
     }
   }

--- a/src/material/core/option/_option-theme.scss
+++ b/src/material/core/option/_option-theme.scss
@@ -33,21 +33,16 @@
 @mixin density($theme) {
 }
 
-@mixin theme($theme-or-color-config) {
-  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+@mixin theme($theme) {
   @include theming.private-check-duplicate-theme-styles($theme, 'mat-option') {
-    $color: theming.get-color-config($theme);
-    $density: theming.get-density-config($theme);
-    $typography: theming.get-typography-config($theme);
-
     @if inspection.theme-has($theme, color) {
       @include color($theme);
     }
     @if inspection.theme-has($theme, density) {
-      @include density($density);
+      @include density($theme);
     }
     @if inspection.theme-has($theme, typography) {
-      @include typography($typography);
+      @include typography($theme);
     }
   }
 }

--- a/src/material/core/ripple/_ripple-theme.scss
+++ b/src/material/core/ripple/_ripple-theme.scss
@@ -20,8 +20,7 @@
   }
 }
 
-@mixin theme($theme-or-color-config) {
-  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+@mixin theme($theme) {
   @include theming.private-check-duplicate-theme-styles($theme, 'mat-ripple') {
     @if inspection.theme-has($theme, color) {
       @include color($theme);

--- a/src/material/core/ripple/_ripple-theme.scss
+++ b/src/material/core/ripple/_ripple-theme.scss
@@ -3,7 +3,7 @@
 @use '../theming/inspection';
 
 // Colors for the ripple elements.
-@mixin color($config-or-theme) {
+@mixin color($theme) {
   $foreground-base: inspection.get-theme-color($theme, foreground, base);
   $color-opacity: 0.1;
 
@@ -23,7 +23,6 @@
 @mixin theme($theme-or-color-config) {
   $theme: theming.private-legacy-get-theme($theme-or-color-config);
   @include theming.private-check-duplicate-theme-styles($theme, 'mat-ripple') {
-    $color: theming.get-color-config($theme);
     @if inspection.theme-has($theme, color) {
       @include color($theme);
     }

--- a/src/material/core/ripple/_ripple-theme.scss
+++ b/src/material/core/ripple/_ripple-theme.scss
@@ -1,12 +1,11 @@
 @use 'sass:map';
 @use 'sass:meta';
 @use '../theming/theming';
+@use '../theming/inspection';
 
 // Colors for the ripple elements.
-@mixin color($config-or-theme) {
-  $config: theming.get-color-config($config-or-theme);
-  $foreground: map.get($config, foreground);
-  $foreground-base: map.get($foreground, base);
+@mixin color($theme) {
+  $foreground-base: inspection.get-theme-color($theme, foreground, base);
   $color-opacity: 0.1;
 
   .mat-ripple-element {
@@ -26,8 +25,8 @@
   $theme: theming.private-legacy-get-theme($theme-or-color-config);
   @include theming.private-check-duplicate-theme-styles($theme, 'mat-ripple') {
     $color: theming.get-color-config($theme);
-    @if $color != null {
-      @include color($color);
+    @if inspection.theme-has($theme, color) {
+      @include color($theme);
     }
   }
 }

--- a/src/material/core/ripple/_ripple-theme.scss
+++ b/src/material/core/ripple/_ripple-theme.scss
@@ -1,10 +1,9 @@
-@use 'sass:map';
 @use 'sass:meta';
 @use '../theming/theming';
 @use '../theming/inspection';
 
 // Colors for the ripple elements.
-@mixin color($theme) {
+@mixin color($config-or-theme) {
   $foreground-base: inspection.get-theme-color($theme, foreground, base);
   $color-opacity: 0.1;
 

--- a/src/material/core/selection/pseudo-checkbox/_pseudo-checkbox-theme.scss
+++ b/src/material/core/selection/pseudo-checkbox/_pseudo-checkbox-theme.scss
@@ -1,4 +1,3 @@
-@use 'sass:map';
 @use '../../theming/theming';
 @use '../../theming/inspection';
 
@@ -20,7 +19,7 @@
   }
 }
 
-@mixin color($theme) {
+@mixin color($config-or-theme) {
   $is-dark-theme: inspection.get-theme-type($theme) == dark;
   $primary: inspection.get-theme-color($theme, primary);
   $accent: inspection.get-theme-color($theme, accent);
@@ -73,7 +72,7 @@
   }
 }
 
-@mixin typography($theme) {}
+@mixin typography($config-or-theme) {}
 
 @mixin _density($theme) {}
 

--- a/src/material/core/selection/pseudo-checkbox/_pseudo-checkbox-theme.scss
+++ b/src/material/core/selection/pseudo-checkbox/_pseudo-checkbox-theme.scss
@@ -76,8 +76,7 @@
 
 @mixin _density($theme) {}
 
-@mixin theme($theme-or-color-config) {
-  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+@mixin theme($theme) {
   @include theming.private-check-duplicate-theme-styles($theme, 'mat-pseudo-checkbox') {
     @if inspection.theme-has($theme, color) {
       @include color($theme);

--- a/src/material/core/selection/pseudo-checkbox/_pseudo-checkbox-theme.scss
+++ b/src/material/core/selection/pseudo-checkbox/_pseudo-checkbox-theme.scss
@@ -19,7 +19,7 @@
   }
 }
 
-@mixin color($config-or-theme) {
+@mixin color($theme) {
   $is-dark-theme: inspection.get-theme-type($theme) == dark;
   $primary: inspection.get-theme-color($theme, primary);
   $accent: inspection.get-theme-color($theme, accent);
@@ -72,7 +72,7 @@
   }
 }
 
-@mixin typography($config-or-theme) {}
+@mixin typography($theme) {}
 
 @mixin _density($theme) {}
 

--- a/src/material/core/selection/pseudo-checkbox/_pseudo-checkbox-theme.scss
+++ b/src/material/core/selection/pseudo-checkbox/_pseudo-checkbox-theme.scss
@@ -1,5 +1,6 @@
 @use 'sass:map';
 @use '../../theming/theming';
+@use '../../theming/inspection';
 
 @mixin _psuedo-checkbox-styles-with-color($text-color, $background) {
   .mat-pseudo-checkbox-checked,
@@ -19,15 +20,13 @@
   }
 }
 
-@mixin color($config-or-theme) {
-  $config: theming.get-color-config($config-or-theme);
-  $is-dark-theme: map.get($config, is-dark);
-
-  $primary: theming.get-color-from-palette(map.get($config, primary));
-  $accent: theming.get-color-from-palette(map.get($config, accent));
-  $warn: theming.get-color-from-palette(map.get($config, warn));
-  $background: theming.get-color-from-palette(map.get($config, background), background);
-  $secondary-text: theming.get-color-from-palette(map.get($config, foreground), secondary-text);
+@mixin color($theme) {
+  $is-dark-theme: inspection.get-theme-type($theme) == dark;
+  $primary: inspection.get-theme-color($theme, primary);
+  $accent: inspection.get-theme-color($theme, accent);
+  $warn: inspection.get-theme-color($theme, warn);
+  $background: inspection.get-theme-color($theme, background, background);
+  $secondary-text: inspection.get-theme-color($theme, foreground, secondary-text);
 
   // NOTE(traviskaufman): While the spec calls for translucent blacks/whites for disabled colors,
   // this does not work well with elements layered on top of one another. To get around this we
@@ -74,25 +73,21 @@
   }
 }
 
-@mixin typography($config-or-theme) {}
+@mixin typography($theme) {}
 
-@mixin _density($config-or-theme) {}
+@mixin _density($theme) {}
 
 @mixin theme($theme-or-color-config) {
   $theme: theming.private-legacy-get-theme($theme-or-color-config);
   @include theming.private-check-duplicate-theme-styles($theme, 'mat-pseudo-checkbox') {
-    $color: theming.get-color-config($theme);
-    $density: theming.get-density-config($theme);
-    $typography: theming.get-typography-config($theme);
-
-    @if $color != null {
-      @include color($color);
+    @if inspection.theme-has($theme, color) {
+      @include color($theme);
     }
-    @if $density != null {
-      @include _density($density);
+    @if inspection.theme-has($theme, density) {
+      @include _density($theme);
     }
-    @if $typography != null {
-      @include typography($typography);
+    @if inspection.theme-has($theme, typoraphyg) {
+      @include typography($theme);
     }
   }
 }

--- a/src/material/core/selection/pseudo-checkbox/_pseudo-checkbox-theme.scss
+++ b/src/material/core/selection/pseudo-checkbox/_pseudo-checkbox-theme.scss
@@ -84,7 +84,7 @@
     @if inspection.theme-has($theme, density) {
       @include _density($theme);
     }
-    @if inspection.theme-has($theme, typoraphyg) {
+    @if inspection.theme-has($theme, typography) {
       @include typography($theme);
     }
   }

--- a/src/material/core/style/_private.scss
+++ b/src/material/core/style/_private.scss
@@ -1,9 +1,9 @@
 @use 'sass:map';
 @use './elevation';
+@use '../theming/inspection';
 
-@mixin private-theme-elevation($zValue, $config) {
-  $foreground: map.get($config, foreground);
-  $elevation-color: map.get($foreground, elevation);
+@mixin private-theme-elevation($zValue, $theme) {
+  $elevation-color: inspection.get-theme-color($theme, foreground, elevation);
   $elevation-color-or-default: if($elevation-color == null, elevation.$color, $elevation-color);
 
   @include elevation.elevation($zValue, $elevation-color-or-default);

--- a/src/material/core/style/_sass-utils.scss
+++ b/src/material/core/style/_sass-utils.scss
@@ -1,3 +1,4 @@
+@use 'sass:color';
 @use 'sass:map';
 @use 'sass:meta';
 
@@ -46,4 +47,10 @@
 ///     $value.
 @function coerce-to-list($value) {
   @return if(meta.type-of($value) != 'list', ($value,), $value);
+}
+
+/// A version of the Sass `color.change` function that is safe ot use with CSS variables.
+@function safe-color-change($color, $args...) {
+  $args: meta.keywords($args);
+  @return if(meta.type-of($color) == 'color', color.change($color, $args...), $color);
 }

--- a/src/material/core/theming/_m2-inspection.scss
+++ b/src/material/core/theming/_m2-inspection.scss
@@ -1,14 +1,33 @@
 @use 'sass:list';
 @use 'sass:map';
+@use 'sass:meta';
 @use './theming';
 @use '../typography/typography-utils';
 
+$_internals: _mat-theming-internals-do-not-access;
+
 $_typography-properties: (font, font-family, line-height, font-size, letter-spacing, font-weight);
+
+/// Checks whether the given theme contains error objects.
+@function _is-error-theme($theme) {
+  @if meta.type-of($theme) != 'map' {
+    @return false;
+  }
+  @if map.get($theme, ERROR) {
+    @return true;
+  }
+  @return _is-error-theme(list.nth(map.values($theme), 1));
+}
 
 /// Gets the m2-config from the theme.
 @function _get-m2-config($theme) {
-  $internal: map.get($theme, _mat-theming-internals-do-not-access, m2-config);
-  @return $internal or $theme;
+  // It is possible for a user to pass a "density theme" that is just a number.
+  @if meta.type-of($theme) != 'map' {
+    @return $theme;
+  }
+  $internal: map.get($theme, $_internals, m2-config);
+  $theme: map.remove($theme, $_internals);
+  @return if(_is-error-theme($theme), $internal, $theme or $internal);
 }
 
 /// Gets the type of theme represented by a theme object (light or dark).
@@ -20,6 +39,11 @@ $_typography-properties: (font, font-family, line-height, font-size, letter-spac
     @error 'Color information is not available on this theme.';
   }
   $colors: theming.get-color-config($theme);
+  // Some apps seem to have mistakenly created nested color themes that somehow work with our old
+  // theme normalization logic. This check allows those apps to keep working.
+  @if theme-has($colors, color) {
+    $colors: theming.get-color-config($colors);
+  }
   @return if(map.get($colors, is-dark), dark, light);
 }
 
@@ -38,6 +62,11 @@ $_typography-properties: (font, font-family, line-height, font-size, letter-spac
     @error 'Color information is not available on this theme.';
   }
   $colors: theming.get-color-config($theme);
+  // Some apps seem to have mistakenly created nested color themes that somehow work with our old
+  // theme normalization logic. This check allows those apps to keep working.
+  @if theme-has($colors, color) {
+    $colors: theming.get-color-config($colors);
+  }
   $palette: map.get($colors, $palette-name);
   @if not $palette {
     @error 'Unrecognized palette name:' $palette-name;
@@ -65,7 +94,8 @@ $_typography-properties: (font, font-family, line-height, font-size, letter-spac
     @return ($font-weight list.slash($font-size, $line-height) $font-family);
   }
   @else if $property == font-family {
-    @return typography-utils.font-family($typography, $typescale);
+    $result: typography-utils.font-family($typography, $typescale);
+    @return $result or typography-utils.font-family($typography);
   }
   @else if $property == font-size {
     @return typography-utils.font-size($typography, $typescale);
@@ -102,7 +132,6 @@ $_typography-properties: (font, font-family, line-height, font-size, letter-spac
 /// @param {Boolean} Whether the theme has information about the system.
 @function theme-has($theme, $system) {
   $theme: _get-m2-config($theme);
-  $theme: theming.private-legacy-get-theme($theme);
   @if $system == base {
     @return true;
   }

--- a/src/material/core/theming/_m2-inspection.scss
+++ b/src/material/core/theming/_m2-inspection.scss
@@ -198,6 +198,11 @@ $_typography-properties: (font, font-family, line-height, font-size, letter-spac
     @return $typography != null and _has-any-key($typography, $_typography-keys);
   }
   @if $system == density {
+    // Backwards compatibility for the case where an explicit, but invalid density is given
+    // (this was previously treated as density 0).
+    @if meta.type-of($theme) == 'map' and map.get($theme, density) {
+      @return true;
+    }
     $density: theming.get-density-config($theme);
     @return $density != null and _is-density-value($density);
   }

--- a/src/material/core/theming/_m2-inspection.scss
+++ b/src/material/core/theming/_m2-inspection.scss
@@ -27,7 +27,7 @@ $_typography-properties: (font, font-family, line-height, font-size, letter-spac
   }
   $internal: map.get($theme, $_internals, m2-config);
   $theme: map.remove($theme, $_internals);
-  @return if(_is-error-theme($theme), $internal, $theme or $internal);
+  @return if(_is-error-theme($theme), $internal, $theme);
 }
 
 /// Gets the type of theme represented by a theme object (light or dark).
@@ -142,7 +142,7 @@ $_typography-properties: (font, font-family, line-height, font-size, letter-spac
     @return theming.get-typography-config($theme) != null;
   }
   @if $system == density {
-    @return theming.get-density-config($theme, $default: null) != null;
+    @return theming.get-density-config($theme) != null;
   }
   @error 'Valid systems are: base, color, typography, density. Got:' $system;
 }

--- a/src/material/core/theming/_m2-inspection.scss
+++ b/src/material/core/theming/_m2-inspection.scss
@@ -5,8 +5,10 @@
 @use '../typography/typography-utils';
 @use '../typography/typography';
 
+/// Key used to access the Angular Material theme internals.
 $_internals: _mat-theming-internals-do-not-access;
 
+/// Keys that indicate a config object is a color config.
 $_color-keys: (
   primary,
   accent,
@@ -17,6 +19,7 @@ $_color-keys: (
   color, /* included for themes that incorrectly nest the color config: (color: (color: (....))) */
 );
 
+/// Keys that indicate a config object is a typography config.
 $_typography-keys: (
   headline-1,
   headline-2,
@@ -34,18 +37,8 @@ $_typography-keys: (
   overline,
 );
 
+/// The CSS typography properties supported by the inspection API.
 $_typography-properties: (font, font-family, line-height, font-size, letter-spacing, font-weight);
-
-/// Checks whether the given theme contains error objects.
-@function _is-error-theme($theme) {
-  @if meta.type-of($theme) != 'map' {
-    @return false;
-  }
-  @if map.get($theme, ERROR) {
-    @return true;
-  }
-  @return _is-error-theme(list.nth(map.values($theme), 1));
-}
 
 /// Gets the m2-config from the theme.
 @function _get-m2-config($theme) {
@@ -56,6 +49,39 @@ $_typography-properties: (font, font-family, line-height, font-size, letter-spac
   $internal: map.get($theme, $_internals, m2-config);
   $theme: map.remove($theme, $_internals);
   @return if(_is-error-theme($theme), $internal, $theme);
+}
+
+/// Checks whether the given theme contains error values.
+/// @param {*} $theme The theme to check.
+/// @return {Boolean} true if the theme contains error values, else false.
+@function _is-error-theme($theme) {
+  @if meta.type-of($theme) != 'map' {
+    @return false;
+  }
+  @if map.get($theme, ERROR) {
+    @return true;
+  }
+  @return _is-error-theme(list.nth(map.values($theme), 1));
+}
+
+/// Checks whether the given theme object has any of the given keys.
+/// @param {Map} $theme The theme to check
+/// @param {List} $keys The keys to check for
+/// @return {Boolean} Whether the theme has any of the given keys.
+@function _has-any-key($theme, $keys) {
+  @each $key in $keys {
+    @if map.has-key($theme, $key) {
+      @return true;
+    }
+  }
+  @return false;
+}
+
+/// Checks whether the given theme is a density scale value.
+/// @param {*} $theme The theme to check.
+/// @return {Boolean} true if the theme is a density scale value, else false.
+@function _is-density-value($theme) {
+  @return $theme == minimum or $theme == maximum or meta.type-of($theme) == 'number';
 }
 
 /// Gets the type of theme represented by a theme object (light or dark).
@@ -176,17 +202,4 @@ $_typography-properties: (font, font-family, line-height, font-size, letter-spac
     @return $density != null and _is-density-value($density);
   }
   @error 'Valid systems are: base, color, typography, density. Got:' $system;
-}
-
-@function _has-any-key($theme, $keys) {
-  @each $key in $keys {
-    @if map.has-key($theme, $key) {
-      @return true;
-    }
-  }
-  @return false;
-}
-
-@function _is-density-value($theme) {
-  @return $theme == minimum or $theme == maximum or meta.type-of($theme) == 'number';
 }

--- a/src/material/core/theming/_m2-inspection.scss
+++ b/src/material/core/theming/_m2-inspection.scss
@@ -7,6 +7,33 @@
 
 $_internals: _mat-theming-internals-do-not-access;
 
+$_color-keys: (
+  primary,
+  accent,
+  warn,
+  foreground,
+  background,
+  is-dark,
+  color, /* included for themes that incorrectly nest the color config: (color: (color: (....))) */
+);
+
+$_typography-keys: (
+  headline-1,
+  headline-2,
+  headline-3,
+  headline-4,
+  headline-5,
+  headline-6,
+  subtitle-1,
+  font-famiy,
+  subtitle-2,
+  body-1,
+  body-2,
+  button,
+  caption,
+  overline,
+);
+
 $_typography-properties: (font, font-family, line-height, font-size, letter-spacing, font-weight);
 
 /// Checks whether the given theme contains error objects.
@@ -137,22 +164,29 @@ $_typography-properties: (font, font-family, line-height, font-size, letter-spac
     @return true;
   }
   @if $system == color {
-    @if not theming.private-is-theme-object($theme) {
-      @return map.has-key($theme, primary);
-    }
-    @return theming.get-color-config($theme) != null;
+    $color: theming.get-color-config($theme);
+    @return $color != null and _has-any-key($color, $_color-keys);
   }
   @if $system == typography {
-    @if not theming.private-is-theme-object($theme) {
-      @return map.has-key($theme, body-1);
-    }
-    @return theming.get-typography-config($theme) != null;
+    $typography: theming.get-typography-config($theme);
+    @return $typography != null and _has-any-key($typography, $_typography-keys);
   }
   @if $system == density {
-    @if not theming.private-is-theme-object($theme) {
-      @return $theme == minimum or $theme == maximum or meta.type-of($theme) == 'number';
-    }
-    @return theming.get-density-config($theme) != null;
+    $density: theming.get-density-config($theme);
+    @return $density != null and _is-density-value($density);
   }
   @error 'Valid systems are: base, color, typography, density. Got:' $system;
+}
+
+@function _has-any-key($theme, $keys) {
+  @each $key in $keys {
+    @if map.has-key($theme, $key) {
+      @return true;
+    }
+  }
+  @return false;
+}
+
+@function _is-density-value($theme) {
+  @return $theme == minimum or $theme == maximum or meta.type-of($theme) == 'number';
 }

--- a/src/material/core/theming/_m2-inspection.scss
+++ b/src/material/core/theming/_m2-inspection.scss
@@ -137,12 +137,21 @@ $_typography-properties: (font, font-family, line-height, font-size, letter-spac
     @return true;
   }
   @if $system == color {
+    @if not theming.private-is-theme-object($theme) {
+      @return map.has-key($theme, primary);
+    }
     @return theming.get-color-config($theme) != null;
   }
   @if $system == typography {
+    @if not theming.private-is-theme-object($theme) {
+      @return map.has-key($theme, body-1);
+    }
     @return theming.get-typography-config($theme) != null;
   }
   @if $system == density {
+    @if not theming.private-is-theme-object($theme) {
+      @return $theme == minimum or $theme == maximum or meta.type-of($theme) == 'number';
+    }
     @return theming.get-density-config($theme) != null;
   }
   @error 'Valid systems are: base, color, typography, density. Got:' $system;

--- a/src/material/core/theming/_m2-inspection.scss
+++ b/src/material/core/theming/_m2-inspection.scss
@@ -3,6 +3,7 @@
 @use 'sass:meta';
 @use './theming';
 @use '../typography/typography-utils';
+@use '../typography/typography';
 
 $_internals: _mat-theming-internals-do-not-access;
 
@@ -85,7 +86,7 @@ $_typography-properties: (font, font-family, line-height, font-size, letter-spac
   @if not theme-has($theme, typography) {
     @error 'Typography information is not available on this theme.';
   }
-  $typography: theming.get-typography-config($theme);
+  $typography: typography.private-typography-to-2018-config(theming.get-typography-config($theme));
   @if $property == font {
     $font-weight: typography-utils.font-weight($typography, $typescale);
     $font-size: typography-utils.font-size($typography, $typescale);

--- a/src/material/core/theming/_theming.scss
+++ b/src/material/core/theming/_theming.scss
@@ -633,5 +633,5 @@ $_internals: _mat-theming-internals-do-not-access;
     }
     @return $value;
   }
-  @return ('ERROR': $message);
+  @return (ERROR: $message);
 }

--- a/src/material/core/theming/_theming.scss
+++ b/src/material/core/theming/_theming.scss
@@ -5,6 +5,7 @@
 @use 'palette';
 @use '../density/private/compatibility';
 
+// Whether to enable compatibility with legacy methods for accessing theme information.
 $theme-legacy-inspection-api-compatibility: true !default;
 
 // Whether duplication warnings should be disabled. Warnings enabled by default.
@@ -186,10 +187,10 @@ $_emitted-base: () !default;
   // configuration for the `color` theming part.
   @if $accent != null {
     @warn $_legacy-theme-warning;
-    @return private-create-backwards-compatibility-theme(_mat-validate-theme((
+    @return _internalize-theme(private-create-backwards-compatibility-theme(_mat-validate-theme((
       _is-legacy-theme: true,
       color: _mat-create-light-color-config($primary, $accent, $warn),
-    )));
+    ))));
   }
   // If the map pattern is used (1), we just pass-through the configurations for individual
   // parts of the theming system, but update the `color` configuration if set. As explained
@@ -202,7 +203,8 @@ $_emitted-base: () !default;
     $warn: map.get($color-settings, warn);
     $result: map.merge($result, (color: _mat-create-light-color-config($primary, $accent, $warn)));
   }
-  @return private-create-backwards-compatibility-theme(_mat-validate-theme($result));
+  @return _internalize-theme(
+      private-create-backwards-compatibility-theme(_mat-validate-theme($result)));
 }
 
 // TODO: Remove legacy API and rename below `$primary` to `$config`. Currently it cannot be renamed
@@ -227,10 +229,10 @@ $_emitted-base: () !default;
   // configuration for the `color` theming part.
   @if $accent != null {
     @warn $_legacy-theme-warning;
-    @return private-create-backwards-compatibility-theme(_mat-validate-theme((
+    @return _internalize-theme(private-create-backwards-compatibility-theme(_mat-validate-theme((
       _is-legacy-theme: true,
       color: _mat-create-dark-color-config($primary, $accent, $warn),
-    )));
+    ))));
   }
   // If the map pattern is used (1), we just pass-through the configurations for individual
   // parts of the theming system, but update the `color` configuration if set. As explained
@@ -243,7 +245,8 @@ $_emitted-base: () !default;
     $warn: map.get($color-settings, warn);
     $result: map.merge($result, (color: _mat-create-dark-color-config($primary, $accent, $warn)));
   }
-  @return private-create-backwards-compatibility-theme(_mat-validate-theme($result));
+  @return _internalize-theme(
+      private-create-backwards-compatibility-theme(_mat-validate-theme($result)));
 }
 
 /// Gets the color configuration from the given theme or configuration.
@@ -546,14 +549,7 @@ $_internals: _mat-theming-internals-do-not-access;
     @return $theme;
   }
   $color: map.get($theme, color);
-  $m2-config: map.merge($theme, $color);
-  $theme: (
-    _mat-theming-internals-do-not-access: (
-      theme-version: 0,
-      m2-config: $m2-config,
-    )
-  );
-  @return map.merge(if($theme-legacy-inspection-api-compatibility, $m2-config, ()), $theme);
+  @return map.merge($theme, $color);
 }
 
 // Gets the theme from the given value that is either already a theme, or a color configuration.
@@ -603,4 +599,39 @@ $_internals: _mat-theming-internals-do-not-access;
     @return $max;
   }
   @return $density-scale;
+}
+
+@function _internalize-theme($theme) {
+  @if map.has-key($theme, $_internals) {
+    @return $theme;
+  }
+  $internalized-theme: (
+    $_internals: (
+      theme-version: 0,
+      m2-config: $theme
+    )
+  );
+  @if ($theme-legacy-inspection-api-compatibility) {
+    @return map.merge($theme, $internalized-theme);
+  }
+  $error-theme:
+    _replace-values-with-errors($theme, 'Theme may only be accessed via theme inspection API');
+  @return map.merge($error-theme, $internalized-theme);
+}
+
+@function _replace-values-with-errors($value, $message) {
+  $value-type: meta.type-of($value);
+  @if $value-type == 'map' {
+    @each $k, $v in $value {
+      $value: map.set($value, $k, _replace-values-with-errors($v, $message));
+    }
+    @return $value;
+  }
+  @else if $value-type == 'list' and list.length($value) > 0 {
+    @for $i from 1 through list.length() {
+      $value: list.set-nth($value, $i, _replace-values-with-errors(list.nth($value, $i), $message));
+    }
+    @return $value;
+  }
+  @return ('ERROR': $message);
 }

--- a/src/material/core/theming/_theming.scss
+++ b/src/material/core/theming/_theming.scss
@@ -601,6 +601,10 @@ $_internals: _mat-theming-internals-do-not-access;
   @return $density-scale;
 }
 
+/// Copies the given theme object and nests it within itself under a secret key and replaces the
+/// original map keys with error values. This allows the inspection API which is aware of the secret
+/// key to access the real values, but attempts to directly access the map will result in errors.
+/// @param {Map} $theme The theme map.
 @function _internalize-theme($theme) {
   @if map.has-key($theme, $_internals) {
     @return $theme;
@@ -619,6 +623,15 @@ $_internals: _mat-theming-internals-do-not-access;
   @return map.merge($error-theme, $internalized-theme);
 }
 
+/// Replaces concrete CSS values with errors in a theme object.
+/// Errors are represented as a map `(ERROR: <message>)`. Because maps are not valid CSS values,
+/// the Sass will not compile if the user tries to use any of the error theme values in their CSS.
+/// Users will see a message about `(ERROR: <message>)` not being a valid CSS value. Using the
+/// message, that winds up getting shown, we can help explain to users why they're getting the
+/// error.
+/// @param {*} $value The theme value to replace with errors.
+/// @param {String} $message The error message to sow users.
+/// @return {Map} A version of $value where concrete CSS values have been replaced with errors
 @function _replace-values-with-errors($value, $message) {
   $value-type: meta.type-of($value);
   @if $value-type == 'map' {

--- a/src/material/core/theming/tests/test-css-variables-theme.scss
+++ b/src/material/core/theming/tests/test-css-variables-theme.scss
@@ -10,11 +10,13 @@
   $output: ();
 
   @each $key, $value in $palette {
-    @if (meta.type-of($value) == 'map') {
-      $output: map.merge(($key: _replace-all-values($value, $replacement)), $output);
-    }
-    @else {
-      $output: map.merge(($key: $replacement), $output);
+    @if $key != _mat-theming-internals-do-not-access {
+      @if (meta.type-of($value) == 'map') {
+        $output: map.merge(($key: _replace-all-values($value, $replacement)), $output);
+      }
+ @else {
+        $output: map.merge(($key: $replacement), $output);
+      }
     }
   }
 

--- a/src/material/core/tokens/m2/mat/_card.scss
+++ b/src/material/core/tokens/m2/mat/_card.scss
@@ -1,8 +1,5 @@
-@use 'sass:map';
 @use '../../token-utils';
-@use '../../../theming/theming';
 @use '../../../theming/inspection';
-@use '../../../typography/typography-utils';
 @use '../../../style/sass-utils';
 
 // The prefix used to generate the fully qualified name for tokens in this file.

--- a/src/material/core/tokens/m2/mat/_card.scss
+++ b/src/material/core/tokens/m2/mat/_card.scss
@@ -1,6 +1,7 @@
 @use 'sass:map';
 @use '../../token-utils';
 @use '../../../theming/theming';
+@use '../../../theming/inspection';
 @use '../../../typography/typography-utils';
 @use '../../../style/sass-utils';
 
@@ -14,45 +15,41 @@ $prefix: (mat, card);
 }
 
 // Tokens that can be configured through Angular Material's color theming API.
-@function get-color-tokens($config) {
-  $foreground: map.get($config, foreground);
-
+@function get-color-tokens($theme) {
   @return (
     // Text color of the card's subtitle.
-    subtitle-text-color: theming.get-color-from-palette($foreground, secondary-text),
+    subtitle-text-color: inspection.get-theme-color($theme, foreground, secondary-text),
   );
 }
 
 // Tokens that can be configured through Angular Material's typography theming API.
-@function get-typography-tokens($config) {
+@function get-typography-tokens($theme) {
   @return (
     // Font family of the card's title.
-    title-text-font: typography-utils.font-family($config, headline-6)
-          or typography-utils.font-family($config),
+    title-text-font: inspection.get-theme-typography($theme, headline-6, font-family),
     // Line height of the card's title.
-    title-text-line-height: typography-utils.line-height($config, headline-6),
+    title-text-line-height: inspection.get-theme-typography($theme, headline-6, line-height),
     // Font size of the card's title.
-    title-text-size: typography-utils.font-size($config, headline-6),
+    title-text-size: inspection.get-theme-typography($theme, headline-6, font-size),
     // Letter spacing of the card's title.
-    title-text-tracking: typography-utils.letter-spacing($config, headline-6),
+    title-text-tracking: inspection.get-theme-typography($theme, headline-6, letter-spacing),
     // Font weight of the card's title.
-    title-text-weight: typography-utils.font-weight($config, headline-6),
+    title-text-weight: inspection.get-theme-typography($theme, headline-6, font-weight),
     // Font family of the card's subtitle.
-    subtitle-text-font: typography-utils.font-family($config, subtitle-2)
-          or typography-utils.font-family($config),
+    subtitle-text-font: inspection.get-theme-typography($theme, subtitle-2, font-family),
     // Line height of the card's subtitle.
-    subtitle-text-line-height: typography-utils.line-height($config, subtitle-2),
+    subtitle-text-line-height: inspection.get-theme-typography($theme, subtitle-2, line-height),
     // Font size of the card's subtitle.
-    subtitle-text-size: typography-utils.font-size($config, subtitle-2),
+    subtitle-text-size: inspection.get-theme-typography($theme, subtitle-2, font-size),
     // Letter spacing of the card's subtitle.
-    subtitle-text-tracking: typography-utils.letter-spacing($config, subtitle-2),
+    subtitle-text-tracking: inspection.get-theme-typography($theme, subtitle-2, letter-spacing),
     // Font weight of the card's subtitle.
-    subtitle-text-weight: typography-utils.font-weight($config, subtitle-2),
+    subtitle-text-weight: inspection.get-theme-typography($theme, subtitle-2, font-weight),
   );
 }
 
 // Tokens that can be configured through Angular Material's density theming API.
-@function get-density-tokens($config) {
+@function get-density-tokens($theme) {
   @return ();
 }
 

--- a/src/material/core/tokens/m2/mat/_form-field.scss
+++ b/src/material/core/tokens/m2/mat/_form-field.scss
@@ -2,6 +2,7 @@
 @use '../../token-utils';
 @use '../../../style/sass-utils';
 @use '../../../theming/theming';
+@use '../../../theming/inspection';
 @use '../../../theming/palette';
 @use '../../../typography/typography-utils';
 
@@ -15,17 +16,16 @@ $prefix: (mat, form-field);
 }
 
 // Tokens that can be configured through Angular Material's color theming API.
-@function get-color-tokens($config) {
-  $warn: map.get($config, warn);
-  $is-dark: map.get($config, is-dark);
+@function get-color-tokens($theme) {
+  $is-dark: inspection.get-theme-type($theme) == dark;
   $on-surface: if($is-dark, #fff, #000);
-  $color-tokens: private-get-color-palette-color-tokens($config, primary);
+  $color-tokens: private-get-color-palette-color-tokens($theme, primary);
 
   @return map.merge($color-tokens, (
     // MDC has a token for the enabled placeholder, but not for the disabled one.
     disabled-input-text-placeholder-color: rgba($on-surface, 0.38),
     state-layer-color: rgba($on-surface, 0.87),
-    error-text-color: theming.get-color-from-palette($warn),
+    error-text-color: inspection.get-theme-color($theme, warn),
 
     // On dark themes we set the native `select` color to some shade of white,
     // however the color propagates to all of the `option` elements, which are
@@ -48,27 +48,25 @@ $prefix: (mat, form-field);
 }
 
 // Generates the mapping for the properties that change based on the form field color.
-@function private-get-color-palette-color-tokens($config, $palette-name) {
-  $palette: map.get($config, $palette-name);
+@function private-get-color-palette-color-tokens($theme, $palette-name) {
+  $palette-color: inspection.get-theme-color($theme, $palette-name);
 
   @return (
-    focus-select-arrow-color: theming.get-color-from-palette($palette, default, 0.87),
+    focus-select-arrow-color: rgba($palette-color, 0.87),
   );
 }
 
 // Tokens that can be configured through Angular Material's typography theming API.
-@function get-typography-tokens($config) {
-  $fallback-font-family: typography-utils.font-family($config);
-
+@function get-typography-tokens($theme) {
   @return (
     // MDC uses `subtitle1` for the input value, placeholder and floating label. The spec
     // shows `body1` for text fields though, so we manually override the typography.
     // Note: Form controls inherit the typography from the parent form field.
-    container-text-font: typography-utils.font-family($config, body-1) or $fallback-font-family,
-    container-text-line-height: typography-utils.line-height($config, body-1),
-    container-text-size: typography-utils.font-size($config, body-1),
-    container-text-tracking: typography-utils.letter-spacing($config, body-1),
-    container-text-weight: typography-utils.font-weight($config, body-1),
+    container-text-font: inspection.get-theme-typography($theme, body-1, font-family),
+    container-text-line-height: inspection.get-theme-typography($theme, body-1, line-height),
+    container-text-size: inspection.get-theme-typography($theme, body-1, font-size),
+    container-text-tracking: inspection.get-theme-typography($theme, body-1, letter-spacing),
+    container-text-weight: inspection.get-theme-typography($theme, body-1, font-weight),
 
     // In the container styles, we updated the floating label to use the `body-1` typography level.
     // The MDC notched outline overrides this accidentally (only when the label floats) to a
@@ -78,18 +76,18 @@ $prefix: (mat, form-field);
     // https://github.com/material-components/material-components-web/blob/master/packages/mdc-notched-outline/_mixins.scss#L272-L292.
     // This is why we can't use their `label-text-populated-size` token and we have to declare
     // our own version of it.
-    outlined-label-text-populated-size: typography-utils.font-size($config, body-1),
+    outlined-label-text-populated-size: inspection.get-theme-typography($theme, body-1, font-size),
 
-    subscript-text-font: typography-utils.font-family($config, caption) or $fallback-font-family,
-    subscript-text-line-height: typography-utils.line-height($config, caption),
-    subscript-text-size: typography-utils.font-size($config, caption),
-    subscript-text-tracking: typography-utils.letter-spacing($config, caption),
-    subscript-text-weight: typography-utils.font-weight($config, caption),
+    subscript-text-font: inspection.get-theme-typography($theme, caption, font-family),
+    subscript-text-line-height: inspection.get-theme-typography($theme, caption, line-height),
+    subscript-text-size: inspection.get-theme-typography($theme, caption, font-size),
+    subscript-text-tracking: inspection.get-theme-typography($theme, caption, letter-spacing),
+    subscript-text-weight: inspection.get-theme-typography($theme, caption, font-weight),
   );
 }
 
 // Tokens that can be configured through Angular Material's density theming API.
-@function get-density-tokens($config) {
+@function get-density-tokens($theme) {
   @return ();
 }
 

--- a/src/material/core/tokens/m2/mat/_form-field.scss
+++ b/src/material/core/tokens/m2/mat/_form-field.scss
@@ -1,10 +1,8 @@
 @use 'sass:map';
 @use '../../token-utils';
 @use '../../../style/sass-utils';
-@use '../../../theming/theming';
 @use '../../../theming/inspection';
 @use '../../../theming/palette';
-@use '../../../typography/typography-utils';
 
 // The prefix used to generate the fully qualified name for tokens in this file.
 $prefix: (mat, form-field);

--- a/src/material/core/tokens/m2/mat/_form-field.scss
+++ b/src/material/core/tokens/m2/mat/_form-field.scss
@@ -50,7 +50,7 @@ $prefix: (mat, form-field);
   $palette-color: inspection.get-theme-color($theme, $palette-name);
 
   @return (
-    focus-select-arrow-color: rgba($palette-color, 0.87),
+    focus-select-arrow-color: sass-utils.safe-color-change($palette-color, $alpha: 0.87),
   );
 }
 

--- a/src/material/core/tokens/m2/mat/_optgroup.scss
+++ b/src/material/core/tokens/m2/mat/_optgroup.scss
@@ -1,6 +1,7 @@
 @use 'sass:map';
 @use '../../token-utils';
 @use '../../../theming/theming';
+@use '../../../theming/inspection';
 @use '../../../style/sass-utils';
 @use '../../../typography/typography-utils';
 @use '../../../mdc-helpers/mdc-helpers';
@@ -15,36 +16,33 @@ $prefix: (mat, optgroup);
 }
 
 // Tokens that can be configured through Angular Material's color theming API.
-@function get-color-tokens($config) {
-  $foreground: map.get($config, foreground);
-
+@function get-color-tokens($theme) {
   @return (
-    label-text-color: theming.get-color-from-palette($foreground, text),
+    label-text-color: inspection.get-theme-color($theme, foreground, text),
   );
 }
 
 // Tokens that can be configured through Angular Material's typography theming API.
-@function get-typography-tokens($config) {
+@function get-typography-tokens($theme) {
   // TODO(crisbeto): The earlier implementation of the option used MDC's APIs to create the
   // typography tokens. As a result, we unintentionally allowed `null` typography configs to be
   // passed in. Since there a lot of apps that now depend on this pattern, we need this temporary
   // fallback.
-  @if ($config == null) {
-    $config: mdc-helpers.private-fallback-typography-from-mdc();
+  @if ($theme == null) {
+    $theme: mdc-helpers.private-fallback-typography-from-mdc();
   }
 
   @return (
-    label-text-font: typography-utils.font-family($config, body-1) or
-      typography-utils.font-family($config),
-    label-text-line-height: typography-utils.line-height($config, body-1),
-    label-text-size: typography-utils.font-size($config, body-1),
-    label-text-tracking: typography-utils.letter-spacing($config, body-1),
-    label-text-weight: typography-utils.font-weight($config, body-1)
+    label-text-font: inspection.get-theme-typography($theme, body-1, font-family),
+    label-text-line-height: inspection.get-theme-typography($theme, body-1, line-height),
+    label-text-size: inspection.get-theme-typography($theme, body-1, font-size),
+    label-text-tracking: inspection.get-theme-typography($theme, body-1, letter-spacing),
+    label-text-weight: inspection.get-theme-typography($theme, body-1, font-weight)
   );
 }
 
 // Tokens that can be configured through Angular Material's density theming API.
-@function get-density-tokens($config) {
+@function get-density-tokens($theme) {
   @return ();
 }
 

--- a/src/material/core/tokens/m2/mat/_optgroup.scss
+++ b/src/material/core/tokens/m2/mat/_optgroup.scss
@@ -1,9 +1,6 @@
-@use 'sass:map';
 @use '../../token-utils';
-@use '../../../theming/theming';
 @use '../../../theming/inspection';
 @use '../../../style/sass-utils';
-@use '../../../typography/typography-utils';
 @use '../../../mdc-helpers/mdc-helpers';
 
 // The prefix used to generate the fully qualified name for tokens in this file.

--- a/src/material/core/tokens/m2/mat/_option.scss
+++ b/src/material/core/tokens/m2/mat/_option.scss
@@ -1,6 +1,7 @@
 @use 'sass:map';
 @use '../../token-utils';
 @use '../../../theming/theming';
+@use '../../../theming/inspection';
 @use '../../../style/sass-utils';
 @use '../../../typography/typography-utils';
 @use '../../../mdc-helpers/mdc-helpers';
@@ -15,51 +16,41 @@ $prefix: (mat, option);
 }
 
 // Tokens that can be configured through Angular Material's color theming API.
-@function get-color-tokens($config) {
-  $is-dark: map.get($config, is-dark);
-  $foreground: map.get($config, foreground);
-  $primary: map.get($config, primary);
+@function get-color-tokens($theme, $palette-name: primary) {
+  $is-dark: inspection.get-theme-type($theme) == dark;
   $on-surface: if($is-dark, #fff, #000);
   $active-state-layer-color: rgba($on-surface, if($is-dark, 0.08, 0.04));
-  $palette-tokens: private-get-color-palette-color-tokens($primary);
 
-  @return map.merge($palette-tokens, (
-    label-text-color: theming.get-color-from-palette($foreground, text),
+  @return (
+    selected-state-label-text-color: inspection.get-theme-color($theme, $palette-name),
+    label-text-color: inspection.get-theme-color($theme, foreground, text),
     hover-state-layer-color: $active-state-layer-color,
     focus-state-layer-color: $active-state-layer-color,
     selected-state-layer-color: $active-state-layer-color,
-  ));
+  );
 }
 
 // Tokens that can be configured through Angular Material's typography theming API.
-@function get-typography-tokens($config) {
+@function get-typography-tokens($theme) {
   // TODO(crisbeto): The earlier implementation of the option used MDC's APIs to create the
   // typography tokens. As a result, we unintentionally allowed `null` typography configs to be
   // passed in. Since there a lot of apps that now depend on this pattern, we need this temporary
   // fallback.
-  @if ($config == null) {
-    $config: mdc-helpers.private-fallback-typography-from-mdc();
+  @if ($theme == null) {
+    $theme: mdc-helpers.private-fallback-typography-from-mdc();
   }
 
   @return (
-    label-text-font: typography-utils.font-family($config, body-1) or
-      typography-utils.font-family($config),
-    label-text-line-height: typography-utils.line-height($config, body-1),
-    label-text-size: typography-utils.font-size($config, body-1),
-    label-text-tracking: typography-utils.letter-spacing($config, body-1),
-    label-text-weight: typography-utils.font-weight($config, body-1)
-  );
-}
-
-// Generates the tokens used to theme the option based on a palette.
-@function private-get-color-palette-color-tokens($palette) {
-  @return (
-    selected-state-label-text-color: theming.get-color-from-palette($palette),
+    label-text-font: inspection.get-theme-typography($theme, body-1, font-family),
+    label-text-line-height: inspection.get-theme-typography($theme, body-1, line-height),
+    label-text-size: inspection.get-theme-typography($theme, body-1, font-size),
+    label-text-tracking: inspection.get-theme-typography($theme, body-1, letter-spacing),
+    label-text-weight: inspection.get-theme-typography($theme, body-1, font-weight)
   );
 }
 
 // Tokens that can be configured through Angular Material's density theming API.
-@function get-density-tokens($config) {
+@function get-density-tokens($theme) {
   @return ();
 }
 

--- a/src/material/core/tokens/m2/mat/_option.scss
+++ b/src/material/core/tokens/m2/mat/_option.scss
@@ -1,9 +1,6 @@
-@use 'sass:map';
 @use '../../token-utils';
-@use '../../../theming/theming';
 @use '../../../theming/inspection';
 @use '../../../style/sass-utils';
-@use '../../../typography/typography-utils';
 @use '../../../mdc-helpers/mdc-helpers';
 
 // The prefix used to generate the fully qualified name for tokens in this file.

--- a/src/material/core/tokens/m2/mdc/_elevated-card.scss
+++ b/src/material/core/tokens/m2/mdc/_elevated-card.scss
@@ -1,6 +1,7 @@
 @use 'sass:map';
 @use '../../../style/elevation';
 @use '../../../theming/theming';
+@use '../../../theming/inspection';
 @use '../../../style/sass-utils';
 @use '../../token-utils';
 
@@ -45,14 +46,12 @@ $prefix: (mdc, elevated-card);
 }
 
 // Tokens that can be configured through Angular Material's color theming API.
-@function get-color-tokens($config) {
-  $background: map.get($config, background);
-  $foreground: map.get($config, foreground);
-  $elevation: theming.get-color-from-palette($foreground, elevation);
+@function get-color-tokens($theme) {
+  $elevation: inspection.get-theme-color($theme, foreground, elevation);
 
   @return (
     // The background color of the card.
-    container-color: theming.get-color-from-palette($background, card),
+    container-color: inspection.get-theme-color($theme, background, card),
     // The elevation level of the card.
     // (Part of the color tokens because it needs to be combined with the shadow color to generate
     // the final box-shadow).
@@ -63,12 +62,12 @@ $prefix: (mdc, elevated-card);
 }
 
 // Tokens that can be configured through Angular Material's typography theming API.
-@function get-typography-tokens($config) {
+@function get-typography-tokens($theme) {
   @return ();
 }
 
 // Tokens that can be configured through Angular Material's density theming API.
-@function get-density-tokens($config) {
+@function get-density-tokens($theme) {
   @return ();
 }
 

--- a/src/material/core/tokens/m2/mdc/_elevated-card.scss
+++ b/src/material/core/tokens/m2/mdc/_elevated-card.scss
@@ -1,6 +1,4 @@
-@use 'sass:map';
 @use '../../../style/elevation';
-@use '../../../theming/theming';
 @use '../../../theming/inspection';
 @use '../../../style/sass-utils';
 @use '../../token-utils';

--- a/src/material/core/tokens/m2/mdc/_filled-text-field.scss
+++ b/src/material/core/tokens/m2/mdc/_filled-text-field.scss
@@ -2,6 +2,7 @@
 @use 'sass:map';
 @use 'sass:meta';
 @use '../../../theming/theming';
+@use '../../../theming/inspection';
 @use '../../../style/sass-utils';
 @use '../../../typography/typography-utils';
 @use '../../token-utils';
@@ -93,15 +94,12 @@ $prefix: (mdc, filled-text-field);
 }
 
 // Tokens that can be configured through Angular Material's color theming API.
-@function get-color-tokens($config) {
-  $foreground: map.get($config, foreground);
-  $background: map.get($config, background);
-  $warn: map.get($config, warn);
-  $is-dark: map.get($config, is-dark);
-  $surface: theming.get-color-from-palette($background, card);
+@function get-color-tokens($theme) {
+  $is-dark: inspection.get-theme-type($theme) == dark;
+  $surface: inspection.get-theme-color($theme, background, card);
   $on-surface: if($is-dark, #fff, #000);
-  $warn-color: theming.get-color-from-palette($warn);
-  $color-tokens: private-get-color-palette-color-tokens($config, primary);
+  $warn-color: inspection.get-theme-color($theme, warn);
+  $color-tokens: private-get-color-palette-color-tokens($theme, primary);
 
   @return map.merge($color-tokens, (
     container-color: _variable-safe-mix($on-surface, $surface, 4%),
@@ -135,31 +133,29 @@ $prefix: (mdc, filled-text-field);
 }
 
 // Generates the mapping for the properties that change based on the text field color.
-@function private-get-color-palette-color-tokens($config, $palette-name) {
-  $palette: map.get($config, $palette-name);
-  $palette-color: theming.get-color-from-palette($palette);
+@function private-get-color-palette-color-tokens($theme, $palette-name) {
+  $palette: map.get($theme, $palette-name);
+  $palette-color: inspection.get-theme-color($theme, $palette-name);
 
   @return (
     caret-color: $palette-color,
     focus-active-indicator-color: $palette-color,
-    focus-label-text-color: theming.get-color-from-palette($palette, default, 0.87),
+    focus-label-text-color: rgba($palette-color, 0.87),
   );
 }
 
 // Tokens that can be configured through Angular Material's typography theming API.
-@function get-typography-tokens($config) {
-  $fallback-font-family: typography-utils.font-family($config);
-
+@function get-typography-tokens($theme) {
   @return (
-    label-text-font: typography-utils.font-family($config, body-1) or $fallback-font-family,
-    label-text-size: typography-utils.font-size($config, body-1),
-    label-text-tracking: typography-utils.letter-spacing($config, body-1),
-    label-text-weight: typography-utils.font-weight($config, body-1),
+    label-text-font: inspection.get-theme-typography($theme, body-1, font-family),
+    label-text-size: inspection.get-theme-typography($theme, body-1, font-size),
+    label-text-tracking: inspection.get-theme-typography($theme, body-1, letter-spacing),
+    label-text-weight: inspection.get-theme-typography($theme, body-1, font-weight),
   );
 }
 
 // Tokens that can be configured through Angular Material's density theming API.
-@function get-density-tokens($config) {
+@function get-density-tokens($theme) {
   @return ();
 }
 

--- a/src/material/core/tokens/m2/mdc/_filled-text-field.scss
+++ b/src/material/core/tokens/m2/mdc/_filled-text-field.scss
@@ -1,10 +1,8 @@
 @use 'sass:color';
 @use 'sass:map';
 @use 'sass:meta';
-@use '../../../theming/theming';
 @use '../../../theming/inspection';
 @use '../../../style/sass-utils';
-@use '../../../typography/typography-utils';
 @use '../../token-utils';
 
 // The prefix used to generate the fully qualified name for tokens in this file.

--- a/src/material/core/tokens/m2/mdc/_filled-text-field.scss
+++ b/src/material/core/tokens/m2/mdc/_filled-text-field.scss
@@ -138,7 +138,7 @@ $prefix: (mdc, filled-text-field);
   @return (
     caret-color: $palette-color,
     focus-active-indicator-color: $palette-color,
-    focus-label-text-color: rgba($palette-color, 0.87),
+    focus-label-text-color: sass-utils.safe-color-change($palette-color, $alpha: 0.87),
   );
 }
 

--- a/src/material/core/tokens/m2/mdc/_linear-progress.scss
+++ b/src/material/core/tokens/m2/mdc/_linear-progress.scss
@@ -1,4 +1,5 @@
 @use '../../../theming/theming';
+@use '../../../theming/inspection';
 @use '../../../style/sass-utils';
 @use '../../token-utils';
 @use 'sass:color';
@@ -27,26 +28,26 @@ $prefix: (mdc, linear-progress);
 }
 
 // Tokens that can be configured through Angular Material's color theming API.
-@function get-color-tokens($config) {
-  $primary: theming.get-color-from-palette(map.get($config, primary));
+@function get-color-tokens($theme, $palette-name: primary) {
+  $palette-color: inspection.get-theme-color($theme, $palette-name);
   @return (
     // The color of the progress bar's active section.
-    active-indicator-color: $primary,
+    active-indicator-color: $palette-color,
     track-color: if(
-        meta.type-of($primary) == color,
-        color.adjust($primary, $alpha: -0.75),
-        $primary
+        meta.type-of($palette-color) == color,
+        color.adjust($palette-color, $alpha: -0.75),
+        $palette-color
     )
   );
 }
 
 // Tokens that can be configured through Angular Material's typography theming API.
-@function get-typography-tokens($config) {
+@function get-typography-tokens($theme) {
   @return ();
 }
 
 // Tokens that can be configured through Angular Material's density theming API.
-@function get-density-tokens($config) {
+@function get-density-tokens($theme) {
   @return ();
 }
 

--- a/src/material/core/tokens/m2/mdc/_linear-progress.scss
+++ b/src/material/core/tokens/m2/mdc/_linear-progress.scss
@@ -1,9 +1,7 @@
-@use '../../../theming/theming';
 @use '../../../theming/inspection';
 @use '../../../style/sass-utils';
 @use '../../token-utils';
 @use 'sass:color';
-@use 'sass:map';
 @use 'sass:meta';
 
 // The prefix used to generate the fully qualified name for tokens in this file.

--- a/src/material/core/tokens/m2/mdc/_outlined-card.scss
+++ b/src/material/core/tokens/m2/mdc/_outlined-card.scss
@@ -1,6 +1,7 @@
 @use 'sass:map';
 @use '../../../style/elevation';
 @use '../../../theming/theming';
+@use '../../../theming/inspection';
 @use '../../../style/sass-utils';
 @use '../../token-utils';
 
@@ -51,16 +52,14 @@ $prefix: (mdc, outlined-card);
 }
 
 // Tokens that can be configured through Angular Material's color theming API.
-@function get-color-tokens($config) {
-  $background: map.get($config, background);
-  $foreground: map.get($config, foreground);
-  $elevation: theming.get-color-from-palette($foreground, elevation);
+@function get-color-tokens($theme) {
+  $elevation: inspection.get-theme-color($theme, foreground, elevation);
 
   @return (
     // The background color of the card.
-    container-color: theming.get-color-from-palette($background, card),
+    container-color: inspection.get-theme-color($theme, background, card),
     // The border color of the card.
-    outline-color: theming.get-color-from-palette($foreground, base, 0.12),
+    outline-color: rgba(inspection.get-theme-color($theme, foreground, base), 0.12),
     // The elevation level of the card.
     // (Part of the color tokens because it needs to be combined with the shadow color to generate
     // the final box-shadow).
@@ -71,12 +70,12 @@ $prefix: (mdc, outlined-card);
 }
 
 // Tokens that can be configured through Angular Material's typography theming API.
-@function get-typography-tokens($config) {
+@function get-typography-tokens($theme) {
   @return ();
 }
 
 // Tokens that can be configured through Angular Material's density theming API.
-@function get-density-tokens($config) {
+@function get-density-tokens($theme) {
   @return ();
 }
 

--- a/src/material/core/tokens/m2/mdc/_outlined-card.scss
+++ b/src/material/core/tokens/m2/mdc/_outlined-card.scss
@@ -1,6 +1,4 @@
-@use 'sass:map';
 @use '../../../style/elevation';
-@use '../../../theming/theming';
 @use '../../../theming/inspection';
 @use '../../../style/sass-utils';
 @use '../../token-utils';

--- a/src/material/core/tokens/m2/mdc/_outlined-text-field.scss
+++ b/src/material/core/tokens/m2/mdc/_outlined-text-field.scss
@@ -121,7 +121,7 @@ $prefix: (mdc, outlined-text-field);
   @return (
     caret-color: $palette-color,
     focus-outline-color: $palette-color,
-    focus-label-text-color: rgba($palette-color, 0.87),
+    focus-label-text-color: sass-utils.safe-color-change($palette-color, $alpha: 0.87),
   );
 }
 

--- a/src/material/core/tokens/m2/mdc/_outlined-text-field.scss
+++ b/src/material/core/tokens/m2/mdc/_outlined-text-field.scss
@@ -1,8 +1,6 @@
 @use 'sass:map';
-@use '../../../theming/theming';
 @use '../../../theming/inspection';
 @use '../../../style/sass-utils';
-@use '../../../typography/typography-utils';
 @use '../../token-utils';
 
 // The prefix used to generate the fully qualified name for tokens in this file.

--- a/src/material/core/tokens/m2/mdc/_outlined-text-field.scss
+++ b/src/material/core/tokens/m2/mdc/_outlined-text-field.scss
@@ -1,5 +1,6 @@
 @use 'sass:map';
 @use '../../../theming/theming';
+@use '../../../theming/inspection';
 @use '../../../style/sass-utils';
 @use '../../../typography/typography-utils';
 @use '../../token-utils';
@@ -87,13 +88,11 @@ $prefix: (mdc, outlined-text-field);
 }
 
 // Tokens that can be configured through Angular Material's color theming API.
-@function get-color-tokens($config) {
-  $foreground: map.get($config, foreground);
-  $warn: map.get($config, warn);
-  $is-dark: map.get($config, is-dark);
+@function get-color-tokens($theme) {
+  $is-dark: inspection.get-theme-type($theme) == dark;
   $on-surface: if($is-dark, #fff, #000);
-  $warn-color: theming.get-color-from-palette($warn);
-  $color-tokens: private-get-color-palette-color-tokens($config, primary);
+  $warn-color: inspection.get-theme-color($theme, warn);
+  $color-tokens: private-get-color-palette-color-tokens($theme, primary);
 
   @return map.merge($color-tokens, (
     label-text-color: rgba($on-surface, 0.6),
@@ -118,31 +117,28 @@ $prefix: (mdc, outlined-text-field);
 }
 
 // Generates the mapping for the properties that change based on the text field color.
-@function private-get-color-palette-color-tokens($config, $palette-name) {
-  $palette: map.get($config, $palette-name);
-  $palette-color: theming.get-color-from-palette($palette);
+@function private-get-color-palette-color-tokens($theme, $palette-name) {
+  $palette-color: inspection.get-theme-color($theme, $palette-name);
 
   @return (
     caret-color: $palette-color,
     focus-outline-color: $palette-color,
-    focus-label-text-color: theming.get-color-from-palette($palette, default, 0.87),
+    focus-label-text-color: rgba($palette-color, 0.87),
   );
 }
 
 // Tokens that can be configured through Angular Material's typography theming API.
-@function get-typography-tokens($config) {
-  $fallback-font-family: typography-utils.font-family($config);
-
+@function get-typography-tokens($theme) {
   @return (
-    label-text-font: typography-utils.font-family($config, body-1) or $fallback-font-family,
-    label-text-size: typography-utils.font-size($config, body-1),
-    label-text-tracking: typography-utils.letter-spacing($config, body-1),
-    label-text-weight: typography-utils.font-weight($config, body-1),
+    label-text-font: inspection.get-theme-typography($theme, body-1, font-family),
+    label-text-size: inspection.get-theme-typography($theme, body-1, font-size),
+    label-text-tracking: inspection.get-theme-typography($theme, body-1, letter-spacing),
+    label-text-weight: inspection.get-theme-typography($theme, body-1, font-weight),
   );
 }
 
 // Tokens that can be configured through Angular Material's density theming API.
-@function get-density-tokens($config) {
+@function get-density-tokens($theme) {
   @return ();
 }
 

--- a/src/material/form-field/_form-field-density.scss
+++ b/src/material/form-field/_form-field-density.scss
@@ -3,6 +3,7 @@
 @use '@material/density' as mdc-density;
 @use '@material/textfield' as mdc-textfield;
 @use '../core/theming/theming';
+@use '../core/theming/inspection';
 
 @use './form-field-sizing';
 
@@ -39,12 +40,11 @@
 // provide spacing that makes arbitrary controls align as specified in the Material Design
 // specification. In order to support density, we need to adjust the vertical spacing to be
 // based on the density scale.
-@mixin private-form-field-density($config-or-theme) {
-  $density-scale: theming.get-density-config($config-or-theme);
+@mixin private-form-field-density($theme) {
   // Height of the form field that is based on the current density scale.
   $height: mdc-density.prop-value(
     $density-config: mdc-textfield.$density-config,
-    $density-scale: $density-scale,
+    $density-scale: inspection.get-theme-density($theme),
     $property-name: height,
   );
 

--- a/src/material/form-field/_form-field-density.scss
+++ b/src/material/form-field/_form-field-density.scss
@@ -2,7 +2,6 @@
 @use 'sass:math';
 @use '@material/density' as mdc-density;
 @use '@material/textfield' as mdc-textfield;
-@use '../core/theming/theming';
 @use '../core/theming/inspection';
 
 @use './form-field-sizing';

--- a/src/material/form-field/_form-field-theme.scss
+++ b/src/material/form-field/_form-field-theme.scss
@@ -11,7 +11,7 @@
 @use '../core/tokens/token-utils';
 @use './form-field-density';
 
-@mixin color($config-or-theme) {
+@mixin color($theme) {
   @include sass-utils.current-selector-or-root() {
     @include mdc-filled-text-field-theme.theme(
       tokens-mdc-filled-text-field.get-color-tokens($theme));
@@ -40,7 +40,7 @@
   }
 }
 
-@mixin typography($config-or-theme) {
+@mixin typography($theme) {
   @include sass-utils.current-selector-or-root() {
     @include mdc-filled-text-field-theme.theme(
       tokens-mdc-filled-text-field.get-typography-tokens($theme));
@@ -51,7 +51,7 @@
   }
 }
 
-@mixin density($config-or-theme) {
+@mixin density($theme) {
   @include form-field-density.private-form-field-density($theme);
 }
 

--- a/src/material/form-field/_form-field-theme.scss
+++ b/src/material/form-field/_form-field-theme.scss
@@ -11,7 +11,7 @@
 @use '../core/tokens/token-utils';
 @use './form-field-density';
 
-@mixin color($theme) {
+@mixin color($config-or-theme) {
   @include sass-utils.current-selector-or-root() {
     @include mdc-filled-text-field-theme.theme(
       tokens-mdc-filled-text-field.get-color-tokens($theme));
@@ -40,7 +40,7 @@
   }
 }
 
-@mixin typography($theme) {
+@mixin typography($config-or-theme) {
   @include sass-utils.current-selector-or-root() {
     @include mdc-filled-text-field-theme.theme(
       tokens-mdc-filled-text-field.get-typography-tokens($theme));
@@ -51,7 +51,7 @@
   }
 }
 
-@mixin density($theme) {
+@mixin density($config-or-theme) {
   @include form-field-density.private-form-field-density($theme);
 }
 

--- a/src/material/form-field/_form-field-theme.scss
+++ b/src/material/form-field/_form-field-theme.scss
@@ -55,8 +55,7 @@
   @include form-field-density.private-form-field-density($theme);
 }
 
-@mixin theme($theme-or-color-config) {
-  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+@mixin theme($theme) {
   @include theming.private-check-duplicate-theme-styles($theme, 'mat-form-field') {
     @if inspection.theme-has($theme, color) {
       @include color($theme);

--- a/src/material/form-field/_form-field-theme.scss
+++ b/src/material/form-field/_form-field-theme.scss
@@ -5,76 +5,67 @@
 @use '../core/tokens/m2/mdc/outlined-text-field' as tokens-mdc-outlined-text-field;
 @use '../core/tokens/m2/mat/form-field' as tokens-mat-form-field;
 @use '../core/theming/theming';
+@use '../core/theming/inspection';
 @use '../core/typography/typography';
 @use '../core/style/sass-utils';
 @use '../core/tokens/token-utils';
 @use './form-field-density';
 
-@mixin color($config-or-theme) {
-  $config: theming.get-color-config($config-or-theme);
-
+@mixin color($theme) {
   @include sass-utils.current-selector-or-root() {
     @include mdc-filled-text-field-theme.theme(
-      tokens-mdc-filled-text-field.get-color-tokens($config));
+      tokens-mdc-filled-text-field.get-color-tokens($theme));
     @include mdc-outlined-text-field-theme.theme(
-      tokens-mdc-outlined-text-field.get-color-tokens($config));
+      tokens-mdc-outlined-text-field.get-color-tokens($theme));
     @include token-utils.create-token-values(tokens-mat-form-field.$prefix,
-      tokens-mat-form-field.get-color-tokens($config));
+      tokens-mat-form-field.get-color-tokens($theme));
   }
 
   .mat-mdc-form-field.mat-accent {
     @include mdc-filled-text-field-theme.theme(
-      tokens-mdc-filled-text-field.private-get-color-palette-color-tokens($config, accent));
+      tokens-mdc-filled-text-field.private-get-color-palette-color-tokens($theme, accent));
     @include mdc-outlined-text-field-theme.theme(
-      tokens-mdc-outlined-text-field.private-get-color-palette-color-tokens($config, accent));
+      tokens-mdc-outlined-text-field.private-get-color-palette-color-tokens($theme, accent));
     @include token-utils.create-token-values(tokens-mat-form-field.$prefix,
-      tokens-mat-form-field.private-get-color-palette-color-tokens($config, accent));
+      tokens-mat-form-field.private-get-color-palette-color-tokens($theme, accent));
   }
 
   .mat-mdc-form-field.mat-warn {
     @include mdc-filled-text-field-theme.theme(
-      tokens-mdc-filled-text-field.private-get-color-palette-color-tokens($config, warn));
+      tokens-mdc-filled-text-field.private-get-color-palette-color-tokens($theme, warn));
     @include mdc-outlined-text-field-theme.theme(
-      tokens-mdc-outlined-text-field.private-get-color-palette-color-tokens($config, warn));
+      tokens-mdc-outlined-text-field.private-get-color-palette-color-tokens($theme, warn));
     @include token-utils.create-token-values(tokens-mat-form-field.$prefix,
-      tokens-mat-form-field.private-get-color-palette-color-tokens($config, warn));
+      tokens-mat-form-field.private-get-color-palette-color-tokens($theme, warn));
   }
 }
 
-@mixin typography($config-or-theme) {
-  $config: typography.private-typography-to-2018-config(
-      theming.get-typography-config($config-or-theme));
-
+@mixin typography($theme) {
   @include sass-utils.current-selector-or-root() {
     @include mdc-filled-text-field-theme.theme(
-      tokens-mdc-filled-text-field.get-typography-tokens($config));
+      tokens-mdc-filled-text-field.get-typography-tokens($theme));
     @include mdc-outlined-text-field-theme.theme(
-      tokens-mdc-outlined-text-field.get-typography-tokens($config));
+      tokens-mdc-outlined-text-field.get-typography-tokens($theme));
     @include token-utils.create-token-values(tokens-mat-form-field.$prefix,
-      tokens-mat-form-field.get-typography-tokens($config));
+      tokens-mat-form-field.get-typography-tokens($theme));
   }
 }
 
-@mixin density($config-or-theme) {
-  $density-scale: theming.get-density-config($config-or-theme);
-  @include form-field-density.private-form-field-density($density-scale);
+@mixin density($theme) {
+  @include form-field-density.private-form-field-density($theme);
 }
 
 @mixin theme($theme-or-color-config) {
   $theme: theming.private-legacy-get-theme($theme-or-color-config);
   @include theming.private-check-duplicate-theme-styles($theme, 'mat-form-field') {
-    $color: theming.get-color-config($theme);
-    $density: theming.get-density-config($theme);
-    $typography: theming.get-typography-config($theme);
-
-    @if $color != null {
-      @include color($color);
+    @if inspection.theme-has($theme, color) {
+      @include color($theme);
     }
-    @if $density != null {
-      @include density($density);
+    @if inspection.theme-has($theme, density) {
+      @include density($theme);
     }
-    @if $typography != null {
-      @include typography($typography);
+    @if inspection.theme-has($theme, typography) {
+      @include typography($theme);
     }
   }
 }

--- a/src/material/progress-bar/_progress-bar-theme.scss
+++ b/src/material/progress-bar/_progress-bar-theme.scss
@@ -5,7 +5,7 @@
 @use '@material/linear-progress/linear-progress-theme' as mdc-linear-progress-theme;
 @use 'sass:map';
 
-@mixin base($config-or-theme) {
+@mixin base($theme) {
   // Add default values for tokens not related to color, typography, or density.
   @include sass-utils.current-selector-or-root() {
     @include mdc-linear-progress-theme.theme(tokens-mdc-linear-progress.get-unthemable-tokens());
@@ -30,7 +30,7 @@
   @include mdc-linear-progress-theme.theme($color-tokens);
 }
 
-@mixin color($config-or-theme) {
+@mixin color($theme) {
   .mat-mdc-progress-bar {
     @include _palette-styles($theme, primary);
 
@@ -44,9 +44,9 @@
   }
 }
 
-@mixin typography($config-or-theme) {}
+@mixin typography($theme) {}
 
-@mixin density($config-or-theme) {}
+@mixin density($theme) {}
 
 @mixin theme($theme-or-color-config) {
   $theme: theming.private-legacy-get-theme($theme-or-color-config);

--- a/src/material/progress-bar/_progress-bar-theme.scss
+++ b/src/material/progress-bar/_progress-bar-theme.scss
@@ -48,8 +48,7 @@
 
 @mixin density($theme) {}
 
-@mixin theme($theme-or-color-config) {
-  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+@mixin theme($theme) {
   @include theming.private-check-duplicate-theme-styles($theme, 'mat-progress-bar') {
     @include base($theme);
     @if inspection.theme-has($theme, color) {

--- a/src/material/progress-bar/_progress-bar-theme.scss
+++ b/src/material/progress-bar/_progress-bar-theme.scss
@@ -1,5 +1,6 @@
 @use '../core/style/sass-utils';
 @use '../core/theming/theming';
+@use '../core/theming/inspection';
 @use '../core/tokens/m2/mdc/linear-progress' as tokens-mdc-linear-progress;
 @use '@material/linear-progress/linear-progress-theme' as mdc-linear-progress-theme;
 @use 'sass:map';
@@ -11,9 +12,8 @@
   }
 }
 
-@mixin _palette-styles($config, $palette-name) {
-  $palette-config: map.merge($config, (primary: map.get($config, $palette-name)));
-  $color-tokens: tokens-mdc-linear-progress.get-color-tokens($palette-config);
+@mixin _palette-styles($theme, $palette-name) {
+  $color-tokens: tokens-mdc-linear-progress.get-color-tokens($theme, $palette-name);
 
   // We can't set the `track-color` using `theme`, because it isn't possible for it to use a CSS
   // variable since MDC's buffer animation works by constructing an SVG string from this color.
@@ -30,18 +30,16 @@
   @include mdc-linear-progress-theme.theme($color-tokens);
 }
 
-@mixin color($config-or-theme) {
-  $config: theming.get-color-config($config-or-theme);
-
+@mixin color($theme) {
   .mat-mdc-progress-bar {
-    @include _palette-styles($config, primary);
+    @include _palette-styles($theme, primary);
 
     &.mat-accent {
-      @include _palette-styles($config, accent);
+      @include _palette-styles($theme, accent);
     }
 
     &.mat-warn {
-      @include _palette-styles($config, warn);
+      @include _palette-styles($theme, warn);
     }
   }
 }
@@ -53,19 +51,15 @@
 @mixin theme($theme-or-color-config) {
   $theme: theming.private-legacy-get-theme($theme-or-color-config);
   @include theming.private-check-duplicate-theme-styles($theme, 'mat-progress-bar') {
-    $color: theming.get-color-config($theme);
-    $density: theming.get-density-config($theme);
-    $typography: theming.get-typography-config($theme);
-
     @include base($theme);
-    @if $color != null {
-      @include color($color);
+    @if inspection.theme-has($theme, color) {
+      @include color($theme);
     }
-    @if $density != null {
-      @include density($density);
+    @if inspection.theme-has($theme, density) {
+      @include density($theme);
     }
-    @if $typography != null {
-      @include typography($typography);
+    @if inspection.theme-has($theme, typography) {
+      @include typography($theme);
     }
   }
 }

--- a/src/material/progress-bar/_progress-bar-theme.scss
+++ b/src/material/progress-bar/_progress-bar-theme.scss
@@ -30,7 +30,7 @@
   @include mdc-linear-progress-theme.theme($color-tokens);
 }
 
-@mixin color($theme) {
+@mixin color($config-or-theme) {
   .mat-mdc-progress-bar {
     @include _palette-styles($theme, primary);
 


### PR DESCRIPTION
Converts the following components to use the new theme inspection API
under the hood: card, core, form-field, optgroup, option, progress-bar,
pseudo-checkbox, ripple

As a side effect, this allows us to start cleaning up all of the
theme normalization logic that previously had to be baked into every
theme mixin.

The goal once all components are converted is that apps can opt
themselves into only supporting the inspection API to access theme
values and throw errors on all attempts to access the theme via other
means. This will identify usages of the theme that need to be updated to
work with M3.