### PR TITLE
fix(material/expansion): fix mat-expansion-indicator is slightly off …

### DIFF
--- a/src/material/expansion/expansion-panel-header.scss
+++ b/src/material/expansion/expansion-panel-header.scss
@@ -138,20 +138,24 @@
   }
 }
 
-// Creates the expansion indicator arrow. Done using ::after
-// rather than havingadditional nodes in the template.
-.mat-expansion-indicator::after {
-  border-style: solid;
-  border-width: 0 2px 2px 0;
-  content: '';
-  display: inline-block;
-  padding: 3px;
-  transform: rotate(45deg);
-  vertical-align: middle;
+.mat-expansion-indicator {
+  display: flex;
 
-  @include token-utils.use-tokens(
-    tokens-mat-expansion.$prefix, tokens-mat-expansion.get-token-slots()) {
-    @include token-utils.create-token-slot(color, header-indicator-color);
+  // Creates the expansion indicator arrow. Done using ::after
+  // rather than havingadditional nodes in the template.
+  &::after {
+    border-style: solid;
+    border-width: 0 2px 2px 0;
+    content: '';
+    display: inline-block;
+    padding: 3px;
+    transform: rotate(45deg);
+    vertical-align: middle;
+
+    @include token-utils.use-tokens(
+      tokens-mat-expansion.$prefix, tokens-mat-expansion.get-token-slots()) {
+      @include token-utils.create-token-slot(color, header-indicator-color);
+    }
   }
 }
 


### PR DESCRIPTION
…center

fixes bug mat-expansion-indicator is slightly off center. Added flex to the mat-expansion indicator aligns the indicator center with the the sibling elements.

Fixes #28037


Before: 
<img width="1427" alt="bug expansion panel" src="https://github.com/angular/components/assets/47988127/dd51bb79-4af1-4b51-a4ef-3d89949c9331">

After Fix:
<img width="1302" alt="fix expansion panel" src="https://github.com/angular/components/assets/47988127/d7e4fe3a-e2ec-4f21-8a64-d33e9485a316">
<img width="1336" alt="Screenshot 2023-11-14 at 12 41 13 AM" src="https://github.com/angular/components/assets/47988127/c746ce3e-68cb-411a-8b95-3884ee887a7f">

<img width="1440" alt="Screenshot 2023-11-14 at 12 42 34 AM" src="https://github.com/angular/components/assets/47988127/99b96ff3-cf95-4e37-9f44-34e51570bab5">
