### PR TITLE
ci: migrate saucelabs and browserstack tests to GHA

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,47 +205,6 @@ jobs:
       - run: bazel test --build_tag_filters=-e2e --test_tag_filters=-e2e --build_tests_only -- src/...
       - *slack_notify_on_failure
 
-  # ----------------------------------------------------------------------------
-  # Job that runs the unit tests on Browserstack. The browsers that will be used
-  # to run the unit tests on Browserstack are set in: test/browser-providers.js
-  # ----------------------------------------------------------------------------
-  tests_browserstack:
-    <<: *job_defaults
-    resource_class: xlarge
-    environment:
-      BROWSER_STACK_USERNAME: 'angulardevops_uNDx4q'
-      BROWSER_STACK_ACCESS_KEY: 'PXeXP2qrTvRooAFG7DPW'
-    steps:
-      - checkout_and_rebase
-      - *restore_cache
-      - *setup_bazel_ci_config
-      - *yarn_install
-
-      - run: ./scripts/circleci/run-browserstack-tests.sh
-      - *slack_notify_on_failure
-
-  # ----------------------------------------------------------------------------
-  # Job that runs the unit tests on Saucelabs. The browsers that will be used
-  # to run the unit tests on Saucelabs are set in: test/browser-providers.js
-  # ----------------------------------------------------------------------------
-  tests_saucelabs:
-    <<: *job_defaults
-    resource_class: xlarge
-    environment:
-      SAUCE_USERNAME: 'angular-components'
-      SAUCE_ACCESS_KEY: '687f2bb5cacc-3bcb-5b64-8e8a-3825fc13'
-      # Note: This number should not be too high because otherwise we might run into
-      # a rate limit exception.
-      KARMA_PARALLEL_BROWSERS: 2
-    steps:
-      - checkout_and_rebase
-      - *restore_cache
-      - *setup_bazel_ci_config
-      - *yarn_install
-
-      - run: ./scripts/circleci/run-saucelabs-tests.sh
-      - *slack_notify_on_failure
-
   # -------------------------------------------------------------------------------------------
   # Job that builds all release packages. The built packages can be then used in the same
   # workflow to publish snapshot builds.
@@ -450,10 +409,6 @@ workflows:
       - bazel_build:
           filters: *ignore_presubmit_branch_filter
       - tests_browsers:
-          filters: *ignore_presubmit_branch_filter
-      - tests_browserstack:
-          filters: *ignore_presubmit_branch_filter
-      - tests_saucelabs:
           filters: *ignore_presubmit_branch_filter
       - build_release_packages:
           filters: *ignore_presubmit_branch_filter

--- a/.github/angular-robot.yml
+++ b/.github/angular-robot.yml
@@ -56,8 +56,6 @@ merge:
     requiredStatuses:
       - 'ci/circleci: bazel_build'
       - 'ci/circleci: tests_browsers'
-      - 'ci/circleci: tests_browserstack'
-      - 'ci/circleci: tests_saucelabs'
       - 'ci/circleci: build_release_packages'
 
   # the comment that will be added when the merge label is added despite failing checks, leave empty or set to false to disable

--- a/.github/workflows/ci-privileged.yml
+++ b/.github/workflows/ci-privileged.yml
@@ -1,0 +1,61 @@
+name: CI
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  saucelabs:
+    runs-on: ubuntu-latest
+    env:
+      SAUCE_USERNAME: ${{ vars.SAUCE_USERNAME }}
+      SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
+      KARMA_PARALLEL_BROWSERS: 2
+      CI_NODE_INDEX: 0
+      CI_NODE_TOTAL: 1
+      CI_RUNNER_NUMBER: ${{ github.run_id }}
+    steps:
+      - name: Initialize environment
+        uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@ba9b4487ced515e5b4d87edd681a3bd9792444d6
+        with:
+          cache-node-modules: true
+          # Checking out the pull request commit is intended here as we need to run the changed code tests.
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Install node modules
+        run: yarn install --frozen-lockfile
+      - name: Setup Bazel
+        uses: angular/dev-infra/github-actions/bazel/setup@ba9b4487ced515e5b4d87edd681a3bd9792444d6
+      - name: Run tests on Saucelabs
+        run: ./scripts/circleci/run-saucelabs-tests.sh
+
+  browserstack:
+    runs-on: ubuntu-latest
+    env:
+      BROWSER_STACK_USERNAME: ${{ vars.BROWSER_STACK_USERNAME }}
+      BROWSER_STACK_ACCESS_KEY: ${{ secrets.BROWSER_STACK_ACCESS_KEY }}
+      CI_NODE_INDEX: 0
+      CI_NODE_TOTAL: 1
+      CI_RUNNER_NUMBER: ${{ github.run_id }}
+    steps:
+      - name: Initialize environment
+        uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@ba9b4487ced515e5b4d87edd681a3bd9792444d6
+        with:
+          cache-node-modules: true
+          # Checking out the pull request commit is intended here as we need to run the changed code tests.
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Install node modules
+        run: yarn install --frozen-lockfile
+      - name: Setup Bazel
+        uses: angular/dev-infra/github-actions/bazel/setup@ba9b4487ced515e5b4d87edd681a3bd9792444d6
+      - name: Run tests on Browserstack
+        run: ./scripts/circleci/run-browserstack-tests.sh

--- a/scripts/saucelabs/start-tunnel.sh
+++ b/scripts/saucelabs/start-tunnel.sh
@@ -29,8 +29,8 @@ rm ${tunnelFileName}
 # Command arguments that will be passed to sauce-connect.
 sauceArgs="--readyfile ${tunnelReadyFile} --pidfile ${tunnelPidFile}"
 
-if [ ! -z "${CIRCLE_BUILD_NUM}" ]; then
-  sauceArgs="${sauceArgs} --tunnel-identifier angular-material-${CIRCLE_BUILD_NUM}-${CIRCLE_NODE_INDEX}"
+if [ ! -z "${CI_RUNNER_NUMBER}" ]; then
+  sauceArgs="${sauceArgs} --tunnel-identifier angular-material-${CI_RUNNER_NUMBER}-${CI_NODE_INDEX}"
 fi
 
 echo "Starting Sauce Connect in the background. Passed arguments: ${sauceArgs}"

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -102,14 +102,14 @@ module.exports = config => {
     },
   });
 
-  if (process.env['CIRCLECI']) {
-    const containerInstanceIndex = Number(process.env['CIRCLE_NODE_INDEX']);
-    const maxParallelContainerInstances = Number(process.env['CIRCLE_NODE_TOTAL']);
-    const tunnelIdentifier = `angular-material-${process.env['CIRCLE_BUILD_NUM']}-${containerInstanceIndex}`;
-    const buildIdentifier = `circleci-${tunnelIdentifier}`;
+  if (process.env['CI']) {
+    const containerInstanceIndex = Number(process.env['CI_NODE_INDEX']) || 0;
+    const maxParallelContainerInstances = Number(process.env['CI_NODE_TOTAL']) || 1;
+    const tunnelIdentifier = `angular-material-${process.env['CI_RUNNER_NUMBER']}-${containerInstanceIndex}`;
+    const buildIdentifier = `ci-${tunnelIdentifier}`;
     const testPlatform = process.env['TEST_PLATFORM'];
 
-    // This defines how often a given browser should be launched in the same CircleCI
+    // This defines how often a given browser should be launched in the same CI
     // container. This is helpful if we want to shard tests across the same browser.
     const parallelBrowserInstances = Number(process.env['KARMA_PARALLEL_BROWSERS']) || 1;
 


### PR DESCRIPTION
Move Browserstack and Saucelabs testing from CircleCI to GHA

In testing I found no appreciable difference between different runner sizes and opted to use the free tier, we can revisit if we identify issues in the future.