### PR TITLE
refactor(multiple): use Renderer2 for theming instead of direct DOM manipulation

### DIFF
--- a/src/material/core/common-behaviors/color.spec.ts
+++ b/src/material/core/common-behaviors/color.spec.ts
@@ -1,10 +1,23 @@
+import {TestBed} from '@angular/core/testing';
 import {mixinColor} from './color';
-import {ElementRef} from '@angular/core';
+import {Component, ElementRef, Inject} from '@angular/core';
 
 describe('MixinColor', () => {
   it('should augment an existing class with a color property', () => {
-    const classWithColor = mixinColor(TestClass);
-    const instance = new classWithColor();
+    @Component({})
+    class TestComponent extends mixinColor(BaseComponent) {
+      constructor(elementRef: ElementRef) {
+        super(elementRef);
+      }
+    }
+
+    TestBed.configureTestingModule({
+      imports: [],
+      declarations: [TestComponent],
+    });
+
+    const fixture = TestBed.createComponent(TestComponent);
+    const instance = fixture.componentInstance;
 
     expect(instance.color)
       .withContext('Expected the mixed-into class to have a color property')
@@ -18,82 +31,131 @@ describe('MixinColor', () => {
   });
 
   it('should remove old color classes if new color is set', () => {
-    const classWithColor = mixinColor(TestClass);
-    const instance = new classWithColor();
+    @Component({})
+    class TestComponent extends mixinColor(BaseComponent) {
+      constructor(elementRef: ElementRef) {
+        super(elementRef);
+      }
+    }
 
-    expect(instance.testElement.classList.length)
+    TestBed.configureTestingModule({
+      imports: [],
+      declarations: [TestComponent],
+    });
+
+    const fixture = TestBed.createComponent(TestComponent);
+    const instance = fixture.componentInstance;
+    const testElement = instance._elementRef.nativeElement;
+
+    expect(testElement.classList.length)
       .withContext('Expected the element to not have any classes at initialization')
       .toBe(0);
 
     instance.color = 'primary';
 
-    expect(instance.testElement.classList)
+    expect(testElement.classList)
       .withContext('Expected the element to have the "mat-primary" class set')
       .toContain('mat-primary');
 
     instance.color = 'accent';
 
-    expect(instance.testElement.classList).not.toContain(
+    expect(testElement.classList).not.toContain(
       'mat-primary',
       'Expected the element to no longer have "mat-primary" set.',
     );
-    expect(instance.testElement.classList)
+    expect(testElement.classList)
       .withContext('Expected the element to have the "mat-accent" class set')
       .toContain('mat-accent');
   });
 
   it('should allow having no color set', () => {
-    const classWithColor = mixinColor(TestClass);
-    const instance = new classWithColor();
+    @Component({})
+    class TestComponent extends mixinColor(BaseComponent) {
+      constructor(elementRef: ElementRef) {
+        super(elementRef);
+      }
+    }
 
-    expect(instance.testElement.classList.length)
+    TestBed.configureTestingModule({
+      imports: [],
+      declarations: [TestComponent],
+    });
+
+    const fixture = TestBed.createComponent(TestComponent);
+    const instance = fixture.componentInstance;
+    const testElement = instance._elementRef.nativeElement;
+
+    expect(testElement.classList.length)
       .withContext('Expected the element to not have any classes at initialization')
       .toBe(0);
 
     instance.color = 'primary';
 
-    expect(instance.testElement.classList)
+    expect(testElement.classList)
       .withContext('Expected the element to have the "mat-primary" class set')
       .toContain('mat-primary');
 
     instance.color = undefined;
 
-    expect(instance.testElement.classList.length)
+    expect(testElement.classList.length)
       .withContext('Expected the element to have no color class set.')
       .toBe(0);
   });
 
   it('should allow having a default color if specified', () => {
-    const classWithColor = mixinColor(TestClass, 'accent');
-    const instance = new classWithColor();
+    @Component({})
+    class TestComponent extends mixinColor(BaseComponent, 'accent') {
+      constructor(elementRef: ElementRef) {
+        super(elementRef);
+      }
+    }
 
-    expect(instance.testElement.classList)
+    TestBed.configureTestingModule({
+      imports: [],
+      declarations: [TestComponent],
+    });
+
+    const fixture = TestBed.createComponent(TestComponent);
+    const instance = fixture.componentInstance;
+    const testElement = instance._elementRef.nativeElement;
+
+    expect(testElement.classList)
       .withContext('Expected the element to have the "mat-accent" class by default.')
       .toContain('mat-accent');
 
     instance.color = undefined;
 
-    expect(instance.testElement.classList)
+    expect(testElement.classList)
       .withContext('Expected the default color "mat-accent" to be set.')
       .toContain('mat-accent');
   });
 
   it('should allow for the default color to change after init', () => {
-    const classWithColor = mixinColor(TestClass, 'accent');
-    const instance = new classWithColor();
+    @Component({})
+    class TestComponent extends mixinColor(BaseComponent, 'accent') {
+      constructor(elementRef: ElementRef) {
+        super(elementRef);
+      }
+    }
 
-    expect(instance.testElement.classList).toContain('mat-accent');
+    TestBed.configureTestingModule({
+      imports: [],
+      declarations: [TestComponent],
+    });
+
+    const fixture = TestBed.createComponent(TestComponent);
+    const instance = fixture.componentInstance;
+    const testElement = instance._elementRef.nativeElement;
+
+    expect(testElement.classList).toContain('mat-accent');
 
     instance.defaultColor = 'warn';
     instance.color = undefined;
 
-    expect(instance.testElement.classList).toContain('mat-warn');
+    expect(testElement.classList).toContain('mat-warn');
   });
 });
 
-class TestClass {
-  testElement: HTMLElement = document.createElement('div');
-
-  /** Fake instance of an ElementRef. */
-  _elementRef = new ElementRef<HTMLElement>(this.testElement);
+class BaseComponent {
+  constructor(public readonly _elementRef: ElementRef) {}
 }

--- a/src/material/core/common-behaviors/color.ts
+++ b/src/material/core/common-behaviors/color.ts
@@ -7,7 +7,7 @@
  */
 
 import {AbstractConstructor, Constructor} from './constructor';
-import {ElementRef} from '@angular/core';
+import {ElementRef, Renderer2, inject} from '@angular/core';
 
 /** @docs-private */
 export interface CanColor {
@@ -38,6 +38,8 @@ export function mixinColor<T extends Constructor<HasElementRef>>(
   defaultColor?: ThemePalette,
 ): CanColorCtor & T {
   return class extends base {
+    private _renderer = inject(Renderer2);
+
     private _color: ThemePalette;
     defaultColor = defaultColor;
 
@@ -49,10 +51,10 @@ export function mixinColor<T extends Constructor<HasElementRef>>(
 
       if (colorPalette !== this._color) {
         if (this._color) {
-          this._elementRef.nativeElement.classList.remove(`mat-${this._color}`);
+          this._renderer.removeClass(this._elementRef.nativeElement, `mat-${this._color}`);
         }
         if (colorPalette) {
-          this._elementRef.nativeElement.classList.add(`mat-${colorPalette}`);
+          this._renderer.addClass(this._elementRef.nativeElement, `mat-${colorPalette}`);
         }
 
         this._color = colorPalette;


### PR DESCRIPTION
Instead of directly manipulating the DOM via ElementRef (which requires DOM emulation), this change makes it use the Renderer2 interface instead.