### PR TITLE
fix(cdk/text-field): AutosizeTextarea miscalculates line height

### DIFF
--- a/src/cdk/text-field/autosize.spec.ts
+++ b/src/cdk/text-field/autosize.spec.ts
@@ -29,6 +29,7 @@ describe('CdkTextareaAutosize', () => {
         AutosizeTextAreaWithValue,
         AutosizeTextareaWithNgModel,
         AutosizeTextareaWithoutAutosize,
+        AutosizeTextAreaWithHeights,
       ],
     });
   }));
@@ -394,6 +395,22 @@ describe('CdkTextareaAutosize', () => {
 
     expect(textarea.hasAttribute('placeholder')).toBe(false);
   });
+
+  it('should calculate the proper row height with fixture with heights', () => {
+    const fixtureWithHeights = TestBed.createComponent(AutosizeTextAreaWithHeights);
+    fixtureWithHeights.detectChanges();
+    textarea = fixtureWithHeights.nativeElement.querySelector('textarea');
+    textarea.value = 'one line';
+    const autosizeWithHeights = fixtureWithHeights.debugElement
+      .query(By.directive(CdkTextareaAutosize))!
+      .injector.get<CdkTextareaAutosize>(CdkTextareaAutosize);
+
+    autosizeWithHeights.resizeToFitContent();
+
+    expect(textarea.clientHeight)
+      .withContext('Expected textarea with heights to have the proper height')
+      .toBeLessThanOrEqual(45);
+  });
 });
 
 // Styles to reset padding and border to make measurement comparisons easier.
@@ -444,4 +461,21 @@ class AutosizeTextareaWithNgModel {
 })
 class AutosizeTextareaWithoutAutosize {
   content: string = '';
+}
+
+// Styles to ensure line height is properly calculated
+const textareaStyleWithHeights = `
+    textarea {
+      min-height: 200px;
+      max-height: 400px;
+    }`;
+
+@Component({
+  template: `<textarea #autosize="cdkTextareaAutosize" cdkTextareaAutosize [cdkAutosizeMinRows]="3" [value]="value"></textarea>`,
+  styles: [textareaStyleReset, textareaStyleWithHeights],
+})
+class AutosizeTextAreaWithHeights {
+  @ViewChild('autosize') autosize: CdkTextareaAutosize;
+  maxRows: number | null = null;
+  value: string = '';
 }

--- a/src/cdk/text-field/autosize.ts
+++ b/src/cdk/text-field/autosize.ts
@@ -7,23 +7,23 @@
  */
 
 import {NumberInput, coerceNumberProperty} from '@angular/cdk/coercion';
-import {
-  Directive,
-  ElementRef,
-  Input,
-  AfterViewInit,
-  DoCheck,
-  OnDestroy,
-  NgZone,
-  booleanAttribute,
-  inject,
-  Renderer2,
-} from '@angular/core';
-import {DOCUMENT} from '@angular/common';
 import {Platform} from '@angular/cdk/platform';
 import {_CdkPrivateStyleLoader} from '@angular/cdk/private';
-import {auditTime} from 'rxjs/operators';
+import {DOCUMENT} from '@angular/common';
+import {
+  AfterViewInit,
+  Directive,
+  DoCheck,
+  ElementRef,
+  Input,
+  NgZone,
+  OnDestroy,
+  Renderer2,
+  booleanAttribute,
+  inject,
+} from '@angular/core';
 import {Subject} from 'rxjs';
+import {auditTime} from 'rxjs/operators';
 import {_CdkTextFieldStyleLoader} from './text-field-style-loader';
 
 /** Directive to automatically resize a textarea to fit its content. */
@@ -209,9 +209,9 @@ export class CdkTextareaAutosize implements AfterViewInit, DoCheck, OnDestroy {
     cloneStyles.visibility = 'hidden';
     cloneStyles.border = 'none';
     cloneStyles.padding = '0';
-    cloneStyles.height = '';
-    cloneStyles.minHeight = '';
-    cloneStyles.maxHeight = '';
+    cloneStyles.height = 'initial';
+    cloneStyles.minHeight = 'initial';
+    cloneStyles.maxHeight = 'initial';
 
     // App styles might be messing with the height through the positioning properties.
     cloneStyles.top = cloneStyles.bottom = cloneStyles.left = cloneStyles.right = 'auto';


### PR DESCRIPTION
Fixes a bug in the Angular cdk `cdkAutosizeTextarea` component where the line height is miscalculated because of `height` or `min-height` styles set by css on the textarea.

Fixes #28101