### PR TITLE
docs(material/toolbar): fix indentation in example

### DIFF
--- a/src/components-examples/material/toolbar/toolbar-overview/toolbar-overview-example.html
+++ b/src/components-examples/material/toolbar/toolbar-overview/toolbar-overview-example.html
@@ -1,25 +1,25 @@
 <p>
-<!-- #docregion toolbar-simple -->
+  <!-- #docregion toolbar-simple -->
   <mat-toolbar>
     <span>My Application</span>
   </mat-toolbar>
-<!-- #enddocregion toolbar-simple -->
+  <!-- #enddocregion toolbar-simple -->
 </p>
 
 <p>
   <mat-toolbar>
-   <button mat-icon-button class="example-icon" aria-label="Example icon-button with menu icon">
-    <mat-icon>menu</mat-icon>
-  </button>
-  <span>My App</span>
-  <span class="example-spacer"></span>
-  <button mat-icon-button class="example-icon favorite-icon" aria-label="Example icon-button with heart icon">
-    <mat-icon>favorite</mat-icon>
-  </button>
-  <button mat-icon-button class="example-icon" aria-label="Example icon-button with share icon">
-   <mat-icon>share</mat-icon>
- </button>
-</mat-toolbar>
+    <button mat-icon-button class="example-icon" aria-label="Example icon-button with menu icon">
+      <mat-icon>menu</mat-icon>
+    </button>
+    <span>My App</span>
+    <span class="example-spacer"></span>
+    <button mat-icon-button class="example-icon favorite-icon" aria-label="Example icon-button with heart icon">
+      <mat-icon>favorite</mat-icon>
+    </button>
+    <button mat-icon-button class="example-icon" aria-label="Example icon-button with share icon">
+      <mat-icon>share</mat-icon>
+    </button>
+  </mat-toolbar>
 </p>
 
 <p>


### PR DESCRIPTION
Fixes the indentation of the toolbars' Overview example code.