### PR TITLE
Remove dedicated required validator directives

### DIFF
--- a/src/material/checkbox/checkbox-required-validator.ts
+++ b/src/material/checkbox/checkbox-required-validator.ts
@@ -9,18 +9,23 @@
 import {Directive, forwardRef, Provider} from '@angular/core';
 import {CheckboxRequiredValidator, NG_VALIDATORS} from '@angular/forms';
 
+/**
+ * @deprecated No longer used, `MatCheckbox` implements required validation directly.
+ * @breaking-change 19.0.0
+ */
 export const MAT_CHECKBOX_REQUIRED_VALIDATOR: Provider = {
   provide: NG_VALIDATORS,
   useExisting: forwardRef(() => MatCheckboxRequiredValidator),
   multi: true,
 };
 
-// TODO(crisbeto): this should be deprecated and moved into `MatCheckbox`.
-
 /**
  * Validator for Material checkbox's required attribute in template-driven checkbox.
  * Current CheckboxRequiredValidator only work with `input type=checkbox` and does not
  * work with `mat-checkbox`.
+ *
+ * @deprecated No longer used, `MatCheckbox` implements required validation directly.
+ * @breaking-change 19.0.0
  */
 @Directive({
   selector: `mat-checkbox[required][formControlName],

--- a/src/material/checkbox/checkbox.spec.ts
+++ b/src/material/checkbox/checkbox.spec.ts
@@ -10,7 +10,6 @@ import {
   MatCheckbox,
   MatCheckboxChange,
   MatCheckboxModule,
-  MatCheckboxRequiredValidator,
 } from './index';
 
 describe('MDC-based MatCheckbox', () => {
@@ -1100,7 +1099,7 @@ class SingleCheckbox {
   template: `<mat-checkbox [required]="isRequired" [(ngModel)]="isGood"
                            [disabled]="isDisabled">Be good</mat-checkbox>`,
   standalone: true,
-  imports: [MatCheckbox, MatCheckboxRequiredValidator, FormsModule],
+  imports: [MatCheckbox, FormsModule],
 })
 class CheckboxWithNgModel {
   isGood: boolean = false;

--- a/src/material/checkbox/module.ts
+++ b/src/material/checkbox/module.ts
@@ -7,11 +7,14 @@
  */
 
 import {NgModule} from '@angular/core';
-import {MatCommonModule, MatRippleModule} from '@angular/material/core';
+import {MatCommonModule} from '@angular/material/core';
 import {MatCheckbox} from './checkbox';
 import {MatCheckboxRequiredValidator} from './checkbox-required-validator';
 
-/** This module is used by both original and MDC-based checkbox implementations. */
+/**
+ * @deprecated No longer used, `MatCheckbox` implements required validation directly.
+ * @breaking-change 19.0.0
+ */
 @NgModule({
   imports: [MatCheckboxRequiredValidator],
   exports: [MatCheckboxRequiredValidator],
@@ -19,7 +22,7 @@ import {MatCheckboxRequiredValidator} from './checkbox-required-validator';
 export class _MatCheckboxRequiredValidatorModule {}
 
 @NgModule({
-  imports: [MatCommonModule, MatRippleModule, _MatCheckboxRequiredValidatorModule, MatCheckbox],
-  exports: [MatCheckbox, MatCommonModule, _MatCheckboxRequiredValidatorModule],
+  imports: [MatCheckbox, MatCommonModule],
+  exports: [MatCheckbox, MatCommonModule],
 })
 export class MatCheckboxModule {}

--- a/src/material/slide-toggle/module.ts
+++ b/src/material/slide-toggle/module.ts
@@ -7,11 +7,14 @@
  */
 
 import {NgModule} from '@angular/core';
-import {MatCommonModule, MatRippleModule} from '@angular/material/core';
+import {MatCommonModule} from '@angular/material/core';
 import {MatSlideToggle} from './slide-toggle';
 import {MatSlideToggleRequiredValidator} from './slide-toggle-required-validator';
 
-/** This module is used by both original and MDC-based slide-toggle implementations. */
+/**
+ * @deprecated No longer used, `MatSlideToggle` implements required validation directly.
+ * @breaking-change 19.0.0
+ */
 @NgModule({
   imports: [MatSlideToggleRequiredValidator],
   exports: [MatSlideToggleRequiredValidator],
@@ -19,12 +22,7 @@ import {MatSlideToggleRequiredValidator} from './slide-toggle-required-validator
 export class _MatSlideToggleRequiredValidatorModule {}
 
 @NgModule({
-  imports: [
-    _MatSlideToggleRequiredValidatorModule,
-    MatCommonModule,
-    MatRippleModule,
-    MatSlideToggle,
-  ],
-  exports: [_MatSlideToggleRequiredValidatorModule, MatSlideToggle, MatCommonModule],
+  imports: [MatSlideToggle, MatCommonModule],
+  exports: [MatSlideToggle, MatCommonModule],
 })
 export class MatSlideToggleModule {}

--- a/src/material/slide-toggle/slide-toggle-required-validator.ts
+++ b/src/material/slide-toggle/slide-toggle-required-validator.ts
@@ -9,6 +9,10 @@
 import {Directive, forwardRef, Provider} from '@angular/core';
 import {CheckboxRequiredValidator, NG_VALIDATORS} from '@angular/forms';
 
+/**
+ * @deprecated No longer used, `MatCheckbox` implements required validation directly.
+ * @breaking-change 19.0.0
+ */
 export const MAT_SLIDE_TOGGLE_REQUIRED_VALIDATOR: Provider = {
   provide: NG_VALIDATORS,
   useExisting: forwardRef(() => MatSlideToggleRequiredValidator),
@@ -22,6 +26,9 @@ export const MAT_SLIDE_TOGGLE_REQUIRED_VALIDATOR: Provider = {
  * where the value is always defined.
  *
  * Required slide-toggle form controls are valid when checked.
+ *
+ * @deprecated No longer used, `MatCheckbox` implements required validation directly.
+ * @breaking-change 19.0.0
  */
 @Directive({
   selector: `mat-slide-toggle[required][formControlName],

--- a/tools/public_api_guard/material/checkbox.md
+++ b/tools/public_api_guard/material/checkbox.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import { AbstractControl } from '@angular/forms';
 import { AfterViewInit } from '@angular/core';
 import { ChangeDetectorRef } from '@angular/core';
 import { CheckboxRequiredValidator } from '@angular/forms';
@@ -12,14 +13,18 @@ import { ElementRef } from '@angular/core';
 import { EventEmitter } from '@angular/core';
 import { FocusableOption } from '@angular/cdk/a11y';
 import * as i0 from '@angular/core';
-import * as i2 from '@angular/material/core';
+import * as i3 from '@angular/material/core';
 import { InjectionToken } from '@angular/core';
 import { MatRipple } from '@angular/material/core';
 import { NgZone } from '@angular/core';
+import { OnChanges } from '@angular/core';
 import { Provider } from '@angular/core';
+import { SimpleChanges } from '@angular/core';
 import { ThemePalette } from '@angular/material/core';
+import { ValidationErrors } from '@angular/forms';
+import { Validator } from '@angular/forms';
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const MAT_CHECKBOX_CONTROL_VALUE_ACCESSOR: any;
 
 // @public
@@ -28,11 +33,11 @@ export const MAT_CHECKBOX_DEFAULT_OPTIONS: InjectionToken<MatCheckboxDefaultOpti
 // @public
 export function MAT_CHECKBOX_DEFAULT_OPTIONS_FACTORY(): MatCheckboxDefaultOptions;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const MAT_CHECKBOX_REQUIRED_VALIDATOR: Provider;
 
 // @public (undocumented)
-export class MatCheckbox implements AfterViewInit, ControlValueAccessor, FocusableOption {
+export class MatCheckbox implements AfterViewInit, OnChanges, ControlValueAccessor, Validator, FocusableOption {
     constructor(_elementRef: ElementRef<HTMLElement>, _changeDetectorRef: ChangeDetectorRef, _ngZone: NgZone, tabIndex: string, _animationMode?: string | undefined, _options?: MatCheckboxDefaultOptions | undefined);
     protected _animationClasses: {
         uncheckedToChecked: string;
@@ -87,6 +92,8 @@ export class MatCheckbox implements AfterViewInit, ControlValueAccessor, Focusab
     // (undocumented)
     ngAfterViewInit(): void;
     // (undocumented)
+    ngOnChanges(changes: SimpleChanges): void;
+    // (undocumented)
     _onBlur(): void;
     // (undocumented)
     _onInputClick(): void;
@@ -101,6 +108,8 @@ export class MatCheckbox implements AfterViewInit, ControlValueAccessor, Focusab
     registerOnChange(fn: (value: any) => void): void;
     // (undocumented)
     registerOnTouched(fn: any): void;
+    // (undocumented)
+    registerOnValidatorChange(fn: () => void): void;
     required: boolean;
     // @deprecated
     ripple: MatRipple;
@@ -108,6 +117,8 @@ export class MatCheckbox implements AfterViewInit, ControlValueAccessor, Focusab
     setDisabledState(isDisabled: boolean): void;
     tabIndex: number;
     toggle(): void;
+    // (undocumented)
+    validate(control: AbstractControl<boolean>): ValidationErrors | null;
     value: string;
     // (undocumented)
     writeValue(value: any): void;
@@ -139,10 +150,10 @@ export class MatCheckboxModule {
     // (undocumented)
     static ɵinj: i0.ɵɵInjectorDeclaration<MatCheckboxModule>;
     // (undocumented)
-    static ɵmod: i0.ɵɵNgModuleDeclaration<MatCheckboxModule, never, [typeof i2.MatCommonModule, typeof i2.MatRippleModule, typeof _MatCheckboxRequiredValidatorModule, typeof i3.MatCheckbox], [typeof i3.MatCheckbox, typeof i2.MatCommonModule, typeof _MatCheckboxRequiredValidatorModule]>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<MatCheckboxModule, never, [typeof i2.MatCheckbox, typeof i3.MatCommonModule], [typeof i2.MatCheckbox, typeof i3.MatCommonModule]>;
 }
 
-// @public
+// @public @deprecated
 export class MatCheckboxRequiredValidator extends CheckboxRequiredValidator {
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<MatCheckboxRequiredValidator, "mat-checkbox[required][formControlName],             mat-checkbox[required][formControl], mat-checkbox[required][ngModel]", never, {}, {}, never, never, true, never>;
@@ -150,7 +161,7 @@ export class MatCheckboxRequiredValidator extends CheckboxRequiredValidator {
     static ɵfac: i0.ɵɵFactoryDeclaration<MatCheckboxRequiredValidator, never>;
 }
 
-// @public
+// @public @deprecated (undocumented)
 export class _MatCheckboxRequiredValidatorModule {
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<_MatCheckboxRequiredValidatorModule, never>;

--- a/tools/public_api_guard/material/slide-toggle.md
+++ b/tools/public_api_guard/material/slide-toggle.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import { AbstractControl } from '@angular/forms';
 import { AfterContentInit } from '@angular/core';
 import { ChangeDetectorRef } from '@angular/core';
 import { CheckboxRequiredValidator } from '@angular/forms';
@@ -12,20 +13,24 @@ import { ElementRef } from '@angular/core';
 import { EventEmitter } from '@angular/core';
 import { FocusMonitor } from '@angular/cdk/a11y';
 import * as i0 from '@angular/core';
-import * as i2 from '@angular/material/core';
+import * as i3 from '@angular/material/core';
 import { InjectionToken } from '@angular/core';
+import { OnChanges } from '@angular/core';
 import { OnDestroy } from '@angular/core';
 import { Provider } from '@angular/core';
+import { SimpleChanges } from '@angular/core';
 import { ThemePalette } from '@angular/material/core';
 import { Type } from '@angular/core';
+import { ValidationErrors } from '@angular/forms';
+import { Validator } from '@angular/forms';
 
 // @public
 export const MAT_SLIDE_TOGGLE_DEFAULT_OPTIONS: InjectionToken<MatSlideToggleDefaultOptions>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const MAT_SLIDE_TOGGLE_REQUIRED_VALIDATOR: Provider;
 
-// @public
+// @public @deprecated (undocumented)
 export const MAT_SLIDE_TOGGLE_VALUE_ACCESSOR: {
     provide: InjectionToken<readonly ControlValueAccessor[]>;
     useExisting: Type<any>;
@@ -33,7 +38,7 @@ export const MAT_SLIDE_TOGGLE_VALUE_ACCESSOR: {
 };
 
 // @public (undocumented)
-export class MatSlideToggle implements OnDestroy, AfterContentInit, ControlValueAccessor {
+export class MatSlideToggle implements OnDestroy, AfterContentInit, OnChanges, ControlValueAccessor, Validator {
     constructor(_elementRef: ElementRef, _focusMonitor: FocusMonitor, _changeDetectorRef: ChangeDetectorRef, tabIndex: string, defaults: MatSlideToggleDefaultOptions, animationMode?: string);
     ariaDescribedby: string;
     ariaLabel: string | null;
@@ -78,16 +83,20 @@ export class MatSlideToggle implements OnDestroy, AfterContentInit, ControlValue
     // (undocumented)
     ngAfterContentInit(): void;
     // (undocumented)
+    ngOnChanges(changes: SimpleChanges): void;
+    // (undocumented)
     ngOnDestroy(): void;
     _noopAnimations: boolean;
     registerOnChange(fn: any): void;
     registerOnTouched(fn: any): void;
+    registerOnValidatorChange(fn: () => void): void;
     required: boolean;
     setDisabledState(isDisabled: boolean): void;
     _switchElement: ElementRef<HTMLElement>;
     tabIndex: number;
     toggle(): void;
     readonly toggleChange: EventEmitter<void>;
+    validate(control: AbstractControl<boolean>): ValidationErrors | null;
     writeValue(value: any): void;
     // (undocumented)
     static ɵcmp: i0.ɵɵComponentDeclaration<MatSlideToggle, "mat-slide-toggle", ["matSlideToggle"], { "disabled": { "alias": "disabled"; "required": false; }; "disableRipple": { "alias": "disableRipple"; "required": false; }; "color": { "alias": "color"; "required": false; }; "tabIndex": { "alias": "tabIndex"; "required": false; }; "name": { "alias": "name"; "required": false; }; "id": { "alias": "id"; "required": false; }; "labelPosition": { "alias": "labelPosition"; "required": false; }; "ariaLabel": { "alias": "aria-label"; "required": false; }; "ariaLabelledby": { "alias": "aria-labelledby"; "required": false; }; "ariaDescribedby": { "alias": "aria-describedby"; "required": false; }; "required": { "alias": "required"; "required": false; }; "checked": { "alias": "checked"; "required": false; }; "hideIcon": { "alias": "hideIcon"; "required": false; }; }, { "change": "change"; "toggleChange": "toggleChange"; }, never, ["*"], true, never>;
@@ -118,10 +127,10 @@ export class MatSlideToggleModule {
     // (undocumented)
     static ɵinj: i0.ɵɵInjectorDeclaration<MatSlideToggleModule>;
     // (undocumented)
-    static ɵmod: i0.ɵɵNgModuleDeclaration<MatSlideToggleModule, never, [typeof _MatSlideToggleRequiredValidatorModule, typeof i2.MatCommonModule, typeof i2.MatRippleModule, typeof i3.MatSlideToggle], [typeof _MatSlideToggleRequiredValidatorModule, typeof i3.MatSlideToggle, typeof i2.MatCommonModule]>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<MatSlideToggleModule, never, [typeof i2.MatSlideToggle, typeof i3.MatCommonModule], [typeof i2.MatSlideToggle, typeof i3.MatCommonModule]>;
 }
 
-// @public
+// @public @deprecated
 export class MatSlideToggleRequiredValidator extends CheckboxRequiredValidator {
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<MatSlideToggleRequiredValidator, "mat-slide-toggle[required][formControlName],             mat-slide-toggle[required][formControl], mat-slide-toggle[required][ngModel]", never, {}, {}, never, never, true, never>;
@@ -129,7 +138,7 @@ export class MatSlideToggleRequiredValidator extends CheckboxRequiredValidator {
     static ɵfac: i0.ɵɵFactoryDeclaration<MatSlideToggleRequiredValidator, never>;
 }
 
-// @public
+// @public @deprecated (undocumented)
 export class _MatSlideToggleRequiredValidatorModule {
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<_MatSlideToggleRequiredValidatorModule, never>;


### PR DESCRIPTION
Currently `MatCheckbox` and `MatSlideToggle` implement required validation with separate directives, similarly to how `@angular/forms` handles it. This is problematic, because it would require `standalone` users to add two imports.

These changes deprecate the separate directives and move the required validation into the components.