### PR TITLE
ci: publish snapshots to correct builds repository branch

### DIFF
--- a/scripts/deploy/publish-build-artifacts.sh
+++ b/scripts/deploy/publish-build-artifacts.sh
@@ -40,7 +40,7 @@ publishPackage() {
 
   buildDir="$(pwd)/dist/releases/${packageName}"
   buildVersion=$(node -pe "require('./package.json').version")
-  branchName=${CIRCLE_BRANCH:-'main'}
+  branchName=${GITHUB_REF_NAME:-'main'}
 
   commitSha=$(git rev-parse --short HEAD)
   commitAuthorName=$(git --no-pager show -s --format='%an' HEAD)

--- a/scripts/deploy/publish-docs-content.sh
+++ b/scripts/deploy/publish-docs-content.sh
@@ -34,7 +34,7 @@ docsContentRepoUrl="https://github.com/angular/material2-docs-content"
 buildVersion=$(node -pe "require('./package.json').version")
 
 # Name of the branch that is currently being deployed.
-branchName=${CIRCLE_BRANCH:-'main'}
+branchName=${GITHUB_REF_NAME:-'main'}
 
 # Additional information about the last commit for docs-content commits.
 commitSha=$(git rev-parse --short HEAD)


### PR DESCRIPTION
With https://github.com/angular/components/commit/1d677215ee047967dc5e6f25ccb09e0225c16f1a, the snapshots CI job was migrated from CircleCI to GitHub actions, but the underlying
scripts were not updated to no longer depend on CircleCI specifics.