### PR TITLE
refactor(multiple): remove DOM emulation usage from table components

### DIFF
--- a/src/cdk/table/sticky-styler.ts
+++ b/src/cdk/table/sticky-styler.ts
@@ -49,7 +49,6 @@ export class StickyStyler {
     private _stickCellCss: string,
     public direction: Direction,
     private _coalescedStyleScheduler: _CoalescedStyleScheduler,
-    private _isBrowser = true,
     private readonly _needsPositionStickyOnElement = true,
     private readonly _positionListener?: StickyPositioningListener,
   ) {
@@ -109,7 +108,6 @@ export class StickyStyler {
   ) {
     if (
       !rows.length ||
-      !this._isBrowser ||
       !(stickyStartStates.some(state => state) || stickyEndStates.some(state => state))
     ) {
       if (this._positionListener) {
@@ -183,11 +181,6 @@ export class StickyStyler {
    *
    */
   stickRows(rowsToStick: HTMLElement[], stickyStates: boolean[], position: 'top' | 'bottom') {
-    // Since we can't measure the rows on the server, we can't stick the rows properly.
-    if (!this._isBrowser) {
-      return;
-    }
-
     // If positioning the rows to the bottom, reverse their order when evaluating the sticky
     // position such that the last row stuck will be "bottom: 0px" and so on. Note that the
     // sticky states need to be reversed as well.

--- a/src/cdk/table/table-module.ts
+++ b/src/cdk/table/table-module.ts
@@ -14,6 +14,11 @@ import {
   CdkRecycleRows,
   FooterRowOutlet,
   NoDataRowOutlet,
+  NativeBody,
+  NativeFoot,
+  NativeHead,
+  TableOutlet,
+  OutletSource,
 } from './table';
 import {
   CdkCellOutlet,
@@ -60,6 +65,11 @@ const EXPORTED_DECLARATIONS = [
   CdkNoDataRow,
   CdkRecycleRows,
   NoDataRowOutlet,
+  NativeBody,
+  NativeFoot,
+  NativeHead,
+  TableOutlet,
+  OutletSource,
 ];
 
 @NgModule({

--- a/src/cdk/table/table.spec.ts
+++ b/src/cdk/table/table.spec.ts
@@ -228,8 +228,9 @@ describe('CdkTable', () => {
     });
 
     it('should clear the row view containers on destroy', () => {
-      const rowOutlet = fixture.componentInstance.table._rowOutlet.viewContainer;
-      const headerPlaceholder = fixture.componentInstance.table._headerRowOutlet.viewContainer;
+      const rowOutlet = fixture.componentInstance.table._outletSource.rowOutlet.viewContainer;
+      const headerPlaceholder =
+        fixture.componentInstance.table._outletSource.headerRowOutlet.viewContainer;
 
       spyOn(rowOutlet, 'clear').and.callThrough();
       spyOn(headerPlaceholder, 'clear').and.callThrough();

--- a/src/material/table/table.ts
+++ b/src/material/table/table.ts
@@ -45,10 +45,29 @@ export class MatRecycleRows {}
   template: `
     <ng-content select="caption"></ng-content>
     <ng-content select="colgroup, col"></ng-content>
-    <ng-container headerRowOutlet></ng-container>
-    <ng-container rowOutlet></ng-container>
-    <ng-container noDataRowOutlet></ng-container>
-    <ng-container footerRowOutlet></ng-container>
+    <ng-template #defaultTable>
+      <ng-container [outletSource]="_tableOutlet">
+        <ng-container headerRowOutlet></ng-container>
+        <ng-container rowOutlet></ng-container>
+        <ng-container noDataRowOutlet></ng-container>
+        <ng-container footerRowOutlet></ng-container>
+      </ng-container>
+    </ng-template>
+    <ng-template #nativeTable>
+      <ng-container [outletSource]="_tableOutlet">
+        <thead nativeHead role="rowgroup">
+          <ng-container headerRowOutlet></ng-container>
+        </thead>
+        <tbody nativeBody role="rowgroup">
+          <ng-container rowOutlet></ng-container>
+          <ng-container noDataRowOutlet></ng-container>
+        </tbody>
+        <tfoot nativeFoot role="rowgroup">
+          <ng-container footerRowOutlet></ng-container>
+        </tfoot>
+      </ng-container>
+    </ng-template>
+    <ng-template [tableOutlet]="_isNativeHtmlTable ? nativeTable : defaultTable"></ng-template>
   `,
   styleUrls: ['table.css'],
   host: {
@@ -85,8 +104,8 @@ export class MatTable<T> extends CdkTable<T> implements OnInit {
     // tfoot). MDC requires the `mdc-data-table__content` class to be added to the body. Note that
     // this only applies to native tables, because we don't wrap the content of flexbox-based ones.
     if (this._isNativeHtmlTable) {
-      const tbody = this._elementRef.nativeElement.querySelector('tbody');
-      tbody.classList.add('mdc-data-table__content');
+      const tbody = this._outletSource.nativeBody.elementRef;
+      this._renderer.addClass(tbody.nativeElement, 'mdc-data-table__content');
     }
   }
 }


### PR DESCRIPTION
### Note: this is just an experiment. Do not merge!

---

DOM manipulation and emulation prevents the table component from being hydrated. These changes refactor it to avoid them.