### PR TITLE
fix(material/select): remove unnecessary announcement

### DIFF
--- a/src/material/select/BUILD.bazel
+++ b/src/material/select/BUILD.bazel
@@ -63,7 +63,6 @@ ng_test_library(
     ),
     deps = [
         ":select",
-        "//src/cdk/a11y",
         "//src/cdk/bidi",
         "//src/cdk/keycodes",
         "//src/cdk/overlay",

--- a/src/material/select/select.spec.ts
+++ b/src/material/select/select.spec.ts
@@ -39,7 +39,6 @@ import {
   ComponentFixture,
   fakeAsync,
   flush,
-  inject,
   TestBed,
   tick,
 } from '@angular/core/testing';
@@ -63,7 +62,6 @@ import {
 } from '@angular/material/form-field';
 import {By} from '@angular/platform-browser';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
-import {LiveAnnouncer} from '@angular/cdk/a11y';
 import {Subject, Subscription, EMPTY, Observable} from 'rxjs';
 import {map} from 'rxjs/operators';
 import {MatSelectModule} from './index';
@@ -504,18 +502,6 @@ describe('MDC-based MatSelect', () => {
             .toBe(options[1].value);
           flush();
         }));
-
-        it('should announce changes via the keyboard on a closed select', fakeAsync(
-          inject([LiveAnnouncer], (liveAnnouncer: LiveAnnouncer) => {
-            spyOn(liveAnnouncer, 'announce');
-
-            dispatchKeyboardEvent(select, 'keydown', RIGHT_ARROW);
-
-            expect(liveAnnouncer.announce).toHaveBeenCalledWith('Steak', jasmine.any(Number));
-
-            flush();
-          }),
-        ));
 
         it('should not throw when reaching a reset option using the arrow keys on a closed select', fakeAsync(() => {
           fixture.componentInstance.foods = [

--- a/src/material/select/select.ts
+++ b/src/material/select/select.ts
@@ -937,14 +937,6 @@ export class MatSelect
     } else if (!this.multiple) {
       const previouslySelectedOption = this.selected;
       manager.onKeydown(event);
-      const selectedOption = this.selected;
-
-      // Since the value has changed, we need to announce it ourselves.
-      if (selectedOption && previouslySelectedOption !== selectedOption) {
-        // We set a duration on the live announcement, because we want the live element to be
-        // cleared after a while so that users can't navigate to it using the arrow keys.
-        this._liveAnnouncer.announce((selectedOption as MatOption).viewValue, 10000);
-      }
     }
   }
 


### PR DESCRIPTION
Fix accessibility issue in MatSelect component. Remove announcement when making selections while popup is closed. Address disruption announcement causes when using MatSelect with assistive technology. Address difficultly using MatSelect with Braile device.