### PR TITLE
fix(material/autocomplete): regression in requireSelection when options are filtered

### DIFF
--- a/src/material/autocomplete/autocomplete-trigger.ts
+++ b/src/material/autocomplete/autocomplete-trigger.ts
@@ -600,7 +600,6 @@ export class MatAutocompleteTrigger
                 //   of the available options,
                 // - if a valid string is entered after an invalid one.
                 if (this.panelOpen) {
-                  this._captureValueOnAttach();
                   this._emitOpened();
                 } else {
                   this.autocomplete.closed.emit();
@@ -624,11 +623,6 @@ export class MatAutocompleteTrigger
    */
   private _emitOpened() {
     this.autocomplete.opened.emit();
-  }
-
-  /** Intended to be called when the panel is attached. Captures the current value of the input. */
-  private _captureValueOnAttach() {
-    this._valueOnAttach = this._element.nativeElement.value;
   }
 
   /** Destroys the autocomplete suggestion panel. */
@@ -744,6 +738,7 @@ export class MatAutocompleteTrigger
 
     if (overlayRef && !overlayRef.hasAttached()) {
       overlayRef.attach(this._portal);
+      this._valueOnAttach = this._element.nativeElement.value;
       this._closingActionsSubscription = this._subscribeToClosingActions();
     }
 
@@ -753,7 +748,6 @@ export class MatAutocompleteTrigger
     this.autocomplete._setColor(this._formField?.color);
     this._updatePanelState();
     this._applyModalPanelOwnership();
-    this._captureValueOnAttach();
 
     // We need to do an extra `panelOpen` check in here, because the
     // autocomplete won't be shown if there are no options.

--- a/tools/public_api_guard/material/autocomplete.md
+++ b/tools/public_api_guard/material/autocomplete.md
@@ -190,7 +190,7 @@ export class MatAutocompleteTrigger implements ControlValueAccessor, AfterViewIn
     // (undocumented)
     _handleKeydown(event: KeyboardEvent): void;
     // (undocumented)
-    static ngAcceptInputType_autocompleteDisabled: unknown /** Handles keyboard events coming from the overlay panel. */;
+    static ngAcceptInputType_autocompleteDisabled: unknown;
     // (undocumented)
     ngAfterViewInit(): void;
     // (undocumented)


### PR DESCRIPTION
In #27781 the call to capture the input value was moved into the root of `_attachOverlay` in order to capture it even when there are no options. This is problematic, because `_attachOverlay` is called as the user is typing which basically breaks the `requireSelection` feature.

These changes resolve the issue while preserving the original fix by only capturing the value when the overlay is actually attached.

Fixes #28113.