### PR TITLE
fix(material/table): move unthemable tokens to theme mixin

### DIFF
--- a/src/material/_index.scss
+++ b/src/material/_index.scss
@@ -127,7 +127,7 @@ list-density, list-base;
 @forward './stepper/stepper-theme' as stepper-* show stepper-theme, stepper-color,
   stepper-typography, stepper-density;
 @forward './table/table-theme' as table-* show table-theme, table-color, table-typography,
-  table-density;
+  table-density, table-base;
 @forward './tabs/tabs-theme' as tabs-* show tabs-theme, tabs-color, tabs-typography, tabs-density;
 @forward './toolbar/toolbar-theme' as toolbar-* show toolbar-theme, toolbar-color,
   toolbar-typography, toolbar-density;

--- a/src/material/table/_table-theme.scss
+++ b/src/material/table/_table-theme.scss
@@ -3,34 +3,31 @@
 @use '../core/theming/inspection';
 @use '../core/typography/typography';
 @use '../core/tokens/token-utils';
+@use '../core/style/sass-utils';
 
-@mixin _output-tokens {
-  @if (&) {
-    @content;
-  }
-  @else {
-    html {
-      @content;
-    }
+@mixin base($theme) {
+  @include sass-utils.current-selector-or-root() {
+    @include token-utils.create-token-values(
+        tokens-mat-table.$prefix, tokens-mat-table.get-unthemable-tokens());
   }
 }
 
 @mixin color($theme) {
-  @include _output-tokens {
+  @include sass-utils.current-selector-or-root() {
     @include token-utils.create-token-values(tokens-mat-table.$prefix,
       tokens-mat-table.get-color-tokens($theme));
   }
 }
 
 @mixin typography($theme) {
-  @include _output-tokens {
+  @include sass-utils.current-selector-or-root() {
     @include token-utils.create-token-values(tokens-mat-table.$prefix,
       tokens-mat-table.get-typography-tokens($theme));
   }
 }
 
 @mixin density($theme) {
-  @include _output-tokens {
+  @include sass-utils.current-selector-or-root() {
     @include token-utils.create-token-values(tokens-mat-table.$prefix,
       tokens-mat-table.get-density-tokens($theme));
   }
@@ -38,6 +35,7 @@
 
 @mixin theme($theme) {
   @include theming.private-check-duplicate-theme-styles($theme, 'mat-table') {
+    @include base($theme);
     @if inspection.theme-has($theme, color) {
       @include color($theme);
     }

--- a/src/material/table/table.scss
+++ b/src/material/table/table.scss
@@ -32,9 +32,6 @@
 @include table-flex-styles.private-table-flex-styles();
 
 .mat-mdc-table {
-  @include token-utils.create-token-values(
-    tokens-mat-table.$prefix, tokens-mat-table.get-unthemable-tokens());
-
   // MDC Table applies `table-layout: fixed`, but this is a backwards incompatible
   // change since the table did not previously apply it.
   // TODO: Add a mixin to MDC to set the layout instead of including this override,


### PR DESCRIPTION
Though these tokens are not currently affected by the theme, in the future they will be affected by the design system used for theming (M2 or M3)

BREAKING CHANGE:
There are new styles emitted by mat.table-theme that are not emitted by any of: mat.table-color, mat.table-typography, mat.table-density. If you rely on the partial mixins only and don't call mat.table-theme, you can add mat.table-base to get the missing styles.