### PR TITLE
fix(material/datepicker): fix create control value when null

### DIFF
--- a/src/components-examples/material/datepicker/datepicker-views-selection/datepicker-views-selection-example.ts
+++ b/src/components-examples/material/datepicker/datepicker-views-selection/datepicker-views-selection-example.ts
@@ -60,7 +60,7 @@ export class DatepickerViewsSelectionExample {
   date = new FormControl(moment());
 
   setMonthAndYear(normalizedMonthAndYear: Moment, datepicker: MatDatepicker<Moment>) {
-    const ctrlValue = this.date.value!;
+    const ctrlValue = this.date.value ?? moment();
     ctrlValue.month(normalizedMonthAndYear.month());
     ctrlValue.year(normalizedMonthAndYear.year());
     this.date.setValue(ctrlValue);


### PR DESCRIPTION
Datepicker emulating a Year and month picker:

If the user deletes the value of the control manually leaving the value of the control as null, the function "setMonthAndYear" breaks because the variable "ctrlValue" does not have the functions that assign the month and year (year, month). Allowing to enter the day (option that should not be shown).