### PR TITLE
ci: deploy dev-app to ng-comp-devapp.web.app

### DIFF
--- a/.github/workflows/deploy-dev-app-main-push.yml
+++ b/.github/workflows/deploy-dev-app-main-push.yml
@@ -9,8 +9,8 @@ permissions:
 
 env:
   PREVIEW_PROJECT: ng-dev-previews
-  PREVIEW_SITE: ng-dev-previews-comp
-  PREVIEW_CHANNEL: main-branch
+  PREVIEW_SITE: ng-comp-devapp
+  PREVIEW_CHANNEL: live
 
 jobs:
   deploy-material2-dev:


### PR DESCRIPTION
Instead of using a preview channel, we are deploying to a live channel so that we have a static URL for team members.

For this we created a separate new sub-site in the ng-dev-previews Firebase project- still allowing us to benefit from the dev-infra maintenance of the project (and token/secret management).