### PR TITLE
fix(cdk/tree): add injectable key manager and opt-out

### DIFF
--- a/src/cdk/a11y/key-manager/legacy-tree-key-manager.ts
+++ b/src/cdk/a11y/key-manager/legacy-tree-key-manager.ts
@@ -1,0 +1,91 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Subject} from 'rxjs';
+import {
+  TREE_KEY_MANAGER,
+  TreeKeyManagerFactory,
+  TreeKeyManagerItem,
+  TreeKeyManagerStrategy,
+} from './tree-key-manager';
+
+/**
+ * @docs-private
+ *
+ * @deprecated LegacyTreeKeyManager deprecated. Use TreeKeyManager or inject a
+ * TreeKeyManagerStrategy instead. To be removed in a future version.
+ *
+ * @breaking-change 19.0.0
+ */
+// LegacyTreeKeyManager is a "noop" implementation of TreeKeyMangerStrategy. Methods are noops. Does
+// not emit to streams.
+//
+// Used for applications built before TreeKeyManager to opt-out of TreeKeyManager and revert to
+// legacy behavior.
+export class LegacyTreeKeyManager<T extends TreeKeyManagerItem>
+  implements TreeKeyManagerStrategy<T>
+{
+  get _isLegacyTreeKeyManager() {
+    return true;
+  }
+
+  // Provide change as required by TreeKeyManagerStrategy. LegacyTreeKeyManager is a "noop"
+  // implementation that does not emit to streams.
+  readonly change = new Subject<T | null>();
+
+  onKeydown() {
+    // noop
+  }
+
+  getActiveItemIndex() {
+    // Always return null. LegacyTreeKeyManager is a "noop" implementation that does not maintain
+    // the active item.
+    return null;
+  }
+
+  getActiveItem() {
+    // Always return null. LegacyTreeKeyManager is a "noop" implementation that does not maintain
+    // the active item.
+    return null;
+  }
+
+  onInitialFocus() {
+    // noop
+  }
+
+  focusItem() {
+    // noop
+  }
+}
+
+/**
+ * @docs-private
+ *
+ * @deprecated LegacyTreeKeyManager deprecated. Use TreeKeyManager or inject a
+ * TreeKeyManagerStrategy instead. To be removed in a future version.
+ *
+ * @breaking-change 19.0.0
+ */
+export function LEGACY_TREE_KEY_MANAGER_FACTORY<
+  T extends TreeKeyManagerItem,
+>(): TreeKeyManagerFactory<T> {
+  return () => new LegacyTreeKeyManager<T>();
+}
+
+/**
+ * @docs-private
+ *
+ * @deprecated LegacyTreeKeyManager deprecated. Use TreeKeyManager or inject a
+ * TreeKeyManagerStrategy instead. To be removed in a future version.
+ *
+ * @breaking-change 19.0.0
+ */
+export const LEGACY_TREE_KEY_MANAGER_FACTORY_PROVIDER = {
+  provide: TREE_KEY_MANAGER,
+  useFactory: LEGACY_TREE_KEY_MANAGER_FACTORY,
+};

--- a/src/cdk/a11y/public-api.ts
+++ b/src/cdk/a11y/public-api.ts
@@ -9,6 +9,7 @@ export * from './aria-describer/aria-describer';
 export * from './aria-describer/aria-reference';
 export * from './key-manager/activedescendant-key-manager';
 export * from './key-manager/focus-key-manager';
+export * from './key-manager/legacy-tree-key-manager';
 export * from './key-manager/list-key-manager';
 export * from './key-manager/tree-key-manager';
 export * from './focus-trap/configurable-focus-trap';

--- a/src/cdk/tree/tree-module.ts
+++ b/src/cdk/tree/tree-module.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {TREE_KEY_MANAGER_FACTORY_PROVIDER} from '@angular/cdk/a11y';
 import {NgModule} from '@angular/core';
 import {CdkTreeNodeOutlet} from './outlet';
 import {CdkTreeNodePadding} from './padding';
@@ -27,5 +28,6 @@ const EXPORTED_DECLARATIONS = [
 @NgModule({
   exports: EXPORTED_DECLARATIONS,
   declarations: EXPORTED_DECLARATIONS,
+  providers: [TREE_KEY_MANAGER_FACTORY_PROVIDER],
 })
 export class CdkTreeModule {}

--- a/src/components-examples/cdk/tree/cdk-tree-custom-key-manager/cdk-tree-custom-key-manager-example.css
+++ b/src/components-examples/cdk/tree/cdk-tree-custom-key-manager/cdk-tree-custom-key-manager-example.css
@@ -1,0 +1,4 @@
+.example-tree-node {
+  display: flex;
+  align-items: center;
+}

--- a/src/components-examples/cdk/tree/cdk-tree-custom-key-manager/cdk-tree-custom-key-manager-example.html
+++ b/src/components-examples/cdk/tree/cdk-tree-custom-key-manager/cdk-tree-custom-key-manager-example.html
@@ -1,0 +1,28 @@
+<cdk-tree [dataSource]="dataSource" [treeControl]="treeControl">
+  <!-- This is the tree node template for leaf nodes -->
+  <cdk-tree-node *cdkTreeNodeDef="let node" cdkTreeNodePadding
+                 [style.display]="shouldRender(node) ? 'flex' : 'none'"
+                 [isDisabled]="!shouldRender(node)"
+                 class="example-tree-node">
+    <!-- use a disabled button to provide padding for tree leaf -->
+    <button mat-icon-button disabled></button>
+    {{node.name}}
+  </cdk-tree-node>
+  <!-- This is the tree node template for expandable nodes -->
+  <cdk-tree-node *cdkTreeNodeDef="let node; when: hasChild" cdkTreeNodePadding
+                 cdkTreeNodeToggle
+                 [style.display]="shouldRender(node) ? 'flex' : 'none'"
+                 [isDisabled]="!shouldRender(node)"
+                 (expandedChange)="node.isExpanded = $event"
+                 class="example-tree-node"
+                 tabindex="0">
+    <button mat-icon-button cdkTreeNodeToggle
+            [attr.aria-label]="'Toggle ' + node.name"
+            [style.visibility]="node.expandable ? 'visible' : 'hidden'">
+      <mat-icon class="mat-icon-rtl-mirror">
+        {{treeControl.isExpanded(node) ? 'expand_more' : 'chevron_right'}}
+      </mat-icon>
+    </button>
+    {{node.name}}
+  </cdk-tree-node>
+</cdk-tree>

--- a/src/components-examples/cdk/tree/cdk-tree-custom-key-manager/cdk-tree-custom-key-manager-example.ts
+++ b/src/components-examples/cdk/tree/cdk-tree-custom-key-manager/cdk-tree-custom-key-manager-example.ts
@@ -1,0 +1,399 @@
+import {Component, QueryList} from '@angular/core';
+import {ArrayDataSource} from '@angular/cdk/collections';
+import {FlatTreeControl, CdkTreeModule} from '@angular/cdk/tree';
+import {MatIconModule} from '@angular/material/icon';
+import {MatButtonModule} from '@angular/material/button';
+import {
+  TREE_KEY_MANAGER,
+  TreeKeyManagerFactory,
+  TreeKeyManagerItem,
+  TreeKeyManagerStrategy,
+} from '@angular/cdk/a11y';
+import {
+  DOWN_ARROW,
+  END,
+  ENTER,
+  H,
+  HOME,
+  J,
+  K,
+  L,
+  LEFT_ARROW,
+  RIGHT_ARROW,
+  SPACE,
+  TAB,
+  UP_ARROW,
+} from '@angular/cdk/keycodes';
+import {of as observableOf, Subject, isObservable, Observable} from 'rxjs';
+import {take} from 'rxjs/operators';
+
+const TREE_DATA: ExampleFlatNode[] = [
+  {
+    name: 'Fruit',
+    expandable: true,
+    level: 0,
+  },
+  {
+    name: 'Apple',
+    expandable: false,
+    level: 1,
+  },
+  {
+    name: 'Banana',
+    expandable: false,
+    level: 1,
+  },
+  {
+    name: 'Fruit loops',
+    expandable: false,
+    level: 1,
+  },
+  {
+    name: 'Vegetables',
+    expandable: true,
+    level: 0,
+  },
+  {
+    name: 'Green',
+    expandable: true,
+    level: 1,
+  },
+  {
+    name: 'Broccoli',
+    expandable: false,
+    level: 2,
+  },
+  {
+    name: 'Brussels sprouts',
+    expandable: false,
+    level: 2,
+  },
+  {
+    name: 'Orange',
+    expandable: true,
+    level: 1,
+  },
+  {
+    name: 'Pumpkins',
+    expandable: false,
+    level: 2,
+  },
+  {
+    name: 'Carrots',
+    expandable: false,
+    level: 2,
+  },
+];
+
+/** Flat node with expandable and level information */
+interface ExampleFlatNode {
+  expandable: boolean;
+  name: string;
+  level: number;
+  isExpanded?: boolean;
+}
+
+function coerceObservable<T>(data: T | Observable<T>): Observable<T> {
+  if (!isObservable(data)) {
+    return observableOf(data);
+  }
+  return data;
+}
+
+/**
+ * This class manages keyboard events for trees. If you pass it a QueryList or other list of tree
+ * items, it will set the active item, focus, handle expansion and typeahead correctly when
+ * keyboard events occur.
+ */
+export class VimTreeKeyManager<T extends TreeKeyManagerItem> implements TreeKeyManagerStrategy<T> {
+  private _activeItemIndex = -1;
+  private _activeItem: T | null = null;
+
+  private _items: T[] = [];
+
+  // TreeKeyManagerOptions not implemented.
+  constructor(items: Observable<T[]> | QueryList<T> | T[]) {
+    // We allow for the items to be an array or Observable because, in some cases, the consumer may
+    // not have access to a QueryList of the items they want to manage (e.g. when the
+    // items aren't being collected via `ViewChildren` or `ContentChildren`).
+    if (items instanceof QueryList) {
+      this._items = items.toArray();
+      items.changes.subscribe((newItems: QueryList<T>) => {
+        this._items = newItems.toArray();
+        this._updateActiveItemIndex(this._items);
+      });
+    } else if (isObservable(items)) {
+      items.subscribe(newItems => {
+        this._items = newItems;
+        this._updateActiveItemIndex(newItems);
+      });
+    } else {
+      this._items = items;
+    }
+  }
+
+  /** Stream that emits any time the focused item changes. */
+  readonly change = new Subject<T | null>();
+
+  /**
+   * Handles a keyboard event on the tree.
+   * @param event Keyboard event that represents the user interaction with the tree.
+   */
+  onKeydown(event: KeyboardEvent) {
+    const keyCode = event.keyCode;
+
+    switch (keyCode) {
+      case TAB:
+        // NB: return here, in order to allow Tab to actually tab out of the tree
+        return;
+
+      case DOWN_ARROW:
+      case J:
+        this._focusNextItem();
+        break;
+
+      case UP_ARROW:
+      case K:
+        this._focusPreviousItem();
+        break;
+
+      case RIGHT_ARROW:
+      case L:
+        this._expandCurrentItem();
+        break;
+
+      case LEFT_ARROW:
+      case H:
+        this._collapseCurrentItem();
+        break;
+
+      case HOME:
+        this._focusFirstItem();
+        break;
+
+      case END:
+        this._focusLastItem();
+        break;
+
+      case ENTER:
+      case SPACE:
+        this._activateCurrentItem();
+        break;
+    }
+  }
+
+  /** Index of the currently active item. */
+  getActiveItemIndex(): number | null {
+    return this._activeItemIndex;
+  }
+
+  /** The currently active item. */
+  getActiveItem(): T | null {
+    return this._activeItem;
+  }
+
+  /**
+   * Focus the initial element; this is intended to be called when the tree is focused for
+   * the first time.
+   */
+  onInitialFocus(): void {
+    this._focusFirstItem();
+  }
+
+  /**
+   * Focus the provided item by index.
+   * @param index The index of the item to focus.
+   * @param options Additional focusing options.
+   */
+  focusItem(index: number, options?: {emitChangeEvent?: boolean}): void;
+  /**
+   * Focus the provided item.
+   * @param item The item to focus. Equality is determined via the trackBy function.
+   * @param options Additional focusing options.
+   */
+  focusItem(item: T, options?: {emitChangeEvent?: boolean}): void;
+  focusItem(itemOrIndex: number | T, options?: {emitChangeEvent?: boolean}): void;
+  focusItem(itemOrIndex: number | T, options: {emitChangeEvent?: boolean} = {}) {
+    // Set default options
+    options.emitChangeEvent ??= true;
+
+    let index =
+      typeof itemOrIndex === 'number'
+        ? itemOrIndex
+        : this._items.findIndex(item => item === itemOrIndex);
+    if (index < 0 || index >= this._items.length) {
+      return;
+    }
+    const activeItem = this._items[index];
+
+    // If we're just setting the same item, don't re-call activate or focus
+    if (this._activeItem !== null && activeItem === this._activeItem) {
+      return;
+    }
+
+    this._activeItem = activeItem ?? null;
+    this._activeItemIndex = index;
+
+    if (options.emitChangeEvent) {
+      // Emit to `change` stream as required by TreeKeyManagerStrategy interface.
+      this.change.next(this._activeItem);
+    }
+    this._activeItem?.focus();
+    this._activateCurrentItem();
+  }
+
+  private _updateActiveItemIndex(newItems: T[]) {
+    const activeItem = this._activeItem;
+    if (activeItem) {
+      const newIndex = newItems.findIndex(item => item === activeItem);
+
+      if (newIndex > -1 && newIndex !== this._activeItemIndex) {
+        this._activeItemIndex = newIndex;
+      }
+    }
+  }
+
+  /** Focus the first available item. */
+  private _focusFirstItem(): void {
+    this.focusItem(this._findNextAvailableItemIndex(-1));
+  }
+
+  /** Focus the last available item. */
+  private _focusLastItem(): void {
+    this.focusItem(this._findPreviousAvailableItemIndex(this._items.length));
+  }
+
+  /** Focus the next available item. */
+  private _focusNextItem(): void {
+    this.focusItem(this._findNextAvailableItemIndex(this._activeItemIndex));
+  }
+
+  /** Focus the previous available item. */
+  private _focusPreviousItem(): void {
+    this.focusItem(this._findPreviousAvailableItemIndex(this._activeItemIndex));
+  }
+
+  //// Navigational methods
+  private _findNextAvailableItemIndex(startingIndex: number) {
+    if (startingIndex + 1 < this._items.length) {
+      return startingIndex + 1;
+    }
+    return startingIndex;
+  }
+
+  private _findPreviousAvailableItemIndex(startingIndex: number) {
+    if (startingIndex - 1 >= 0) {
+      return startingIndex - 1;
+    }
+    return startingIndex;
+  }
+
+  /**
+   * If the item is already expanded, we collapse the item. Otherwise, we will focus the parent.
+   */
+  private _collapseCurrentItem() {
+    if (!this._activeItem) {
+      return;
+    }
+
+    if (this._isCurrentItemExpanded()) {
+      this._activeItem.collapse();
+    } else {
+      const parent = this._activeItem.getParent();
+      if (!parent) {
+        return;
+      }
+      this.focusItem(parent as T);
+    }
+  }
+
+  /**
+   * If the item is already collapsed, we expand the item. Otherwise, we will focus the first child.
+   */
+  private _expandCurrentItem() {
+    if (!this._activeItem) {
+      return;
+    }
+
+    if (!this._isCurrentItemExpanded()) {
+      this._activeItem.expand();
+    } else {
+      coerceObservable(this._activeItem.getChildren())
+        .pipe(take(1))
+        .subscribe(children => {
+          const firstChild = children[0];
+          if (!firstChild) {
+            return;
+          }
+          this.focusItem(firstChild as T);
+        });
+    }
+  }
+
+  private _isCurrentItemExpanded() {
+    if (!this._activeItem) {
+      return false;
+    }
+    return typeof this._activeItem.isExpanded === 'boolean'
+      ? this._activeItem.isExpanded
+      : this._activeItem.isExpanded();
+  }
+
+  private _activateCurrentItem() {
+    this._activeItem?.activate();
+  }
+}
+
+function VimTreeKeyManagerFactory<T extends TreeKeyManagerItem>(): TreeKeyManagerFactory<T> {
+  return items => new VimTreeKeyManager(items);
+}
+
+const VIM_TREE_KEY_MANAGER_PROVIDER = {
+  provide: TREE_KEY_MANAGER,
+  useFactory: VimTreeKeyManagerFactory,
+};
+
+/**
+ * @title Tree with vim keyboard commands.
+ */
+@Component({
+  selector: 'cdk-tree-custom-key-manager-example',
+  templateUrl: 'cdk-tree-custom-key-manager-example.html',
+  styleUrls: ['cdk-tree-custom-key-manager-example.css'],
+  standalone: true,
+  imports: [CdkTreeModule, MatButtonModule, MatIconModule],
+  providers: [VIM_TREE_KEY_MANAGER_PROVIDER],
+})
+export class CdkTreeCustomKeyManagerExample {
+  treeControl = new FlatTreeControl<ExampleFlatNode>(
+    node => node.level,
+    node => node.expandable,
+  );
+
+  dataSource = new ArrayDataSource(TREE_DATA);
+
+  hasChild = (_: number, node: ExampleFlatNode) => node.expandable;
+
+  getParentNode(node: ExampleFlatNode) {
+    const nodeIndex = TREE_DATA.indexOf(node);
+
+    for (let i = nodeIndex - 1; i >= 0; i--) {
+      if (TREE_DATA[i].level === node.level - 1) {
+        return TREE_DATA[i];
+      }
+    }
+
+    return null;
+  }
+
+  shouldRender(node: ExampleFlatNode) {
+    let parent = this.getParentNode(node);
+    while (parent) {
+      if (!parent.isExpanded) {
+        return false;
+      }
+      parent = this.getParentNode(parent);
+    }
+    return true;
+  }
+}

--- a/src/components-examples/cdk/tree/cdk-tree-legacy-keyboard-interface/cdk-tree-legacy-keyboard-interface-example.css
+++ b/src/components-examples/cdk/tree/cdk-tree-legacy-keyboard-interface/cdk-tree-legacy-keyboard-interface-example.css
@@ -1,0 +1,4 @@
+.example-tree-node {
+  display: flex;
+  align-items: center;
+}

--- a/src/components-examples/cdk/tree/cdk-tree-legacy-keyboard-interface/cdk-tree-legacy-keyboard-interface-example.html
+++ b/src/components-examples/cdk/tree/cdk-tree-legacy-keyboard-interface/cdk-tree-legacy-keyboard-interface-example.html
@@ -1,0 +1,18 @@
+<cdk-tree [dataSource]="dataSource" [treeControl]="treeControl">
+  <!-- This is the tree node template for leaf nodes -->
+  <cdk-tree-node *cdkTreeNodeDef="let node" cdkTreeNodePadding
+                 class="example-tree-node"
+                 tabindex="0">
+    <!-- use a disabled button to provide padding for tree leaf -->
+    <button mat-icon-button disabled></button>
+    {{node.name}}
+  </cdk-tree-node>
+  <!-- This is the tree node template for expandable nodes -->
+  <cdk-tree-node *cdkTreeNodeDef="let node; when: hasChild" cdkTreeNodePadding
+                 isExpandable
+                 [isExpanded]="true"
+                 class="example-tree-node"
+                 tabindex="0">
+    {{node.name}}
+  </cdk-tree-node>
+</cdk-tree>

--- a/src/components-examples/cdk/tree/cdk-tree-legacy-keyboard-interface/cdk-tree-legacy-keyboard-interface-example.ts
+++ b/src/components-examples/cdk/tree/cdk-tree-legacy-keyboard-interface/cdk-tree-legacy-keyboard-interface-example.ts
@@ -1,0 +1,105 @@
+import {Component} from '@angular/core';
+import {ArrayDataSource} from '@angular/cdk/collections';
+import {FlatTreeControl, CdkTreeModule} from '@angular/cdk/tree';
+import {MatIconModule} from '@angular/material/icon';
+import {MatButtonModule} from '@angular/material/button';
+import {LEGACY_TREE_KEY_MANAGER_FACTORY_PROVIDER} from '@angular/cdk/a11y';
+
+const TREE_DATA: ExampleFlatNode[] = [
+  {
+    name: 'Fruit',
+    expandable: true,
+    level: 0,
+  },
+  {
+    name: 'Apple',
+    expandable: false,
+    level: 1,
+  },
+  {
+    name: 'Banana',
+    expandable: false,
+    level: 1,
+  },
+  {
+    name: 'Fruit loops',
+    expandable: false,
+    level: 1,
+  },
+  {
+    name: 'Vegetables',
+    expandable: true,
+    level: 0,
+  },
+  {
+    name: 'Green',
+    expandable: true,
+    level: 1,
+  },
+  {
+    name: 'Broccoli',
+    expandable: false,
+    level: 2,
+  },
+  {
+    name: 'Brussels sprouts',
+    expandable: false,
+    level: 2,
+  },
+  {
+    name: 'Orange',
+    expandable: true,
+    level: 1,
+  },
+  {
+    name: 'Pumpkins',
+    expandable: false,
+    level: 2,
+  },
+  {
+    name: 'Carrots',
+    expandable: false,
+    level: 2,
+  },
+];
+
+/** Flat node with expandable and level information */
+interface ExampleFlatNode {
+  expandable: boolean;
+  name: string;
+  level: number;
+}
+
+/**
+ * @title Tree with flat nodes
+ */
+@Component({
+  selector: 'cdk-tree-legacy-keyboard-interface-example',
+  templateUrl: 'cdk-tree-legacy-keyboard-interface-example.html',
+  styleUrls: ['cdk-tree-legacy-keyboard-interface-example.css'],
+  standalone: true,
+  imports: [CdkTreeModule, MatButtonModule, MatIconModule],
+  providers: [LEGACY_TREE_KEY_MANAGER_FACTORY_PROVIDER],
+})
+export class CdkTreeLegacyKeyboardInterfaceExample {
+  treeControl = new FlatTreeControl<ExampleFlatNode>(
+    node => node.level,
+    node => node.expandable,
+  );
+
+  dataSource = new ArrayDataSource(TREE_DATA);
+
+  hasChild = (_: number, node: ExampleFlatNode) => node.expandable;
+
+  getParentNode(node: ExampleFlatNode) {
+    const nodeIndex = TREE_DATA.indexOf(node);
+
+    for (let i = nodeIndex - 1; i >= 0; i--) {
+      if (TREE_DATA[i].level === node.level - 1) {
+        return TREE_DATA[i];
+      }
+    }
+
+    return null;
+  }
+}

--- a/src/components-examples/cdk/tree/index.ts
+++ b/src/components-examples/cdk/tree/index.ts
@@ -5,3 +5,5 @@ export {CdkTreeNestedLevelAccessorExample} from './cdk-tree-nested-level-accesso
 export {CdkTreeNestedChildrenAccessorExample} from './cdk-tree-nested-children-accessor/cdk-tree-nested-children-accessor-example';
 export {CdkTreeNestedExample} from './cdk-tree-nested/cdk-tree-nested-example';
 export {CdkTreeComplexExample} from './cdk-tree-complex/cdk-tree-complex-example';
+export {CdkTreeCustomKeyManagerExample} from './cdk-tree-custom-key-manager/cdk-tree-custom-key-manager-example';
+export {CdkTreeLegacyKeyboardInterfaceExample} from './cdk-tree-legacy-keyboard-interface/cdk-tree-legacy-keyboard-interface-example';

--- a/src/dev-app/tree/tree-demo.html
+++ b/src/dev-app/tree/tree-demo.html
@@ -43,4 +43,12 @@
     <mat-expansion-panel-header>Complex tree (Redux pattern)</mat-expansion-panel-header>
     <cdk-tree-complex-example></cdk-tree-complex-example>
   </mat-expansion-panel>
+  <mat-expansion-panel>
+    <mat-expansion-panel-header>Custom Key Manager</mat-expansion-panel-header>
+    <cdk-tree-custom-key-manager-example></cdk-tree-custom-key-manager-example>
+  </mat-expansion-panel>
+  <mat-expansion-panel>
+    <mat-expansion-panel-header>Legacy Keyboard Interface</mat-expansion-panel-header>
+    <cdk-tree-legacy-keyboard-interface-example></cdk-tree-legacy-keyboard-interface-example>
+  </mat-expansion-panel>
 </mat-accordion>

--- a/src/dev-app/tree/tree-demo.ts
+++ b/src/dev-app/tree/tree-demo.ts
@@ -16,6 +16,8 @@ import {
   CdkTreeNestedChildrenAccessorExample,
   CdkTreeFlatChildrenAccessorExample,
   CdkTreeComplexExample,
+  CdkTreeCustomKeyManagerExample,
+  CdkTreeLegacyKeyboardInterfaceExample,
 } from '@angular/components-examples/cdk/tree';
 import {
   TreeDynamicExample,
@@ -41,10 +43,12 @@ import {MatTreeModule} from '@angular/material/tree';
   standalone: true,
   imports: [
     CdkTreeModule,
+    CdkTreeCustomKeyManagerExample,
     CdkTreeFlatExample,
     CdkTreeNestedExample,
     CdkTreeFlatChildrenAccessorExample,
     CdkTreeFlatLevelAccessorExample,
+    CdkTreeLegacyKeyboardInterfaceExample,
     CdkTreeNestedChildrenAccessorExample,
     CdkTreeNestedLevelAccessorExample,
     CdkTreeComplexExample,

--- a/tools/public_api_guard/cdk/a11y.md
+++ b/tools/public_api_guard/cdk/a11y.md
@@ -345,6 +345,33 @@ export class IsFocusableConfig {
     ignoreVisibility: boolean;
 }
 
+// @public @deprecated
+export function LEGACY_TREE_KEY_MANAGER_FACTORY<T extends TreeKeyManagerItem>(): TreeKeyManagerFactory<T>;
+
+// @public @deprecated
+export const LEGACY_TREE_KEY_MANAGER_FACTORY_PROVIDER: {
+    provide: InjectionToken<TreeKeyManagerFactory<any>>;
+    useFactory: typeof LEGACY_TREE_KEY_MANAGER_FACTORY;
+};
+
+// @public @deprecated
+export class LegacyTreeKeyManager<T extends TreeKeyManagerItem> implements TreeKeyManagerStrategy<T> {
+    // (undocumented)
+    readonly change: Subject<T | null>;
+    // (undocumented)
+    focusItem(): void;
+    // (undocumented)
+    getActiveItem(): null;
+    // (undocumented)
+    getActiveItemIndex(): null;
+    // (undocumented)
+    get _isLegacyTreeKeyManager(): boolean;
+    // (undocumented)
+    onInitialFocus(): void;
+    // (undocumented)
+    onKeydown(): void;
+}
+
 // @public
 export class ListKeyManager<T extends ListKeyManagerOption> {
     constructor(_items: QueryList<T> | T[]);
@@ -427,37 +454,40 @@ export interface RegisteredMessage {
 export function removeAriaReferencedId(el: Element, attr: `aria-${string}`, id: string): void;
 
 // @public
-export class TreeKeyManager<T extends TreeKeyManagerItem> {
-    constructor({ items, skipPredicate, trackBy, horizontalOrientation, activationFollowsFocus, typeAheadDebounceInterval, }: TreeKeyManagerOptions<T>);
+export const TREE_KEY_MANAGER: InjectionToken<TreeKeyManagerFactory<any>>;
+
+// @public
+export function TREE_KEY_MANAGER_FACTORY<T extends TreeKeyManagerItem>(): TreeKeyManagerFactory<T>;
+
+// @public
+export const TREE_KEY_MANAGER_FACTORY_PROVIDER: {
+    provide: InjectionToken<TreeKeyManagerFactory<any>>;
+    useFactory: typeof TREE_KEY_MANAGER_FACTORY;
+};
+
+// @public
+export class TreeKeyManager<T extends TreeKeyManagerItem> implements TreeKeyManagerStrategy<T> {
+    constructor(items: Observable<T[]> | QueryList<T> | T[], { skipPredicate, trackBy, horizontalOrientation, activationFollowsFocus, typeAheadDebounceInterval, }: TreeKeyManagerOptions<T>);
     readonly change: Subject<T | null>;
-    focusFirstItem(): void;
     focusItem(index: number, options?: {
         emitChangeEvent?: boolean;
     }): void;
+    // (undocumented)
     focusItem(item: T, options?: {
         emitChangeEvent?: boolean;
     }): void;
-    focusLastItem(): void;
-    focusNextItem(): void;
-    focusPreviousItem(): void;
+    // (undocumented)
+    focusItem(itemOrIndex: number | T, options?: {
+        emitChangeEvent?: boolean;
+    }): void;
     getActiveItem(): T | null;
     getActiveItemIndex(): number | null;
     onInitialFocus(): void;
     onKeydown(event: KeyboardEvent): void;
-    // (undocumented)
-    setActiveItem(index: number, options?: {
-        emitChangeEvent?: boolean;
-    }): void;
-    // (undocumented)
-    setActiveItem(item: T, options?: {
-        emitChangeEvent?: boolean;
-    }): void;
-    // (undocumented)
-    setActiveItem(itemOrIndex: number | T, options?: {
-        emitChangeEvent?: boolean;
-    }): void;
-    readonly tabOut: Subject<void>;
 }
+
+// @public (undocumented)
+export type TreeKeyManagerFactory<T extends TreeKeyManagerItem> = (items: Observable<T[]> | QueryList<T> | T[], options: TreeKeyManagerOptions<T>) => TreeKeyManagerStrategy<T>;
 
 // @public
 export interface TreeKeyManagerItem {
@@ -476,11 +506,28 @@ export interface TreeKeyManagerItem {
 export interface TreeKeyManagerOptions<T extends TreeKeyManagerItem> {
     activationFollowsFocus?: boolean;
     horizontalOrientation?: 'rtl' | 'ltr';
-    // (undocumented)
-    items: Observable<T[]> | QueryList<T> | T[];
     skipPredicate?: (item: T) => boolean;
     trackBy?: (treeItem: T) => unknown;
     typeAheadDebounceInterval?: true | number;
+}
+
+// @public (undocumented)
+export interface TreeKeyManagerStrategy<T extends TreeKeyManagerItem> {
+    readonly change: Subject<T | null>;
+    focusItem(index: number, options?: {
+        emitChangeEvent?: boolean;
+    }): void;
+    focusItem(item: T, options?: {
+        emitChangeEvent?: boolean;
+    }): void;
+    // (undocumented)
+    focusItem(itemOrIndex: number | T, options?: {
+        emitChangeEvent?: boolean;
+    }): void;
+    getActiveItem(): T | null;
+    getActiveItemIndex(): number | null;
+    onInitialFocus(): void;
+    onKeydown(event: KeyboardEvent): void;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/tools/public_api_guard/cdk/tree.md
+++ b/tools/public_api_guard/cdk/tree.md
@@ -27,8 +27,8 @@ import { SelectionModel } from '@angular/cdk/collections';
 import { Subject } from 'rxjs';
 import { TemplateRef } from '@angular/core';
 import { TrackByFunction } from '@angular/core';
-import { TreeKeyManager } from '@angular/cdk/a11y';
 import { TreeKeyManagerItem } from '@angular/cdk/a11y';
+import { TreeKeyManagerStrategy } from '@angular/cdk/a11y';
 import { ViewContainerRef } from '@angular/core';
 
 // @public @deprecated
@@ -102,7 +102,7 @@ export class CdkTree<T, K = T> implements AfterContentChecked, AfterContentInit,
     _getSetSize(dataNode: T): number;
     insertNode(nodeData: T, index: number, viewContainer?: ViewContainerRef, parentData?: T): void;
     isExpanded(dataNode: T): boolean;
-    _keyManager: TreeKeyManager<CdkTreeNode<T, K>>;
+    _keyManager: TreeKeyManagerStrategy<CdkTreeNode<T, K>>;
     levelAccessor?: (dataNode: T) => number;
     // (undocumented)
     ngAfterContentChecked(): void;
@@ -167,6 +167,8 @@ export class CdkTreeNode<T, K = T> implements OnDestroy, OnInit, TreeKeyManagerI
     expand(): void;
     readonly expandedChange: EventEmitter<boolean>;
     focus(): void;
+    // (undocumented)
+    _focusItem(): void;
     _getAriaExpanded(): string | null;
     // (undocumented)
     getChildren(): CdkTreeNode<T, K>[] | Observable<CdkTreeNode<T, K>[]>;
@@ -191,8 +193,6 @@ export class CdkTreeNode<T, K = T> implements OnDestroy, OnInit, TreeKeyManagerI
     // @deprecated
     get role(): 'treeitem' | 'group';
     set role(_role: 'treeitem' | 'group');
-    // (undocumented)
-    _setActiveItem(): void;
     // (undocumented)
     _setTabFocusable(): void;
     // (undocumented)

--- a/tools/public_api_guard/material/tree.md
+++ b/tools/public_api_guard/material/tree.md
@@ -113,18 +113,22 @@ export class MatTreeNestedDataSource<T> extends DataSource<T> {
 
 // @public
 export class MatTreeNode<T, K = T> extends CdkTreeNode<T, K> implements CanDisable, HasTabIndex, OnInit, OnDestroy {
-    constructor(elementRef: ElementRef<HTMLElement>, tree: CdkTree<T, K>, tabIndex: string);
+    constructor(elementRef: ElementRef<HTMLElement>, tree: CdkTree<T, K>,
+    tabIndex: string);
     // @deprecated
     defaultTabIndex: number;
     // @deprecated
     get disabled(): boolean;
     set disabled(value: BooleanInput);
     // (undocumented)
+    protected _getTabindexAttribute(): number;
+    // (undocumented)
     ngOnDestroy(): void;
     // (undocumented)
     ngOnInit(): void;
     // @deprecated
-    tabIndex: number;
+    get tabIndex(): number;
+    set tabIndex(value: number);
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<MatTreeNode<any, any>, "mat-tree-node", ["matTreeNode"], { "role": { "alias": "role"; "required": false; }; "disabled": { "alias": "disabled"; "required": false; }; "tabIndex": { "alias": "tabIndex"; "required": false; }; "isExpandable": { "alias": "isExpandable"; "required": false; }; "isExpanded": { "alias": "isExpanded"; "required": false; }; "isDisabled": { "alias": "isDisabled"; "required": false; }; }, { "activation": "activation"; "expandedChange": "expandedChange"; }, never, never, false, never>;
     // (undocumented)


### PR DESCRIPTION
[fix(cdk/tree): add injectable key manager and opt-out](https://github.com/angular/components/pull/27985/commits/95fd972b2f15451d1a8b46899263285c127e7573) 

Make backwards compatibility improvements to cdk-tree-revamp regarding
focus management, the key manager and tabindex attribute.

 * Add TreeKeyMangerStrategy interface
 * Add injection toekn for tree key manager
 * Add LegacyTreeKeyManager

Provide LegacyTreeKeyManager to use legacy tabindex behavior from before
TreeKeyManager was introducted.

This commit message will be squashed away.