### PR TITLE
fix(doc): mat-error can only rendered if the input has touched and is invalid state

### DIFF
--- a/src/material/input/input.md
+++ b/src/material/input/input.md
@@ -50,7 +50,7 @@ element. In some cases that `<mat-form-field>` may use the placeholder as the la
 The `<mat-form-field>` allows you to
 [associate error messages](https://material.angular.io/components/form-field/overview#error-messages)
 with your `matNativeControl`. By default, these error messages are shown when the control is invalid and
-either the user has interacted with (touched) the element or the parent form has been submitted. If
+the user has interacted with (touched) the element or the parent form has been submitted. If
 you wish to override this behavior (e.g. to show the error as soon as the invalid control is dirty
 or when a parent form group is invalid), you can use the `errorStateMatcher` property of the
 `matNativeControl`. The property takes an instance of an `ErrorStateMatcher` object. An `ErrorStateMatcher`


### PR DESCRIPTION
The mat-error can only rendered if the input has touched and the input is invalid. The "either" term in the explanation may be confusing and lead to the assumption that the mat-error is rendered if it has a touch or an invalid status.