### PR TITLE
Remove mixin usages from a handful of components

### DIFF
--- a/src/dev-app/drag-drop/drag-drop-demo.ts
+++ b/src/dev-app/drag-drop/drag-drop-demo.ts
@@ -16,7 +16,6 @@ import {
   transferArrayItem,
   Point,
   DragRef,
-  CdkDrag,
 } from '@angular/cdk/drag-drop';
 import {CommonModule} from '@angular/common';
 import {FormsModule} from '@angular/forms';

--- a/src/dev-app/slider/slider-demo.ts
+++ b/src/dev-app/slider/slider-demo.ts
@@ -14,6 +14,7 @@ import {MatButtonToggleModule} from '@angular/material/button-toggle';
 import {MatCheckboxModule} from '@angular/material/checkbox';
 import {MatDialog, MatDialogModule, MAT_DIALOG_DATA} from '@angular/material/dialog';
 import {MatButtonModule} from '@angular/material/button';
+import {ThemePalette} from '@angular/material/core';
 
 interface DialogData {
   color: string;
@@ -40,7 +41,7 @@ interface DialogData {
 export class SliderDemo {
   discrete = true;
   showTickMarks = true;
-  colorModel = 'primary';
+  colorModel: ThemePalette = 'primary';
 
   noop = () => {};
   min = '0';

--- a/src/material/autocomplete/autocomplete-trigger.ts
+++ b/src/material/autocomplete/autocomplete-trigger.ts
@@ -9,6 +9,7 @@
 import {addAriaReferencedId, removeAriaReferencedId} from '@angular/cdk/a11y';
 import {
   AfterViewInit,
+  booleanAttribute,
   ChangeDetectorRef,
   Directive,
   ElementRef,
@@ -26,7 +27,6 @@ import {
 } from '@angular/core';
 import {DOCUMENT} from '@angular/common';
 import {Directionality} from '@angular/cdk/bidi';
-import {BooleanInput, coerceBooleanProperty} from '@angular/cdk/coercion';
 import {DOWN_ARROW, ENTER, ESCAPE, TAB, UP_ARROW, hasModifierKey} from '@angular/cdk/keycodes';
 import {_getEventTarget} from '@angular/cdk/platform';
 import {TemplatePortal} from '@angular/cdk/portal';
@@ -125,7 +125,6 @@ export class MatAutocompleteTrigger
   private _overlayRef: OverlayRef | null;
   private _portal: TemplatePortal;
   private _componentDestroyed = false;
-  private _autocompleteDisabled = false;
   private _scrollStrategy: () => ScrollStrategy;
   private _keydownSubscription: Subscription | null;
   private _outsideClickSubscription: Subscription | null;
@@ -213,13 +212,8 @@ export class MatAutocompleteTrigger
    * Whether the autocomplete is disabled. When disabled, the element will
    * act as a regular input and the user won't be able to open the panel.
    */
-  @Input('matAutocompleteDisabled')
-  get autocompleteDisabled(): boolean {
-    return this._autocompleteDisabled;
-  }
-  set autocompleteDisabled(value: BooleanInput) {
-    this._autocompleteDisabled = coerceBooleanProperty(value);
-  }
+  @Input({alias: 'matAutocompleteDisabled', transform: booleanAttribute})
+  autocompleteDisabled: boolean;
 
   constructor(
     private _element: ElementRef<HTMLInputElement>,
@@ -897,7 +891,7 @@ export class MatAutocompleteTrigger
   /** Determines whether the panel can be opened. */
   private _canOpen(): boolean {
     const element = this._element.nativeElement;
-    return !element.readOnly && !element.disabled && !this._autocompleteDisabled;
+    return !element.readOnly && !element.disabled && !this.autocompleteDisabled;
   }
 
   /** Use defaultView of injected document if available or fallback to global window reference */

--- a/src/material/badge/BUILD.bazel
+++ b/src/material/badge/BUILD.bazel
@@ -17,13 +17,12 @@ ng_module(
     ),
     deps = [
         "//src:dev_mode_types",
+        "//src/cdk/a11y",
+        "//src/material/core",
+        "@npm//@angular/animations",
         "@npm//@angular/common",
         "@npm//@angular/core",
         "@npm//@angular/platform-browser",
-        "@npm//@angular/animations",
-        "//src/cdk/a11y",
-        "//src/cdk/coercion",
-        "//src/material/core",
     ] + glob(["**/*.html"]),
 )
 

--- a/src/material/badge/badge.ts
+++ b/src/material/badge/badge.ts
@@ -7,9 +7,9 @@
  */
 
 import {AriaDescriber, InteractivityChecker} from '@angular/cdk/a11y';
-import {BooleanInput, coerceBooleanProperty} from '@angular/cdk/coercion';
 import {DOCUMENT} from '@angular/common';
 import {
+  booleanAttribute,
   Directive,
   ElementRef,
   inject,
@@ -21,14 +21,10 @@ import {
   Optional,
   Renderer2,
 } from '@angular/core';
-import {CanDisable, mixinDisabled, ThemePalette} from '@angular/material/core';
+import {ThemePalette} from '@angular/material/core';
 import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 
 let nextId = 0;
-
-// Boilerplate for applying mixins to MatBadge.
-/** @docs-private */
-const _MatBadgeBase = mixinDisabled(class {});
 
 /** Allowed position options for matBadgePosition */
 export type MatBadgePosition =
@@ -49,7 +45,6 @@ const BADGE_CONTENT_CLASS = 'mat-badge-content';
 /** Directive to display a text badge. */
 @Directive({
   selector: '[matBadge]',
-  inputs: ['disabled: matBadgeDisabled'],
   host: {
     'class': 'mat-badge',
     '[class.mat-badge-overlap]': 'overlap',
@@ -64,7 +59,7 @@ const BADGE_CONTENT_CLASS = 'mat-badge-content';
     '[class.mat-badge-disabled]': 'disabled',
   },
 })
-export class MatBadge extends _MatBadgeBase implements OnInit, OnDestroy, CanDisable {
+export class MatBadge implements OnInit, OnDestroy {
   /** The color of the badge. Can be `primary`, `accent`, or `warn`. */
   @Input('matBadgeColor')
   get color(): ThemePalette {
@@ -77,14 +72,10 @@ export class MatBadge extends _MatBadgeBase implements OnInit, OnDestroy, CanDis
   private _color: ThemePalette = 'primary';
 
   /** Whether the badge should overlap its contents or not */
-  @Input('matBadgeOverlap')
-  get overlap(): boolean {
-    return this._overlap;
-  }
-  set overlap(val: BooleanInput) {
-    this._overlap = coerceBooleanProperty(val);
-  }
-  private _overlap: boolean = true;
+  @Input({alias: 'matBadgeOverlap', transform: booleanAttribute}) overlap: boolean = true;
+
+  /** Whether the badge is disabled. */
+  @Input({alias: 'matBadgeDisabled', transform: booleanAttribute}) disabled: boolean;
 
   /**
    * Position the badge should reside.
@@ -116,14 +107,7 @@ export class MatBadge extends _MatBadgeBase implements OnInit, OnDestroy, CanDis
   @Input('matBadgeSize') size: MatBadgeSize = 'medium';
 
   /** Whether the badge is hidden. */
-  @Input('matBadgeHidden')
-  get hidden(): boolean {
-    return this._hidden;
-  }
-  set hidden(val: BooleanInput) {
-    this._hidden = coerceBooleanProperty(val);
-  }
-  private _hidden: boolean;
+  @Input({alias: 'matBadgeHidden', transform: booleanAttribute}) hidden: boolean;
 
   /** Unique id for the badge */
   _id: number = nextId++;
@@ -149,8 +133,6 @@ export class MatBadge extends _MatBadgeBase implements OnInit, OnDestroy, CanDis
     private _renderer: Renderer2,
     @Optional() @Inject(ANIMATION_MODULE_TYPE) private _animationMode?: string,
   ) {
-    super();
-
     if (typeof ngDevMode === 'undefined' || ngDevMode) {
       const nativeElement = _elementRef.nativeElement;
       if (nativeElement.nodeType !== nativeElement.ELEMENT_NODE) {

--- a/src/material/button-toggle/BUILD.bazel
+++ b/src/material/button-toggle/BUILD.bazel
@@ -20,7 +20,6 @@ ng_module(
     deps = [
         "//src:dev_mode_types",
         "//src/cdk/a11y",
-        "//src/cdk/coercion",
         "//src/cdk/collections",
         "//src/material/core",
         "@npm//@angular/core",

--- a/src/material/button-toggle/button-toggle.ts
+++ b/src/material/button-toggle/button-toggle.ts
@@ -7,7 +7,6 @@
  */
 
 import {FocusMonitor} from '@angular/cdk/a11y';
-import {BooleanInput, coerceBooleanProperty} from '@angular/cdk/coercion';
 import {SelectionModel} from '@angular/cdk/collections';
 import {
   AfterContentInit,
@@ -31,9 +30,9 @@ import {
   InjectionToken,
   Inject,
   AfterViewInit,
+  booleanAttribute,
 } from '@angular/core';
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
-import {CanDisableRipple, mixinDisableRipple} from '@angular/material/core';
 
 /**
  * @deprecated No longer used.
@@ -115,7 +114,6 @@ export class MatButtonToggleChange {
   exportAs: 'matButtonToggleGroup',
 })
 export class MatButtonToggleGroup implements ControlValueAccessor, OnInit, AfterContentInit {
-  private _vertical = false;
   private _multiple = false;
   private _disabled = false;
   private _selectionModel: SelectionModel<MatButtonToggle>;
@@ -160,13 +158,7 @@ export class MatButtonToggleGroup implements ControlValueAccessor, OnInit, After
   private _name = `mat-button-toggle-group-${uniqueIdCounter++}`;
 
   /** Whether the toggle group is vertical. */
-  @Input()
-  get vertical(): boolean {
-    return this._vertical;
-  }
-  set vertical(value: BooleanInput) {
-    this._vertical = coerceBooleanProperty(value);
-  }
+  @Input({transform: booleanAttribute}) vertical: boolean;
 
   /** Value of the toggle group. */
   @Input()
@@ -198,22 +190,22 @@ export class MatButtonToggleGroup implements ControlValueAccessor, OnInit, After
   }
 
   /** Whether multiple button toggles can be selected. */
-  @Input()
+  @Input({transform: booleanAttribute})
   get multiple(): boolean {
     return this._multiple;
   }
-  set multiple(value: BooleanInput) {
-    this._multiple = coerceBooleanProperty(value);
+  set multiple(value: boolean) {
+    this._multiple = value;
     this._markButtonsForCheck();
   }
 
   /** Whether multiple button toggle group is disabled. */
-  @Input()
+  @Input({transform: booleanAttribute})
   get disabled(): boolean {
     return this._disabled;
   }
-  set disabled(value: BooleanInput) {
-    this._disabled = coerceBooleanProperty(value);
+  set disabled(value: boolean) {
+    this._disabled = value;
     this._markButtonsForCheck();
   }
 
@@ -385,10 +377,6 @@ export class MatButtonToggleGroup implements ControlValueAccessor, OnInit, After
   }
 }
 
-// Boilerplate for applying mixins to the MatButtonToggle class.
-/** @docs-private */
-const _MatButtonToggleBase = mixinDisableRipple(class {});
-
 /** Single button inside of a toggle group. */
 @Component({
   selector: 'mat-button-toggle',
@@ -397,7 +385,6 @@ const _MatButtonToggleBase = mixinDisableRipple(class {});
   encapsulation: ViewEncapsulation.None,
   exportAs: 'matButtonToggle',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  inputs: ['disableRipple'],
   host: {
     '[class.mat-button-toggle-standalone]': '!buttonToggleGroup',
     '[class.mat-button-toggle-checked]': 'checked',
@@ -412,10 +399,7 @@ const _MatButtonToggleBase = mixinDisableRipple(class {});
     'role': 'presentation',
   },
 })
-export class MatButtonToggle
-  extends _MatButtonToggleBase
-  implements OnInit, AfterViewInit, CanDisableRipple, OnDestroy
-{
+export class MatButtonToggle implements OnInit, AfterViewInit, OnDestroy {
   private _checked = false;
 
   /**
@@ -452,6 +436,9 @@ export class MatButtonToggle
   /** Tabindex for the toggle. */
   @Input() tabIndex: number | null;
 
+  /** Whether ripples are disabled on the button toggle. */
+  @Input({transform: booleanAttribute}) disableRipple: boolean;
+
   /** The appearance style of the button. */
   @Input()
   get appearance(): MatButtonToggleAppearance {
@@ -463,15 +450,13 @@ export class MatButtonToggle
   private _appearance: MatButtonToggleAppearance;
 
   /** Whether the button is checked. */
-  @Input()
+  @Input({transform: booleanAttribute})
   get checked(): boolean {
     return this.buttonToggleGroup ? this.buttonToggleGroup._isSelected(this) : this._checked;
   }
-  set checked(value: BooleanInput) {
-    const newValue = coerceBooleanProperty(value);
-
-    if (newValue !== this._checked) {
-      this._checked = newValue;
+  set checked(value: boolean) {
+    if (value !== this._checked) {
+      this._checked = value;
 
       if (this.buttonToggleGroup) {
         this.buttonToggleGroup._syncButtonToggle(this, this._checked);
@@ -482,12 +467,12 @@ export class MatButtonToggle
   }
 
   /** Whether the button is disabled. */
-  @Input()
+  @Input({transform: booleanAttribute})
   get disabled(): boolean {
     return this._disabled || (this.buttonToggleGroup && this.buttonToggleGroup.disabled);
   }
-  set disabled(value: BooleanInput) {
-    this._disabled = coerceBooleanProperty(value);
+  set disabled(value: boolean) {
+    this._disabled = value;
   }
   private _disabled: boolean = false;
 
@@ -505,8 +490,6 @@ export class MatButtonToggle
     @Inject(MAT_BUTTON_TOGGLE_DEFAULT_OPTIONS)
     defaultOptions?: MatButtonToggleDefaultOptions,
   ) {
-    super();
-
     const parsedTabIndex = Number(defaultTabIndex);
     this.tabIndex = parsedTabIndex || parsedTabIndex === 0 ? parsedTabIndex : null;
     this.buttonToggleGroup = toggleGroup;

--- a/src/material/checkbox/BUILD.bazel
+++ b/src/material/checkbox/BUILD.bazel
@@ -20,7 +20,6 @@ ng_module(
     ),
     assets = [":checkbox_scss"] + glob(["**/*.html"]),
     deps = [
-        "//src/cdk/coercion",
         "//src/material/core",
         "@npm//@angular/animations",
         "@npm//@angular/core",

--- a/src/material/checkbox/checkbox.html
+++ b/src/material/checkbox/checkbox.html
@@ -18,7 +18,7 @@
            [disabled]="disabled"
            [id]="inputId"
            [required]="required"
-           [tabIndex]="tabIndex"
+           [tabIndex]="disabled ? -1 : tabIndex"
            (blur)="_onBlur()"
            (click)="_onInputClick()"
            (change)="_onInteractionEvent($event)"/>

--- a/src/material/core/option/optgroup.ts
+++ b/src/material/core/option/optgroup.ts
@@ -14,8 +14,8 @@ import {
   Inject,
   Optional,
   InjectionToken,
+  booleanAttribute,
 } from '@angular/core';
-import {CanDisable, mixinDisabled} from '../common-behaviors/disabled';
 import {MatOptionParentComponent, MAT_OPTION_PARENT_COMPONENT} from './option-parent';
 
 // Notes on the accessibility pattern used for `mat-optgroup`.
@@ -38,10 +38,6 @@ import {MatOptionParentComponent, MAT_OPTION_PARENT_COMPONENT} from './option-pa
 // 3. `<mat-option aria-labelledby="optionLabel groupLabel"` - This works on Chrome, but Safari
 //     doesn't read out the text at all. Furthermore, on
 
-// Boilerplate for applying mixins to MatOptgroup.
-/** @docs-private */
-const _MatOptgroupMixinBase = mixinDisabled(class {});
-
 // Counter for unique group ids.
 let _uniqueOptgroupIdCounter = 0;
 
@@ -61,7 +57,6 @@ export const MAT_OPTGROUP = new InjectionToken<MatOptgroup>('MatOptgroup');
   templateUrl: 'optgroup.html',
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  inputs: ['disabled'],
   styleUrls: ['optgroup.css'],
   host: {
     'class': 'mat-mdc-optgroup',
@@ -71,9 +66,12 @@ export const MAT_OPTGROUP = new InjectionToken<MatOptgroup>('MatOptgroup');
   },
   providers: [{provide: MAT_OPTGROUP, useExisting: MatOptgroup}],
 })
-export class MatOptgroup extends _MatOptgroupMixinBase implements CanDisable {
+export class MatOptgroup {
   /** Label for the option group. */
   @Input() label: string;
+
+  /** whether the option group is disabled. */
+  @Input({transform: booleanAttribute}) disabled: boolean = false;
 
   /** Unique id for the underlying label. */
   _labelId: string = `mat-optgroup-label-${_uniqueOptgroupIdCounter++}`;
@@ -82,7 +80,6 @@ export class MatOptgroup extends _MatOptgroupMixinBase implements CanDisable {
   _inert: boolean;
 
   constructor(@Inject(MAT_OPTION_PARENT_COMPONENT) @Optional() parent?: MatOptionParentComponent) {
-    super();
     this._inert = parent?.inertGroups ?? false;
   }
 }

--- a/src/material/core/option/option.ts
+++ b/src/material/core/option/option.ts
@@ -7,7 +7,6 @@
  */
 
 import {FocusableOption, FocusOrigin} from '@angular/cdk/a11y';
-import {BooleanInput, coerceBooleanProperty} from '@angular/cdk/coercion';
 import {ENTER, hasModifierKey, SPACE} from '@angular/cdk/keycodes';
 import {
   Component,
@@ -24,6 +23,7 @@ import {
   EventEmitter,
   QueryList,
   ViewChild,
+  booleanAttribute,
 } from '@angular/core';
 import {Subject} from 'rxjs';
 import {MAT_OPTGROUP, MatOptgroup} from './optgroup';
@@ -101,12 +101,12 @@ export class MatOption<T = any> implements FocusableOption, AfterViewChecked, On
   @Input() id: string = `mat-option-${_uniqueIdCounter++}`;
 
   /** Whether the option is disabled. */
-  @Input()
+  @Input({transform: booleanAttribute})
   get disabled(): boolean {
     return (this.group && this.group.disabled) || this._disabled;
   }
-  set disabled(value: BooleanInput) {
-    this._disabled = coerceBooleanProperty(value);
+  set disabled(value: boolean) {
+    this._disabled = value;
   }
 
   /** Whether ripples for the option are disabled. */

--- a/src/material/menu/menu-item.ts
+++ b/src/material/menu/menu-item.ts
@@ -17,21 +17,12 @@ import {
   Input,
   AfterViewInit,
   ChangeDetectorRef,
+  booleanAttribute,
 } from '@angular/core';
-import {
-  CanDisable,
-  CanDisableRipple,
-  mixinDisabled,
-  mixinDisableRipple,
-} from '@angular/material/core';
 import {FocusableOption, FocusMonitor, FocusOrigin} from '@angular/cdk/a11y';
 import {Subject} from 'rxjs';
 import {DOCUMENT} from '@angular/common';
 import {MatMenuPanel, MAT_MENU_PANEL} from './menu-panel';
-
-// Boilerplate for applying mixins to MatMenuItem.
-/** @docs-private */
-const _MatMenuItemBase = mixinDisableRipple(mixinDisabled(class {}));
 
 /**
  * Single item inside a `mat-menu`. Provides the menu item styling and accessibility treatment.
@@ -39,7 +30,6 @@ const _MatMenuItemBase = mixinDisableRipple(mixinDisabled(class {}));
 @Component({
   selector: '[mat-menu-item]',
   exportAs: 'matMenuItem',
-  inputs: ['disabled', 'disableRipple'],
   host: {
     '[attr.role]': 'role',
     'class': 'mat-mdc-menu-item mat-mdc-focus-indicator',
@@ -55,12 +45,15 @@ const _MatMenuItemBase = mixinDisableRipple(mixinDisabled(class {}));
   encapsulation: ViewEncapsulation.None,
   templateUrl: 'menu-item.html',
 })
-export class MatMenuItem
-  extends _MatMenuItemBase
-  implements FocusableOption, CanDisable, CanDisableRipple, AfterViewInit, OnDestroy
-{
+export class MatMenuItem implements FocusableOption, AfterViewInit, OnDestroy {
   /** ARIA role for the menu item. */
   @Input() role: 'menuitem' | 'menuitemradio' | 'menuitemcheckbox' = 'menuitem';
+
+  /** Whether the menu item is disabled. */
+  @Input({transform: booleanAttribute}) disabled: boolean = false;
+
+  /** Whether ripples are disabled on the menu item. */
+  @Input({transform: booleanAttribute}) disableRipple: boolean = false;
 
   /** Stream that emits when the menu item is hovered. */
   readonly _hovered: Subject<MatMenuItem> = new Subject<MatMenuItem>();
@@ -101,7 +94,6 @@ export class MatMenuItem
     @Inject(MAT_MENU_PANEL) @Optional() public _parentMenu?: MatMenuPanel<MatMenuItem>,
     private _changeDetectorRef?: ChangeDetectorRef,
   ) {
-    super();
     _parentMenu?.addItem?.(this);
   }
 

--- a/src/material/menu/menu.ts
+++ b/src/material/menu/menu.ts
@@ -26,11 +26,11 @@ import {
   ViewEncapsulation,
   OnInit,
   ChangeDetectorRef,
+  booleanAttribute,
 } from '@angular/core';
 import {AnimationEvent} from '@angular/animations';
 import {FocusKeyManager, FocusOrigin} from '@angular/cdk/a11y';
 import {Direction} from '@angular/cdk/bidi';
-import {BooleanInput, coerceBooleanProperty} from '@angular/cdk/coercion';
 import {
   ESCAPE,
   LEFT_ARROW,
@@ -204,24 +204,11 @@ export class MatMenu implements AfterContentInit, MatMenuPanel<MatMenuItem>, OnI
   @ContentChild(MAT_MENU_CONTENT) lazyContent: MatMenuContent;
 
   /** Whether the menu should overlap its trigger. */
-  @Input()
-  get overlapTrigger(): boolean {
-    return this._overlapTrigger;
-  }
-  set overlapTrigger(value: BooleanInput) {
-    this._overlapTrigger = coerceBooleanProperty(value);
-  }
-  private _overlapTrigger: boolean;
+  @Input({transform: booleanAttribute}) overlapTrigger: boolean;
 
   /** Whether the menu has a backdrop. */
-  @Input()
-  get hasBackdrop(): boolean | undefined {
-    return this._hasBackdrop;
-  }
-  set hasBackdrop(value: BooleanInput) {
-    this._hasBackdrop = coerceBooleanProperty(value);
-  }
-  private _hasBackdrop: boolean | undefined;
+  @Input({transform: (value: any) => (value == null ? null : booleanAttribute(value))})
+  hasBackdrop?: boolean;
 
   /**
    * This method takes classes set on the host mat-menu element and applies them on the
@@ -307,8 +294,8 @@ export class MatMenu implements AfterContentInit, MatMenuPanel<MatMenuItem>, OnI
     this._xPosition = defaultOptions.xPosition;
     this._yPosition = defaultOptions.yPosition;
     this.backdropClass = defaultOptions.backdropClass;
-    this._overlapTrigger = defaultOptions.overlapTrigger;
-    this._hasBackdrop = defaultOptions.hasBackdrop;
+    this.overlapTrigger = defaultOptions.overlapTrigger;
+    this.hasBackdrop = defaultOptions.hasBackdrop;
   }
 
   ngOnInit() {

--- a/src/material/slide-toggle/BUILD.bazel
+++ b/src/material/slide-toggle/BUILD.bazel
@@ -21,7 +21,6 @@ ng_module(
     ),
     assets = [":slide_toggle_scss"] + glob(["**/*.html"]),
     deps = [
-        "//src/cdk/coercion",
         "//src/material/core",
         "@npm//@angular/animations",
         "@npm//@angular/common",

--- a/src/material/slide-toggle/slide-toggle.html
+++ b/src/material/slide-toggle/slide-toggle.html
@@ -8,7 +8,7 @@
     [class.mdc-switch--unselected]="!checked"
     [class.mdc-switch--checked]="checked"
     [class.mdc-switch--disabled]="disabled"
-    [tabIndex]="tabIndex"
+    [tabIndex]="disabled ? -1 : tabIndex"
     [disabled]="disabled"
     [attr.id]="buttonId"
     [attr.name]="name"

--- a/tools/public_api_guard/material/autocomplete.md
+++ b/tools/public_api_guard/material/autocomplete.md
@@ -4,15 +4,11 @@
 
 ```ts
 
-import { _AbstractConstructor } from '@angular/material/core';
 import { ActiveDescendantKeyManager } from '@angular/cdk/a11y';
 import { AfterContentInit } from '@angular/core';
 import { AfterViewInit } from '@angular/core';
 import { AnimationEvent as AnimationEvent_2 } from '@angular/animations';
-import { BooleanInput } from '@angular/cdk/coercion';
-import { CanDisableRipple } from '@angular/material/core';
 import { ChangeDetectorRef } from '@angular/core';
-import { _Constructor } from '@angular/material/core';
 import { ControlValueAccessor } from '@angular/forms';
 import { Directionality } from '@angular/cdk/bidi';
 import { ElementRef } from '@angular/core';
@@ -67,15 +63,13 @@ export const MAT_AUTOCOMPLETE_SCROLL_STRATEGY_FACTORY_PROVIDER: {
 export const MAT_AUTOCOMPLETE_VALUE_ACCESSOR: any;
 
 // @public
-export class MatAutocomplete extends _MatAutocompleteMixinBase implements AfterContentInit, CanDisableRipple, OnDestroy {
+export class MatAutocomplete implements AfterContentInit, OnDestroy {
     constructor(_changeDetectorRef: ChangeDetectorRef, _elementRef: ElementRef<HTMLElement>, _defaults: MatAutocompleteDefaultOptions, platform?: Platform);
     _animationDone: EventEmitter<AnimationEvent_2>;
     ariaLabel: string;
     ariaLabelledby: string;
-    get autoActiveFirstOption(): boolean;
-    set autoActiveFirstOption(value: BooleanInput);
-    get autoSelectActiveOption(): boolean;
-    set autoSelectActiveOption(value: BooleanInput);
+    autoActiveFirstOption: boolean;
+    autoSelectActiveOption: boolean;
     set classList(value: string | string[]);
     // (undocumented)
     _classList: {
@@ -84,18 +78,29 @@ export class MatAutocomplete extends _MatAutocompleteMixinBase implements AfterC
     readonly closed: EventEmitter<void>;
     // (undocumented)
     protected _defaults: MatAutocompleteDefaultOptions;
+    disableRipple: boolean;
     displayWith: ((value: any) => string) | null;
     _emitSelectEvent(option: MatOption): void;
     _getPanelAriaLabelledby(labelId: string | null): string | null;
     _getScrollTop(): number;
     get hideSingleSelectionIndicator(): boolean;
-    set hideSingleSelectionIndicator(value: BooleanInput);
+    set hideSingleSelectionIndicator(value: boolean);
     id: string;
     readonly inertGroups: boolean;
     get isOpen(): boolean;
     // (undocumented)
     _isOpen: boolean;
     _keyManager: ActiveDescendantKeyManager<MatOption>;
+    // (undocumented)
+    static ngAcceptInputType_autoActiveFirstOption: unknown;
+    // (undocumented)
+    static ngAcceptInputType_autoSelectActiveOption: unknown;
+    // (undocumented)
+    static ngAcceptInputType_disableRipple: unknown;
+    // (undocumented)
+    static ngAcceptInputType_hideSingleSelectionIndicator: unknown;
+    // (undocumented)
+    static ngAcceptInputType_requireSelection: unknown;
     // (undocumented)
     ngAfterContentInit(): void;
     // (undocumented)
@@ -107,8 +112,7 @@ export class MatAutocomplete extends _MatAutocompleteMixinBase implements AfterC
     readonly optionSelected: EventEmitter<MatAutocompleteSelectedEvent>;
     panel: ElementRef;
     panelWidth: string | number;
-    get requireSelection(): boolean;
-    set requireSelection(value: BooleanInput);
+    requireSelection: boolean;
     _setColor(value: ThemePalette): void;
     _setScrollTop(scrollTop: number): void;
     _setVisibility(): void;
@@ -118,7 +122,7 @@ export class MatAutocomplete extends _MatAutocompleteMixinBase implements AfterC
     _syncParentProperties(): void;
     template: TemplateRef<any>;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<MatAutocomplete, "mat-autocomplete", ["matAutocomplete"], { "disableRipple": { "alias": "disableRipple"; "required": false; }; "ariaLabel": { "alias": "aria-label"; "required": false; }; "ariaLabelledby": { "alias": "aria-labelledby"; "required": false; }; "displayWith": { "alias": "displayWith"; "required": false; }; "autoActiveFirstOption": { "alias": "autoActiveFirstOption"; "required": false; }; "autoSelectActiveOption": { "alias": "autoSelectActiveOption"; "required": false; }; "requireSelection": { "alias": "requireSelection"; "required": false; }; "panelWidth": { "alias": "panelWidth"; "required": false; }; "classList": { "alias": "class"; "required": false; }; "hideSingleSelectionIndicator": { "alias": "hideSingleSelectionIndicator"; "required": false; }; }, { "optionSelected": "optionSelected"; "opened": "opened"; "closed": "closed"; "optionActivated": "optionActivated"; }, ["options", "optionGroups"], ["*"], false, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MatAutocomplete, "mat-autocomplete", ["matAutocomplete"], { "ariaLabel": { "alias": "aria-label"; "required": false; }; "ariaLabelledby": { "alias": "aria-labelledby"; "required": false; }; "displayWith": { "alias": "displayWith"; "required": false; }; "autoActiveFirstOption": { "alias": "autoActiveFirstOption"; "required": false; }; "autoSelectActiveOption": { "alias": "autoSelectActiveOption"; "required": false; }; "requireSelection": { "alias": "requireSelection"; "required": false; }; "panelWidth": { "alias": "panelWidth"; "required": false; }; "disableRipple": { "alias": "disableRipple"; "required": false; }; "classList": { "alias": "class"; "required": false; }; "hideSingleSelectionIndicator": { "alias": "hideSingleSelectionIndicator"; "required": false; }; }, { "optionSelected": "optionSelected"; "opened": "opened"; "closed": "closed"; "optionActivated": "optionActivated"; }, ["options", "optionGroups"], ["*"], false, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatAutocomplete, never>;
 }
@@ -174,8 +178,7 @@ export class MatAutocompleteTrigger implements ControlValueAccessor, AfterViewIn
     get activeOption(): MatOption | null;
     autocomplete: MatAutocomplete;
     autocompleteAttribute: string;
-    get autocompleteDisabled(): boolean;
-    set autocompleteDisabled(value: BooleanInput);
+    autocompleteDisabled: boolean;
     closePanel(): void;
     connectedTo: MatAutocompleteOrigin;
     // (undocumented)
@@ -186,6 +189,8 @@ export class MatAutocompleteTrigger implements ControlValueAccessor, AfterViewIn
     _handleInput(event: KeyboardEvent): void;
     // (undocumented)
     _handleKeydown(event: KeyboardEvent): void;
+    // (undocumented)
+    static ngAcceptInputType_autocompleteDisabled: unknown;
     // (undocumented)
     ngAfterViewInit(): void;
     // (undocumented)

--- a/tools/public_api_guard/material/badge.md
+++ b/tools/public_api_guard/material/badge.md
@@ -4,11 +4,7 @@
 
 ```ts
 
-import { _AbstractConstructor } from '@angular/material/core';
 import { AriaDescriber } from '@angular/cdk/a11y';
-import { BooleanInput } from '@angular/cdk/coercion';
-import { CanDisable } from '@angular/material/core';
-import { _Constructor } from '@angular/material/core';
 import { ElementRef } from '@angular/core';
 import * as i0 from '@angular/core';
 import * as i2 from '@angular/cdk/a11y';
@@ -20,7 +16,7 @@ import { Renderer2 } from '@angular/core';
 import { ThemePalette } from '@angular/material/core';
 
 // @public
-export class MatBadge extends _MatBadgeBase implements OnInit, OnDestroy, CanDisable {
+export class MatBadge implements OnInit, OnDestroy {
     constructor(_ngZone: NgZone, _elementRef: ElementRef<HTMLElement>, _ariaDescriber: AriaDescriber, _renderer: Renderer2, _animationMode?: string | undefined);
     get color(): ThemePalette;
     set color(value: ThemePalette);
@@ -28,22 +24,27 @@ export class MatBadge extends _MatBadgeBase implements OnInit, OnDestroy, CanDis
     set content(newContent: string | number | undefined | null);
     get description(): string;
     set description(newDescription: string);
+    disabled: boolean;
     getBadgeElement(): HTMLElement | undefined;
-    get hidden(): boolean;
-    set hidden(val: BooleanInput);
+    hidden: boolean;
     _id: number;
     isAbove(): boolean;
     isAfter(): boolean;
     // (undocumented)
+    static ngAcceptInputType_disabled: unknown;
+    // (undocumented)
+    static ngAcceptInputType_hidden: unknown;
+    // (undocumented)
+    static ngAcceptInputType_overlap: unknown;
+    // (undocumented)
     ngOnDestroy(): void;
     // (undocumented)
     ngOnInit(): void;
-    get overlap(): boolean;
-    set overlap(val: BooleanInput);
+    overlap: boolean;
     position: MatBadgePosition;
     size: MatBadgeSize;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<MatBadge, "[matBadge]", never, { "disabled": { "alias": "matBadgeDisabled"; "required": false; }; "color": { "alias": "matBadgeColor"; "required": false; }; "overlap": { "alias": "matBadgeOverlap"; "required": false; }; "position": { "alias": "matBadgePosition"; "required": false; }; "content": { "alias": "matBadge"; "required": false; }; "description": { "alias": "matBadgeDescription"; "required": false; }; "size": { "alias": "matBadgeSize"; "required": false; }; "hidden": { "alias": "matBadgeHidden"; "required": false; }; }, {}, never, never, false, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<MatBadge, "[matBadge]", never, { "color": { "alias": "matBadgeColor"; "required": false; }; "overlap": { "alias": "matBadgeOverlap"; "required": false; }; "disabled": { "alias": "matBadgeDisabled"; "required": false; }; "position": { "alias": "matBadgePosition"; "required": false; }; "content": { "alias": "matBadge"; "required": false; }; "description": { "alias": "matBadgeDescription"; "required": false; }; "size": { "alias": "matBadgeSize"; "required": false; }; "hidden": { "alias": "matBadgeHidden"; "required": false; }; }, {}, never, never, false, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatBadge, [null, null, null, null, { optional: true; }]>;
 }

--- a/tools/public_api_guard/material/button-toggle.md
+++ b/tools/public_api_guard/material/button-toggle.md
@@ -4,13 +4,9 @@
 
 ```ts
 
-import { _AbstractConstructor } from '@angular/material/core';
 import { AfterContentInit } from '@angular/core';
 import { AfterViewInit } from '@angular/core';
-import { BooleanInput } from '@angular/cdk/coercion';
-import { CanDisableRipple } from '@angular/material/core';
 import { ChangeDetectorRef } from '@angular/core';
-import { _Constructor } from '@angular/material/core';
 import { ControlValueAccessor } from '@angular/forms';
 import { ElementRef } from '@angular/core';
 import { EventEmitter } from '@angular/core';
@@ -32,7 +28,7 @@ export const MAT_BUTTON_TOGGLE_GROUP: InjectionToken<MatButtonToggleGroup>;
 export const MAT_BUTTON_TOGGLE_GROUP_VALUE_ACCESSOR: any;
 
 // @public
-export class MatButtonToggle extends _MatButtonToggleBase implements OnInit, AfterViewInit, CanDisableRipple, OnDestroy {
+export class MatButtonToggle implements OnInit, AfterViewInit, OnDestroy {
     constructor(toggleGroup: MatButtonToggleGroup, _changeDetectorRef: ChangeDetectorRef, _elementRef: ElementRef<HTMLElement>, _focusMonitor: FocusMonitor, defaultTabIndex: string, defaultOptions?: MatButtonToggleDefaultOptions);
     get appearance(): MatButtonToggleAppearance;
     set appearance(value: MatButtonToggleAppearance);
@@ -43,14 +39,21 @@ export class MatButtonToggle extends _MatButtonToggleBase implements OnInit, Aft
     buttonToggleGroup: MatButtonToggleGroup;
     readonly change: EventEmitter<MatButtonToggleChange>;
     get checked(): boolean;
-    set checked(value: BooleanInput);
+    set checked(value: boolean);
     get disabled(): boolean;
-    set disabled(value: BooleanInput);
+    set disabled(value: boolean);
+    disableRipple: boolean;
     focus(options?: FocusOptions): void;
     _getButtonName(): string | null;
     id: string;
     _markForCheck(): void;
     name: string;
+    // (undocumented)
+    static ngAcceptInputType_checked: unknown;
+    // (undocumented)
+    static ngAcceptInputType_disabled: unknown;
+    // (undocumented)
+    static ngAcceptInputType_disableRipple: unknown;
     // (undocumented)
     ngAfterViewInit(): void;
     // (undocumented)
@@ -61,7 +64,7 @@ export class MatButtonToggle extends _MatButtonToggleBase implements OnInit, Aft
     tabIndex: number | null;
     value: any;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<MatButtonToggle, "mat-button-toggle", ["matButtonToggle"], { "disableRipple": { "alias": "disableRipple"; "required": false; }; "ariaLabel": { "alias": "aria-label"; "required": false; }; "ariaLabelledby": { "alias": "aria-labelledby"; "required": false; }; "id": { "alias": "id"; "required": false; }; "name": { "alias": "name"; "required": false; }; "value": { "alias": "value"; "required": false; }; "tabIndex": { "alias": "tabIndex"; "required": false; }; "appearance": { "alias": "appearance"; "required": false; }; "checked": { "alias": "checked"; "required": false; }; "disabled": { "alias": "disabled"; "required": false; }; }, { "change": "change"; }, never, ["*"], false, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MatButtonToggle, "mat-button-toggle", ["matButtonToggle"], { "ariaLabel": { "alias": "aria-label"; "required": false; }; "ariaLabelledby": { "alias": "aria-labelledby"; "required": false; }; "id": { "alias": "id"; "required": false; }; "name": { "alias": "name"; "required": false; }; "value": { "alias": "value"; "required": false; }; "tabIndex": { "alias": "tabIndex"; "required": false; }; "disableRipple": { "alias": "disableRipple"; "required": false; }; "appearance": { "alias": "appearance"; "required": false; }; "checked": { "alias": "checked"; "required": false; }; "disabled": { "alias": "disabled"; "required": false; }; }, { "change": "change"; }, never, ["*"], false, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatButtonToggle, [{ optional: true; }, null, null, null, { attribute: "tabindex"; }, { optional: true; }]>;
 }
@@ -91,14 +94,20 @@ export class MatButtonToggleGroup implements ControlValueAccessor, OnInit, After
     readonly change: EventEmitter<MatButtonToggleChange>;
     _controlValueAccessorChangeFn: (value: any) => void;
     get disabled(): boolean;
-    set disabled(value: BooleanInput);
+    set disabled(value: boolean);
     _emitChangeEvent(toggle: MatButtonToggle): void;
     _isPrechecked(toggle: MatButtonToggle): boolean;
     _isSelected(toggle: MatButtonToggle): boolean;
     get multiple(): boolean;
-    set multiple(value: BooleanInput);
+    set multiple(value: boolean);
     get name(): string;
     set name(value: string);
+    // (undocumented)
+    static ngAcceptInputType_disabled: unknown;
+    // (undocumented)
+    static ngAcceptInputType_multiple: unknown;
+    // (undocumented)
+    static ngAcceptInputType_vertical: unknown;
     // (undocumented)
     ngAfterContentInit(): void;
     // (undocumented)
@@ -115,8 +124,7 @@ export class MatButtonToggleGroup implements ControlValueAccessor, OnInit, After
     get value(): any;
     set value(newValue: any);
     readonly valueChange: EventEmitter<any>;
-    get vertical(): boolean;
-    set vertical(value: BooleanInput);
+    vertical: boolean;
     writeValue(value: any): void;
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<MatButtonToggleGroup, "mat-button-toggle-group", ["matButtonToggleGroup"], { "appearance": { "alias": "appearance"; "required": false; }; "name": { "alias": "name"; "required": false; }; "vertical": { "alias": "vertical"; "required": false; }; "value": { "alias": "value"; "required": false; }; "multiple": { "alias": "multiple"; "required": false; }; "disabled": { "alias": "disabled"; "required": false; }; }, { "valueChange": "valueChange"; "change": "change"; }, ["_buttonToggles"], never, false, never>;

--- a/tools/public_api_guard/material/checkbox.md
+++ b/tools/public_api_guard/material/checkbox.md
@@ -4,20 +4,13 @@
 
 ```ts
 
-import { _AbstractConstructor } from '@angular/material/core';
 import { AfterViewInit } from '@angular/core';
-import { BooleanInput } from '@angular/cdk/coercion';
-import { CanColor } from '@angular/material/core';
-import { CanDisable } from '@angular/material/core';
-import { CanDisableRipple } from '@angular/material/core';
 import { ChangeDetectorRef } from '@angular/core';
 import { CheckboxRequiredValidator } from '@angular/forms';
-import { _Constructor } from '@angular/material/core';
 import { ControlValueAccessor } from '@angular/forms';
 import { ElementRef } from '@angular/core';
 import { EventEmitter } from '@angular/core';
 import { FocusableOption } from '@angular/cdk/a11y';
-import { HasTabIndex } from '@angular/material/core';
 import * as i0 from '@angular/core';
 import * as i3 from '@angular/material/core';
 import { InjectionToken } from '@angular/core';
@@ -39,8 +32,8 @@ export function MAT_CHECKBOX_DEFAULT_OPTIONS_FACTORY(): MatCheckboxDefaultOption
 export const MAT_CHECKBOX_REQUIRED_VALIDATOR: Provider;
 
 // @public (undocumented)
-export class MatCheckbox extends _MatCheckboxMixinBase implements AfterViewInit, ControlValueAccessor, CanColor, CanDisable, HasTabIndex, CanDisableRipple, FocusableOption {
-    constructor(elementRef: ElementRef<HTMLElement>, _changeDetectorRef: ChangeDetectorRef, _ngZone: NgZone, tabIndex: string, _animationMode?: string | undefined, _options?: MatCheckboxDefaultOptions | undefined);
+export class MatCheckbox implements AfterViewInit, ControlValueAccessor, FocusableOption {
+    constructor(_elementRef: ElementRef<HTMLElement>, _changeDetectorRef: ChangeDetectorRef, _ngZone: NgZone, tabIndex: string, _animationMode?: string | undefined, _options?: MatCheckboxDefaultOptions | undefined);
     protected _animationClasses: {
         uncheckedToChecked: string;
         uncheckedToIndeterminate: string;
@@ -56,17 +49,21 @@ export class MatCheckbox extends _MatCheckboxMixinBase implements AfterViewInit,
     ariaLabelledby: string | null;
     readonly change: EventEmitter<MatCheckboxChange>;
     get checked(): boolean;
-    set checked(value: BooleanInput);
+    set checked(value: boolean);
+    color: string | undefined;
     protected _createChangeEvent(isChecked: boolean): MatCheckboxChange;
     get disabled(): boolean;
-    set disabled(value: BooleanInput);
+    set disabled(value: boolean);
+    disableRipple: boolean;
+    // (undocumented)
+    _elementRef: ElementRef<HTMLElement>;
     focus(): void;
     protected _getAnimationTargetElement(): HTMLInputElement;
     // (undocumented)
     protected _handleInputClick(): void;
     id: string;
     get indeterminate(): boolean;
-    set indeterminate(value: BooleanInput);
+    set indeterminate(value: boolean);
     readonly indeterminateChange: EventEmitter<boolean>;
     _inputElement: ElementRef<HTMLInputElement>;
     get inputId(): string;
@@ -75,6 +72,18 @@ export class MatCheckbox extends _MatCheckboxMixinBase implements AfterViewInit,
     _labelElement: ElementRef<HTMLInputElement>;
     labelPosition: 'before' | 'after';
     name: string | null;
+    // (undocumented)
+    static ngAcceptInputType_checked: unknown;
+    // (undocumented)
+    static ngAcceptInputType_disabled: unknown;
+    // (undocumented)
+    static ngAcceptInputType_disableRipple: unknown;
+    // (undocumented)
+    static ngAcceptInputType_indeterminate: unknown;
+    // (undocumented)
+    static ngAcceptInputType_required: unknown;
+    // (undocumented)
+    static ngAcceptInputType_tabIndex: unknown;
     // (undocumented)
     ngAfterViewInit(): void;
     // (undocumented)
@@ -92,18 +101,18 @@ export class MatCheckbox extends _MatCheckboxMixinBase implements AfterViewInit,
     registerOnChange(fn: (value: any) => void): void;
     // (undocumented)
     registerOnTouched(fn: any): void;
-    get required(): boolean;
-    set required(value: BooleanInput);
+    required: boolean;
     // @deprecated
     ripple: MatRipple;
     // (undocumented)
     setDisabledState(isDisabled: boolean): void;
+    tabIndex: number;
     toggle(): void;
     value: string;
     // (undocumented)
     writeValue(value: any): void;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<MatCheckbox, "mat-checkbox", ["matCheckbox"], { "disableRipple": { "alias": "disableRipple"; "required": false; }; "color": { "alias": "color"; "required": false; }; "tabIndex": { "alias": "tabIndex"; "required": false; }; "ariaLabel": { "alias": "aria-label"; "required": false; }; "ariaLabelledby": { "alias": "aria-labelledby"; "required": false; }; "ariaDescribedby": { "alias": "aria-describedby"; "required": false; }; "id": { "alias": "id"; "required": false; }; "required": { "alias": "required"; "required": false; }; "labelPosition": { "alias": "labelPosition"; "required": false; }; "name": { "alias": "name"; "required": false; }; "value": { "alias": "value"; "required": false; }; "checked": { "alias": "checked"; "required": false; }; "disabled": { "alias": "disabled"; "required": false; }; "indeterminate": { "alias": "indeterminate"; "required": false; }; }, { "change": "change"; "indeterminateChange": "indeterminateChange"; }, never, ["*"], false, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MatCheckbox, "mat-checkbox", ["matCheckbox"], { "ariaLabel": { "alias": "aria-label"; "required": false; }; "ariaLabelledby": { "alias": "aria-labelledby"; "required": false; }; "ariaDescribedby": { "alias": "aria-describedby"; "required": false; }; "id": { "alias": "id"; "required": false; }; "required": { "alias": "required"; "required": false; }; "labelPosition": { "alias": "labelPosition"; "required": false; }; "name": { "alias": "name"; "required": false; }; "value": { "alias": "value"; "required": false; }; "disableRipple": { "alias": "disableRipple"; "required": false; }; "tabIndex": { "alias": "tabIndex"; "required": false; }; "color": { "alias": "color"; "required": false; }; "checked": { "alias": "checked"; "required": false; }; "disabled": { "alias": "disabled"; "required": false; }; "indeterminate": { "alias": "indeterminate"; "required": false; }; }, { "change": "change"; "indeterminateChange": "indeterminateChange"; }, never, ["*"], false, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatCheckbox, [null, null, null, { attribute: "tabindex"; }, { optional: true; }, { optional: true; }]>;
 }

--- a/tools/public_api_guard/material/core.md
+++ b/tools/public_api_guard/material/core.md
@@ -4,12 +4,9 @@
 
 ```ts
 
-import { _AbstractConstructor as _AbstractConstructor_2 } from '@angular/material/core';
 import { AbstractControl } from '@angular/forms';
 import { AfterViewChecked } from '@angular/core';
-import { BooleanInput } from '@angular/cdk/coercion';
 import { ChangeDetectorRef } from '@angular/core';
-import { _Constructor as _Constructor_2 } from '@angular/material/core';
 import { ElementRef } from '@angular/core';
 import { EventEmitter } from '@angular/core';
 import { FocusableOption } from '@angular/cdk/a11y';
@@ -240,13 +237,16 @@ export class MatNativeDateModule {
 }
 
 // @public
-export class MatOptgroup extends _MatOptgroupMixinBase implements CanDisable {
+export class MatOptgroup {
     constructor(parent?: MatOptionParentComponent);
+    disabled: boolean;
     _inert: boolean;
     label: string;
     _labelId: string;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<MatOptgroup, "mat-optgroup", ["matOptgroup"], { "disabled": { "alias": "disabled"; "required": false; }; "label": { "alias": "label"; "required": false; }; }, {}, never, ["*", "mat-option, ng-container"], false, never>;
+    static ngAcceptInputType_disabled: unknown;
+    // (undocumented)
+    static ɵcmp: i0.ɵɵComponentDeclaration<MatOptgroup, "mat-optgroup", ["matOptgroup"], { "label": { "alias": "label"; "required": false; }; "disabled": { "alias": "disabled"; "required": false; }; }, {}, never, ["*", "mat-option, ng-container"], false, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatOptgroup, [{ optional: true; }]>;
 }
@@ -259,7 +259,7 @@ export class MatOption<T = any> implements FocusableOption, AfterViewChecked, On
     _changeDetectorRef: ChangeDetectorRef;
     deselect(emitEvent?: boolean): void;
     get disabled(): boolean;
-    set disabled(value: BooleanInput);
+    set disabled(value: boolean);
     get disableRipple(): boolean;
     focus(_origin?: FocusOrigin, options?: FocusOptions): void;
     _getHostElement(): HTMLElement;
@@ -271,6 +271,8 @@ export class MatOption<T = any> implements FocusableOption, AfterViewChecked, On
     get hideSingleSelectionIndicator(): boolean;
     id: string;
     get multiple(): boolean | undefined;
+    // (undocumented)
+    static ngAcceptInputType_disabled: unknown;
     // (undocumented)
     ngAfterViewChecked(): void;
     // (undocumented)

--- a/tools/public_api_guard/material/menu.md
+++ b/tools/public_api_guard/material/menu.md
@@ -4,18 +4,13 @@
 
 ```ts
 
-import { _AbstractConstructor } from '@angular/material/core';
 import { AfterContentInit } from '@angular/core';
 import { AfterViewInit } from '@angular/core';
 import { AnimationEvent as AnimationEvent_2 } from '@angular/animations';
 import { AnimationTriggerMetadata } from '@angular/animations';
 import { ApplicationRef } from '@angular/core';
-import { BooleanInput } from '@angular/cdk/coercion';
-import { CanDisable } from '@angular/material/core';
-import { CanDisableRipple } from '@angular/material/core';
 import { ChangeDetectorRef } from '@angular/core';
 import { ComponentFactoryResolver } from '@angular/core';
-import { _Constructor } from '@angular/material/core';
 import { Direction } from '@angular/cdk/bidi';
 import { Directionality } from '@angular/cdk/bidi';
 import { ElementRef } from '@angular/core';
@@ -89,13 +84,16 @@ export class MatMenu implements AfterContentInit, MatMenuPanel<MatMenuItem>, OnI
     direction: Direction;
     focusFirstItem(origin?: FocusOrigin): void;
     _handleKeydown(event: KeyboardEvent): void;
-    get hasBackdrop(): boolean | undefined;
-    set hasBackdrop(value: BooleanInput);
+    hasBackdrop?: boolean;
     _hovered(): Observable<MatMenuItem>;
     _isAnimating: boolean;
     // @deprecated
     items: QueryList<MatMenuItem>;
     lazyContent: MatMenuContent;
+    // (undocumented)
+    static ngAcceptInputType_hasBackdrop: any;
+    // (undocumented)
+    static ngAcceptInputType_overlapTrigger: unknown;
     // (undocumented)
     ngAfterContentInit(): void;
     // (undocumented)
@@ -105,8 +103,7 @@ export class MatMenu implements AfterContentInit, MatMenuPanel<MatMenuItem>, OnI
     _onAnimationDone(event: AnimationEvent_2): void;
     // (undocumented)
     _onAnimationStart(event: AnimationEvent_2): void;
-    get overlapTrigger(): boolean;
-    set overlapTrigger(value: BooleanInput);
+    overlapTrigger: boolean;
     overlayPanelClass: string | string[];
     _panelAnimationState: 'void' | 'enter';
     set panelClass(classes: string);
@@ -164,11 +161,13 @@ export interface MatMenuDefaultOptions {
 }
 
 // @public
-export class MatMenuItem extends _MatMenuItemBase implements FocusableOption, CanDisable, CanDisableRipple, AfterViewInit, OnDestroy {
+export class MatMenuItem implements FocusableOption, AfterViewInit, OnDestroy {
     constructor(elementRef: ElementRef<HTMLElement>, document: any, focusMonitor: FocusMonitor, parentMenu: MatMenuPanel<MatMenuItem> | undefined, changeDetectorRef: ChangeDetectorRef);
     // @deprecated
     constructor(elementRef: ElementRef<HTMLElement>, document?: any, focusMonitor?: FocusMonitor, parentMenu?: MatMenuPanel<MatMenuItem>, changeDetectorRef?: ChangeDetectorRef);
     _checkDisabled(event: Event): void;
+    disabled: boolean;
+    disableRipple: boolean;
     focus(origin?: FocusOrigin, options?: FocusOptions): void;
     readonly _focused: Subject<MatMenuItem>;
     _getHostElement(): HTMLElement;
@@ -179,6 +178,10 @@ export class MatMenuItem extends _MatMenuItemBase implements FocusableOption, Ca
     _hasFocus(): boolean;
     _highlighted: boolean;
     readonly _hovered: Subject<MatMenuItem>;
+    // (undocumented)
+    static ngAcceptInputType_disabled: unknown;
+    // (undocumented)
+    static ngAcceptInputType_disableRipple: unknown;
     // (undocumented)
     ngAfterViewInit(): void;
     // (undocumented)
@@ -192,7 +195,7 @@ export class MatMenuItem extends _MatMenuItemBase implements FocusableOption, Ca
     _setTriggersSubmenu(triggersSubmenu: boolean): void;
     _triggersSubmenu: boolean;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<MatMenuItem, "[mat-menu-item]", ["matMenuItem"], { "disabled": { "alias": "disabled"; "required": false; }; "disableRipple": { "alias": "disableRipple"; "required": false; }; "role": { "alias": "role"; "required": false; }; }, {}, never, ["mat-icon, [matMenuItemIcon]", "*"], false, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MatMenuItem, "[mat-menu-item]", ["matMenuItem"], { "role": { "alias": "role"; "required": false; }; "disabled": { "alias": "disabled"; "required": false; }; "disableRipple": { "alias": "disableRipple"; "required": false; }; }, {}, never, ["mat-icon, [matMenuItemIcon]", "*"], false, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatMenuItem, [null, null, null, { optional: true; }, null]>;
 }

--- a/tools/public_api_guard/material/slide-toggle.md
+++ b/tools/public_api_guard/material/slide-toggle.md
@@ -4,20 +4,13 @@
 
 ```ts
 
-import { _AbstractConstructor } from '@angular/material/core';
 import { AfterContentInit } from '@angular/core';
-import { BooleanInput } from '@angular/cdk/coercion';
-import { CanColor } from '@angular/material/core';
-import { CanDisable } from '@angular/material/core';
-import { CanDisableRipple } from '@angular/material/core';
 import { ChangeDetectorRef } from '@angular/core';
 import { CheckboxRequiredValidator } from '@angular/forms';
-import { _Constructor } from '@angular/material/core';
 import { ControlValueAccessor } from '@angular/forms';
 import { ElementRef } from '@angular/core';
 import { EventEmitter } from '@angular/core';
 import { FocusMonitor } from '@angular/cdk/a11y';
-import { HasTabIndex } from '@angular/material/core';
 import * as i0 from '@angular/core';
 import * as i3 from '@angular/material/core';
 import * as i4 from '@angular/common';
@@ -41,8 +34,8 @@ export const MAT_SLIDE_TOGGLE_VALUE_ACCESSOR: {
 };
 
 // @public (undocumented)
-export class MatSlideToggle extends _MatSlideToggleMixinBase implements OnDestroy, AfterContentInit, ControlValueAccessor, CanDisable, CanColor, HasTabIndex, CanDisableRipple {
-    constructor(elementRef: ElementRef, _focusMonitor: FocusMonitor, _changeDetectorRef: ChangeDetectorRef, tabIndex: string, defaults: MatSlideToggleDefaultOptions, animationMode?: string);
+export class MatSlideToggle implements OnDestroy, AfterContentInit, ControlValueAccessor {
+    constructor(_elementRef: ElementRef, _focusMonitor: FocusMonitor, _changeDetectorRef: ChangeDetectorRef, tabIndex: string, defaults: MatSlideToggleDefaultOptions, animationMode?: string);
     ariaDescribedby: string;
     ariaLabel: string | null;
     ariaLabelledby: string | null;
@@ -51,9 +44,12 @@ export class MatSlideToggle extends _MatSlideToggleMixinBase implements OnDestro
     // (undocumented)
     protected _changeDetectorRef: ChangeDetectorRef;
     get checked(): boolean;
-    set checked(value: BooleanInput);
+    set checked(value: boolean);
+    color: string | undefined;
     // (undocumented)
     defaults: MatSlideToggleDefaultOptions;
+    disabled: boolean;
+    disableRipple: boolean;
     protected _emitChangeEvent(): void;
     focus(): void;
     _focused: boolean;
@@ -62,13 +58,24 @@ export class MatSlideToggle extends _MatSlideToggleMixinBase implements OnDestro
     // (undocumented)
     _getAriaLabelledBy(): string | null;
     _handleClick(): void;
-    get hideIcon(): boolean;
-    set hideIcon(value: BooleanInput);
+    hideIcon: boolean;
     id: string;
     get inputId(): string;
     _labelId: string;
     labelPosition: 'before' | 'after';
     name: string | null;
+    // (undocumented)
+    static ngAcceptInputType_checked: unknown;
+    // (undocumented)
+    static ngAcceptInputType_disabled: unknown;
+    // (undocumented)
+    static ngAcceptInputType_disableRipple: unknown;
+    // (undocumented)
+    static ngAcceptInputType_hideIcon: unknown;
+    // (undocumented)
+    static ngAcceptInputType_required: unknown;
+    // (undocumented)
+    static ngAcceptInputType_tabIndex: unknown;
     // (undocumented)
     ngAfterContentInit(): void;
     // (undocumented)
@@ -76,10 +83,10 @@ export class MatSlideToggle extends _MatSlideToggleMixinBase implements OnDestro
     _noopAnimations: boolean;
     registerOnChange(fn: any): void;
     registerOnTouched(fn: any): void;
-    get required(): boolean;
-    set required(value: BooleanInput);
+    required: boolean;
     setDisabledState(isDisabled: boolean): void;
     _switchElement: ElementRef<HTMLElement>;
+    tabIndex: number;
     toggle(): void;
     readonly toggleChange: EventEmitter<void>;
     writeValue(value: any): void;

--- a/tslint.json
+++ b/tslint.json
@@ -94,7 +94,6 @@
         "Component": {
           "argument": 0,
           "properties": {
-            "!host": "\\[class\\]",
             "!preserveWhitespaces": ".*",
             "!styles": ".*",
             "!moduleId": ".*",


### PR DESCRIPTION
Reworks some of the components not to use mixin classes anymore. I'll be sending PRs like this to tackle mixins in batches to reduce the amount of breakages during TGP. Includes changes in the following components:
* Checkbox
* Autocomplete
* Badge
* Button toggle
* Option and option group
* Menu
* Slide toggle