### PR TITLE
build: custom lint rules not working locally

### DIFF
--- a/test/angular-test-init-spec.ts
+++ b/test/angular-test-init-spec.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {TestBed} from '@angular/core/testing';
 import {
   BrowserDynamicTestingModule,

--- a/tools/tslint-rules/lightweightTokensRule.ts
+++ b/tools/tslint-rules/lightweightTokensRule.ts
@@ -1,7 +1,5 @@
 import ts from 'typescript';
 import minimatch from 'minimatch';
-
-import * as path from 'path';
 import * as Lint from 'tslint';
 
 /** Arguments this rule supports. */
@@ -43,10 +41,7 @@ export class Rule extends Lint.Rules.TypedRule {
  * for which lightweight tokens are suitable (for optimized tree shaking).
  */
 function checkSourceFileForLightweightTokens(ctx: Context, typeChecker: ts.TypeChecker): void {
-  // Relative path for the current TypeScript source file. This allows for
-  // relative globs being used in the rule options.
-  const relativeFilePath = path.relative(process.cwd(), ctx.sourceFile.fileName);
-  const [enabledFilesGlobs] = ctx.options;
+  const [disabledFileGlobs] = ctx.options;
   const visitNode = (node: ts.Node) => {
     if (ts.isClassDeclaration(node)) {
       checkClassDeclarationForLightweightToken(node, ctx, typeChecker);
@@ -55,7 +50,7 @@ function checkSourceFileForLightweightTokens(ctx: Context, typeChecker: ts.TypeC
     }
   };
 
-  if (enabledFilesGlobs.some(g => minimatch(relativeFilePath, g))) {
+  if (!disabledFileGlobs.some(g => minimatch(ctx.sourceFile.fileName, g))) {
     ts.forEachChild(ctx.sourceFile, visitNode);
   }
 }

--- a/tools/tslint-rules/noLifecycleInvocationRule.ts
+++ b/tools/tslint-rules/noLifecycleInvocationRule.ts
@@ -1,4 +1,3 @@
-import * as path from 'path';
 import * as Lint from 'tslint';
 import ts from 'typescript';
 import minimatch from 'minimatch';
@@ -28,9 +27,8 @@ class Walker extends Lint.RuleWalker {
 
   constructor(sourceFile: ts.SourceFile, options: Lint.IOptions) {
     super(sourceFile, options);
-    const fileGlobs = options.ruleArguments;
-    const relativeFilePath = path.relative(process.cwd(), sourceFile.fileName);
-    this._enabled = fileGlobs.some(p => minimatch(relativeFilePath, p));
+    const fileGlobs: string[] = options.ruleArguments[0];
+    this._enabled = !fileGlobs.some(p => minimatch(sourceFile.fileName, p));
   }
 
   override visitPropertyAccessExpression(node: ts.PropertyAccessExpression) {

--- a/tools/tslint-rules/requireLicenseBannerRule.ts
+++ b/tools/tslint-rules/requireLicenseBannerRule.ts
@@ -1,4 +1,3 @@
-import * as path from 'path';
 import * as Lint from 'tslint';
 import minimatch from 'minimatch';
 import ts from 'typescript';
@@ -38,13 +37,10 @@ class RequireLicenseBannerWalker extends Lint.RuleWalker {
     super(sourceFile, options);
 
     // Globs that are used to determine which files to lint.
-    const fileGlobs = options.ruleArguments;
-
-    // Relative path for the current TypeScript source file.
-    const relativeFilePath = path.relative(process.cwd(), sourceFile.fileName);
+    const fileGlobs: string[] = options.ruleArguments[0];
 
     // Whether the file should be checked at all.
-    this._enabled = fileGlobs.some(p => minimatch(relativeFilePath, p));
+    this._enabled = !fileGlobs.some(p => minimatch(sourceFile.fileName, p));
   }
 
   override visitSourceFile(sourceFile: ts.SourceFile) {

--- a/tools/tslint-rules/validateDecoratorsRule.ts
+++ b/tools/tslint-rules/validateDecoratorsRule.ts
@@ -1,4 +1,3 @@
-import * as path from 'path';
 import * as Lint from 'tslint';
 import ts from 'typescript';
 import minimatch from 'minimatch';
@@ -69,15 +68,13 @@ class Walker extends Lint.RuleWalker {
   constructor(sourceFile: ts.SourceFile, options: Lint.IOptions) {
     super(sourceFile, options);
 
-    // Globs that are used to determine which files to lint.
-    const fileGlobs = options.ruleArguments.slice(1) || [];
-
-    // Relative path for the current TypeScript source file.
-    const relativeFilePath = path.relative(process.cwd(), sourceFile.fileName);
+    // Globs that are used to determine which files to exclude from linting.
+    const fileGlobs: string[] = options.ruleArguments[1] || [];
 
     this._rules = this._generateRules(options.ruleArguments[0]);
     this._enabled =
-      Object.keys(this._rules).length > 0 && fileGlobs.some(p => minimatch(relativeFilePath, p));
+      Object.keys(this._rules).length > 0 &&
+      !fileGlobs.some(p => minimatch(sourceFile.fileName, p));
   }
 
   override visitClassDeclaration(node: ts.ClassDeclaration) {

--- a/tslint.json
+++ b/tslint.json
@@ -69,10 +69,10 @@
     "require-breaking-change-version": true,
     "no-nested-ternary": true,
     "prefer-plain-enum": true,
-    "no-lifecycle-invocation": [true, "**/!(*.spec).ts"],
+    "no-lifecycle-invocation": [true, ["**/*.spec.ts"]],
     "lightweight-tokens": [
       true,
-      ["src/**/!(*.spec).ts"],
+      ["**/*.spec.ts"],
       // Directionality is always used in Angular Material and therefore does not
       // need a lightweight token. Date Adapter is not very significant and does not
       // need a dedicated token.
@@ -120,18 +120,29 @@
           }
         }
       },
-      "src/!(e2e-app|components-examples|universal-app|dev-app)/**/!(*.spec).ts"
+      [
+        // Internal code that doesn't need to follow the same standards.
+        "**/+(e2e-app|components-examples|universal-app|dev-app|integration)/**",
+        "**/*.spec.ts"
+      ]
     ],
     "require-license-banner": [
       true,
-      "src/!(e2e-app|components-examples|universal-app)/**/!(*.spec).ts"
+      [
+        // Internal files that don't need license banners.
+        "**/+(e2e-app|components-examples|universal-app|dev-app|integration|tools|scripts)/**",
+        "**/*.spec.ts"
+      ]
     ],
     "no-cross-entry-point-relative-imports": [
       true,
-      "src/!(e2e-app|components-examples|universal-app|dev-app)/**/!(*.spec).ts",
-      "!src/+(cdk|material)/schematics/**/*",
-      "!src/cdk/testing/+(private|tests)/**/*",
-      "!src/google-maps/testing/**/*"
+      [
+        // Files that we don't publish to npm so the relative imports don't matter.
+        "**/+(dev-app|components-examples|schematics|tools)/**",
+        "**/google-maps/testing/**",
+        "**/cdk/testing/+(tests|private)/**",
+        "**/*.spec.ts"
+      ]
     ],
     "file-name-casing": [
       true,


### PR DESCRIPTION
We have some custom lint rules that only apply to specific files. Currently the filtering is implemented by opting in specific files through a glob pattern. We do so by converting the absolute `SourceFile.fileName` to a relative one and checking it against the pattern.

The problem is that in some recent version either the OS or TypeScript started returning lower-cased paths in `SourceFile.fileName` while `process.cwd()` which we resolve the path against is case-sensitive. This ends up producing an invalid path which doesn't get covered by the lint rules.

These changes fix the issue by having custom rules apply to all files and using the glob pattern to _exclude_ some of them.