### PR TITLE
docs(material/slider): Page Up/Down increase value but not by 10 steps

### DIFF
--- a/src/material/slider/slider.md
+++ b/src/material/slider/slider.md
@@ -68,8 +68,8 @@ The slider has the following keyboard bindings:
 | Up arrow    | Increment the slider value by one step.                                            |
 | Left arrow  | Decrement the slider value by one step (increments in RTL).                        |
 | Down arrow  | Decrement the slider value by one step.                                            |
-| Page up     | Increment the slider value by 10 steps.                                            |
-| Page down   | Decrement the slider value by 10 steps.                                            |
+| Page up     | Increment the slider value by 10% (of the max value).                              |
+| Page down   | Decrement the slider value by 10% (of the max value).                              |
 | End         | Set the value to the maximum possible.                                             |
 | Home        | Set the value to the minimum possible.                                             |
 


### PR DESCRIPTION
Change the documentation so it's clearer that the Page Up/Down buttons of the slider component increase/decrease the value of the slider by 10% (of the max value), rather than 10 steps as it was described previously.

Fixes #27402.