### PR TITLE
docs(material/chips): remove instructions to announce deletion

### DIFF
--- a/src/material/chips/chips.md
+++ b/src/material/chips/chips.md
@@ -191,6 +191,4 @@ When using MatChipListbox, never nest other interactive controls inside of the `
 
 By default, `MatChipListbox` displays a checkmark to identify selected items. While you can hide the checkmark indicator for single-selection via `hideSingleSelectionIndicator`, this makes the component less accessible by making it harder or impossible for users to visually identify selected items.
 
-When using `MatChipRemove`, you should always communicate removals for assistive technology. One way to accomplish this is by sending a message with `LiveAnnouncer`. Otherwise, removing a chip may only be communicated visually.
-
 When a chip is editable, provide instructions to assistive technology how to edit the chip using a keyboard. One way to accomplish this is adding an `aria-description` attribute with instructions to press enter to edit the chip.


### PR DESCRIPTION
Update Chips a11y documentation. Remove instructions to make an announcement when deleting chips.

Remove the call to LiveAnnouncer. Remove unnecessary live regions to avoid disrupting users who use Assistive Technology.