### PR TITLE
docs(material/snack-bar): adjust docs for standalone

### DIFF
--- a/src/components-examples/material-experimental/popover-edit/popover-edit-mat-table/popover-edit-mat-table-example.ts
+++ b/src/components-examples/material-experimental/popover-edit/popover-edit-mat-table/popover-edit-mat-table-example.ts
@@ -2,7 +2,7 @@ import {Component} from '@angular/core';
 import {DataSource} from '@angular/cdk/collections';
 import {FormValueContainer, CdkPopoverEditModule} from '@angular/cdk-experimental/popover-edit';
 import {NgForm, FormsModule} from '@angular/forms';
-import {MatSnackBar, MatSnackBarModule} from '@angular/material/snack-bar';
+import {MatSnackBar} from '@angular/material/snack-bar';
 import {BehaviorSubject, Observable} from 'rxjs';
 import {MatListModule} from '@angular/material/list';
 import {MatCheckboxModule} from '@angular/material/checkbox';
@@ -218,7 +218,6 @@ const FANTASY_ELEMENTS: readonly FantasyElement[] = [
     MatIconModule,
     MatCheckboxModule,
     MatListModule,
-    MatSnackBarModule,
   ],
 })
 export class PopoverEditMatTableExample {

--- a/src/components-examples/material/snack-bar/snack-bar-annotated-component/snack-bar-annotated-component-example.ts
+++ b/src/components-examples/material/snack-bar/snack-bar-annotated-component/snack-bar-annotated-component-example.ts
@@ -1,5 +1,11 @@
 import {Component, inject} from '@angular/core';
-import {MatSnackBar, MatSnackBarRef, MatSnackBarModule} from '@angular/material/snack-bar';
+import {
+  MatSnackBar,
+  MatSnackBarAction,
+  MatSnackBarActions,
+  MatSnackBarLabel,
+  MatSnackBarRef,
+} from '@angular/material/snack-bar';
 import {MatButtonModule} from '@angular/material/button';
 import {MatInputModule} from '@angular/material/input';
 import {FormsModule} from '@angular/forms';
@@ -13,7 +19,7 @@ import {MatFormFieldModule} from '@angular/material/form-field';
   templateUrl: 'snack-bar-annotated-component-example.html',
   styleUrls: ['snack-bar-annotated-component-example.css'],
   standalone: true,
-  imports: [MatFormFieldModule, FormsModule, MatInputModule, MatButtonModule, MatSnackBarModule],
+  imports: [MatFormFieldModule, FormsModule, MatInputModule, MatButtonModule],
 })
 export class SnackBarAnnotatedComponentExample {
   durationInSeconds = 5;
@@ -42,7 +48,7 @@ export class SnackBarAnnotatedComponentExample {
   `,
   ],
   standalone: true,
-  imports: [MatButtonModule, MatSnackBarModule],
+  imports: [MatButtonModule, MatSnackBarLabel, MatSnackBarActions, MatSnackBarAction],
 })
 export class PizzaPartyAnnotatedComponent {
   snackBarRef = inject(MatSnackBarRef);

--- a/src/components-examples/material/snack-bar/snack-bar-component/snack-bar-component-example.ts
+++ b/src/components-examples/material/snack-bar/snack-bar-component/snack-bar-component-example.ts
@@ -1,5 +1,5 @@
 import {Component} from '@angular/core';
-import {MatSnackBar, MatSnackBarModule} from '@angular/material/snack-bar';
+import {MatSnackBar} from '@angular/material/snack-bar';
 import {MatButtonModule} from '@angular/material/button';
 import {MatInputModule} from '@angular/material/input';
 import {FormsModule} from '@angular/forms';
@@ -13,7 +13,7 @@ import {MatFormFieldModule} from '@angular/material/form-field';
   templateUrl: 'snack-bar-component-example.html',
   styleUrls: ['snack-bar-component-example.css'],
   standalone: true,
-  imports: [MatFormFieldModule, FormsModule, MatInputModule, MatButtonModule, MatSnackBarModule],
+  imports: [MatFormFieldModule, FormsModule, MatInputModule, MatButtonModule],
 })
 export class SnackBarComponentExample {
   durationInSeconds = 5;

--- a/src/components-examples/material/snack-bar/snack-bar-harness/snack-bar-harness-example.spec.ts
+++ b/src/components-examples/material/snack-bar/snack-bar-harness/snack-bar-harness-example.spec.ts
@@ -4,7 +4,6 @@ import {HarnessLoader} from '@angular/cdk/testing';
 import {SnackBarHarnessExample} from './snack-bar-harness-example';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {MatSnackBarHarness} from '@angular/material/snack-bar/testing';
-import {MatSnackBarModule} from '@angular/material/snack-bar';
 
 describe('SnackBarHarnessExample', () => {
   let fixture: ComponentFixture<SnackBarHarnessExample>;
@@ -12,7 +11,7 @@ describe('SnackBarHarnessExample', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [MatSnackBarModule, NoopAnimationsModule],
+      imports: [NoopAnimationsModule],
     }).compileComponents();
     fixture = TestBed.createComponent(SnackBarHarnessExample);
     fixture.detectChanges();

--- a/src/components-examples/material/snack-bar/snack-bar-harness/snack-bar-harness-example.ts
+++ b/src/components-examples/material/snack-bar/snack-bar-harness/snack-bar-harness-example.ts
@@ -1,5 +1,5 @@
 import {Component} from '@angular/core';
-import {MatSnackBar, MatSnackBarConfig, MatSnackBarModule} from '@angular/material/snack-bar';
+import {MatSnackBar, MatSnackBarConfig} from '@angular/material/snack-bar';
 
 /**
  * @title Testing with MatSnackBarHarness
@@ -8,7 +8,6 @@ import {MatSnackBar, MatSnackBarConfig, MatSnackBarModule} from '@angular/materi
   selector: 'snack-bar-harness-example',
   templateUrl: 'snack-bar-harness-example.html',
   standalone: true,
-  imports: [MatSnackBarModule],
 })
 export class SnackBarHarnessExample {
   constructor(readonly snackBar: MatSnackBar) {}

--- a/src/components-examples/material/snack-bar/snack-bar-overview/snack-bar-overview-example.ts
+++ b/src/components-examples/material/snack-bar/snack-bar-overview/snack-bar-overview-example.ts
@@ -1,5 +1,5 @@
 import {Component} from '@angular/core';
-import {MatSnackBar, MatSnackBarModule} from '@angular/material/snack-bar';
+import {MatSnackBar} from '@angular/material/snack-bar';
 import {MatButtonModule} from '@angular/material/button';
 import {MatInputModule} from '@angular/material/input';
 import {MatFormFieldModule} from '@angular/material/form-field';
@@ -12,7 +12,7 @@ import {MatFormFieldModule} from '@angular/material/form-field';
   templateUrl: 'snack-bar-overview-example.html',
   styleUrls: ['snack-bar-overview-example.css'],
   standalone: true,
-  imports: [MatFormFieldModule, MatInputModule, MatButtonModule, MatSnackBarModule],
+  imports: [MatFormFieldModule, MatInputModule, MatButtonModule],
 })
 export class SnackBarOverviewExample {
   constructor(private _snackBar: MatSnackBar) {}

--- a/src/components-examples/material/snack-bar/snack-bar-position/snack-bar-position-example.ts
+++ b/src/components-examples/material/snack-bar/snack-bar-position/snack-bar-position-example.ts
@@ -2,7 +2,6 @@ import {Component} from '@angular/core';
 import {
   MatSnackBar,
   MatSnackBarHorizontalPosition,
-  MatSnackBarModule,
   MatSnackBarVerticalPosition,
 } from '@angular/material/snack-bar';
 import {MatButtonModule} from '@angular/material/button';
@@ -17,7 +16,7 @@ import {MatFormFieldModule} from '@angular/material/form-field';
   templateUrl: 'snack-bar-position-example.html',
   styleUrls: ['snack-bar-position-example.css'],
   standalone: true,
-  imports: [MatFormFieldModule, MatSelectModule, MatButtonModule, MatSnackBarModule],
+  imports: [MatFormFieldModule, MatSelectModule, MatButtonModule],
 })
 export class SnackBarPositionExample {
   horizontalPosition: MatSnackBarHorizontalPosition = 'start';

--- a/src/material/snack-bar/testing/snack-bar-harness.spec.ts
+++ b/src/material/snack-bar/testing/snack-bar-harness.spec.ts
@@ -2,7 +2,13 @@ import {Component, TemplateRef, ViewChild} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
-import {MatSnackBar, MatSnackBarConfig, MatSnackBarModule} from '@angular/material/snack-bar';
+import {
+  MatSnackBar,
+  MatSnackBarAction,
+  MatSnackBarActions,
+  MatSnackBarConfig,
+  MatSnackBarLabel,
+} from '@angular/material/snack-bar';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {MatSnackBarHarness} from './snack-bar-harness';
 
@@ -12,8 +18,7 @@ describe('MatSnackBarHarness', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [MatSnackBarModule, NoopAnimationsModule],
-      declarations: [SnackbarHarnessTest],
+      imports: [NoopAnimationsModule],
     }).compileComponents();
 
     fixture = TestBed.createComponent(SnackbarHarnessTest);
@@ -166,6 +171,8 @@ describe('MatSnackBarHarness', () => {
       <div matSnackBarActions><button matSnackBarAction>Ok</button></div>
     </ng-template>
   `,
+  standalone: true,
+  imports: [MatSnackBarLabel, MatSnackBarActions, MatSnackBarAction],
 })
 class SnackbarHarnessTest {
   @ViewChild('custom') customTmpl: TemplateRef<any>;

--- a/src/universal-app/kitchen-sink/kitchen-sink.ts
+++ b/src/universal-app/kitchen-sink/kitchen-sink.ts
@@ -27,7 +27,7 @@ import {MatSelectModule} from '@angular/material/select';
 import {MatSidenavModule} from '@angular/material/sidenav';
 import {MatSliderModule} from '@angular/material/slider';
 import {MatSlideToggleModule} from '@angular/material/slide-toggle';
-import {MatSnackBarModule, MatSnackBar} from '@angular/material/snack-bar';
+import {MatSnackBar} from '@angular/material/snack-bar';
 import {MatTabsModule} from '@angular/material/tabs';
 import {MatToolbarModule} from '@angular/material/toolbar';
 import {MatTooltipModule} from '@angular/material/tooltip';
@@ -93,7 +93,6 @@ export class TestEntryComponent {}
     MatSidenavModule,
     MatSliderModule,
     MatSlideToggleModule,
-    MatSnackBarModule,
     MatTabsModule,
     MatToolbarModule,
     MatTooltipModule,


### PR DESCRIPTION
Now that `@angular/material/snack-bar` was reworked for standalone, we don't have to import the `MatSnackBarModule` everywhere.