### PR TITLE
fix(material/paginator) Visual order does not match reading order

### DIFF
--- a/src/material/paginator/paginator.scss
+++ b/src/material/paginator/paginator.scss
@@ -3,6 +3,7 @@
 @use '../core/tokens/m2/mat/paginator' as tokens-mat-paginator;
 @use '../core/tokens/token-utils';
 
+//test
 $padding: 0 8px;
 $page-size-margin-right: 8px;
 

--- a/src/material/paginator/paginator.scss
+++ b/src/material/paginator/paginator.scss
@@ -3,7 +3,6 @@
 @use '../core/tokens/m2/mat/paginator' as tokens-mat-paginator;
 @use '../core/tokens/token-utils';
 
-//test
 $padding: 0 8px;
 $page-size-margin-right: 8px;
 

--- a/src/material/paginator/paginator.scss
+++ b/src/material/paginator/paginator.scss
@@ -56,7 +56,7 @@ $button-icon-size: 28px;
   align-items: center;
   justify-content: flex-end;
   padding: $padding;
-  flex-wrap: wrap-reverse;
+  flex-wrap: wrap;
   width: 100%;
 
   @include token-utils.use-tokens(


### PR DESCRIPTION
On certain mobile devices like iPhone 12 and Google Pixel 5, the reading order of the pagination controls does not match the visual order which can be disorienting to visual users who do use screen readers or keyboard only to navigate the page.  The following fix changes the reading order from top to bottom instead of bottom to top. 
**Screenshot of incorrect reading order**:
 ![paginator-reading-order-bug](https://github.com/angular/components/assets/42016383/fa9a34d9-30df-40bf-b83b-4a2ebfe9cffe)

