### PR TITLE
fix(material/badge): aria-hidden warning with icon

### DIFF
--- a/src/material/badge/BUILD.bazel
+++ b/src/material/badge/BUILD.bazel
@@ -44,6 +44,7 @@ ng_test_library(
     deps = [
         ":badge",
         "//src/material/core",
+        "//src/material/icon",
         "@npm//@angular/platform-browser",
     ],
 )

--- a/src/material/badge/badge.spec.ts
+++ b/src/material/badge/badge.spec.ts
@@ -292,13 +292,13 @@ describe('MatBadge with MatIcon', () => {
     expect(console.warn).toHaveBeenCalled();
   });
 
-  it('should not warn about using matBadge on MatIcon with aria-hidden="false', () => {
+  it('should not warn about using matBadge on MatIcon with aria-hidden="false"', () => {
     spyOn(console, 'warn');
 
     const fixture = TestBed.createComponent(IconWithBadgeFalseAriaHidden);
     fixture.detectChanges();
 
-    expect(console.warn).toHaveBeenCalled();
+    expect(console.warn).not.toHaveBeenCalled();
   });
 
   it('should warn about using matBadge on MatIcon with [attr.aria-hidden]="true"', () => {

--- a/src/material/badge/badge.spec.ts
+++ b/src/material/badge/badge.spec.ts
@@ -276,18 +276,18 @@ describe('MatBadge with MatIcon', () => {
     await TestBed.configureTestingModule({
       imports: [MatIconModule, MatBadgeModule],
       declarations: [
-        IconWithBadge,
-        IconWithBadgeFalseAriaHidden,
-        IconWithBadgeAtributeBindedTrueAriaHidden,
-        IconWithBadgeAtributeBindedFalseAriaHidden,
+        BadgeOnIcon,
+        BadgeOnIconWithAriaHiddenFalse,
+        BadgeOnIconWithAriaHiddenBindingTrue,
+        BadgeOnIconWithAriaHiddenBindingFalse,
       ],
     }).compileComponents();
   });
 
-  it('should warn bout using matBadge on MatIcon as its aria-hidden true by default', () => {
+  it('should warn about using matBadge on MatIcon as its aria-hidden true by default', () => {
     spyOn(console, 'warn');
 
-    const fixture = TestBed.createComponent(IconWithBadge);
+    const fixture = TestBed.createComponent(BadgeOnIcon);
     fixture.detectChanges();
 
     expect(console.warn).toHaveBeenCalled();
@@ -296,7 +296,7 @@ describe('MatBadge with MatIcon', () => {
   it('should not warn about using matBadge on MatIcon with aria-hidden="false"', () => {
     spyOn(console, 'warn');
 
-    const fixture = TestBed.createComponent(IconWithBadgeFalseAriaHidden);
+    const fixture = TestBed.createComponent(BadgeOnIconWithAriaHiddenFalse);
     fixture.detectChanges();
 
     expect(console.warn).not.toHaveBeenCalled();
@@ -305,7 +305,7 @@ describe('MatBadge with MatIcon', () => {
   it('should warn about using matBadge on MatIcon with [attr.aria-hidden]="true"', () => {
     spyOn(console, 'warn');
 
-    const fixture = TestBed.createComponent(IconWithBadgeAtributeBindedTrueAriaHidden);
+    const fixture = TestBed.createComponent(BadgeOnIconWithAriaHiddenBindingTrue);
     fixture.detectChanges();
 
     expect(console.warn).toHaveBeenCalled();
@@ -314,7 +314,7 @@ describe('MatBadge with MatIcon', () => {
   it('should not warn about using matBadge on MatIcon with [attr.aria-hidden]="false"', () => {
     spyOn(console, 'warn');
 
-    const fixture = TestBed.createComponent(IconWithBadgeAtributeBindedFalseAriaHidden);
+    const fixture = TestBed.createComponent(BadgeOnIconWithAriaHiddenBindingFalse);
     fixture.detectChanges();
 
     expect(console.warn).not.toHaveBeenCalled();
@@ -383,13 +383,13 @@ class NestedBadge {}
 class BadgeOnTemplate {}
 
 @Component({template: `<mat-icon matBadge="1">home</mat-icon>`})
-class IconWithBadge {}
+class BadgeOnIcon {}
 
 @Component({template: `<mat-icon matBadge="1" aria-hidden="false">home</mat-icon>`})
-class IconWithBadgeFalseAriaHidden {}
+class BadgeOnIconWithAriaHiddenFalse {}
 
 @Component({template: `<mat-icon matBadge="1" [attr.aria-hidden]="true">home</mat-icon>`})
-class IconWithBadgeAtributeBindedTrueAriaHidden {}
+class BadgeOnIconWithAriaHiddenBindingTrue {}
 
 @Component({template: `<mat-icon matBadge="1" [attr.aria-hidden]="false">home</mat-icon>`})
-class IconWithBadgeAtributeBindedFalseAriaHidden {}
+class BadgeOnIconWithAriaHiddenBindingFalse {}

--- a/src/material/badge/badge.spec.ts
+++ b/src/material/badge/badge.spec.ts
@@ -277,6 +277,7 @@ describe('MatBadge with MatIcon', () => {
       imports: [MatIconModule, MatBadgeModule],
       declarations: [
         IconWithBadge,
+        IconWithBadgeFalseAriaHidden,
         IconWithBadgeAtributeBindedTrueAriaHidden,
         IconWithBadgeAtributeBindedFalseAriaHidden,
       ],

--- a/src/material/badge/badge.spec.ts
+++ b/src/material/badge/badge.spec.ts
@@ -3,6 +3,7 @@ import {Component, DebugElement, ViewEncapsulation, ViewChild} from '@angular/co
 import {By} from '@angular/platform-browser';
 import {MatBadge, MatBadgeModule} from './index';
 import {ThemePalette} from '@angular/material/core';
+import {MatIconModule} from '@angular/material/icon';
 
 describe('MatBadge', () => {
   let fixture: ComponentFixture<any>;
@@ -270,6 +271,55 @@ describe('MatBadge', () => {
   });
 });
 
+describe('MatBadge with MatIcon', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MatIconModule, MatBadgeModule],
+      declarations: [
+        IconWithBadge,
+        IconWithBadgeAtributeBindedTrueAriaHidden,
+        IconWithBadgeAtributeBindedFalseAriaHidden,
+      ],
+    }).compileComponents();
+  });
+
+  it('should warn bout using matBadge on MatIcon as its aria-hidden true by default', () => {
+    spyOn(console, 'warn');
+
+    const fixture = TestBed.createComponent(IconWithBadge);
+    fixture.detectChanges();
+
+    expect(console.warn).toHaveBeenCalled();
+  });
+
+  it('should not warn about using matBadge on MatIcon with aria-hidden="false', () => {
+    spyOn(console, 'warn');
+
+    const fixture = TestBed.createComponent(IconWithBadgeFalseAriaHidden);
+    fixture.detectChanges();
+
+    expect(console.warn).toHaveBeenCalled();
+  });
+
+  it('should warn about using matBadge on MatIcon with [attr.aria-hidden]="true"', () => {
+    spyOn(console, 'warn');
+
+    const fixture = TestBed.createComponent(IconWithBadgeAtributeBindedTrueAriaHidden);
+    fixture.detectChanges();
+
+    expect(console.warn).toHaveBeenCalled();
+  });
+
+  it('should not warn about using matBadge on MatIcon with [attr.aria-hidden]="false"', () => {
+    spyOn(console, 'warn');
+
+    const fixture = TestBed.createComponent(IconWithBadgeAtributeBindedFalseAriaHidden);
+    fixture.detectChanges();
+
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+});
+
 /** Test component that contains a MatBadge. */
 @Component({
   // Explicitly set the view encapsulation since we have a test that checks for it.
@@ -330,3 +380,15 @@ class NestedBadge {}
     <ng-template matBadge="1">Notifications</ng-template>`,
 })
 class BadgeOnTemplate {}
+
+@Component({template: `<mat-icon matBadge="1">home</mat-icon>`})
+class IconWithBadge {}
+
+@Component({template: `<mat-icon matBadge="1" aria-hidden="false">home</mat-icon>`})
+class IconWithBadgeFalseAriaHidden {}
+
+@Component({template: `<mat-icon matBadge="1" [attr.aria-hidden]="true">home</mat-icon>`})
+class IconWithBadgeAtributeBindedTrueAriaHidden {}
+
+@Component({template: `<mat-icon matBadge="1" [attr.aria-hidden]="false">home</mat-icon>`})
+class IconWithBadgeAtributeBindedFalseAriaHidden {}

--- a/src/material/badge/badge.ts
+++ b/src/material/badge/badge.ts
@@ -138,22 +138,6 @@ export class MatBadge implements OnInit, OnDestroy {
       if (nativeElement.nodeType !== nativeElement.ELEMENT_NODE) {
         throw Error('matBadge must be attached to an element node.');
       }
-
-      const matIconTagName: string = 'mat-icon';
-
-      // Heads-up for developers to avoid putting matBadge on <mat-icon>
-      // as it is aria-hidden by default docs mention this at:
-      // https://material.angular.io/components/badge/overview#accessibility
-      if (
-        nativeElement.tagName.toLowerCase() === matIconTagName &&
-        nativeElement.getAttribute('aria-hidden') === 'true'
-      ) {
-        console.warn(
-          `Detected a matBadge on an "aria-hidden" "<mat-icon>". ` +
-            `Consider setting aria-hidden="false" in order to surface the information assistive technology.` +
-            `\n${nativeElement.outerHTML}`,
-        );
-      }
     }
   }
 
@@ -184,6 +168,25 @@ export class MatBadge implements OnInit, OnDestroy {
     if (this.content && !this._badgeElement) {
       this._badgeElement = this._createBadgeElement();
       this._updateRenderedContent(this.content);
+    }
+
+    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+      const nativeElement = this._elementRef.nativeElement;
+      const matIconTagName: string = 'mat-icon';
+
+      // Heads-up for developers to avoid putting matBadge on <mat-icon>
+      // as it is aria-hidden by default docs mention this at:
+      // https://material.angular.io/components/badge/overview#accessibility
+      if (
+        nativeElement.tagName.toLowerCase() === matIconTagName &&
+        nativeElement.getAttribute('aria-hidden') === 'true'
+      ) {
+        console.warn(
+          `Detected a matBadge on an "aria-hidden" "<mat-icon>". ` +
+            `Consider setting aria-hidden="false" in order to surface the information assistive technology.` +
+            `\n${nativeElement.outerHTML}`,
+        );
+      }
     }
 
     this._isInitialized = true;

--- a/src/material/badge/badge.ts
+++ b/src/material/badge/badge.ts
@@ -172,7 +172,7 @@ export class MatBadge implements OnInit, OnDestroy {
 
     if (typeof ngDevMode === 'undefined' || ngDevMode) {
       const nativeElement = this._elementRef.nativeElement;
-      const matIconTagName: string = 'mat-icon';
+      const matIconTagName = 'mat-icon';
 
       // Heads-up for developers to avoid putting matBadge on <mat-icon>
       // as it is aria-hidden by default docs mention this at:


### PR DESCRIPTION
fixes the issue where the warning for aria-hidden when used with mat-icon it doesn't account in [attr.aria-hidden]="condition"

fixes #27705