### PR TITLE
fix(material/sidenav): move unthemable tokens to theme mixin

### DIFF
--- a/src/material/_index.scss
+++ b/src/material/_index.scss
@@ -116,7 +116,7 @@ list-density, list-base;
 @forward './select/select-theme' as select-* show select-theme, select-color, select-typography,
   select-density;
 @forward './sidenav/sidenav-theme' as sidenav-* show sidenav-theme, sidenav-color,
-  sidenav-typography, sidenav-density;
+  sidenav-typography, sidenav-density, sidenav-base;
 @forward './slide-toggle/slide-toggle-theme' as slide-toggle-* show
   slide-toggle-theme, slide-toggle-color, slide-toggle-typography, slide-toggle-density;
 @forward './slider/slider-theme' as slider-* show slider-theme, slider-color, slider-typography,

--- a/src/material/sidenav/_sidenav-theme.scss
+++ b/src/material/sidenav/_sidenav-theme.scss
@@ -4,6 +4,13 @@
 @use '../core/tokens/token-utils';
 @use '../core/style/sass-utils';
 
+@mixin base($theme) {
+  @include sass-utils.current-selector-or-root() {
+    @include token-utils.create-token-values(
+        tokens-mat-sidenav.$prefix, tokens-mat-sidenav.get-unthemable-tokens());
+  }
+}
+
 @mixin color($theme) {
   @include sass-utils.current-selector-or-root() {
     @include token-utils.create-token-values(tokens-mat-sidenav.$prefix,
@@ -17,6 +24,7 @@
 
 @mixin theme($theme) {
   @include theming.private-check-duplicate-theme-styles($theme, 'mat-sidenav') {
+    @include base($theme);
     @if inspection.theme-has($theme, color) {
       @include color($theme);
     }

--- a/src/material/sidenav/drawer.scss
+++ b/src/material/sidenav/drawer.scss
@@ -126,8 +126,6 @@ $drawer-over-drawer-z-index: 4;
   // See https://material.io/design/components/navigation-drawer.html
   @include elevation.elevation(16);
   @include drawer-stacking-context($drawer-over-drawer-z-index);
-  @include token-utils.create-token-values(
-    tokens-mat-sidenav.$prefix, tokens-mat-sidenav.get-unthemable-tokens());
 
   @include token-utils.use-tokens(
     tokens-mat-sidenav.$prefix, tokens-mat-sidenav.get-token-slots()) {


### PR DESCRIPTION
Though these tokens are not currently affected by the theme, in the future they will be affected by the design system used for theming (M2 or M3)

BREAKING CHANGE:
There are new styles emitted by mat.sidenav-theme that are not emitted by any of: mat.sidenav-color, mat.sidenav-typography, mat.sidenav-density. If you rely on the partial mixins only and don't call mat.sidenav-theme, you can add mat.sidenav-base to get the missing styles.