### PR TITLE
refactor(material/button): clean up margin reset

### DIFF
--- a/src/material/button/_button-theme.scss
+++ b/src/material/button/_button-theme.scss
@@ -231,16 +231,6 @@
     $density-tokens: tokens-mdc-text-button.get-density-tokens($theme);
     @include mdc-button-text-theme.theme($density-tokens);
     @include button-theme-private.touch-target-density($density-scale);
-
-    // TODO(crisbeto): before the introduction of tokens, MDC's density mixin was adding
-    // `margin-top: 0` and `margin-bottom: 0` in its `density` mixin which a lot of internal
-    // clients came to depend upon. Preserve it to make tokens easier to land.
-    @if ($density-scale < 0) {
-      &.mat-mdc-button-base {
-        margin-top: 0;
-        margin-bottom: 0;
-      }
-    }
   }
 
   .mat-mdc-raised-button {


### PR DESCRIPTION
When tokenizing the text buttons, I found an issue where MDC previously was resetting the margin of buttons on lower densities. This is something that goes against our coding standards since we don't want to affect anything outside of the component.