### PR TITLE
feat(multiple): include MDC CSS fallback values

### DIFF
--- a/src/material/button/fab.scss
+++ b/src/material/button/fab.scss
@@ -11,7 +11,7 @@
 @use '../core/tokens/m2/mdc/extended-fab' as m2-mdc-extended-fab;
 @use '../core/tokens/m2/mdc/fab' as m2-mdc-fab;
 
-@include mdc-custom-properties.configure($emit-fallback-values: false, $emit-fallback-vars: false) {
+@include mdc-custom-properties.configure($emit-declaration-fallback: false, $emit-fallback-vars: false) {
   $mdc-fab-token-slots: m2-mdc-fab.get-token-slots();
   $mdc-extended-fab-token-slots: m2-mdc-extended-fab.get-token-slots();
 

--- a/src/material/button/icon-button.scss
+++ b/src/material/button/icon-button.scss
@@ -8,7 +8,7 @@
 @use '../core/style/private';
 
 // The slots for tokens that will be configured in the theme can be emitted with no fallback.
-@include mdc-custom-properties.configure($emit-fallback-values: false, $emit-fallback-vars: false) {
+@include mdc-custom-properties.configure($emit-declaration-fallback: false, $emit-fallback-vars: false) {
   $token-slots: m2-mdc-icon-button.get-token-slots();
 
   // Add the MDC component static styles.

--- a/src/material/card/card.scss
+++ b/src/material/card/card.scss
@@ -9,7 +9,7 @@
 @use '../core/tokens/m2/mdc/outlined-card' as tokens-mdc-outlined-card;
 
 // TODO(jelbourn): move header and title-group styles to their own files.
-@include mdc-custom-properties.configure($emit-fallback-values: false, $emit-fallback-vars: false) {
+@include mdc-custom-properties.configure($emit-declaration-fallback: false, $emit-fallback-vars: false) {
   $mdc-elevated-card-token-slots: tokens-mdc-elevated-card.get-token-slots();
   $mdc-outlined-card-token-slots: tokens-mdc-outlined-card.get-token-slots();
 

--- a/src/material/checkbox/checkbox.scss
+++ b/src/material/checkbox/checkbox.scss
@@ -11,7 +11,7 @@
 @use '../core/tokens/m2/mdc/checkbox' as tokens-mdc-checkbox;
 @use '../core/tokens/token-utils';
 
-@include mdc-custom-properties.configure($emit-fallback-values: false, $emit-fallback-vars: false) {
+@include mdc-custom-properties.configure($emit-declaration-fallback: false, $emit-fallback-vars: false) {
   // Add the checkbox static styles.
   @include mdc-checkbox.static-styles();
   // TODO(mmalerba): Switch to static-styles, theme-styles, and theme once they're available.

--- a/src/material/chips/chip.scss
+++ b/src/material/chips/chip.scss
@@ -9,7 +9,7 @@
 @use '@material/theme/custom-properties' as mdc-custom-properties;
 
 // The slots for tokens that will be configured in the theme can be emitted with no fallback.
-@include mdc-custom-properties.configure($emit-fallback-values: false, $emit-fallback-vars: false) {
+@include mdc-custom-properties.configure($emit-declaration-fallback: false, $emit-fallback-vars: false) {
   $token-slots: m2-mdc-chip.get-token-slots();
 
   // Add the MDC chip static styles.

--- a/src/material/form-field/form-field.scss
+++ b/src/material/form-field/form-field.scss
@@ -42,7 +42,7 @@
 @include _static-styles(mdc-helpers.$mdc-base-styles-without-animation-query);
 
 @include mdc-custom-properties.configure(
-  $emit-fallback-values: false, $emit-fallback-vars: false) {
+  $emit-declaration-fallback: false, $emit-fallback-vars: false) {
 
   @include sass-utils.current-selector-or-root() {
     @include token-utils.create-token-values(

--- a/src/material/list/list.scss
+++ b/src/material/list/list.scss
@@ -8,7 +8,7 @@
 @use './list-item-hcm-indicator';
 
 // The slots for tokens that will be configured in the theme can be emitted with no fallback.
-@include mdc-custom-properties.configure($emit-fallback-values: false, $emit-fallback-vars: false) {
+@include mdc-custom-properties.configure($emit-declaration-fallback: false, $emit-fallback-vars: false) {
   $mdc-list-token-slots: m2-mdc-list.get-token-slots();
 
   // Add the MDC list static styles.

--- a/src/material/progress-bar/progress-bar.scss
+++ b/src/material/progress-bar/progress-bar.scss
@@ -4,7 +4,7 @@
 @use '@material/linear-progress/linear-progress-theme' as mdc-linear-progress-theme;
 @use '../core/tokens/m2/mdc/linear-progress' as m2-mdc-linear-progress;
 
-@include mdc-custom-properties.configure($emit-fallback-values: false, $emit-fallback-vars: false) {
+@include mdc-custom-properties.configure($emit-declaration-fallback: false, $emit-fallback-vars: false) {
   $mdc-progress-bar-token-slots: m2-mdc-linear-progress.get-token-slots();
 
   // Add the MDC progress-bar static styles.

--- a/src/material/progress-spinner/progress-spinner.scss
+++ b/src/material/progress-spinner/progress-spinner.scss
@@ -5,7 +5,7 @@
 @use '../core/tokens/m2/mdc/circular-progress' as m2-mdc-circular-progress;
 
 // The slots for tokens that will be configured in the theme can be emitted with no fallback.
-@include mdc-custom-properties.configure($emit-fallback-values: false, $emit-fallback-vars: false) {
+@include mdc-custom-properties.configure($emit-declaration-fallback: false, $emit-fallback-vars: false) {
   $mdc-circular-progress-token-slots: m2-mdc-circular-progress.get-token-slots();
 
   // Add the MDC progress spinner static styles.

--- a/src/material/radio/radio.scss
+++ b/src/material/radio/radio.scss
@@ -12,7 +12,7 @@
 @use '../core/style/layout-common';
 
 
-@include mdc-custom-properties.configure($emit-fallback-values: false, $emit-fallback-vars: false) {
+@include mdc-custom-properties.configure($emit-declaration-fallback: false, $emit-fallback-vars: false) {
   @include mdc-radio.static-styles($query: mdc-helpers.$mdc-base-styles-query);
   @include mdc-form-field.core-styles($query: mdc-helpers.$mdc-base-styles-query);
 

--- a/src/material/slide-toggle/slide-toggle.scss
+++ b/src/material/slide-toggle/slide-toggle.scss
@@ -11,7 +11,7 @@
 @use '../core/tokens/m2/mat/slide-toggle' as mat-slide-toggle-tokens;
 @use '../core/tokens/token-utils';
 
-@include mdc-custom-properties.configure($emit-fallback-values: false, $emit-fallback-vars: false) {
+@include mdc-custom-properties.configure($emit-declaration-fallback: false, $emit-fallback-vars: false) {
   $mdc-switch-token-slots: m2-mdc-switch.get-token-slots();
 
   @include mdc-form-field.core-styles($query: mdc-helpers.$mdc-base-styles-query);

--- a/src/material/slider/slider.scss
+++ b/src/material/slider/slider.scss
@@ -9,7 +9,7 @@
 $mat-slider-min-size: 128px !default;
 $mat-slider-horizontal-margin: 8px !default;
 
-@include mdc-custom-properties.configure($emit-fallback-values: false, $emit-fallback-vars: false) {
+@include mdc-custom-properties.configure($emit-declaration-fallback: false, $emit-fallback-vars: false) {
   $mdc-slider-token-slots: m2-mdc-slider.get-token-slots();
 
   // Add MDC slider static styles.

--- a/src/material/snack-bar/snack-bar-container.scss
+++ b/src/material/snack-bar/snack-bar-container.scss
@@ -25,7 +25,7 @@
   }
 }
 
-@include mdc-custom-properties.configure($emit-fallback-values: false, $emit-fallback-vars: false) {
+@include mdc-custom-properties.configure($emit-declaration-fallback: false, $emit-fallback-vars: false) {
   // Include the styles without the animations since we
   // reuse the same animation as the non-MDC version.
   @include mdc-snackbar.static-styles($query: mdc-helpers.$mdc-base-styles-without-animation-query);

--- a/src/material/tabs/_tabs-common.scss
+++ b/src/material/tabs/_tabs-common.scss
@@ -19,7 +19,7 @@ $mat-tab-animation-duration: 500ms !default;
 // Combines the various structural styles we need for the tab group and tab nav bar.
 @mixin structural-styles {
   @include mdc-custom-properties.configure(
-    $emit-fallback-values: false,
+    $emit-declaration-fallback: false,
     $emit-fallback-vars: false
   ) {
     @include mdc-tab.static-styles($query: mdc-helpers.$mdc-base-styles-query);
@@ -38,7 +38,7 @@ $mat-tab-animation-duration: 500ms !default;
 
 @mixin tab {
   @include mdc-custom-properties.configure(
-    $emit-fallback-values: false,
+    $emit-declaration-fallback: false,
     $emit-fallback-vars: false
   ) {
     @include mdc-tab-indicator-theme.theme-styles(tokens-mdc-tab-indicator.get-token-slots());

--- a/src/material/tooltip/tooltip.scss
+++ b/src/material/tooltip/tooltip.scss
@@ -3,7 +3,7 @@
 @use '@material/tooltip/plain-tooltip-theme' as mdc-plain-tooltip-theme;
 @use '../core/tokens/m2/mdc/plain-tooltip' as m2-mdc-plain-tooltip;
 
-@include mdc-custom-properties.configure($emit-fallback-values: false,
+@include mdc-custom-properties.configure($emit-declaration-fallback: false,
 $emit-fallback-vars: false) {
   $mdc-tooltip-token-slots: m2-mdc-plain-tooltip.get-token-slots();
 


### PR DESCRIPTION
Material Web's new CSS styles do not have a configuration to skip variable fallback values. We are including these to help the transition to the new styles. Previously this would also add additional declarative fallback styles on top of variable defaults, but is turned off by the new flag `emit-declaration-fallback`. This new configuration will be pushed out this week

Before:
```
.mdc-checkbox {
    padding: calc((var(--mdc-checkbox-state-layer-size) - 18px) / 2);
    margin: calc((var(--mdc-checkbox-state-layer-size) - var(--mdc-checkbox-state-layer-size)) / 2);
}
```

After:
```
.mdc-checkbox {
    padding: calc((var(--mdc-checkbox-state-layer-size, 40px) - 18px) / 2);
    margin: calc((var(--mdc-checkbox-state-layer-size, 40px) - var(--mdc-checkbox-state-layer-size, 40px)) / 2);
}
```