### PR TITLE
ci: fix preview deploys not working due to folder rename

### DIFF
--- a/.github/workflows/build-dev-app.yml
+++ b/.github/workflows/build-dev-app.yml
@@ -34,7 +34,7 @@ jobs:
       # the number of concurrent actions is determined based on the host resources.
       - run: bazel build //src/dev-app:web_package --symlink_prefix=dist/ --jobs=32
 
-      - uses: angular/dev-infra/github-actions/deploy-previews/pack-and-upload-artifact@9931e1a8d1b62fcd2267e89f9993a494856cc1cd
+      - uses: angular/dev-infra/github-actions/previews/pack-and-upload-artifact@9931e1a8d1b62fcd2267e89f9993a494856cc1cd
         with:
           workflow-artifact-name: 'dev-app'
           pull-number: '${{github.event.pull_request.number}}'

--- a/.github/workflows/deploy-dev-app.yml
+++ b/.github/workflows/deploy-dev-app.yml
@@ -33,7 +33,7 @@ jobs:
           npx -y firebase-tools@latest target:clear --project ${{env.PREVIEW_PROJECT}} hosting dev-app
           npx -y firebase-tools@latest target:apply --project ${{env.PREVIEW_PROJECT}} hosting dev-app ${{env.PREVIEW_SITE}}
 
-      - uses: angular/dev-infra/github-actions/deploy-previews/upload-artifacts-to-firebase@9931e1a8d1b62fcd2267e89f9993a494856cc1cd
+      - uses: angular/dev-infra/github-actions/previews/upload-artifacts-to-firebase@9931e1a8d1b62fcd2267e89f9993a494856cc1cd
         with:
           github-token: '${{secrets.GITHUB_TOKEN}}'
           workflow-artifact-name: 'dev-app'


### PR DESCRIPTION
We renamed the preview deploy folder in dev-infra but looks like the workflow was never updated to reflect this.