### PR TITLE
refactor(material/tree): remove dead code around MatTreeNode#tabindex.

### DIFF
--- a/src/material/tree/node.ts
+++ b/src/material/tree/node.ts
@@ -53,18 +53,20 @@ export class MatTreeNode<T, K = T>
   /**
    * The tabindex of the tree node.
    *
-   * @deprecated This will be ignored; the tree will automatically determine the appropriate tabindex for the tree node. This input will be
-   *   removed in a future version.
-   * @breaking-change 19.0.0 Remove this input
+   * @deprecated MatTreeNode ignores this proprety. Changing tabIndex has no affect. The tree
+   *   automatically determines the appropriate tabindex for the tree node. To be removed in a
+   *   future version.
+   * @breaking-change 19.0.0 Remove this attribute.
    */
   tabIndex: number;
 
   /**
    * The tabindex of the tree node.
    *
-   * @deprecated This will be ignored; the tree will automatically determine the appropriate tabindex for the tree node. This input will be
-   *   removed in a future version.
-   * @breaking-change 19.0.0 Remove this input
+   * @deprecated MatTreeNode ignores this proprety. Changing defaultTabIndex has no affect. The tree
+   *   automatically determines the appropriate tabindex for the tree node. To be removed in a
+   *   future version.
+   * @breaking-change 19.0.0 Remove this attribute.
    */
   defaultTabIndex: number;
 
@@ -85,10 +87,12 @@ export class MatTreeNode<T, K = T>
     elementRef: ElementRef<HTMLElement>,
     tree: CdkTree<T, K>,
     changeDetectorRef: ChangeDetectorRef,
+    // Ignore tabindex attribute. MatTree manages its own active state using TreeKeyManager.
+    // Keeping tabIndex in constructor for backwards compatibility with trees created before
+    // introducing TreeKeyManager.
     @Attribute('tabindex') tabIndex: string,
   ) {
     super(elementRef, tree, changeDetectorRef);
-    this.tabIndex = Number(tabIndex) || 0;
   }
 
   // This is a workaround for https://github.com/angular/angular/issues/23091
@@ -151,27 +155,17 @@ export class MatNestedTreeNode<T, K = T>
     this.isDisabled = coerceBooleanProperty(value);
   }
 
-  /**
-   * The tabindex of the tree node.
-   *
-   * @deprecated This will be ignored; the tree will automatically determine the appropriate tabindex for the tree node. This input will be
-   *   removed in a future version.
-   * @breaking-change 19.0.0 Remove this input
-   */
-  get tabIndex(): number {
-    return Number(this._elementRef.nativeElement.getAttribute('tabindex') ?? '-1');
-  }
-  set tabIndex(value: number) {}
-
   constructor(
     elementRef: ElementRef<HTMLElement>,
     tree: CdkTree<T, K>,
     differs: IterableDiffers,
     changeDetectorRef: ChangeDetectorRef,
+    // Ignore tabindex attribute. MatTree manages its own active state using TreeKeyManager.
+    // Keeping tabIndex in constructor for backwards compatibility with trees created before
+    // introducing TreeKeyManager.
     @Attribute('tabindex') tabIndex: string,
   ) {
     super(elementRef, tree, changeDetectorRef, differs);
-    this.tabIndex = Number(tabIndex) || 0;
   }
 
   // This is a workaround for https://github.com/angular/angular/issues/19145

--- a/tools/public_api_guard/material/tree.md
+++ b/tools/public_api_guard/material/tree.md
@@ -45,9 +45,6 @@ export class MatNestedTreeNode<T, K = T> extends CdkNestedTreeNode<T, K> impleme
     ngOnInit(): void;
     // (undocumented)
     node: T;
-    // @deprecated
-    get tabIndex(): number;
-    set tabIndex(value: number);
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<MatNestedTreeNode<any, any>, "mat-nested-tree-node", ["matNestedTreeNode"], { "role": { "alias": "role"; "required": false; }; "disabled": { "alias": "disabled"; "required": false; }; "tabIndex": { "alias": "tabIndex"; "required": false; }; "isExpandable": { "alias": "isExpandable"; "required": false; }; "isExpanded": { "alias": "isExpanded"; "required": false; }; "isDisabled": { "alias": "isDisabled"; "required": false; }; "node": { "alias": "matNestedTreeNode"; "required": false; }; }, { "activation": "activation"; "expandedChange": "expandedChange"; }, never, never, false, never>;
     // (undocumented)


### PR DESCRIPTION
remove dead code around MatTreeNode#tabinde. update code comments

This commit message will be removed when squashing the cdk-tree-revamp brand.