### PR TITLE
fix(material/checkbox): add aria-checked

### DIFF
--- a/src/material/checkbox/checkbox.html
+++ b/src/material/checkbox/checkbox.html
@@ -11,6 +11,7 @@
            [attr.aria-label]="ariaLabel || null"
            [attr.aria-labelledby]="ariaLabelledby"
            [attr.aria-describedby]="ariaDescribedby"
+           [attr.aria-checked]="indeterminate ? 'mixed' : ''"
            [attr.name]="name"
            [attr.value]="value"
            [checked]="checked"


### PR DESCRIPTION
Material Web's new styling requires indeterminate mode to have `aria-checked=mixed` when enabled.