### PR TITLE
fix(material/badge): automatically set aria-hidden

### DIFF
--- a/src/dev-app/badge/badge-demo.html
+++ b/src/dev-app/badge/badge-demo.html
@@ -39,6 +39,10 @@
     <mat-icon color="primary" matBadge="22" matBadgePosition="below before">
       home
     </mat-icon>
+
+    <mat-icon color="primary" matBadge="22" matBadgeHidden="true">
+      visibility_off
+    </mat-icon>
   </div>
 
    <div class="demo-badge">

--- a/src/material/badge/badge.ts
+++ b/src/material/badge/badge.ts
@@ -46,6 +46,7 @@ const BADGE_CONTENT_CLASS = 'mat-badge-content';
 @Directive({
   selector: '[matBadge]',
   host: {
+    '[attr.aria-hidden]': '_isPlacedOnMatIcon ? (hidden || !content) : _initialAriaHidden',
     'class': 'mat-badge',
     '[class.mat-badge-overlap]': 'overlap',
     '[class.mat-badge-above]': 'isAbove()',
@@ -112,6 +113,12 @@ export class MatBadge implements OnInit, OnDestroy {
   /** Unique id for the badge */
   _id: number = nextId++;
 
+  /** Whether the badge is displayed on a mat-icon */
+  _isPlacedOnMatIcon: boolean;
+
+  /** The initial value of attr.aria-hidden */
+  _initialAriaHidden: boolean;
+
   /** Visible badge element. */
   private _badgeElement: HTMLElement | undefined;
 
@@ -140,20 +147,8 @@ export class MatBadge implements OnInit, OnDestroy {
       }
 
       const matIconTagName: string = 'mat-icon';
-
-      // Heads-up for developers to avoid putting matBadge on <mat-icon>
-      // as it is aria-hidden by default docs mention this at:
-      // https://material.angular.io/components/badge/overview#accessibility
-      if (
-        nativeElement.tagName.toLowerCase() === matIconTagName &&
-        nativeElement.getAttribute('aria-hidden') === 'true'
-      ) {
-        console.warn(
-          `Detected a matBadge on an "aria-hidden" "<mat-icon>". ` +
-            `Consider setting aria-hidden="false" in order to surface the information assistive technology.` +
-            `\n${nativeElement.outerHTML}`,
-        );
-      }
+      this._initialAriaHidden = booleanAttribute(nativeElement.getAttribute('aria-hidden'));
+      this._isPlacedOnMatIcon = nativeElement.tagName.toLowerCase() === matIconTagName;
     }
   }
 


### PR DESCRIPTION
This PR solves issue #27705 by automatically setting `aria-hidden=true` if mat-icons have a visible badge. 

Previously, badges on mat-icons caused a warning, instructing the developer to set this attribute appropriately.