### PR TITLE
fix(material/tooltip): increase specificity of non-interactive styles

### DIFF
--- a/src/material/tooltip/tooltip.scss
+++ b/src/material/tooltip/tooltip.scss
@@ -4,7 +4,7 @@
 @use '../core/tokens/m2/mdc/plain-tooltip' as m2-mdc-plain-tooltip;
 
 @include mdc-custom-properties.configure($emit-fallback-values: false,
-$emit-fallback-vars: false) {
+  $emit-fallback-vars: false) {
   $mdc-tooltip-token-slots: m2-mdc-plain-tooltip.get-token-slots();
 
   // Add the MDC tooltip static styles.
@@ -59,7 +59,8 @@ $emit-fallback-vars: false) {
   }
 }
 
-.mat-mdc-tooltip-panel-non-interactive {
+// We need the additional specificity here, because it can be overridden by `.cdk-overlay-panel`.
+.mat-mdc-tooltip-panel.mat-mdc-tooltip-panel-non-interactive {
   pointer-events: none;
 }
 


### PR DESCRIPTION
Fixes that the specificity of the `mat-mdc-tooltip-panel-non-interactive` class was too low which meant that it was easy to override by other structural styles.

Fixes #28145.