### PR TITLE
fix(material/chips): enable hydration

### DIFF
--- a/src/material/chips/chip-listbox.ts
+++ b/src/material/chips/chip-listbox.ts
@@ -74,7 +74,6 @@ export const MAT_CHIP_LISTBOX_CONTROL_VALUE_ACCESSOR: any = {
     '[attr.aria-disabled]': 'disabled.toString()',
     '[attr.aria-multiselectable]': 'multiple',
     '[attr.aria-orientation]': 'ariaOrientation',
-    'ngSkipHydration': '',
     '[class.mat-mdc-chip-list-disabled]': 'disabled',
     '[class.mat-mdc-chip-list-required]': 'required',
     '(focus)': 'focus()',

--- a/src/universal-app/kitchen-sink/kitchen-sink.html
+++ b/src/universal-app/kitchen-sink/kitchen-sink.html
@@ -85,10 +85,10 @@
   <mat-basic-chip>Basic Chip 3</mat-basic-chip>
 </mat-chip-set>
 
-<mat-chip-listbox>
+<mat-chip-listbox multiple>
   <mat-chip-option>Extra Small</mat-chip-option>
-  <mat-chip-option>Small</mat-chip-option>
-  <mat-chip-option>Medium</mat-chip-option>
+  <mat-chip-option selected>Small</mat-chip-option>
+  <mat-chip-option selected disabled>Medium</mat-chip-option>
   <mat-chip-option>Large</mat-chip-option>
 </mat-chip-listbox>
 


### PR DESCRIPTION
Removes the `ngSkipHydration` from `mat-chip-listbox` since it seems to work fine in the test app.