### PR TITLE
feat(MatOptionHarness): make MatOptionHarness extend ContentContainerComponentHarness

### DIFF
--- a/src/material/core/testing/option-harness.ts
+++ b/src/material/core/testing/option-harness.ts
@@ -7,14 +7,14 @@
  */
 
 import {
-  ComponentHarness,
   ComponentHarnessConstructor,
+  ContentContainerComponentHarness,
   HarnessPredicate,
 } from '@angular/cdk/testing';
 import {OptionHarnessFilters} from './option-harness-filters';
 
 /** Harness for interacting with an MDC-based `mat-option` in tests. */
-export class MatOptionHarness extends ComponentHarness {
+export class MatOptionHarness extends ContentContainerComponentHarness {
   /** Selector used to locate option instances. */
   static hostSelector = '.mat-mdc-option';
 

--- a/tools/public_api_guard/material/core-testing.md
+++ b/tools/public_api_guard/material/core-testing.md
@@ -7,6 +7,7 @@
 import { BaseHarnessFilters } from '@angular/cdk/testing';
 import { ComponentHarness } from '@angular/cdk/testing';
 import { ComponentHarnessConstructor } from '@angular/cdk/testing';
+import { ContentContainerComponentHarness } from '@angular/cdk/testing';
 import { HarnessPredicate } from '@angular/cdk/testing';
 
 // @public
@@ -19,7 +20,7 @@ export class MatOptgroupHarness extends ComponentHarness {
 }
 
 // @public
-export class MatOptionHarness extends ComponentHarness {
+export class MatOptionHarness extends ContentContainerComponentHarness {
     click(): Promise<void>;
     getText(): Promise<string>;
     static hostSelector: string;


### PR DESCRIPTION
This allows users to obtain harnesses for more complex elements inside of the `MatOption`. The current `MatOptionHarness` offers only `getText()`, which is limiting with rich content in the MatOption. [Example from MatAutocomplete documentation](https://material.angular.io/components/autocomplete/examples#autocomplete-overview) where rich content is even encouraged.
