### PR TITLE
fix(mat-menu): Change menu item direction in RTL

### DIFF
--- a/src/material/menu/menu.scss
+++ b/src/material/menu/menu.scss
@@ -135,6 +135,7 @@ mat-menu {
 
   [dir='rtl'] & {
     text-align: right;
+    direction: rtl;
 
     .mat-icon {
       margin-right: 0;


### PR DESCRIPTION
Fixes a bug in the Angular Material component where menu items did not update dynamically upon a direction change. The issue was caused by the absence of the class being set when the direction changed.

Fixes #27498