### PR TITLE
fix(material/form-field): work around closure compiler issue

### DIFF
--- a/src/material/form-field/form-field.ts
+++ b/src/material/form-field/form-field.ts
@@ -46,7 +46,7 @@ import {MAT_PREFIX, MatPrefix} from './directives/prefix';
 import {MAT_SUFFIX, MatSuffix} from './directives/suffix';
 import {BooleanInput, coerceBooleanProperty} from '@angular/cdk/coercion';
 import {matFormFieldAnimations} from './form-field-animations';
-import {MatFormFieldControl} from './form-field-control';
+import {MatFormFieldControl as _MatFormFieldControl} from './form-field-control';
 import {
   getMatFormFieldDuplicatedHintError,
   getMatFormFieldMissingControlError,
@@ -118,6 +118,16 @@ const DEFAULT_SUBSCRIPT_SIZING: SubscriptSizing = 'fixed';
  */
 const FLOATING_LABEL_DEFAULT_DOCKED_TRANSFORM = `translateY(-50%)`;
 
+/**
+ * Despite `MatFormFieldControl` being an abstract class, most of our usages enforce its shape
+ * using `implements` instead of `extends`. This appears to be problematic when Closure compiler
+ * is configured to use type information to rename properties, because it can't figure out which
+ * class properties are coming from. This interface seems to work around the issue while preserving
+ * our type safety (alternative being using `any` everywhere).
+ * @docs-private
+ */
+interface MatFormFieldControl<T> extends _MatFormFieldControl<T> {}
+
 /** Container for form controls that applies Material Design styling and behavior. */
 @Component({
   selector: 'mat-form-field',
@@ -172,7 +182,7 @@ export class MatFormField
 
   @ContentChild(MatLabel) _labelChildNonStatic: MatLabel | undefined;
   @ContentChild(MatLabel, {static: true}) _labelChildStatic: MatLabel | undefined;
-  @ContentChild(MatFormFieldControl) _formFieldControl: MatFormFieldControl<any>;
+  @ContentChild(_MatFormFieldControl) _formFieldControl: MatFormFieldControl<any>;
   @ContentChildren(MAT_PREFIX, {descendants: true}) _prefixChildren: QueryList<MatPrefix>;
   @ContentChildren(MAT_SUFFIX, {descendants: true}) _suffixChildren: QueryList<MatSuffix>;
   @ContentChildren(MAT_ERROR, {descendants: true}) _errorChildren: QueryList<MatError>;

--- a/tools/public_api_guard/material/form-field.md
+++ b/tools/public_api_guard/material/form-field.md
@@ -74,8 +74,8 @@ export class MatFormField implements FloatingLabelParent, AfterContentInit, Afte
     get appearance(): MatFormFieldAppearance;
     set appearance(value: MatFormFieldAppearance);
     color: ThemePalette;
-    get _control(): MatFormFieldControl<any>;
-    set _control(value: MatFormFieldControl<any>);
+    get _control(): MatFormFieldControl_2<any>;
+    set _control(value: MatFormFieldControl_2<any>);
     // (undocumented)
     _elementRef: ElementRef;
     // (undocumented)
@@ -86,7 +86,7 @@ export class MatFormField implements FloatingLabelParent, AfterContentInit, Afte
     set floatLabel(value: FloatLabelType);
     _forceDisplayInfixLabel(): boolean | 0;
     // (undocumented)
-    _formFieldControl: MatFormFieldControl<any>;
+    _formFieldControl: MatFormFieldControl_2<any>;
     getConnectedOverlayOrigin(): ElementRef;
     _getDisplayedMessages(): 'error' | 'hint';
     getLabelId(): string | null;


### PR DESCRIPTION
The changes from #28149 appear to have triggered an error when `mat-chip-grid` is used inside of a `mat-form-field` and optimized with Closure compiler in a configuration that uses type information to do property renaming. These changes work around the issue within `mat-form-field`.