### PR TITLE
refactor(material/core): work around closure issue

### DIFF
--- a/src/material/chips/chip-grid.ts
+++ b/src/material/chips/chip-grid.ts
@@ -248,10 +248,10 @@ export class MatChipGrid
 
   /** Whether the chip grid is in an error state. */
   get errorState() {
-    return this._errorStateTracker.errorState;
+    return this._errorStateTracker.isInErrorState;
   }
   set errorState(value: boolean) {
-    this._errorStateTracker.errorState = value;
+    this._errorStateTracker.isInErrorState = value;
   }
 
   constructor(
@@ -394,7 +394,7 @@ export class MatChipGrid
 
   /** Refreshes the error state of the chip grid. */
   updateErrorState() {
-    this._errorStateTracker.updateErrorState();
+    this._errorStateTracker.recalculateErrorState();
   }
 
   /** When blurred, mark the field as touched when focus moved outside the chip grid. */

--- a/src/material/core/common-behaviors/error-state.ts
+++ b/src/material/core/common-behaviors/error-state.ts
@@ -43,7 +43,7 @@ export interface HasErrorState {
  */
 export class _ErrorStateTracker {
   /** Whether the tracker is currently in an error state. */
-  errorState = false;
+  isInErrorState = false;
 
   /** User-defined matcher for the error state. */
   matcher: ErrorStateMatcher;
@@ -57,8 +57,8 @@ export class _ErrorStateTracker {
   ) {}
 
   /** Updates the error state based on the provided error state matcher. */
-  updateErrorState() {
-    const oldState = this.errorState;
+  recalculateErrorState() {
+    const oldState = this.isInErrorState;
     const parent = this._parentFormGroup || this._parentForm;
     const matcher = this.matcher || this._defaultMatcher;
     const control = this.ngControl ? (this.ngControl.control as AbstractControl) : null;
@@ -68,7 +68,7 @@ export class _ErrorStateTracker {
       typeof matcher?.isErrorState === 'function' ? matcher.isErrorState(control, parent) : false;
 
     if (newState !== oldState) {
-      this.errorState = newState;
+      this.isInErrorState = newState;
       this._stateChanges.next();
     }
   }
@@ -89,10 +89,10 @@ export function mixinErrorState<T extends Constructor<HasErrorState>>(
 
     /** Whether the component is in an error state. */
     get errorState() {
-      return this._getTracker().errorState;
+      return this._getTracker().isInErrorState;
     }
     set errorState(value: boolean) {
-      this._getTracker().errorState = value;
+      this._getTracker().isInErrorState = value;
     }
 
     /** An object used to control the error state of the component. */
@@ -105,7 +105,7 @@ export function mixinErrorState<T extends Constructor<HasErrorState>>(
 
     /** Updates the error state based on the provided error state matcher. */
     updateErrorState() {
-      this._getTracker().updateErrorState();
+      this._getTracker().recalculateErrorState();
     }
 
     private _getTracker() {

--- a/src/material/datepicker/date-range-input-parts.ts
+++ b/src/material/datepicker/date-range-input-parts.ts
@@ -98,10 +98,10 @@ abstract class MatDateRangeInputPartBase<D>
 
   /** Whether the input is in an error state. */
   get errorState() {
-    return this._errorStateTracker.errorState;
+    return this._errorStateTracker.isInErrorState;
   }
   set errorState(value: boolean) {
-    this._errorStateTracker.errorState = value;
+    this._errorStateTracker.isInErrorState = value;
   }
 
   constructor(
@@ -172,7 +172,7 @@ abstract class MatDateRangeInputPartBase<D>
 
   /** Refreshes the error state of the input. */
   updateErrorState() {
-    this._errorStateTracker.updateErrorState();
+    this._errorStateTracker.recalculateErrorState();
   }
 
   /** Handles `input` events on the input element. */

--- a/src/material/input/input.ts
+++ b/src/material/input/input.ts
@@ -242,10 +242,10 @@ export class MatInput
 
   /** Whether the input is in an error state. */
   get errorState() {
-    return this._errorStateTracker.errorState;
+    return this._errorStateTracker.isInErrorState;
   }
   set errorState(value: boolean) {
-    this._errorStateTracker.errorState = value;
+    this._errorStateTracker.isInErrorState = value;
   }
 
   protected _neverEmptyInputTypes = [
@@ -370,7 +370,7 @@ export class MatInput
 
   /** Refreshes the error state of the input. */
   updateErrorState() {
-    this._errorStateTracker.updateErrorState();
+    this._errorStateTracker.recalculateErrorState();
   }
 
   /** Callback for the cases where the focused state of the input changes. */

--- a/src/material/select/select.ts
+++ b/src/material/select/select.ts
@@ -528,10 +528,10 @@ export class MatSelect
 
   /** Whether the select is in an error state. */
   get errorState() {
-    return this._errorStateTracker.errorState;
+    return this._errorStateTracker.isInErrorState;
   }
   set errorState(value: boolean) {
-    this._errorStateTracker.errorState = value;
+    this._errorStateTracker.isInErrorState = value;
   }
 
   /**
@@ -901,7 +901,7 @@ export class MatSelect
 
   /** Refreshes the error state of the select. */
   updateErrorState() {
-    this._errorStateTracker.updateErrorState();
+    this._errorStateTracker.recalculateErrorState();
   }
 
   /** Whether the element is in RTL mode. */

--- a/tools/public_api_guard/material/core.md
+++ b/tools/public_api_guard/material/core.md
@@ -136,11 +136,11 @@ export class ErrorStateMatcher {
 // @public
 export class _ErrorStateTracker {
     constructor(_defaultMatcher: ErrorStateMatcher | null, ngControl: NgControl | null, _parentFormGroup: FormGroupDirective | null, _parentForm: NgForm | null, _stateChanges: Subject<void>);
-    errorState: boolean;
+    isInErrorState: boolean;
     matcher: ErrorStateMatcher;
     // (undocumented)
     ngControl: NgControl | null;
-    updateErrorState(): void;
+    recalculateErrorState(): void;
 }
 
 // @public


### PR DESCRIPTION
Fixes a runtime error with some configurations of Closure compiler, because the `_ErrorStateTracker.errorState` property name was clashing with the same property in other classes.