### PR TITLE
feat(youtube-player): improve initial load performance using a placeholder image

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -136,7 +136,7 @@
     ],
     "linebreaks": "unix",
     "selector-class-pattern": [
-      "^_?(mat-|cdk-|example-|demo-|ng-|mdc-|map-|test-)",
+      "^_?(mat-|cdk-|example-|demo-|ng-|mdc-|map-|test-|youtube-player-)",
       {
         "resolveNestedSelectors": true
       }

--- a/src/dev-app/youtube-player/youtube-player-demo.html
+++ b/src/dev-app/youtube-player/youtube-player-demo.html
@@ -1,5 +1,5 @@
 <div #demoYouTubePlayer class="demo-youtube-player">
-  <h1>Basic Example</h1>
+  <h2>Basic Example</h2>
   <section>
     <div class="demo-video-selection">
       <label>Pick the video:</label>
@@ -12,10 +12,31 @@
     </div>
     <div class="demo-video-selection">
       <mat-checkbox [(ngModel)]="disableCookies">Disable cookies</mat-checkbox>
+      <mat-checkbox [(ngModel)]="disablePlaceholder">Disable placeholder</mat-checkbox>
     </div>
     <youtube-player [videoId]="selectedVideoId"
                     [playerVars]="playerVars"
-                    [width]="videoWidth" [height]="videoHeight"
-                    [disableCookies]="disableCookies"></youtube-player>
+                    [width]="videoWidth"
+                    [height]="videoHeight"
+                    [disableCookies]="disableCookies"
+                    [disablePlaceholder]="disablePlaceholder"
+                    [placeholderImageQuality]="placeholderQuality"></youtube-player>
   </section>
+
+  <h2>Placeholder quality comparison (high to low)</h2>
+  <youtube-player
+    [videoId]="selectedVideoId"
+    [width]="videoWidth"
+    [height]="videoHeight"
+    placeholderImageQuality="high"/>
+  <youtube-player
+    [videoId]="selectedVideoId"
+    [width]="videoWidth"
+    [height]="videoHeight"
+    placeholderImageQuality="standard"/>
+  <youtube-player
+    [videoId]="selectedVideoId"
+    [width]="videoWidth"
+    [height]="videoHeight"
+    placeholderImageQuality="low"/>
 </div>

--- a/src/dev-app/youtube-player/youtube-player-demo.ts
+++ b/src/dev-app/youtube-player/youtube-player-demo.ts
@@ -16,37 +16,60 @@ import {
 } from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {MatRadioModule} from '@angular/material/radio';
-import {YouTubePlayer} from '@angular/youtube-player';
+import {PlaceholderImageQuality, YouTubePlayer} from '@angular/youtube-player';
 import {MatCheckboxModule} from '@angular/material/checkbox';
 
 interface Video {
   id: string;
   name: string;
   isPlaylist?: boolean;
+  autoplay?: boolean;
+  placeholderQuality: PlaceholderImageQuality;
 }
 
 const VIDEOS: Video[] = [
   {
-    id: 'PRQCAL_RMVo',
-    name: 'Instructional',
+    id: 'hsUxJjY-PRg',
+    name: 'Control Flow',
+    placeholderQuality: 'high',
   },
   {
     id: 'O0xx5SvjmnU',
     name: 'Angular Conf',
+    placeholderQuality: 'high',
   },
   {
     id: 'invalidname',
     name: 'Invalid',
+    placeholderQuality: 'high',
   },
   {
     id: 'PLOa5YIicjJ-XCGXwnEmMmpHHCn11gUgvL',
     name: 'Angular Forms Playlist',
     isPlaylist: true,
+    placeholderQuality: 'high',
   },
   {
     id: 'PLOa5YIicjJ-VpOOoLczAGTLEEznZ2JEa6',
     name: 'Angular Router Playlist',
     isPlaylist: true,
+    placeholderQuality: 'high',
+  },
+  {
+    id: 'PXNp4LENMPA',
+    name: 'Angular.dev (autoplay)',
+    autoplay: true,
+    placeholderQuality: 'high',
+  },
+  {
+    id: 'txqiwrbYGrs',
+    name: 'David after dentist (only standard quality placeholder)',
+    placeholderQuality: 'low',
+  },
+  {
+    id: 'EwTZ2xpQwpA',
+    name: 'Chocolate rain (only low quality placeholder)',
+    placeholderQuality: 'low',
   },
 ];
 
@@ -67,6 +90,8 @@ export class YouTubePlayerDemo implements AfterViewInit, OnDestroy {
   videoWidth: number | undefined;
   videoHeight: number | undefined;
   disableCookies = false;
+  disablePlaceholder = false;
+  placeholderQuality: PlaceholderImageQuality;
 
   constructor(private _changeDetectorRef: ChangeDetectorRef) {
     this.selectedVideo = VIDEOS[0];
@@ -102,11 +127,12 @@ export class YouTubePlayerDemo implements AfterViewInit, OnDestroy {
 
   set selectedVideo(value: Video | undefined) {
     this._selectedVideo = value;
+    this.placeholderQuality = value?.placeholderQuality || 'standard';
 
     // If the video is a playlist, don't send a video id, and prepare playerVars instead
 
     if (!value?.isPlaylist) {
-      this._playerVars = undefined;
+      this._playerVars = value?.autoplay ? {autoplay: 1} : undefined;
       this._selectedVideoId = value?.id;
       return;
     }

--- a/src/youtube-player/BUILD.bazel
+++ b/src/youtube-player/BUILD.bazel
@@ -4,6 +4,7 @@ load(
     "ng_package",
     "ng_test_library",
     "ng_web_test_suite",
+    "sass_binary",
 )
 
 package(default_visibility = ["//visibility:public"])
@@ -17,6 +18,9 @@ ng_module(
             "fake-youtube-player.ts",
         ],
     ),
+    assets = [
+        ":youtube_player_placeholder_scss",
+    ],
     deps = [
         "//src:dev_mode_types",
         "@npm//@angular/common",
@@ -24,6 +28,11 @@ ng_module(
         "@npm//@types/youtube",
         "@npm//rxjs",
     ],
+)
+
+sass_binary(
+    name = "youtube_player_placeholder_scss",
+    src = "youtube-player-placeholder.scss",
 )
 
 ng_package(

--- a/src/youtube-player/README.md
+++ b/src/youtube-player/README.md
@@ -58,3 +58,74 @@ import {YouTubePlayer, YOUTUBE_PLAYER_CONFIG} from '@angular/youtube-player';
 })
 export class YourApp {}
 ```
+
+## Loading behavior
+By default the `<youtube-player/>` will show a placeholder element instead of loading the API
+up-front until the user interacts with it. This speeds up the initial render of the page by not
+loading unnecessary JavaScript for a video that might not be played. Once the user clicks on the
+video, the API will be loaded and the placeholder will be swapped out with the actual video.
+
+Note that the placeholder won't be shown in the following scenarios:
+* Video that plays automatically (e.g. `playerVars` contains `autoplay: 1`).
+* The player is showing a playlist (e.g. `playerVars` contains a `list` property).
+
+If you want to disable the placeholder and have the `<youtube-player/>` load the API on
+initialization, you can either pass in the `disablePlaceholder` input:
+
+```html
+<youtube-player videoId="mVjYG9TSN88" disablePlaceholder/>
+```
+
+Or set it at a global level using the `YOUTUBE_PLAYER_CONFIG` injection token:
+
+```typescript
+import {NgModule} from '@angular/core';
+import {YouTubePlayer, YOUTUBE_PLAYER_CONFIG} from '@angular/youtube-player';
+
+@NgModule({
+  imports: [YouTubePlayer],
+  providers: [{
+    provide: YOUTUBE_PLAYER_CONFIG,
+    useValue: {
+      disablePlaceholder: true
+    }
+  }]
+})
+export class YourApp {}
+```
+
+### Placeholder image quality
+YouTube provides different sizes of placeholder images depending on when the video was uploaded
+and the thumbnail that was provided by the uploader. The `<youtube-player/>` defaults to a quality
+that should be available for the majority of videos, but if you're seeing a grey placeholder,
+consider switching to the `low` quality using the `placeholderImageQuality` input or through the
+`YOUTUBE_PLAYER_CONFIG`.
+
+```html
+<!-- Default value, should exist for most videos. -->
+<youtube-player videoId="mVjYG9TSN88" placeholderImageQuality="standard"/>
+
+<!-- High quality image that should be present for most videos from the past few years. -->
+<youtube-player videoId="mVjYG9TSN88" placeholderImageQuality="high"/>
+
+<!-- Very low quality image, but should exist for all videos. -->
+<youtube-player videoId="mVjYG9TSN88" placeholderImageQuality="low"/>
+```
+
+### Placeholder internationalization
+Since the placeholder has an interactive `button` element, it needs an `aria-label` for proper
+accessibility. The default label is "Play video", but you can customize it based on your app through
+the  `placeholderButtonLabel` input or the `YOUTUBE_PLAYER_CONFIG` injection token:
+
+```html
+<youtube-player videoId="mVjYG9TSN88" placeholderButtonLabel="Afspil video"/>
+```
+
+### Placeholder caveats
+There are a couple of considerations when using placeholders:
+1. Different videos support different sizes of placeholder images and there's no way to know
+ahead of time which one is supported. The `<youtube-player/>` defaults to a value that should
+work for most videos, but if you want something higher or lower, you can refer to the
+["Placeholder image quality" section](#placeholder-image-quality).
+2. Unlike the native YouTube placeholder, the Angular component doesn't show the video's title,
+because it isn't known ahead of time.

--- a/src/youtube-player/public-api.ts
+++ b/src/youtube-player/public-api.ts
@@ -8,3 +8,4 @@
 
 export * from './youtube-module';
 export {YouTubePlayer, YOUTUBE_PLAYER_CONFIG, YouTubePlayerConfig} from './youtube-player';
+export {PlaceholderImageQuality} from './youtube-player-placeholder';

--- a/src/youtube-player/youtube-player-placeholder.scss
+++ b/src/youtube-player/youtube-player-placeholder.scss
@@ -1,0 +1,40 @@
+.youtube-player-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  overflow: hidden;
+  cursor: pointer;
+  background-color: #000;
+  background-position: center center;
+  background-size: cover;
+  transition: box-shadow 300ms ease;
+
+  // YouTube has a slight drop shadow on the preview that we try to imitate here.
+  // Note that they use a base64 image, likely for performance reasons. We can't use the
+  // image, because it can break users with a CSP that doesn't allow `data:` URLs.
+  box-shadow: inset 0 120px 90px -90px rgba(0, 0, 0, 0.8);
+}
+
+.youtube-player-placeholder-button {
+  transition: opacity 300ms ease;
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  background: none;
+  border: none;
+  padding: 0;
+  display: flex;
+
+  svg {
+    width: 68px;
+    height: 48px;
+  }
+}
+
+.youtube-player-placeholder-loading {
+  box-shadow: none;
+
+  .youtube-player-placeholder-button {
+    opacity: 0;
+  }
+}

--- a/src/youtube-player/youtube-player-placeholder.ts
+++ b/src/youtube-player/youtube-player-placeholder.ts
@@ -1,0 +1,74 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ChangeDetectionStrategy, Component, Input, ViewEncapsulation} from '@angular/core';
+
+/**  Quality of the placeholder image.  */
+export type PlaceholderImageQuality = 'high' | 'standard' | 'low';
+
+@Component({
+  selector: 'youtube-player-placeholder',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  template: `
+    <button type="button" class="youtube-player-placeholder-button" [attr.aria-label]="buttonLabel">
+      <svg
+        height="100%"
+        version="1.1"
+        viewBox="0 0 68 48"
+        focusable="false"
+        aria-hidden="true">
+        <path d="M66.52,7.74c-0.78-2.93-2.49-5.41-5.42-6.19C55.79,.13,34,0,34,0S12.21,.13,6.9,1.55 C3.97,2.33,2.27,4.81,1.48,7.74C0.06,13.05,0,24,0,24s0.06,10.95,1.48,16.26c0.78,2.93,2.49,5.41,5.42,6.19 C12.21,47.87,34,48,34,48s21.79-0.13,27.1-1.55c2.93-0.78,4.64-3.26,5.42-6.19C67.94,34.95,68,24,68,24S67.94,13.05,66.52,7.74z" fill="#f00"></path>
+        <path d="M 45,24 27,14 27,34" fill="#fff"></path>
+      </svg>
+    </button>
+  `,
+  standalone: true,
+  styleUrl: 'youtube-player-placeholder.css',
+  host: {
+    'class': 'youtube-player-placeholder',
+    '[class.youtube-player-placeholder-loading]': 'isLoading',
+    '[style.background-image]': '_getBackgroundImage()',
+    '[style.width.px]': 'width',
+    '[style.height.px]': 'height',
+  },
+})
+export class YouTubePlayerPlaceholder {
+  /** ID of the video for which to show the placeholder. */
+  @Input() videoId: string;
+
+  /** Width of the video for which to show the placeholder. */
+  @Input() width: number;
+
+  /** Height of the video for which to show the placeholder. */
+  @Input() height: number;
+
+  /** Whether the video is currently being loaded. */
+  @Input() isLoading: boolean;
+
+  /** Accessible label for the play button. */
+  @Input() buttonLabel: string;
+
+  /** Quality of the placeholder image. */
+  @Input() quality: PlaceholderImageQuality;
+
+  /** Gets the background image showing the placeholder. */
+  protected _getBackgroundImage(): string | undefined {
+    let url: string;
+
+    if (this.quality === 'low') {
+      url = `https://i.ytimg.com/vi/${this.videoId}/hqdefault.jpg`;
+    } else if (this.quality === 'high') {
+      url = `https://i.ytimg.com/vi/${this.videoId}/maxresdefault.jpg`;
+    } else {
+      url = `https://i.ytimg.com/vi_webp/${this.videoId}/sddefault.webp`;
+    }
+
+    return `url(${url})`;
+  }
+}

--- a/src/youtube-player/youtube-player.spec.ts
+++ b/src/youtube-player/youtube-player.spec.ts
@@ -7,6 +7,7 @@ import {
   YOUTUBE_PLAYER_CONFIG,
 } from './youtube-player';
 import {createFakeYtNamespace} from './fake-youtube-player';
+import {PlaceholderImageQuality} from './youtube-player-placeholder';
 import {Subscription} from 'rxjs';
 
 const VIDEO_ID = 'a12345';
@@ -36,8 +37,19 @@ describe('YoutubePlayer', () => {
     events = fake.events;
   }));
 
+  function getVideoHost(componentFixture: ComponentFixture<unknown>): HTMLElement {
+    // Not the most resilient selector, but we don't want to introduce any
+    // classes/IDs on the `div` so users don't start depending on it.
+    return componentFixture.nativeElement.querySelector('div > div');
+  }
+
+  function getPlaceholder(componentFixture: ComponentFixture<unknown>): HTMLElement {
+    return componentFixture.nativeElement.querySelector('youtube-player-placeholder');
+  }
+
   describe('API ready', () => {
     beforeEach(() => {
+      TestBed.configureTestingModule({providers: TEST_PROVIDERS});
       fixture = TestBed.createComponent(TestApp);
       testComponent = fixture.debugElement.componentInstance;
       fixture.detectChanges();
@@ -48,21 +60,29 @@ describe('YoutubePlayer', () => {
       window.onYouTubeIframeAPIReady = undefined;
     });
 
-    it('initializes a youtube player', () => {
-      let containerElement = fixture.nativeElement.querySelector('div');
+    it('initializes a youtube player when the placeholder is clicked', () => {
+      getPlaceholder(fixture).click();
+      fixture.detectChanges();
+      events.onReady({target: playerSpy});
+      fixture.detectChanges();
 
       expect(playerCtorSpy).toHaveBeenCalledWith(
-        containerElement,
+        getVideoHost(fixture),
         jasmine.objectContaining({
           videoId: VIDEO_ID,
           width: DEFAULT_PLAYER_WIDTH,
           height: DEFAULT_PLAYER_HEIGHT,
-          playerVars: undefined,
+          playerVars: {autoplay: 1},
         }),
       );
+
+      expect(getPlaceholder(fixture)).toBeFalsy();
     });
 
     it('destroys the iframe when the component is destroyed', () => {
+      getPlaceholder(fixture).click();
+      fixture.detectChanges();
+
       events.onReady({target: playerSpy});
 
       testComponent.visible = false;
@@ -72,7 +92,10 @@ describe('YoutubePlayer', () => {
     });
 
     it('responds to changes in video id', () => {
-      let containerElement = fixture.nativeElement.querySelector('div');
+      getPlaceholder(fixture).click();
+      fixture.detectChanges();
+
+      const containerElement = getVideoHost(fixture);
 
       testComponent.videoId = 'otherId';
       fixture.detectChanges();
@@ -100,6 +123,9 @@ describe('YoutubePlayer', () => {
     });
 
     it('responds to changes in size', () => {
+      getPlaceholder(fixture).click();
+      fixture.detectChanges();
+
       testComponent.width = 5;
       fixture.detectChanges();
 
@@ -147,6 +173,10 @@ describe('YoutubePlayer', () => {
     });
 
     it('passes the configured playerVars to the player', () => {
+      getPlaceholder(fixture).click();
+      fixture.detectChanges();
+      events.onReady({target: playerSpy});
+
       const playerVars: YT.PlayerVars = {modestbranding: YT.ModestBranding.Modest};
       fixture.componentInstance.playerVars = playerVars;
       fixture.detectChanges();
@@ -157,11 +187,14 @@ describe('YoutubePlayer', () => {
       // We expect 2 calls since the first one is run on init and the
       // second one happens after the `playerVars` have changed.
       expect(calls.length).toBe(2);
-      expect(calls[0].args[1]).toEqual(jasmine.objectContaining({playerVars: undefined}));
+      expect(calls[0].args[1]).toEqual(jasmine.objectContaining({playerVars: {autoplay: 1}}));
       expect(calls[1].args[1]).toEqual(jasmine.objectContaining({playerVars}));
     });
 
     it('initializes the player with start and end seconds', () => {
+      getPlaceholder(fixture).click();
+      fixture.detectChanges();
+
       testComponent.startSeconds = 5;
       testComponent.endSeconds = 6;
       fixture.detectChanges();
@@ -199,6 +232,9 @@ describe('YoutubePlayer', () => {
     });
 
     it('sets the suggested quality', () => {
+      getPlaceholder(fixture).click();
+      fixture.detectChanges();
+
       testComponent.suggestedQuality = 'small';
       fixture.detectChanges();
 
@@ -222,6 +258,9 @@ describe('YoutubePlayer', () => {
     });
 
     it('proxies events as output', () => {
+      getPlaceholder(fixture).click();
+      fixture.detectChanges();
+
       events.onReady({target: playerSpy});
       expect(testComponent.onReady).toHaveBeenCalledWith({target: playerSpy});
 
@@ -245,6 +284,9 @@ describe('YoutubePlayer', () => {
     });
 
     it('proxies methods to the player', () => {
+      getPlaceholder(fixture).click();
+      fixture.detectChanges();
+
       events.onReady({target: playerSpy});
 
       testComponent.youtubePlayer.playVideo();
@@ -312,6 +354,9 @@ describe('YoutubePlayer', () => {
     });
 
     it('should play on init if playVideo was called before the API has loaded', () => {
+      getPlaceholder(fixture).click();
+      fixture.detectChanges();
+
       testComponent.youtubePlayer.playVideo();
       expect(testComponent.youtubePlayer.getPlayerState()).toBe(YT.PlayerState.PLAYING);
 
@@ -321,6 +366,9 @@ describe('YoutubePlayer', () => {
     });
 
     it('should pause on init if pauseVideo was called before the API has loaded', () => {
+      getPlaceholder(fixture).click();
+      fixture.detectChanges();
+
       testComponent.youtubePlayer.pauseVideo();
       expect(testComponent.youtubePlayer.getPlayerState()).toBe(YT.PlayerState.PAUSED);
 
@@ -330,6 +378,9 @@ describe('YoutubePlayer', () => {
     });
 
     it('should stop on init if stopVideo was called before the API has loaded', () => {
+      getPlaceholder(fixture).click();
+      fixture.detectChanges();
+
       testComponent.youtubePlayer.stopVideo();
       expect(testComponent.youtubePlayer.getPlayerState()).toBe(YT.PlayerState.CUED);
 
@@ -338,20 +389,22 @@ describe('YoutubePlayer', () => {
       expect(playerSpy.stopVideo).toHaveBeenCalled();
     });
 
-    it(
-      'should set the playback rate on init if setPlaybackRate was called before ' +
-        'the API has loaded',
-      () => {
-        testComponent.youtubePlayer.setPlaybackRate(1337);
-        expect(testComponent.youtubePlayer.getPlaybackRate()).toBe(1337);
+    it('should set the playback rate on init if setPlaybackRate was called before the API has loaded', () => {
+      getPlaceholder(fixture).click();
+      fixture.detectChanges();
 
-        events.onReady({target: playerSpy});
+      testComponent.youtubePlayer.setPlaybackRate(1337);
+      expect(testComponent.youtubePlayer.getPlaybackRate()).toBe(1337);
 
-        expect(playerSpy.setPlaybackRate).toHaveBeenCalledWith(1337);
-      },
-    );
+      events.onReady({target: playerSpy});
+
+      expect(playerSpy.setPlaybackRate).toHaveBeenCalledWith(1337);
+    });
 
     it('should set the volume on init if setVolume was called before the API has loaded', () => {
+      getPlaceholder(fixture).click();
+      fixture.detectChanges();
+
       testComponent.youtubePlayer.setVolume(37);
       expect(testComponent.youtubePlayer.getVolume()).toBe(37);
 
@@ -361,6 +414,9 @@ describe('YoutubePlayer', () => {
     });
 
     it('should mute on init if mute was called before the API has loaded', () => {
+      getPlaceholder(fixture).click();
+      fixture.detectChanges();
+
       testComponent.youtubePlayer.mute();
       expect(testComponent.youtubePlayer.isMuted()).toBe(true);
 
@@ -370,6 +426,9 @@ describe('YoutubePlayer', () => {
     });
 
     it('should unmute on init if umMute was called before the API has loaded', () => {
+      getPlaceholder(fixture).click();
+      fixture.detectChanges();
+
       testComponent.youtubePlayer.unMute();
       expect(testComponent.youtubePlayer.isMuted()).toBe(false);
 
@@ -379,6 +438,9 @@ describe('YoutubePlayer', () => {
     });
 
     it('should seek on init if seekTo was called before the API has loaded', () => {
+      getPlaceholder(fixture).click();
+      fixture.detectChanges();
+
       testComponent.youtubePlayer.seekTo(1337, true);
       expect(testComponent.youtubePlayer.getCurrentTime()).toBe(1337);
 
@@ -388,7 +450,11 @@ describe('YoutubePlayer', () => {
     });
 
     it('should be able to disable cookies', () => {
-      const containerElement = fixture.nativeElement.querySelector('div');
+      getPlaceholder(fixture).click();
+      fixture.detectChanges();
+      events.onReady({target: playerSpy});
+
+      const containerElement = getVideoHost(fixture);
 
       expect(playerCtorSpy).toHaveBeenCalledWith(
         containerElement,
@@ -410,6 +476,8 @@ describe('YoutubePlayer', () => {
     });
 
     it('should play with a playlist id instead of a video id', () => {
+      getPlaceholder(fixture).click();
+      fixture.detectChanges();
       playerCtorSpy.calls.reset();
 
       const playerVars: YT.PlayerVars = {
@@ -462,9 +530,11 @@ describe('YoutubePlayer', () => {
 
     it('waits until the api is ready before initializing', () => {
       (window.YT as any) = YT_LOADING_STATE_MOCK;
-
+      TestBed.configureTestingModule({providers: TEST_PROVIDERS});
       fixture = TestBed.createComponent(TestApp);
       testComponent = fixture.debugElement.componentInstance;
+      fixture.detectChanges();
+      getPlaceholder(fixture).click();
       fixture.detectChanges();
 
       expect(playerCtorSpy).not.toHaveBeenCalled();
@@ -472,10 +542,8 @@ describe('YoutubePlayer', () => {
       window.YT = api!;
       window.onYouTubeIframeAPIReady!();
 
-      let containerElement = fixture.nativeElement.querySelector('div');
-
       expect(playerCtorSpy).toHaveBeenCalledWith(
-        containerElement,
+        getVideoHost(fixture),
         jasmine.objectContaining({
           videoId: VIDEO_ID,
           width: DEFAULT_PLAYER_WIDTH,
@@ -487,9 +555,11 @@ describe('YoutubePlayer', () => {
     it('should not override any pre-existing API loaded callbacks', () => {
       const spy = jasmine.createSpy('other API loaded spy');
       window.onYouTubeIframeAPIReady = spy;
-
+      TestBed.configureTestingModule({providers: TEST_PROVIDERS});
       fixture = TestBed.createComponent(TestApp);
       testComponent = fixture.debugElement.componentInstance;
+      fixture.detectChanges();
+      getPlaceholder(fixture).click();
       fixture.detectChanges();
 
       expect(playerCtorSpy).not.toHaveBeenCalled();
@@ -501,8 +571,111 @@ describe('YoutubePlayer', () => {
     });
   });
 
+  describe('placeholder behavior', () => {
+    beforeEach(() => {
+      TestBed.configureTestingModule({providers: TEST_PROVIDERS});
+      fixture = TestBed.createComponent(TestApp);
+      testComponent = fixture.debugElement.componentInstance;
+      fixture.detectChanges();
+    });
+
+    afterEach(() => {
+      fixture = testComponent = (window as any).YT = window.onYouTubeIframeAPIReady = undefined!;
+    });
+
+    it('should show a placeholder', () => {
+      const placeholder = getPlaceholder(fixture);
+      expect(placeholder).toBeTruthy();
+      expect(placeholder.style.backgroundImage).toContain(
+        `https://i.ytimg.com/vi_webp/${VIDEO_ID}/sddefault.webp`,
+      );
+      expect(placeholder.style.width).toBe(`${DEFAULT_PLAYER_WIDTH}px`);
+      expect(placeholder.style.height).toBe(`${DEFAULT_PLAYER_HEIGHT}px`);
+      expect(placeholder.querySelector('button')).toBeTruthy();
+
+      testComponent.videoId = 'foo123';
+      testComponent.width = 100;
+      testComponent.height = 50;
+      fixture.detectChanges();
+
+      expect(placeholder.style.backgroundImage).toContain(
+        'https://i.ytimg.com/vi_webp/foo123/sddefault.webp',
+      );
+      expect(placeholder.style.width).toBe('100px');
+      expect(placeholder.style.height).toBe('50px');
+    });
+
+    it('should allow for the placeholder to be disabled', () => {
+      expect(getPlaceholder(fixture)).toBeTruthy();
+
+      testComponent.disablePlaceholder = true;
+      fixture.detectChanges();
+
+      expect(getPlaceholder(fixture)).toBeFalsy();
+    });
+
+    it('should allow for the placeholder button label to be changed', () => {
+      const button = getPlaceholder(fixture).querySelector('button')!;
+
+      expect(button.getAttribute('aria-label')).toBe('Play video');
+
+      testComponent.placeholderButtonLabel = 'Play Star Wars';
+      fixture.detectChanges();
+
+      expect(button.getAttribute('aria-label')).toBe('Play Star Wars');
+    });
+
+    it('should not show the placeholder if a playlist is assigned', () => {
+      expect(getPlaceholder(fixture)).toBeTruthy();
+
+      testComponent.videoId = undefined;
+      testComponent.playerVars = {
+        list: 'some-playlist-id',
+        listType: 'playlist',
+      };
+      fixture.detectChanges();
+
+      expect(getPlaceholder(fixture)).toBeFalsy();
+    });
+
+    it('should hide the placeholder and start playing if an autoplaying video is assigned', () => {
+      expect(getPlaceholder(fixture)).toBeTruthy();
+      expect(playerCtorSpy).not.toHaveBeenCalled();
+
+      testComponent.playerVars = {autoplay: 1};
+      fixture.detectChanges();
+      events.onReady({target: playerSpy});
+      fixture.detectChanges();
+
+      expect(getPlaceholder(fixture)).toBeFalsy();
+      expect(playerCtorSpy).toHaveBeenCalled();
+    });
+
+    it('should allow for the placeholder image quality to be changed', () => {
+      const placeholder = getPlaceholder(fixture);
+      expect(placeholder.style.backgroundImage).toContain(
+        `https://i.ytimg.com/vi_webp/${VIDEO_ID}/sddefault.webp`,
+      );
+
+      testComponent.placeholderImageQuality = 'low';
+      fixture.detectChanges();
+      expect(placeholder.style.backgroundImage).toContain(
+        `https://i.ytimg.com/vi/${VIDEO_ID}/hqdefault.jpg`,
+      );
+
+      testComponent.placeholderImageQuality = 'high';
+      fixture.detectChanges();
+      expect(placeholder.style.backgroundImage).toContain(
+        `https://i.ytimg.com/vi/${VIDEO_ID}/maxresdefault.jpg`,
+      );
+    });
+  });
+
   it('should pick up static startSeconds and endSeconds values', () => {
+    TestBed.configureTestingModule({providers: TEST_PROVIDERS});
     const staticSecondsApp = TestBed.createComponent(StaticStartEndSecondsApp);
+    staticSecondsApp.detectChanges();
+    getPlaceholder(staticSecondsApp).click();
     staticSecondsApp.detectChanges();
 
     playerSpy.getPlayerState.and.returnValue(window.YT!.PlayerState.CUED);
@@ -514,7 +687,10 @@ describe('YoutubePlayer', () => {
   });
 
   it('should be able to subscribe to events after initialization', () => {
+    TestBed.configureTestingModule({providers: TEST_PROVIDERS});
     const noEventsApp = TestBed.createComponent(NoEventsApp);
+    noEventsApp.detectChanges();
+    getPlaceholder(noEventsApp).click();
     noEventsApp.detectChanges();
     events.onReady({target: playerSpy});
     noEventsApp.detectChanges();
@@ -561,13 +737,20 @@ describe('YoutubePlayer', () => {
   selector: 'test-app',
   standalone: true,
   imports: [YouTubePlayer],
-  providers: TEST_PROVIDERS,
   template: `
     @if (visible) {
-      <youtube-player #player [videoId]="videoId" [width]="width" [height]="height"
-        [startSeconds]="startSeconds" [endSeconds]="endSeconds" [suggestedQuality]="suggestedQuality"
+      <youtube-player #player
+        [videoId]="videoId"
+        [width]="width"
+        [height]="height"
+        [startSeconds]="startSeconds"
+        [endSeconds]="endSeconds"
+        [suggestedQuality]="suggestedQuality"
         [playerVars]="playerVars"
         [disableCookies]="disableCookies"
+        [disablePlaceholder]="disablePlaceholder"
+        [placeholderButtonLabel]="placeholderButtonLabel"
+        [placeholderImageQuality]="placeholderImageQuality"
         (ready)="onReady($event)"
         (stateChange)="onStateChange($event)"
         (playbackQualityChange)="onPlaybackQualityChange($event)"
@@ -581,6 +764,9 @@ class TestApp {
   videoId: string | undefined = VIDEO_ID;
   disableCookies = false;
   visible = true;
+  disablePlaceholder = false;
+  placeholderButtonLabel = 'Play video';
+  placeholderImageQuality: PlaceholderImageQuality = 'standard';
   width: number | undefined;
   height: number | undefined;
   startSeconds: number | undefined;
@@ -599,7 +785,6 @@ class TestApp {
 @Component({
   standalone: true,
   imports: [YouTubePlayer],
-  providers: TEST_PROVIDERS,
   template: `
     <youtube-player [videoId]="videoId" [startSeconds]="42" [endSeconds]="1337"/>
   `,
@@ -611,7 +796,6 @@ class StaticStartEndSecondsApp {
 @Component({
   standalone: true,
   imports: [YouTubePlayer],
-  providers: TEST_PROVIDERS,
   template: `<youtube-player [videoId]="videoId"/>`,
 })
 class NoEventsApp {

--- a/tools/public_api_guard/youtube-player/youtube-player.md
+++ b/tools/public_api_guard/youtube-player/youtube-player.md
@@ -17,6 +17,9 @@ import { OnDestroy } from '@angular/core';
 import { SimpleChanges } from '@angular/core';
 
 // @public
+export type PlaceholderImageQuality = 'high' | 'standard' | 'low';
+
+// @public
 export const YOUTUBE_PLAYER_CONFIG: InjectionToken<YouTubePlayerConfig>;
 
 // @public
@@ -25,6 +28,7 @@ export class YouTubePlayer implements AfterViewInit, OnChanges, OnDestroy {
     // (undocumented)
     readonly apiChange: Observable<YT.PlayerEvent>;
     disableCookies: boolean;
+    disablePlaceholder: boolean;
     endSeconds: number | undefined;
     // (undocumented)
     readonly error: Observable<YT.OnErrorEvent>;
@@ -39,13 +43,20 @@ export class YouTubePlayer implements AfterViewInit, OnChanges, OnDestroy {
     getVideoLoadedFraction(): number;
     getVideoUrl(): string;
     getVolume(): number;
+    // (undocumented)
+    protected _hasPlaceholder: boolean;
     get height(): number;
     set height(height: number | undefined);
+    // (undocumented)
+    protected _isLoading: boolean;
     isMuted(): boolean;
+    protected _load(playVideo: boolean): void;
     loadApi: boolean;
     mute(): void;
     // (undocumented)
     static ngAcceptInputType_disableCookies: unknown;
+    // (undocumented)
+    static ngAcceptInputType_disablePlaceholder: unknown;
     // (undocumented)
     static ngAcceptInputType_endSeconds: number | undefined;
     // (undocumented)
@@ -65,6 +76,8 @@ export class YouTubePlayer implements AfterViewInit, OnChanges, OnDestroy {
     // (undocumented)
     ngOnDestroy(): void;
     pauseVideo(): void;
+    placeholderButtonLabel: string;
+    placeholderImageQuality: PlaceholderImageQuality;
     // (undocumented)
     readonly playbackQualityChange: Observable<YT.OnPlaybackQualityChangeEvent>;
     // (undocumented)
@@ -75,6 +88,7 @@ export class YouTubePlayer implements AfterViewInit, OnChanges, OnDestroy {
     seekTo(seconds: number, allowSeekAhead: boolean): void;
     setPlaybackRate(playbackRate: number): void;
     setVolume(volume: number): void;
+    protected _shouldShowPlaceholder(): boolean;
     showBeforeIframeApiLoads: boolean;
     startSeconds: number | undefined;
     // (undocumented)
@@ -87,14 +101,17 @@ export class YouTubePlayer implements AfterViewInit, OnChanges, OnDestroy {
     set width(width: number | undefined);
     youtubeContainer: ElementRef<HTMLElement>;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<YouTubePlayer, "youtube-player", never, { "videoId": { "alias": "videoId"; "required": false; }; "height": { "alias": "height"; "required": false; }; "width": { "alias": "width"; "required": false; }; "startSeconds": { "alias": "startSeconds"; "required": false; }; "endSeconds": { "alias": "endSeconds"; "required": false; }; "suggestedQuality": { "alias": "suggestedQuality"; "required": false; }; "playerVars": { "alias": "playerVars"; "required": false; }; "disableCookies": { "alias": "disableCookies"; "required": false; }; "loadApi": { "alias": "loadApi"; "required": false; }; "showBeforeIframeApiLoads": { "alias": "showBeforeIframeApiLoads"; "required": false; }; }, { "ready": "ready"; "stateChange": "stateChange"; "error": "error"; "apiChange": "apiChange"; "playbackQualityChange": "playbackQualityChange"; "playbackRateChange": "playbackRateChange"; }, never, never, true, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<YouTubePlayer, "youtube-player", never, { "videoId": { "alias": "videoId"; "required": false; }; "height": { "alias": "height"; "required": false; }; "width": { "alias": "width"; "required": false; }; "startSeconds": { "alias": "startSeconds"; "required": false; }; "endSeconds": { "alias": "endSeconds"; "required": false; }; "suggestedQuality": { "alias": "suggestedQuality"; "required": false; }; "playerVars": { "alias": "playerVars"; "required": false; }; "disableCookies": { "alias": "disableCookies"; "required": false; }; "loadApi": { "alias": "loadApi"; "required": false; }; "disablePlaceholder": { "alias": "disablePlaceholder"; "required": false; }; "showBeforeIframeApiLoads": { "alias": "showBeforeIframeApiLoads"; "required": false; }; "placeholderButtonLabel": { "alias": "placeholderButtonLabel"; "required": false; }; "placeholderImageQuality": { "alias": "placeholderImageQuality"; "required": false; }; }, { "ready": "ready"; "stateChange": "stateChange"; "error": "error"; "apiChange": "apiChange"; "playbackQualityChange": "playbackQualityChange"; "playbackRateChange": "playbackRateChange"; }, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<YouTubePlayer, never>;
 }
 
 // @public
 export interface YouTubePlayerConfig {
+    disablePlaceholder?: boolean;
     loadApi?: boolean;
+    placeholderButtonLabel?: string;
+    placeholderImageQuality?: PlaceholderImageQuality;
 }
 
 // @public (undocumented)


### PR DESCRIPTION
Currently the `youtube-player` component loads the YouTube API and sets up the video on initialization. This can slow the page down a lot, because it loads and executes ~150kb of JavaScript, even though the video isn't playing.

These changes rework the `youtube-player` component to show the thumbnail of the video and a fake button instead. When the button is clicked, the API will be loaded and the video will be autoplayed, thus moving the YouTube API out of the critical path.

There are a few cases where the placeholder won't be shown:
* A video that plays automatically.
* When the `youtube-player` is showing a playlist, rather than a single video.