### PR TITLE
fix(material/expansion): move unthemable tokens to theme mixin

### DIFF
--- a/src/material/expansion/_expansion-theme.scss
+++ b/src/material/expansion/_expansion-theme.scss
@@ -6,7 +6,10 @@
 @use '../core/tokens/m2/mat/expansion' as tokens-mat-expansion;
 
 @mixin base($theme) {
-  // TODO(mmalerba): Move expansion panel base tokens here
+  @include sass-utils.current-selector-or-root() {
+    @include token-utils.create-token-values(
+        tokens-mat-expansion.$prefix, tokens-mat-expansion.get-unthemable-tokens());
+  }
 }
 
 @mixin color($theme) {

--- a/src/material/expansion/expansion-panel.scss
+++ b/src/material/expansion/expansion-panel.scss
@@ -6,8 +6,6 @@
 @use '../core/style/elevation';
 
 .mat-expansion-panel {
-  @include token-utils.create-token-values(
-    tokens-mat-expansion.$prefix, tokens-mat-expansion.get-unthemable-tokens());
   @include elevation.overridable-elevation(2);
   box-sizing: content-box;
   display: block;


### PR DESCRIPTION
Though these tokens are not currently affected by the theme, in the future they will be affected by the design system used for theming (M2 or M3)