### PR TITLE
fix(material/chips): move unthemable tokens to theme mixin

### DIFF
--- a/src/material/_index.scss
+++ b/src/material/_index.scss
@@ -83,7 +83,7 @@
 @forward './checkbox/checkbox-theme' as checkbox-* show checkbox-theme, checkbox-color,
   checkbox-typography, checkbox-density, checkbox-base;
 @forward './chips/chips-theme' as chips-* show chips-theme, chips-color, chips-typography,
-  chips-density;
+  chips-density, chips-base;
 @forward './datepicker/datepicker-theme' as datepicker-* show datepicker-theme, datepicker-color,
   datepicker-typography, datepicker-date-range-colors, datepicker-density;
 @forward './dialog/dialog-theme' as dialog-* show dialog-theme, dialog-color, dialog-typography,

--- a/src/material/chips/_chips-theme.scss
+++ b/src/material/chips/_chips-theme.scss
@@ -5,6 +5,12 @@
 @use '../core/theming/inspection';
 @use '../core/typography/typography';
 
+@mixin base($theme) {
+  .mat-mdc-standard-chip {
+    @include mdc-chip-theme.theme(tokens-mdc-chip.get-unthemable-tokens());
+  }
+}
+
 @mixin color($theme) {
   .mat-mdc-standard-chip {
     $default-color-tokens: tokens-mdc-chip.get-color-tokens($theme);
@@ -48,6 +54,7 @@
 
 @mixin theme($theme) {
   @include theming.private-check-duplicate-theme-styles($theme, 'mat-chips') {
+    @include base($theme);
     @if inspection.theme-has($theme, color) {
       @include color($theme);
     }

--- a/src/material/chips/chip.scss
+++ b/src/material/chips/chip.scss
@@ -18,9 +18,6 @@
   .mat-mdc-standard-chip {
     // Add the official slots for the MDC chip.
     @include mdc-chip-theme.theme-styles($token-slots);
-
-    // Add default values for tokens that aren't outputted by the theming API.
-    @include mdc-chip-theme.theme(m2-mdc-chip.get-unthemable-tokens());
   }
 
   // Add additional slots for the MDC chip tokens, needed in Angular Material.


### PR DESCRIPTION
Though these tokens are not currently affected by the theme, in the future they will be affected by the design system used for theming (M2 or M3)

BREAKING CHANGE:
There are new styles emitted by mat.chips-theme that are not emitted by any of: mat.chips-color, mat.chips-typography, mat.chips-density. If you rely on the partial mixins only and don't call mat.chips-theme, you can add mat.chips-base to get the missing styles.