### PR TITLE
fix(material/paginator): match visual and reading order

### DIFF
--- a/src/material/paginator/paginator.scss
+++ b/src/material/paginator/paginator.scss
@@ -56,7 +56,7 @@ $button-icon-size: 28px;
   align-items: center;
   justify-content: flex-end;
   padding: $padding;
-  flex-wrap: wrap-reverse;
+  flex-wrap: wrap;
   width: 100%;
 
   @include token-utils.use-tokens(


### PR DESCRIPTION
Fix accessibility issue in MatPaginator component. When screen is narrow, maintain the visual order with the DOM order.

Current behavior is swappign visual order of "Items Per Page" and "1 of 4" on narrow screens. With this commit applied, no longer swap the order.