### PR TITLE
fix(material/divider): move unthemable tokens to theme mixin

### DIFF
--- a/src/material/divider/_divider-theme.scss
+++ b/src/material/divider/_divider-theme.scss
@@ -5,7 +5,10 @@
 @use '../core/tokens/m2/mat/divider' as tokens-mat-divider;
 
 @mixin base($theme) {
-  // TODO(mmalerba): Move divider base tokens here
+  @include sass-utils.current-selector-or-root() {
+    @include token-utils.create-token-values(
+        tokens-mat-divider.$prefix, tokens-mat-divider.get-unthemable-tokens());
+  }
 }
 
 @mixin color($theme) {

--- a/src/material/divider/divider.scss
+++ b/src/material/divider/divider.scss
@@ -1,13 +1,9 @@
 @use '../core/tokens/token-utils';
 @use '../core/tokens/m2/mat/divider' as tokens-mat-divider;
 
-
 $inset-margin: 80px;
 
 .mat-divider {
-  @include token-utils.create-token-values(
-    tokens-mat-divider.$prefix, tokens-mat-divider.get-unthemable-tokens());
-
   display: block;
   margin: 0;
   border-top-style: solid;


### PR DESCRIPTION
Though these tokens are not currently affected by the theme, in the future they will be affected by the design system used for theming (M2 or M3)