### PR TITLE
fix(cdk/accordion): add `CDK_ACCORDION` export

### DIFF
--- a/src/cdk/accordion/public-api.ts
+++ b/src/cdk/accordion/public-api.ts
@@ -7,5 +7,5 @@
  */
 
 export {CdkAccordionItem} from './accordion-item';
-export {CdkAccordion} from './accordion';
+export {CdkAccordion, CDK_ACCORDION} from './accordion';
 export * from './accordion-module';

--- a/tools/public_api_guard/cdk/accordion.md
+++ b/tools/public_api_guard/cdk/accordion.md
@@ -15,6 +15,9 @@ import { Subject } from 'rxjs';
 import { UniqueSelectionDispatcher } from '@angular/cdk/collections';
 
 // @public
+export const CDK_ACCORDION: InjectionToken<CdkAccordion>;
+
+// @public
 export class CdkAccordion implements OnDestroy, OnChanges {
     closeAll(): void;
     readonly id: string;


### PR DESCRIPTION
Fixes an issue in the Angular CDK `accordion` component where `CDK_ACCORDION` injection token cannot be imported from `@angular/cdk/accordion`. This is because `public-api.ts` did not contain `CDK_ACCORDION` export.