### PR TITLE
FIX: Example of mat-tabs deletion is showing wrong index

### DIFF
--- a/src/components-examples/material/tabs/tab-group-dynamic/tab-group-dynamic-example.ts
+++ b/src/components-examples/material/tabs/tab-group-dynamic/tab-group-dynamic-example.ts
@@ -38,5 +38,6 @@ export class TabGroupDynamicExample {
 
   removeTab(index: number) {
     this.tabs.splice(index, 1);
+    this.selected.setValue(index);
   }
 }


### PR DESCRIPTION
bug(mat-tabs): Example of mat-tabs deletion is showing wrong index : FIXED
Set Selected value at time of splicing the array