### PR TITLE
docs(material/slider): clarify behavior of slider range thumbs

### DIFF
--- a/src/material/slider/slider.md
+++ b/src/material/slider/slider.md
@@ -18,9 +18,9 @@ respectively. The initial value is set to the minimum value unless otherwise spe
 ### Selecting a range
 A `<mat-slider>` can be converted into a range slider by projecting both a `matSliderStartThumb` and a
 `matSliderEndThumb` into it. Each thumb has its own value, but both are still
-constrained by the slider's `min` and `max` values. `matSliderStartThumb` cannot have a value
-greater than `matSliderEndThumb` and `matSliderEndThumb` cannot have a value less than `matSliderStartThumb`, though
-they both may have the same value.
+constrained by the slider's `min` and `max` values. The `matSliderStartThumb` cannot have a value
+greater than that of the `matSliderEndThumb` and the `matSliderEndThumb` cannot have a value less than
+that of `matSliderStartThumb`, though they both may have the same value.
 
 ```html
 <mat-slider>

--- a/src/material/slider/slider.md
+++ b/src/material/slider/slider.md
@@ -17,8 +17,10 @@ respectively. The initial value is set to the minimum value unless otherwise spe
 
 ### Selecting a range
 A `<mat-slider>` can be converted into a range slider by projecting both a `matStartThumb` and a
-`matEndThumb` into it. Each of the thumbs has an independent value, but they won't be allowed to
-overlap and they're still bound by the same `min` and `max` from the slider.
+`matEndThumb` into it. Each of the thumbs has its own value, but both are still
+constrained by the slider's `min` and `max` values. `matStartThumb` cannot have a value
+greater than `matEndThumb` and `matEndThumb` cannot have a value less than `matStartThumb`, though
+they both may have the same value.
 
 ```html
 <mat-slider>

--- a/src/material/slider/slider.md
+++ b/src/material/slider/slider.md
@@ -16,10 +16,10 @@ respectively. The initial value is set to the minimum value unless otherwise spe
 ```
 
 ### Selecting a range
-A `<mat-slider>` can be converted into a range slider by projecting both a `matStartThumb` and a
-`matEndThumb` into it. Each of the thumbs has its own value, but both are still
-constrained by the slider's `min` and `max` values. `matStartThumb` cannot have a value
-greater than `matEndThumb` and `matEndThumb` cannot have a value less than `matStartThumb`, though
+A `<mat-slider>` can be converted into a range slider by projecting both a `matSliderStartThumb` and a
+`matSliderEndThumb` into it. Each thumb has its own value, but both are still
+constrained by the slider's `min` and `max` values. `matSliderStartThumb` cannot have a value
+greater than `matSliderEndThumb` and `matSliderEndThumb` cannot have a value less than `matSliderStartThumb`, though
 they both may have the same value.
 
 ```html

--- a/src/material/slider/slider.md
+++ b/src/material/slider/slider.md
@@ -20,7 +20,7 @@ A `<mat-slider>` can be converted into a range slider by projecting both a `matS
 `matSliderEndThumb` into it. Each thumb has its own value, but both are still
 constrained by the slider's `min` and `max` values. The `matSliderStartThumb` cannot have a value
 greater than that of the `matSliderEndThumb` and the `matSliderEndThumb` cannot have a value less than
-that of `matSliderStartThumb`, though they both may have the same value.
+that of the `matSliderStartThumb`, though they both may have the same value.
 
 ```html
 <mat-slider>


### PR DESCRIPTION
Clarifies possible behavior/values of matStartThumb and matEndThumb in slider component 'Selecting a range' documentation.

Addresses #27837