### PR TITLE
fix(material/schematics): account for browser-esbuild builder

### DIFF
--- a/src/cdk/schematics/utils/project-targets.ts
+++ b/src/cdk/schematics/utils/project-targets.ts
@@ -33,7 +33,8 @@ export function getProjectBuildTargets(
     project,
     builder =>
       builder === '@angular-devkit/build-angular:application' ||
-      builder === '@angular-devkit/build-angular:browser',
+      builder === '@angular-devkit/build-angular:browser' ||
+      builder === '@angular-devkit/build-angular:browser-esbuild',
   );
 }
 


### PR DESCRIPTION
Fixes that the schematics would throw if the app is using the `browser-esbuild` builder from the CLI.