### PR TITLE
docs(material/list): Fix code example formatting

### DIFF
--- a/src/components-examples/material/list/list-variants/list-variants-example.html
+++ b/src/components-examples/material/list/list-variants/list-variants-example.html
@@ -45,8 +45,8 @@
 <mat-list class="example-list-wrapping">
   <mat-list-item lines="3">
     <span matListItemTitle>Title</span>
-    <span
-      >Secondary line that will wrap because the list lines is explicitly set to 3 lines. Text
+    <span>
+      Secondary line that will wrap because the list lines is explicitly set to 3 lines. Text
       inside of a `matListItemTitle` or `matListItemLine` will never wrap.
     </span>
   </mat-list-item>


### PR DESCRIPTION
Fix opening `<span>` tag formatting

<img width="1301" alt="image" src="https://github.com/angular/components/assets/3170200/ef1071cf-a4f2-4ff4-96de-a0fc355fe394">
