### PR TITLE
fix(material/slide-toggle): move unthemable tokens to theme mixin

### DIFF
--- a/src/material/_index.scss
+++ b/src/material/_index.scss
@@ -120,7 +120,8 @@ menu-base;
 @forward './sidenav/sidenav-theme' as sidenav-* show sidenav-theme, sidenav-color,
   sidenav-typography, sidenav-density, sidenav-base;
 @forward './slide-toggle/slide-toggle-theme' as slide-toggle-* show
-  slide-toggle-theme, slide-toggle-color, slide-toggle-typography, slide-toggle-density;
+  slide-toggle-theme, slide-toggle-color, slide-toggle-typography, slide-toggle-density,
+  slide-toggle-base;
 @forward './slider/slider-theme' as slider-* show slider-theme, slider-color, slider-typography,
   slider-density, slider-base;
 @forward './snack-bar/snack-bar-theme' as snack-bar-* show snack-bar-theme, snack-bar-color,

--- a/src/material/slide-toggle/_slide-toggle-theme.scss
+++ b/src/material/slide-toggle/_slide-toggle-theme.scss
@@ -8,6 +8,12 @@
 @use '../core/tokens/m2/mat/slide-toggle' as m2-mat-slide-toggle;
 @use '../core/tokens/token-utils';
 
+@mixin base($theme) {
+  .mdc-switch {
+    @include mdc-switch-theme.theme(m2-mdc-switch.get-unthemable-tokens());
+  }
+}
+
 @mixin color($theme) {
   $is-dark: inspection.get-theme-type($theme) == dark;
   $mdc-switch-color-tokens: m2-mdc-switch.get-color-tokens($theme);
@@ -62,6 +68,7 @@
 
 @mixin theme($theme) {
   @include theming.private-check-duplicate-theme-styles($theme, 'mat-slide-toggle') {
+    @include base($theme);
     @if inspection.theme-has($theme, color) {
       @include color($theme);
     }

--- a/src/material/slide-toggle/slide-toggle.scss
+++ b/src/material/slide-toggle/slide-toggle.scss
@@ -38,9 +38,6 @@
     &:disabled .mdc-switch__shadow {
       box-shadow: var(--mdc-switch-disabled-handle-elevation-shadow);
     }
-
-    // Add default values for MDC switch tokens that aren't outputted by the theming API
-    @include mdc-switch-theme.theme(m2-mdc-switch.get-unthemable-tokens());
   }
 
 


### PR DESCRIPTION
Though these tokens are not currently affected by the theme, in the future they will be affected by the design system used for theming (M2 or M3)

BREAKING CHANGE:
There are new styles emitted by mat.slide-toggle-theme that are not emitted by any of: mat.slide-toggle-color, mat.slide-toggle-typography, mat.slide-toggle-density. If you rely on the partial mixins only and don't call mat.slide-toggle-theme, you can add mat.slide-toggle-base to get the missing styles.