### PR TITLE
fix(cdk/tree): cleanup tree-key-manager token

### DIFF
--- a/src/cdk/a11y/key-manager/tree-key-manager.ts
+++ b/src/cdk/a11y/key-manager/tree-key-manager.ts
@@ -542,7 +542,10 @@ export class TreeKeyManager<T extends TreeKeyManagerItem> implements TreeKeyMana
 }
 
 /** Injection token that determines the key manager to use. */
-export const TREE_KEY_MANAGER = new InjectionToken<TreeKeyManagerFactory<any>>('tree-key-manager');
+export const TREE_KEY_MANAGER = new InjectionToken<TreeKeyManagerFactory<any>>('tree-key-manager', {
+  providedIn: 'root',
+  factory: TREE_KEY_MANAGER_FACTORY,
+});
 
 /** @docs-private */
 export function TREE_KEY_MANAGER_FACTORY<T extends TreeKeyManagerItem>(): TreeKeyManagerFactory<T> {

--- a/src/cdk/tree/tree-module.ts
+++ b/src/cdk/tree/tree-module.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {TREE_KEY_MANAGER_FACTORY_PROVIDER} from '@angular/cdk/a11y';
 import {NgModule} from '@angular/core';
 import {CdkTreeNodeOutlet} from './outlet';
 import {CdkTreeNodePadding} from './padding';
@@ -28,6 +27,5 @@ const EXPORTED_DECLARATIONS = [
 @NgModule({
   exports: EXPORTED_DECLARATIONS,
   declarations: EXPORTED_DECLARATIONS,
-  providers: [TREE_KEY_MANAGER_FACTORY_PROVIDER],
 })
 export class CdkTreeModule {}

--- a/src/material/tree/BUILD.bazel
+++ b/src/material/tree/BUILD.bazel
@@ -18,7 +18,6 @@ ng_module(
     ),
     assets = [":tree.css"] + glob(["**/*.html"]),
     deps = [
-        "//src/cdk/a11y",
         "//src/cdk/collections",
         "//src/cdk/tree",
         "//src/material/core",

--- a/src/material/tree/tree-module.ts
+++ b/src/material/tree/tree-module.ts
@@ -8,7 +8,6 @@
 
 import {NgModule} from '@angular/core';
 
-import {TREE_KEY_MANAGER_FACTORY_PROVIDER} from '@angular/cdk/a11y';
 import {CdkTreeModule} from '@angular/cdk/tree';
 import {MatCommonModule} from '@angular/material/core';
 import {MatNestedTreeNode, MatTreeNodeDef, MatTreeNode} from './node';
@@ -31,6 +30,5 @@ const MAT_TREE_DIRECTIVES = [
   imports: [CdkTreeModule, MatCommonModule],
   exports: [MatCommonModule, MAT_TREE_DIRECTIVES],
   declarations: MAT_TREE_DIRECTIVES,
-  providers: [TREE_KEY_MANAGER_FACTORY_PROVIDER],
 })
 export class MatTreeModule {}


### PR DESCRIPTION
Change how tree-key-manager token is provided. Provide default TreeKeyManager at root. Remove provider from NgModule.