### PR TITLE
fix(google-maps): missing setZoom()

### DIFF
--- a/src/google-maps/google-map/google-map.ts
+++ b/src/google-maps/google-map/google-map.ts
@@ -449,6 +449,15 @@ export class GoogleMap implements OnChanges, OnInit, OnDestroy {
 
   /**
    * See
+   * https://developers.google.com/maps/documentation/javascript/reference/map#Map.setZoom
+   */
+  setZoom(zoom: number): void {
+    this._assertInitialized();
+    this.googleMap.setZoom(zoom);
+  }
+
+  /**
+   * See
    * https://developers.google.com/maps/documentation/javascript/reference/map#Map.controls
    */
   get controls(): google.maps.MVCArray<Node>[] {


### PR DESCRIPTION
Exposes the setZoom() method made available by  the underlying Google Maps API.

Fixes [Issue #25274 ](https://github.com/angular/components/issues/25274)