### PR TITLE
docs(material/form-field): use correct input color in custom control example

### DIFF
--- a/src/components-examples/material/form-field/form-field-custom-control/example-tel-input-example.css
+++ b/src/components-examples/material/form-field/form-field-custom-control/example-tel-input-example.css
@@ -9,6 +9,7 @@
   outline: none;
   font: inherit;
   text-align: center;
+  color: currentcolor;
 }
 
 .example-tel-input-spacer {


### PR DESCRIPTION
In the Form Field docs, there is an example how to create a custom control. In this example, the inputs of the custom control don't inherit the text color from the form field. In light mode, this is just fine. But when switching to a dark mode theme, the color of the inputs default to the browser default (black):

<img width="271" alt="image" src="https://github.com/angular/components/assets/18580672/536f00bc-f750-4f73-9491-437c820bbeca">

It should inherit the color from the form field, which is fixed by this PR.