### PR TITLE
fix(cdk/scrolling): unsubscribe from scrolled stream when viewport is destroyed

### DIFF
--- a/src/cdk/scrolling/virtual-scroll-viewport.ts
+++ b/src/cdk/scrolling/virtual-scroll-viewport.ts
@@ -229,6 +229,10 @@ export class CdkVirtualScrollViewport extends CdkVirtualScrollable implements On
             // there are multiple scroll events in the same frame we only need to recheck
             // our layout once.
             auditTime(0, SCROLL_SCHEDULER),
+            // Usually `elementScrolled` is completed when the scrollable is destroyed, but
+            // that may not be the case if a `CdkVirtualScrollableElement` is used so we have
+            // to unsubscribe here just in case.
+            takeUntil(this._destroyed),
           )
           .subscribe(() => this._scrollStrategy.onContentScrolled());
 


### PR DESCRIPTION
Initially the virtual scroll viewport was written under the assumption that it is the scrollable and that it doesn't need to unsubscribe from its `elementScrolled` stream, because it'll be completed on destroy. This might not be the case if a `CdkVirtualScrollableElement` is provided and the viewport might be destroyed without the scrollable being destroyed.

These changes add a `takeUntil` to avoid any potential leaks.

Fixes #27799.