### PR TITLE
fix(material/checkbox): add aria-checked

### DIFF
--- a/src/material/checkbox/checkbox.html
+++ b/src/material/checkbox/checkbox.html
@@ -11,6 +11,7 @@
            [attr.aria-label]="ariaLabel || null"
            [attr.aria-labelledby]="ariaLabelledby"
            [attr.aria-describedby]="ariaDescribedby"
+           [attr.aria-checked]="indeterminate ? 'mixed' : null"
            [attr.name]="name"
            [attr.value]="value"
            [checked]="checked"

--- a/src/material/checkbox/checkbox.spec.ts
+++ b/src/material/checkbox/checkbox.spec.ts
@@ -55,6 +55,9 @@ describe('MDC-based MatCheckbox', () => {
 
       expect(checkboxInstance.checked).toBe(true);
       expect(inputElement.checked).toBe(true);
+      expect(inputElement.hasAttribute('aria-checked'))
+        .withContext('Expect aria-checked attribute to not be used')
+        .toBe(false);
 
       testComponent.isChecked = false;
       fixture.detectChanges();
@@ -103,9 +106,6 @@ describe('MDC-based MatCheckbox', () => {
 
       expect(inputElement.checked).toBe(false);
       expect(inputElement.indeterminate).toBe(true);
-      expect(inputElement.hasAttribute('aria-checked'))
-        .withContext('Expect aria-checked attribute to not be used')
-        .toBe(false);
 
       testComponent.isIndeterminate = false;
       fixture.detectChanges();
@@ -145,9 +145,6 @@ describe('MDC-based MatCheckbox', () => {
       expect(inputElement.indeterminate).toBe(true);
       expect(inputElement.checked).toBe(true);
       expect(testComponent.isIndeterminate).toBe(true);
-      expect(inputElement.hasAttribute('aria-checked'))
-        .withContext('Expect aria-checked attribute to not be used')
-        .toBe(false);
 
       inputElement.click();
       fixture.detectChanges();


### PR DESCRIPTION
Adding aria-checked to the checkbox input. Technically this is redundant but Material Web's new styling requires indeterminate mode to have aria-checked=mixed when enabled.