### PR TITLE
refactor(cdk/dialog): changes to accommodate standalone

### DIFF
--- a/src/cdk/dialog/dialog-container.ts
+++ b/src/cdk/dialog/dialog-container.ts
@@ -20,6 +20,7 @@ import {
   CdkPortalOutlet,
   ComponentPortal,
   DomPortal,
+  PortalModule,
   TemplatePortal,
 } from '@angular/cdk/portal';
 import {DOCUMENT} from '@angular/common';
@@ -54,6 +55,8 @@ export function throwDialogContentAlreadyAttachedError() {
   // Using OnPush for dialogs caused some G3 sync issues. Disabled until we can track them down.
   // tslint:disable-next-line:validate-decorators
   changeDetection: ChangeDetectionStrategy.Default,
+  standalone: true,
+  imports: [PortalModule],
   host: {
     'class': 'cdk-dialog-container',
     'tabindex': '-1',

--- a/src/cdk/dialog/dialog-injectors.ts
+++ b/src/cdk/dialog/dialog-injectors.ts
@@ -6,13 +6,20 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {InjectionToken} from '@angular/core';
+import {InjectionToken, inject} from '@angular/core';
 import {Overlay, ScrollStrategy} from '@angular/cdk/overlay';
 import {DialogConfig} from './dialog-config';
 
 /** Injection token for the Dialog's ScrollStrategy. */
 export const DIALOG_SCROLL_STRATEGY = new InjectionToken<() => ScrollStrategy>(
   'DialogScrollStrategy',
+  {
+    providedIn: 'root',
+    factory: () => {
+      const overlay = inject(Overlay);
+      return () => overlay.scrollStrategies.block();
+    },
+  },
 );
 
 /** Injection token for the Dialog's Data. */
@@ -21,12 +28,20 @@ export const DIALOG_DATA = new InjectionToken<any>('DialogData');
 /** Injection token that can be used to provide default options for the dialog module. */
 export const DEFAULT_DIALOG_CONFIG = new InjectionToken<DialogConfig>('DefaultDialogConfig');
 
-/** @docs-private */
+/**
+ * @docs-private
+ * @deprecated No longer used. To be removed.
+ * @breaking-change 19.0.0
+ */
 export function DIALOG_SCROLL_STRATEGY_PROVIDER_FACTORY(overlay: Overlay): () => ScrollStrategy {
   return () => overlay.scrollStrategies.block();
 }
 
-/** @docs-private */
+/**
+ * @docs-private
+ * @deprecated No longer used. To be removed.
+ * @breaking-change 19.0.0
+ */
 export const DIALOG_SCROLL_STRATEGY_PROVIDER = {
   provide: DIALOG_SCROLL_STRATEGY,
   deps: [Overlay],

--- a/src/cdk/dialog/dialog-module.ts
+++ b/src/cdk/dialog/dialog-module.ts
@@ -12,17 +12,15 @@ import {PortalModule} from '@angular/cdk/portal';
 import {A11yModule} from '@angular/cdk/a11y';
 import {Dialog} from './dialog';
 import {CdkDialogContainer} from './dialog-container';
-import {DIALOG_SCROLL_STRATEGY_PROVIDER} from './dialog-injectors';
 
 @NgModule({
-  imports: [OverlayModule, PortalModule, A11yModule],
+  imports: [OverlayModule, PortalModule, A11yModule, CdkDialogContainer],
   exports: [
     // Re-export the PortalModule so that people extending the `CdkDialogContainer`
     // don't have to remember to import it or be faced with an unhelpful error.
     PortalModule,
     CdkDialogContainer,
   ],
-  declarations: [CdkDialogContainer],
-  providers: [Dialog, DIALOG_SCROLL_STRATEGY_PROVIDER],
+  providers: [Dialog],
 })
 export class DialogModule {}

--- a/src/cdk/dialog/dialog.ts
+++ b/src/cdk/dialog/dialog.ts
@@ -39,7 +39,7 @@ import {CdkDialogContainer} from './dialog-container';
 /** Unique id for the created dialog. */
 let uniqueId = 0;
 
-@Injectable()
+@Injectable({providedIn: 'root'})
 export class Dialog implements OnDestroy {
   private _openDialogsAtThisLevel: DialogRef<any, any>[] = [];
   private readonly _afterAllClosedAtThisLevel = new Subject<void>();

--- a/tools/public_api_guard/cdk/dialog.md
+++ b/tools/public_api_guard/cdk/dialog.md
@@ -18,9 +18,9 @@ import { FocusMonitor } from '@angular/cdk/a11y';
 import { FocusOrigin } from '@angular/cdk/a11y';
 import { FocusTrapFactory } from '@angular/cdk/a11y';
 import * as i0 from '@angular/core';
-import * as i2 from '@angular/cdk/overlay';
-import * as i3 from '@angular/cdk/portal';
-import * as i4 from '@angular/cdk/a11y';
+import * as i1 from '@angular/cdk/overlay';
+import * as i2 from '@angular/cdk/portal';
+import * as i3 from '@angular/cdk/a11y';
 import { InjectionToken } from '@angular/core';
 import { Injector } from '@angular/core';
 import { InteractivityChecker } from '@angular/cdk/a11y';
@@ -70,7 +70,7 @@ export class CdkDialogContainer<C extends DialogConfig = DialogConfig> extends B
     _recaptureFocus(): void;
     protected _trapFocus(): void;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<CdkDialogContainer<any>, "cdk-dialog-container", never, {}, {}, never, never, false, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<CdkDialogContainer<any>, "cdk-dialog-container", never, {}, {}, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<CdkDialogContainer<any>, [null, null, { optional: true; }, null, null, null, null, null]>;
 }
@@ -104,14 +104,14 @@ export const DIALOG_DATA: InjectionToken<any>;
 // @public
 export const DIALOG_SCROLL_STRATEGY: InjectionToken<() => ScrollStrategy>;
 
-// @public
+// @public @deprecated
 export const DIALOG_SCROLL_STRATEGY_PROVIDER: {
     provide: InjectionToken<() => ScrollStrategy>;
     deps: (typeof Overlay)[];
     useFactory: typeof DIALOG_SCROLL_STRATEGY_PROVIDER_FACTORY;
 };
 
-// @public
+// @public @deprecated
 export function DIALOG_SCROLL_STRATEGY_PROVIDER_FACTORY(overlay: Overlay): () => ScrollStrategy;
 
 // @public
@@ -164,7 +164,7 @@ export class DialogModule {
     // (undocumented)
     static ɵinj: i0.ɵɵInjectorDeclaration<DialogModule>;
     // (undocumented)
-    static ɵmod: i0.ɵɵNgModuleDeclaration<DialogModule, [typeof i1.CdkDialogContainer], [typeof i2.OverlayModule, typeof i3.PortalModule, typeof i4.A11yModule], [typeof i3.PortalModule, typeof i1.CdkDialogContainer]>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<DialogModule, never, [typeof i1.OverlayModule, typeof i2.PortalModule, typeof i3.A11yModule, typeof i4.CdkDialogContainer], [typeof i2.PortalModule, typeof i4.CdkDialogContainer]>;
 }
 
 // @public


### PR DESCRIPTION
Reworks the CDK dialog to use a standalone component and to use `providedIn: 'root'` for its providers.