### PR TITLE
Set up basic ng add schematics for all packages

### DIFF
--- a/.ng-dev/google-sync-config.json
+++ b/.ng-dev/google-sync-config.json
@@ -24,6 +24,7 @@
     "src/**/*spec.ts",
     "src/cdk/schematics/**/*",
     "src/material/schematics/**/*",
+    "src/google-maps/schematics/**/*",
     "src/cdk/testing/testbed/zone-types.d.ts",
     "src/material/_theming.scss",
     "src/material/index.ts",

--- a/src/google-maps/BUILD.bazel
+++ b/src/google-maps/BUILD.bazel
@@ -23,6 +23,7 @@ ng_module(
 ng_package(
     name = "npm_package",
     srcs = ["package.json"],
+    nested_packages = ["//src/google-maps/schematics:npm_package"],
     tags = ["release-package"],
     deps = [":google-maps"],
 )

--- a/src/google-maps/README.md
+++ b/src/google-maps/README.md
@@ -6,7 +6,7 @@ File any bugs against the [angular/components repo](https://github.com/angular/c
 
 ## Installation
 
-To install, run `npm install @angular/google-maps`.
+To install, run `ng add @angular/google-maps`.
 
 ## Getting the API Key
 

--- a/src/google-maps/package.json
+++ b/src/google-maps/package.json
@@ -26,5 +26,6 @@
     "rxjs": "0.0.0-RXJS"
   },
   "sideEffects": false,
+  "schematics": "./schematics/collection.json",
   "ng-update": {}
 }

--- a/src/google-maps/schematics/BUILD.bazel
+++ b/src/google-maps/schematics/BUILD.bazel
@@ -1,0 +1,34 @@
+load("@build_bazel_rules_nodejs//:index.bzl", "copy_to_bin")
+load("//tools:defaults.bzl", "pkg_npm", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
+
+copy_to_bin(
+    name = "schematics_assets",
+    srcs = glob(["**/*.json"]),
+)
+
+ts_library(
+    name = "schematics",
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["**/*.spec.ts"],
+    ),
+    # Schematics can not yet run in ESM module. For now we continue to use CommonJS.
+    # TODO(ESM): remove this once the Angular CLI supports ESM schematics.
+    devmode_module = "commonjs",
+    prodmode_module = "commonjs",
+    deps = [
+        "@npm//@angular-devkit/schematics",
+        "@npm//@types/node",
+    ],
+)
+
+# This package is intended to be combined into the main @angular/google-maps package as a dep.
+pkg_npm(
+    name = "npm_package",
+    deps = [
+        ":schematics",
+        ":schematics_assets",
+    ],
+)

--- a/src/google-maps/schematics/collection.json
+++ b/src/google-maps/schematics/collection.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../node_modules/@angular-devkit/schematics/collection-schema.json",
+  "schematics": {
+    "ng-add": {
+      "description": "Installs the Angular Google Maps module",
+      "factory": "./ng-add/index",
+      "hidden": true
+    }
+  }
+}

--- a/src/google-maps/schematics/ng-add/index.ts
+++ b/src/google-maps/schematics/ng-add/index.ts
@@ -1,0 +1,15 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Rule} from '@angular-devkit/schematics';
+
+export default function (): Rule {
+  // Noop schematic so the CLI doesn't throw if users try to `ng add` this package.
+  // Also allows us to add more functionality in the future.
+  return () => {};
+}

--- a/src/google-maps/schematics/package.json
+++ b/src/google-maps/schematics/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/src/material-date-fns-adapter/BUILD.bazel
+++ b/src/material-date-fns-adapter/BUILD.bazel
@@ -39,6 +39,7 @@ ng_web_test_suite(
 ng_package(
     name = "npm_package",
     srcs = ["package.json"],
+    nested_packages = ["//src/material-date-fns-adapter/schematics:npm_package"],
     tags = ["release-package"],
     deps = [":material-date-fns-adapter"],
 )

--- a/src/material-date-fns-adapter/package.json
+++ b/src/material-date-fns-adapter/package.json
@@ -26,5 +26,6 @@
       "@angular/material-date-fns-adapter"
     ]
   },
+  "schematics": "./schematics/collection.json",
   "sideEffects": false
 }

--- a/src/material-date-fns-adapter/schematics/BUILD.bazel
+++ b/src/material-date-fns-adapter/schematics/BUILD.bazel
@@ -1,0 +1,34 @@
+load("@build_bazel_rules_nodejs//:index.bzl", "copy_to_bin")
+load("//tools:defaults.bzl", "pkg_npm", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
+
+copy_to_bin(
+    name = "schematics_assets",
+    srcs = glob(["**/*.json"]),
+)
+
+ts_library(
+    name = "schematics",
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["**/*.spec.ts"],
+    ),
+    # Schematics can not yet run in ESM module. For now we continue to use CommonJS.
+    # TODO(ESM): remove this once the Angular CLI supports ESM schematics.
+    devmode_module = "commonjs",
+    prodmode_module = "commonjs",
+    deps = [
+        "@npm//@angular-devkit/schematics",
+        "@npm//@types/node",
+    ],
+)
+
+# This package is intended to be combined into the main @angular/material-date-fns-adapter package as a dep.
+pkg_npm(
+    name = "npm_package",
+    deps = [
+        ":schematics",
+        ":schematics_assets",
+    ],
+)

--- a/src/material-date-fns-adapter/schematics/collection.json
+++ b/src/material-date-fns-adapter/schematics/collection.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../node_modules/@angular-devkit/schematics/collection-schema.json",
+  "schematics": {
+    "ng-add": {
+      "description": "Installs the Angular YouTube Player",
+      "factory": "./ng-add/index",
+      "hidden": true
+    }
+  }
+}

--- a/src/material-date-fns-adapter/schematics/ng-add/index.ts
+++ b/src/material-date-fns-adapter/schematics/ng-add/index.ts
@@ -1,0 +1,15 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Rule} from '@angular-devkit/schematics';
+
+export default function (): Rule {
+  // Noop schematic so the CLI doesn't throw if users try to `ng add` this package.
+  // Also allows us to add more functionality in the future.
+  return () => {};
+}

--- a/src/material-date-fns-adapter/schematics/package.json
+++ b/src/material-date-fns-adapter/schematics/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/src/material-luxon-adapter/BUILD.bazel
+++ b/src/material-luxon-adapter/BUILD.bazel
@@ -41,6 +41,7 @@ ng_web_test_suite(
 ng_package(
     name = "npm_package",
     srcs = ["package.json"],
+    nested_packages = ["//src/material-luxon-adapter/schematics:npm_package"],
     tags = ["release-package"],
     deps = [":material-luxon-adapter"],
 )

--- a/src/material-luxon-adapter/package.json
+++ b/src/material-luxon-adapter/package.json
@@ -26,5 +26,6 @@
       "@angular/material-luxon-adapter"
     ]
   },
+  "schematics": "./schematics/collection.json",
   "sideEffects": false
 }

--- a/src/material-luxon-adapter/schematics/BUILD.bazel
+++ b/src/material-luxon-adapter/schematics/BUILD.bazel
@@ -1,0 +1,34 @@
+load("@build_bazel_rules_nodejs//:index.bzl", "copy_to_bin")
+load("//tools:defaults.bzl", "pkg_npm", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
+
+copy_to_bin(
+    name = "schematics_assets",
+    srcs = glob(["**/*.json"]),
+)
+
+ts_library(
+    name = "schematics",
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["**/*.spec.ts"],
+    ),
+    # Schematics can not yet run in ESM module. For now we continue to use CommonJS.
+    # TODO(ESM): remove this once the Angular CLI supports ESM schematics.
+    devmode_module = "commonjs",
+    prodmode_module = "commonjs",
+    deps = [
+        "@npm//@angular-devkit/schematics",
+        "@npm//@types/node",
+    ],
+)
+
+# This package is intended to be combined into the main @angular/material-luxon-adapter package as a dep.
+pkg_npm(
+    name = "npm_package",
+    deps = [
+        ":schematics",
+        ":schematics_assets",
+    ],
+)

--- a/src/material-luxon-adapter/schematics/collection.json
+++ b/src/material-luxon-adapter/schematics/collection.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../node_modules/@angular-devkit/schematics/collection-schema.json",
+  "schematics": {
+    "ng-add": {
+      "description": "Installs the Angular YouTube Player",
+      "factory": "./ng-add/index",
+      "hidden": true
+    }
+  }
+}

--- a/src/material-luxon-adapter/schematics/ng-add/index.ts
+++ b/src/material-luxon-adapter/schematics/ng-add/index.ts
@@ -1,0 +1,15 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Rule} from '@angular-devkit/schematics';
+
+export default function (): Rule {
+  // Noop schematic so the CLI doesn't throw if users try to `ng add` this package.
+  // Also allows us to add more functionality in the future.
+  return () => {};
+}

--- a/src/material-luxon-adapter/schematics/package.json
+++ b/src/material-luxon-adapter/schematics/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/src/material-moment-adapter/BUILD.bazel
+++ b/src/material-moment-adapter/BUILD.bazel
@@ -40,6 +40,7 @@ ng_web_test_suite(
 ng_package(
     name = "npm_package",
     srcs = ["package.json"],
+    nested_packages = ["//src/material-moment-adapter/schematics:npm_package"],
     tags = ["release-package"],
     deps = [":material-moment-adapter"],
 )

--- a/src/material-moment-adapter/package.json
+++ b/src/material-moment-adapter/package.json
@@ -26,5 +26,6 @@
       "@angular/material-moment-adapter"
     ]
   },
+  "schematics": "./schematics/collection.json",
   "sideEffects": false
 }

--- a/src/material-moment-adapter/schematics/BUILD.bazel
+++ b/src/material-moment-adapter/schematics/BUILD.bazel
@@ -1,0 +1,34 @@
+load("@build_bazel_rules_nodejs//:index.bzl", "copy_to_bin")
+load("//tools:defaults.bzl", "pkg_npm", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
+
+copy_to_bin(
+    name = "schematics_assets",
+    srcs = glob(["**/*.json"]),
+)
+
+ts_library(
+    name = "schematics",
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["**/*.spec.ts"],
+    ),
+    # Schematics can not yet run in ESM module. For now we continue to use CommonJS.
+    # TODO(ESM): remove this once the Angular CLI supports ESM schematics.
+    devmode_module = "commonjs",
+    prodmode_module = "commonjs",
+    deps = [
+        "@npm//@angular-devkit/schematics",
+        "@npm//@types/node",
+    ],
+)
+
+# This package is intended to be combined into the main @angular/material-moment-adapter package as a dep.
+pkg_npm(
+    name = "npm_package",
+    deps = [
+        ":schematics",
+        ":schematics_assets",
+    ],
+)

--- a/src/material-moment-adapter/schematics/collection.json
+++ b/src/material-moment-adapter/schematics/collection.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../node_modules/@angular-devkit/schematics/collection-schema.json",
+  "schematics": {
+    "ng-add": {
+      "description": "Installs the Angular YouTube Player",
+      "factory": "./ng-add/index",
+      "hidden": true
+    }
+  }
+}

--- a/src/material-moment-adapter/schematics/ng-add/index.ts
+++ b/src/material-moment-adapter/schematics/ng-add/index.ts
@@ -1,0 +1,15 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Rule} from '@angular-devkit/schematics';
+
+export default function (): Rule {
+  // Noop schematic so the CLI doesn't throw if users try to `ng add` this package.
+  // Also allows us to add more functionality in the future.
+  return () => {};
+}

--- a/src/material-moment-adapter/schematics/package.json
+++ b/src/material-moment-adapter/schematics/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/src/material/datepicker/datepicker.md
+++ b/src/material/datepicker/datepicker.md
@@ -161,7 +161,7 @@ that point.
 
 <!-- example(datepicker-filter) -->
 
-In this example the user cannot select any date that falls on a Saturday or Sunday, but all of the 
+In this example the user cannot select any date that falls on a Saturday or Sunday, but all of the
 dates which fall on other days of the week are selectable.
 
 Each validation property has a different error that can be checked:
@@ -336,7 +336,7 @@ The easiest way to ensure this is to import one of the provided date modules:
   </tbody>
 </table>
 
-`MatDateFnsModule` (installed via `@angular/material-date-fns-adapter`)
+`MatDateFnsModule` (installed via `ng add @angular/material-date-fns-adapter`)
 
 <table>
   <tbody>
@@ -359,7 +359,7 @@ The easiest way to ensure this is to import one of the provided date modules:
   </tbody>
 </table>
 
-`MatLuxonDateModule` (installed via `@angular/material-luxon-adapter`)
+`MatLuxonDateModule` (installed via `ng add @angular/material-luxon-adapter`)
 
 <table>
   <tbody>
@@ -382,7 +382,7 @@ The easiest way to ensure this is to import one of the provided date modules:
   </tbody>
 </table>
 
-`MatMomentDateModule` (installed via `@angular/material-moment-adapter`)
+`MatMomentDateModule` (installed via `ng add @angular/material-moment-adapter`)
 
 <table>
   <tbody>

--- a/src/youtube-player/BUILD.bazel
+++ b/src/youtube-player/BUILD.bazel
@@ -38,6 +38,7 @@ sass_binary(
 ng_package(
     name = "npm_package",
     srcs = ["package.json"],
+    nested_packages = ["//src/youtube-player/schematics:npm_package"],
     tags = ["release-package"],
     deps = [":youtube-player"],
 )

--- a/src/youtube-player/README.md
+++ b/src/youtube-player/README.md
@@ -5,7 +5,7 @@ This component provides a simple Angular wrapper around the
 File any bugs against the [angular/components repo](https://github.com/angular/components/issues).
 
 ## Installation
-To install, run `npm install @angular/youtube-player`.
+To install, run `ng add @angular/youtube-player`.
 
 ## Usage
 Import the component either by adding the `YouTubePlayerModule` to your app or  by importing

--- a/src/youtube-player/package.json
+++ b/src/youtube-player/package.json
@@ -26,5 +26,6 @@
     "rxjs": "0.0.0-RXJS"
   },
   "sideEffects": false,
+  "schematics": "./schematics/collection.json",
   "ng-update": {}
 }

--- a/src/youtube-player/schematics/BUILD.bazel
+++ b/src/youtube-player/schematics/BUILD.bazel
@@ -1,0 +1,34 @@
+load("@build_bazel_rules_nodejs//:index.bzl", "copy_to_bin")
+load("//tools:defaults.bzl", "pkg_npm", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
+
+copy_to_bin(
+    name = "schematics_assets",
+    srcs = glob(["**/*.json"]),
+)
+
+ts_library(
+    name = "schematics",
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["**/*.spec.ts"],
+    ),
+    # Schematics can not yet run in ESM module. For now we continue to use CommonJS.
+    # TODO(ESM): remove this once the Angular CLI supports ESM schematics.
+    devmode_module = "commonjs",
+    prodmode_module = "commonjs",
+    deps = [
+        "@npm//@angular-devkit/schematics",
+        "@npm//@types/node",
+    ],
+)
+
+# This package is intended to be combined into the main @angular/youtube-player package as a dep.
+pkg_npm(
+    name = "npm_package",
+    deps = [
+        ":schematics",
+        ":schematics_assets",
+    ],
+)

--- a/src/youtube-player/schematics/collection.json
+++ b/src/youtube-player/schematics/collection.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../node_modules/@angular-devkit/schematics/collection-schema.json",
+  "schematics": {
+    "ng-add": {
+      "description": "Installs the Angular YouTube Player",
+      "factory": "./ng-add/index",
+      "hidden": true
+    }
+  }
+}

--- a/src/youtube-player/schematics/ng-add/index.ts
+++ b/src/youtube-player/schematics/ng-add/index.ts
@@ -1,0 +1,15 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Rule} from '@angular-devkit/schematics';
+
+export default function (): Rule {
+  // Noop schematic so the CLI doesn't throw if users try to `ng add` this package.
+  // Also allows us to add more functionality in the future.
+  return () => {};
+}

--- a/src/youtube-player/schematics/package.json
+++ b/src/youtube-player/schematics/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}


### PR DESCRIPTION
Currently only `@angular/material` and `@angular/cdk` have `ng add` schematics which means that running something like `ng add @angular/youtube-player` results in an error. These changes add some basic noop schematics to avoid the error and to allows us to add more functionality in the future (e.g. installing Moment together with the `moment-date-adapter`).