### PR TITLE
fix(material/snack-bar): snack-bar action button does not follow material guidelines

### DIFF
--- a/src/material/core/tokens/m2/mat/_snack-bar.scss
+++ b/src/material/core/tokens/m2/mat/_snack-bar.scss
@@ -16,8 +16,12 @@ $prefix: (mat, snack-bar);
   $is-dark: inspection.get-theme-type($theme) == dark;
 
   @return (
-    button-color: if(
-        $is-dark, rgba(0, 0, 0, 0.87), inspection.get-theme-color($theme, accent, text))
+    button-color:
+      if(
+        $is-dark,
+        inspection.get-theme-color($theme, primary, 500),
+        inspection.get-theme-color($theme, primary, 100)
+      )
   );
 }
 


### PR DESCRIPTION
Fixes a bug in the Angular Material snack-bar, where accent color is used for action button color in light themes and grey is used in dark themes. This does not follow the material design guidelines which recommend a tone of primary color is used in both light and dark themes, and that the color should contrast with the background.

Fixes #13905