### PR TITLE
Remove most remaining usages of TypeScript mixins

### DIFF
--- a/src/cdk/stepper/BUILD.bazel
+++ b/src/cdk/stepper/BUILD.bazel
@@ -12,7 +12,6 @@ ng_module(
         "//src:dev_mode_types",
         "//src/cdk/a11y",
         "//src/cdk/bidi",
-        "//src/cdk/coercion",
         "//src/cdk/keycodes",
         "//src/cdk/platform",
         "@npm//@angular/core",

--- a/src/cdk/tree/BUILD.bazel
+++ b/src/cdk/tree/BUILD.bazel
@@ -18,7 +18,6 @@ ng_module(
         "//src:dev_mode_types",
         "//src/cdk/a11y",
         "//src/cdk/bidi",
-        "//src/cdk/coercion",
         "//src/cdk/collections",
         "@npm//@angular/core",
         "@npm//rxjs",

--- a/src/cdk/tree/nested-node.ts
+++ b/src/cdk/tree/nested-node.ts
@@ -32,7 +32,6 @@ import {getTreeControlFunctionsMissingError} from './tree-errors';
 @Directive({
   selector: 'cdk-nested-tree-node',
   exportAs: 'cdkNestedTreeNode',
-  inputs: ['role', 'disabled', 'tabIndex'],
   providers: [
     {provide: CdkTreeNode, useExisting: CdkNestedTreeNode},
     {provide: CDK_TREE_NODE_OUTLET_NODE, useExisting: CdkNestedTreeNode},

--- a/src/cdk/tree/padding.ts
+++ b/src/cdk/tree/padding.ts
@@ -7,8 +7,7 @@
  */
 
 import {Directionality} from '@angular/cdk/bidi';
-import {coerceNumberProperty, NumberInput} from '@angular/cdk/coercion';
-import {Directive, ElementRef, Input, OnDestroy, Optional} from '@angular/core';
+import {Directive, ElementRef, Input, numberAttribute, OnDestroy, Optional} from '@angular/core';
 import {takeUntil} from 'rxjs/operators';
 import {Subject} from 'rxjs';
 import {CdkTree, CdkTreeNode} from './tree';
@@ -34,11 +33,11 @@ export class CdkTreeNodePadding<T, K = T> implements OnDestroy {
   indentUnits = 'px';
 
   /** The level of depth of the tree node. The padding will be `level * indent` pixels. */
-  @Input('cdkTreeNodePadding')
+  @Input({alias: 'cdkTreeNodePadding', transform: numberAttribute})
   get level(): number {
     return this._level;
   }
-  set level(value: NumberInput) {
+  set level(value: number) {
     this._setLevelInput(value);
   }
   _level: number;
@@ -107,11 +106,11 @@ export class CdkTreeNodePadding<T, K = T> implements OnDestroy {
    * TS 4.0 doesn't allow properties to override accessors or vice-versa.
    * @docs-private
    */
-  protected _setLevelInput(value: NumberInput) {
+  protected _setLevelInput(value: number) {
     // Set to null as the fallback value so that _setPadding can fall back to the node level if the
     // consumer set the directive as `cdkTreeNodePadding=""`. We still want to take this value if
     // they set 0 explicitly.
-    this._level = coerceNumberProperty(value, null)!;
+    this._level = isNaN(value) ? null! : value;
     this._setPadding();
   }
 
@@ -132,7 +131,7 @@ export class CdkTreeNodePadding<T, K = T> implements OnDestroy {
     }
 
     this.indentUnits = units;
-    this._indent = coerceNumberProperty(value);
+    this._indent = numberAttribute(value);
     this._setPadding();
   }
 }

--- a/src/cdk/tree/toggle.ts
+++ b/src/cdk/tree/toggle.ts
@@ -6,8 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {BooleanInput, coerceBooleanProperty} from '@angular/cdk/coercion';
-import {Directive, Input} from '@angular/core';
+import {Directive, Input, booleanAttribute} from '@angular/core';
 
 import {CdkTree, CdkTreeNode} from './tree';
 
@@ -22,16 +21,13 @@ import {CdkTree, CdkTreeNode} from './tree';
 })
 export class CdkTreeNodeToggle<T, K = T> {
   /** Whether expand/collapse the node recursively. */
-  @Input('cdkTreeNodeToggleRecursive')
-  get recursive(): boolean {
-    return this._recursive;
-  }
-  set recursive(value: BooleanInput) {
-    this._recursive = coerceBooleanProperty(value);
-  }
-  protected _recursive = false;
+  @Input({alias: 'cdkTreeNodeToggleRecursive', transform: booleanAttribute})
+  recursive: boolean = false;
 
-  constructor(protected _tree: CdkTree<T, K>, protected _treeNode: CdkTreeNode<T, K>) {}
+  constructor(
+    protected _tree: CdkTree<T, K>,
+    protected _treeNode: CdkTreeNode<T, K>,
+  ) {}
 
   _toggle(event: Event): void {
     this.recursive

--- a/src/cdk/tree/tree.ts
+++ b/src/cdk/tree/tree.ts
@@ -26,6 +26,7 @@ import {
   ViewChild,
   ViewContainerRef,
   ViewEncapsulation,
+  numberAttribute,
 } from '@angular/core';
 import {
   BehaviorSubject,
@@ -46,7 +47,6 @@ import {
   getTreeMultipleDefaultNodeDefsError,
   getTreeNoValidDataSourceError,
 } from './tree-errors';
-import {coerceNumberProperty} from '@angular/cdk/coercion';
 
 /**
  * CDK tree component that connects with a data source to retrieve data of type `T` and renders
@@ -133,7 +133,10 @@ export class CdkTree<T, K = T> implements AfterContentChecked, CollectionViewer,
     end: Number.MAX_VALUE,
   });
 
-  constructor(private _differs: IterableDiffers, private _changeDetectorRef: ChangeDetectorRef) {}
+  constructor(
+    private _differs: IterableDiffers,
+    private _changeDetectorRef: ChangeDetectorRef,
+  ) {}
 
   ngOnInit() {
     this._dataDiffer = this._differs.find([]).create(this.trackBy);
@@ -376,7 +379,10 @@ export class CdkTreeNode<T, K = T> implements FocusableOption, OnDestroy, OnInit
       : this._parentNodeAriaLevel;
   }
 
-  constructor(protected _elementRef: ElementRef<HTMLElement>, protected _tree: CdkTree<T, K>) {
+  constructor(
+    protected _elementRef: ElementRef<HTMLElement>,
+    protected _tree: CdkTree<T, K>,
+  ) {
     CdkTreeNode.mostRecentTreeNode = this as CdkTreeNode<T, K>;
     this.role = 'treeitem';
   }
@@ -428,7 +434,7 @@ function getParentNodeAriaLevel(nodeElement: HTMLElement): number {
       return -1;
     }
   } else if (parent.classList.contains('cdk-nested-tree-node')) {
-    return coerceNumberProperty(parent.getAttribute('aria-level')!);
+    return numberAttribute(parent.getAttribute('aria-level')!);
   } else {
     // The ancestor element is the cdk-tree itself
     return 0;

--- a/src/dev-app/slider/slider-demo.ts
+++ b/src/dev-app/slider/slider-demo.ts
@@ -17,7 +17,7 @@ import {MatButtonModule} from '@angular/material/button';
 import {ThemePalette} from '@angular/material/core';
 
 interface DialogData {
-  color: string;
+  color: ThemePalette;
   discrete: boolean;
   showTickMarks: boolean;
 }

--- a/src/material/chips/chip-action.ts
+++ b/src/material/chips/chip-action.ts
@@ -6,17 +6,16 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {BooleanInput, coerceBooleanProperty} from '@angular/cdk/coercion';
+import {
+  Directive,
+  ElementRef,
+  Inject,
+  Input,
+  booleanAttribute,
+  numberAttribute,
+} from '@angular/core';
 import {ENTER, SPACE} from '@angular/cdk/keycodes';
-import {Directive, ElementRef, Inject, Input} from '@angular/core';
-import {HasTabIndex, mixinTabIndex} from '@angular/material/core';
 import {MAT_CHIP} from './tokens';
-
-abstract class _MatChipActionBase {
-  abstract disabled: boolean;
-}
-
-const _MatChipActionMixinBase = mixinTabIndex(_MatChipActionBase, -1);
 
 /**
  * Section within a chip.
@@ -24,7 +23,6 @@ const _MatChipActionMixinBase = mixinTabIndex(_MatChipActionBase, -1);
  */
 @Directive({
   selector: '[matChipAction]',
-  inputs: ['disabled', 'tabIndex'],
   host: {
     'class': 'mdc-evolution-chip__action mat-mdc-chip-action',
     '[class.mdc-evolution-chip__action--primary]': '_isPrimary',
@@ -37,7 +35,7 @@ const _MatChipActionMixinBase = mixinTabIndex(_MatChipActionBase, -1);
     '(keydown)': '_handleKeydown($event)',
   },
 })
-export class MatChipAction extends _MatChipActionMixinBase implements HasTabIndex {
+export class MatChipAction {
   /** Whether the action is interactive. */
   @Input() isInteractive = true;
 
@@ -45,14 +43,20 @@ export class MatChipAction extends _MatChipActionMixinBase implements HasTabInde
   _isPrimary = true;
 
   /** Whether the action is disabled. */
-  @Input()
+  @Input({transform: booleanAttribute})
   get disabled(): boolean {
     return this._disabled || this._parentChip.disabled;
   }
-  set disabled(value: BooleanInput) {
-    this._disabled = coerceBooleanProperty(value);
+  set disabled(value: boolean) {
+    this._disabled = value;
   }
   private _disabled = false;
+
+  /** Tab index of the action. */
+  @Input({
+    transform: (value: unknown) => (value == null ? -1 : numberAttribute(value)),
+  })
+  tabIndex: number = -1;
 
   /**
    * Private API to allow focusing this chip when it is disabled.
@@ -88,8 +92,6 @@ export class MatChipAction extends _MatChipActionMixinBase implements HasTabInde
       _isEditing?: boolean;
     },
   ) {
-    super();
-
     if (_elementRef.nativeElement.nodeName === 'BUTTON') {
       _elementRef.nativeElement.setAttribute('type', 'button');
     }

--- a/src/material/chips/chip-grid.ts
+++ b/src/material/chips/chip-grid.ts
@@ -6,11 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {BooleanInput, coerceBooleanProperty} from '@angular/cdk/coercion';
 import {hasModifierKey, TAB} from '@angular/cdk/keycodes';
 import {
   AfterContentInit,
   AfterViewInit,
+  booleanAttribute,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
@@ -55,8 +55,15 @@ export class MatChipGridChange {
 
 /**
  * Boilerplate for applying mixins to MatChipGrid.
+ * Important! this class needs to be marked as a component or a directive, because
+ * leaving it without metadata cuases the framework to execute the host bindings multiple
+ * times which breaks the keyboard navigation. We can't use `@Directive()` here, because
+ * `MatChipSet` is a component. We should able to remove this class altogether once
+ * the error state is moved away from using mixins.
  * @docs-private
  */
+// tslint:disable-next-line:validate-decorators
+@Component({template: ''})
 class MatChipGridBase extends MatChipSet {
   /**
    * Emits whenever the component state changes and should cause the parent
@@ -96,11 +103,10 @@ const _MatChipGridMixinBase = mixinErrorState(MatChipGridBase);
     </div>
   `,
   styleUrls: ['chip-set.css'],
-  inputs: ['tabIndex'],
   host: {
     'class': 'mat-mdc-chip-set mat-mdc-chip-grid mdc-evolution-chip-set',
     '[attr.role]': 'role',
-    '[tabIndex]': '_chips && _chips.length === 0 ? -1 : tabIndex',
+    '[attr.tabindex]': '(disabled || (_chips && _chips.length === 0)) ? -1 : tabIndex',
     '[attr.aria-disabled]': 'disabled.toString()',
     '[attr.aria-invalid]': 'errorState',
     '[class.mat-mdc-chip-list-disabled]': 'disabled',
@@ -156,12 +162,12 @@ export class MatChipGrid
    * Implemented as part of MatFormFieldControl.
    * @docs-private
    */
-  @Input()
+  @Input({transform: booleanAttribute})
   override get disabled(): boolean {
     return this.ngControl ? !!this.ngControl.disabled : this._disabled;
   }
-  override set disabled(value: BooleanInput) {
-    this._disabled = coerceBooleanProperty(value);
+  override set disabled(value: boolean) {
+    this._disabled = value;
     this._syncChipsState();
   }
 
@@ -206,12 +212,12 @@ export class MatChipGrid
    * Implemented as part of MatFormFieldControl.
    * @docs-private
    */
-  @Input()
+  @Input({transform: booleanAttribute})
   get required(): boolean {
     return this._required ?? this.ngControl?.control?.hasValidator(Validators.required) ?? false;
   }
-  set required(value: BooleanInput) {
-    this._required = coerceBooleanProperty(value);
+  set required(value: boolean) {
+    this._required = value;
     this.stateChanges.next();
   }
   protected _required: boolean | undefined;

--- a/src/material/chips/chip-input.ts
+++ b/src/material/chips/chip-input.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {BooleanInput, coerceBooleanProperty} from '@angular/cdk/coercion';
 import {BACKSPACE, hasModifierKey} from '@angular/cdk/keycodes';
 import {
   AfterContentInit,
@@ -19,6 +18,7 @@ import {
   OnDestroy,
   Optional,
   Output,
+  booleanAttribute,
 } from '@angular/core';
 import {MatFormField, MAT_FORM_FIELD} from '@angular/material/form-field';
 import {MatChipsDefaultOptions, MAT_CHIPS_DEFAULT_OPTIONS} from './tokens';
@@ -92,14 +92,8 @@ export class MatChipInput implements MatChipTextControl, AfterContentInit, OnCha
   /**
    * Whether or not the chipEnd event will be emitted when the input is blurred.
    */
-  @Input('matChipInputAddOnBlur')
-  get addOnBlur(): boolean {
-    return this._addOnBlur;
-  }
-  set addOnBlur(value: BooleanInput) {
-    this._addOnBlur = coerceBooleanProperty(value);
-  }
-  _addOnBlur: boolean = false;
+  @Input({alias: 'matChipInputAddOnBlur', transform: booleanAttribute})
+  addOnBlur: boolean = false;
 
   /**
    * The list of key codes that will trigger a chipEnd event.
@@ -120,12 +114,12 @@ export class MatChipInput implements MatChipTextControl, AfterContentInit, OnCha
   @Input() id: string = `mat-mdc-chip-list-input-${nextUniqueId++}`;
 
   /** Whether the input is disabled. */
-  @Input()
+  @Input({transform: booleanAttribute})
   get disabled(): boolean {
     return this._disabled || (this._chipGrid && this._chipGrid.disabled);
   }
-  set disabled(value: BooleanInput) {
-    this._disabled = coerceBooleanProperty(value);
+  set disabled(value: boolean) {
+    this._disabled = value;
   }
   private _disabled: boolean = false;
 

--- a/src/material/chips/chip-listbox.ts
+++ b/src/material/chips/chip-listbox.ts
@@ -6,11 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {BooleanInput, coerceBooleanProperty} from '@angular/cdk/coercion';
-import {MatChipAction} from './chip-action';
-import {TAB} from '@angular/cdk/keycodes';
 import {
   AfterContentInit,
+  booleanAttribute,
   ChangeDetectionStrategy,
   Component,
   ContentChildren,
@@ -26,9 +24,11 @@ import {
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
 import {Observable} from 'rxjs';
 import {startWith, takeUntil} from 'rxjs/operators';
+import {TAB} from '@angular/cdk/keycodes';
 import {MatChip, MatChipEvent} from './chip';
 import {MatChipOption, MatChipSelectionChange} from './chip-option';
 import {MatChipSet} from './chip-set';
+import {MatChipAction} from './chip-action';
 import {MAT_CHIPS_DEFAULT_OPTIONS} from './tokens';
 
 /** Change event object that is emitted when the chip listbox value has changed. */
@@ -64,11 +64,10 @@ export const MAT_CHIP_LISTBOX_CONTROL_VALUE_ACCESSOR: any = {
     </div>
   `,
   styleUrls: ['chip-set.css'],
-  inputs: ['tabIndex'],
   host: {
     'class': 'mdc-evolution-chip-set mat-mdc-chip-listbox',
     '[attr.role]': 'role',
-    '[tabIndex]': 'empty ? -1 : tabIndex',
+    '[tabIndex]': '(disabled || empty) ? -1 : tabIndex',
     // TODO: replace this binding with use of AriaDescriber
     '[attr.aria-describedby]': '_ariaDescribedby || null',
     '[attr.aria-required]': 'role ? required : null',
@@ -112,12 +111,12 @@ export class MatChipListbox
   private _defaultOptions = inject(MAT_CHIPS_DEFAULT_OPTIONS, {optional: true});
 
   /** Whether the user should be allowed to select multiple chips. */
-  @Input()
+  @Input({transform: booleanAttribute})
   get multiple(): boolean {
     return this._multiple;
   }
-  set multiple(value: BooleanInput) {
-    this._multiple = coerceBooleanProperty(value);
+  set multiple(value: boolean) {
+    this._multiple = value;
     this._syncListboxProperties();
   }
   private _multiple: boolean = false;
@@ -137,12 +136,12 @@ export class MatChipListbox
    * When a chip listbox is not selectable, the selected states for all
    * the chips inside the chip listbox are always ignored.
    */
-  @Input()
+  @Input({transform: booleanAttribute})
   get selectable(): boolean {
     return this._selectable;
   }
-  set selectable(value: BooleanInput) {
-    this._selectable = coerceBooleanProperty(value);
+  set selectable(value: boolean) {
+    this._selectable = value;
     this._syncListboxProperties();
   }
   protected _selectable: boolean = true;
@@ -155,22 +154,16 @@ export class MatChipListbox
   @Input() compareWith: (o1: any, o2: any) => boolean = (o1: any, o2: any) => o1 === o2;
 
   /** Whether this chip listbox is required. */
-  @Input()
-  get required(): boolean {
-    return this._required;
-  }
-  set required(value: BooleanInput) {
-    this._required = coerceBooleanProperty(value);
-  }
-  protected _required: boolean = false;
+  @Input({transform: booleanAttribute})
+  required: boolean = false;
 
   /** Whether checkmark indicator for single-selection options is hidden. */
-  @Input()
+  @Input({transform: booleanAttribute})
   get hideSingleSelectionIndicator(): boolean {
     return this._hideSingleSelectionIndicator;
   }
-  set hideSingleSelectionIndicator(value: BooleanInput) {
-    this._hideSingleSelectionIndicator = coerceBooleanProperty(value);
+  set hideSingleSelectionIndicator(value: boolean) {
+    this._hideSingleSelectionIndicator = value;
     this._syncListboxProperties();
   }
   private _hideSingleSelectionIndicator: boolean =

--- a/src/material/chips/chip-option.ts
+++ b/src/material/chips/chip-option.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {BooleanInput, coerceBooleanProperty} from '@angular/cdk/coercion';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -16,6 +15,7 @@ import {
   ViewEncapsulation,
   OnInit,
   inject,
+  booleanAttribute,
 } from '@angular/core';
 import {MatChip} from './chip';
 import {MAT_CHIP, MAT_CHIPS_DEFAULT_OPTIONS} from './tokens';
@@ -42,7 +42,6 @@ export class MatChipSelectionChange {
   selector: 'mat-basic-chip-option, [mat-basic-chip-option], mat-chip-option, [mat-chip-option]',
   templateUrl: 'chip-option.html',
   styleUrls: ['chip.css'],
-  inputs: ['color', 'disabled', 'disableRipple', 'tabIndex'],
   host: {
     'class': 'mat-mdc-chip mat-mdc-chip-option',
     '[class.mdc-evolution-chip]': '!_isBasicChip',
@@ -99,23 +98,23 @@ export class MatChipOption extends MatChip implements OnInit {
    * ignored. By default an option chip is selectable, and it becomes
    * non-selectable if its parent chip list is not selectable.
    */
-  @Input()
+  @Input({transform: booleanAttribute})
   get selectable(): boolean {
     return this._selectable && this.chipListSelectable;
   }
-  set selectable(value: BooleanInput) {
-    this._selectable = coerceBooleanProperty(value);
+  set selectable(value: boolean) {
+    this._selectable = value;
     this._changeDetectorRef.markForCheck();
   }
   protected _selectable: boolean = true;
 
   /** Whether the chip is selected. */
-  @Input()
+  @Input({transform: booleanAttribute})
   get selected(): boolean {
     return this._selected;
   }
-  set selected(value: BooleanInput) {
-    this._setSelectedState(coerceBooleanProperty(value), false, true);
+  set selected(value: boolean) {
+    this._setSelectedState(value, false, true);
   }
   private _selected = false;
 

--- a/src/material/chips/chip-row.ts
+++ b/src/material/chips/chip-row.ts
@@ -47,7 +47,6 @@ export interface MatChipEditedEvent extends MatChipEvent {
   selector: 'mat-chip-row, [mat-chip-row], mat-basic-chip-row, [mat-basic-chip-row]',
   templateUrl: 'chip-row.html',
   styleUrls: ['chip.css'],
-  inputs: ['color', 'disabled', 'disableRipple', 'tabIndex'],
   host: {
     'class': 'mat-mdc-chip mat-mdc-chip-row mdc-evolution-chip',
     '[class.mat-mdc-chip-with-avatar]': 'leadingIcon',

--- a/src/material/chips/chip-set.ts
+++ b/src/material/chips/chip-set.ts
@@ -8,7 +8,6 @@
 
 import {FocusKeyManager} from '@angular/cdk/a11y';
 import {Directionality} from '@angular/cdk/bidi';
-import {BooleanInput, coerceBooleanProperty} from '@angular/cdk/coercion';
 import {
   AfterViewInit,
   ChangeDetectionStrategy,
@@ -21,22 +20,13 @@ import {
   Optional,
   QueryList,
   ViewEncapsulation,
+  booleanAttribute,
+  numberAttribute,
 } from '@angular/core';
-import {HasTabIndex, mixinTabIndex} from '@angular/material/core';
 import {merge, Observable, Subject} from 'rxjs';
 import {startWith, switchMap, takeUntil} from 'rxjs/operators';
 import {MatChip, MatChipEvent} from './chip';
 import {MatChipAction} from './chip-action';
-
-/**
- * Boilerplate for applying mixins to MatChipSet.
- * @docs-private
- */
-abstract class MatChipSetBase {
-  abstract disabled: boolean;
-  constructor(_elementRef: ElementRef) {}
-}
-const _MatChipSetMixinBase = mixinTabIndex(MatChipSetBase);
 
 /**
  * Basic container component for the MatChip component.
@@ -59,10 +49,7 @@ const _MatChipSetMixinBase = mixinTabIndex(MatChipSetBase);
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class MatChipSet
-  extends _MatChipSetMixinBase
-  implements AfterViewInit, HasTabIndex, OnDestroy
-{
+export class MatChipSet implements AfterViewInit, OnDestroy {
   /** Index of the last destroyed chip that had focus. */
   private _lastDestroyedFocusedChipIndex: number | null = null;
 
@@ -91,12 +78,12 @@ export class MatChipSet
   }
 
   /** Whether the chip set is disabled. */
-  @Input()
+  @Input({transform: booleanAttribute})
   get disabled(): boolean {
     return this._disabled;
   }
-  set disabled(value: BooleanInput) {
-    this._disabled = coerceBooleanProperty(value);
+  set disabled(value: boolean) {
+    this._disabled = value;
     this._syncChipsState();
   }
   protected _disabled: boolean = false;
@@ -115,6 +102,12 @@ export class MatChipSet
 
     return this.empty ? null : this._defaultRole;
   }
+
+  /** Tabindex of the chip set. */
+  @Input({
+    transform: (value: unknown) => (value == null ? 0 : numberAttribute(value)),
+  })
+  tabIndex: number = 0;
 
   set role(value: string | null) {
     this._explicitRole = value;
@@ -141,9 +134,7 @@ export class MatChipSet
     protected _elementRef: ElementRef<HTMLElement>,
     protected _changeDetectorRef: ChangeDetectorRef,
     @Optional() private _dir: Directionality,
-  ) {
-    super(_elementRef);
-  }
+  ) {}
 
   ngAfterViewInit() {
     this._setUpFocusManagement();

--- a/src/material/chips/chip.ts
+++ b/src/material/chips/chip.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {BooleanInput, coerceBooleanProperty} from '@angular/cdk/coercion';
 import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 import {
   AfterViewInit,
@@ -31,19 +30,13 @@ import {
   OnInit,
   DoCheck,
   inject,
+  booleanAttribute,
+  numberAttribute,
 } from '@angular/core';
 import {DOCUMENT} from '@angular/common';
 import {
-  CanColor,
-  CanDisable,
-  CanDisableRipple,
-  HasTabIndex,
   MatRipple,
   MAT_RIPPLE_GLOBAL_OPTIONS,
-  mixinColor,
-  mixinDisableRipple,
-  mixinTabIndex,
-  mixinDisabled,
   RippleGlobalOptions,
   MatRippleLoader,
 } from '@angular/material/core';
@@ -64,36 +57,18 @@ export interface MatChipEvent {
 }
 
 /**
- * Boilerplate for applying mixins to MatChip.
- * @docs-private
- */
-const _MatChipMixinBase = mixinTabIndex(
-  mixinColor(
-    mixinDisableRipple(
-      mixinDisabled(
-        class {
-          constructor(public _elementRef: ElementRef<HTMLElement>) {}
-        },
-      ),
-    ),
-    'primary',
-  ),
-  -1,
-);
-
-/**
  * Material design styled Chip base component. Used inside the MatChipSet component.
  *
  * Extended by MatChipOption and MatChipRow for different interaction patterns.
  */
 @Component({
   selector: 'mat-basic-chip, [mat-basic-chip], mat-chip, [mat-chip]',
-  inputs: ['color', 'disabled', 'disableRipple', 'tabIndex'],
   exportAs: 'matChip',
   templateUrl: 'chip.html',
   styleUrls: ['chip.css'],
   host: {
     'class': 'mat-mdc-chip',
+    '[class]': '"mat-" + (color || "primary")',
     '[class.mdc-evolution-chip]': '!_isBasicChip',
     '[class.mdc-evolution-chip--disabled]': 'disabled',
     '[class.mdc-evolution-chip--with-trailing-action]': '_hasTrailingIcon()',
@@ -109,7 +84,7 @@ const _MatChipMixinBase = mixinTabIndex(
     '[class._mat-animation-noopable]': '_animationsDisabled',
     '[id]': 'id',
     '[attr.role]': 'role',
-    '[attr.tabindex]': 'role ? tabIndex : null',
+    '[attr.tabindex]': '_getTabIndex()',
     '[attr.aria-label]': 'ariaLabel',
     '(keydown)': '_handleKeydown($event)',
   },
@@ -117,19 +92,7 @@ const _MatChipMixinBase = mixinTabIndex(
   changeDetection: ChangeDetectionStrategy.OnPush,
   providers: [{provide: MAT_CHIP, useExisting: MatChip}],
 })
-export class MatChip
-  extends _MatChipMixinBase
-  implements
-    OnInit,
-    AfterViewInit,
-    AfterContentInit,
-    CanColor,
-    CanDisableRipple,
-    CanDisable,
-    DoCheck,
-    HasTabIndex,
-    OnDestroy
-{
+export class MatChip implements OnInit, AfterViewInit, AfterContentInit, DoCheck, OnDestroy {
   protected _document: Document;
 
   /** Emits when the chip is focused. */
@@ -205,29 +168,35 @@ export class MatChip
   }
   protected _value: any;
 
+  // TODO: should be typed as `ThemePalette` but internal apps pass in arbitrary strings.
+  /** Theme color palette of the chip. */
+  @Input() color?: string | null;
+
   /**
    * Determines whether or not the chip displays the remove styling and emits (removed) events.
    */
-  @Input()
-  get removable(): boolean {
-    return this._removable;
-  }
-  set removable(value: BooleanInput) {
-    this._removable = coerceBooleanProperty(value);
-  }
-  protected _removable: boolean = true;
+  @Input({transform: booleanAttribute})
+  removable: boolean = true;
 
   /**
    * Colors the chip for emphasis as if it were selected.
    */
-  @Input()
-  get highlighted(): boolean {
-    return this._highlighted;
-  }
-  set highlighted(value: BooleanInput) {
-    this._highlighted = coerceBooleanProperty(value);
-  }
-  protected _highlighted: boolean = false;
+  @Input({transform: booleanAttribute})
+  highlighted: boolean = false;
+
+  /** Whether the ripple effect is disabled or not. */
+  @Input({transform: booleanAttribute})
+  disableRipple: boolean = false;
+
+  /** Whether the chip is disabled. */
+  @Input({transform: booleanAttribute})
+  disabled: boolean = false;
+
+  /** Tab index of the chip. */
+  @Input({
+    transform: (value: unknown) => (value == null ? undefined : numberAttribute(value)),
+  })
+  tabIndex: number = -1;
 
   /** Emitted when a chip is to be removed. */
   @Output() readonly removed: EventEmitter<MatChipEvent> = new EventEmitter<MatChipEvent>();
@@ -270,7 +239,7 @@ export class MatChip
 
   constructor(
     public _changeDetectorRef: ChangeDetectorRef,
-    elementRef: ElementRef<HTMLElement>,
+    public _elementRef: ElementRef<HTMLElement>,
     protected _ngZone: NgZone,
     private _focusMonitor: FocusMonitor,
     @Inject(DOCUMENT) _document: any,
@@ -280,11 +249,10 @@ export class MatChip
     private _globalRippleOptions?: RippleGlobalOptions,
     @Attribute('tabindex') tabIndex?: string,
   ) {
-    super(elementRef);
     this._document = _document;
     this._animationsDisabled = animationMode === 'NoopAnimations';
     if (tabIndex != null) {
-      this.tabIndex = parseInt(tabIndex) ?? this.defaultTabIndex;
+      this.tabIndex = parseInt(tabIndex) ?? -1;
     }
     this._monitorFocus();
 
@@ -412,6 +380,14 @@ export class MatChip
   /** Handles interactions with the primary action of the chip. */
   _handlePrimaryActionInteraction() {
     // Empty here, but is overwritten in child classes.
+  }
+
+  /** Gets the tabindex of the chip. */
+  _getTabIndex() {
+    if (!this.role) {
+      return null;
+    }
+    return this.disabled ? -1 : this.tabIndex;
   }
 
   /** Starts the focus monitoring process on the chip. */

--- a/src/material/chips/testing/BUILD.bazel
+++ b/src/material/chips/testing/BUILD.bazel
@@ -9,7 +9,6 @@ ts_library(
         exclude = ["**/*.spec.ts"],
     ),
     deps = [
-        "//src/cdk/coercion",
         "//src/cdk/testing",
     ],
 )

--- a/src/material/datepicker/date-range-input.ts
+++ b/src/material/datepicker/date-range-input.ts
@@ -21,13 +21,13 @@ import {
   Inject,
   OnChanges,
   SimpleChanges,
+  booleanAttribute,
 } from '@angular/core';
 import {MatFormFieldControl, MAT_FORM_FIELD} from '@angular/material/form-field';
 import {ThemePalette, DateAdapter} from '@angular/material/core';
 import {NgControl, ControlContainer, Validators} from '@angular/forms';
 import {Subject, merge, Subscription} from 'rxjs';
 import {FocusOrigin} from '@angular/cdk/a11y';
-import {coerceBooleanProperty, BooleanInput} from '@angular/cdk/coercion';
 import {
   MatStartDate,
   MatEndDate,
@@ -128,7 +128,7 @@ export class MatDateRangeInput<D>
   private _rangePicker: MatDatepickerPanel<MatDatepickerControl<D>, DateRange<D>, D>;
 
   /** Whether the input is required. */
-  @Input()
+  @Input({transform: booleanAttribute})
   get required(): boolean {
     return (
       this._required ??
@@ -138,8 +138,8 @@ export class MatDateRangeInput<D>
       false
     );
   }
-  set required(value: BooleanInput) {
-    this._required = coerceBooleanProperty(value);
+  set required(value: boolean) {
+    this._required = value;
   }
   private _required: boolean | undefined;
 
@@ -196,17 +196,15 @@ export class MatDateRangeInput<D>
   private _max: D | null;
 
   /** Whether the input is disabled. */
-  @Input()
+  @Input({transform: booleanAttribute})
   get disabled(): boolean {
     return this._startInput && this._endInput
       ? this._startInput.disabled && this._endInput.disabled
       : this._groupDisabled;
   }
-  set disabled(value: BooleanInput) {
-    const newValue = coerceBooleanProperty(value);
-
-    if (newValue !== this._groupDisabled) {
-      this._groupDisabled = newValue;
+  set disabled(value: boolean) {
+    if (value !== this._groupDisabled) {
+      this._groupDisabled = value;
       this.stateChanges.next(undefined);
     }
   }

--- a/src/material/datepicker/datepicker-base.ts
+++ b/src/material/datepicker/datepicker-base.ts
@@ -7,7 +7,7 @@
  */
 
 import {Directionality} from '@angular/cdk/bidi';
-import {BooleanInput, coerceBooleanProperty, coerceStringArray} from '@angular/cdk/coercion';
+import {coerceStringArray} from '@angular/cdk/coercion';
 import {
   DOWN_ARROW,
   ESCAPE,
@@ -50,8 +50,9 @@ import {
   SimpleChanges,
   OnInit,
   inject,
+  booleanAttribute,
 } from '@angular/core';
-import {CanColor, DateAdapter, mixinColor, ThemePalette} from '@angular/material/core';
+import {DateAdapter, ThemePalette} from '@angular/material/core';
 import {AnimationEvent} from '@angular/animations';
 import {merge, Subject, Observable, Subscription} from 'rxjs';
 import {filter, take} from 'rxjs/operators';
@@ -99,14 +100,6 @@ export const MAT_DATEPICKER_SCROLL_STRATEGY_FACTORY_PROVIDER = {
   useFactory: MAT_DATEPICKER_SCROLL_STRATEGY_FACTORY,
 };
 
-// Boilerplate for applying mixins to MatDatepickerContent.
-/** @docs-private */
-const _MatDatepickerContentBase = mixinColor(
-  class {
-    constructor(public _elementRef: ElementRef) {}
-  },
-);
-
 /**
  * Component used as the content for the datepicker overlay. We use this instead of using
  * MatCalendar directly as the content so we can control the initial focus. This also gives us a
@@ -120,6 +113,7 @@ const _MatDatepickerContentBase = mixinColor(
   styleUrls: ['datepicker-content.css'],
   host: {
     'class': 'mat-datepicker-content',
+    '[class]': 'color ? "mat-" + color : ""',
     '[@transformPanel]': '_animationState',
     '(@transformPanel.start)': '_handleAnimationEvent($event)',
     '(@transformPanel.done)': '_handleAnimationEvent($event)',
@@ -129,16 +123,17 @@ const _MatDatepickerContentBase = mixinColor(
   exportAs: 'matDatepickerContent',
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  inputs: ['color'],
 })
 export class MatDatepickerContent<S, D = ExtractDateTypeFromSelection<S>>
-  extends _MatDatepickerContentBase
-  implements OnInit, AfterViewInit, OnDestroy, CanColor
+  implements OnInit, AfterViewInit, OnDestroy
 {
   private _subscriptions = new Subscription();
   private _model: MatDateSelectionModel<S, D>;
   /** Reference to the internal calendar component. */
   @ViewChild(MatCalendar) _calendar: MatCalendar<D>;
+
+  /** Palette color of the internal calendar. */
+  @Input() color: ThemePalette;
 
   /** Reference to the datepicker that created the overlay. */
   datepicker: MatDatepickerBase<any, S, D>;
@@ -180,7 +175,7 @@ export class MatDatepickerContent<S, D = ExtractDateTypeFromSelection<S>>
   _dialogLabelId: string | null;
 
   constructor(
-    elementRef: ElementRef,
+    protected _elementRef: ElementRef,
     private _changeDetectorRef: ChangeDetectorRef,
     private _globalModel: MatDateSelectionModel<S, D>,
     private _dateAdapter: DateAdapter<D>,
@@ -189,7 +184,6 @@ export class MatDatepickerContent<S, D = ExtractDateTypeFromSelection<S>>
     private _rangeSelectionStrategy: MatDateRangeSelectionStrategy<D>,
     intl: MatDatepickerIntl,
   ) {
-    super(elementRef);
     this._closeButtonText = intl.closeCalendarLabel;
   }
 
@@ -333,10 +327,11 @@ export interface MatDatepickerPanel<
 /** Base class for a datepicker. */
 @Directive()
 export abstract class MatDatepickerBase<
-  C extends MatDatepickerControl<D>,
-  S,
-  D = ExtractDateTypeFromSelection<S>,
-> implements MatDatepickerPanel<C, S, D>, OnDestroy, OnChanges
+    C extends MatDatepickerControl<D>,
+    S,
+    D = ExtractDateTypeFromSelection<S>,
+  >
+  implements MatDatepickerPanel<C, S, D>, OnDestroy, OnChanges
 {
   private _scrollStrategy: () => ScrollStrategy;
   private _inputStateChanges = Subscription.EMPTY;
@@ -376,27 +371,19 @@ export abstract class MatDatepickerBase<
    * Whether the calendar UI is in touch mode. In touch mode the calendar opens in a dialog rather
    * than a dropdown and elements have more padding to allow for bigger touch targets.
    */
-  @Input()
-  get touchUi(): boolean {
-    return this._touchUi;
-  }
-  set touchUi(value: BooleanInput) {
-    this._touchUi = coerceBooleanProperty(value);
-  }
-  private _touchUi = false;
+  @Input({transform: booleanAttribute})
+  touchUi: boolean = false;
 
   /** Whether the datepicker pop-up should be disabled. */
-  @Input()
+  @Input({transform: booleanAttribute})
   get disabled(): boolean {
     return this._disabled === undefined && this.datepickerInput
       ? this.datepickerInput.disabled
       : !!this._disabled;
   }
-  set disabled(value: BooleanInput) {
-    const newValue = coerceBooleanProperty(value);
-
-    if (newValue !== this._disabled) {
-      this._disabled = newValue;
+  set disabled(value: boolean) {
+    if (value !== this._disabled) {
+      this._disabled = value;
       this.stateChanges.next(undefined);
     }
   }
@@ -415,14 +402,8 @@ export abstract class MatDatepickerBase<
    * Note that automatic focus restoration is an accessibility feature and it is recommended that
    * you provide your own equivalent, if you decide to turn it off.
    */
-  @Input()
-  get restoreFocus(): boolean {
-    return this._restoreFocus;
-  }
-  set restoreFocus(value: BooleanInput) {
-    this._restoreFocus = coerceBooleanProperty(value);
-  }
-  private _restoreFocus = true;
+  @Input({transform: booleanAttribute})
+  restoreFocus: boolean = true;
 
   /**
    * Emits selected year in multiyear view.
@@ -466,12 +447,16 @@ export abstract class MatDatepickerBase<
   private _panelClass: string[];
 
   /** Whether the calendar is open. */
-  @Input()
+  @Input({transform: booleanAttribute})
   get opened(): boolean {
     return this._opened;
   }
-  set opened(value: BooleanInput) {
-    coerceBooleanProperty(value) ? this.open() : this.close();
+  set opened(value: boolean) {
+    if (value) {
+      this.open();
+    } else {
+      this.close();
+    }
   }
   private _opened = false;
 
@@ -639,7 +624,7 @@ export abstract class MatDatepickerBase<
     }
 
     const canRestoreFocus =
-      this._restoreFocus &&
+      this.restoreFocus &&
       this._focusedElementBeforeOpen &&
       typeof this._focusedElementBeforeOpen.focus === 'function';
 

--- a/src/material/datepicker/datepicker-input-base.ts
+++ b/src/material/datepicker/datepicker-input-base.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {BooleanInput, coerceBooleanProperty} from '@angular/cdk/coercion';
 import {DOWN_ARROW, hasModifierKey, ModifierKey} from '@angular/cdk/keycodes';
 import {
   Directive,
@@ -20,6 +19,7 @@ import {
   AfterViewInit,
   OnChanges,
   SimpleChanges,
+  booleanAttribute,
 } from '@angular/core';
 import {
   AbstractControl,
@@ -92,12 +92,12 @@ export abstract class MatDatepickerInputBase<S, D = ExtractDateTypeFromSelection
   protected _model: MatDateSelectionModel<S, D> | undefined;
 
   /** Whether the datepicker-input is disabled. */
-  @Input()
+  @Input({transform: booleanAttribute})
   get disabled(): boolean {
     return !!this._disabled || this._parentDisabled();
   }
-  set disabled(value: BooleanInput) {
-    const newValue = coerceBooleanProperty(value);
+  set disabled(value: boolean) {
+    const newValue = value;
     const element = this._elementRef.nativeElement;
 
     if (this._disabled !== newValue) {

--- a/src/material/datepicker/datepicker-toggle.ts
+++ b/src/material/datepicker/datepicker-toggle.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {BooleanInput, coerceBooleanProperty} from '@angular/cdk/coercion';
 import {
   AfterContentInit,
   Attribute,
@@ -21,6 +20,7 @@ import {
   SimpleChanges,
   ViewEncapsulation,
   ViewChild,
+  booleanAttribute,
 } from '@angular/core';
 import {MatButton} from '@angular/material/button';
 import {merge, Observable, of as observableOf, Subscription} from 'rxjs';
@@ -67,7 +67,7 @@ export class MatDatepickerToggle<D> implements AfterContentInit, OnChanges, OnDe
   @Input('aria-label') ariaLabel: string;
 
   /** Whether the toggle button is disabled. */
-  @Input()
+  @Input({transform: booleanAttribute})
   get disabled(): boolean {
     if (this._disabled === undefined && this.datepicker) {
       return this.datepicker.disabled;
@@ -75,8 +75,8 @@ export class MatDatepickerToggle<D> implements AfterContentInit, OnChanges, OnDe
 
     return !!this._disabled;
   }
-  set disabled(value: BooleanInput) {
-    this._disabled = coerceBooleanProperty(value);
+  set disabled(value: boolean) {
+    this._disabled = value;
   }
   private _disabled: boolean;
 

--- a/src/material/expansion/BUILD.bazel
+++ b/src/material/expansion/BUILD.bazel
@@ -23,7 +23,6 @@ ng_module(
     deps = [
         "//src/cdk/a11y",
         "//src/cdk/accordion",
-        "//src/cdk/coercion",
         "//src/cdk/collections",
         "//src/cdk/keycodes",
         "//src/cdk/portal",

--- a/src/material/expansion/accordion.ts
+++ b/src/material/expansion/accordion.ts
@@ -13,8 +13,8 @@ import {
   QueryList,
   AfterContentInit,
   OnDestroy,
+  booleanAttribute,
 } from '@angular/core';
-import {BooleanInput, coerceBooleanProperty} from '@angular/cdk/coercion';
 import {CdkAccordion} from '@angular/cdk/accordion';
 import {FocusKeyManager} from '@angular/cdk/a11y';
 import {startWith} from 'rxjs/operators';
@@ -60,14 +60,8 @@ export class MatAccordion
   _headers: QueryList<MatExpansionPanelHeader>;
 
   /** Whether the expansion indicator should be hidden. */
-  @Input()
-  get hideToggle(): boolean {
-    return this._hideToggle;
-  }
-  set hideToggle(show: BooleanInput) {
-    this._hideToggle = coerceBooleanProperty(show);
-  }
-  private _hideToggle: boolean = false;
+  @Input({transform: booleanAttribute})
+  hideToggle: boolean = false;
 
   /**
    * Display mode used for all expansion panels in the accordion. Currently two display

--- a/src/material/expansion/expansion-panel-header.ts
+++ b/src/material/expansion/expansion-panel-header.ts
@@ -19,12 +19,12 @@ import {
   Host,
   Inject,
   Input,
+  numberAttribute,
   OnDestroy,
   Optional,
   ViewEncapsulation,
 } from '@angular/core';
 import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
-import {HasTabIndex, mixinTabIndex} from '@angular/material/core';
 import {EMPTY, merge, Subscription} from 'rxjs';
 import {filter} from 'rxjs/operators';
 import {MatAccordionTogglePosition} from './accordion-base';
@@ -35,13 +35,6 @@ import {
   MAT_EXPANSION_PANEL_DEFAULT_OPTIONS,
 } from './expansion-panel';
 
-// Boilerplate for applying mixins to MatExpansionPanelHeader.
-/** @docs-private */
-abstract class MatExpansionPanelHeaderBase {
-  abstract readonly disabled: boolean;
-}
-const _MatExpansionPanelHeaderMixinBase = mixinTabIndex(MatExpansionPanelHeaderBase);
-
 /**
  * Header element of a `<mat-expansion-panel>`.
  */
@@ -51,13 +44,12 @@ const _MatExpansionPanelHeaderMixinBase = mixinTabIndex(MatExpansionPanelHeaderB
   templateUrl: 'expansion-panel-header.html',
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  inputs: ['tabIndex'],
   animations: [matExpansionAnimations.indicatorRotate],
   host: {
     'class': 'mat-expansion-panel-header mat-focus-indicator',
     'role': 'button',
     '[attr.id]': 'panel._headerId',
-    '[attr.tabindex]': 'tabIndex',
+    '[attr.tabindex]': 'disabled ? -1 : tabIndex',
     '[attr.aria-controls]': '_getPanelId()',
     '[attr.aria-expanded]': '_isExpanded()',
     '[attr.aria-disabled]': 'panel.disabled',
@@ -70,10 +62,7 @@ const _MatExpansionPanelHeaderMixinBase = mixinTabIndex(MatExpansionPanelHeaderB
     '(keydown)': '_keydown($event)',
   },
 })
-export class MatExpansionPanelHeader
-  extends _MatExpansionPanelHeaderMixinBase
-  implements AfterViewInit, OnDestroy, FocusableOption, HasTabIndex
-{
+export class MatExpansionPanelHeader implements AfterViewInit, OnDestroy, FocusableOption {
   private _parentChangeSubscription = Subscription.EMPTY;
 
   constructor(
@@ -87,7 +76,6 @@ export class MatExpansionPanelHeader
     @Optional() @Inject(ANIMATION_MODULE_TYPE) public _animationMode?: string,
     @Attribute('tabindex') tabIndex?: string,
   ) {
-    super();
     const accordionHideToggleChange = panel.accordion
       ? panel.accordion._stateChanges.pipe(
           filter(changes => !!(changes['hideToggle'] || changes['togglePosition'])),
@@ -124,6 +112,12 @@ export class MatExpansionPanelHeader
 
   /** Height of the header while the panel is collapsed. */
   @Input() collapsedHeight: string;
+
+  /** Tab index of the header. */
+  @Input({
+    transform: (value: unknown) => (value == null ? 0 : numberAttribute(value)),
+  })
+  tabIndex: number = 0;
 
   /**
    * Whether the associated panel is disabled. Implemented as a part of `FocusableOption`.

--- a/src/material/expansion/expansion-panel.ts
+++ b/src/material/expansion/expansion-panel.ts
@@ -8,7 +8,6 @@
 
 import {AnimationEvent} from '@angular/animations';
 import {CdkAccordionItem} from '@angular/cdk/accordion';
-import {BooleanInput, coerceBooleanProperty} from '@angular/cdk/coercion';
 import {UniqueSelectionDispatcher} from '@angular/cdk/collections';
 import {TemplatePortal} from '@angular/cdk/portal';
 import {DOCUMENT} from '@angular/common';
@@ -33,6 +32,7 @@ import {
   ViewChild,
   ViewContainerRef,
   ViewEncapsulation,
+  booleanAttribute,
 } from '@angular/core';
 import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 import {Subject} from 'rxjs';
@@ -102,17 +102,16 @@ export class MatExpansionPanel
   implements AfterContentInit, OnChanges, OnDestroy
 {
   private _document: Document;
-  private _hideToggle = false;
-  private _togglePosition: MatAccordionTogglePosition;
 
   /** Whether the toggle indicator should be hidden. */
-  @Input()
+  @Input({transform: booleanAttribute})
   get hideToggle(): boolean {
     return this._hideToggle || (this.accordion && this.accordion.hideToggle);
   }
-  set hideToggle(value: BooleanInput) {
-    this._hideToggle = coerceBooleanProperty(value);
+  set hideToggle(value: boolean) {
+    this._hideToggle = value;
   }
+  private _hideToggle = false;
 
   /** The position of the expansion indicator. */
   @Input()
@@ -122,6 +121,7 @@ export class MatExpansionPanel
   set togglePosition(value: MatAccordionTogglePosition) {
     this._togglePosition = value;
   }
+  private _togglePosition: MatAccordionTogglePosition;
 
   /** An event emitted after the body's expansion animation happens. */
   @Output() readonly afterExpand = new EventEmitter<void>();

--- a/src/material/expansion/testing/BUILD.bazel
+++ b/src/material/expansion/testing/BUILD.bazel
@@ -9,7 +9,6 @@ ts_library(
         exclude = ["**/*.spec.ts"],
     ),
     deps = [
-        "//src/cdk/coercion",
         "//src/cdk/testing",
     ],
 )

--- a/src/material/icon/BUILD.bazel
+++ b/src/material/icon/BUILD.bazel
@@ -19,7 +19,6 @@ ng_module(
     assets = [":icon.css"] + glob(["**/*.html"]),
     deps = [
         "//src:dev_mode_types",
-        "//src/cdk/coercion",
         "//src/material/core",
         "@npm//@angular/common",
         "@npm//@angular/core",

--- a/src/material/icon/testing/BUILD.bazel
+++ b/src/material/icon/testing/BUILD.bazel
@@ -9,7 +9,6 @@ ng_module(
         exclude = ["**/*.spec.ts"],
     ),
     deps = [
-        "//src/cdk/coercion",
         "//src/cdk/testing",
         "//src/material/icon",
         "@npm//@angular/common",

--- a/src/material/paginator/BUILD.bazel
+++ b/src/material/paginator/BUILD.bazel
@@ -18,7 +18,6 @@ ng_module(
     ),
     assets = [":paginator.css"] + glob(["**/*.html"]),
     deps = [
-        "//src/cdk/coercion",
         "//src/material/button",
         "//src/material/core",
         "//src/material/select",

--- a/src/material/paginator/paginator.ts
+++ b/src/material/paginator/paginator.ts
@@ -19,22 +19,12 @@ import {
   Optional,
   Output,
   ViewEncapsulation,
+  booleanAttribute,
+  numberAttribute,
 } from '@angular/core';
 import {MatFormFieldAppearance} from '@angular/material/form-field';
-import {
-  CanDisable,
-  HasInitialized,
-  mixinDisabled,
-  mixinInitialized,
-  ThemePalette,
-} from '@angular/material/core';
+import {HasInitialized, mixinInitialized, ThemePalette} from '@angular/material/core';
 import {Subscription} from 'rxjs';
-import {
-  BooleanInput,
-  coerceBooleanProperty,
-  coerceNumberProperty,
-  NumberInput,
-} from '@angular/cdk/coercion';
 import {MatPaginatorIntl} from './paginator-intl';
 
 /** The default page size if there is no page size and there are no provided page size options. */
@@ -99,7 +89,7 @@ export const MAT_PAGINATOR_DEFAULT_OPTIONS = new InjectionToken<MatPaginatorDefa
 
 // Boilerplate for applying mixins to _MatPaginatorBase.
 /** @docs-private */
-const _MatPaginatorMixinBase = mixinDisabled(mixinInitialized(class {}));
+const _MatPaginatorMixinBase = mixinInitialized(class {});
 
 let nextUniqueId = 0;
 
@@ -113,7 +103,6 @@ let nextUniqueId = 0;
   exportAs: 'matPaginator',
   templateUrl: 'paginator.html',
   styleUrls: ['paginator.css'],
-  inputs: ['disabled'],
   host: {
     'class': 'mat-mdc-paginator',
     'role': 'group',
@@ -123,7 +112,7 @@ let nextUniqueId = 0;
 })
 export class MatPaginator
   extends _MatPaginatorMixinBase
-  implements OnInit, OnDestroy, CanDisable, HasInitialized
+  implements OnInit, OnDestroy, HasInitialized
 {
   /** If set, styles the "page size" form field with the designated style. */
   _formFieldAppearance?: MatFormFieldAppearance;
@@ -138,34 +127,34 @@ export class MatPaginator
   @Input() color: ThemePalette;
 
   /** The zero-based page index of the displayed list of items. Defaulted to 0. */
-  @Input()
+  @Input({transform: numberAttribute})
   get pageIndex(): number {
     return this._pageIndex;
   }
-  set pageIndex(value: NumberInput) {
-    this._pageIndex = Math.max(coerceNumberProperty(value), 0);
+  set pageIndex(value: number) {
+    this._pageIndex = Math.max(value || 0, 0);
     this._changeDetectorRef.markForCheck();
   }
   private _pageIndex = 0;
 
   /** The length of the total number of items that are being paginated. Defaulted to 0. */
-  @Input()
+  @Input({transform: numberAttribute})
   get length(): number {
     return this._length;
   }
-  set length(value: NumberInput) {
-    this._length = coerceNumberProperty(value);
+  set length(value: number) {
+    this._length = value || 0;
     this._changeDetectorRef.markForCheck();
   }
   private _length = 0;
 
   /** Number of items to display on a page. By default set to 50. */
-  @Input()
+  @Input({transform: numberAttribute})
   get pageSize(): number {
     return this._pageSize;
   }
-  set pageSize(value: NumberInput) {
-    this._pageSize = Math.max(coerceNumberProperty(value), 0);
+  set pageSize(value: number) {
+    this._pageSize = Math.max(value || 0, 0);
     this._updateDisplayedPageSizeOptions();
   }
   private _pageSize: number;
@@ -176,33 +165,25 @@ export class MatPaginator
     return this._pageSizeOptions;
   }
   set pageSizeOptions(value: number[] | readonly number[]) {
-    this._pageSizeOptions = (value || ([] as number[])).map(p => coerceNumberProperty(p));
+    this._pageSizeOptions = (value || ([] as number[])).map(p => numberAttribute(p, 0));
     this._updateDisplayedPageSizeOptions();
   }
   private _pageSizeOptions: number[] = [];
 
   /** Whether to hide the page size selection UI from the user. */
-  @Input()
-  get hidePageSize(): boolean {
-    return this._hidePageSize;
-  }
-  set hidePageSize(value: BooleanInput) {
-    this._hidePageSize = coerceBooleanProperty(value);
-  }
-  private _hidePageSize = false;
+  @Input({transform: booleanAttribute})
+  hidePageSize: boolean = false;
 
   /** Whether to show the first/last buttons UI to the user. */
-  @Input()
-  get showFirstLastButtons(): boolean {
-    return this._showFirstLastButtons;
-  }
-  set showFirstLastButtons(value: BooleanInput) {
-    this._showFirstLastButtons = coerceBooleanProperty(value);
-  }
-  private _showFirstLastButtons = false;
+  @Input({transform: booleanAttribute})
+  showFirstLastButtons: boolean = false;
 
   /** Used to configure the underlying `MatSelect` inside the paginator. */
   @Input() selectConfig: MatPaginatorSelectConfig = {};
+
+  /** Whether the paginator is disabled. */
+  @Input({transform: booleanAttribute})
+  disabled: boolean = false;
 
   /** Event emitted when the paginator changes the page size or page index. */
   @Output() readonly page: EventEmitter<PageEvent> = new EventEmitter<PageEvent>();
@@ -230,11 +211,11 @@ export class MatPaginator
       }
 
       if (hidePageSize != null) {
-        this._hidePageSize = hidePageSize;
+        this.hidePageSize = hidePageSize;
       }
 
       if (showFirstLastButtons != null) {
-        this._showFirstLastButtons = showFirstLastButtons;
+        this.showFirstLastButtons = showFirstLastButtons;
       }
     }
 

--- a/src/material/progress-bar/progress-bar.ts
+++ b/src/material/progress-bar/progress-bar.ts
@@ -22,11 +22,11 @@ import {
   ChangeDetectorRef,
   InjectionToken,
   inject,
+  numberAttribute,
 } from '@angular/core';
 import {DOCUMENT} from '@angular/common';
-import {CanColor, mixinColor, ThemePalette} from '@angular/material/core';
+import {ThemePalette} from '@angular/material/core';
 import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
-import {coerceNumberProperty, NumberInput} from '@angular/cdk/coercion';
 
 /** Last animation end data. */
 export interface ProgressAnimationEnd {
@@ -77,15 +77,6 @@ export function MAT_PROGRESS_BAR_LOCATION_FACTORY(): MatProgressBarLocation {
   };
 }
 
-// Boilerplate for applying mixins to MatProgressBar.
-/** @docs-private */
-const _MatProgressBarBase = mixinColor(
-  class {
-    constructor(public _elementRef: ElementRef<HTMLElement>) {}
-  },
-  'primary',
-);
-
 export type ProgressBarMode = 'determinate' | 'indeterminate' | 'buffer' | 'query';
 
 @Component({
@@ -101,22 +92,19 @@ export type ProgressBarMode = 'determinate' | 'indeterminate' | 'buffer' | 'quer
     '[attr.aria-valuenow]': '_isIndeterminate() ? null : value',
     '[attr.mode]': 'mode',
     'class': 'mat-mdc-progress-bar mdc-linear-progress',
+    '[class]': '"mat-" + color',
     '[class._mat-animation-noopable]': '_isNoopAnimation',
     '[class.mdc-linear-progress--animation-ready]': '!_isNoopAnimation',
     '[class.mdc-linear-progress--indeterminate]': '_isIndeterminate()',
   },
-  inputs: ['color'],
   templateUrl: 'progress-bar.html',
   styleUrls: ['progress-bar.css'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
 })
-export class MatProgressBar
-  extends _MatProgressBarBase
-  implements AfterViewInit, OnDestroy, CanColor
-{
+export class MatProgressBar implements AfterViewInit, OnDestroy {
   constructor(
-    elementRef: ElementRef<HTMLElement>,
+    readonly _elementRef: ElementRef<HTMLElement>,
     private _ngZone: NgZone,
     private _changeDetectorRef: ChangeDetectorRef,
     @Optional() @Inject(ANIMATION_MODULE_TYPE) public _animationMode?: string,
@@ -124,12 +112,11 @@ export class MatProgressBar
     @Inject(MAT_PROGRESS_BAR_DEFAULT_OPTIONS)
     defaults?: MatProgressBarDefaultOptions,
   ) {
-    super(elementRef);
     this._isNoopAnimation = _animationMode === 'NoopAnimations';
 
     if (defaults) {
       if (defaults.color) {
-        this.color = this.defaultColor = defaults.color;
+        this.color = this._defaultColor = defaults.color;
       }
 
       this.mode = defaults.mode || this.mode;
@@ -139,24 +126,36 @@ export class MatProgressBar
   /** Flag that indicates whether NoopAnimations mode is set to true. */
   _isNoopAnimation = false;
 
-  /** Value of the progress bar. Defaults to zero. Mirrored to aria-valuenow. */
+  // TODO: should be typed as `ThemePalette` but internal apps pass in arbitrary strings.
+  /** Theme palette color of the progress bar. */
   @Input()
+  get color() {
+    return this._color || this._defaultColor;
+  }
+  set color(value: string | null | undefined) {
+    this._color = value;
+  }
+  private _color: string | null | undefined;
+  private _defaultColor: ThemePalette = 'primary';
+
+  /** Value of the progress bar. Defaults to zero. Mirrored to aria-valuenow. */
+  @Input({transform: numberAttribute})
   get value(): number {
     return this._value;
   }
-  set value(v: NumberInput) {
-    this._value = clamp(coerceNumberProperty(v));
+  set value(v: number) {
+    this._value = clamp(v || 0);
     this._changeDetectorRef.markForCheck();
   }
   private _value = 0;
 
   /** Buffer value of the progress bar. Defaults to zero. */
-  @Input()
+  @Input({transform: numberAttribute})
   get bufferValue(): number {
     return this._bufferValue || 0;
   }
-  set bufferValue(v: NumberInput) {
-    this._bufferValue = clamp(coerceNumberProperty(v));
+  set bufferValue(v: number) {
+    this._bufferValue = clamp(v || 0);
     this._changeDetectorRef.markForCheck();
   }
   private _bufferValue = 0;

--- a/src/material/progress-spinner/progress-spinner.ts
+++ b/src/material/progress-spinner/progress-spinner.ts
@@ -16,18 +16,10 @@ import {
   Optional,
   ViewChild,
   ViewEncapsulation,
+  numberAttribute,
 } from '@angular/core';
-import {CanColor, mixinColor, ThemePalette} from '@angular/material/core';
+import {ThemePalette} from '@angular/material/core';
 import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
-import {coerceNumberProperty, NumberInput} from '@angular/cdk/coercion';
-
-// Boilerplate for applying mixins to MatProgressBar.
-const _MatProgressSpinnerBase = mixinColor(
-  class {
-    constructor(public _elementRef: ElementRef) {}
-  },
-  'primary',
-);
 
 /** Possible mode for a progress spinner. */
 export type ProgressSpinnerMode = 'determinate' | 'indeterminate';
@@ -78,6 +70,7 @@ const BASE_STROKE_WIDTH = 10;
     // set tab index to -1 so screen readers will read the aria-label
     // Note: there is a known issue with JAWS that does not read progressbar aria labels on FireFox
     'tabindex': '-1',
+    '[class]': '"mat-" + color',
     '[class._mat-animation-noopable]': `_noopAnimations`,
     '[class.mdc-circular-progress--indeterminate]': 'mode === "indeterminate"',
     '[style.width.px]': 'diameter',
@@ -89,32 +82,46 @@ const BASE_STROKE_WIDTH = 10;
     '[attr.aria-valuenow]': 'mode === "determinate" ? value : null',
     '[attr.mode]': 'mode',
   },
-  inputs: ['color'],
   templateUrl: 'progress-spinner.html',
   styleUrls: ['progress-spinner.css'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
 })
-export class MatProgressSpinner extends _MatProgressSpinnerBase implements CanColor {
+export class MatProgressSpinner {
   /** Whether the _mat-animation-noopable class should be applied, disabling animations.  */
   _noopAnimations: boolean;
+
+  // TODO: should be typed as `ThemePalette` but internal apps pass in arbitrary strings.
+  /** Theme palette color of the progress spinner. */
+  @Input()
+  get color() {
+    return this._color || this._defaultColor;
+  }
+  set color(value: string | null | undefined) {
+    this._color = value;
+  }
+  private _color: string | null | undefined;
+  private _defaultColor: ThemePalette = 'primary';
 
   /** The element of the determinate spinner. */
   @ViewChild('determinateSpinner') _determinateCircle: ElementRef<HTMLElement>;
 
   constructor(
-    elementRef: ElementRef<HTMLElement>,
+    readonly _elementRef: ElementRef<HTMLElement>,
     @Optional() @Inject(ANIMATION_MODULE_TYPE) animationMode: string,
     @Inject(MAT_PROGRESS_SPINNER_DEFAULT_OPTIONS)
     defaults?: MatProgressSpinnerDefaultOptions,
   ) {
-    super(elementRef);
     this._noopAnimations =
       animationMode === 'NoopAnimations' && !!defaults && !defaults._forceAnimations;
+    this.mode =
+      _elementRef.nativeElement.nodeName.toLowerCase() === 'mat-spinner'
+        ? 'indeterminate'
+        : 'determinate';
 
     if (defaults) {
       if (defaults.color) {
-        this.color = this.defaultColor = defaults.color;
+        this.color = this._defaultColor = defaults.color;
       }
 
       if (defaults.diameter) {
@@ -134,38 +141,35 @@ export class MatProgressSpinner extends _MatProgressSpinnerBase implements CanCo
    * 'determinate'.
    * Mirrored to mode attribute.
    */
-  @Input() mode: ProgressSpinnerMode =
-    this._elementRef.nativeElement.nodeName.toLowerCase() === 'mat-spinner'
-      ? 'indeterminate'
-      : 'determinate';
+  @Input() mode: ProgressSpinnerMode;
 
   /** Value of the progress bar. Defaults to zero. Mirrored to aria-valuenow. */
-  @Input()
+  @Input({transform: numberAttribute})
   get value(): number {
     return this.mode === 'determinate' ? this._value : 0;
   }
-  set value(v: NumberInput) {
-    this._value = Math.max(0, Math.min(100, coerceNumberProperty(v)));
+  set value(v: number) {
+    this._value = Math.max(0, Math.min(100, v || 0));
   }
   private _value = 0;
 
   /** The diameter of the progress spinner (will set width and height of svg). */
-  @Input()
+  @Input({transform: numberAttribute})
   get diameter(): number {
     return this._diameter;
   }
-  set diameter(size: NumberInput) {
-    this._diameter = coerceNumberProperty(size);
+  set diameter(size: number) {
+    this._diameter = size || 0;
   }
   private _diameter = BASE_SIZE;
 
   /** Stroke width of the progress spinner. */
-  @Input()
+  @Input({transform: numberAttribute})
   get strokeWidth(): number {
     return this._strokeWidth ?? this.diameter / 10;
   }
-  set strokeWidth(value: NumberInput) {
-    this._strokeWidth = coerceNumberProperty(value);
+  set strokeWidth(value: number) {
+    this._strokeWidth = value || 0;
   }
   private _strokeWidth: number;
 

--- a/src/material/radio/BUILD.bazel
+++ b/src/material/radio/BUILD.bazel
@@ -19,7 +19,6 @@ ng_module(
     assets = [":radio_scss"] + glob(["**/*.html"]),
     deps = [
         "//src/cdk/a11y",
-        "//src/cdk/coercion",
         "//src/cdk/collections",
         "//src/material/core",
         "@npm//@angular/forms",

--- a/src/material/radio/radio.spec.ts
+++ b/src/material/radio/radio.spec.ts
@@ -79,7 +79,7 @@ describe('MDC-based MatRadio', () => {
     });
 
     it('should coerce the disabled binding on the radio group', () => {
-      (groupInstance as any).disabled = '';
+      (testComponent as any).isGroupDisabled = '';
       fixture.detectChanges();
 
       radioLabelElements[0].click();

--- a/src/material/radio/radio.ts
+++ b/src/material/radio/radio.ts
@@ -10,6 +10,7 @@ import {
   AfterContentInit,
   AfterViewInit,
   Attribute,
+  booleanAttribute,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
@@ -22,6 +23,7 @@ import {
   Inject,
   InjectionToken,
   Input,
+  numberAttribute,
   OnDestroy,
   OnInit,
   Optional,
@@ -30,15 +32,8 @@ import {
   ViewChild,
   ViewEncapsulation,
 } from '@angular/core';
-import {
-  CanDisableRipple,
-  HasTabIndex,
-  mixinDisableRipple,
-  mixinTabIndex,
-  ThemePalette,
-} from '@angular/material/core';
+import {ThemePalette} from '@angular/material/core';
 import {FocusMonitor, FocusOrigin} from '@angular/cdk/a11y';
-import {BooleanInput, coerceBooleanProperty, coerceNumberProperty} from '@angular/cdk/coercion';
 import {UniqueSelectionDispatcher} from '@angular/cdk/collections';
 import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
@@ -217,22 +212,22 @@ export class MatRadioGroup implements AfterContentInit, OnDestroy, ControlValueA
   }
 
   /** Whether the radio group is disabled */
-  @Input()
+  @Input({transform: booleanAttribute})
   get disabled(): boolean {
     return this._disabled;
   }
-  set disabled(value: BooleanInput) {
-    this._disabled = coerceBooleanProperty(value);
+  set disabled(value: boolean) {
+    this._disabled = value;
     this._markRadiosForCheck();
   }
 
   /** Whether the radio group is required */
-  @Input()
+  @Input({transform: booleanAttribute})
   get required(): boolean {
     return this._required;
   }
-  set required(value: BooleanInput) {
-    this._required = coerceBooleanProperty(value);
+  set required(value: boolean) {
+    this._required = value;
     this._markRadiosForCheck();
   }
 
@@ -348,18 +343,6 @@ export class MatRadioGroup implements AfterContentInit, OnDestroy, ControlValueA
   }
 }
 
-// Boilerplate for applying mixins to MatRadioButton.
-/** @docs-private */
-abstract class MatRadioButtonBase {
-  // Since the disabled property is manually defined for the MatRadioButton and isn't set up in
-  // the mixin base class. To be able to use the tabindex mixin, a disabled property must be
-  // defined to properly work.
-  abstract disabled: boolean;
-  constructor(public _elementRef: ElementRef) {}
-}
-
-const _MatRadioButtonMixinBase = mixinDisableRipple(mixinTabIndex(MatRadioButtonBase));
-
 @Component({
   selector: 'mat-radio-button',
   templateUrl: 'radio.html',
@@ -382,15 +365,11 @@ const _MatRadioButtonMixinBase = mixinDisableRipple(mixinTabIndex(MatRadioButton
     // the focus to the native element.
     '(focus)': '_inputElement.nativeElement.focus()',
   },
-  inputs: ['disableRipple', 'tabIndex'],
   exportAs: 'matRadioButton',
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class MatRadioButton
-  extends _MatRadioButtonMixinBase
-  implements OnInit, AfterViewInit, DoCheck, OnDestroy, CanDisableRipple, HasTabIndex
-{
+export class MatRadioButton implements OnInit, AfterViewInit, DoCheck, OnDestroy {
   private _uniqueId: string = `mat-radio-${++nextUniqueId}`;
 
   /** The unique ID for the radio button. */
@@ -408,24 +387,33 @@ export class MatRadioButton
   /** The 'aria-describedby' attribute is read after the element's label and field type. */
   @Input('aria-describedby') ariaDescribedby: string;
 
+  /** Whether ripples are disabled inside the radio button */
+  @Input({transform: booleanAttribute})
+  disableRipple: boolean = false;
+
+  /** Tabindex of the radio button. */
+  @Input({
+    transform: (value: unknown) => (value == null ? 0 : numberAttribute(value)),
+  })
+  tabIndex: number = 0;
+
   /** Whether this radio button is checked. */
-  @Input()
+  @Input({transform: booleanAttribute})
   get checked(): boolean {
     return this._checked;
   }
-  set checked(value: BooleanInput) {
-    const newCheckedState = coerceBooleanProperty(value);
-    if (this._checked !== newCheckedState) {
-      this._checked = newCheckedState;
-      if (newCheckedState && this.radioGroup && this.radioGroup.value !== this.value) {
+  set checked(value: boolean) {
+    if (this._checked !== value) {
+      this._checked = value;
+      if (value && this.radioGroup && this.radioGroup.value !== this.value) {
         this.radioGroup.selected = this;
-      } else if (!newCheckedState && this.radioGroup && this.radioGroup.value === this.value) {
+      } else if (!value && this.radioGroup && this.radioGroup.value === this.value) {
         // When unchecking the selected radio button, update the selected radio
         // property on the group.
         this.radioGroup.selected = null;
       }
 
-      if (newCheckedState) {
+      if (value) {
         // Notify all radio buttons with the same name to un-check.
         this._radioDispatcher.notify(this.id, this.name);
       }
@@ -464,21 +452,21 @@ export class MatRadioButton
   private _labelPosition: 'before' | 'after';
 
   /** Whether the radio button is disabled. */
-  @Input()
+  @Input({transform: booleanAttribute})
   get disabled(): boolean {
     return this._disabled || (this.radioGroup !== null && this.radioGroup.disabled);
   }
-  set disabled(value: BooleanInput) {
-    this._setDisabled(coerceBooleanProperty(value));
+  set disabled(value: boolean) {
+    this._setDisabled(value);
   }
 
   /** Whether the radio button is required. */
-  @Input()
+  @Input({transform: booleanAttribute})
   get required(): boolean {
     return this._required || (this.radioGroup && this.radioGroup.required);
   }
-  set required(value: BooleanInput) {
-    this._required = coerceBooleanProperty(value);
+  set required(value: boolean) {
+    this._required = value;
   }
 
   /** Theme color of the radio button. */
@@ -539,7 +527,7 @@ export class MatRadioButton
 
   constructor(
     @Optional() @Inject(MAT_RADIO_GROUP) radioGroup: MatRadioGroup,
-    elementRef: ElementRef,
+    protected _elementRef: ElementRef,
     private _changeDetector: ChangeDetectorRef,
     private _focusMonitor: FocusMonitor,
     private _radioDispatcher: UniqueSelectionDispatcher,
@@ -549,15 +537,13 @@ export class MatRadioButton
     private _providerOverride?: MatRadioDefaultOptions,
     @Attribute('tabindex') tabIndex?: string,
   ) {
-    super(elementRef);
-
     // Assertions. Ideally these should be stripped out by the compiler.
     // TODO(jelbourn): Assert that there's no name binding AND a parent radio group.
     this.radioGroup = radioGroup;
     this._noopAnimations = animationMode === 'NoopAnimations';
 
     if (tabIndex) {
-      this.tabIndex = coerceNumberProperty(tabIndex, 0);
+      this.tabIndex = numberAttribute(tabIndex, 0);
     }
   }
 

--- a/src/material/select/BUILD.bazel
+++ b/src/material/select/BUILD.bazel
@@ -23,7 +23,6 @@ ng_module(
         "//src:dev_mode_types",
         "//src/cdk/a11y",
         "//src/cdk/bidi",
-        "//src/cdk/coercion",
         "//src/cdk/collections",
         "//src/cdk/keycodes",
         "//src/cdk/overlay",

--- a/src/material/slider/BUILD.bazel
+++ b/src/material/slider/BUILD.bazel
@@ -24,7 +24,6 @@ ng_module(
     ] + glob(["**/*.html"]),
     deps = [
         "//src/cdk/bidi",
-        "//src/cdk/coercion",
         "//src/cdk/platform",
         "//src/material/core",
         "@npm//@angular/forms",

--- a/src/material/slider/slider-input.ts
+++ b/src/material/slider/slider-input.ts
@@ -7,12 +7,7 @@
  */
 
 import {
-  BooleanInput,
-  coerceBooleanProperty,
-  coerceNumberProperty,
-  NumberInput,
-} from '@angular/cdk/coercion';
-import {
+  booleanAttribute,
   ChangeDetectorRef,
   Directive,
   ElementRef,
@@ -22,6 +17,7 @@ import {
   Inject,
   Input,
   NgZone,
+  numberAttribute,
   OnDestroy,
   Output,
 } from '@angular/core';
@@ -87,20 +83,21 @@ export const MAT_SLIDER_RANGE_THUMB_VALUE_ACCESSOR: any = {
   ],
 })
 export class MatSliderThumb implements _MatSliderThumb, OnDestroy, ControlValueAccessor {
-  @Input()
+  @Input({transform: numberAttribute})
   get value(): number {
-    return coerceNumberProperty(this._hostElement.value);
+    return numberAttribute(this._hostElement.value, 0);
   }
-  set value(v: NumberInput) {
-    const val = coerceNumberProperty(v).toString();
+  set value(value: number) {
+    value = isNaN(value) ? 0 : value;
+    const stringValue = value + '';
     if (!this._hasSetInitialValue) {
-      this._initialValue = val;
+      this._initialValue = stringValue;
       return;
     }
     if (this._isActive) {
       return;
     }
-    this._hostElement.value = val;
+    this._hostElement.value = stringValue;
     this._updateThumbUIByValue();
     this._slider._onValueChange(this);
     this._cdr.detectChanges();
@@ -144,36 +141,36 @@ export class MatSliderThumb implements _MatSliderThumb, OnDestroy, ControlValueA
 
   /** @docs-private */
   get min(): number {
-    return coerceNumberProperty(this._hostElement.min);
+    return numberAttribute(this._hostElement.min, 0);
   }
-  set min(v: NumberInput) {
-    this._hostElement.min = coerceNumberProperty(v).toString();
+  set min(v: number) {
+    this._hostElement.min = v + '';
     this._cdr.detectChanges();
   }
 
   /** @docs-private */
   get max(): number {
-    return coerceNumberProperty(this._hostElement.max);
+    return numberAttribute(this._hostElement.max, 0);
   }
-  set max(v: NumberInput) {
-    this._hostElement.max = coerceNumberProperty(v).toString();
+  set max(v: number) {
+    this._hostElement.max = v + '';
     this._cdr.detectChanges();
   }
 
   get step(): number {
-    return coerceNumberProperty(this._hostElement.step);
+    return numberAttribute(this._hostElement.step, 0);
   }
-  set step(v: NumberInput) {
-    this._hostElement.step = coerceNumberProperty(v).toString();
+  set step(v: number) {
+    this._hostElement.step = v + '';
     this._cdr.detectChanges();
   }
 
   /** @docs-private */
   get disabled(): boolean {
-    return coerceBooleanProperty(this._hostElement.disabled);
+    return booleanAttribute(this._hostElement.disabled);
   }
-  set disabled(v: BooleanInput) {
-    this._hostElement.disabled = coerceBooleanProperty(v);
+  set disabled(v: boolean) {
+    this._hostElement.disabled = v;
     this._cdr.detectChanges();
 
     if (this._slider.disabled !== this.disabled) {

--- a/src/material/slider/slider.ts
+++ b/src/material/slider/slider.ts
@@ -7,15 +7,10 @@
  */
 
 import {Directionality} from '@angular/cdk/bidi';
-import {
-  BooleanInput,
-  coerceBooleanProperty,
-  coerceNumberProperty,
-  NumberInput,
-} from '@angular/cdk/coercion';
 import {Platform} from '@angular/cdk/platform';
 import {
   AfterViewInit,
+  booleanAttribute,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
@@ -26,6 +21,7 @@ import {
   Inject,
   Input,
   NgZone,
+  numberAttribute,
   OnDestroy,
   Optional,
   QueryList,
@@ -33,13 +29,7 @@ import {
   ViewChildren,
   ViewEncapsulation,
 } from '@angular/core';
-import {
-  CanDisableRipple,
-  MAT_RIPPLE_GLOBAL_OPTIONS,
-  mixinColor,
-  mixinDisableRipple,
-  RippleGlobalOptions,
-} from '@angular/material/core';
+import {MAT_RIPPLE_GLOBAL_OPTIONS, RippleGlobalOptions, ThemePalette} from '@angular/material/core';
 import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 import {Subscription} from 'rxjs';
 import {
@@ -60,16 +50,6 @@ import {
 // 2. tab to disable checkbox
 // 3. without ending drag, disable the slider
 
-// Boilerplate for applying mixins to MatSlider.
-const _MatSliderMixinBase = mixinColor(
-  mixinDisableRipple(
-    class {
-      constructor(public _elementRef: ElementRef<HTMLElement>) {}
-    },
-  ),
-  'primary',
-);
-
 /**
  * Allows users to select from a range of values by moving the slider thumb. It is similar in
  * behavior to the native `<input type="range">` element.
@@ -80,6 +60,7 @@ const _MatSliderMixinBase = mixinColor(
   styleUrls: ['slider.css'],
   host: {
     'class': 'mat-mdc-slider mdc-slider',
+    '[class]': '"mat-" + (color || "primary")',
     '[class.mdc-slider--range]': '_isRange',
     '[class.mdc-slider--disabled]': 'disabled',
     '[class.mdc-slider--discrete]': 'discrete',
@@ -89,13 +70,9 @@ const _MatSliderMixinBase = mixinColor(
   exportAs: 'matSlider',
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
-  inputs: ['color', 'disableRipple'],
   providers: [{provide: MAT_SLIDER, useExisting: MatSlider}],
 })
-export class MatSlider
-  extends _MatSliderMixinBase
-  implements AfterViewInit, CanDisableRipple, OnDestroy, _MatSlider
-{
+export class MatSlider implements AfterViewInit, OnDestroy, _MatSlider {
   /** The active portion of the slider track. */
   @ViewChild('trackActive') _trackActive: ElementRef<HTMLElement>;
 
@@ -110,12 +87,12 @@ export class MatSlider
   _inputs: QueryList<_MatSliderRangeThumb>;
 
   /** Whether the slider is disabled. */
-  @Input()
+  @Input({transform: booleanAttribute})
   get disabled(): boolean {
     return this._disabled;
   }
-  set disabled(v: BooleanInput) {
-    this._disabled = coerceBooleanProperty(v);
+  set disabled(v: boolean) {
+    this._disabled = v;
     const endInput = this._getInput(_MatThumb.END);
     const startInput = this._getInput(_MatThumb.START);
 
@@ -129,38 +106,40 @@ export class MatSlider
   private _disabled: boolean = false;
 
   /** Whether the slider displays a numeric value label upon pressing the thumb. */
-  @Input()
+  @Input({transform: booleanAttribute})
   get discrete(): boolean {
     return this._discrete;
   }
-  set discrete(v: BooleanInput) {
-    this._discrete = coerceBooleanProperty(v);
+  set discrete(v: boolean) {
+    this._discrete = v;
     this._updateValueIndicatorUIs();
   }
   private _discrete: boolean = false;
 
   /** Whether the slider displays tick marks along the slider track. */
-  @Input()
-  get showTickMarks(): boolean {
-    return this._showTickMarks;
-  }
-  set showTickMarks(v: BooleanInput) {
-    this._showTickMarks = coerceBooleanProperty(v);
-  }
-  private _showTickMarks: boolean = false;
+  @Input({transform: booleanAttribute})
+  showTickMarks: boolean = false;
 
   /** The minimum value that the slider can have. */
-  @Input()
+  @Input({transform: numberAttribute})
   get min(): number {
     return this._min;
   }
-  set min(v: NumberInput) {
-    const min = coerceNumberProperty(v, this._min);
+  set min(v: number) {
+    const min = isNaN(v) ? this._min : v;
     if (this._min !== min) {
       this._updateMin(min);
     }
   }
   private _min: number = 0;
+
+  /** Palette color of the slider. */
+  @Input()
+  color: ThemePalette;
+
+  /** Whether ripples are disabled in the slider. */
+  @Input({transform: booleanAttribute})
+  disableRipple: boolean = false;
 
   private _updateMin(min: number): void {
     const prevMin = this._min;
@@ -212,12 +191,12 @@ export class MatSlider
   }
 
   /** The maximum value that the slider can have. */
-  @Input()
+  @Input({transform: numberAttribute})
   get max(): number {
     return this._max;
   }
-  set max(v: NumberInput) {
-    const max = coerceNumberProperty(v, this._max);
+  set max(v: number) {
+    const max = isNaN(v) ? this._max : v;
     if (this._max !== max) {
       this._updateMax(max);
     }
@@ -274,12 +253,12 @@ export class MatSlider
   }
 
   /** The values at which the thumb will snap. */
-  @Input()
+  @Input({transform: numberAttribute})
   get step(): number {
     return this._step;
   }
-  set step(v: NumberInput) {
-    const step = coerceNumberProperty(v, this._step);
+  set step(v: number) {
+    const step = isNaN(v) ? this._step : v;
     if (this._step !== step) {
       this._updateStep(step);
     }
@@ -410,14 +389,13 @@ export class MatSlider
   constructor(
     readonly _ngZone: NgZone,
     readonly _cdr: ChangeDetectorRef,
-    elementRef: ElementRef<HTMLElement>,
+    readonly _elementRef: ElementRef<HTMLElement>,
     @Optional() readonly _dir: Directionality,
     @Optional()
     @Inject(MAT_RIPPLE_GLOBAL_OPTIONS)
     readonly _globalRippleOptions?: RippleGlobalOptions,
     @Optional() @Inject(ANIMATION_MODULE_TYPE) animationMode?: string,
   ) {
-    super(elementRef);
     this._noopAnimations = animationMode === 'NoopAnimations';
     this._dirChangeSubscription = this._dir.change.subscribe(() => this._onDirChange());
     this._isRtl = this._dir.value === 'rtl';

--- a/src/material/sort/BUILD.bazel
+++ b/src/material/sort/BUILD.bazel
@@ -20,7 +20,6 @@ ng_module(
     deps = [
         "//src:dev_mode_types",
         "//src/cdk/a11y",
-        "//src/cdk/coercion",
         "//src/cdk/keycodes",
         "//src/material/core",
         "@npm//@angular/animations",

--- a/src/material/sort/sort-header.ts
+++ b/src/material/sort/sort-header.ts
@@ -7,7 +7,6 @@
  */
 
 import {AriaDescriber, FocusMonitor} from '@angular/cdk/a11y';
-import {BooleanInput, coerceBooleanProperty} from '@angular/cdk/coercion';
 import {ENTER, SPACE} from '@angular/cdk/keycodes';
 import {
   AfterViewInit,
@@ -21,8 +20,8 @@ import {
   OnInit,
   Optional,
   ViewEncapsulation,
+  booleanAttribute,
 } from '@angular/core';
-import {CanDisable, mixinDisabled} from '@angular/material/core';
 import {merge, Subscription} from 'rxjs';
 import {
   MAT_SORT_DEFAULT_OPTIONS,
@@ -35,10 +34,6 @@ import {matSortAnimations} from './sort-animations';
 import {SortDirection} from './sort-direction';
 import {getSortHeaderNotContainedWithinSortError} from './sort-errors';
 import {MatSortHeaderIntl} from './sort-header-intl';
-
-// Boilerplate for applying mixins to the sort header.
-/** @docs-private */
-const _MatSortHeaderBase = mixinDisabled(class {});
 
 /**
  * Valid positions for the arrow to be in for its opacity and translation. If the state is a
@@ -90,7 +85,6 @@ interface MatSortHeaderColumnDef {
   },
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  inputs: ['disabled'],
   animations: [
     matSortAnimations.indicator,
     matSortAnimations.leftPointer,
@@ -100,10 +94,7 @@ interface MatSortHeaderColumnDef {
     matSortAnimations.allowChildren,
   ],
 })
-export class MatSortHeader
-  extends _MatSortHeaderBase
-  implements CanDisable, MatSortable, OnDestroy, OnInit, AfterViewInit
-{
+export class MatSortHeader implements MatSortable, OnDestroy, OnInit, AfterViewInit {
   private _rerenderSubscription: Subscription;
 
   /**
@@ -145,6 +136,10 @@ export class MatSortHeader
   /** Overrides the sort start value of the containing MatSort for this MatSortable. */
   @Input() start: SortDirection;
 
+  /** whether the sort header is disabled. */
+  @Input({transform: booleanAttribute})
+  disabled: boolean = false;
+
   /**
    * Description applied to MatSortHeader's button element with aria-describedby. This text should
    * describe the action that will occur when the user clicks the sort header.
@@ -162,14 +157,8 @@ export class MatSortHeader
   private _sortActionDescription: string = 'Sort';
 
   /** Overrides the disable clear value of the containing MatSort for this MatSortable. */
-  @Input()
-  get disableClear(): boolean {
-    return this._disableClear;
-  }
-  set disableClear(v: BooleanInput) {
-    this._disableClear = coerceBooleanProperty(v);
-  }
-  private _disableClear: boolean;
+  @Input({transform: booleanAttribute})
+  disableClear: boolean;
 
   constructor(
     /**
@@ -196,8 +185,6 @@ export class MatSortHeader
     // `material/table` and `cdk/table` and we can't have the CDK depending on Material,
     // and we want to avoid having the sort header depending on the CDK table because
     // of this single reference.
-    super();
-
     if (!_sort && (typeof ngDevMode === 'undefined' || ngDevMode)) {
       throw getSortHeaderNotContainedWithinSortError();
     }

--- a/src/material/sort/sort.ts
+++ b/src/material/sort/sort.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {BooleanInput, coerceBooleanProperty} from '@angular/cdk/coercion';
 import {
   Directive,
   EventEmitter,
@@ -18,8 +17,9 @@ import {
   OnInit,
   Optional,
   Output,
+  booleanAttribute,
 } from '@angular/core';
-import {CanDisable, HasInitialized, mixinDisabled, mixinInitialized} from '@angular/material/core';
+import {HasInitialized, mixinInitialized} from '@angular/material/core';
 import {Subject} from 'rxjs';
 import {SortDirection} from './sort-direction';
 import {
@@ -67,7 +67,7 @@ export const MAT_SORT_DEFAULT_OPTIONS = new InjectionToken<MatSortDefaultOptions
 
 // Boilerplate for applying mixins to MatSort.
 /** @docs-private */
-const _MatSortBase = mixinInitialized(mixinDisabled(class {}));
+const _MatSortBase = mixinInitialized(class {});
 
 /** Container for MatSortables to manage the sort state and provide default sort parameters. */
 @Directive({
@@ -76,12 +76,8 @@ const _MatSortBase = mixinInitialized(mixinDisabled(class {}));
   host: {
     'class': 'mat-sort',
   },
-  inputs: ['disabled: matSortDisabled'],
 })
-export class MatSort
-  extends _MatSortBase
-  implements CanDisable, HasInitialized, OnChanges, OnDestroy, OnInit
-{
+export class MatSort extends _MatSortBase implements HasInitialized, OnChanges, OnDestroy, OnInit {
   /** Collection of all registered sortables that this directive manages. */
   sortables = new Map<string, MatSortable>();
 
@@ -119,14 +115,12 @@ export class MatSort
    * Whether to disable the user from clearing the sort by finishing the sort direction cycle.
    * May be overridden by the MatSortable's disable clear input.
    */
-  @Input('matSortDisableClear')
-  get disableClear(): boolean {
-    return this._disableClear;
-  }
-  set disableClear(v: BooleanInput) {
-    this._disableClear = coerceBooleanProperty(v);
-  }
-  private _disableClear: boolean;
+  @Input({alias: 'matSortDisableClear', transform: booleanAttribute})
+  disableClear: boolean;
+
+  /** Whether the sortable is disabled. */
+  @Input({alias: 'matSortDisabled', transform: booleanAttribute})
+  disabled: boolean = false;
 
   /** Event emitted when the user changes either the active sort or sort direction. */
   @Output('matSortChange') readonly sortChange: EventEmitter<Sort> = new EventEmitter<Sort>();

--- a/src/material/stepper/step-header.ts
+++ b/src/material/stepper/step-header.ts
@@ -23,35 +23,21 @@ import {MatStepLabel} from './step-label';
 import {MatStepperIntl} from './stepper-intl';
 import {MatStepperIconContext} from './stepper-icon';
 import {CdkStepHeader, StepState} from '@angular/cdk/stepper';
-import {mixinColor, CanColor} from '@angular/material/core';
-
-// Boilerplate for applying mixins to MatStepHeader.
-/** @docs-private */
-const _MatStepHeaderBase = mixinColor(
-  class MatStepHeaderBase extends CdkStepHeader {
-    constructor(elementRef: ElementRef) {
-      super(elementRef);
-    }
-  },
-  'primary',
-);
+import {ThemePalette} from '@angular/material/core';
 
 @Component({
   selector: 'mat-step-header',
   templateUrl: 'step-header.html',
   styleUrls: ['step-header.css'],
-  inputs: ['color'],
   host: {
     'class': 'mat-step-header',
+    '[class]': '"mat-" + (color || "primary")',
     'role': 'tab',
   },
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class MatStepHeader
-  extends _MatStepHeaderBase
-  implements AfterViewInit, OnDestroy, CanColor
-{
+export class MatStepHeader extends CdkStepHeader implements AfterViewInit, OnDestroy {
   private _intlSubscription: Subscription;
 
   /** State of the given step. */
@@ -80,6 +66,9 @@ export class MatStepHeader
 
   /** Whether the ripple should be disabled. */
   @Input() disableRipple: boolean;
+
+  /** Theme palette color of the step header. */
+  @Input() color: ThemePalette;
 
   constructor(
     public _intl: MatStepperIntl,

--- a/src/material/tabs/paginated-tab-header.ts
+++ b/src/material/tabs/paginated-tab-header.ts
@@ -20,14 +20,10 @@ import {
   Directive,
   Inject,
   Input,
+  booleanAttribute,
+  numberAttribute,
 } from '@angular/core';
 import {Direction, Directionality} from '@angular/cdk/bidi';
-import {
-  BooleanInput,
-  coerceBooleanProperty,
-  coerceNumberProperty,
-  NumberInput,
-} from '@angular/cdk/coercion';
 import {ViewportRuler} from '@angular/cdk/scrolling';
 import {FocusKeyManager, FocusableOption} from '@angular/cdk/a11y';
 import {ENTER, SPACE, hasModifierKey} from '@angular/cdk/keycodes';
@@ -128,21 +124,15 @@ export abstract class MatPaginatedTabHeader
    * Whether pagination should be disabled. This can be used to avoid unnecessary
    * layout recalculations if it's known that pagination won't be required.
    */
-  @Input()
-  get disablePagination(): boolean {
-    return this._disablePagination;
-  }
-  set disablePagination(value: BooleanInput) {
-    this._disablePagination = coerceBooleanProperty(value);
-  }
-  private _disablePagination: boolean = false;
+  @Input({transform: booleanAttribute})
+  disablePagination: boolean = false;
 
   /** The index of the active tab. */
   get selectedIndex(): number {
     return this._selectedIndex;
   }
-  set selectedIndex(value: NumberInput) {
-    value = coerceNumberProperty(value);
+  set selectedIndex(v: unknown) {
+    const value = numberAttribute(v, 0);
 
     if (this._selectedIndex != value) {
       this._selectedIndexChanged = true;

--- a/src/material/tabs/tab-group.ts
+++ b/src/material/tabs/tab-group.ts
@@ -23,23 +23,13 @@ import {
   QueryList,
   ViewChild,
   ViewEncapsulation,
+  booleanAttribute,
+  numberAttribute,
 } from '@angular/core';
 import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 import {MAT_TAB_GROUP, MatTab} from './tab';
 import {MatTabHeader} from './tab-header';
-import {
-  BooleanInput,
-  coerceBooleanProperty,
-  coerceNumberProperty,
-  NumberInput,
-} from '@angular/cdk/coercion';
-import {
-  CanColor,
-  CanDisableRipple,
-  mixinColor,
-  mixinDisableRipple,
-  ThemePalette,
-} from '@angular/material/core';
+import {ThemePalette} from '@angular/material/core';
 import {merge, Subscription} from 'rxjs';
 import {MAT_TABS_CONFIG, MatTabsConfig} from './tab-config';
 import {startWith} from 'rxjs/operators';
@@ -47,17 +37,6 @@ import {FocusOrigin} from '@angular/cdk/a11y';
 
 /** Used to generate unique ID's for each tab component */
 let nextId = 0;
-
-// Boilerplate for applying mixins to MatTabGroup.
-/** @docs-private */
-const _MatTabGroupMixinBase = mixinColor(
-  mixinDisableRipple(
-    class {
-      constructor(public _elementRef: ElementRef) {}
-    },
-  ),
-  'primary',
-);
 
 /** @docs-private */
 export interface MatTabGroupBaseHeader {
@@ -82,7 +61,6 @@ export type MatTabHeaderPosition = 'above' | 'below';
   encapsulation: ViewEncapsulation.None,
   // tslint:disable-next-line:validate-decorators
   changeDetection: ChangeDetectionStrategy.Default,
-  inputs: ['color', 'disableRipple'],
   providers: [
     {
       provide: MAT_TAB_GROUP,
@@ -92,16 +70,14 @@ export type MatTabHeaderPosition = 'above' | 'below';
   host: {
     'ngSkipHydration': '',
     'class': 'mat-mdc-tab-group',
+    '[class]': '"mat-" + (color || "primary")',
     '[class.mat-mdc-tab-group-dynamic-height]': 'dynamicHeight',
     '[class.mat-mdc-tab-group-inverted-header]': 'headerPosition === "below"',
     '[class.mat-mdc-tab-group-stretch-tabs]': 'stretchTabs',
     '[style.--mat-tab-animation-duration]': 'animationDuration',
   },
 })
-export class MatTabGroup
-  extends _MatTabGroupMixinBase
-  implements AfterContentInit, AfterContentChecked, OnDestroy, CanColor, CanDisableRipple
-{
+export class MatTabGroup implements AfterContentInit, AfterContentChecked, OnDestroy {
   /**
    * All tabs inside the tab group. This includes tabs that belong to groups that are nested
    * inside the current one. We filter out only the tabs that belong to this group in `_tabs`.
@@ -128,49 +104,37 @@ export class MatTabGroup
   /** Subscription to changes in the tab labels. */
   private _tabLabelSubscription = Subscription.EMPTY;
 
-  /** Whether the ink bar should fit its width to the size of the tab label content. */
+  /** Theme color of the tab group. */
   @Input()
+  color: ThemePalette;
+
+  /** Whether the ink bar should fit its width to the size of the tab label content. */
+  @Input({transform: booleanAttribute})
   get fitInkBarToContent(): boolean {
     return this._fitInkBarToContent;
   }
-  set fitInkBarToContent(v: BooleanInput) {
-    this._fitInkBarToContent = coerceBooleanProperty(v);
+  set fitInkBarToContent(value: boolean) {
+    this._fitInkBarToContent = value;
     this._changeDetectorRef.markForCheck();
   }
   private _fitInkBarToContent = false;
 
   /** Whether tabs should be stretched to fill the header. */
-  @Input('mat-stretch-tabs')
-  get stretchTabs(): boolean {
-    return this._stretchTabs;
-  }
-  set stretchTabs(v: BooleanInput) {
-    this._stretchTabs = coerceBooleanProperty(v);
-  }
-  private _stretchTabs = true;
+  @Input({alias: 'mat-stretch-tabs', transform: booleanAttribute})
+  stretchTabs: boolean = true;
 
   /** Whether the tab group should grow to the size of the active tab. */
-  @Input()
-  get dynamicHeight(): boolean {
-    return this._dynamicHeight;
-  }
-
-  set dynamicHeight(value: BooleanInput) {
-    this._dynamicHeight = coerceBooleanProperty(value);
-  }
-
-  private _dynamicHeight: boolean = false;
+  @Input({transform: booleanAttribute})
+  dynamicHeight: boolean = false;
 
   /** The index of the active tab. */
-  @Input()
+  @Input({transform: numberAttribute})
   get selectedIndex(): number | null {
     return this._selectedIndex;
   }
-
-  set selectedIndex(value: NumberInput) {
-    this._indexToSelect = coerceNumberProperty(value, null);
+  set selectedIndex(value: number) {
+    this._indexToSelect = isNaN(value) ? null : value;
   }
-
   private _selectedIndex: number | null = null;
 
   /** Position of the tab header. */
@@ -181,11 +145,10 @@ export class MatTabGroup
   get animationDuration(): string {
     return this._animationDuration;
   }
-
-  set animationDuration(value: NumberInput) {
-    this._animationDuration = /^\d+$/.test(value + '') ? value + 'ms' : (value as string);
+  set animationDuration(value: string | number) {
+    const stringValue = value + '';
+    this._animationDuration = /^\d+$/.test(stringValue) ? value + 'ms' : stringValue;
   }
-
   private _animationDuration: string;
 
   /**
@@ -194,13 +157,13 @@ export class MatTabGroup
    * The `tabindex` will be removed automatically for inactive tabs.
    * Read more at https://www.w3.org/TR/wai-aria-practices/examples/tabs/tabs-2/tabs.html
    */
-  @Input()
+  @Input({transform: numberAttribute})
   get contentTabIndex(): number | null {
     return this._contentTabIndex;
   }
 
-  set contentTabIndex(value: NumberInput) {
-    this._contentTabIndex = coerceNumberProperty(value, null);
+  set contentTabIndex(value: number) {
+    this._contentTabIndex = isNaN(value) ? null : value;
   }
 
   private _contentTabIndex: number | null;
@@ -209,32 +172,20 @@ export class MatTabGroup
    * Whether pagination should be disabled. This can be used to avoid unnecessary
    * layout recalculations if it's known that pagination won't be required.
    */
-  @Input()
-  get disablePagination(): boolean {
-    return this._disablePagination;
-  }
+  @Input({transform: booleanAttribute})
+  disablePagination: boolean = false;
 
-  set disablePagination(value: BooleanInput) {
-    this._disablePagination = coerceBooleanProperty(value);
-  }
-
-  private _disablePagination: boolean = false;
+  /** Whether ripples in the tab group are disabled. */
+  @Input({transform: booleanAttribute})
+  disableRipple: boolean = false;
 
   /**
    * By default tabs remove their content from the DOM while it's off-screen.
    * Setting this to `true` will keep it in the DOM which will prevent elements
    * like iframes and videos from reloading next time it comes back into the view.
    */
-  @Input()
-  get preserveContent(): boolean {
-    return this._preserveContent;
-  }
-
-  set preserveContent(value: BooleanInput) {
-    this._preserveContent = coerceBooleanProperty(value);
-  }
-
-  private _preserveContent: boolean = false;
+  @Input({transform: booleanAttribute})
+  preserveContent: boolean = false;
 
   /** Background color of the tab group. */
   @Input()
@@ -273,12 +224,11 @@ export class MatTabGroup
   private _groupId: number;
 
   constructor(
-    elementRef: ElementRef,
+    readonly _elementRef: ElementRef,
     private _changeDetectorRef: ChangeDetectorRef,
     @Inject(MAT_TABS_CONFIG) @Optional() defaultConfig?: MatTabsConfig,
     @Optional() @Inject(ANIMATION_MODULE_TYPE) public _animationMode?: string,
   ) {
-    super(elementRef);
     this._groupId = nextId++;
     this.animationDuration =
       defaultConfig && defaultConfig.animationDuration ? defaultConfig.animationDuration : '500ms';
@@ -288,7 +238,9 @@ export class MatTabGroup
         : false;
     this.dynamicHeight =
       defaultConfig && defaultConfig.dynamicHeight != null ? defaultConfig.dynamicHeight : false;
-    this.contentTabIndex = defaultConfig?.contentTabIndex ?? null;
+    if (defaultConfig?.contentTabIndex != null) {
+      this.contentTabIndex = defaultConfig.contentTabIndex;
+    }
     this.preserveContent = !!defaultConfig?.preserveContent;
     this.fitInkBarToContent =
       defaultConfig && defaultConfig.fitInkBarToContent != null
@@ -502,7 +454,7 @@ export class MatTabGroup
    * height property is true.
    */
   _setTabBodyWrapperHeight(tabHeight: number): void {
-    if (!this._dynamicHeight || !this._tabBodyWrapperHeight) {
+    if (!this.dynamicHeight || !this._tabBodyWrapperHeight) {
       return;
     }
 

--- a/src/material/tabs/tab-header.ts
+++ b/src/material/tabs/tab-header.ts
@@ -23,6 +23,7 @@ import {
   QueryList,
   ViewChild,
   ViewEncapsulation,
+  booleanAttribute,
 } from '@angular/core';
 import {ViewportRuler} from '@angular/cdk/scrolling';
 import {Platform} from '@angular/cdk/platform';
@@ -31,7 +32,6 @@ import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 import {MatTabLabelWrapper} from './tab-label-wrapper';
 import {MatInkBar} from './ink-bar';
 import {MatPaginatedTabHeader} from './paginated-tab-header';
-import {BooleanInput, coerceBooleanProperty} from '@angular/cdk/coercion';
 
 /**
  * The header of the tab group which displays a list of all the tabs in the tab group. Includes
@@ -68,16 +68,8 @@ export class MatTabHeader
   _inkBar: MatInkBar;
 
   /** Whether the ripple effect is disabled or not. */
-  @Input()
-  get disableRipple(): boolean {
-    return this._disableRipple;
-  }
-
-  set disableRipple(value: BooleanInput) {
-    this._disableRipple = coerceBooleanProperty(value);
-  }
-
-  private _disableRipple: boolean = false;
+  @Input({transform: booleanAttribute})
+  disableRipple: boolean = false;
 
   constructor(
     elementRef: ElementRef,

--- a/src/material/tabs/tab-label-wrapper.ts
+++ b/src/material/tabs/tab-label-wrapper.ts
@@ -6,18 +6,15 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, ElementRef} from '@angular/core';
+import {Directive, ElementRef, Input, booleanAttribute} from '@angular/core';
 import {mixinInkBarItem} from './ink-bar';
-import {CanDisable, mixinDisabled} from '@angular/material/core';
 
 // Boilerplate for applying mixins to MatTabLabelWrapper.
 /** @docs-private */
 const _MatTabLabelWrapperMixinBase = mixinInkBarItem(
-  mixinDisabled(
-    class {
-      elementRef: ElementRef;
-    },
-  ),
+  class {
+    elementRef: ElementRef;
+  },
 );
 
 /**
@@ -26,13 +23,17 @@ const _MatTabLabelWrapperMixinBase = mixinInkBarItem(
  */
 @Directive({
   selector: '[matTabLabelWrapper]',
-  inputs: ['disabled', 'fitInkBarToContent'],
+  inputs: ['fitInkBarToContent'],
   host: {
     '[class.mat-mdc-tab-disabled]': 'disabled',
     '[attr.aria-disabled]': '!!disabled',
   },
 })
-export class MatTabLabelWrapper extends _MatTabLabelWrapperMixinBase implements CanDisable {
+export class MatTabLabelWrapper extends _MatTabLabelWrapperMixinBase {
+  /** Whether the tab is disabled. */
+  @Input({transform: booleanAttribute})
+  disabled: boolean = false;
+
   constructor(override elementRef: ElementRef) {
     super();
   }

--- a/src/material/tabs/tab-nav-bar/tab-nav-bar.ts
+++ b/src/material/tabs/tab-nav-bar/tab-nav-bar.ts
@@ -10,6 +10,7 @@ import {
   AfterContentInit,
   AfterViewInit,
   Attribute,
+  booleanAttribute,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
@@ -19,6 +20,7 @@ import {
   Inject,
   Input,
   NgZone,
+  numberAttribute,
   OnDestroy,
   Optional,
   QueryList,
@@ -27,13 +29,7 @@ import {
 } from '@angular/core';
 import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 import {
-  CanDisable,
-  CanDisableRipple,
-  HasTabIndex,
   MAT_RIPPLE_GLOBAL_OPTIONS,
-  mixinDisabled,
-  mixinDisableRipple,
-  mixinTabIndex,
   RippleConfig,
   RippleGlobalOptions,
   RippleTarget,
@@ -44,7 +40,6 @@ import {Directionality} from '@angular/cdk/bidi';
 import {ViewportRuler} from '@angular/cdk/scrolling';
 import {Platform} from '@angular/cdk/platform';
 import {MatInkBar, mixinInkBarItem} from '../ink-bar';
-import {BooleanInput, coerceBooleanProperty, NumberInput} from '@angular/cdk/coercion';
 import {BehaviorSubject, Subject} from 'rxjs';
 import {startWith, takeUntil} from 'rxjs/operators';
 import {ENTER, SPACE} from '@angular/cdk/keycodes';
@@ -61,7 +56,6 @@ let nextUniqueId = 0;
 @Component({
   selector: '[mat-tab-nav-bar]',
   exportAs: 'matTabNavBar, matTabNav',
-  inputs: ['color'],
   templateUrl: 'tab-nav-bar.html',
   styleUrls: ['tab-nav-bar.css'],
   host: {
@@ -85,33 +79,28 @@ export class MatTabNav
   implements AfterContentChecked, AfterContentInit, OnDestroy, AfterViewInit
 {
   /** Whether the ink bar should fit its width to the size of the tab label content. */
-  @Input()
+  @Input({transform: booleanAttribute})
   get fitInkBarToContent(): boolean {
     return this._fitInkBarToContent.value;
   }
-  set fitInkBarToContent(v: BooleanInput) {
-    this._fitInkBarToContent.next(coerceBooleanProperty(v));
+  set fitInkBarToContent(value: boolean) {
+    this._fitInkBarToContent.next(value);
     this._changeDetectorRef.markForCheck();
   }
   _fitInkBarToContent = new BehaviorSubject(false);
 
   /** Whether tabs should be stretched to fill the header. */
-  @Input('mat-stretch-tabs')
-  get stretchTabs(): boolean {
-    return this._stretchTabs;
-  }
-  set stretchTabs(v: BooleanInput) {
-    this._stretchTabs = coerceBooleanProperty(v);
-  }
-  private _stretchTabs = true;
+  @Input({alias: 'mat-stretch-tabs', transform: booleanAttribute})
+  stretchTabs: boolean = true;
 
   @Input()
   get animationDuration(): string {
     return this._animationDuration;
   }
 
-  set animationDuration(value: NumberInput) {
-    this._animationDuration = /^\d+$/.test(value + '') ? value + 'ms' : (value as string);
+  set animationDuration(value: string | number) {
+    const stringValue = value + '';
+    this._animationDuration = /^\d+$/.test(stringValue) ? value + 'ms' : stringValue;
   }
 
   private _animationDuration: string;
@@ -139,16 +128,8 @@ export class MatTabNav
   private _backgroundColor: ThemePalette;
 
   /** Whether the ripple effect is disabled or not. */
-  @Input()
-  get disableRipple(): boolean {
-    return this._disableRipple;
-  }
-
-  set disableRipple(value: BooleanInput) {
-    this._disableRipple = coerceBooleanProperty(value);
-  }
-
-  private _disableRipple: boolean = false;
+  @Input({transform: booleanAttribute})
+  disableRipple: boolean = false;
 
   /** Theme color of the nav bar. */
   @Input() color: ThemePalette = 'primary';
@@ -245,15 +226,9 @@ export class MatTabNav
 
 // Boilerplate for applying mixins to MatTabLink.
 const _MatTabLinkMixinBase = mixinInkBarItem(
-  mixinTabIndex(
-    mixinDisableRipple(
-      mixinDisabled(
-        class {
-          elementRef: ElementRef;
-        },
-      ),
-    ),
-  ),
+  class {
+    elementRef: ElementRef;
+  },
 );
 
 /**
@@ -262,7 +237,7 @@ const _MatTabLinkMixinBase = mixinInkBarItem(
 @Component({
   selector: '[mat-tab-link], [matTabLink]',
   exportAs: 'matTabLink',
-  inputs: ['disabled', 'disableRipple', 'tabIndex', 'active', 'id'],
+  inputs: ['active', 'id'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   templateUrl: 'tab-link.html',
@@ -284,14 +259,7 @@ const _MatTabLinkMixinBase = mixinInkBarItem(
 })
 export class MatTabLink
   extends _MatTabLinkMixinBase
-  implements
-    AfterViewInit,
-    OnDestroy,
-    CanDisable,
-    CanDisableRipple,
-    HasTabIndex,
-    RippleTarget,
-    FocusableOption
+  implements AfterViewInit, OnDestroy, RippleTarget, FocusableOption
 {
   private readonly _destroyed = new Subject<void>();
 
@@ -299,19 +267,30 @@ export class MatTabLink
   protected _isActive: boolean = false;
 
   /** Whether the link is active. */
-  @Input()
+  @Input({transform: booleanAttribute})
   get active(): boolean {
     return this._isActive;
   }
 
-  set active(value: BooleanInput) {
-    const newValue = coerceBooleanProperty(value);
-
-    if (newValue !== this._isActive) {
-      this._isActive = newValue;
+  set active(value: boolean) {
+    if (value !== this._isActive) {
+      this._isActive = value;
       this._tabNavBar.updateActiveLink();
     }
   }
+
+  /** Whether the tab link is disabled. */
+  @Input({transform: booleanAttribute})
+  disabled: boolean = false;
+
+  /** Whether ripples are disabled on the tab link. */
+  @Input({transform: booleanAttribute})
+  disableRipple: boolean = false;
+
+  @Input({
+    transform: (value: unknown) => (value == null ? 0 : numberAttribute(value)),
+  })
+  tabIndex: number = 0;
 
   /**
    * Ripple configuration for ripples that are launched on pointer down. The ripple config
@@ -419,7 +398,7 @@ export class MatTabLink
     if (this._tabNavBar.tabPanel) {
       return this._isActive && !this.disabled ? 0 : -1;
     } else {
-      return this.tabIndex;
+      return this.disabled ? -1 : this.tabIndex;
     }
   }
 }

--- a/src/material/tabs/tab.ts
+++ b/src/material/tabs/tab.ts
@@ -22,16 +22,12 @@ import {
   ViewChild,
   ViewContainerRef,
   ViewEncapsulation,
+  booleanAttribute,
 } from '@angular/core';
 import {MatTabContent} from './tab-content';
 import {MAT_TAB, MatTabLabel} from './tab-label';
-import {CanDisable, mixinDisabled} from '@angular/material/core';
 import {TemplatePortal} from '@angular/cdk/portal';
 import {Subject} from 'rxjs';
-
-// Boilerplate for applying mixins to MatTab.
-/** @docs-private */
-const _MatTabMixinBase = mixinDisabled(class {});
 
 /**
  * Used to provide a tab group to a tab without causing a circular dependency.
@@ -46,16 +42,18 @@ export const MAT_TAB_GROUP = new InjectionToken<any>('MAT_TAB_GROUP');
   // the inlined template of `MatTab` isn't duplicated, however the template is small enough
   // that creating the extra class will generate more code than just duplicating the template.
   templateUrl: 'tab.html',
-  inputs: ['disabled'],
   // tslint:disable-next-line:validate-decorators
   changeDetection: ChangeDetectionStrategy.Default,
   encapsulation: ViewEncapsulation.None,
   exportAs: 'matTab',
   providers: [{provide: MAT_TAB, useExisting: MatTab}],
 })
-export class MatTab extends _MatTabMixinBase implements CanDisable, OnInit, OnChanges, OnDestroy {
+export class MatTab implements OnInit, OnChanges, OnDestroy {
+  /** whether the tab is disabled. */
+  @Input({transform: booleanAttribute})
+  disabled: boolean = false;
+
   /** Content for the tab label given by `<ng-template mat-tab-label>`. */
-  private _templateLabel: MatTabLabel;
   @ContentChild(MatTabLabel)
   get templateLabel(): MatTabLabel {
     return this._templateLabel;
@@ -63,6 +61,7 @@ export class MatTab extends _MatTabMixinBase implements CanDisable, OnInit, OnCh
   set templateLabel(value: MatTabLabel) {
     this._setTemplateLabelInput(value);
   }
+  private _templateLabel: MatTabLabel;
 
   /**
    * Template provided in the tab content that will be used if present, used to enable lazy-loading
@@ -129,9 +128,7 @@ export class MatTab extends _MatTabMixinBase implements CanDisable, OnInit, OnCh
   constructor(
     private _viewContainerRef: ViewContainerRef,
     @Inject(MAT_TAB_GROUP) @Optional() public _closestTabGroup: any,
-  ) {
-    super();
-  }
+  ) {}
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes.hasOwnProperty('textLabel') || changes.hasOwnProperty('disabled')) {

--- a/src/material/tabs/testing/BUILD.bazel
+++ b/src/material/tabs/testing/BUILD.bazel
@@ -9,7 +9,6 @@ ts_library(
         exclude = ["**/*.spec.ts"],
     ),
     deps = [
-        "//src/cdk/coercion",
         "//src/cdk/testing",
     ],
 )

--- a/src/material/toolbar/toolbar.ts
+++ b/src/material/toolbar/toolbar.ts
@@ -16,18 +16,10 @@ import {
   Directive,
   ElementRef,
   Inject,
+  Input,
   QueryList,
   ViewEncapsulation,
 } from '@angular/core';
-import {CanColor, mixinColor} from '@angular/material/core';
-
-// Boilerplate for applying mixins to MatToolbar.
-/** @docs-private */
-const _MatToolbarBase = mixinColor(
-  class {
-    constructor(public _elementRef: ElementRef) {}
-  },
-);
 
 @Directive({
   selector: 'mat-toolbar-row',
@@ -41,28 +33,30 @@ export class MatToolbarRow {}
   exportAs: 'matToolbar',
   templateUrl: 'toolbar.html',
   styleUrls: ['toolbar.css'],
-  inputs: ['color'],
   host: {
     'class': 'mat-toolbar',
+    '[class]': 'color ? "mat-" + color : ""',
     '[class.mat-toolbar-multiple-rows]': '_toolbarRows.length > 0',
     '[class.mat-toolbar-single-row]': '_toolbarRows.length === 0',
   },
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
 })
-export class MatToolbar extends _MatToolbarBase implements CanColor, AfterViewInit {
+export class MatToolbar implements AfterViewInit {
+  // TODO: should be typed as `ThemePalette` but internal apps pass in arbitrary strings.
+  /** Palette color of the toolbar. */
+  @Input() color?: string | null;
+
   private _document: Document;
 
   /** Reference to all toolbar row elements that have been projected. */
   @ContentChildren(MatToolbarRow, {descendants: true}) _toolbarRows: QueryList<MatToolbarRow>;
 
   constructor(
-    elementRef: ElementRef,
+    protected _elementRef: ElementRef,
     private _platform: Platform,
     @Inject(DOCUMENT) document?: any,
   ) {
-    super(elementRef);
-
     // TODO: make the document a required param when doing breaking changes.
     this._document = document;
   }

--- a/src/material/tree/node.ts
+++ b/src/material/tree/node.ts
@@ -22,11 +22,9 @@ import {
   IterableDiffers,
   OnDestroy,
   OnInit,
+  booleanAttribute,
+  numberAttribute,
 } from '@angular/core';
-import {CanDisable, HasTabIndex, mixinDisabled, mixinTabIndex} from '@angular/material/core';
-import {BooleanInput, coerceBooleanProperty} from '@angular/cdk/coercion';
-
-const _MatTreeNodeBase = mixinTabIndex(mixinDisabled(CdkTreeNode));
 
 /**
  * Wrapper for the CdkTree node with Material design styles.
@@ -34,16 +32,22 @@ const _MatTreeNodeBase = mixinTabIndex(mixinDisabled(CdkTreeNode));
 @Directive({
   selector: 'mat-tree-node',
   exportAs: 'matTreeNode',
-  inputs: ['role', 'disabled', 'tabIndex'],
   providers: [{provide: CdkTreeNode, useExisting: MatTreeNode}],
   host: {
     'class': 'mat-tree-node',
   },
 })
-export class MatTreeNode<T, K = T>
-  extends _MatTreeNodeBase<T, K>
-  implements CanDisable, HasTabIndex, OnInit, OnDestroy
-{
+export class MatTreeNode<T, K = T> extends CdkTreeNode<T, K> implements OnInit, OnDestroy {
+  /** Whether the node is disabled. */
+  @Input({transform: booleanAttribute})
+  disabled: boolean = false;
+
+  /** Tabindex of the node. */
+  @Input({
+    transform: (value: unknown) => (value == null ? 0 : numberAttribute(value)),
+  })
+  tabIndex: number;
+
   constructor(
     elementRef: ElementRef<HTMLElement>,
     tree: CdkTree<T, K>,
@@ -83,7 +87,6 @@ export class MatTreeNodeDef<T> extends CdkTreeNodeDef<T> {
 @Directive({
   selector: 'mat-nested-tree-node',
   exportAs: 'matNestedTreeNode',
-  inputs: ['role', 'disabled', 'tabIndex'],
   providers: [
     {provide: CdkNestedTreeNode, useExisting: MatNestedTreeNode},
     {provide: CdkTreeNode, useExisting: MatNestedTreeNode},
@@ -100,14 +103,8 @@ export class MatNestedTreeNode<T, K = T>
   @Input('matNestedTreeNode') node: T;
 
   /** Whether the node is disabled. */
-  @Input()
-  get disabled(): boolean {
-    return this._disabled;
-  }
-  set disabled(value: BooleanInput) {
-    this._disabled = coerceBooleanProperty(value);
-  }
-  private _disabled = false;
+  @Input({transform: booleanAttribute})
+  disabled: boolean = false;
 
   /** Tabindex for the node. */
   @Input()

--- a/src/material/tree/padding.ts
+++ b/src/material/tree/padding.ts
@@ -5,9 +5,8 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {NumberInput} from '@angular/cdk/coercion';
 import {CdkTreeNodePadding} from '@angular/cdk/tree';
-import {Directive, Input} from '@angular/core';
+import {Directive, Input, numberAttribute} from '@angular/core';
 
 /**
  * Wrapper for the CdkTree padding with Material design styles.
@@ -18,11 +17,11 @@ import {Directive, Input} from '@angular/core';
 })
 export class MatTreeNodePadding<T, K = T> extends CdkTreeNodePadding<T, K> {
   /** The level of depth of the tree node. The padding will be `level * indent` pixels. */
-  @Input('matTreeNodePadding')
+  @Input({alias: 'matTreeNodePadding', transform: numberAttribute})
   override get level(): number {
     return this._level;
   }
-  override set level(value: NumberInput) {
+  override set level(value: number) {
     this._setLevelInput(value);
   }
 

--- a/tools/public_api_guard/cdk/tree.md
+++ b/tools/public_api_guard/cdk/tree.md
@@ -7,7 +7,6 @@
 import { AfterContentChecked } from '@angular/core';
 import { AfterContentInit } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
-import { BooleanInput } from '@angular/cdk/coercion';
 import { ChangeDetectorRef } from '@angular/core';
 import { CollectionViewer } from '@angular/cdk/collections';
 import { DataSource } from '@angular/cdk/collections';
@@ -18,7 +17,6 @@ import * as i0 from '@angular/core';
 import { InjectionToken } from '@angular/core';
 import { IterableDiffer } from '@angular/core';
 import { IterableDiffers } from '@angular/core';
-import { NumberInput } from '@angular/cdk/coercion';
 import { Observable } from 'rxjs';
 import { OnDestroy } from '@angular/core';
 import { OnInit } from '@angular/core';
@@ -70,7 +68,7 @@ export class CdkNestedTreeNode<T, K = T> extends CdkTreeNode<T, K> implements Af
     nodeOutlet: QueryList<CdkTreeNodeOutlet>;
     protected updateChildrenNodes(children?: T[]): void;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkNestedTreeNode<any, any>, "cdk-nested-tree-node", ["cdkNestedTreeNode"], { "role": { "alias": "role"; "required": false; }; "disabled": { "alias": "disabled"; "required": false; }; "tabIndex": { "alias": "tabIndex"; "required": false; }; }, {}, ["nodeOutlet"], never, false, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkNestedTreeNode<any, any>, "cdk-nested-tree-node", ["cdkNestedTreeNode"], {}, {}, ["nodeOutlet"], never, false, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<CdkNestedTreeNode<any, any>, never>;
 }
@@ -191,14 +189,16 @@ export class CdkTreeNodePadding<T, K = T> implements OnDestroy {
     _indent: number;
     indentUnits: string;
     get level(): number;
-    set level(value: NumberInput);
+    set level(value: number);
     // (undocumented)
     _level: number;
+    // (undocumented)
+    static ngAcceptInputType_level: unknown;
     // (undocumented)
     ngOnDestroy(): void;
     _paddingIndent(): string | null;
     protected _setIndentInput(indent: number | string): void;
-    protected _setLevelInput(value: NumberInput): void;
+    protected _setLevelInput(value: number): void;
     // (undocumented)
     _setPadding(forceChange?: boolean): void;
     // (undocumented)
@@ -210,10 +210,9 @@ export class CdkTreeNodePadding<T, K = T> implements OnDestroy {
 // @public
 export class CdkTreeNodeToggle<T, K = T> {
     constructor(_tree: CdkTree<T, K>, _treeNode: CdkTreeNode<T, K>);
-    get recursive(): boolean;
-    set recursive(value: BooleanInput);
     // (undocumented)
-    protected _recursive: boolean;
+    static ngAcceptInputType_recursive: unknown;
+    recursive: boolean;
     // (undocumented)
     _toggle(event: Event): void;
     // (undocumented)

--- a/tools/public_api_guard/material/chips.md
+++ b/tools/public_api_guard/material/chips.md
@@ -7,10 +7,6 @@
 import { _AbstractConstructor } from '@angular/material/core';
 import { AfterContentInit } from '@angular/core';
 import { AfterViewInit } from '@angular/core';
-import { BooleanInput } from '@angular/cdk/coercion';
-import { CanColor } from '@angular/material/core';
-import { CanDisable } from '@angular/material/core';
-import { CanDisableRipple } from '@angular/material/core';
 import { CanUpdateErrorState } from '@angular/material/core';
 import { ChangeDetectorRef } from '@angular/core';
 import { _Constructor } from '@angular/material/core';
@@ -23,7 +19,6 @@ import { EventEmitter } from '@angular/core';
 import { FocusKeyManager } from '@angular/cdk/a11y';
 import { FocusMonitor } from '@angular/cdk/a11y';
 import { FormGroupDirective } from '@angular/forms';
-import { HasTabIndex } from '@angular/material/core';
 import * as i0 from '@angular/core';
 import * as i11 from '@angular/material/core';
 import { InjectionToken } from '@angular/core';
@@ -61,8 +56,8 @@ export const MAT_CHIP_TRAILING_ICON: InjectionToken<unknown>;
 export const MAT_CHIPS_DEFAULT_OPTIONS: InjectionToken<MatChipsDefaultOptions>;
 
 // @public
-export class MatChip extends _MatChipMixinBase implements OnInit, AfterViewInit, AfterContentInit, CanColor, CanDisableRipple, CanDisable, DoCheck, HasTabIndex, OnDestroy {
-    constructor(_changeDetectorRef: ChangeDetectorRef, elementRef: ElementRef<HTMLElement>, _ngZone: NgZone, _focusMonitor: FocusMonitor, _document: any, animationMode?: string, _globalRippleOptions?: RippleGlobalOptions | undefined, tabIndex?: string);
+export class MatChip implements OnInit, AfterViewInit, AfterContentInit, DoCheck, OnDestroy {
+    constructor(_changeDetectorRef: ChangeDetectorRef, _elementRef: ElementRef<HTMLElement>, _ngZone: NgZone, _focusMonitor: FocusMonitor, _document: any, animationMode?: string, _globalRippleOptions?: RippleGlobalOptions | undefined, tabIndex?: string);
     protected _allLeadingIcons: QueryList<MatChipAvatar>;
     protected _allRemoveIcons: QueryList<MatChipRemove>;
     protected _allTrailingIcons: QueryList<MatChipTrailingIcon>;
@@ -73,25 +68,38 @@ export class MatChip extends _MatChipMixinBase implements OnInit, AfterViewInit,
     protected basicChipAttrName: string;
     // (undocumented)
     _changeDetectorRef: ChangeDetectorRef;
+    color?: string | null;
     readonly destroyed: EventEmitter<MatChipEvent>;
+    disabled: boolean;
+    disableRipple: boolean;
     // (undocumented)
     protected _document: Document;
+    // (undocumented)
+    _elementRef: ElementRef<HTMLElement>;
     focus(): void;
     _getActions(): MatChipAction[];
     _getSourceAction(target: Node): MatChipAction | undefined;
+    _getTabIndex(): number | null;
     _handleKeydown(event: KeyboardEvent): void;
     _handlePrimaryActionInteraction(): void;
     // (undocumented)
     _hasFocus(): boolean;
     _hasTrailingIcon(): boolean;
-    get highlighted(): boolean;
-    set highlighted(value: BooleanInput);
-    // (undocumented)
-    protected _highlighted: boolean;
+    highlighted: boolean;
     id: string;
     _isBasicChip: boolean;
     _isRippleDisabled(): boolean;
     leadingIcon: MatChipAvatar;
+    // (undocumented)
+    static ngAcceptInputType_disabled: unknown;
+    // (undocumented)
+    static ngAcceptInputType_disableRipple: unknown;
+    // (undocumented)
+    static ngAcceptInputType_highlighted: unknown;
+    // (undocumented)
+    static ngAcceptInputType_removable: unknown;
+    // (undocumented)
+    static ngAcceptInputType_tabIndex: unknown;
     // (undocumented)
     ngAfterContentInit(): void;
     // (undocumented)
@@ -107,10 +115,7 @@ export class MatChip extends _MatChipMixinBase implements OnInit, AfterViewInit,
     readonly _onBlur: Subject<MatChipEvent>;
     readonly _onFocus: Subject<MatChipEvent>;
     primaryAction: MatChipAction;
-    get removable(): boolean;
-    set removable(value: BooleanInput);
-    // (undocumented)
-    protected _removable: boolean;
+    removable: boolean;
     remove(): void;
     readonly removed: EventEmitter<MatChipEvent>;
     removeIcon: MatChipRemove;
@@ -119,13 +124,14 @@ export class MatChip extends _MatChipMixinBase implements OnInit, AfterViewInit,
     set ripple(v: MatRipple);
     _rippleLoader: MatRippleLoader;
     role: string | null;
+    tabIndex: number;
     trailingIcon: MatChipTrailingIcon;
     get value(): any;
     set value(value: any);
     // (undocumented)
     protected _value: any;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<MatChip, "mat-basic-chip, [mat-basic-chip], mat-chip, [mat-chip]", ["matChip"], { "color": { "alias": "color"; "required": false; }; "disabled": { "alias": "disabled"; "required": false; }; "disableRipple": { "alias": "disableRipple"; "required": false; }; "tabIndex": { "alias": "tabIndex"; "required": false; }; "role": { "alias": "role"; "required": false; }; "id": { "alias": "id"; "required": false; }; "ariaLabel": { "alias": "aria-label"; "required": false; }; "ariaDescription": { "alias": "aria-description"; "required": false; }; "value": { "alias": "value"; "required": false; }; "removable": { "alias": "removable"; "required": false; }; "highlighted": { "alias": "highlighted"; "required": false; }; }, { "removed": "removed"; "destroyed": "destroyed"; }, ["leadingIcon", "trailingIcon", "removeIcon", "_allLeadingIcons", "_allTrailingIcons", "_allRemoveIcons"], ["mat-chip-avatar, [matChipAvatar]", "*", "mat-chip-trailing-icon,[matChipRemove],[matChipTrailingIcon]"], false, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MatChip, "mat-basic-chip, [mat-basic-chip], mat-chip, [mat-chip]", ["matChip"], { "role": { "alias": "role"; "required": false; }; "id": { "alias": "id"; "required": false; }; "ariaLabel": { "alias": "aria-label"; "required": false; }; "ariaDescription": { "alias": "aria-description"; "required": false; }; "value": { "alias": "value"; "required": false; }; "color": { "alias": "color"; "required": false; }; "removable": { "alias": "removable"; "required": false; }; "highlighted": { "alias": "highlighted"; "required": false; }; "disableRipple": { "alias": "disableRipple"; "required": false; }; "disabled": { "alias": "disabled"; "required": false; }; "tabIndex": { "alias": "tabIndex"; "required": false; }; }, { "removed": "removed"; "destroyed": "destroyed"; }, ["leadingIcon", "trailingIcon", "removeIcon", "_allLeadingIcons", "_allTrailingIcons", "_allRemoveIcons"], ["mat-chip-avatar, [matChipAvatar]", "*", "mat-chip-trailing-icon,[matChipRemove],[matChipTrailingIcon]"], false, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatChip, [null, null, null, null, null, { optional: true; }, { optional: true; }, { attribute: "tabindex"; }]>;
 }
@@ -179,7 +185,7 @@ export class MatChipGrid extends _MatChipGridMixinBase implements AfterContentIn
     // (undocumented)
     protected _defaultRole: string;
     get disabled(): boolean;
-    set disabled(value: BooleanInput);
+    set disabled(value: boolean);
     get empty(): boolean;
     errorStateMatcher: ErrorStateMatcher;
     focus(): void;
@@ -188,6 +194,10 @@ export class MatChipGrid extends _MatChipGridMixinBase implements AfterContentIn
     _focusLastChip(): void;
     _handleKeydown(event: KeyboardEvent): void;
     get id(): string;
+    // (undocumented)
+    static ngAcceptInputType_disabled: unknown;
+    // (undocumented)
+    static ngAcceptInputType_required: unknown;
     // (undocumented)
     ngAfterContentInit(): void;
     // (undocumented)
@@ -207,7 +217,7 @@ export class MatChipGrid extends _MatChipGridMixinBase implements AfterContentIn
     registerOnChange(fn: (value: any) => void): void;
     registerOnTouched(fn: () => void): void;
     get required(): boolean;
-    set required(value: BooleanInput);
+    set required(value: boolean);
     // (undocumented)
     protected _required: boolean | undefined;
     setDescribedByIds(ids: string[]): void;
@@ -220,7 +230,7 @@ export class MatChipGrid extends _MatChipGridMixinBase implements AfterContentIn
     readonly valueChange: EventEmitter<any>;
     writeValue(value: any): void;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<MatChipGrid, "mat-chip-grid", never, { "tabIndex": { "alias": "tabIndex"; "required": false; }; "disabled": { "alias": "disabled"; "required": false; }; "placeholder": { "alias": "placeholder"; "required": false; }; "required": { "alias": "required"; "required": false; }; "value": { "alias": "value"; "required": false; }; "errorStateMatcher": { "alias": "errorStateMatcher"; "required": false; }; }, { "change": "change"; "valueChange": "valueChange"; }, ["_chips"], ["*"], false, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MatChipGrid, "mat-chip-grid", never, { "disabled": { "alias": "disabled"; "required": false; }; "placeholder": { "alias": "placeholder"; "required": false; }; "required": { "alias": "required"; "required": false; }; "value": { "alias": "value"; "required": false; }; "errorStateMatcher": { "alias": "errorStateMatcher"; "required": false; }; }, { "change": "change"; "valueChange": "valueChange"; }, ["_chips"], ["*"], false, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatChipGrid, [null, null, { optional: true; }, { optional: true; }, { optional: true; }, null, { optional: true; self: true; }]>;
 }
@@ -237,17 +247,14 @@ export class MatChipGridChange {
 // @public
 export class MatChipInput implements MatChipTextControl, AfterContentInit, OnChanges, OnDestroy {
     constructor(_elementRef: ElementRef<HTMLInputElement>, defaultOptions: MatChipsDefaultOptions, formField?: MatFormField);
-    get addOnBlur(): boolean;
-    set addOnBlur(value: BooleanInput);
-    // (undocumented)
-    _addOnBlur: boolean;
+    addOnBlur: boolean;
     _blur(): void;
     readonly chipEnd: EventEmitter<MatChipInputEvent>;
     get chipGrid(): MatChipGrid;
     set chipGrid(value: MatChipGrid);
     clear(): void;
     get disabled(): boolean;
-    set disabled(value: BooleanInput);
+    set disabled(value: boolean);
     // (undocumented)
     protected _elementRef: ElementRef<HTMLInputElement>;
     _emitChipEnd(event?: KeyboardEvent): void;
@@ -260,6 +267,10 @@ export class MatChipInput implements MatChipTextControl, AfterContentInit, OnCha
     readonly inputElement: HTMLInputElement;
     _keydown(event?: KeyboardEvent): void;
     _keyup(event: KeyboardEvent): void;
+    // (undocumented)
+    static ngAcceptInputType_addOnBlur: unknown;
+    // (undocumented)
+    static ngAcceptInputType_disabled: unknown;
     // (undocumented)
     ngAfterContentInit(): void;
     // (undocumented)
@@ -300,23 +311,28 @@ export class MatChipListbox extends MatChipSet implements AfterContentInit, OnDe
     protected _defaultRole: string;
     focus(): void;
     get hideSingleSelectionIndicator(): boolean;
-    set hideSingleSelectionIndicator(value: BooleanInput);
+    set hideSingleSelectionIndicator(value: boolean);
     // (undocumented)
     _keydown(event: KeyboardEvent): void;
     get multiple(): boolean;
-    set multiple(value: BooleanInput);
+    set multiple(value: boolean);
+    // (undocumented)
+    static ngAcceptInputType_hideSingleSelectionIndicator: unknown;
+    // (undocumented)
+    static ngAcceptInputType_multiple: unknown;
+    // (undocumented)
+    static ngAcceptInputType_required: unknown;
+    // (undocumented)
+    static ngAcceptInputType_selectable: unknown;
     // (undocumented)
     ngAfterContentInit(): void;
     _onChange: (value: any) => void;
     _onTouched: () => void;
     registerOnChange(fn: (value: any) => void): void;
     registerOnTouched(fn: () => void): void;
-    get required(): boolean;
-    set required(value: BooleanInput);
-    // (undocumented)
-    protected _required: boolean;
+    required: boolean;
     get selectable(): boolean;
-    set selectable(value: BooleanInput);
+    set selectable(value: boolean);
     // (undocumented)
     protected _selectable: boolean;
     get selected(): MatChipOption[] | MatChipOption;
@@ -329,7 +345,7 @@ export class MatChipListbox extends MatChipSet implements AfterContentInit, OnDe
     protected _value: any;
     writeValue(value: any): void;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<MatChipListbox, "mat-chip-listbox", never, { "tabIndex": { "alias": "tabIndex"; "required": false; }; "multiple": { "alias": "multiple"; "required": false; }; "ariaOrientation": { "alias": "aria-orientation"; "required": false; }; "selectable": { "alias": "selectable"; "required": false; }; "compareWith": { "alias": "compareWith"; "required": false; }; "required": { "alias": "required"; "required": false; }; "hideSingleSelectionIndicator": { "alias": "hideSingleSelectionIndicator"; "required": false; }; "value": { "alias": "value"; "required": false; }; }, { "change": "change"; }, ["_chips"], ["*"], false, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MatChipListbox, "mat-chip-listbox", never, { "multiple": { "alias": "multiple"; "required": false; }; "ariaOrientation": { "alias": "aria-orientation"; "required": false; }; "selectable": { "alias": "selectable"; "required": false; }; "compareWith": { "alias": "compareWith"; "required": false; }; "required": { "alias": "required"; "required": false; }; "hideSingleSelectionIndicator": { "alias": "hideSingleSelectionIndicator"; "required": false; }; "value": { "alias": "value"; "required": false; }; }, { "change": "change"; }, ["_chips"], ["*"], false, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatChipListbox, never>;
 }
@@ -356,21 +372,25 @@ export class MatChipOption extends MatChip implements OnInit {
     // (undocumented)
     _hasLeadingGraphic(): boolean;
     // (undocumented)
+    static ngAcceptInputType_selectable: unknown;
+    // (undocumented)
+    static ngAcceptInputType_selected: unknown;
+    // (undocumented)
     ngOnInit(): void;
     select(): void;
     get selectable(): boolean;
-    set selectable(value: BooleanInput);
+    set selectable(value: boolean);
     // (undocumented)
     protected _selectable: boolean;
     get selected(): boolean;
-    set selected(value: BooleanInput);
+    set selected(value: boolean);
     readonly selectionChange: EventEmitter<MatChipSelectionChange>;
     selectViaInteraction(): void;
     // (undocumented)
     _setSelectedState(isSelected: boolean, isUserInput: boolean, emitEvent: boolean): void;
     toggleSelected(isUserInput?: boolean): boolean;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<MatChipOption, "mat-basic-chip-option, [mat-basic-chip-option], mat-chip-option, [mat-chip-option]", never, { "color": { "alias": "color"; "required": false; }; "disabled": { "alias": "disabled"; "required": false; }; "disableRipple": { "alias": "disableRipple"; "required": false; }; "tabIndex": { "alias": "tabIndex"; "required": false; }; "selectable": { "alias": "selectable"; "required": false; }; "selected": { "alias": "selected"; "required": false; }; }, { "selectionChange": "selectionChange"; }, never, ["mat-chip-avatar, [matChipAvatar]", "*", "mat-chip-trailing-icon,[matChipRemove],[matChipTrailingIcon]"], false, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MatChipOption, "mat-basic-chip-option, [mat-basic-chip-option], mat-chip-option, [mat-chip-option]", never, { "selectable": { "alias": "selectable"; "required": false; }; "selected": { "alias": "selected"; "required": false; }; }, { "selectionChange": "selectionChange"; }, never, ["mat-chip-avatar, [matChipAvatar]", "*", "mat-chip-trailing-icon,[matChipRemove],[matChipTrailingIcon]"], false, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatChipOption, never>;
 }
@@ -411,7 +431,7 @@ export class MatChipRow extends MatChip implements AfterViewInit {
     // (undocumented)
     _isRippleDisabled(): boolean;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<MatChipRow, "mat-chip-row, [mat-chip-row], mat-basic-chip-row, [mat-basic-chip-row]", never, { "color": { "alias": "color"; "required": false; }; "disabled": { "alias": "disabled"; "required": false; }; "disableRipple": { "alias": "disableRipple"; "required": false; }; "tabIndex": { "alias": "tabIndex"; "required": false; }; "editable": { "alias": "editable"; "required": false; }; }, { "edited": "edited"; }, ["contentEditInput"], ["mat-chip-avatar, [matChipAvatar]", "[matChipEditInput]", "*", "mat-chip-trailing-icon,[matChipRemove],[matChipTrailingIcon]"], false, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MatChipRow, "mat-chip-row, [mat-chip-row], mat-basic-chip-row, [mat-basic-chip-row]", never, { "editable": { "alias": "editable"; "required": false; }; }, { "edited": "edited"; }, ["contentEditInput"], ["mat-chip-avatar, [matChipAvatar]", "[matChipEditInput]", "*", "mat-chip-trailing-icon,[matChipRemove],[matChipTrailingIcon]"], false, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatChipRow, [null, null, null, null, null, { optional: true; }, { optional: true; }, { attribute: "tabindex"; }]>;
 }
@@ -434,7 +454,7 @@ export class MatChipSelectionChange {
 }
 
 // @public
-export class MatChipSet extends _MatChipSetMixinBase implements AfterViewInit, HasTabIndex, OnDestroy {
+export class MatChipSet implements AfterViewInit, OnDestroy {
     constructor(_elementRef: ElementRef<HTMLElement>, _changeDetectorRef: ChangeDetectorRef, _dir: Directionality);
     protected _allowFocusEscape(): void;
     // (undocumented)
@@ -447,7 +467,7 @@ export class MatChipSet extends _MatChipSetMixinBase implements AfterViewInit, H
     protected _defaultRole: string;
     protected _destroyed: Subject<void>;
     get disabled(): boolean;
-    set disabled(value: BooleanInput);
+    set disabled(value: boolean);
     // (undocumented)
     protected _disabled: boolean;
     // (undocumented)
@@ -461,6 +481,10 @@ export class MatChipSet extends _MatChipSetMixinBase implements AfterViewInit, H
     protected _isValidIndex(index: number): boolean;
     protected _keyManager: FocusKeyManager<MatChipAction>;
     // (undocumented)
+    static ngAcceptInputType_disabled: unknown;
+    // (undocumented)
+    static ngAcceptInputType_tabIndex: unknown;
+    // (undocumented)
     ngAfterViewInit(): void;
     // (undocumented)
     ngOnDestroy(): void;
@@ -469,8 +493,9 @@ export class MatChipSet extends _MatChipSetMixinBase implements AfterViewInit, H
     set role(value: string | null);
     protected _skipPredicate(action: MatChipAction): boolean;
     protected _syncChipsState(): void;
+    tabIndex: number;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<MatChipSet, "mat-chip-set", never, { "disabled": { "alias": "disabled"; "required": false; }; "role": { "alias": "role"; "required": false; }; }, {}, ["_chips"], ["*"], false, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MatChipSet, "mat-chip-set", never, { "disabled": { "alias": "disabled"; "required": false; }; "role": { "alias": "role"; "required": false; }; "tabIndex": { "alias": "tabIndex"; "required": false; }; }, {}, ["_chips"], ["*"], false, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatChipSet, [null, null, { optional: true; }]>;
 }

--- a/tools/public_api_guard/material/datepicker.md
+++ b/tools/public_api_guard/material/datepicker.md
@@ -11,8 +11,6 @@ import { AfterViewChecked } from '@angular/core';
 import { AfterViewInit } from '@angular/core';
 import { AnimationEvent as AnimationEvent_2 } from '@angular/animations';
 import { AnimationTriggerMetadata } from '@angular/animations';
-import { BooleanInput } from '@angular/cdk/coercion';
-import { CanColor } from '@angular/material/core';
 import { CanUpdateErrorState } from '@angular/material/core';
 import { ChangeDetectorRef } from '@angular/core';
 import { ComponentType } from '@angular/cdk/portal';
@@ -372,8 +370,8 @@ export class MatDatepickerCancel {
 }
 
 // @public
-export class MatDatepickerContent<S, D = ExtractDateTypeFromSelection<S>> extends _MatDatepickerContentBase implements OnInit, AfterViewInit, OnDestroy, CanColor {
-    constructor(elementRef: ElementRef, _changeDetectorRef: ChangeDetectorRef, _globalModel: MatDateSelectionModel<S, D>, _dateAdapter: DateAdapter<D>, _rangeSelectionStrategy: MatDateRangeSelectionStrategy<D>, intl: MatDatepickerIntl);
+export class MatDatepickerContent<S, D = ExtractDateTypeFromSelection<S>> implements OnInit, AfterViewInit, OnDestroy {
+    constructor(_elementRef: ElementRef, _changeDetectorRef: ChangeDetectorRef, _globalModel: MatDateSelectionModel<S, D>, _dateAdapter: DateAdapter<D>, _rangeSelectionStrategy: MatDateRangeSelectionStrategy<D>, intl: MatDatepickerIntl);
     _actionsPortal: TemplatePortal | null;
     readonly _animationDone: Subject<void>;
     _animationState: 'enter-dropdown' | 'enter-dialog' | 'void';
@@ -382,10 +380,13 @@ export class MatDatepickerContent<S, D = ExtractDateTypeFromSelection<S>> extend
     _calendar: MatCalendar<D>;
     _closeButtonFocused: boolean;
     _closeButtonText: string;
+    color: ThemePalette;
     comparisonEnd: D | null;
     comparisonStart: D | null;
     datepicker: MatDatepickerBase<any, S, D>;
     _dialogLabelId: string | null;
+    // (undocumented)
+    protected _elementRef: ElementRef;
     endDateAccessibleName: string | null;
     // (undocumented)
     _getSelected(): D | DateRange<D> | null;
@@ -537,10 +538,12 @@ export class MatDatepickerToggle<D> implements AfterContentInit, OnChanges, OnDe
     _customIcon: MatDatepickerToggleIcon;
     datepicker: MatDatepickerPanel<MatDatepickerControl<any>, D>;
     get disabled(): boolean;
-    set disabled(value: BooleanInput);
+    set disabled(value: boolean);
     disableRipple: boolean;
     // (undocumented)
     _intl: MatDatepickerIntl;
+    // (undocumented)
+    static ngAcceptInputType_disabled: unknown;
     // (undocumented)
     ngAfterContentInit(): void;
     // (undocumented)
@@ -574,7 +577,7 @@ export class MatDateRangeInput<D> implements MatFormFieldControl<DateRange<D>>, 
     get dateFilter(): DateFilterFn<D>;
     set dateFilter(value: DateFilterFn<D>);
     get disabled(): boolean;
-    set disabled(value: BooleanInput);
+    set disabled(value: boolean);
     get empty(): boolean;
     // (undocumented)
     _endInput: MatEndDate<D>;
@@ -599,6 +602,10 @@ export class MatDateRangeInput<D> implements MatFormFieldControl<DateRange<D>>, 
     get min(): D | null;
     set min(value: D | null);
     // (undocumented)
+    static ngAcceptInputType_disabled: unknown;
+    // (undocumented)
+    static ngAcceptInputType_required: unknown;
+    // (undocumented)
     ngAfterContentInit(): void;
     ngControl: NgControl | null;
     // (undocumented)
@@ -611,7 +618,7 @@ export class MatDateRangeInput<D> implements MatFormFieldControl<DateRange<D>>, 
     get rangePicker(): MatDatepickerPanel<MatDatepickerControl<D>, DateRange<D>, D>;
     set rangePicker(rangePicker: MatDatepickerPanel<MatDatepickerControl<D>, DateRange<D>, D>);
     get required(): boolean;
-    set required(value: BooleanInput);
+    set required(value: boolean);
     separator: string;
     setDescribedByIds(ids: string[]): void;
     _shouldHidePlaceholders(): boolean;

--- a/tools/public_api_guard/material/expansion.md
+++ b/tools/public_api_guard/material/expansion.md
@@ -4,22 +4,18 @@
 
 ```ts
 
-import { _AbstractConstructor } from '@angular/material/core';
 import { AfterContentInit } from '@angular/core';
 import { AfterViewInit } from '@angular/core';
 import { AnimationEvent as AnimationEvent_2 } from '@angular/animations';
 import { AnimationTriggerMetadata } from '@angular/animations';
-import { BooleanInput } from '@angular/cdk/coercion';
 import { CdkAccordion } from '@angular/cdk/accordion';
 import { CdkAccordionItem } from '@angular/cdk/accordion';
 import { ChangeDetectorRef } from '@angular/core';
-import { _Constructor } from '@angular/material/core';
 import { ElementRef } from '@angular/core';
 import { EventEmitter } from '@angular/core';
 import { FocusableOption } from '@angular/cdk/a11y';
 import { FocusMonitor } from '@angular/cdk/a11y';
 import { FocusOrigin } from '@angular/cdk/a11y';
-import { HasTabIndex } from '@angular/material/core';
 import * as i0 from '@angular/core';
 import * as i5 from '@angular/material/core';
 import * as i6 from '@angular/cdk/accordion';
@@ -54,8 +50,9 @@ export class MatAccordion extends CdkAccordion implements MatAccordionBase, Afte
     _handleHeaderFocus(header: MatExpansionPanelHeader): void;
     _handleHeaderKeydown(event: KeyboardEvent): void;
     _headers: QueryList<MatExpansionPanelHeader>;
-    get hideToggle(): boolean;
-    set hideToggle(show: BooleanInput);
+    hideToggle: boolean;
+    // (undocumented)
+    static ngAcceptInputType_hideToggle: unknown;
     // (undocumented)
     ngAfterContentInit(): void;
     // (undocumented)
@@ -114,9 +111,11 @@ export class MatExpansionPanel extends CdkAccordionItem implements AfterContentI
     _hasSpacing(): boolean;
     _headerId: string;
     get hideToggle(): boolean;
-    set hideToggle(value: BooleanInput);
+    set hideToggle(value: boolean);
     readonly _inputChanges: Subject<SimpleChanges>;
     _lazyContent: MatExpansionPanelContent;
+    // (undocumented)
+    static ngAcceptInputType_hideToggle: unknown;
     // (undocumented)
     ngAfterContentInit(): void;
     // (undocumented)
@@ -171,7 +170,7 @@ export class MatExpansionPanelDescription {
 }
 
 // @public
-export class MatExpansionPanelHeader extends _MatExpansionPanelHeaderMixinBase implements AfterViewInit, OnDestroy, FocusableOption, HasTabIndex {
+export class MatExpansionPanelHeader implements AfterViewInit, OnDestroy, FocusableOption {
     constructor(panel: MatExpansionPanel, _element: ElementRef, _focusMonitor: FocusMonitor, _changeDetectorRef: ChangeDetectorRef, defaultOptions?: MatExpansionPanelDefaultOptions, _animationMode?: string | undefined, tabIndex?: string);
     // (undocumented)
     _animationMode?: string | undefined;
@@ -186,15 +185,18 @@ export class MatExpansionPanelHeader extends _MatExpansionPanelHeaderMixinBase i
     _isExpanded(): boolean;
     _keydown(event: KeyboardEvent): void;
     // (undocumented)
+    static ngAcceptInputType_tabIndex: unknown;
+    // (undocumented)
     ngAfterViewInit(): void;
     // (undocumented)
     ngOnDestroy(): void;
     // (undocumented)
     panel: MatExpansionPanel;
     _showToggle(): boolean;
+    tabIndex: number;
     _toggle(): void;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<MatExpansionPanelHeader, "mat-expansion-panel-header", never, { "tabIndex": { "alias": "tabIndex"; "required": false; }; "expandedHeight": { "alias": "expandedHeight"; "required": false; }; "collapsedHeight": { "alias": "collapsedHeight"; "required": false; }; }, {}, never, ["mat-panel-title", "mat-panel-description", "*"], false, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MatExpansionPanelHeader, "mat-expansion-panel-header", never, { "expandedHeight": { "alias": "expandedHeight"; "required": false; }; "collapsedHeight": { "alias": "collapsedHeight"; "required": false; }; "tabIndex": { "alias": "tabIndex"; "required": false; }; }, {}, never, ["mat-panel-title", "mat-panel-description", "*"], false, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatExpansionPanelHeader, [{ host: true; }, null, null, null, { optional: true; }, { optional: true; }, { attribute: "tabindex"; }]>;
 }

--- a/tools/public_api_guard/material/icon.md
+++ b/tools/public_api_guard/material/icon.md
@@ -4,11 +4,7 @@
 
 ```ts
 
-import { _AbstractConstructor } from '@angular/material/core';
 import { AfterViewChecked } from '@angular/core';
-import { BooleanInput } from '@angular/cdk/coercion';
-import { CanColor } from '@angular/material/core';
-import { _Constructor } from '@angular/material/core';
 import { DomSanitizer } from '@angular/platform-browser';
 import { ElementRef } from '@angular/core';
 import { ErrorHandler } from '@angular/core';
@@ -65,14 +61,19 @@ export const MAT_ICON_LOCATION: InjectionToken<MatIconLocation>;
 export function MAT_ICON_LOCATION_FACTORY(): MatIconLocation;
 
 // @public
-export class MatIcon extends _MatIconBase implements OnInit, AfterViewChecked, CanColor, OnDestroy {
-    constructor(elementRef: ElementRef<HTMLElement>, _iconRegistry: MatIconRegistry, ariaHidden: string, _location: MatIconLocation, _errorHandler: ErrorHandler, defaults?: MatIconDefaultOptions);
+export class MatIcon implements OnInit, AfterViewChecked, OnDestroy {
+    constructor(_elementRef: ElementRef<HTMLElement>, _iconRegistry: MatIconRegistry, ariaHidden: string, _location: MatIconLocation, _errorHandler: ErrorHandler, defaults?: MatIconDefaultOptions);
+    get color(): string | null | undefined;
+    set color(value: string | null | undefined);
+    // (undocumented)
+    readonly _elementRef: ElementRef<HTMLElement>;
     get fontIcon(): string;
     set fontIcon(value: string);
     get fontSet(): string;
     set fontSet(value: string);
-    get inline(): boolean;
-    set inline(inline: BooleanInput);
+    inline: boolean;
+    // (undocumented)
+    static ngAcceptInputType_inline: unknown;
     // (undocumented)
     ngAfterViewChecked(): void;
     // (undocumented)

--- a/tools/public_api_guard/material/paginator.md
+++ b/tools/public_api_guard/material/paginator.md
@@ -4,11 +4,7 @@
 
 ```ts
 
-import { _AbstractConstructor } from '@angular/material/core';
-import { BooleanInput } from '@angular/cdk/coercion';
-import { CanDisable } from '@angular/material/core';
 import { ChangeDetectorRef } from '@angular/core';
-import { _Constructor } from '@angular/material/core';
 import { EventEmitter } from '@angular/core';
 import { HasInitialized } from '@angular/material/core';
 import * as i0 from '@angular/core';
@@ -17,7 +13,6 @@ import * as i3 from '@angular/material/select';
 import * as i4 from '@angular/material/tooltip';
 import { InjectionToken } from '@angular/core';
 import { MatFormFieldAppearance } from '@angular/material/form-field';
-import { NumberInput } from '@angular/cdk/coercion';
 import { OnDestroy } from '@angular/core';
 import { OnInit } from '@angular/core';
 import { Optional } from '@angular/core';
@@ -38,44 +33,55 @@ export const MAT_PAGINATOR_INTL_PROVIDER: {
 export function MAT_PAGINATOR_INTL_PROVIDER_FACTORY(parentIntl: MatPaginatorIntl): MatPaginatorIntl;
 
 // @public
-export class MatPaginator extends _MatPaginatorMixinBase implements OnInit, OnDestroy, CanDisable, HasInitialized {
+export class MatPaginator extends _MatPaginatorMixinBase implements OnInit, OnDestroy, HasInitialized {
     constructor(_intl: MatPaginatorIntl, _changeDetectorRef: ChangeDetectorRef, defaults?: MatPaginatorDefaultOptions);
     _changePageSize(pageSize: number): void;
     color: ThemePalette;
+    disabled: boolean;
     _displayedPageSizeOptions: number[];
     firstPage(): void;
     _formFieldAppearance?: MatFormFieldAppearance;
     getNumberOfPages(): number;
     hasNextPage(): boolean;
     hasPreviousPage(): boolean;
-    get hidePageSize(): boolean;
-    set hidePageSize(value: BooleanInput);
+    hidePageSize: boolean;
     // (undocumented)
     _intl: MatPaginatorIntl;
     lastPage(): void;
     get length(): number;
-    set length(value: NumberInput);
+    set length(value: number);
     _nextButtonsDisabled(): boolean;
     nextPage(): void;
+    // (undocumented)
+    static ngAcceptInputType_disabled: unknown;
+    // (undocumented)
+    static ngAcceptInputType_hidePageSize: unknown;
+    // (undocumented)
+    static ngAcceptInputType_length: unknown;
+    // (undocumented)
+    static ngAcceptInputType_pageIndex: unknown;
+    // (undocumented)
+    static ngAcceptInputType_pageSize: unknown;
+    // (undocumented)
+    static ngAcceptInputType_showFirstLastButtons: unknown;
     // (undocumented)
     ngOnDestroy(): void;
     // (undocumented)
     ngOnInit(): void;
     readonly page: EventEmitter<PageEvent>;
     get pageIndex(): number;
-    set pageIndex(value: NumberInput);
+    set pageIndex(value: number);
     get pageSize(): number;
-    set pageSize(value: NumberInput);
+    set pageSize(value: number);
     readonly _pageSizeLabelId: string;
     get pageSizeOptions(): number[];
     set pageSizeOptions(value: number[] | readonly number[]);
     _previousButtonsDisabled(): boolean;
     previousPage(): void;
     selectConfig: MatPaginatorSelectConfig;
-    get showFirstLastButtons(): boolean;
-    set showFirstLastButtons(value: BooleanInput);
+    showFirstLastButtons: boolean;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<MatPaginator, "mat-paginator", ["matPaginator"], { "disabled": { "alias": "disabled"; "required": false; }; "color": { "alias": "color"; "required": false; }; "pageIndex": { "alias": "pageIndex"; "required": false; }; "length": { "alias": "length"; "required": false; }; "pageSize": { "alias": "pageSize"; "required": false; }; "pageSizeOptions": { "alias": "pageSizeOptions"; "required": false; }; "hidePageSize": { "alias": "hidePageSize"; "required": false; }; "showFirstLastButtons": { "alias": "showFirstLastButtons"; "required": false; }; "selectConfig": { "alias": "selectConfig"; "required": false; }; }, { "page": "page"; }, never, never, false, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MatPaginator, "mat-paginator", ["matPaginator"], { "color": { "alias": "color"; "required": false; }; "pageIndex": { "alias": "pageIndex"; "required": false; }; "length": { "alias": "length"; "required": false; }; "pageSize": { "alias": "pageSize"; "required": false; }; "pageSizeOptions": { "alias": "pageSizeOptions"; "required": false; }; "hidePageSize": { "alias": "hidePageSize"; "required": false; }; "showFirstLastButtons": { "alias": "showFirstLastButtons"; "required": false; }; "selectConfig": { "alias": "selectConfig"; "required": false; }; "disabled": { "alias": "disabled"; "required": false; }; }, { "page": "page"; }, never, never, false, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatPaginator, [null, null, { optional: true; }]>;
 }

--- a/tools/public_api_guard/material/progress-bar.md
+++ b/tools/public_api_guard/material/progress-bar.md
@@ -4,18 +4,14 @@
 
 ```ts
 
-import { _AbstractConstructor } from '@angular/material/core';
 import { AfterViewInit } from '@angular/core';
-import { CanColor } from '@angular/material/core';
 import { ChangeDetectorRef } from '@angular/core';
-import { _Constructor } from '@angular/material/core';
 import { ElementRef } from '@angular/core';
 import { EventEmitter } from '@angular/core';
 import * as i0 from '@angular/core';
 import * as i2 from '@angular/material/core';
 import { InjectionToken } from '@angular/core';
 import { NgZone } from '@angular/core';
-import { NumberInput } from '@angular/cdk/coercion';
 import { OnDestroy } from '@angular/core';
 import { ThemePalette } from '@angular/material/core';
 
@@ -29,13 +25,17 @@ export const MAT_PROGRESS_BAR_LOCATION: InjectionToken<MatProgressBarLocation>;
 export function MAT_PROGRESS_BAR_LOCATION_FACTORY(): MatProgressBarLocation;
 
 // @public (undocumented)
-export class MatProgressBar extends _MatProgressBarBase implements AfterViewInit, OnDestroy, CanColor {
-    constructor(elementRef: ElementRef<HTMLElement>, _ngZone: NgZone, _changeDetectorRef: ChangeDetectorRef, _animationMode?: string | undefined, defaults?: MatProgressBarDefaultOptions);
+export class MatProgressBar implements AfterViewInit, OnDestroy {
+    constructor(_elementRef: ElementRef<HTMLElement>, _ngZone: NgZone, _changeDetectorRef: ChangeDetectorRef, _animationMode?: string | undefined, defaults?: MatProgressBarDefaultOptions);
     readonly animationEnd: EventEmitter<ProgressAnimationEnd>;
     // (undocumented)
     _animationMode?: string | undefined;
     get bufferValue(): number;
-    set bufferValue(v: NumberInput);
+    set bufferValue(v: number);
+    get color(): string | null | undefined;
+    set color(value: string | null | undefined);
+    // (undocumented)
+    readonly _elementRef: ElementRef<HTMLElement>;
     _getBufferBarFlexBasis(): string;
     _getPrimaryBarTransform(): string;
     _isIndeterminate(): boolean;
@@ -43,11 +43,15 @@ export class MatProgressBar extends _MatProgressBarBase implements AfterViewInit
     get mode(): ProgressBarMode;
     set mode(value: ProgressBarMode);
     // (undocumented)
+    static ngAcceptInputType_bufferValue: unknown;
+    // (undocumented)
+    static ngAcceptInputType_value: unknown;
+    // (undocumented)
     ngAfterViewInit(): void;
     // (undocumented)
     ngOnDestroy(): void;
     get value(): number;
-    set value(v: NumberInput);
+    set value(v: number);
     // (undocumented)
     static ɵcmp: i0.ɵɵComponentDeclaration<MatProgressBar, "mat-progress-bar", ["matProgressBar"], { "color": { "alias": "color"; "required": false; }; "value": { "alias": "value"; "required": false; }; "bufferValue": { "alias": "bufferValue"; "required": false; }; "mode": { "alias": "mode"; "required": false; }; }, { "animationEnd": "animationEnd"; }, never, never, false, never>;
     // (undocumented)

--- a/tools/public_api_guard/material/progress-spinner.md
+++ b/tools/public_api_guard/material/progress-spinner.md
@@ -4,15 +4,11 @@
 
 ```ts
 
-import { _AbstractConstructor } from '@angular/material/core';
-import { CanColor } from '@angular/material/core';
-import { _Constructor } from '@angular/material/core';
 import { ElementRef } from '@angular/core';
 import * as i0 from '@angular/core';
 import * as i2 from '@angular/common';
 import * as i3 from '@angular/material/core';
 import { InjectionToken } from '@angular/core';
-import { NumberInput } from '@angular/cdk/coercion';
 import { ThemePalette } from '@angular/material/core';
 
 // @public
@@ -22,21 +18,31 @@ export const MAT_PROGRESS_SPINNER_DEFAULT_OPTIONS: InjectionToken<MatProgressSpi
 export function MAT_PROGRESS_SPINNER_DEFAULT_OPTIONS_FACTORY(): MatProgressSpinnerDefaultOptions;
 
 // @public (undocumented)
-export class MatProgressSpinner extends _MatProgressSpinnerBase implements CanColor {
-    constructor(elementRef: ElementRef<HTMLElement>, animationMode: string, defaults?: MatProgressSpinnerDefaultOptions);
+export class MatProgressSpinner {
+    constructor(_elementRef: ElementRef<HTMLElement>, animationMode: string, defaults?: MatProgressSpinnerDefaultOptions);
     _circleRadius(): number;
     _circleStrokeWidth(): number;
+    get color(): string | null | undefined;
+    set color(value: string | null | undefined);
     _determinateCircle: ElementRef<HTMLElement>;
     get diameter(): number;
-    set diameter(size: NumberInput);
+    set diameter(size: number);
+    // (undocumented)
+    readonly _elementRef: ElementRef<HTMLElement>;
     mode: ProgressSpinnerMode;
+    // (undocumented)
+    static ngAcceptInputType_diameter: unknown;
+    // (undocumented)
+    static ngAcceptInputType_strokeWidth: unknown;
+    // (undocumented)
+    static ngAcceptInputType_value: unknown;
     _noopAnimations: boolean;
     _strokeCircumference(): number;
     _strokeDashOffset(): number | null;
     get strokeWidth(): number;
-    set strokeWidth(value: NumberInput);
+    set strokeWidth(value: number);
     get value(): number;
-    set value(v: NumberInput);
+    set value(v: number);
     _viewBox(): string;
     // (undocumented)
     static ɵcmp: i0.ɵɵComponentDeclaration<MatProgressSpinner, "mat-progress-spinner, mat-spinner", ["matProgressSpinner"], { "color": { "alias": "color"; "required": false; }; "mode": { "alias": "mode"; "required": false; }; "value": { "alias": "value"; "required": false; }; "diameter": { "alias": "diameter"; "required": false; }; "strokeWidth": { "alias": "strokeWidth"; "required": false; }; }, {}, never, never, false, never>;

--- a/tools/public_api_guard/material/radio.md
+++ b/tools/public_api_guard/material/radio.md
@@ -4,20 +4,15 @@
 
 ```ts
 
-import { _AbstractConstructor } from '@angular/material/core';
 import { AfterContentInit } from '@angular/core';
 import { AfterViewInit } from '@angular/core';
-import { BooleanInput } from '@angular/cdk/coercion';
-import { CanDisableRipple } from '@angular/material/core';
 import { ChangeDetectorRef } from '@angular/core';
-import { _Constructor } from '@angular/material/core';
 import { ControlValueAccessor } from '@angular/forms';
 import { DoCheck } from '@angular/core';
 import { ElementRef } from '@angular/core';
 import { EventEmitter } from '@angular/core';
 import { FocusMonitor } from '@angular/cdk/a11y';
 import { FocusOrigin } from '@angular/cdk/a11y';
-import { HasTabIndex } from '@angular/material/core';
 import * as i0 from '@angular/core';
 import * as i2 from '@angular/material/core';
 import * as i3 from '@angular/common';
@@ -41,18 +36,21 @@ export const MAT_RADIO_GROUP: InjectionToken<MatRadioGroup>;
 export const MAT_RADIO_GROUP_CONTROL_VALUE_ACCESSOR: any;
 
 // @public (undocumented)
-export class MatRadioButton extends _MatRadioButtonMixinBase implements OnInit, AfterViewInit, DoCheck, OnDestroy, CanDisableRipple, HasTabIndex {
-    constructor(radioGroup: MatRadioGroup, elementRef: ElementRef, _changeDetector: ChangeDetectorRef, _focusMonitor: FocusMonitor, _radioDispatcher: UniqueSelectionDispatcher, animationMode?: string, _providerOverride?: MatRadioDefaultOptions | undefined, tabIndex?: string);
+export class MatRadioButton implements OnInit, AfterViewInit, DoCheck, OnDestroy {
+    constructor(radioGroup: MatRadioGroup, _elementRef: ElementRef, _changeDetector: ChangeDetectorRef, _focusMonitor: FocusMonitor, _radioDispatcher: UniqueSelectionDispatcher, animationMode?: string, _providerOverride?: MatRadioDefaultOptions | undefined, tabIndex?: string);
     ariaDescribedby: string;
     ariaLabel: string;
     ariaLabelledby: string;
     readonly change: EventEmitter<MatRadioChange>;
     get checked(): boolean;
-    set checked(value: BooleanInput);
+    set checked(value: boolean);
     get color(): ThemePalette;
     set color(newValue: ThemePalette);
     get disabled(): boolean;
-    set disabled(value: BooleanInput);
+    set disabled(value: boolean);
+    disableRipple: boolean;
+    // (undocumented)
+    protected _elementRef: ElementRef;
     focus(options?: FocusOptions, origin?: FocusOrigin): void;
     id: string;
     _inputElement: ElementRef<HTMLInputElement>;
@@ -63,6 +61,16 @@ export class MatRadioButton extends _MatRadioButtonMixinBase implements OnInit, 
     set labelPosition(value: 'before' | 'after');
     _markForCheck(): void;
     name: string;
+    // (undocumented)
+    static ngAcceptInputType_checked: unknown;
+    // (undocumented)
+    static ngAcceptInputType_disabled: unknown;
+    // (undocumented)
+    static ngAcceptInputType_disableRipple: unknown;
+    // (undocumented)
+    static ngAcceptInputType_required: unknown;
+    // (undocumented)
+    static ngAcceptInputType_tabIndex: unknown;
     // (undocumented)
     ngAfterViewInit(): void;
     // (undocumented)
@@ -78,12 +86,13 @@ export class MatRadioButton extends _MatRadioButtonMixinBase implements OnInit, 
     _onTouchTargetClick(event: Event): void;
     radioGroup: MatRadioGroup;
     get required(): boolean;
-    set required(value: BooleanInput);
+    set required(value: boolean);
     protected _setDisabled(value: boolean): void;
+    tabIndex: number;
     get value(): any;
     set value(value: any);
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<MatRadioButton, "mat-radio-button", ["matRadioButton"], { "disableRipple": { "alias": "disableRipple"; "required": false; }; "tabIndex": { "alias": "tabIndex"; "required": false; }; "id": { "alias": "id"; "required": false; }; "name": { "alias": "name"; "required": false; }; "ariaLabel": { "alias": "aria-label"; "required": false; }; "ariaLabelledby": { "alias": "aria-labelledby"; "required": false; }; "ariaDescribedby": { "alias": "aria-describedby"; "required": false; }; "checked": { "alias": "checked"; "required": false; }; "value": { "alias": "value"; "required": false; }; "labelPosition": { "alias": "labelPosition"; "required": false; }; "disabled": { "alias": "disabled"; "required": false; }; "required": { "alias": "required"; "required": false; }; "color": { "alias": "color"; "required": false; }; }, { "change": "change"; }, never, ["*"], false, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MatRadioButton, "mat-radio-button", ["matRadioButton"], { "id": { "alias": "id"; "required": false; }; "name": { "alias": "name"; "required": false; }; "ariaLabel": { "alias": "aria-label"; "required": false; }; "ariaLabelledby": { "alias": "aria-labelledby"; "required": false; }; "ariaDescribedby": { "alias": "aria-describedby"; "required": false; }; "disableRipple": { "alias": "disableRipple"; "required": false; }; "tabIndex": { "alias": "tabIndex"; "required": false; }; "checked": { "alias": "checked"; "required": false; }; "value": { "alias": "value"; "required": false; }; "labelPosition": { "alias": "labelPosition"; "required": false; }; "disabled": { "alias": "disabled"; "required": false; }; "required": { "alias": "required"; "required": false; }; "color": { "alias": "color"; "required": false; }; }, { "change": "change"; }, never, ["*"], false, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatRadioButton, [{ optional: true; }, null, null, null, null, { optional: true; }, { optional: true; }, { attribute: "tabindex"; }]>;
 }
@@ -112,7 +121,7 @@ export class MatRadioGroup implements AfterContentInit, OnDestroy, ControlValueA
     color: ThemePalette;
     _controlValueAccessorChangeFn: (value: any) => void;
     get disabled(): boolean;
-    set disabled(value: BooleanInput);
+    set disabled(value: boolean);
     _emitChangeEvent(): void;
     get labelPosition(): 'before' | 'after';
     set labelPosition(v: 'before' | 'after');
@@ -120,6 +129,10 @@ export class MatRadioGroup implements AfterContentInit, OnDestroy, ControlValueA
     _markRadiosForCheck(): void;
     get name(): string;
     set name(value: string);
+    // (undocumented)
+    static ngAcceptInputType_disabled: unknown;
+    // (undocumented)
+    static ngAcceptInputType_required: unknown;
     ngAfterContentInit(): void;
     // (undocumented)
     ngOnDestroy(): void;
@@ -128,7 +141,7 @@ export class MatRadioGroup implements AfterContentInit, OnDestroy, ControlValueA
     registerOnChange(fn: (value: any) => void): void;
     registerOnTouched(fn: any): void;
     get required(): boolean;
-    set required(value: BooleanInput);
+    set required(value: boolean);
     get selected(): MatRadioButton | null;
     set selected(selected: MatRadioButton | null);
     setDisabledState(isDisabled: boolean): void;

--- a/tools/public_api_guard/material/select.md
+++ b/tools/public_api_guard/material/select.md
@@ -8,9 +8,6 @@ import { _AbstractConstructor } from '@angular/material/core';
 import { ActiveDescendantKeyManager } from '@angular/cdk/a11y';
 import { AfterContentInit } from '@angular/core';
 import { AnimationTriggerMetadata } from '@angular/animations';
-import { BooleanInput } from '@angular/cdk/coercion';
-import { CanDisable } from '@angular/material/core';
-import { CanDisableRipple } from '@angular/material/core';
 import { CanUpdateErrorState } from '@angular/material/core';
 import { CdkConnectedOverlay } from '@angular/cdk/overlay';
 import { CdkOverlayOrigin } from '@angular/cdk/overlay';
@@ -24,7 +21,6 @@ import { ElementRef } from '@angular/core';
 import { ErrorStateMatcher } from '@angular/material/core';
 import { EventEmitter } from '@angular/core';
 import { FormGroupDirective } from '@angular/forms';
-import { HasTabIndex } from '@angular/material/core';
 import * as i0 from '@angular/core';
 import * as i2 from '@angular/common';
 import * as i3 from '@angular/cdk/overlay';
@@ -41,7 +37,6 @@ import { MatOptionSelectionChange } from '@angular/material/core';
 import { NgControl } from '@angular/forms';
 import { NgForm } from '@angular/forms';
 import { NgZone } from '@angular/core';
-import { NumberInput } from '@angular/cdk/coercion';
 import { Observable } from 'rxjs';
 import { OnChanges } from '@angular/core';
 import { OnDestroy } from '@angular/core';
@@ -74,7 +69,7 @@ export function MAT_SELECT_SCROLL_STRATEGY_PROVIDER_FACTORY(overlay: Overlay): (
 export const MAT_SELECT_TRIGGER: InjectionToken<MatSelectTrigger>;
 
 // @public (undocumented)
-export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, OnChanges, OnDestroy, OnInit, DoCheck, ControlValueAccessor, CanDisable, HasTabIndex, MatFormFieldControl<any>, CanUpdateErrorState, CanDisableRipple {
+export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, OnChanges, OnDestroy, OnInit, DoCheck, ControlValueAccessor, MatFormFieldControl<any>, CanUpdateErrorState {
     constructor(_viewportRuler: ViewportRuler, _changeDetectorRef: ChangeDetectorRef, _ngZone: NgZone, _defaultErrorStateMatcher: ErrorStateMatcher, elementRef: ElementRef, _dir: Directionality, _parentForm: NgForm, _parentFormGroup: FormGroupDirective, _parentFormField: MatFormField, ngControl: NgControl, tabIndex: string, scrollStrategyFactory: any, _liveAnnouncer: LiveAnnouncer, _defaultOptions?: MatSelectConfig | undefined);
     ariaLabel: string;
     ariaLabelledby: string;
@@ -90,8 +85,9 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
     // (undocumented)
     protected _defaultOptions?: MatSelectConfig | undefined;
     protected readonly _destroy: Subject<void>;
-    get disableOptionCentering(): boolean;
-    set disableOptionCentering(value: BooleanInput);
+    disabled: boolean;
+    disableOptionCentering: boolean;
+    disableRipple: boolean;
     get empty(): boolean;
     errorStateMatcher: ErrorStateMatcher;
     focus(options?: FocusOptions): void;
@@ -101,13 +97,29 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
     _getPanelTheme(): string;
     _handleKeydown(event: KeyboardEvent): void;
     get hideSingleSelectionIndicator(): boolean;
-    set hideSingleSelectionIndicator(value: BooleanInput);
+    set hideSingleSelectionIndicator(value: boolean);
     get id(): string;
     set id(value: string);
     _isRtl(): boolean;
     _keyManager: ActiveDescendantKeyManager<MatOption>;
     get multiple(): boolean;
-    set multiple(value: BooleanInput);
+    set multiple(value: boolean);
+    // (undocumented)
+    static ngAcceptInputType_disabled: unknown;
+    // (undocumented)
+    static ngAcceptInputType_disableOptionCentering: unknown;
+    // (undocumented)
+    static ngAcceptInputType_disableRipple: unknown;
+    // (undocumented)
+    static ngAcceptInputType_hideSingleSelectionIndicator: unknown;
+    // (undocumented)
+    static ngAcceptInputType_multiple: unknown;
+    // (undocumented)
+    static ngAcceptInputType_required: unknown;
+    // (undocumented)
+    static ngAcceptInputType_tabIndex: unknown;
+    // (undocumented)
+    static ngAcceptInputType_typeaheadDebounceInterval: unknown;
     // (undocumented)
     ngAfterContentInit(): void;
     // (undocumented)
@@ -154,7 +166,7 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
     registerOnChange(fn: (value: any) => void): void;
     registerOnTouched(fn: () => {}): void;
     get required(): boolean;
-    set required(value: BooleanInput);
+    set required(value: boolean);
     _scrollOptionIntoView(index: number): void;
     _scrollStrategy: ScrollStrategy;
     get selected(): MatOption | MatOption[];
@@ -165,11 +177,11 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
     get shouldLabelFloat(): boolean;
     sortComparator: (a: MatOption, b: MatOption, options: MatOption[]) => number;
     _syncParentProperties(): void;
+    tabIndex: number;
     toggle(): void;
     trigger: ElementRef;
     get triggerValue(): string;
-    get typeaheadDebounceInterval(): number;
-    set typeaheadDebounceInterval(value: NumberInput);
+    typeaheadDebounceInterval: number;
     userAriaDescribedBy: string;
     get value(): any;
     set value(newValue: any);
@@ -179,7 +191,7 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
     protected _viewportRuler: ViewportRuler;
     writeValue(value: any): void;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<MatSelect, "mat-select", ["matSelect"], { "disabled": { "alias": "disabled"; "required": false; }; "disableRipple": { "alias": "disableRipple"; "required": false; }; "tabIndex": { "alias": "tabIndex"; "required": false; }; "userAriaDescribedBy": { "alias": "aria-describedby"; "required": false; }; "panelClass": { "alias": "panelClass"; "required": false; }; "hideSingleSelectionIndicator": { "alias": "hideSingleSelectionIndicator"; "required": false; }; "placeholder": { "alias": "placeholder"; "required": false; }; "required": { "alias": "required"; "required": false; }; "multiple": { "alias": "multiple"; "required": false; }; "disableOptionCentering": { "alias": "disableOptionCentering"; "required": false; }; "compareWith": { "alias": "compareWith"; "required": false; }; "value": { "alias": "value"; "required": false; }; "ariaLabel": { "alias": "aria-label"; "required": false; }; "ariaLabelledby": { "alias": "aria-labelledby"; "required": false; }; "errorStateMatcher": { "alias": "errorStateMatcher"; "required": false; }; "typeaheadDebounceInterval": { "alias": "typeaheadDebounceInterval"; "required": false; }; "sortComparator": { "alias": "sortComparator"; "required": false; }; "id": { "alias": "id"; "required": false; }; "panelWidth": { "alias": "panelWidth"; "required": false; }; }, { "openedChange": "openedChange"; "_openedStream": "opened"; "_closedStream": "closed"; "selectionChange": "selectionChange"; "valueChange": "valueChange"; }, ["customTrigger", "options", "optionGroups"], ["mat-select-trigger", "*"], false, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MatSelect, "mat-select", ["matSelect"], { "userAriaDescribedBy": { "alias": "aria-describedby"; "required": false; }; "panelClass": { "alias": "panelClass"; "required": false; }; "disabled": { "alias": "disabled"; "required": false; }; "disableRipple": { "alias": "disableRipple"; "required": false; }; "tabIndex": { "alias": "tabIndex"; "required": false; }; "hideSingleSelectionIndicator": { "alias": "hideSingleSelectionIndicator"; "required": false; }; "placeholder": { "alias": "placeholder"; "required": false; }; "required": { "alias": "required"; "required": false; }; "multiple": { "alias": "multiple"; "required": false; }; "disableOptionCentering": { "alias": "disableOptionCentering"; "required": false; }; "compareWith": { "alias": "compareWith"; "required": false; }; "value": { "alias": "value"; "required": false; }; "ariaLabel": { "alias": "aria-label"; "required": false; }; "ariaLabelledby": { "alias": "aria-labelledby"; "required": false; }; "errorStateMatcher": { "alias": "errorStateMatcher"; "required": false; }; "typeaheadDebounceInterval": { "alias": "typeaheadDebounceInterval"; "required": false; }; "sortComparator": { "alias": "sortComparator"; "required": false; }; "id": { "alias": "id"; "required": false; }; "panelWidth": { "alias": "panelWidth"; "required": false; }; }, { "openedChange": "openedChange"; "_openedStream": "opened"; "_closedStream": "closed"; "selectionChange": "selectionChange"; "valueChange": "valueChange"; }, ["customTrigger", "options", "optionGroups"], ["mat-select-trigger", "*"], false, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatSelect, [null, null, null, null, null, { optional: true; }, { optional: true; }, { optional: true; }, { optional: true; }, { optional: true; self: true; }, { attribute: "tabindex"; }, null, null, { optional: true; }]>;
 }

--- a/tools/public_api_guard/material/slider.md
+++ b/tools/public_api_guard/material/slider.md
@@ -4,13 +4,8 @@
 
 ```ts
 
-import { _AbstractConstructor } from '@angular/material/core';
 import { AfterViewInit } from '@angular/core';
-import { BooleanInput } from '@angular/cdk/coercion';
-import { CanColor } from '@angular/material/core';
-import { CanDisableRipple } from '@angular/material/core';
 import { ChangeDetectorRef } from '@angular/core';
-import { _Constructor } from '@angular/material/core';
 import { ControlValueAccessor } from '@angular/forms';
 import { Directionality } from '@angular/cdk/bidi';
 import { ElementRef } from '@angular/core';
@@ -19,15 +14,15 @@ import * as i0 from '@angular/core';
 import * as i4 from '@angular/material/core';
 import { MatRipple } from '@angular/material/core';
 import { NgZone } from '@angular/core';
-import { NumberInput } from '@angular/cdk/coercion';
 import { OnDestroy } from '@angular/core';
 import { QueryList } from '@angular/core';
 import { RippleGlobalOptions } from '@angular/material/core';
 import { Subject } from 'rxjs';
+import { ThemePalette } from '@angular/material/core';
 
 // @public
-export class MatSlider extends _MatSliderMixinBase implements AfterViewInit, CanDisableRipple, OnDestroy, _MatSlider {
-    constructor(_ngZone: NgZone, _cdr: ChangeDetectorRef, elementRef: ElementRef<HTMLElement>, _dir: Directionality, _globalRippleOptions?: RippleGlobalOptions | undefined, animationMode?: string);
+export class MatSlider implements AfterViewInit, OnDestroy, _MatSlider {
+    constructor(_ngZone: NgZone, _cdr: ChangeDetectorRef, _elementRef: ElementRef<HTMLElement>, _dir: Directionality, _globalRippleOptions?: RippleGlobalOptions | undefined, animationMode?: string);
     // (undocumented)
     _cachedLeft: number;
     // (undocumented)
@@ -35,13 +30,17 @@ export class MatSlider extends _MatSliderMixinBase implements AfterViewInit, Can
     _calcTickMarkTransform(index: number): string;
     // (undocumented)
     readonly _cdr: ChangeDetectorRef;
+    color: ThemePalette;
     // (undocumented)
     readonly _dir: Directionality;
     get disabled(): boolean;
-    set disabled(v: BooleanInput);
+    set disabled(v: boolean);
+    disableRipple: boolean;
     get discrete(): boolean;
-    set discrete(v: BooleanInput);
+    set discrete(v: boolean);
     displayWith: (value: number) => string;
+    // (undocumented)
+    readonly _elementRef: ElementRef<HTMLElement>;
     // (undocumented)
     _endThumbTransform: string;
     protected endValueIndicatorText: string;
@@ -63,9 +62,23 @@ export class MatSlider extends _MatSliderMixinBase implements AfterViewInit, Can
     _isRtl: boolean;
     _knobRadius: number;
     get max(): number;
-    set max(v: NumberInput);
+    set max(v: number);
     get min(): number;
-    set min(v: NumberInput);
+    set min(v: number);
+    // (undocumented)
+    static ngAcceptInputType_disabled: unknown;
+    // (undocumented)
+    static ngAcceptInputType_disableRipple: unknown;
+    // (undocumented)
+    static ngAcceptInputType_discrete: unknown;
+    // (undocumented)
+    static ngAcceptInputType_max: unknown;
+    // (undocumented)
+    static ngAcceptInputType_min: unknown;
+    // (undocumented)
+    static ngAcceptInputType_showTickMarks: unknown;
+    // (undocumented)
+    static ngAcceptInputType_step: unknown;
     // (undocumented)
     ngAfterViewInit(): void;
     // (undocumented)
@@ -93,13 +106,12 @@ export class MatSlider extends _MatSliderMixinBase implements AfterViewInit, Can
     }): void;
     // (undocumented)
     _setTransition(withAnimation: boolean): void;
-    get showTickMarks(): boolean;
-    set showTickMarks(v: BooleanInput);
+    showTickMarks: boolean;
     // (undocumented)
     _startThumbTransform: string;
     protected startValueIndicatorText: string;
     get step(): number;
-    set step(v: NumberInput);
+    set step(v: number);
     _thumbs: QueryList<_MatSliderVisualThumb>;
     _tickMarks: _MatTickMark[];
     _tickMarkTrackWidth: number;
@@ -110,7 +122,7 @@ export class MatSlider extends _MatSliderMixinBase implements AfterViewInit, Can
     _updateTrackUI(source: _MatSliderThumb): void;
     _updateValueIndicatorUI(source: _MatSliderThumb): void;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<MatSlider, "mat-slider", ["matSlider"], { "color": { "alias": "color"; "required": false; }; "disableRipple": { "alias": "disableRipple"; "required": false; }; "disabled": { "alias": "disabled"; "required": false; }; "discrete": { "alias": "discrete"; "required": false; }; "showTickMarks": { "alias": "showTickMarks"; "required": false; }; "min": { "alias": "min"; "required": false; }; "max": { "alias": "max"; "required": false; }; "step": { "alias": "step"; "required": false; }; "displayWith": { "alias": "displayWith"; "required": false; }; }, {}, ["_input", "_inputs"], ["*"], false, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MatSlider, "mat-slider", ["matSlider"], { "disabled": { "alias": "disabled"; "required": false; }; "discrete": { "alias": "discrete"; "required": false; }; "showTickMarks": { "alias": "showTickMarks"; "required": false; }; "min": { "alias": "min"; "required": false; }; "color": { "alias": "color"; "required": false; }; "disableRipple": { "alias": "disableRipple"; "required": false; }; "max": { "alias": "max"; "required": false; }; "step": { "alias": "step"; "required": false; }; "displayWith": { "alias": "displayWith"; "required": false; }; }, {}, ["_input", "_inputs"], ["*"], false, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatSlider, [null, null, null, { optional: true; }, { optional: true; }, { optional: true; }]>;
 }
@@ -197,7 +209,7 @@ export class MatSliderThumb implements _MatSliderThumb, OnDestroy, ControlValueA
     _clamp(v: number): number;
     protected readonly _destroyed: Subject<void>;
     get disabled(): boolean;
-    set disabled(v: BooleanInput);
+    set disabled(v: boolean);
     readonly dragEnd: EventEmitter<MatSliderDragEvent>;
     readonly dragStart: EventEmitter<MatSliderDragEvent>;
     // (undocumented)
@@ -219,9 +231,11 @@ export class MatSliderThumb implements _MatSliderThumb, OnDestroy, ControlValueA
     _isFocused: boolean;
     _knobRadius: number;
     get max(): number;
-    set max(v: NumberInput);
+    set max(v: number);
     get min(): number;
-    set min(v: NumberInput);
+    set min(v: number);
+    // (undocumented)
+    static ngAcceptInputType_value: unknown;
     // (undocumented)
     ngOnDestroy(): void;
     // (undocumented)
@@ -252,7 +266,7 @@ export class MatSliderThumb implements _MatSliderThumb, OnDestroy, ControlValueA
     protected _slider: _MatSlider;
     // (undocumented)
     get step(): number;
-    set step(v: NumberInput);
+    set step(v: number);
     thumbPosition: _MatThumb;
     get translateX(): number;
     set translateX(v: number);
@@ -272,7 +286,7 @@ export class MatSliderThumb implements _MatSliderThumb, OnDestroy, ControlValueA
     _updateWidthInactive(): void;
     // (undocumented)
     get value(): number;
-    set value(v: NumberInput);
+    set value(value: number);
     readonly valueChange: EventEmitter<number>;
     _valuetext: string;
     writeValue(value: any): void;

--- a/tools/public_api_guard/material/sort.md
+++ b/tools/public_api_guard/material/sort.md
@@ -4,14 +4,10 @@
 
 ```ts
 
-import { _AbstractConstructor } from '@angular/material/core';
 import { AfterViewInit } from '@angular/core';
 import { AnimationTriggerMetadata } from '@angular/animations';
 import { AriaDescriber } from '@angular/cdk/a11y';
-import { BooleanInput } from '@angular/cdk/coercion';
-import { CanDisable } from '@angular/material/core';
 import { ChangeDetectorRef } from '@angular/core';
-import { _Constructor } from '@angular/material/core';
 import { ElementRef } from '@angular/core';
 import { EventEmitter } from '@angular/core';
 import { FocusMonitor } from '@angular/cdk/a11y';
@@ -50,15 +46,19 @@ export const MAT_SORT_HEADER_INTL_PROVIDER: {
 export function MAT_SORT_HEADER_INTL_PROVIDER_FACTORY(parentIntl: MatSortHeaderIntl): MatSortHeaderIntl;
 
 // @public
-export class MatSort extends _MatSortBase implements CanDisable, HasInitialized, OnChanges, OnDestroy, OnInit {
+export class MatSort extends _MatSortBase implements HasInitialized, OnChanges, OnDestroy, OnInit {
     constructor(_defaultOptions?: MatSortDefaultOptions | undefined);
     active: string;
     deregister(sortable: MatSortable): void;
     get direction(): SortDirection;
     set direction(direction: SortDirection);
-    get disableClear(): boolean;
-    set disableClear(v: BooleanInput);
+    disableClear: boolean;
+    disabled: boolean;
     getNextSortDirection(sortable: MatSortable): SortDirection;
+    // (undocumented)
+    static ngAcceptInputType_disableClear: unknown;
+    // (undocumented)
+    static ngAcceptInputType_disabled: unknown;
     // (undocumented)
     ngOnChanges(): void;
     // (undocumented)
@@ -72,7 +72,7 @@ export class MatSort extends _MatSortBase implements CanDisable, HasInitialized,
     start: SortDirection;
     readonly _stateChanges: Subject<void>;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<MatSort, "[matSort]", ["matSort"], { "disabled": { "alias": "matSortDisabled"; "required": false; }; "active": { "alias": "matSortActive"; "required": false; }; "start": { "alias": "matSortStart"; "required": false; }; "direction": { "alias": "matSortDirection"; "required": false; }; "disableClear": { "alias": "matSortDisableClear"; "required": false; }; }, { "sortChange": "matSortChange"; }, never, never, false, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<MatSort, "[matSort]", ["matSort"], { "active": { "alias": "matSortActive"; "required": false; }; "start": { "alias": "matSortStart"; "required": false; }; "direction": { "alias": "matSortDirection"; "required": false; }; "disableClear": { "alias": "matSortDisableClear"; "required": false; }; "disabled": { "alias": "matSortDisabled"; "required": false; }; }, { "sortChange": "matSortChange"; }, never, never, false, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatSort, [{ optional: true; }]>;
 }
@@ -101,7 +101,7 @@ export interface MatSortDefaultOptions {
 }
 
 // @public
-export class MatSortHeader extends _MatSortHeaderBase implements CanDisable, MatSortable, OnDestroy, OnInit, AfterViewInit {
+export class MatSortHeader implements MatSortable, OnDestroy, OnInit, AfterViewInit {
     constructor(
     _intl: MatSortHeaderIntl, _changeDetectorRef: ChangeDetectorRef, _sort: MatSort, _columnDef: MatSortHeaderColumnDef, _focusMonitor: FocusMonitor, _elementRef: ElementRef<HTMLElement>,
     _ariaDescriber?: AriaDescriber | null | undefined, defaultOptions?: MatSortDefaultOptions);
@@ -109,8 +109,8 @@ export class MatSortHeader extends _MatSortHeaderBase implements CanDisable, Mat
     arrowPosition: SortHeaderArrowPosition;
     // (undocumented)
     _columnDef: MatSortHeaderColumnDef;
-    get disableClear(): boolean;
-    set disableClear(v: BooleanInput);
+    disableClear: boolean;
+    disabled: boolean;
     _disableViewStateAnimation: boolean;
     _getAriaSortAttribute(): "none" | "ascending" | "descending";
     _getArrowDirectionState(): string;
@@ -125,6 +125,10 @@ export class MatSortHeader extends _MatSortHeaderBase implements CanDisable, Mat
     // (undocumented)
     _isDisabled(): boolean;
     _isSorted(): boolean;
+    // (undocumented)
+    static ngAcceptInputType_disableClear: unknown;
+    // (undocumented)
+    static ngAcceptInputType_disabled: unknown;
     // (undocumented)
     ngAfterViewInit(): void;
     // (undocumented)
@@ -144,7 +148,7 @@ export class MatSortHeader extends _MatSortHeaderBase implements CanDisable, Mat
     _updateArrowDirection(): void;
     _viewState: ArrowViewStateTransition;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<MatSortHeader, "[mat-sort-header]", ["matSortHeader"], { "disabled": { "alias": "disabled"; "required": false; }; "id": { "alias": "mat-sort-header"; "required": false; }; "arrowPosition": { "alias": "arrowPosition"; "required": false; }; "start": { "alias": "start"; "required": false; }; "sortActionDescription": { "alias": "sortActionDescription"; "required": false; }; "disableClear": { "alias": "disableClear"; "required": false; }; }, {}, never, ["*"], false, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MatSortHeader, "[mat-sort-header]", ["matSortHeader"], { "id": { "alias": "mat-sort-header"; "required": false; }; "arrowPosition": { "alias": "arrowPosition"; "required": false; }; "start": { "alias": "start"; "required": false; }; "disabled": { "alias": "disabled"; "required": false; }; "sortActionDescription": { "alias": "sortActionDescription"; "required": false; }; "disableClear": { "alias": "disableClear"; "required": false; }; }, {}, never, ["*"], false, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatSortHeader, [null, null, { optional: true; }, { optional: true; }, null, null, { optional: true; }, { optional: true; }]>;
 }

--- a/tools/public_api_guard/material/stepper.md
+++ b/tools/public_api_guard/material/stepper.md
@@ -4,20 +4,18 @@
 
 ```ts
 
-import { _AbstractConstructor } from '@angular/material/core';
 import { AbstractControl } from '@angular/forms';
 import { AfterContentInit } from '@angular/core';
 import { AfterViewInit } from '@angular/core';
 import { AnimationEvent as AnimationEvent_2 } from '@angular/animations';
 import { AnimationTriggerMetadata } from '@angular/animations';
-import { CanColor } from '@angular/material/core';
 import { CdkStep } from '@angular/cdk/stepper';
+import { CdkStepHeader } from '@angular/cdk/stepper';
 import { CdkStepLabel } from '@angular/cdk/stepper';
 import { CdkStepper } from '@angular/cdk/stepper';
 import { CdkStepperNext } from '@angular/cdk/stepper';
 import { CdkStepperPrevious } from '@angular/cdk/stepper';
 import { ChangeDetectorRef } from '@angular/core';
-import { _Constructor } from '@angular/material/core';
 import { Directionality } from '@angular/cdk/bidi';
 import { ElementRef } from '@angular/core';
 import { ErrorStateMatcher } from '@angular/material/core';
@@ -84,9 +82,10 @@ export class MatStepContent {
 }
 
 // @public (undocumented)
-export class MatStepHeader extends _MatStepHeaderBase implements AfterViewInit, OnDestroy, CanColor {
+export class MatStepHeader extends CdkStepHeader implements AfterViewInit, OnDestroy {
     constructor(_intl: MatStepperIntl, _focusMonitor: FocusMonitor, _elementRef: ElementRef<HTMLElement>, changeDetectorRef: ChangeDetectorRef);
     active: boolean;
+    color: ThemePalette;
     disableRipple: boolean;
     errorMessage: string;
     focus(origin?: FocusOrigin, options?: FocusOptions): void;
@@ -111,7 +110,7 @@ export class MatStepHeader extends _MatStepHeaderBase implements AfterViewInit, 
     _stringLabel(): string | null;
     _templateLabel(): MatStepLabel | null;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<MatStepHeader, "mat-step-header", never, { "color": { "alias": "color"; "required": false; }; "state": { "alias": "state"; "required": false; }; "label": { "alias": "label"; "required": false; }; "errorMessage": { "alias": "errorMessage"; "required": false; }; "iconOverrides": { "alias": "iconOverrides"; "required": false; }; "index": { "alias": "index"; "required": false; }; "selected": { "alias": "selected"; "required": false; }; "active": { "alias": "active"; "required": false; }; "optional": { "alias": "optional"; "required": false; }; "disableRipple": { "alias": "disableRipple"; "required": false; }; }, {}, never, never, false, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MatStepHeader, "mat-step-header", never, { "state": { "alias": "state"; "required": false; }; "label": { "alias": "label"; "required": false; }; "errorMessage": { "alias": "errorMessage"; "required": false; }; "iconOverrides": { "alias": "iconOverrides"; "required": false; }; "index": { "alias": "index"; "required": false; }; "selected": { "alias": "selected"; "required": false; }; "active": { "alias": "active"; "required": false; }; "optional": { "alias": "optional"; "required": false; }; "disableRipple": { "alias": "disableRipple"; "required": false; }; "color": { "alias": "color"; "required": false; }; }, {}, never, never, false, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatStepHeader, never>;
 }

--- a/tools/public_api_guard/material/tabs.md
+++ b/tools/public_api_guard/material/tabs.md
@@ -4,22 +4,16 @@
 
 ```ts
 
-import { _AbstractConstructor } from '@angular/material/core';
 import { AfterContentChecked } from '@angular/core';
 import { AfterContentInit } from '@angular/core';
 import { AfterViewInit } from '@angular/core';
 import { AnimationEvent as AnimationEvent_2 } from '@angular/animations';
 import { AnimationTriggerMetadata } from '@angular/animations';
 import { BehaviorSubject } from 'rxjs';
-import { BooleanInput } from '@angular/cdk/coercion';
-import { CanColor } from '@angular/material/core';
-import { CanDisable } from '@angular/material/core';
-import { CanDisableRipple } from '@angular/material/core';
 import { CdkPortal } from '@angular/cdk/portal';
 import { CdkPortalOutlet } from '@angular/cdk/portal';
 import { ChangeDetectorRef } from '@angular/core';
 import { ComponentFactoryResolver } from '@angular/core';
-import { _Constructor } from '@angular/material/core';
 import { Direction } from '@angular/cdk/bidi';
 import { Directionality } from '@angular/cdk/bidi';
 import { ElementRef } from '@angular/core';
@@ -27,7 +21,6 @@ import { EventEmitter } from '@angular/core';
 import { FocusableOption } from '@angular/cdk/a11y';
 import { FocusMonitor } from '@angular/cdk/a11y';
 import { FocusOrigin } from '@angular/cdk/a11y';
-import { HasTabIndex } from '@angular/material/core';
 import * as i0 from '@angular/core';
 import * as i10 from '@angular/material/core';
 import * as i11 from '@angular/cdk/portal';
@@ -36,7 +29,6 @@ import * as i13 from '@angular/cdk/a11y';
 import * as i9 from '@angular/common';
 import { InjectionToken } from '@angular/core';
 import { NgZone } from '@angular/core';
-import { NumberInput } from '@angular/cdk/coercion';
 import { OnChanges } from '@angular/core';
 import { OnDestroy } from '@angular/core';
 import { OnInit } from '@angular/core';
@@ -101,8 +93,7 @@ export abstract class MatPaginatedTabHeader implements AfterContentChecked, Afte
     _checkPaginationEnabled(): void;
     _checkScrollingControls(): void;
     protected readonly _destroyed: Subject<void>;
-    get disablePagination(): boolean;
-    set disablePagination(value: BooleanInput);
+    disablePagination: boolean;
     _disableScrollAfter: boolean;
     _disableScrollBefore: boolean;
     // (undocumented)
@@ -127,6 +118,8 @@ export abstract class MatPaginatedTabHeader implements AfterContentChecked, Afte
     // (undocumented)
     abstract _nextPaginator: ElementRef<HTMLElement>;
     // (undocumented)
+    static ngAcceptInputType_disablePagination: unknown;
+    // (undocumented)
     ngAfterContentChecked(): void;
     // (undocumented)
     ngAfterContentInit(): void;
@@ -145,7 +138,7 @@ export abstract class MatPaginatedTabHeader implements AfterContentChecked, Afte
     };
     _scrollToLabel(labelIndex: number): void;
     get selectedIndex(): number;
-    set selectedIndex(value: NumberInput);
+    set selectedIndex(v: unknown);
     readonly selectFocusedIndex: EventEmitter<number>;
     _setTabFocus(tabIndex: number): void;
     _showPaginationControls: boolean;
@@ -165,7 +158,7 @@ export abstract class MatPaginatedTabHeader implements AfterContentChecked, Afte
 }
 
 // @public (undocumented)
-export class MatTab extends _MatTabMixinBase implements CanDisable, OnInit, OnChanges, OnDestroy {
+export class MatTab implements OnInit, OnChanges, OnDestroy {
     constructor(_viewContainerRef: ViewContainerRef, _closestTabGroup: any);
     ariaLabel: string;
     ariaLabelledby: string;
@@ -173,9 +166,12 @@ export class MatTab extends _MatTabMixinBase implements CanDisable, OnInit, OnCh
     // (undocumented)
     _closestTabGroup: any;
     get content(): TemplatePortal | null;
+    disabled: boolean;
     _implicitContent: TemplateRef<any>;
     isActive: boolean;
     labelClass: string | string[];
+    // (undocumented)
+    static ngAcceptInputType_disabled: unknown;
     // (undocumented)
     ngOnChanges(changes: SimpleChanges): void;
     // (undocumented)
@@ -185,7 +181,6 @@ export class MatTab extends _MatTabMixinBase implements CanDisable, OnInit, OnCh
     origin: number | null;
     position: number | null;
     readonly _stateChanges: Subject<void>;
-    // (undocumented)
     get templateLabel(): MatTabLabel;
     set templateLabel(value: MatTabLabel);
     textLabel: string;
@@ -258,24 +253,26 @@ export class MatTabContent {
 }
 
 // @public
-export class MatTabGroup extends _MatTabGroupMixinBase implements AfterContentInit, AfterContentChecked, OnDestroy, CanColor, CanDisableRipple {
-    constructor(elementRef: ElementRef, _changeDetectorRef: ChangeDetectorRef, defaultConfig?: MatTabsConfig, _animationMode?: string | undefined);
+export class MatTabGroup implements AfterContentInit, AfterContentChecked, OnDestroy {
+    constructor(_elementRef: ElementRef, _changeDetectorRef: ChangeDetectorRef, defaultConfig?: MatTabsConfig, _animationMode?: string | undefined);
     _allTabs: QueryList<MatTab>;
     readonly animationDone: EventEmitter<void>;
     get animationDuration(): string;
-    set animationDuration(value: NumberInput);
+    set animationDuration(value: string | number);
     // (undocumented)
     _animationMode?: string | undefined;
     get backgroundColor(): ThemePalette;
     set backgroundColor(value: ThemePalette);
+    color: ThemePalette;
     get contentTabIndex(): number | null;
-    set contentTabIndex(value: NumberInput);
-    get disablePagination(): boolean;
-    set disablePagination(value: BooleanInput);
-    get dynamicHeight(): boolean;
-    set dynamicHeight(value: BooleanInput);
+    set contentTabIndex(value: number);
+    disablePagination: boolean;
+    disableRipple: boolean;
+    dynamicHeight: boolean;
+    // (undocumented)
+    readonly _elementRef: ElementRef;
     get fitInkBarToContent(): boolean;
-    set fitInkBarToContent(v: BooleanInput);
+    set fitInkBarToContent(value: boolean);
     readonly focusChange: EventEmitter<MatTabChangeEvent>;
     // (undocumented)
     _focusChanged(index: number): void;
@@ -285,22 +282,36 @@ export class MatTabGroup extends _MatTabGroupMixinBase implements AfterContentIn
     _getTabLabelId(i: number): string;
     _handleClick(tab: MatTab, tabHeader: MatTabGroupBaseHeader, index: number): void;
     headerPosition: MatTabHeaderPosition;
+    // (undocumented)
+    static ngAcceptInputType_contentTabIndex: unknown;
+    // (undocumented)
+    static ngAcceptInputType_disablePagination: unknown;
+    // (undocumented)
+    static ngAcceptInputType_disableRipple: unknown;
+    // (undocumented)
+    static ngAcceptInputType_dynamicHeight: unknown;
+    // (undocumented)
+    static ngAcceptInputType_fitInkBarToContent: unknown;
+    // (undocumented)
+    static ngAcceptInputType_preserveContent: unknown;
+    // (undocumented)
+    static ngAcceptInputType_selectedIndex: unknown;
+    // (undocumented)
+    static ngAcceptInputType_stretchTabs: unknown;
     ngAfterContentChecked(): void;
     // (undocumented)
     ngAfterContentInit(): void;
     // (undocumented)
     ngOnDestroy(): void;
-    get preserveContent(): boolean;
-    set preserveContent(value: BooleanInput);
+    preserveContent: boolean;
     realignInkBar(): void;
     _removeTabBodyWrapperHeight(): void;
     get selectedIndex(): number | null;
-    set selectedIndex(value: NumberInput);
+    set selectedIndex(value: number);
     readonly selectedIndexChange: EventEmitter<number>;
     readonly selectedTabChange: EventEmitter<MatTabChangeEvent>;
     _setTabBodyWrapperHeight(tabHeight: number): void;
-    get stretchTabs(): boolean;
-    set stretchTabs(v: BooleanInput);
+    stretchTabs: boolean;
     // (undocumented)
     _tabBodyWrapper: ElementRef;
     _tabFocusChanged(focusOrigin: FocusOrigin, index: number): void;
@@ -309,7 +320,7 @@ export class MatTabGroup extends _MatTabGroupMixinBase implements AfterContentIn
     _tabs: QueryList<MatTab>;
     updatePagination(): void;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<MatTabGroup, "mat-tab-group", ["matTabGroup"], { "color": { "alias": "color"; "required": false; }; "disableRipple": { "alias": "disableRipple"; "required": false; }; "fitInkBarToContent": { "alias": "fitInkBarToContent"; "required": false; }; "stretchTabs": { "alias": "mat-stretch-tabs"; "required": false; }; "dynamicHeight": { "alias": "dynamicHeight"; "required": false; }; "selectedIndex": { "alias": "selectedIndex"; "required": false; }; "headerPosition": { "alias": "headerPosition"; "required": false; }; "animationDuration": { "alias": "animationDuration"; "required": false; }; "contentTabIndex": { "alias": "contentTabIndex"; "required": false; }; "disablePagination": { "alias": "disablePagination"; "required": false; }; "preserveContent": { "alias": "preserveContent"; "required": false; }; "backgroundColor": { "alias": "backgroundColor"; "required": false; }; }, { "selectedIndexChange": "selectedIndexChange"; "focusChange": "focusChange"; "animationDone": "animationDone"; "selectedTabChange": "selectedTabChange"; }, ["_allTabs"], never, false, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MatTabGroup, "mat-tab-group", ["matTabGroup"], { "color": { "alias": "color"; "required": false; }; "fitInkBarToContent": { "alias": "fitInkBarToContent"; "required": false; }; "stretchTabs": { "alias": "mat-stretch-tabs"; "required": false; }; "dynamicHeight": { "alias": "dynamicHeight"; "required": false; }; "selectedIndex": { "alias": "selectedIndex"; "required": false; }; "headerPosition": { "alias": "headerPosition"; "required": false; }; "animationDuration": { "alias": "animationDuration"; "required": false; }; "contentTabIndex": { "alias": "contentTabIndex"; "required": false; }; "disablePagination": { "alias": "disablePagination"; "required": false; }; "disableRipple": { "alias": "disableRipple"; "required": false; }; "preserveContent": { "alias": "preserveContent"; "required": false; }; "backgroundColor": { "alias": "backgroundColor"; "required": false; }; }, { "selectedIndexChange": "selectedIndexChange"; "focusChange": "focusChange"; "animationDone": "animationDone"; "selectedTabChange": "selectedTabChange"; }, ["_allTabs"], never, false, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatTabGroup, [null, null, { optional: true; }, { optional: true; }]>;
 }
@@ -327,8 +338,7 @@ export interface MatTabGroupBaseHeader {
 // @public
 export class MatTabHeader extends MatPaginatedTabHeader implements AfterContentChecked, AfterContentInit, AfterViewInit, OnDestroy {
     constructor(elementRef: ElementRef, changeDetectorRef: ChangeDetectorRef, viewportRuler: ViewportRuler, dir: Directionality, ngZone: NgZone, platform: Platform, animationMode?: string);
-    get disableRipple(): boolean;
-    set disableRipple(value: BooleanInput);
+    disableRipple: boolean;
     // (undocumented)
     _inkBar: MatInkBar;
     // (undocumented)
@@ -337,6 +347,8 @@ export class MatTabHeader extends MatPaginatedTabHeader implements AfterContentC
     protected _itemSelected(event: KeyboardEvent): void;
     // (undocumented)
     _nextPaginator: ElementRef<HTMLElement>;
+    // (undocumented)
+    static ngAcceptInputType_disableRipple: unknown;
     // (undocumented)
     ngAfterContentInit(): void;
     // (undocumented)
@@ -368,8 +380,9 @@ export class MatTabLabel extends CdkPortal {
 }
 
 // @public
-export class MatTabLabelWrapper extends _MatTabLabelWrapperMixinBase implements CanDisable {
+export class MatTabLabelWrapper extends _MatTabLabelWrapperMixinBase {
     constructor(elementRef: ElementRef);
+    disabled: boolean;
     // (undocumented)
     elementRef: ElementRef;
     focus(): void;
@@ -378,17 +391,21 @@ export class MatTabLabelWrapper extends _MatTabLabelWrapperMixinBase implements 
     // (undocumented)
     getOffsetWidth(): number;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<MatTabLabelWrapper, "[matTabLabelWrapper]", never, { "disabled": { "alias": "disabled"; "required": false; }; "fitInkBarToContent": { "alias": "fitInkBarToContent"; "required": false; }; }, {}, never, never, false, never>;
+    static ngAcceptInputType_disabled: unknown;
+    // (undocumented)
+    static ɵdir: i0.ɵɵDirectiveDeclaration<MatTabLabelWrapper, "[matTabLabelWrapper]", never, { "fitInkBarToContent": { "alias": "fitInkBarToContent"; "required": false; }; "disabled": { "alias": "disabled"; "required": false; }; }, {}, never, never, false, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatTabLabelWrapper, never>;
 }
 
 // @public
-export class MatTabLink extends _MatTabLinkMixinBase implements AfterViewInit, OnDestroy, CanDisable, CanDisableRipple, HasTabIndex, RippleTarget, FocusableOption {
+export class MatTabLink extends _MatTabLinkMixinBase implements AfterViewInit, OnDestroy, RippleTarget, FocusableOption {
     constructor(_tabNavBar: MatTabNav,
     elementRef: ElementRef, globalRippleOptions: RippleGlobalOptions | null, tabIndex: string, _focusMonitor: FocusMonitor, animationMode?: string);
     get active(): boolean;
-    set active(value: BooleanInput);
+    set active(value: boolean);
+    disabled: boolean;
+    disableRipple: boolean;
     elementRef: ElementRef;
     focus(): void;
     // (undocumented)
@@ -408,13 +425,23 @@ export class MatTabLink extends _MatTabLinkMixinBase implements AfterViewInit, O
     id: string;
     protected _isActive: boolean;
     // (undocumented)
+    static ngAcceptInputType_active: unknown;
+    // (undocumented)
+    static ngAcceptInputType_disabled: unknown;
+    // (undocumented)
+    static ngAcceptInputType_disableRipple: unknown;
+    // (undocumented)
+    static ngAcceptInputType_tabIndex: unknown;
+    // (undocumented)
     ngAfterViewInit(): void;
     // (undocumented)
     ngOnDestroy(): void;
     rippleConfig: RippleConfig & RippleGlobalOptions;
     get rippleDisabled(): boolean;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<MatTabLink, "[mat-tab-link], [matTabLink]", ["matTabLink"], { "disabled": { "alias": "disabled"; "required": false; }; "disableRipple": { "alias": "disableRipple"; "required": false; }; "tabIndex": { "alias": "tabIndex"; "required": false; }; "active": { "alias": "active"; "required": false; }; "id": { "alias": "id"; "required": false; }; }, {}, never, ["*"], false, never>;
+    tabIndex: number;
+    // (undocumented)
+    static ɵcmp: i0.ɵɵComponentDeclaration<MatTabLink, "[mat-tab-link], [matTabLink]", ["matTabLink"], { "active": { "alias": "active"; "required": false; }; "id": { "alias": "id"; "required": false; }; "disabled": { "alias": "disabled"; "required": false; }; "disableRipple": { "alias": "disableRipple"; "required": false; }; "tabIndex": { "alias": "tabIndex"; "required": false; }; }, {}, never, ["*"], false, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatTabLink, [null, null, { optional: true; }, { attribute: "tabindex"; }, null, { optional: true; }]>;
 }
@@ -424,14 +451,13 @@ export class MatTabNav extends MatPaginatedTabHeader implements AfterContentChec
     constructor(elementRef: ElementRef, dir: Directionality, ngZone: NgZone, changeDetectorRef: ChangeDetectorRef, viewportRuler: ViewportRuler, platform: Platform, animationMode?: string, defaultConfig?: MatTabsConfig);
     // (undocumented)
     get animationDuration(): string;
-    set animationDuration(value: NumberInput);
+    set animationDuration(value: string | number);
     get backgroundColor(): ThemePalette;
     set backgroundColor(value: ThemePalette);
     color: ThemePalette;
-    get disableRipple(): boolean;
-    set disableRipple(value: BooleanInput);
+    disableRipple: boolean;
     get fitInkBarToContent(): boolean;
-    set fitInkBarToContent(v: BooleanInput);
+    set fitInkBarToContent(value: boolean);
     // (undocumented)
     _fitInkBarToContent: BehaviorSubject<boolean>;
     // (undocumented)
@@ -444,13 +470,18 @@ export class MatTabNav extends MatPaginatedTabHeader implements AfterContentChec
     // (undocumented)
     _nextPaginator: ElementRef<HTMLElement>;
     // (undocumented)
+    static ngAcceptInputType_disableRipple: unknown;
+    // (undocumented)
+    static ngAcceptInputType_fitInkBarToContent: unknown;
+    // (undocumented)
+    static ngAcceptInputType_stretchTabs: unknown;
+    // (undocumented)
     ngAfterContentInit(): void;
     // (undocumented)
     ngAfterViewInit(): void;
     // (undocumented)
     _previousPaginator: ElementRef<HTMLElement>;
-    get stretchTabs(): boolean;
-    set stretchTabs(v: BooleanInput);
+    stretchTabs: boolean;
     // (undocumented)
     _tabList: ElementRef;
     // (undocumented)
@@ -460,7 +491,7 @@ export class MatTabNav extends MatPaginatedTabHeader implements AfterContentChec
     tabPanel?: MatTabNavPanel;
     updateActiveLink(): void;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<MatTabNav, "[mat-tab-nav-bar]", ["matTabNavBar", "matTabNav"], { "color": { "alias": "color"; "required": false; }; "fitInkBarToContent": { "alias": "fitInkBarToContent"; "required": false; }; "stretchTabs": { "alias": "mat-stretch-tabs"; "required": false; }; "animationDuration": { "alias": "animationDuration"; "required": false; }; "backgroundColor": { "alias": "backgroundColor"; "required": false; }; "disableRipple": { "alias": "disableRipple"; "required": false; }; "tabPanel": { "alias": "tabPanel"; "required": false; }; }, {}, ["_items"], ["*"], false, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MatTabNav, "[mat-tab-nav-bar]", ["matTabNavBar", "matTabNav"], { "fitInkBarToContent": { "alias": "fitInkBarToContent"; "required": false; }; "stretchTabs": { "alias": "mat-stretch-tabs"; "required": false; }; "animationDuration": { "alias": "animationDuration"; "required": false; }; "backgroundColor": { "alias": "backgroundColor"; "required": false; }; "disableRipple": { "alias": "disableRipple"; "required": false; }; "color": { "alias": "color"; "required": false; }; "tabPanel": { "alias": "tabPanel"; "required": false; }; }, {}, ["_items"], ["*"], false, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatTabNav, [null, { optional: true; }, null, null, null, null, { optional: true; }, { optional: true; }]>;
 }

--- a/tools/public_api_guard/material/toolbar.md
+++ b/tools/public_api_guard/material/toolbar.md
@@ -4,10 +4,7 @@
 
 ```ts
 
-import { _AbstractConstructor } from '@angular/material/core';
 import { AfterViewInit } from '@angular/core';
-import { CanColor } from '@angular/material/core';
-import { _Constructor } from '@angular/material/core';
 import { ElementRef } from '@angular/core';
 import * as i0 from '@angular/core';
 import * as i2 from '@angular/material/core';
@@ -15,8 +12,11 @@ import { Platform } from '@angular/cdk/platform';
 import { QueryList } from '@angular/core';
 
 // @public (undocumented)
-export class MatToolbar extends _MatToolbarBase implements CanColor, AfterViewInit {
-    constructor(elementRef: ElementRef, _platform: Platform, document?: any);
+export class MatToolbar implements AfterViewInit {
+    constructor(_elementRef: ElementRef, _platform: Platform, document?: any);
+    color?: string | null;
+    // (undocumented)
+    protected _elementRef: ElementRef;
     // (undocumented)
     ngAfterViewInit(): void;
     _toolbarRows: QueryList<MatToolbarRow>;

--- a/tools/public_api_guard/material/tree.md
+++ b/tools/public_api_guard/material/tree.md
@@ -4,10 +4,7 @@
 
 ```ts
 
-import { _AbstractConstructor } from '@angular/material/core';
 import { AfterContentInit } from '@angular/core';
-import { BooleanInput } from '@angular/cdk/coercion';
-import { CanDisable } from '@angular/material/core';
 import { CdkNestedTreeNode } from '@angular/cdk/tree';
 import { CdkTree } from '@angular/cdk/tree';
 import { CdkTreeNode } from '@angular/cdk/tree';
@@ -16,16 +13,13 @@ import { CdkTreeNodeOutlet } from '@angular/cdk/tree';
 import { CdkTreeNodePadding } from '@angular/cdk/tree';
 import { CdkTreeNodeToggle } from '@angular/cdk/tree';
 import { CollectionViewer } from '@angular/cdk/collections';
-import { _Constructor } from '@angular/material/core';
 import { DataSource } from '@angular/cdk/collections';
 import { ElementRef } from '@angular/core';
 import { FlatTreeControl } from '@angular/cdk/tree';
-import { HasTabIndex } from '@angular/material/core';
 import * as i0 from '@angular/core';
 import * as i6 from '@angular/cdk/tree';
 import * as i7 from '@angular/material/core';
 import { IterableDiffers } from '@angular/core';
-import { NumberInput } from '@angular/cdk/coercion';
 import { Observable } from 'rxjs';
 import { OnDestroy } from '@angular/core';
 import { OnInit } from '@angular/core';
@@ -35,8 +29,9 @@ import { ViewContainerRef } from '@angular/core';
 // @public
 export class MatNestedTreeNode<T, K = T> extends CdkNestedTreeNode<T, K> implements AfterContentInit, OnDestroy, OnInit {
     constructor(elementRef: ElementRef<HTMLElement>, tree: CdkTree<T, K>, differs: IterableDiffers, tabIndex: string);
-    get disabled(): boolean;
-    set disabled(value: BooleanInput);
+    disabled: boolean;
+    // (undocumented)
+    static ngAcceptInputType_disabled: unknown;
     // (undocumented)
     ngAfterContentInit(): void;
     // (undocumented)
@@ -48,7 +43,7 @@ export class MatNestedTreeNode<T, K = T> extends CdkNestedTreeNode<T, K> impleme
     get tabIndex(): number;
     set tabIndex(value: number);
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<MatNestedTreeNode<any, any>, "mat-nested-tree-node", ["matNestedTreeNode"], { "role": { "alias": "role"; "required": false; }; "disabled": { "alias": "disabled"; "required": false; }; "tabIndex": { "alias": "tabIndex"; "required": false; }; "node": { "alias": "matNestedTreeNode"; "required": false; }; }, {}, never, never, false, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<MatNestedTreeNode<any, any>, "mat-nested-tree-node", ["matNestedTreeNode"], { "node": { "alias": "matNestedTreeNode"; "required": false; }; "disabled": { "alias": "disabled"; "required": false; }; "tabIndex": { "alias": "tabIndex"; "required": false; }; }, {}, never, never, false, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatNestedTreeNode<any, any>, [null, null, null, { attribute: "tabindex"; }]>;
 }
@@ -115,14 +110,20 @@ export class MatTreeNestedDataSource<T> extends DataSource<T> {
 }
 
 // @public
-export class MatTreeNode<T, K = T> extends _MatTreeNodeBase<T, K> implements CanDisable, HasTabIndex, OnInit, OnDestroy {
+export class MatTreeNode<T, K = T> extends CdkTreeNode<T, K> implements OnInit, OnDestroy {
     constructor(elementRef: ElementRef<HTMLElement>, tree: CdkTree<T, K>, tabIndex: string);
+    disabled: boolean;
+    // (undocumented)
+    static ngAcceptInputType_disabled: unknown;
+    // (undocumented)
+    static ngAcceptInputType_tabIndex: unknown;
     // (undocumented)
     ngOnDestroy(): void;
     // (undocumented)
     ngOnInit(): void;
+    tabIndex: number;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<MatTreeNode<any, any>, "mat-tree-node", ["matTreeNode"], { "role": { "alias": "role"; "required": false; }; "disabled": { "alias": "disabled"; "required": false; }; "tabIndex": { "alias": "tabIndex"; "required": false; }; }, {}, never, never, false, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<MatTreeNode<any, any>, "mat-tree-node", ["matTreeNode"], { "disabled": { "alias": "disabled"; "required": false; }; "tabIndex": { "alias": "tabIndex"; "required": false; }; }, {}, never, never, false, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatTreeNode<any, any>, [null, null, { attribute: "tabindex"; }]>;
 }
@@ -155,7 +156,9 @@ export class MatTreeNodePadding<T, K = T> extends CdkTreeNodePadding<T, K> {
     get indent(): number | string;
     set indent(indent: number | string);
     get level(): number;
-    set level(value: NumberInput);
+    set level(value: number);
+    // (undocumented)
+    static ngAcceptInputType_level: unknown;
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<MatTreeNodePadding<any, any>, "[matTreeNodePadding]", never, { "level": { "alias": "matTreeNodePadding"; "required": false; }; "indent": { "alias": "matTreeNodePaddingIndent"; "required": false; }; }, {}, never, never, false, never>;
     // (undocumented)


### PR DESCRIPTION
These changes remove all the remaining usages of `mixinColor`, `mixinDisabled`, `mixinDisableRipple` and `mixinTabindex` in favor of using input transforms and host bindings. There are still some usages of `mixinErrorState` and `mixinInitialized` that have to be migrated separately.

I've made this refactor, because:
1. We need to switch away from `mixinColor`, because it uses direct DOM manipulation. This is problematic for future hydration and SSR efforts.
2. Mixins add a lot of boilerplate, increase the prototype chain and can be difficult to reason about. `mixinDisabled`, `mixinDisableRipple` and `mixinTabindex` were only used for input coercion which can be replaced with input transforms.