### PR TITLE
fix(material/tabs): nav bar not navigating on enter presses

### DIFF
--- a/src/material/tabs/tab-nav-bar/tab-nav-bar.spec.ts
+++ b/src/material/tabs/tab-nav-bar/tab-nav-bar.spec.ts
@@ -327,6 +327,19 @@ describe('MDC-based MatTabNavBar', () => {
     expect(tabLinks[1].classList.contains('mdc-tab--active')).toBe(true);
   });
 
+  it('should activate a link when enter is pressed', () => {
+    const fixture = TestBed.createComponent(SimpleTabNavBarTestApp);
+    fixture.detectChanges();
+
+    const tabLinks = fixture.nativeElement.querySelectorAll('.mat-mdc-tab-link');
+    expect(tabLinks[1].classList.contains('mdc-tab--active')).toBe(false);
+
+    dispatchKeyboardEvent(tabLinks[1], 'keydown', ENTER);
+    fixture.detectChanges();
+
+    expect(tabLinks[1].classList.contains('mdc-tab--active')).toBe(true);
+  });
+
   describe('ripples', () => {
     let fixture: ComponentFixture<SimpleTabNavBarTestApp>;
 

--- a/src/material/tabs/tab-nav-bar/tab-nav-bar.ts
+++ b/src/material/tabs/tab-nav-bar/tab-nav-bar.ts
@@ -384,10 +384,12 @@ export class MatTabLink
   }
 
   _handleKeydown(event: KeyboardEvent) {
-    if (this.disabled && (event.keyCode === SPACE || event.keyCode === ENTER)) {
-      event.preventDefault();
-    } else if (this._tabNavBar.tabPanel && event.keyCode === SPACE) {
-      this.elementRef.nativeElement.click();
+    if (event.keyCode === SPACE || event.keyCode === ENTER) {
+      if (this.disabled) {
+        event.preventDefault();
+      } else if (this._tabNavBar.tabPanel) {
+        this.elementRef.nativeElement.click();
+      }
     }
   }
 


### PR DESCRIPTION
Fixes that the tab nav bar wasn't navigating when pressing the enter key.

Fixes #27843.