### PR TITLE
Remove error mixin usages

### DIFF
--- a/src/material/core/common-behaviors/error-state.ts
+++ b/src/material/core/common-behaviors/error-state.ts
@@ -38,6 +38,43 @@ export interface HasErrorState {
 }
 
 /**
+ * Class that tracks the error state of a component.
+ * @docs-private
+ */
+export class _ErrorStateTracker {
+  /** Whether the tracker is currently in an error state. */
+  errorState = false;
+
+  /** User-defined matcher for the error state. */
+  matcher: ErrorStateMatcher;
+
+  constructor(
+    private _defaultMatcher: ErrorStateMatcher | null,
+    public ngControl: NgControl | null,
+    private _parentFormGroup: FormGroupDirective | null,
+    private _parentForm: NgForm | null,
+    private _stateChanges: Subject<void>,
+  ) {}
+
+  /** Updates the error state based on the provided error state matcher. */
+  updateErrorState() {
+    const oldState = this.errorState;
+    const parent = this._parentFormGroup || this._parentForm;
+    const matcher = this.matcher || this._defaultMatcher;
+    const control = this.ngControl ? (this.ngControl.control as AbstractControl) : null;
+    // Note: the null check here shouldn't be necessary, but there's an internal
+    // test that appears to pass an object whose `isErrorState` isn't a function.
+    const newState =
+      typeof matcher?.isErrorState === 'function' ? matcher.isErrorState(control, parent) : false;
+
+    if (newState !== oldState) {
+      this.errorState = newState;
+      this._stateChanges.next();
+    }
+  }
+}
+
+/**
  * Mixin to augment a directive with updateErrorState method.
  * For component with `errorState` and need to update `errorState`.
  */
@@ -48,24 +85,41 @@ export function mixinErrorState<T extends Constructor<HasErrorState>>(
   base: T,
 ): CanUpdateErrorStateCtor & T {
   return class extends base {
+    private _tracker: _ErrorStateTracker | undefined;
+
     /** Whether the component is in an error state. */
-    errorState: boolean = false;
+    get errorState() {
+      return this._getTracker().errorState;
+    }
+    set errorState(value: boolean) {
+      this._getTracker().errorState = value;
+    }
 
     /** An object used to control the error state of the component. */
-    errorStateMatcher: ErrorStateMatcher;
+    get errorStateMatcher() {
+      return this._getTracker().matcher;
+    }
+    set errorStateMatcher(value: ErrorStateMatcher) {
+      this._getTracker().matcher = value;
+    }
 
     /** Updates the error state based on the provided error state matcher. */
     updateErrorState() {
-      const oldState = this.errorState;
-      const parent = this._parentFormGroup || this._parentForm;
-      const matcher = this.errorStateMatcher || this._defaultErrorStateMatcher;
-      const control = this.ngControl ? (this.ngControl.control as AbstractControl) : null;
-      const newState = matcher.isErrorState(control, parent);
+      this._getTracker().updateErrorState();
+    }
 
-      if (newState !== oldState) {
-        this.errorState = newState;
-        this.stateChanges.next();
+    private _getTracker() {
+      if (!this._tracker) {
+        this._tracker = new _ErrorStateTracker(
+          this._defaultErrorStateMatcher,
+          this.ngControl,
+          this._parentFormGroup,
+          this._parentForm,
+          this.stateChanges,
+        );
       }
+
+      return this._tracker;
     }
 
     constructor(...args: any[]) {

--- a/src/material/core/common-behaviors/index.ts
+++ b/src/material/core/common-behaviors/index.ts
@@ -26,5 +26,5 @@ export {CanDisable, mixinDisabled} from './disabled';
 export {CanColor, mixinColor, ThemePalette} from './color';
 export {CanDisableRipple, mixinDisableRipple} from './disable-ripple';
 export {HasTabIndex, mixinTabIndex} from './tabindex';
-export {CanUpdateErrorState, mixinErrorState} from './error-state';
+export {CanUpdateErrorState, mixinErrorState, _ErrorStateTracker} from './error-state';
 export {HasInitialized, mixinInitialized} from './initialized';

--- a/src/material/input/input.ts
+++ b/src/material/input/input.ts
@@ -23,7 +23,7 @@ import {
   Self,
 } from '@angular/core';
 import {FormGroupDirective, NgControl, NgForm, Validators} from '@angular/forms';
-import {CanUpdateErrorState, ErrorStateMatcher, mixinErrorState} from '@angular/material/core';
+import {ErrorStateMatcher, _ErrorStateTracker} from '@angular/material/core';
 import {MatFormFieldControl, MatFormField, MAT_FORM_FIELD} from '@angular/material/form-field';
 import {Subject} from 'rxjs';
 import {getMatInputUnsupportedTypeError} from './input-errors';
@@ -43,31 +43,6 @@ const MAT_INPUT_INVALID_TYPES = [
 ];
 
 let nextUniqueId = 0;
-
-// Boilerplate for applying mixins to MatInput.
-/** @docs-private */
-const _MatInputBase = mixinErrorState(
-  class {
-    /**
-     * Emits whenever the component state changes and should cause the parent
-     * form field to update. Implemented as part of `MatFormFieldControl`.
-     * @docs-private
-     */
-    readonly stateChanges = new Subject<void>();
-
-    constructor(
-      public _defaultErrorStateMatcher: ErrorStateMatcher,
-      public _parentForm: NgForm,
-      public _parentFormGroup: FormGroupDirective,
-      /**
-       * Form control bound to the component.
-       * Implemented as part of `MatFormFieldControl`.
-       * @docs-private
-       */
-      public ngControl: NgControl,
-    ) {}
-  },
-);
 
 @Directive({
   selector: `input[matInput], textarea[matInput], select[matNativeControl],
@@ -104,19 +79,13 @@ const _MatInputBase = mixinErrorState(
   providers: [{provide: MatFormFieldControl, useExisting: MatInput}],
 })
 export class MatInput
-  extends _MatInputBase
-  implements
-    MatFormFieldControl<any>,
-    OnChanges,
-    OnDestroy,
-    AfterViewInit,
-    DoCheck,
-    CanUpdateErrorState
+  implements MatFormFieldControl<any>, OnChanges, OnDestroy, AfterViewInit, DoCheck
 {
   protected _uid = `mat-input-${nextUniqueId++}`;
   protected _previousNativeValue: any;
   private _inputValueAccessor: {value: any};
   private _previousPlaceholder: string | null;
+  private _errorStateTracker: _ErrorStateTracker;
 
   /** Whether the component is being rendered on the server. */
   readonly _isServer: boolean;
@@ -140,7 +109,7 @@ export class MatInput
    * Implemented as part of MatFormFieldControl.
    * @docs-private
    */
-  override readonly stateChanges: Subject<void> = new Subject<void>();
+  readonly stateChanges: Subject<void> = new Subject<void>();
 
   /**
    * Implemented as part of MatFormFieldControl.
@@ -231,7 +200,13 @@ export class MatInput
   protected _type = 'text';
 
   /** An object used to control when error messages are shown. */
-  @Input() override errorStateMatcher: ErrorStateMatcher;
+  @Input()
+  get errorStateMatcher() {
+    return this._errorStateTracker.matcher;
+  }
+  set errorStateMatcher(value: ErrorStateMatcher) {
+    this._errorStateTracker.matcher = value;
+  }
 
   /**
    * Implemented as part of MatFormFieldControl.
@@ -264,6 +239,14 @@ export class MatInput
   }
   private _readonly = false;
 
+  /** Whether the input is in an error state. */
+  get errorState() {
+    return this._errorStateTracker.errorState;
+  }
+  set errorState(value: boolean) {
+    this._errorStateTracker.errorState = value;
+  }
+
   protected _neverEmptyInputTypes = [
     'date',
     'datetime',
@@ -276,10 +259,10 @@ export class MatInput
   constructor(
     protected _elementRef: ElementRef<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>,
     protected _platform: Platform,
-    @Optional() @Self() ngControl: NgControl,
-    @Optional() _parentForm: NgForm,
-    @Optional() _parentFormGroup: FormGroupDirective,
-    _defaultErrorStateMatcher: ErrorStateMatcher,
+    @Optional() @Self() public ngControl: NgControl,
+    @Optional() parentForm: NgForm,
+    @Optional() parentFormGroup: FormGroupDirective,
+    defaultErrorStateMatcher: ErrorStateMatcher,
     @Optional() @Self() @Inject(MAT_INPUT_VALUE_ACCESSOR) inputValueAccessor: any,
     private _autofillMonitor: AutofillMonitor,
     ngZone: NgZone,
@@ -287,8 +270,6 @@ export class MatInput
     // to inject the form field for determining whether the placeholder has been promoted.
     @Optional() @Inject(MAT_FORM_FIELD) protected _formField?: MatFormField,
   ) {
-    super(_defaultErrorStateMatcher, _parentForm, _parentFormGroup, ngControl);
-
     const element = this._elementRef.nativeElement;
     const nodeName = element.nodeName.toLowerCase();
 
@@ -310,6 +291,13 @@ export class MatInput
       });
     }
 
+    this._errorStateTracker = new _ErrorStateTracker(
+      defaultErrorStateMatcher,
+      ngControl,
+      parentFormGroup,
+      parentForm,
+      this.stateChanges,
+    );
     this._isServer = !this._platform.isBrowser;
     this._isNativeSelect = nodeName === 'select';
     this._isTextarea = nodeName === 'textarea';
@@ -377,6 +365,11 @@ export class MatInput
   /** Focuses the input. */
   focus(options?: FocusOptions): void {
     this._elementRef.nativeElement.focus(options);
+  }
+
+  /** Refreshes the error state of the input. */
+  updateErrorState() {
+    this._errorStateTracker.updateErrorState();
   }
 
   /** Callback for the cases where the focused state of the input changes. */

--- a/tools/public_api_guard/material/chips.md
+++ b/tools/public_api_guard/material/chips.md
@@ -4,12 +4,9 @@
 
 ```ts
 
-import { _AbstractConstructor } from '@angular/material/core';
 import { AfterContentInit } from '@angular/core';
 import { AfterViewInit } from '@angular/core';
-import { CanUpdateErrorState } from '@angular/material/core';
 import { ChangeDetectorRef } from '@angular/core';
-import { _Constructor } from '@angular/material/core';
 import { ControlValueAccessor } from '@angular/forms';
 import { Directionality } from '@angular/cdk/bidi';
 import { DoCheck } from '@angular/core';
@@ -172,7 +169,7 @@ export interface MatChipEvent {
 }
 
 // @public
-export class MatChipGrid extends _MatChipGridMixinBase implements AfterContentInit, AfterViewInit, CanUpdateErrorState, ControlValueAccessor, DoCheck, MatFormFieldControl<any>, OnDestroy {
+export class MatChipGrid extends MatChipSet implements AfterContentInit, AfterViewInit, ControlValueAccessor, DoCheck, MatFormFieldControl<any>, OnDestroy {
     constructor(elementRef: ElementRef, changeDetectorRef: ChangeDetectorRef, dir: Directionality, parentForm: NgForm, parentFormGroup: FormGroupDirective, defaultErrorStateMatcher: ErrorStateMatcher, ngControl: NgControl);
     protected _allowFocusEscape(): void;
     _blur(): void;
@@ -187,7 +184,10 @@ export class MatChipGrid extends _MatChipGridMixinBase implements AfterContentIn
     get disabled(): boolean;
     set disabled(value: boolean);
     get empty(): boolean;
-    errorStateMatcher: ErrorStateMatcher;
+    get errorState(): boolean;
+    set errorState(value: boolean);
+    get errorStateMatcher(): ErrorStateMatcher;
+    set errorStateMatcher(value: ErrorStateMatcher);
     focus(): void;
     get focused(): boolean;
     // (undocumented)
@@ -202,6 +202,8 @@ export class MatChipGrid extends _MatChipGridMixinBase implements AfterContentIn
     ngAfterContentInit(): void;
     // (undocumented)
     ngAfterViewInit(): void;
+    // (undocumented)
+    ngControl: NgControl;
     // (undocumented)
     ngDoCheck(): void;
     // (undocumented)
@@ -223,6 +225,8 @@ export class MatChipGrid extends _MatChipGridMixinBase implements AfterContentIn
     setDescribedByIds(ids: string[]): void;
     setDisabledState(isDisabled: boolean): void;
     get shouldLabelFloat(): boolean;
+    readonly stateChanges: Subject<void>;
+    updateErrorState(): void;
     get value(): any;
     set value(value: any);
     // (undocumented)

--- a/tools/public_api_guard/material/core.md
+++ b/tools/public_api_guard/material/core.md
@@ -134,6 +134,16 @@ export class ErrorStateMatcher {
 }
 
 // @public
+export class _ErrorStateTracker {
+    constructor(_defaultMatcher: ErrorStateMatcher | null, ngControl: NgControl | null, _parentFormGroup: FormGroupDirective | null, _parentForm: NgForm | null, _stateChanges: Subject<void>);
+    errorState: boolean;
+    matcher: ErrorStateMatcher;
+    // (undocumented)
+    ngControl: NgControl | null;
+    updateErrorState(): void;
+}
+
+// @public
 export function _getOptionScrollPosition(optionOffset: number, optionHeight: number, currentScrollPosition: number, panelHeight: number): number;
 
 // @public

--- a/tools/public_api_guard/material/datepicker.md
+++ b/tools/public_api_guard/material/datepicker.md
@@ -4,17 +4,14 @@
 
 ```ts
 
-import { _AbstractConstructor } from '@angular/material/core';
 import { AbstractControl } from '@angular/forms';
 import { AfterContentInit } from '@angular/core';
 import { AfterViewChecked } from '@angular/core';
 import { AfterViewInit } from '@angular/core';
 import { AnimationEvent as AnimationEvent_2 } from '@angular/animations';
 import { AnimationTriggerMetadata } from '@angular/animations';
-import { CanUpdateErrorState } from '@angular/material/core';
 import { ChangeDetectorRef } from '@angular/core';
 import { ComponentType } from '@angular/cdk/portal';
-import { _Constructor } from '@angular/material/core';
 import { ControlContainer } from '@angular/forms';
 import { ControlValueAccessor } from '@angular/forms';
 import { DateAdapter } from '@angular/material/core';
@@ -676,7 +673,7 @@ export abstract class MatDateSelectionModel<S, D = ExtractDateTypeFromSelection<
 }
 
 // @public
-export class MatEndDate<D> extends _MatDateRangeInputBase<D> implements CanUpdateErrorState {
+export class MatEndDate<D> extends MatDateRangeInputPartBase<D> {
     constructor(rangeInput: MatDateRangeInputParent<D>, elementRef: ElementRef<HTMLInputElement>, defaultErrorStateMatcher: ErrorStateMatcher, injector: Injector, parentForm: NgForm, parentFormGroup: FormGroupDirective, dateAdapter: DateAdapter<D>, dateFormats: MatDateFormats);
     // (undocumented)
     protected _assignValueToModel(value: D | null): void;
@@ -689,7 +686,7 @@ export class MatEndDate<D> extends _MatDateRangeInputBase<D> implements CanUpdat
     // (undocumented)
     protected _validator: ValidatorFn | null;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<MatEndDate<any>, "input[matEndDate]", never, { "errorStateMatcher": { "alias": "errorStateMatcher"; "required": false; }; }, { "dateChange": "dateChange"; "dateInput": "dateInput"; }, never, never, false, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<MatEndDate<any>, "input[matEndDate]", never, {}, { "dateChange": "dateChange"; "dateInput": "dateInput"; }, never, never, false, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatEndDate<any>, [null, null, null, null, { optional: true; }, { optional: true; }, { optional: true; }, { optional: true; }]>;
 }
@@ -826,7 +823,7 @@ export class MatSingleDateSelectionModel<D> extends MatDateSelectionModel<D | nu
 }
 
 // @public
-export class MatStartDate<D> extends _MatDateRangeInputBase<D> implements CanUpdateErrorState {
+export class MatStartDate<D> extends MatDateRangeInputPartBase<D> {
     constructor(rangeInput: MatDateRangeInputParent<D>, elementRef: ElementRef<HTMLInputElement>, defaultErrorStateMatcher: ErrorStateMatcher, injector: Injector, parentForm: NgForm, parentFormGroup: FormGroupDirective, dateAdapter: DateAdapter<D>, dateFormats: MatDateFormats);
     // (undocumented)
     protected _assignValueToModel(value: D | null): void;
@@ -841,7 +838,7 @@ export class MatStartDate<D> extends _MatDateRangeInputBase<D> implements CanUpd
     // (undocumented)
     protected _validator: ValidatorFn | null;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<MatStartDate<any>, "input[matStartDate]", never, { "errorStateMatcher": { "alias": "errorStateMatcher"; "required": false; }; }, { "dateChange": "dateChange"; "dateInput": "dateInput"; }, never, never, false, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<MatStartDate<any>, "input[matStartDate]", never, {}, { "dateChange": "dateChange"; "dateInput": "dateInput"; }, never, never, false, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatStartDate<any>, [null, null, null, null, { optional: true; }, { optional: true; }, { optional: true; }, { optional: true; }]>;
 }

--- a/tools/public_api_guard/material/input.md
+++ b/tools/public_api_guard/material/input.md
@@ -4,12 +4,9 @@
 
 ```ts
 
-import { _AbstractConstructor } from '@angular/material/core';
 import { AfterViewInit } from '@angular/core';
 import { AutofillMonitor } from '@angular/cdk/text-field';
 import { BooleanInput } from '@angular/cdk/coercion';
-import { CanUpdateErrorState } from '@angular/material/core';
-import { _Constructor } from '@angular/material/core';
 import { DoCheck } from '@angular/core';
 import { ElementRef } from '@angular/core';
 import { ErrorStateMatcher } from '@angular/material/core';
@@ -38,8 +35,8 @@ export const MAT_INPUT_VALUE_ACCESSOR: InjectionToken<{
 }>;
 
 // @public (undocumented)
-export class MatInput extends _MatInputBase implements MatFormFieldControl<any>, OnChanges, OnDestroy, AfterViewInit, DoCheck, CanUpdateErrorState {
-    constructor(_elementRef: ElementRef<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>, _platform: Platform, ngControl: NgControl, _parentForm: NgForm, _parentFormGroup: FormGroupDirective, _defaultErrorStateMatcher: ErrorStateMatcher, inputValueAccessor: any, _autofillMonitor: AutofillMonitor, ngZone: NgZone, _formField?: MatFormField | undefined);
+export class MatInput implements MatFormFieldControl<any>, OnChanges, OnDestroy, AfterViewInit, DoCheck {
+    constructor(_elementRef: ElementRef<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>, _platform: Platform, ngControl: NgControl, parentForm: NgForm, parentFormGroup: FormGroupDirective, defaultErrorStateMatcher: ErrorStateMatcher, inputValueAccessor: any, _autofillMonitor: AutofillMonitor, ngZone: NgZone, _formField?: MatFormField | undefined);
     autofilled: boolean;
     controlType: string;
     protected _dirtyCheckNativeValue(): void;
@@ -50,7 +47,10 @@ export class MatInput extends _MatInputBase implements MatFormFieldControl<any>,
     // (undocumented)
     protected _elementRef: ElementRef<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>;
     get empty(): boolean;
-    errorStateMatcher: ErrorStateMatcher;
+    get errorState(): boolean;
+    set errorState(value: boolean);
+    get errorStateMatcher(): ErrorStateMatcher;
+    set errorStateMatcher(value: ErrorStateMatcher);
     focus(options?: FocusOptions): void;
     _focusChanged(isFocused: boolean): void;
     focused: boolean;
@@ -73,6 +73,8 @@ export class MatInput extends _MatInputBase implements MatFormFieldControl<any>,
     protected _neverEmptyInputTypes: string[];
     // (undocumented)
     ngAfterViewInit(): void;
+    // (undocumented)
+    ngControl: NgControl;
     // (undocumented)
     ngDoCheck(): void;
     // (undocumented)
@@ -102,6 +104,7 @@ export class MatInput extends _MatInputBase implements MatFormFieldControl<any>,
     protected _type: string;
     // (undocumented)
     protected _uid: string;
+    updateErrorState(): void;
     userAriaDescribedBy: string;
     protected _validateType(): void;
     get value(): string;

--- a/tools/public_api_guard/material/select.md
+++ b/tools/public_api_guard/material/select.md
@@ -4,16 +4,13 @@
 
 ```ts
 
-import { _AbstractConstructor } from '@angular/material/core';
 import { ActiveDescendantKeyManager } from '@angular/cdk/a11y';
 import { AfterContentInit } from '@angular/core';
 import { AnimationTriggerMetadata } from '@angular/animations';
-import { CanUpdateErrorState } from '@angular/material/core';
 import { CdkConnectedOverlay } from '@angular/cdk/overlay';
 import { CdkOverlayOrigin } from '@angular/cdk/overlay';
 import { ChangeDetectorRef } from '@angular/core';
 import { ConnectedPosition } from '@angular/cdk/overlay';
-import { _Constructor } from '@angular/material/core';
 import { ControlValueAccessor } from '@angular/forms';
 import { Directionality } from '@angular/cdk/bidi';
 import { DoCheck } from '@angular/core';
@@ -69,8 +66,8 @@ export function MAT_SELECT_SCROLL_STRATEGY_PROVIDER_FACTORY(overlay: Overlay): (
 export const MAT_SELECT_TRIGGER: InjectionToken<MatSelectTrigger>;
 
 // @public (undocumented)
-export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, OnChanges, OnDestroy, OnInit, DoCheck, ControlValueAccessor, MatFormFieldControl<any>, CanUpdateErrorState {
-    constructor(_viewportRuler: ViewportRuler, _changeDetectorRef: ChangeDetectorRef, _ngZone: NgZone, _defaultErrorStateMatcher: ErrorStateMatcher, elementRef: ElementRef, _dir: Directionality, _parentForm: NgForm, _parentFormGroup: FormGroupDirective, _parentFormField: MatFormField, ngControl: NgControl, tabIndex: string, scrollStrategyFactory: any, _liveAnnouncer: LiveAnnouncer, _defaultOptions?: MatSelectConfig | undefined);
+export class MatSelect implements AfterContentInit, OnChanges, OnDestroy, OnInit, DoCheck, ControlValueAccessor, MatFormFieldControl<any> {
+    constructor(_viewportRuler: ViewportRuler, _changeDetectorRef: ChangeDetectorRef, _ngZone: NgZone, defaultErrorStateMatcher: ErrorStateMatcher, _elementRef: ElementRef, _dir: Directionality, parentForm: NgForm, parentFormGroup: FormGroupDirective, _parentFormField: MatFormField, ngControl: NgControl, tabIndex: string, scrollStrategyFactory: any, _liveAnnouncer: LiveAnnouncer, _defaultOptions?: MatSelectConfig | undefined);
     ariaLabel: string;
     ariaLabelledby: string;
     protected _canOpen(): boolean;
@@ -88,8 +85,13 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
     disabled: boolean;
     disableOptionCentering: boolean;
     disableRipple: boolean;
+    // (undocumented)
+    readonly _elementRef: ElementRef;
     get empty(): boolean;
-    errorStateMatcher: ErrorStateMatcher;
+    get errorState(): boolean;
+    set errorState(value: boolean);
+    get errorStateMatcher(): ErrorStateMatcher;
+    set errorStateMatcher(value: ErrorStateMatcher);
     focus(options?: FocusOptions): void;
     get focused(): boolean;
     _getAriaActiveDescendant(): string | null;
@@ -122,6 +124,8 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
     static ngAcceptInputType_typeaheadDebounceInterval: unknown;
     // (undocumented)
     ngAfterContentInit(): void;
+    // (undocumented)
+    ngControl: NgControl;
     // (undocumented)
     ngDoCheck(): void;
     // (undocumented)
@@ -176,12 +180,14 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
     setDisabledState(isDisabled: boolean): void;
     get shouldLabelFloat(): boolean;
     sortComparator: (a: MatOption, b: MatOption, options: MatOption[]) => number;
+    readonly stateChanges: Subject<void>;
     _syncParentProperties(): void;
     tabIndex: number;
     toggle(): void;
     trigger: ElementRef;
     get triggerValue(): string;
     typeaheadDebounceInterval: number;
+    updateErrorState(): void;
     userAriaDescribedBy: string;
     get value(): any;
     set value(newValue: any);


### PR DESCRIPTION
Removes all remaining usages of the error mixin by moving the functionality into a new class that is used internally inside the components. This allows us to further clean up some boilerplate and a hacky workaround in the chip grid.