### PR TITLE
fix(material/schematics): AsyncPipe and NgIF not imported

### DIFF
--- a/src/material/schematics/ng-generate/navigation/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.ts.template
+++ b/src/material/schematics/ng-generate/navigation/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.ts.template
@@ -7,6 +7,7 @@ import { MatListModule } from '@angular/material/list';
 import { MatIconModule } from '@angular/material/icon';<% } %>
 import { Observable } from 'rxjs';
 import { map, shareReplay } from 'rxjs/operators';
+import { AsyncPipe, NgIf } from '@angular/common';
 
 @Component({
   selector: '<%= selector %>',<% if(inlineTemplate) { %>
@@ -26,7 +27,9 @@ import { map, shareReplay } from 'rxjs/operators';
     MatButtonModule,
     MatSidenavModule,
     MatListModule,
-    MatIconModule
+    MatIconModule,
+    AsyncPipe,
+    NgIf
   ]<% } %>
 })
 export class <%= classify(name) %>Component {


### PR DESCRIPTION
When running `ng generate @angular/material:navigation navigation`, the `asyncPipe` is used in the generated template but never imported into the Standalone Component imports.

While the `AsyncPipe`  should be imported to fix the issue, the `*ngIf` is also used in the template (even though I think this disappears when the new control flow syntax adoption is finalized).
The fix proposes to import the  `CommonModule`  as we usually do when working with Standalone Components.