### PR TITLE
refactor(material/card): remove legacy theme normalization

### DIFF
--- a/src/material/card/_card-theme.scss
+++ b/src/material/card/_card-theme.scss
@@ -87,9 +87,7 @@
   }
 }
 
-@mixin theme($theme-or-color-config) {
-  $theme: theming.private-legacy-get-theme($theme-or-color-config);
-
+@mixin theme($theme) {
   @include theming.private-check-duplicate-theme-styles($theme, 'mat-card') {
     @if inspection.get-theme-version($theme) == 1 {
       @include _theme-from-tokens(inspection.get-theme-tokens($theme));


### PR DESCRIPTION
This is no longer needed now that everything is using the new theme inspection APIs