### PR TITLE
docs(material/expansion): remove unused styling

### DIFF
--- a/src/components-examples/material/expansion/expansion-overview/expansion-overview-example.css
+++ b/src/components-examples/material/expansion/expansion-overview/expansion-overview-example.css
@@ -1,3 +1,0 @@
-.mat-mdc-form-field + .mat-mdc-form-field {
-  margin-left: 8px;
-}

--- a/src/components-examples/material/expansion/expansion-overview/expansion-overview-example.ts
+++ b/src/components-examples/material/expansion/expansion-overview/expansion-overview-example.ts
@@ -7,7 +7,6 @@ import {MatExpansionModule} from '@angular/material/expansion';
 @Component({
   selector: 'expansion-overview-example',
   templateUrl: 'expansion-overview-example.html',
-  styleUrls: ['expansion-overview-example.css'],
   standalone: true,
   imports: [MatExpansionModule],
 })


### PR DESCRIPTION
This particular example had css for a mdc form field that isn't reference in the mat-expansion docs overview example, so I removed it here. 