### PR TITLE
fix(material/datepicker): Fix raw date value being compared

### DIFF
--- a/src/material/datepicker/calendar-body.ts
+++ b/src/material/datepicker/calendar-body.ts
@@ -186,7 +186,10 @@ export class MatCalendarBody<D = any> implements OnChanges, OnDestroy, AfterView
 
   private _didDragSinceMouseDown = false;
 
-  constructor(private _elementRef: ElementRef<HTMLElement>, private _ngZone: NgZone) {
+  constructor(
+    private _elementRef: ElementRef<HTMLElement>,
+    private _ngZone: NgZone,
+  ) {
     _ngZone.runOutsideAngular(() => {
       const element = _elementRef.nativeElement;
 

--- a/src/material/datepicker/calendar-body.ts
+++ b/src/material/datepicker/calendar-body.ts
@@ -512,7 +512,7 @@ export class MatCalendarBody<D = any> implements OnChanges, OnDestroy, AfterView
     this._didDragSinceMouseDown = false;
     // Begin a drag if a cell within the current range was targeted.
     const cell = event.target && this._getCellFromElement(event.target as HTMLElement);
-    if (!cell || !this._isInRange(cell.rawValue)) {
+    if (!cell || !this._isInRange(cell.compareValue)) {
       return;
     }
 


### PR DESCRIPTION
In the function [`isInRange`](https://github.com/angular/components/blob/bdef0c399ae37a64cf6cb204fdb273b5e619daf5/src/material/datepicker/calendar-body.ts#L617) numeric values are supposed to be compared. It is being called from [`_isInRange`](https://github.com/angular/components/blob/bdef0c399ae37a64cf6cb204fdb273b5e619daf5/src/material/datepicker/calendar-body.ts#L342) where `value` is compared to `startValue` and `endValue` which are calculated in [`_setRanges`](https://github.com/angular/components/blob/1dc30e8eacae1f318b53a9d22a462571b9de8ddb/src/material/datepicker/month-view.ts#L599-L600) using [`_getCellCompareValue`](https://github.com/angular/components/blob/1dc30e8eacae1f318b53a9d22a462571b9de8ddb/src/material/datepicker/month-view.ts#L578) which returns a number derived from `Date` derived from the original generic date object. `value` though is not a number like the typing might suggest, but a generic date object [retrieved from `MatCalendarCell.rawValue`](https://github.com/angular/components/blob/bdef0c399ae37a64cf6cb204fdb273b5e619daf5/src/material/datepicker/calendar-body.ts#L515).

The correct way to compare these values would be to derive **all** 3 `startValue`, `endValue` and `value` using `_getCellCompareValue`, luckily the `MatCalendarCell` already contains such a derived value: [`compareValue`](https://github.com/angular/components/blob/bdef0c399ae37a64cf6cb204fdb273b5e619daf5/src/material/datepicker/calendar-body.ts#L47), which is being [derived using `_getCellCompareValue`]()

#### Why is this a problem and why isn't it a problem for most?
Normally when using `Date` as your generic date object of choice, the [`isInRange`](https://github.com/angular/components/blob/bdef0c399ae37a64cf6cb204fdb273b5e619daf5/src/material/datepicker/calendar-body.ts#L617) function implicitly calls the `valueOf()` function from `Date`, which happens to be equivalent to the logic in [`_getCellCompareValue`](https://github.com/angular/components/blob/1dc30e8eacae1f318b53a9d22a462571b9de8ddb/src/material/datepicker/month-view.ts#L578).

But we are using the Picker with `Temporal.PlainDate` (using a polyfill), which [explicitly forbids](https://tc39.es/proposal-temporal/docs/plaindate.html#valueOf) calling the `valueOf()` function and the logic breaks down. This change should not result in any visible change for anyone using generic date objects that already do the conversion to unix timestamp implicitly, just that it's done explicitly now, but it will fix compatibility with other choices that don't do this.

Also on another note: The current way this is implemented violates TypeScript constraints, because it passes a `Date` or another date type to a function which only accepts a `number`, but because it's any, typescript doesn't complain.