### PR TITLE
refactor: use enum instead of const enum

### DIFF
--- a/src/cdk-experimental/popover-edit/edit-event-dispatcher.ts
+++ b/src/cdk-experimental/popover-edit/edit-event-dispatcher.ts
@@ -35,7 +35,7 @@ const FOCUS_DELAY = 0;
  * FOCUSABLE - Rendered in the dom and styled for its contents to be focusable but invisible.
  * ON - Rendered and fully visible.
  */
-export const enum HoverContentState {
+export enum HoverContentState {
   OFF = 0,
   FOCUSABLE,
   ON,

--- a/src/cdk-experimental/popover-edit/focus-escape-notifier.ts
+++ b/src/cdk-experimental/popover-edit/focus-escape-notifier.ts
@@ -12,7 +12,7 @@ import {FocusTrap, InteractivityChecker} from '@angular/cdk/a11y';
 import {Observable, Subject} from 'rxjs';
 
 /** Value indicating whether focus left the target area before or after the enclosed elements. */
-export const enum FocusEscapeNotifierDirection {
+export enum FocusEscapeNotifierDirection {
   START,
   END,
 }

--- a/src/cdk/a11y/focus-monitor/focus-monitor.ts
+++ b/src/cdk/a11y/focus-monitor/focus-monitor.ts
@@ -43,7 +43,7 @@ export interface FocusOptions {
 }
 
 /** Detection mode used for attributing the origin of a focus event. */
-export const enum FocusMonitorDetectionMode {
+export enum FocusMonitorDetectionMode {
   /**
    * Any mousedown, keydown, or touchstart event that happened in the previous
    * tick or the current tick will be used to assign a focus event's origin (to
@@ -623,7 +623,10 @@ export class CdkMonitorFocus implements AfterViewInit, OnDestroy {
 
   @Output() readonly cdkFocusChange = new EventEmitter<FocusOrigin>();
 
-  constructor(private _elementRef: ElementRef<HTMLElement>, private _focusMonitor: FocusMonitor) {}
+  constructor(
+    private _elementRef: ElementRef<HTMLElement>,
+    private _focusMonitor: FocusMonitor,
+  ) {}
 
   get focusOrigin(): FocusOrigin {
     return this._focusOrigin;

--- a/src/cdk/a11y/high-contrast-mode/high-contrast-mode-detector.ts
+++ b/src/cdk/a11y/high-contrast-mode/high-contrast-mode-detector.ts
@@ -13,7 +13,7 @@ import {DOCUMENT} from '@angular/common';
 import {Subscription} from 'rxjs';
 
 /** Set of possible high-contrast mode backgrounds. */
-export const enum HighContrastMode {
+export enum HighContrastMode {
   NONE,
   BLACK_ON_WHITE,
   WHITE_ON_BLACK,
@@ -49,7 +49,10 @@ export class HighContrastModeDetector implements OnDestroy {
   private _document: Document;
   private _breakpointSubscription: Subscription;
 
-  constructor(private _platform: Platform, @Inject(DOCUMENT) document: any) {
+  constructor(
+    private _platform: Platform,
+    @Inject(DOCUMENT) document: any,
+  ) {
     this._document = document;
 
     this._breakpointSubscription = inject(BreakpointObserver)

--- a/src/cdk/collections/view-repeater.ts
+++ b/src/cdk/collections/view-repeater.ts
@@ -58,7 +58,7 @@ export type _ViewRepeaterItemContextFactory<T, R, C extends _ViewRepeaterItemCon
 export type _ViewRepeaterItemValueResolver<T, R> = (record: IterableChangeRecord<R>) => T;
 
 /** Indicates how a view was changed by a {@link _ViewRepeater}. */
-export const enum _ViewRepeaterOperation {
+export enum _ViewRepeaterOperation {
   /** The content of an existing view was replaced with another item. */
   REPLACED,
   /** A new view was created with `createEmbeddedView`. */

--- a/src/cdk/drag-drop/drop-list-ref.ts
+++ b/src/cdk/drag-drop/drop-list-ref.ts
@@ -34,14 +34,14 @@ const DROP_PROXIMITY_THRESHOLD = 0.05;
 const SCROLL_PROXIMITY_THRESHOLD = 0.05;
 
 /** Vertical direction in which we can auto-scroll. */
-const enum AutoScrollVerticalDirection {
+enum AutoScrollVerticalDirection {
   NONE,
   UP,
   DOWN,
 }
 
 /** Horizontal direction in which we can auto-scroll. */
-const enum AutoScrollHorizontalDirection {
+enum AutoScrollHorizontalDirection {
   NONE,
   LEFT,
   RIGHT,

--- a/src/cdk/menu/menu-stack.ts
+++ b/src/cdk/menu/menu-stack.ts
@@ -11,7 +11,7 @@ import {Observable, Subject} from 'rxjs';
 import {debounceTime, distinctUntilChanged, startWith} from 'rxjs/operators';
 
 /** The relative item in the inline menu to focus after closing all popup menus. */
-export const enum FocusNext {
+export enum FocusNext {
   nextItem,
   previousItem,
   currentItem,

--- a/src/cdk/platform/features/scrolling.ts
+++ b/src/cdk/platform/features/scrolling.ts
@@ -7,7 +7,7 @@
  */
 
 /** The possible ways the browser may handle the horizontal scroll axis in RTL languages. */
-export const enum RtlScrollAxisType {
+export enum RtlScrollAxisType {
   /**
    * scrollLeft is 0 when scrolled all the way left and (scrollWidth - clientWidth) when scrolled
    * all the way right.

--- a/src/cdk/schematics/update-tool/target-version.ts
+++ b/src/cdk/schematics/update-tool/target-version.ts
@@ -7,7 +7,7 @@
  */
 
 /** Possible versions that can be automatically migrated by `ng update`. */
-// Used in an `Object.keys` call below so it can't be `const enum`.
+
 // tslint:disable-next-line:prefer-const-enum
 export enum TargetVersion {
   V17 = 'version 17',

--- a/src/material/card/testing/card-harness.ts
+++ b/src/material/card/testing/card-harness.ts
@@ -14,7 +14,7 @@ import {
 import {CardHarnessFilters} from './card-harness-filters';
 
 /** Selectors for different sections of the mat-card that can container user content. */
-export const enum MatCardSection {
+export enum MatCardSection {
   HEADER = '.mat-mdc-card-header',
   CONTENT = '.mat-mdc-card-content',
   ACTIONS = '.mat-mdc-card-actions',

--- a/src/material/checkbox/checkbox.ts
+++ b/src/material/checkbox/checkbox.ts
@@ -39,7 +39,7 @@ import {
  * Represents the different states that require custom transitions between them.
  * @docs-private
  */
-export const enum TransitionCheckState {
+export enum TransitionCheckState {
   /** The initial state of the component before any user interaction. */
   Init,
   /** The state representing the component when it's becoming checked. */

--- a/src/material/core/ripple/ripple-ref.ts
+++ b/src/material/core/ripple/ripple-ref.ts
@@ -7,7 +7,7 @@
  */
 
 /** Possible states for a ripple element. */
-export const enum RippleState {
+export enum RippleState {
   FADING_IN,
   VISIBLE,
   FADING_OUT,

--- a/src/material/datepicker/testing/calendar-harness.ts
+++ b/src/material/datepicker/testing/calendar-harness.ts
@@ -11,7 +11,7 @@ import {CalendarHarnessFilters, CalendarCellHarnessFilters} from './datepicker-h
 import {MatCalendarCellHarness} from './calendar-cell-harness';
 
 /** Possible views of a `MatCalendarHarness`. */
-export const enum CalendarView {
+export enum CalendarView {
   MONTH,
   YEAR,
   MULTI_YEAR,

--- a/src/material/dialog/dialog-ref.ts
+++ b/src/material/dialog/dialog-ref.ts
@@ -17,7 +17,7 @@ import {ESCAPE, hasModifierKey} from '@angular/cdk/keycodes';
 import {GlobalPositionStrategy} from '@angular/cdk/overlay';
 import {ComponentRef} from '@angular/core';
 
-export const enum MatDialogState {
+export enum MatDialogState {
   OPEN,
   CLOSING,
   CLOSED,

--- a/src/material/dialog/testing/dialog-harness.ts
+++ b/src/material/dialog/testing/dialog-harness.ts
@@ -16,7 +16,7 @@ import {DialogHarnessFilters} from './dialog-harness-filters';
 import {DialogRole} from '@angular/material/dialog';
 
 /** Selectors for different sections of the mat-dialog that can contain user content. */
-export const enum MatDialogSection {
+export enum MatDialogSection {
   TITLE = '.mat-mdc-dialog-title',
   CONTENT = '.mat-mdc-dialog-content',
   ACTIONS = '.mat-mdc-dialog-actions',

--- a/src/material/expansion/testing/expansion-harness.ts
+++ b/src/material/expansion/testing/expansion-harness.ts
@@ -14,7 +14,7 @@ import {
 import {ExpansionPanelHarnessFilters} from './expansion-harness-filters';
 
 /** Selectors for the various `mat-expansion-panel` sections that may contain user content. */
-export const enum MatExpansionPanelSection {
+export enum MatExpansionPanelSection {
   HEADER = '.mat-expansion-panel-header',
   TITLE = '.mat-expansion-panel-header-title',
   DESCRIPTION = '.mat-expansion-panel-header-description',

--- a/src/material/grid-list/testing/grid-tile-harness.ts
+++ b/src/material/grid-list/testing/grid-tile-harness.ts
@@ -10,7 +10,7 @@ import {ContentContainerComponentHarness, HarnessPredicate} from '@angular/cdk/t
 import {GridTileHarnessFilters} from './grid-list-harness-filters';
 
 /** Selectors for the various `mat-grid-tile` sections that may contain user content. */
-export const enum MatGridTileSection {
+export enum MatGridTileSection {
   HEADER = '.mat-grid-tile-header',
   FOOTER = '.mat-grid-tile-footer',
 }

--- a/src/material/icon/testing/icon-harness-filters.ts
+++ b/src/material/icon/testing/icon-harness-filters.ts
@@ -9,7 +9,7 @@
 import {BaseHarnessFilters} from '@angular/cdk/testing';
 
 /** Possible types of icons. */
-export const enum IconType {
+export enum IconType {
   SVG,
   FONT,
 }

--- a/src/material/list/testing/list-item-harness-base.ts
+++ b/src/material/list/testing/list-item-harness-base.ts
@@ -67,12 +67,12 @@ export class MatSubheaderHarness extends ComponentHarness {
 }
 
 /** Selectors for the various list item sections that may contain user content. */
-export const enum MatListItemSection {
+export enum MatListItemSection {
   CONTENT = '.mdc-list-item__content',
 }
 
 /** Enum describing the possible variants of a list item. */
-export const enum MatListItemType {
+export enum MatListItemType {
   ONE_LINE_ITEM,
   TWO_LINE_ITEM,
   THREE_LINE_ITEM,

--- a/src/material/schematics/ng-generate/mdc-migration/rules/components/slider/slider-template.ts
+++ b/src/material/schematics/ng-generate/mdc-migration/rules/components/slider/slider-template.ts
@@ -24,7 +24,7 @@ interface Binding {
 }
 
 /** Describes the different types of bindings we care about. */
-const enum BindingType {
+enum BindingType {
   INPUT,
   OUTPUT,
   ATTRIBUTE,

--- a/src/material/slider/slider-interface.ts
+++ b/src/material/slider/slider-interface.ts
@@ -13,13 +13,13 @@ import {MatRipple, RippleGlobalOptions} from '@angular/material/core';
  * Thumb types: range slider has two thumbs (START, END) whereas single point
  * slider only has one thumb (END).
  */
-export const enum _MatThumb {
+export enum _MatThumb {
   START = 1,
   END = 2,
 }
 
 /** Tick mark enum, for discrete sliders. */
-export const enum _MatTickMark {
+export enum _MatTickMark {
   ACTIVE = 0,
   INACTIVE = 1,
 }

--- a/src/material/slider/slider.e2e.spec.ts
+++ b/src/material/slider/slider.e2e.spec.ts
@@ -168,7 +168,7 @@ async function getCoordsForValue(slider: ElementFinder, value: number): Promise<
   return {x, y};
 }
 
-const enum Thumb {
+enum Thumb {
   START = 1,
   END = 2,
 }

--- a/src/material/slider/testing/slider-harness-filters.ts
+++ b/src/material/slider/testing/slider-harness-filters.ts
@@ -8,7 +8,7 @@
 import {BaseHarnessFilters} from '@angular/cdk/testing';
 
 /** Possible positions of a slider thumb. */
-export const enum ThumbPosition {
+export enum ThumbPosition {
   START,
   END,
 }

--- a/src/material/stepper/testing/step-harness-filters.ts
+++ b/src/material/stepper/testing/step-harness-filters.ts
@@ -8,7 +8,7 @@
 import {BaseHarnessFilters} from '@angular/cdk/testing';
 
 /** Possible orientations for a stepper. */
-export const enum StepperOrientation {
+export enum StepperOrientation {
   HORIZONTAL,
   VERTICAL,
 }

--- a/src/material/toolbar/testing/toolbar-harness.ts
+++ b/src/material/toolbar/testing/toolbar-harness.ts
@@ -10,7 +10,7 @@ import {ContentContainerComponentHarness, HarnessPredicate, parallel} from '@ang
 import {ToolbarHarnessFilters} from './toolbar-harness-filters';
 
 /** Selectors for different sections of the mat-toolbar that contain user content. */
-export const enum MatToolbarSection {
+export enum MatToolbarSection {
   ROW = '.mat-toolbar-row',
 }
 

--- a/tools/public_api_guard/cdk/a11y.md
+++ b/tools/public_api_guard/cdk/a11y.md
@@ -195,7 +195,7 @@ export class FocusMonitor implements OnDestroy {
 }
 
 // @public
-export const enum FocusMonitorDetectionMode {
+export enum FocusMonitorDetectionMode {
     EVENTUAL = 1,
     IMMEDIATE = 0
 }
@@ -264,7 +264,7 @@ export interface FocusTrapInertStrategy {
 export function getAriaReferenceIds(el: Element, attr: string): string[];
 
 // @public
-export const enum HighContrastMode {
+export enum HighContrastMode {
     // (undocumented)
     BLACK_ON_WHITE = 1,
     // (undocumented)

--- a/tools/public_api_guard/cdk/collections.md
+++ b/tools/public_api_guard/cdk/collections.md
@@ -154,7 +154,7 @@ export interface _ViewRepeaterItemInsertArgs<C> {
 export type _ViewRepeaterItemValueResolver<T, R> = (record: IterableChangeRecord<R>) => T;
 
 // @public
-export const enum _ViewRepeaterOperation {
+export enum _ViewRepeaterOperation {
     INSERTED = 1,
     MOVED = 2,
     REMOVED = 3,

--- a/tools/public_api_guard/cdk/menu.md
+++ b/tools/public_api_guard/cdk/menu.md
@@ -275,7 +275,7 @@ export interface FocusableElement {
 }
 
 // @public
-export const enum FocusNext {
+export enum FocusNext {
     // (undocumented)
     currentItem = 2,
     // (undocumented)

--- a/tools/public_api_guard/cdk/platform.md
+++ b/tools/public_api_guard/cdk/platform.md
@@ -56,7 +56,7 @@ export class PlatformModule {
 }
 
 // @public
-export const enum RtlScrollAxisType {
+export enum RtlScrollAxisType {
     INVERTED = 2,
     NEGATED = 1,
     NORMAL = 0

--- a/tools/public_api_guard/material/card-testing.md
+++ b/tools/public_api_guard/material/card-testing.md
@@ -26,7 +26,7 @@ export class MatCardHarness extends ContentContainerComponentHarness<MatCardSect
 }
 
 // @public
-export const enum MatCardSection {
+export enum MatCardSection {
     // (undocumented)
     ACTIONS = ".mat-mdc-card-actions",
     // (undocumented)

--- a/tools/public_api_guard/material/checkbox.md
+++ b/tools/public_api_guard/material/checkbox.md
@@ -161,7 +161,7 @@ export class _MatCheckboxRequiredValidatorModule {
 }
 
 // @public
-export const enum TransitionCheckState {
+export enum TransitionCheckState {
     Checked = 1,
     Indeterminate = 3,
     Init = 0,

--- a/tools/public_api_guard/material/core.md
+++ b/tools/public_api_guard/material/core.md
@@ -546,7 +546,7 @@ export class RippleRenderer implements EventListenerObject {
 }
 
 // @public
-export const enum RippleState {
+export enum RippleState {
     // (undocumented)
     FADING_IN = 0,
     // (undocumented)

--- a/tools/public_api_guard/material/datepicker-testing.md
+++ b/tools/public_api_guard/material/datepicker-testing.md
@@ -26,7 +26,7 @@ export interface CalendarHarnessFilters extends BaseHarnessFilters {
 }
 
 // @public
-export const enum CalendarView {
+export enum CalendarView {
     // (undocumented)
     MONTH = 0,
     // (undocumented)

--- a/tools/public_api_guard/material/dialog-testing.md
+++ b/tools/public_api_guard/material/dialog-testing.md
@@ -44,7 +44,7 @@ export class MatDialogHarness extends ContentContainerComponentHarness<MatDialog
 }
 
 // @public
-export const enum MatDialogSection {
+export enum MatDialogSection {
     // (undocumented)
     ACTIONS = ".mat-mdc-dialog-actions",
     // (undocumented)

--- a/tools/public_api_guard/material/dialog.md
+++ b/tools/public_api_guard/material/dialog.md
@@ -243,7 +243,7 @@ export class MatDialogRef<T, R = any> {
 }
 
 // @public (undocumented)
-export const enum MatDialogState {
+export enum MatDialogState {
     // (undocumented)
     CLOSED = 2,
     // (undocumented)

--- a/tools/public_api_guard/material/expansion-testing.md
+++ b/tools/public_api_guard/material/expansion-testing.md
@@ -60,7 +60,7 @@ export class MatExpansionPanelHarness extends ContentContainerComponentHarness<M
 }
 
 // @public
-export const enum MatExpansionPanelSection {
+export enum MatExpansionPanelSection {
     // (undocumented)
     CONTENT = ".mat-expansion-panel-content",
     // (undocumented)

--- a/tools/public_api_guard/material/grid-list-testing.md
+++ b/tools/public_api_guard/material/grid-list-testing.md
@@ -45,7 +45,7 @@ export class MatGridTileHarness extends ContentContainerComponentHarness<MatGrid
 }
 
 // @public
-export const enum MatGridTileSection {
+export enum MatGridTileSection {
     // (undocumented)
     FOOTER = ".mat-grid-tile-footer",
     // (undocumented)

--- a/tools/public_api_guard/material/icon-testing.md
+++ b/tools/public_api_guard/material/icon-testing.md
@@ -60,7 +60,7 @@ export interface IconHarnessFilters extends BaseHarnessFilters {
 }
 
 // @public
-export const enum IconType {
+export enum IconType {
     // (undocumented)
     FONT = 1,
     // (undocumented)

--- a/tools/public_api_guard/material/list-testing.md
+++ b/tools/public_api_guard/material/list-testing.md
@@ -82,13 +82,13 @@ export class MatListItemHarness extends MatListItemHarnessBase {
 }
 
 // @public
-export const enum MatListItemSection {
+export enum MatListItemSection {
     // (undocumented)
     CONTENT = ".mdc-list-item__content"
 }
 
 // @public
-export const enum MatListItemType {
+export enum MatListItemType {
     // (undocumented)
     ONE_LINE_ITEM = 0,
     // (undocumented)

--- a/tools/public_api_guard/material/slider-testing.md
+++ b/tools/public_api_guard/material/slider-testing.md
@@ -55,7 +55,7 @@ export interface SliderThumbHarnessFilters extends BaseHarnessFilters {
 }
 
 // @public
-export const enum ThumbPosition {
+export enum ThumbPosition {
     // (undocumented)
     END = 1,
     // (undocumented)

--- a/tools/public_api_guard/material/stepper-testing.md
+++ b/tools/public_api_guard/material/stepper-testing.md
@@ -66,7 +66,7 @@ export interface StepperHarnessFilters extends BaseHarnessFilters {
 }
 
 // @public
-export const enum StepperOrientation {
+export enum StepperOrientation {
     // (undocumented)
     HORIZONTAL = 0,
     // (undocumented)

--- a/tools/public_api_guard/material/toolbar-testing.md
+++ b/tools/public_api_guard/material/toolbar-testing.md
@@ -18,7 +18,7 @@ export class MatToolbarHarness extends ContentContainerComponentHarness<MatToolb
 }
 
 // @public
-export const enum MatToolbarSection {
+export enum MatToolbarSection {
     // (undocumented)
     ROW = ".mat-toolbar-row"
 }

--- a/tools/tslint-rules/preferPlainEnumRule.ts
+++ b/tools/tslint-rules/preferPlainEnumRule.ts
@@ -2,7 +2,7 @@ import ts from 'typescript';
 import * as Lint from 'tslint';
 
 /**
- * Rule that enforces that we use `const enum` rather than a plain `enum`.
+ * Rule that enforces that we use plain `enum` rather than `const enum`.
  */
 export class Rule extends Lint.Rules.AbstractRule {
   apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
@@ -12,8 +12,8 @@ export class Rule extends Lint.Rules.AbstractRule {
 
 class Walker extends Lint.RuleWalker {
   override visitEnumDeclaration(node: ts.EnumDeclaration) {
-    if (!node.modifiers?.some(({kind}) => kind === ts.SyntaxKind.ConstKeyword)) {
-      this.addFailureAtNode(node.name, 'Enums should be declared as `const enum`.');
+    if (node.modifiers?.some(({kind}) => kind === ts.SyntaxKind.ConstKeyword)) {
+      this.addFailureAtNode(node.name, 'Const enums are not allowed! Prefer plain `enum` instead.');
     }
 
     super.visitEnumDeclaration(node);

--- a/tslint.json
+++ b/tslint.json
@@ -68,7 +68,7 @@
     "lifecycle-hook-interface": true,
     "require-breaking-change-version": true,
     "no-nested-ternary": true,
-    "prefer-const-enum": true,
+    "prefer-plain-enum": true,
     "no-lifecycle-invocation": [true, "**/!(*.spec).ts"],
     "lightweight-tokens": [
       true,


### PR DESCRIPTION
Const enums prevent enabling the `isolatedModules` check which is needed for fast TS compilation based on transpileModule API.

This the counterpart of #51670 in Angular repo.