### PR TITLE
ci: incorporate static dev-app deploy URL in GitHub deployments UI

### DIFF
--- a/.github/workflows/deploy-dev-app-main-push.yml
+++ b/.github/workflows/deploy-dev-app-main-push.yml
@@ -46,14 +46,10 @@ jobs:
           entryPoint: './'
           channelId: '${{env.PREVIEW_CHANNEL}}'
 
-      - name: Result
-        run: |
-          echo "Deployed to: ${{steps.deploy.outputs.details_url}}"
-
       - name: Deployment Status
         uses: zattoo/deploy-status@c8a0267e54a90ea07765fa88f7c7c35171859eec # v1
         with:
           token: '${{github.token}}'
           environment: 'dev'
-          environment_url: '${{steps.deploy.outputs.details_url}}'
+          environment_url: 'https://ng-comp-devapp.web.app'
           state: success


### PR DESCRIPTION
That way the static URL to the dev-app is always easy to discover.