### PR TITLE
fix(material/bottom-sheet): move unthemable tokens to theme mixin

### DIFF
--- a/src/material/_index.scss
+++ b/src/material/_index.scss
@@ -69,7 +69,7 @@
 @forward './badge/badge-theme' as badge-* show badge-theme, badge-color, badge-typography,
   badge-density, badge-base;
 @forward './bottom-sheet/bottom-sheet-theme' as bottom-sheet-* show bottom-sheet-theme,
-  bottom-sheet-color, bottom-sheet-typography, bottom-sheet-density;
+  bottom-sheet-color, bottom-sheet-typography, bottom-sheet-density, bottom-sheet-base;
 @forward './button/button-theme' as button-* show button-theme, button-color, button-typography,
   button-density;
 @forward './button/fab-theme' as fab-* show fab-color, fab-typography,

--- a/src/material/bottom-sheet/_bottom-sheet-theme.scss
+++ b/src/material/bottom-sheet/_bottom-sheet-theme.scss
@@ -5,6 +5,13 @@
 @use '../core/tokens/token-utils';
 @use '../core/tokens/m2/mat/bottom-sheet' as tokens-mat-bottom-sheet;
 
+@mixin base($theme) {
+  @include sass-utils.current-selector-or-root() {
+    @include token-utils.create-token-values(
+        tokens-mat-bottom-sheet.$prefix, tokens-mat-bottom-sheet.get-unthemable-tokens());
+  }
+}
+
 @mixin color($theme) {
   @include sass-utils.current-selector-or-root() {
     @include token-utils.create-token-values(tokens-mat-bottom-sheet.$prefix,
@@ -23,6 +30,7 @@
 
 @mixin theme($theme) {
   @include theming.private-check-duplicate-theme-styles($theme, 'mat-bottom-sheet') {
+    @include base($theme);
     @if inspection.theme-has($theme, color) {
       @include color($theme);
     }

--- a/src/material/bottom-sheet/bottom-sheet-container.scss
+++ b/src/material/bottom-sheet/bottom-sheet-container.scss
@@ -11,8 +11,6 @@ $container-vertical-padding: 8px !default;
 $container-horizontal-padding: 16px !default;
 
 .mat-bottom-sheet-container {
-  @include token-utils.create-token-values(
-    tokens-mat-bottom-sheet.$prefix, tokens-mat-bottom-sheet.get-unthemable-tokens());
   @include elevation.elevation(16);
   padding: $container-vertical-padding
            $container-horizontal-padding;


### PR DESCRIPTION
Though these tokens are not currently affected by the theme, in the future they will be affected by the design system used for theming (M2 or M3)

BREAKING CHANGE:
There are new styles emitted by mat.bottom-sheet-theme that are not emitted by any of: mat.bottom-sheet-color, mat.bottom-sheet-typography, mat.bottom-sheet-density. If you rely on the partial mixins only and don't call mat.bottom-sheet-theme, you can add mat.bottom-sheet-base to get the missing styles.