### PR TITLE
feat(material/button): add the ability to interact with disabled buttons

### DIFF
--- a/src/components-examples/material/button/button-disabled-interactive/button-disabled-interactive-example.css
+++ b/src/components-examples/material/button/button-disabled-interactive/button-disabled-interactive-example.css
@@ -1,0 +1,3 @@
+button {
+  margin-right: 8px;
+}

--- a/src/components-examples/material/button/button-disabled-interactive/button-disabled-interactive-example.html
+++ b/src/components-examples/material/button/button-disabled-interactive/button-disabled-interactive-example.html
@@ -1,0 +1,10 @@
+<button
+  mat-raised-button
+  disabled
+  disabledInteractive
+  matTooltip="This is a tooltip!">Disabled button allowing interactivity</button>
+
+<button
+  mat-raised-button
+  disabled
+  matTooltip="This is a tooltip!">Default disabled button</button>

--- a/src/components-examples/material/button/button-disabled-interactive/button-disabled-interactive-example.ts
+++ b/src/components-examples/material/button/button-disabled-interactive/button-disabled-interactive-example.ts
@@ -1,0 +1,15 @@
+import {Component} from '@angular/core';
+import {MatButton} from '@angular/material/button';
+import {MatTooltip} from '@angular/material/tooltip';
+
+/**
+ * @title Interactive disabled buttons
+ */
+@Component({
+  selector: 'button-disabled-interactive-example',
+  templateUrl: 'button-disabled-interactive-example.html',
+  styleUrls: ['button-disabled-interactive-example.css'],
+  standalone: true,
+  imports: [MatButton, MatTooltip],
+})
+export class ButtonDisabledInteractiveExample {}

--- a/src/components-examples/material/button/index.ts
+++ b/src/components-examples/material/button/index.ts
@@ -1,3 +1,4 @@
 export {ButtonOverviewExample} from './button-overview/button-overview-example';
 export {ButtonTypesExample} from './button-types/button-types-example';
+export {ButtonDisabledInteractiveExample} from './button-disabled-interactive/button-disabled-interactive-example';
 export {ButtonHarnessExample} from './button-harness/button-harness-example';

--- a/src/dev-app/button/BUILD.bazel
+++ b/src/dev-app/button/BUILD.bazel
@@ -11,7 +11,9 @@ ng_module(
     ],
     deps = [
         "//src/material/button",
+        "//src/material/checkbox",
         "//src/material/icon",
+        "//src/material/tooltip",
     ],
 )
 

--- a/src/dev-app/button/button-demo.html
+++ b/src/dev-app/button/button-demo.html
@@ -19,18 +19,52 @@
     </button>
   </section>
   <section>
-    <button mat-button disabled>normal</button>
-    <button mat-raised-button disabled>raised</button>
-    <button mat-stroked-button disabled>stroked</button>
-    <button mat-flat-button disabled>flat</button>
-    <button mat-fab disabled>
+    <button
+      mat-button
+      disabled
+      [disabledInteractive]="disabledInteractive"
+      [matTooltip]="tooltipText">normal</button>
+    <button
+      mat-raised-button
+      disabled
+      [disabledInteractive]="disabledInteractive"
+      [matTooltip]="tooltipText">raised</button>
+    <button
+      mat-stroked-button
+      disabled
+      [disabledInteractive]="disabledInteractive"
+      [matTooltip]="tooltipText">stroked</button>
+    <button
+      mat-flat-button
+      disabled
+      [disabledInteractive]="disabledInteractive"
+      [matTooltip]="tooltipText">flat</button>
+    <button
+      mat-fab
+      disabled
+      [disabledInteractive]="disabledInteractive"
+      [matTooltip]="tooltipText">
       <mat-icon>check</mat-icon>
     </button>
-    <button mat-mini-fab disabled>
+    <button
+      mat-mini-fab
+      disabled
+      [disabledInteractive]="disabledInteractive"
+      [matTooltip]="tooltipText">
       <mat-icon>check</mat-icon>
     </button>
-    <button mat-fab extended disabled>Search</button>
-    <button mat-fab extended disabled>
+    <button
+      mat-fab
+      extended
+      disabled
+      [disabledInteractive]="disabledInteractive"
+      [matTooltip]="tooltipText">Search</button>
+    <button
+      mat-fab
+      extended
+      disabled
+      [disabledInteractive]="disabledInteractive"
+      [matTooltip]="tooltipText">
       <mat-icon>check</mat-icon>
       Search
       <mat-icon iconPositionEnd>check</mat-icon>
@@ -57,18 +91,61 @@
     </a>
   </section>
   <section>
-    <a href="//www.google.com" disabled mat-button color="primary">SEARCH</a>
-    <a href="//www.google.com" disabled mat-raised-button>SEARCH</a>
-    <a href="//www.google.com" disabled mat-stroked-button color="primary">SEARCH</a>
-    <a href="//www.google.com" disabled mat-flat-button>SEARCH</a>
-    <a href="//www.google.com" disabled mat-fab>
+    <a
+      href="//www.google.com"
+      disabled
+      [disabledInteractive]="disabledInteractive"
+      [matTooltip]="tooltipText"
+      mat-button
+      color="primary">SEARCH</a>
+    <a
+      href="//www.google.com"
+      disabled
+      [disabledInteractive]="disabledInteractive"
+      [matTooltip]="tooltipText"
+      mat-raised-button>SEARCH</a>
+    <a
+      href="//www.google.com"
+      disabled
+      [disabledInteractive]="disabledInteractive"
+      [matTooltip]="tooltipText"
+      mat-stroked-button color="primary">SEARCH</a>
+    <a
+      href="//www.google.com"
+      disabled
+      [disabledInteractive]="disabledInteractive"
+      [matTooltip]="tooltipText"
+      mat-flat-button>SEARCH</a>
+    <a
+      href="//www.google.com"
+      disabled
+      [disabledInteractive]="disabledInteractive"
+      [matTooltip]="tooltipText"
+      mat-fab>
       <mat-icon>check</mat-icon>
     </a>
-    <a href="//www.google.com" disabled mat-mini-fab>
+    <a
+      href="//www.google.com"
+      disabled
+      [disabledInteractive]="disabledInteractive"
+      [matTooltip]="tooltipText"
+      mat-mini-fab>
       <mat-icon>check</mat-icon>
     </a>
-    <a href="//www.google.com" disabled mat-fab extended>Search</a>
-    <a href="//www.google.com" disabled mat-fab extended>
+    <a
+      href="//www.google.com"
+      disabled
+      [disabledInteractive]="disabledInteractive"
+      [matTooltip]="tooltipText"
+      mat-fab
+      extended>Search</a>
+    <a
+      href="//www.google.com"
+      disabled
+      [disabledInteractive]="disabledInteractive"
+      [matTooltip]="tooltipText"
+      mat-fab
+      extended>
       <mat-icon>check</mat-icon>
       Search
       <mat-icon iconPositionEnd>check</mat-icon>
@@ -81,7 +158,11 @@
     <button mat-button color="primary">primary</button>
     <button mat-button color="accent">accent</button>
     <button mat-button color="warn">warn</button>
-    <button mat-button disabled>disabled</button>
+    <button
+      mat-button
+      disabled
+      [disabledInteractive]="disabledInteractive"
+      [matTooltip]="tooltipText">disabled</button>
     <button mat-button>
       <mat-icon>home</mat-icon>
       with icons
@@ -95,7 +176,11 @@
     <button mat-raised-button color="primary">primary</button>
     <button mat-raised-button color="accent">accent</button>
     <button mat-raised-button color="warn">warn</button>
-    <button mat-raised-button disabled>disabled</button>
+    <button
+      mat-raised-button
+      disabled
+      [disabledInteractive]="disabledInteractive"
+      [matTooltip]="tooltipText">disabled</button>
     <button mat-raised-button>
       <mat-icon>home</mat-icon>
       with icons
@@ -109,7 +194,11 @@
     <button mat-stroked-button color="primary">primary</button>
     <button mat-stroked-button color="accent">accent</button>
     <button mat-stroked-button color="warn">warn</button>
-    <button mat-stroked-button disabled>disabled</button>
+    <button
+      mat-stroked-button
+      disabled
+      [disabledInteractive]="disabledInteractive"
+      [matTooltip]="tooltipText">disabled</button>
     <button mat-stroked-button>
       <mat-icon>home</mat-icon>
       with icons
@@ -123,7 +212,11 @@
     <button mat-flat-button color="primary">primary</button>
     <button mat-flat-button color="accent">accent</button>
     <button mat-flat-button color="warn">warn</button>
-    <button mat-flat-button disabled>disabled</button>
+    <button
+      mat-flat-button
+      disabled
+      [disabledInteractive]="disabledInteractive"
+      [matTooltip]="tooltipText">disabled</button>
     <button mat-flat-button>
       <mat-icon>home</mat-icon>
       with icons
@@ -145,12 +238,16 @@
     <button mat-icon-button color="warn">
       <mat-icon>trending_up</mat-icon>
     </button>
-    <button mat-icon-button disabled>
+    <button
+      mat-icon-button
+      disabled
+      [disabledInteractive]="disabledInteractive"
+      [matTooltip]="tooltipText">
       <mat-icon>visibility</mat-icon>
     </button>
   </section>
 
-  <h4 class="demo-section-header"> Icon Button Anchors [mat-icon-button]</h4>
+  <h4 class="demo-section-header">Icon Button Anchors [mat-icon-button]</h4>
   <section>
     <a href="#" mat-icon-button>
       <mat-icon>cached</mat-icon>
@@ -164,7 +261,12 @@
     <a href="#" mat-icon-button color="warn">
       <mat-icon>trending_up</mat-icon>
     </a>
-    <a href="#" mat-icon-button disabled>
+    <a
+      href="#"
+      mat-icon-button
+      disabled
+      [disabledInteractive]="disabledInteractive"
+      [matTooltip]="tooltipText">
       <mat-icon>visibility</mat-icon>
     </a>
   </section>
@@ -183,7 +285,11 @@
     <button mat-fab color="warn">
       <mat-icon>home</mat-icon>
     </button>
-    <button mat-fab disabled>
+    <button
+      mat-fab
+      disabled
+      [disabledInteractive]="disabledInteractive"
+      [matTooltip]="tooltipText">
       <mat-icon>favorite</mat-icon>
     </button>
   </section>
@@ -202,7 +308,11 @@
     <button mat-mini-fab color="warn">
       <mat-icon>filter_list</mat-icon>
     </button>
-    <button mat-mini-fab disabled>
+    <button
+      mat-mini-fab
+      disabled
+      [disabledInteractive]="disabledInteractive"
+      [matTooltip]="tooltipText">
       <mat-icon>home</mat-icon>
     </button>
   </section>
@@ -212,9 +322,12 @@
     <div>
       <p>isDisabled: {{isDisabled}}</p>
       <p>Button 1 as been clicked {{clickCounter}} times</p>
-      <button mat-flat-button (click)="isDisabled=!isDisabled">
-        {{isDisabled ? 'Enable All' : 'Disable All'}}
-      </button>
+      <p>
+        <mat-checkbox [(ngModel)]="disabledInteractive">Allow disabled button interactivity</mat-checkbox>
+      </p>
+      <p>
+        <mat-checkbox [(ngModel)]="isDisabled">All disabled</mat-checkbox>
+      </p>
       <button mat-flat-button (click)="button1.focus()">Focus 1</button>
       <button mat-flat-button (click)="button2.focus()">Focus 2</button>
       <button mat-flat-button (click)="button3.focus()">Focus 3</button>

--- a/src/dev-app/button/button-demo.ts
+++ b/src/dev-app/button/button-demo.ts
@@ -7,18 +7,45 @@
  */
 
 import {Component} from '@angular/core';
-import {MatButtonModule} from '@angular/material/button';
-import {MatIconModule} from '@angular/material/icon';
+import {FormsModule} from '@angular/forms';
+import {
+  MatButton,
+  MatAnchor,
+  MatFabButton,
+  MatFabAnchor,
+  MatIconButton,
+  MatIconAnchor,
+  MatMiniFabButton,
+  MatMiniFabAnchor,
+} from '@angular/material/button';
+import {MatIcon} from '@angular/material/icon';
+import {MatTooltip} from '@angular/material/tooltip';
+import {MatCheckbox} from '@angular/material/checkbox';
 
 @Component({
   selector: 'button-demo',
   templateUrl: 'button-demo.html',
   styleUrls: ['button-demo.css'],
   standalone: true,
-  imports: [MatButtonModule, MatIconModule],
+  imports: [
+    MatButton,
+    MatAnchor,
+    MatFabButton,
+    MatFabAnchor,
+    MatMiniFabButton,
+    MatMiniFabAnchor,
+    MatIconButton,
+    MatIconAnchor,
+    MatIcon,
+    MatTooltip,
+    MatCheckbox,
+    FormsModule,
+  ],
 })
 export class ButtonDemo {
-  isDisabled: boolean = false;
-  clickCounter: number = 0;
-  toggleDisable: boolean = false;
+  isDisabled = false;
+  clickCounter = 0;
+  toggleDisable = false;
+  tooltipText = 'This is a button tooltip!';
+  disabledInteractive = false;
 }

--- a/src/material/button/_button-base.scss
+++ b/src/material/button/_button-base.scss
@@ -68,12 +68,17 @@
       @include token-utils.create-token-slot(background-color, state-layer-color);
     }
 
+    &.mat-mdc-button-disabled .mat-mdc-button-persistent-ripple::before {
+      @include token-utils.create-token-slot(background-color, disabled-state-layer-color);
+    }
+
     &:hover .mat-mdc-button-persistent-ripple::before {
       @include token-utils.create-token-slot(opacity, hover-state-layer-opacity);
     }
 
     &.cdk-program-focused,
-    &.cdk-keyboard-focused {
+    &.cdk-keyboard-focused,
+    &.mat-mdc-button-disabled-interactive:focus {
       .mat-mdc-button-persistent-ripple::before {
         @include token-utils.create-token-slot(opacity, focus-state-layer-opacity);
       }
@@ -91,10 +96,17 @@
 // and note that having pointer-events may have unintended side-effects, e.g. allowing the user
 // to click the target underneath the button.
 @mixin mat-private-button-disabled() {
-  &[disabled] {
+  // `[disabled]` shouldn't be necessary, but we keep it to maintain
+  // compatibility with apps setting it through host bindings.
+  &[disabled],
+  &.mat-mdc-button-disabled {
     cursor: default;
     pointer-events: none;
     @content;
+  }
+
+  &.mat-mdc-button-disabled-interactive {
+    pointer-events: auto;
   }
 }
 

--- a/src/material/button/button-base.ts
+++ b/src/material/button/button-base.ts
@@ -14,6 +14,7 @@ import {
   Directive,
   ElementRef,
   inject,
+  InjectionToken,
   Input,
   NgZone,
   numberAttribute,
@@ -22,9 +23,21 @@ import {
 } from '@angular/core';
 import {MatRipple, MatRippleLoader} from '@angular/material/core';
 
+/** Object that can be used to configure the default options for the button component. */
+export interface MatButtonConfig {
+  /** Whether disabled buttons should be interactive. */
+  disabledInteractive?: boolean;
+}
+
+/** Injection token that can be used to provide the default options the button component. */
+export const MAT_BUTTON_CONFIG = new InjectionToken<MatButtonConfig>('MAT_BUTTON_CONFIG');
+
 /** Shared host configuration for all buttons */
 export const MAT_BUTTON_HOST = {
-  '[attr.disabled]': 'disabled || null',
+  '[attr.disabled]': '_getDisabledAttribute()',
+  '[attr.aria-disabled]': '_getAriaDisabled()',
+  '[class.mat-mdc-button-disabled]': 'disabled',
+  '[class.mat-mdc-button-disabled-interactive]': 'disabledInteractive',
   '[class._mat-animation-noopable]': '_animationMode === "NoopAnimations"',
   // MDC automatically applies the primary theme color to the button, but we want to support
   // an unthemed version. If color is undefined, apply a CSS class that makes it easy to
@@ -108,6 +121,7 @@ export class MatButtonBase implements AfterViewInit, OnDestroy {
   }
   private _disableRipple: boolean = false;
 
+  /** Whether the button is disabled. */
   @Input({transform: booleanAttribute})
   get disabled(): boolean {
     return this._disabled;
@@ -118,18 +132,36 @@ export class MatButtonBase implements AfterViewInit, OnDestroy {
   }
   private _disabled: boolean = false;
 
+  /** `aria-disabled` value of the button. */
+  @Input({transform: booleanAttribute, alias: 'aria-disabled'})
+  ariaDisabled: boolean | undefined;
+
+  /**
+   * Natively disabled buttons prevent focus and any pointer events from reaching the button.
+   * In some scenarios this might not be desirable, because it can prevent users from finding out
+   * why the button is disabled (e.g. via tooltip).
+   *
+   * Enabling this input will change the button so that it is styled to be disabled and will be
+   * marked as `aria-disabled`, but it will allow the button to receive events and focus.
+   *
+   * Note that by enabling this, you need to set the `tabindex` yourself if the button isn't
+   * meant to be tabbable and you have to prevent the button action (e.g. form submissions).
+   */
+  @Input({transform: booleanAttribute})
+  disabledInteractive: boolean;
+
   constructor(
     public _elementRef: ElementRef,
     public _platform: Platform,
     public _ngZone: NgZone,
     public _animationMode?: string,
   ) {
-    this._rippleLoader?.configureRipple(this._elementRef.nativeElement, {
-      className: 'mat-mdc-button-ripple',
-    });
-
-    const element = this._elementRef.nativeElement;
+    const config = inject(MAT_BUTTON_CONFIG, {optional: true});
+    const element = _elementRef.nativeElement;
     const classList = (element as HTMLElement).classList;
+
+    this.disabledInteractive = config?.disabledInteractive ?? false;
+    this._rippleLoader?.configureRipple(element, {className: 'mat-mdc-button-ripple'});
 
     // For each of the variant selectors that is present in the button's host
     // attributes, add the correct corresponding MDC classes.
@@ -150,12 +182,24 @@ export class MatButtonBase implements AfterViewInit, OnDestroy {
   }
 
   /** Focuses the button. */
-  focus(_origin: FocusOrigin = 'program', options?: FocusOptions): void {
-    if (_origin) {
-      this._focusMonitor.focusVia(this._elementRef.nativeElement, _origin, options);
+  focus(origin: FocusOrigin = 'program', options?: FocusOptions): void {
+    if (origin) {
+      this._focusMonitor.focusVia(this._elementRef.nativeElement, origin, options);
     } else {
       this._elementRef.nativeElement.focus(options);
     }
+  }
+
+  protected _getAriaDisabled() {
+    if (this.ariaDisabled != null) {
+      return this.ariaDisabled;
+    }
+
+    return this.disabled && this.disabledInteractive ? true : null;
+  }
+
+  protected _getDisabledAttribute() {
+    return this.disabledInteractive || !this.disabled ? null : true;
   }
 
   private _updateRippleDisabled(): void {
@@ -168,14 +212,16 @@ export class MatButtonBase implements AfterViewInit, OnDestroy {
 
 /** Shared host configuration for buttons using the `<a>` tag. */
 export const MAT_ANCHOR_HOST = {
-  '[attr.disabled]': 'disabled || null',
+  '[attr.disabled]': '_getDisabledAttribute()',
+  '[class.mat-mdc-button-disabled]': 'disabled',
+  '[class.mat-mdc-button-disabled-interactive]': 'disabledInteractive',
   '[class._mat-animation-noopable]': '_animationMode === "NoopAnimations"',
 
   // Note that we ignore the user-specified tabindex when it's disabled for
   // consistency with the `mat-button` applied on native buttons where even
   // though they have an index, they're not tabbable.
-  '[attr.tabindex]': 'disabled ? -1 : tabIndex',
-  '[attr.aria-disabled]': 'disabled.toString()',
+  '[attr.tabindex]': 'disabled && !disabledInteractive ? -1 : tabIndex',
+  '[attr.aria-disabled]': '_getDisabledAttribute()',
   // MDC automatically applies the primary theme color to the button, but we want to support
   // an unthemed version. If color is undefined, apply a CSS class that makes it easy to
   // select and style this "theme".
@@ -220,4 +266,8 @@ export class MatAnchorBase extends MatButtonBase implements OnInit, OnDestroy {
       event.stopImmediatePropagation();
     }
   };
+
+  protected override _getAriaDisabled() {
+    return this.ariaDisabled == null ? this.disabled : this.ariaDisabled;
+  }
 }

--- a/src/material/button/button.md
+++ b/src/material/button/button.md
@@ -45,6 +45,19 @@ not.
 </button>
 ```
 
+### Interactive disabled buttons
+Native disabled `<button>` elements cannot receive focus and do not dispatch any events. This can
+be problematic in some cases because it can prevent the app from telling the user why the button is
+disabled. You can use the `disabledInteractive` input to style the button as disabled but allow for
+it to receive focus and dispatch events. The button will have `aria-disabled="true"` for assistive
+technology. The behavior can be configured globally through the `MAT_BUTTON_CONFIG` injection token.
+
+**Note:** Using the `disabledInteractive` input can result in buttons that previously prevented
+actions to no longer do so, for example a submit button in a form. When using this input, you should
+guard against such cases in your component.
+
+<!-- example(button-disabled-interactive) -->
+
 ### Accessibility
 Angular Material uses native `<button>` and `<a>` elements to ensure an accessible experience by
 default. A `<button>` element should be used for any interaction that _performs an action on the

--- a/src/material/button/button.scss
+++ b/src/material/button/button.scss
@@ -79,7 +79,7 @@
         @include token-utils.create-token-slot(background-color, disabled-container-color);
 
         // Since we're still doing elevation through the theme, we need additional specificity here.
-        &[disabled] {
+        &.mat-mdc-button-disabled {
           box-shadow: none;
         }
       }

--- a/src/material/button/button.spec.ts
+++ b/src/material/button/button.spec.ts
@@ -39,6 +39,21 @@ describe('MDC-based MatButton', () => {
     expect(aDebugElement.nativeElement.classList).not.toContain('mat-accent');
   });
 
+  it('should apply class based on the disabled state', () => {
+    const fixture = TestBed.createComponent(TestApp);
+    const button = fixture.debugElement.query(By.css('button'))!.nativeElement;
+    const anchor = fixture.debugElement.query(By.css('a'))!.nativeElement;
+
+    expect(button.classList).not.toContain('mat-mdc-button-disabled');
+    expect(anchor.classList).not.toContain('mat-mdc-button-disabled');
+
+    fixture.componentInstance.isDisabled = true;
+    fixture.detectChanges();
+
+    expect(button.classList).toContain('mat-mdc-button-disabled');
+    expect(anchor.classList).toContain('mat-mdc-button-disabled');
+  });
+
   it('should expose the ripple instance', () => {
     const fixture = TestBed.createComponent(TestApp);
     fixture.detectChanges();
@@ -181,7 +196,7 @@ describe('MDC-based MatButton', () => {
       let testComponent = fixture.debugElement.componentInstance;
       let buttonDebugElement = fixture.debugElement.query(By.css('a'))!;
       fixture.detectChanges();
-      expect(buttonDebugElement.nativeElement.getAttribute('aria-disabled')).toBe('false');
+      expect(buttonDebugElement.nativeElement.hasAttribute('aria-disabled')).toBe(false);
 
       testComponent.isDisabled = true;
       fixture.detectChanges();
@@ -193,21 +208,13 @@ describe('MDC-based MatButton', () => {
       let testComponent = fixture.debugElement.componentInstance;
       let buttonDebugElement = fixture.debugElement.query(By.css('a'))!;
       fixture.detectChanges();
-      expect(buttonDebugElement.nativeElement.getAttribute('aria-disabled'))
-        .withContext('Expect aria-disabled="false"')
-        .toBe('false');
-      expect(buttonDebugElement.nativeElement.getAttribute('disabled'))
-        .withContext('Expect disabled="false"')
-        .toBeNull();
+      expect(buttonDebugElement.nativeElement.hasAttribute('aria-disabled')).toBe(false);
+      expect(buttonDebugElement.nativeElement.getAttribute('disabled')).toBeNull();
 
       testComponent.isDisabled = false;
       fixture.detectChanges();
-      expect(buttonDebugElement.nativeElement.getAttribute('aria-disabled'))
-        .withContext('Expect no aria-disabled')
-        .toBe('false');
-      expect(buttonDebugElement.nativeElement.getAttribute('disabled'))
-        .withContext('Expect no disabled')
-        .toBeNull();
+      expect(buttonDebugElement.nativeElement.hasAttribute('aria-disabled')).toBe(false);
+      expect(buttonDebugElement.nativeElement.getAttribute('disabled')).toBeNull();
     });
 
     it('should be able to set a custom tabindex', () => {
@@ -349,6 +356,45 @@ describe('MDC-based MatButton', () => {
       buttonNativeElements.every(element => !!element.querySelector('.mat-mdc-focus-indicator')),
     ).toBe(true);
   });
+
+  describe('interactive disabled buttons', () => {
+    let fixture: ComponentFixture<TestApp>;
+    let button: HTMLButtonElement;
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(TestApp);
+      fixture.componentInstance.isDisabled = true;
+      fixture.detectChanges();
+      button = fixture.debugElement.query(By.css('button'))!.nativeElement;
+    });
+
+    it('should set a class when allowing disabled interactivity', () => {
+      expect(button.classList).not.toContain('mat-mdc-button-disabled-interactive');
+
+      fixture.componentInstance.disabledInteractive = true;
+      fixture.detectChanges();
+
+      expect(button.classList).toContain('mat-mdc-button-disabled-interactive');
+    });
+
+    it('should set aria-disabled when allowing disabled interactivity', () => {
+      expect(button.hasAttribute('aria-disabled')).toBe(false);
+
+      fixture.componentInstance.disabledInteractive = true;
+      fixture.detectChanges();
+
+      expect(button.getAttribute('aria-disabled')).toBe('true');
+    });
+
+    it('should not set the disabled attribute when allowing disabled interactivity', () => {
+      expect(button.getAttribute('disabled')).toBe('true');
+
+      fixture.componentInstance.disabledInteractive = true;
+      fixture.detectChanges();
+
+      expect(button.hasAttribute('disabled')).toBe(false);
+    });
+  });
 });
 
 describe('MatFabDefaultOptions', () => {
@@ -383,11 +429,12 @@ describe('MatFabDefaultOptions', () => {
   selector: 'test-app',
   template: `
     <button [tabIndex]="tabIndex" mat-button type="button" (click)="increment()"
-      [disabled]="isDisabled" [color]="buttonColor" [disableRipple]="rippleDisabled">
+      [disabled]="isDisabled" [color]="buttonColor" [disableRipple]="rippleDisabled"
+      [disabledInteractive]="disabledInteractive">
       Go
     </button>
     <a [tabIndex]="tabIndex" href="https://www.google.com" mat-button [disabled]="isDisabled"
-      [color]="buttonColor">
+      [color]="buttonColor" [disabledInteractive]="disabledInteractive">
       Link
     </a>
     <button mat-fab>Fab Button</button>
@@ -398,12 +445,13 @@ describe('MatFabDefaultOptions', () => {
   imports: [MatButtonModule],
 })
 class TestApp {
-  clickCount: number = 0;
-  isDisabled: boolean = false;
-  rippleDisabled: boolean = false;
+  clickCount = 0;
+  isDisabled = false;
+  rippleDisabled = false;
   buttonColor: ThemePalette;
   tabIndex: number;
-  extended: boolean = false;
+  extended = false;
+  disabledInteractive = false;
 
   increment() {
     this.clickCount++;

--- a/src/material/button/fab.scss
+++ b/src/material/button/fab.scss
@@ -61,6 +61,11 @@
   @include button-base.mat-private-button-disabled {
     @include elevation.elevation(0);
 
+    // Necessary for interactive disabled buttons.
+    &:focus {
+      @include elevation.elevation(0);
+    }
+
     @include token-utils.use-tokens(tokens-mat-fab.$prefix, tokens-mat-fab.get-token-slots()) {
       @include token-utils.create-token-slot(color, disabled-state-foreground-color);
       @include token-utils.create-token-slot(background-color, disabled-state-container-color);

--- a/src/material/button/public-api.ts
+++ b/src/material/button/public-api.ts
@@ -10,3 +10,4 @@ export * from './button';
 export * from './fab';
 export * from './icon-button';
 export * from './module';
+export {MAT_BUTTON_CONFIG, MatButtonConfig} from './button-base';

--- a/src/material/button/testing/button-harness.ts
+++ b/src/material/button/testing/button-harness.ts
@@ -60,8 +60,11 @@ export class MatButtonHarness extends ContentContainerComponentHarness {
 
   /** Gets a boolean promise indicating if the button is disabled. */
   async isDisabled(): Promise<boolean> {
-    const disabled = (await this.host()).getAttribute('disabled');
-    return booleanAttribute(await disabled);
+    const host = await this.host();
+    return (
+      booleanAttribute(await host.getAttribute('disabled')) ||
+      (await host.hasClass('mat-mdc-button-disabled'))
+    );
   }
 
   /** Gets a promise for the button's label text. */

--- a/src/material/core/tokens/m2/mat/_fab.scss
+++ b/src/material/core/tokens/m2/mat/_fab.scss
@@ -30,6 +30,9 @@ $prefix: (mat, fab);
     // Color of the element that shows the hover, focus and pressed states.
     state-layer-color: $on-surface,
 
+    // Color of the element that shows the hover, focus and pressed states while disabled.
+    disabled-state-layer-color: $on-surface,
+
     // Color of the ripple element.
     ripple-color: rgba($on-surface, 0.1),
 

--- a/src/material/core/tokens/m2/mat/_filled-button.scss
+++ b/src/material/core/tokens/m2/mat/_filled-button.scss
@@ -27,6 +27,9 @@ $prefix: (mat, filled-button);
     // Color of the element that shows the hover, focus and pressed states.
     state-layer-color: $on-surface,
 
+    // Color of the element that shows the hover, focus and pressed states while disabled.
+    disabled-state-layer-color: $on-surface,
+
     // Color of the ripple element.
     ripple-color: rgba($on-surface, 0.1),
 

--- a/src/material/core/tokens/m2/mat/_icon-button.scss
+++ b/src/material/core/tokens/m2/mat/_icon-button.scss
@@ -27,6 +27,9 @@ $prefix: (mat, icon-button);
     // Color of the element that shows the hover, focus and pressed states.
     state-layer-color: $on-surface,
 
+    // Color of the element that shows the hover, focus and pressed states while disabled.
+    disabled-state-layer-color: $on-surface,
+
     // Color of the ripple element.
     ripple-color: rgba($on-surface, 0.1),
 

--- a/src/material/core/tokens/m2/mat/_outlined-button.scss
+++ b/src/material/core/tokens/m2/mat/_outlined-button.scss
@@ -27,6 +27,9 @@ $prefix: (mat, outlined-button);
     // Color of the element that shows the hover, focus and pressed states.
     state-layer-color: $on-surface,
 
+    // Color of the element that shows the hover, focus and pressed states while disabled.
+    disabled-state-layer-color: $on-surface,
+
     // Color of the ripple element.
     ripple-color: rgba($on-surface, 0.1),
 

--- a/src/material/core/tokens/m2/mat/_protected-button.scss
+++ b/src/material/core/tokens/m2/mat/_protected-button.scss
@@ -27,6 +27,9 @@ $prefix: (mat, protected-button);
     // Color of the element that shows the hover, focus and pressed states.
     state-layer-color: $on-surface,
 
+    // Color of the element that shows the hover, focus and pressed states while disabled.
+    disabled-state-layer-color: $on-surface,
+
     // Color of the ripple element.
     ripple-color: rgba($on-surface, 0.1),
 

--- a/src/material/core/tokens/m2/mat/_text-button.scss
+++ b/src/material/core/tokens/m2/mat/_text-button.scss
@@ -27,6 +27,9 @@ $prefix: (mat, text-button);
     // Color of the element that shows the hover, focus and pressed states.
     state-layer-color: $on-surface,
 
+    // Color of the element that shows the hover, focus and pressed states while disabled.
+    disabled-state-layer-color: $on-surface,
+
     // Color of the ripple element.
     ripple-color: rgba($on-surface, 0.1),
 

--- a/tools/public_api_guard/material/button.md
+++ b/tools/public_api_guard/material/button.md
@@ -19,6 +19,9 @@ import { Platform } from '@angular/cdk/platform';
 import { ThemePalette } from '@angular/material/core';
 
 // @public
+export const MAT_BUTTON_CONFIG: InjectionToken<MatButtonConfig>;
+
+// @public
 export const MAT_FAB_DEFAULT_OPTIONS: InjectionToken<MatFabDefaultOptions>;
 
 // @public
@@ -40,6 +43,11 @@ export class MatButton extends MatButtonBase {
     static ɵcmp: i0.ɵɵComponentDeclaration<MatButton, "    button[mat-button], button[mat-raised-button], button[mat-flat-button],    button[mat-stroked-button]  ", ["matButton"], {}, {}, never, [".material-icons:not([iconPositionEnd]), mat-icon:not([iconPositionEnd]), [matButtonIcon]:not([iconPositionEnd])", "*", ".material-icons[iconPositionEnd], mat-icon[iconPositionEnd], [matButtonIcon][iconPositionEnd]"], true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatButton, [null, null, null, { optional: true; }]>;
+}
+
+// @public
+export interface MatButtonConfig {
+    disabledInteractive?: boolean;
 }
 
 // @public (undocumented)


### PR DESCRIPTION
Native disabled buttons don't allow focus and prevent the button from dispatching events. In some cases this can be problematic, because it prevents the app from showing to the user why the button is disabled.

These changes introduce a new opt-in input that will style buttons as disabled and set `aria-disabled="true"`, but not set the native `disabled` attribute, allowing them to be interactive.

**Note for reviewers:** there's an example of the feature in the button demo, but you have to scroll down and check the "Allow disabled button interactivity" checkbox. Afterwards you should see tooltips when hovering over the disabled buttons.