### PR TITLE
fix(material/paginator): visual order does not match reading order

### DIFF
--- a/src/material/paginator/paginator.scss
+++ b/src/material/paginator/paginator.scss
@@ -56,7 +56,7 @@ $button-icon-size: 28px;
   align-items: center;
   justify-content: flex-end;
   padding: $padding;
-  flex-wrap: wrap-reverse;
+  flex-wrap: wrap;
   width: 100%;
 
   @include token-utils.use-tokens(


### PR DESCRIPTION
OBSERVED RESULTS:

The reading order of the pagination controls does not match the visual order which can be disorienting to visual users who do use screen readers or keyboard only to navigate the page.

Screenshot/screencast: https://screenshot.googleplex.com/Bd6psV6wJZ4sgji.png
User provided screenshot

EXPECTED RESULTS:

If possible, try to match the reading/focus order of elements with the visual order. Typically it is left to right, top to bottom.
STEPS TO REPRODUCE:

Enable screen reader
Navigate to https://xap-gallery.corp.google.com/embed/a11y/mdc-paginator
Navigate to the pagination controls
Observe
[RELEVANT GAR SHEET](https://docs.google.com/spreadsheets/d/1-_8Tppqw-ylYLRHkGSwTdoCIsAqh_eq-I6YjwVcP7jI/edit#gid=1798853167)

[RELEVANT GAR GUIDELINE](http://go/gar-mobile-run-through-screen-reader)

ENVIRONMENT DETAILS:

Google Pixel 5

Android version 13
Talkback
Canary 116.0.5813.0
iPhone 12

iOS 16.4.1
VoiceOver
Dev 116.0.5805.1
Bug filing time:

10min