### PR TITLE
docs(material/slider): value should go in the input tag

### DIFF
--- a/src/material/slider/slider.md
+++ b/src/material/slider/slider.md
@@ -11,7 +11,7 @@ respectively. The initial value is set to the minimum value unless otherwise spe
 
 ```html
 <mat-slider min="1" max="5" step="0.5">
-<input matSliderThumb value="1.5">
+  <input matSliderThumb value="1.5">
 </mat-slider>
 ```
 

--- a/src/material/slider/slider.md
+++ b/src/material/slider/slider.md
@@ -10,8 +10,8 @@ in increments of `1`. These values can be changed by setting the `min`, `max`, a
 respectively. The initial value is set to the minimum value unless otherwise specified.
 
 ```html
-<mat-slider min="1" max="5" step="0.5" value="1.5">
-  <input matSliderThumb>
+<mat-slider min="1" max="5" step="0.5">
+  <input matSliderThumb value="1.5">
 </mat-slider>
 ```
 

--- a/src/material/slider/slider.md
+++ b/src/material/slider/slider.md
@@ -11,7 +11,7 @@ respectively. The initial value is set to the minimum value unless otherwise spe
 
 ```html
 <mat-slider min="1" max="5" step="0.5">
-  <input matSliderThumb value="1.5">
+<input matSliderThumb value="1.5">
 </mat-slider>
 ```
 


### PR DESCRIPTION
this screen is correct
![Screen Shot 2023-12-09 at 8 12 10 PM](https://github.com/angular/components/assets/15058177/424d941e-e81f-43da-9f12-04d167088b7d)
but this screen is wrong because the value should go in the input tag
![Screen Shot 2023-12-09 at 8 13 10 PM](https://github.com/angular/components/assets/15058177/607cf309-069c-41cf-91ac-235825bc2361)