### PR TITLE
refactor(material/button): handle disabled states through tokens

### DIFF
--- a/src/material/button/_button-base.scss
+++ b/src/material/button/_button-base.scss
@@ -1,4 +1,3 @@
-@use 'sass:map';
 @use '@material/touch-target' as mdc-touch-target;
 
 @use '../core/style/layout-common';
@@ -88,16 +87,4 @@
       $set-width: $is-square,
       $query: mdc-helpers.$mdc-base-styles-query);
   }
-}
-
-// Changes a button token set to exclude the ripple styles.
-@function mat-private-button-remove-ripple($tokens) {
-  @return map.merge($tokens, (
-    focus-state-layer-color: null,
-    focus-state-layer-opacity: null,
-    hover-state-layer-color: null,
-    hover-state-layer-opacity: null,
-    pressed-state-layer-color: null,
-    pressed-state-layer-opacity: null,
-  ));
 }

--- a/src/material/button/_button-theme-private.scss
+++ b/src/material/button/_button-theme-private.scss
@@ -45,18 +45,6 @@
   }
 }
 
-// Wraps the content style in a selector for the disabled state.
-// MDC adds theme color by using :not(:disabled), so just using [disabled] once will not
-// override this, neither will it apply to anchor tags. This needs to override the
-// previously set theme color, so it must be ordered after the theme styles.
-// TODO(andrewseguin): Discuss with the MDC team to see if we can avoid the :not(:disabled) by
-// manually styling disabled buttons with a [disabled] selector.
-@mixin apply-disabled-style() {
-  &[disabled][disabled] {
-    @content;
-  }
-}
-
 // Hides the touch target on lower densities.
 @mixin touch-target-density($scale) {
   @include mdc-helpers.if-touch-targets-unsupported($scale) {

--- a/src/material/button/_button-theme.scss
+++ b/src/material/button/_button-theme.scss
@@ -3,7 +3,6 @@
 @use '@material/button/button-filled-theme' as mdc-button-filled-theme;
 @use '@material/button/button-protected-theme' as mdc-button-protected-theme;
 @use '@material/button/button-outlined-theme' as mdc-button-outlined-theme;
-@use '@material/theme/theme-color' as mdc-theme-color;
 @use '@material/elevation/elevation-theme' as mdc-elevation-theme;
 
 @use './button-theme-private';
@@ -21,35 +20,11 @@
   @return if(mdc-helpers.variable-safe-contrast-tone($palette, $is-dark) == 'dark', #000, #fff);
 }
 
-@mixin _outlined-button-variant($color) {
-  @include mdc-button-outlined-theme.theme((
-    label-text-color: $color,
-  ));
-}
-
 @mixin base($theme) {
   // TODO(mmalerba): Move button base tokens here
 }
 
 @mixin color($theme) {
-  @include mdc-helpers.using-mdc-theme($theme) {
-    $is-dark: inspection.get-theme-type($theme) == dark;
-    $on-surface: mdc-theme-color.prop-value(on-surface);
-    $disabled-ink-color: rgba($on-surface, if($is-dark, 0.5, 0.38));
-    $primary: mdc-theme-color.prop-value(primary);
-    $secondary: mdc-theme-color.prop-value(secondary);
-    $error: mdc-theme-color.prop-value(error);
-
-    // Ripple colors
-    .mat-mdc-button, .mat-mdc-outlined-button {
-      @include button-theme-private.ripple-theme-styles($theme, false);
-    }
-
-    .mat-mdc-raised-button, .mat-mdc-unelevated-button {
-      @include button-theme-private.ripple-theme-styles($theme, true);
-    }
-  }
-
   $surface: inspection.get-theme-color($theme, background, card);
   $primary: inspection.get-theme-color($theme, primary);
   $accent: inspection.get-theme-color($theme, accent);
@@ -59,6 +34,18 @@
   $on-primary: _on-color($theme, $primary);
   $on-accent: _on-color($theme, $accent);
   $on-error: _on-color($theme, $error);
+
+  // TODO: remove these when tokenizing the ripples.
+  @include mdc-helpers.using-mdc-theme($theme) {
+    // Ripple colors
+    .mat-mdc-button, .mat-mdc-outlined-button {
+      @include button-theme-private.ripple-theme-styles($theme, false);
+    }
+
+    .mat-mdc-raised-button, .mat-mdc-unelevated-button {
+      @include button-theme-private.ripple-theme-styles($theme, true);
+    }
+  }
 
   .mat-mdc-button {
     @include mdc-button-text-theme.theme(tokens-mdc-text-button.get-color-tokens($theme));
@@ -174,55 +161,6 @@
 
     &.mat-warn {
       @include mdc-button-outlined-theme.theme($warn-color-tokens);
-    }
-  }
-
-  $is-dark: inspection.get-theme-type($theme) == dark;
-  $disabled-ink-color: rgba($on-surface, if($is-dark, 0.5, 0.38));
-  $disabled-container-color: rgba($on-surface, 0.12);
-
-  // TODO: these disabled styles are a bit too specific currently.
-  // Once the buttons are fully tokenized, we should rework how they're applied.
-  .mat-mdc-button {
-    @include button-theme-private.apply-disabled-style() {
-      @include mdc-button-text-theme.theme((
-        disabled-label-text-color: $disabled-ink-color,
-        label-text-color: $disabled-ink-color,
-      ));
-    }
-  }
-
-  .mat-mdc-raised-button {
-    @include button-theme-private.apply-disabled-style() {
-      @include mdc-elevation-theme.elevation(0);
-      @include mdc-button-protected-theme.theme((
-        disabled-container-color: $disabled-container-color,
-        disabled-label-text-color: $disabled-ink-color,
-        container-color: $disabled-container-color,
-        label-text-color: $disabled-ink-color,
-      ));
-    }
-  }
-
-  .mat-mdc-outlined-button {
-    @include button-theme-private.apply-disabled-style() {
-      @include mdc-button-outlined-theme.theme((
-        label-text-color: $disabled-ink-color,
-        disabled-label-text-color: $disabled-ink-color,
-        disabled-outline-color: rgba($on-surface, 0.12),
-        outline-color: rgba($on-surface, 0.12),
-      ));
-    }
-  }
-
-  .mat-mdc-unelevated-button {
-    @include button-theme-private.apply-disabled-style() {
-      @include mdc-button-filled-theme.theme((
-        disabled-container-color: $disabled-container-color,
-        disabled-label-text-color: $disabled-ink-color,
-        container-color: $disabled-container-color,
-        label-text-color: $disabled-ink-color,
-      ));
     }
   }
 }

--- a/src/material/button/button.scss
+++ b/src/material/button/button.scss
@@ -10,6 +10,7 @@
 @use './button-base';
 @use '../core/mdc-helpers/mdc-helpers';
 @use '../core/style/private' as style-private;
+@use '../core/tokens/token-utils';
 @use '../core/focus-indicators/private' as focus-indicators-private;
 @use '../core/tokens/m2/mdc/filled-button' as tokens-mdc-filled-button;
 @use '../core/tokens/m2/mdc/outlined-button' as tokens-mdc-outlined-button;
@@ -22,12 +23,20 @@
 
 @include mdc-custom-properties.configure($emit-fallback-values: false, $emit-fallback-vars: false) {
   .mat-mdc-button {
-    @include mdc-button-text-theme.theme-styles(tokens-mdc-text-button.get-token-slots());
+    $mdc-text-button-slots: tokens-mdc-text-button.get-token-slots();
+
+    @include mdc-button-text-theme.theme-styles($mdc-text-button-slots);
     @include mdc-button-text-theme.theme(tokens-mdc-text-button.get-unthemable-tokens());
+
+    @include token-utils.use-tokens(tokens-mdc-text-button.$prefix, $mdc-text-button-slots) {
+      // We need to re-apply the disabled tokens since MDC uses
+      // `:disabled` which doesn't apply to anchors.
+      @include button-base.mat-private-button-disabled {
+        @include token-utils.create-token-slot(color, disabled-label-text-color);
+      }
+    }
   }
 
-  // Note that we don't include a feature query, because this mixins declare
-  // all the "slots" for CSS variables that will be defined in the theme.
   .mat-mdc-unelevated-button {
     $mdc-filled-button-slots: tokens-mdc-filled-button.get-token-slots();
 
@@ -36,10 +45,17 @@
 
     // Add default values for MDC text button tokens that aren't outputted by the theming API.
     @include mdc-button-filled-theme.theme(tokens-mdc-filled-button.get-unthemable-tokens());
+
+    @include token-utils.use-tokens(tokens-mdc-filled-button.$prefix, $mdc-filled-button-slots) {
+      // We need to re-apply the disabled tokens since MDC uses
+      // `:disabled` which doesn't apply to anchors.
+      @include button-base.mat-private-button-disabled {
+        @include token-utils.create-token-slot(color, disabled-label-text-color);
+        @include token-utils.create-token-slot(background-color, disabled-container-color);
+      }
+    }
   }
 
-  // Note that we don't include a feature query, because this mixins declare
-  // all the "slots" for CSS variables that will be defined in the theme.
   .mat-mdc-raised-button {
     $mdc-button-protected-slots: tokens-mdc-protected-button.get-token-slots();
 
@@ -48,10 +64,24 @@
 
     // Add default values for MDC text button tokens that aren't outputted by the theming API.
     @include mdc-button-protected-theme.theme(tokens-mdc-protected-button.get-unthemable-tokens());
+
+    @include token-utils.use-tokens(
+      tokens-mdc-protected-button.$prefix,
+      $mdc-button-protected-slots) {
+      // We need to re-apply the disabled tokens since MDC uses
+      // `:disabled` which doesn't apply to anchors.
+      @include button-base.mat-private-button-disabled {
+        @include token-utils.create-token-slot(color, disabled-label-text-color);
+        @include token-utils.create-token-slot(background-color, disabled-container-color);
+
+        // Since we're still doing elevation through the theme, we need additional specificity here.
+        &[disabled] {
+          box-shadow: none;
+        }
+      }
+    }
   }
 
-  // Note that we don't include a feature query, because this mixins declare
-  // all the "slots" for CSS variables that will be defined in the theme.
   .mat-mdc-outlined-button {
     $mdc-outlined-button-slots: tokens-mdc-outlined-button.get-token-slots();
 
@@ -60,6 +90,17 @@
 
     // Add default values for MDC text button tokens that aren't outputted by the theming API.
     @include mdc-button-outlined-theme.theme(tokens-mdc-outlined-button.get-unthemable-tokens());
+
+    @include token-utils.use-tokens(
+      tokens-mdc-outlined-button.$prefix,
+      $mdc-outlined-button-slots) {
+      // We need to re-apply the disabled tokens since MDC uses
+      // `:disabled` which doesn't apply to anchors.
+      @include button-base.mat-private-button-disabled {
+        @include token-utils.create-token-slot(color, disabled-label-text-color);
+        @include token-utils.create-token-slot(border-color, disabled-outline-color);
+      }
+    }
   }
 }
 
@@ -68,7 +109,6 @@
 .mat-mdc-raised-button,
 .mat-mdc-outlined-button {
   @include button-base.mat-private-button-interactive();
-  @include button-base.mat-private-button-disabled();
   @include button-base.mat-private-button-touch-target(false);
   @include style-private.private-animation-noop();
 }

--- a/src/material/core/tokens/m2/mdc/_outlined-button.scss
+++ b/src/material/core/tokens/m2/mdc/_outlined-button.scss
@@ -64,12 +64,13 @@ $prefix: (mdc, outlined-button);
 
 // Tokens that can be configured through Angular Material's color theming API.
 @function get-color-tokens($theme, $color: null, $on-color: null) {
+  $is-dark: inspection.get-theme-type($theme) == dark;
   $surface: inspection.get-theme-color($theme, background, card);
   $on-surface: _on-color($theme, $surface);
 
   @return (
     disabled-outline-color: rgba($on-surface, 0.12),
-    disabled-label-text-color: rgba($on-surface, 0.38),
+    disabled-label-text-color: rgba($on-surface, if($is-dark, 0.5, 0.38)),
     label-text-color: if($color, $color, inherit),
     outline-color: rgba($on-surface, 0.12)
   );


### PR DESCRIPTION
MDC applies disabled styles through the `:disabled` selector which forced us to work around it by using a selector like `.mat-mdc-button[disabled][disabled]` and setting both the disabled and enabled button tokens. This is problematic, because it increases the specificity too much and it introduces space for mistakes, because we have to duplicate the tokens values.

These changes resolve the issue by re-applying the token slots to disabled buttons with the correct selector so that they can reuse the same tokens as the `button` nodes.