### PR TITLE
fix(material/menu): move unthemable tokens to theme mixin

### DIFF
--- a/src/material/_index.scss
+++ b/src/material/_index.scss
@@ -102,7 +102,7 @@
   input-density;
 @forward './list/list-theme' as list-* show list-theme, list-color, list-typography,
 list-density, list-base;
-@forward './menu/menu-theme' as menu-* show menu-theme, menu-color, menu-typography, menu-density;
+@forward './menu/menu-theme' as menu-* show menu-theme, menu-color, menu-typography, menu-density, menu-base;
 @forward './paginator/paginator-theme' as paginator-* show paginator-theme, paginator-color,
   paginator-typography, paginator-density;
 @forward './progress-bar/progress-bar-theme' as progress-bar-* show

--- a/src/material/menu/_menu-theme.scss
+++ b/src/material/menu/_menu-theme.scss
@@ -5,6 +5,13 @@
 @use '../core/theming/inspection';
 @use '../core/typography/typography';
 
+@mixin base($theme) {
+  @include sass-utils.current-selector-or-root() {
+    @include token-utils.create-token-values(tokens-mat-menu.$prefix,
+      tokens-mat-menu.get-unthemable-tokens());
+  }
+}
+
 @mixin color($theme) {
   @include sass-utils.current-selector-or-root() {
     @include token-utils.create-token-values(tokens-mat-menu.$prefix,
@@ -23,6 +30,7 @@
 
 @mixin theme($theme) {
   @include theming.private-check-duplicate-theme-styles($theme, 'mat-menu') {
+    @include base($theme);
     @if inspection.theme-has($theme, color) {
       @include color($theme);
     }

--- a/src/material/menu/menu.scss
+++ b/src/material/menu/menu.scss
@@ -33,8 +33,6 @@ mat-menu {
 }
 
 .mat-mdc-menu-panel {
-  @include token-utils.create-token-values(tokens-mat-menu.$prefix,
-    tokens-mat-menu.get-unthemable-tokens());
   @include menu-common.base;
   box-sizing: border-box;
   outline: 0;


### PR DESCRIPTION
Though these tokens are not currently affected by the theme, in the future they will be affected by the design system used for theming (M2 or M3)

BREAKING CHANGE:
There are new styles emitted by mat.menu-theme that are not emitted by any of: mat.menu-color, mat.menu-typography, mat.menu-density. If you rely on the partial mixins only and don't call mat.menu-theme, you can add mat.menu-base to get the missing styles.