### PR TITLE
fix(material/form-field): failing color contrast text to bg color ratio

### DIFF
--- a/src/material/core/tokens/m2/mat/_form-field.scss
+++ b/src/material/core/tokens/m2/mat/_form-field.scss
@@ -45,7 +45,7 @@ $prefix: (mat, form-field);
     disabled-select-arrow-color: rgba($on-surface, 0.38),
 
     hover-state-layer-opacity: if($is-dark, 0.08, 0.04),
-    focus-state-layer-opacity: if($is-dark, 0.24, 0.12),
+    focus-state-layer-opacity: if($is-dark, 0.24, 0.08),
   ));
 }
 


### PR DESCRIPTION

Removes :hover and .mat-focused opacity changes to .form-field-focus-overlay 
which was causing a low color contrast ratio between the text and form-field input
background fill color.