### PR TITLE
docs: release notes for the v17.0.0-rc.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+<a name="17.0.0-rc.2"></a>
+# 17.0.0-rc.2 "beryllium-brilliance" (2023-11-01)
+### cdk
+| Commit | Type | Description |
+| -- | -- | -- |
+| [b361de136b](https://github.com/angular/components/commit/b361de136b40377ce07430f9f2cf8111ffd300ca) | fix | **accordion:** add `CDK_ACCORDION` export ([#27981](https://github.com/angular/components/pull/27981)) |
+### material
+| Commit | Type | Description |
+| -- | -- | -- |
+| [fcaa95e695](https://github.com/angular/components/commit/fcaa95e6955d05773037650f48eb50efc445b24c) | fix | **core:** prevent updates to v17 if project uses legacy components ([#28024](https://github.com/angular/components/pull/28024)) |
+| [c4a62a884f](https://github.com/angular/components/commit/c4a62a884f9eabeacdfd299a91deccc9003fc34c) | fix | **dialog:** MatDialog: change member _dialog (cdk) from private to protected ([#28019](https://github.com/angular/components/pull/28019)) ([#28020](https://github.com/angular/components/pull/28020)) |
+| [7a42a5de98](https://github.com/angular/components/commit/7a42a5de9888fcd2dc459c3887a167860d0726fd) | fix | **schematics:** account for browser-esbuild builder ([#28025](https://github.com/angular/components/pull/28025)) |
+| [9fe4fe1f54](https://github.com/angular/components/commit/9fe4fe1f54f8dab72d4291e2dbee96dc8ade62b6) | fix | **schematics:** don't add the preconnect for fonts ([#28026](https://github.com/angular/components/pull/28026)) |
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="16.2.11"></a>
 # 16.2.11 "fabric-fantasy" (2023-11-01)
 ### cdk


### PR DESCRIPTION
Cherry-picks the changelog from the "17.0.x" branch to the next branch (main).