### PR TITLE
feat(material/chips): expose _chipGrid in MatChipInput and add a stream of chip removal events

### DIFF
--- a/src/material/chips/chip-input.ts
+++ b/src/material/chips/chip-input.ts
@@ -75,16 +75,19 @@ export class MatChipInput implements MatChipTextControl, AfterContentInit, OnCha
 
   /** Whether the control is focused. */
   focused: boolean = false;
-  _chipGrid: MatChipGrid;
 
   /** Register input for chip list */
   @Input('matChipInputFor')
+  get chipGrid(): MatChipGrid {
+    return this._chipGrid;
+  }
   set chipGrid(value: MatChipGrid) {
     if (value) {
       this._chipGrid = value;
       this._chipGrid.registerInput(this);
     }
   }
+  private _chipGrid: MatChipGrid;
 
   /**
    * Whether or not the chipEnd event will be emitted when the input is blurred.

--- a/src/material/chips/chip-set.ts
+++ b/src/material/chips/chip-set.ts
@@ -80,9 +80,14 @@ export class MatChipSet
     return this._getChipStream(chip => chip._onFocus);
   }
 
-  /** Combined stream of all of the child chips' remove events. */
+  /** Combined stream of all of the child chips' destroy events. */
   get chipDestroyedChanges(): Observable<MatChipEvent> {
     return this._getChipStream(chip => chip.destroyed);
+  }
+
+  /** Combined stream of all of the child chips' remove events. */
+  get chipRemovedChanges(): Observable<MatChipEvent> {
+    return this._getChipStream(chip => chip.removed);
   }
 
   /** Whether the chip set is disabled. */

--- a/tools/public_api_guard/material/chips.md
+++ b/tools/public_api_guard/material/chips.md
@@ -243,9 +243,8 @@ export class MatChipInput implements MatChipTextControl, AfterContentInit, OnCha
     _addOnBlur: boolean;
     _blur(): void;
     readonly chipEnd: EventEmitter<MatChipInputEvent>;
+    get chipGrid(): MatChipGrid;
     set chipGrid(value: MatChipGrid);
-    // (undocumented)
-    _chipGrid: MatChipGrid;
     clear(): void;
     get disabled(): boolean;
     set disabled(value: BooleanInput);
@@ -443,6 +442,7 @@ export class MatChipSet extends _MatChipSetMixinBase implements AfterViewInit, H
     _chipActions: QueryList<MatChipAction>;
     get chipDestroyedChanges(): Observable<MatChipEvent>;
     get chipFocusChanges(): Observable<MatChipEvent>;
+    get chipRemovedChanges(): Observable<MatChipEvent>;
     _chips: QueryList<MatChip>;
     protected _defaultRole: string;
     protected _destroyed: Subject<void>;


### PR DESCRIPTION
The original FR is this (https://github.com/angular/components/issues/28012). There are two changes in this PR,
1. Expose _chipGrid from MatChipInput
2. Add a stream of chip removal events in MatChipSet