### PR TITLE
feat(google-maps): add support for dynamic library loading API

### DIFF
--- a/src/dev-app/google-map/google-map-demo.ts
+++ b/src/dev-app/google-map/google-map-demo.ts
@@ -123,7 +123,7 @@ export class GoogleMapDemo {
   };
 
   isGroundOverlayDisplayed = false;
-  hasLoaded: boolean;
+  hasLoaded = false;
   groundOverlayImages = [
     {
       title: 'Red logo',
@@ -284,24 +284,14 @@ export class GoogleMapDemo {
   }
 
   private _loadApi() {
-    this.hasLoaded = !!window.google?.maps;
-
     if (this.hasLoaded) {
       return;
     }
 
     if (!apiLoadingPromise) {
-      // Key can be set through the `GOOGLE_MAPS_KEY` environment variable.
-      const apiKey: string | undefined = (window as any).GOOGLE_MAPS_KEY;
-
-      apiLoadingPromise = Promise.all([
-        this._loadScript(
-          `https://maps.googleapis.com/maps/api/js?libraries=visualization${
-            apiKey ? `&key=${apiKey}` : ''
-          }`,
-        ),
-        this._loadScript('https://unpkg.com/@googlemaps/markerclustererplus/dist/index.min.js'),
-      ]);
+      apiLoadingPromise = this._loadScript(
+        'https://unpkg.com/@googlemaps/markerclustererplus/dist/index.min.js',
+      );
     }
 
     apiLoadingPromise.then(

--- a/src/dev-app/index.html
+++ b/src/dev-app/index.html
@@ -18,5 +18,11 @@
   <dev-app>Loading...</dev-app>
   <script src="zone.js/bundles/zone.umd.js"></script>
   <script src="bundles/dev-app/main.js" type="module"></script>
+  <script>
+    (g=>{var h,a,k,p="The Google Maps JavaScript API",c="google",l="importLibrary",q="__ib__",m=document,b=window;b=b[c]||(b[c]={});var d=b.maps||(b.maps={}),r=new Set,e=new URLSearchParams,u=()=>h||(h=new Promise(async(f,n)=>{await (a=m.createElement("script"));e.set("libraries",[...r]+"");for(k in g)e.set(k.replace(/[A-Z]/g,t=>"_"+t[0].toLowerCase()),g[k]);e.set("callback",c+".maps."+q);a.src=`https://maps.${c}apis.com/maps/api/js?`+e;d[q]=f;a.onerror=()=>h=n(Error(p+" could not load."));a.nonce=m.querySelector("script[nonce]")?.nonce||"";m.head.append(a)}));d[l]?console.warn(p+" only loads once. Ignoring:",g):d[l]=(f,...n)=>r.add(f)&&u().then(()=>d[l](f,...n))})({
+      v: "weekly",
+      key: window.GOOGLE_MAPS_KEY || 'invalid'
+    });
+  </script>
 </body>
 </html>

--- a/src/google-maps/README.md
+++ b/src/google-maps/README.md
@@ -14,62 +14,24 @@ Follow [these steps](https://developers.google.com/maps/gmp-get-started) to get 
 
 ## Loading the API
 
-The API can be loaded when the component is actually used by using the Angular HttpClient jsonp
-method to make sure that the component doesn't load until after the API has loaded.
-
-```typescript
-// google-maps-demo.module.ts
-
-import { NgModule } from '@angular/core';
-import { provideHttpClient, withJsonpSupport } from '@angular/common/http';
-
-import { GoogleMapsDemoComponent } from './google-maps-demo.component';
-
-@NgModule({
-  imports: [GoogleMapsDemoComponent],
-  providers: [provideHttpClient(withJsonpSupport())]
-})
-export class GoogleMapsDemoModule {}
-
-
-// google-maps-demo.component.ts
-
-import { Component } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
-import { GoogleMap } from '@angular/google-maps';
-import { Observable, of } from 'rxjs';
-import { catchError, map } from 'rxjs/operators';
-
-@Component({
-  selector: 'google-maps-demo',
-  templateUrl: './google-maps-demo.component.html',
-  standalone: true,
-  imports: [GoogleMap]
-})
-export class GoogleMapsDemoComponent {
-  apiLoaded: Observable<boolean>;
-
-  constructor(httpClient: HttpClient) {
-    // If you're using the `<map-heatmap-layer>` directive, you also have to include the `visualization` library
-    // when loading the Google Maps API. To do so, you can add `&libraries=visualization` to the script URL:
-    // https://maps.googleapis.com/maps/api/js?key=YOUR_API_KEY&libraries=visualization
-
-    this.apiLoaded = httpClient.jsonp('https://maps.googleapis.com/maps/api/js?key=YOUR_KEY_HERE', 'callback')
-        .pipe(
-          map(() => true),
-          catchError(() => of(false)),
-        );
-  }
-}
-```
+Include the [Dynamic Library Import script](https://developers.google.com/maps/documentation/javascript/load-maps-js-api#dynamic-library-import) in the `index.html` of your app. When a Google Map is being rendered, it'll use the Dynamic Import API to load the necessary JavaScript automatically.
 
 ```html
-<!-- google-maps-demo.component.html -->
-
-@if (apiLoaded | async) {
-  <google-map />
-}
+<!-- index.html -->
+<!DOCTYPE html>
+<body>
+  ...
+  <script>
+    (g=>{var h,a,k,p="The Google Maps JavaScript API",c="google",l="importLibrary",q="__ib__",m=document,b=window;b=b[c]||(b[c]={});var d=b.maps||(b.maps={}),r=new Set,e=new URLSearchParams,u=()=>h||(h=new Promise(async(f,n)=>{await (a=m.createElement("script"));e.set("libraries",[...r]+"");for(k in g)e.set(k.replace(/[A-Z]/g,t=>"_"+t[0].toLowerCase()),g[k]);e.set("callback",c+".maps."+q);a.src=`https://maps.${c}apis.com/maps/api/js?`+e;d[q]=f;a.onerror=()=>h=n(Error(p+" could not load."));a.nonce=m.querySelector("script[nonce]")?.nonce||"";m.head.append(a)}));d[l]?console.warn(p+" only loads once. Ignoring:",g):d[l]=(f,...n)=>r.add(f)&&u().then(()=>d[l](f,...n))})({
+      v: "weekly",
+      key: YOUR_API_KEY_GOES_HERE
+    });
+  </script>
+</body>
+</html>
 ```
+
+**Note:** the component also supports loading the API using the [legacy script tag](https://developers.google.com/maps/documentation/javascript/load-maps-js-api#use-legacy-tag), however it isn't recommended because it requires all of the Google Maps JavaScript to be loaded up-front, even if it isn't used.
 
 ## Components
 

--- a/src/google-maps/google-map/google-map.spec.ts
+++ b/src/google-maps/google-map/google-map.spec.ts
@@ -116,7 +116,7 @@ describe('GoogleMap', () => {
   it('sets center and zoom of the map', () => {
     const options = {center: {lat: 3, lng: 5}, zoom: 7, mapTypeId: DEFAULT_OPTIONS.mapTypeId};
     mapSpy = createMapSpy(options);
-    mapConstructorSpy = createMapConstructorSpy(mapSpy).and.callThrough();
+    mapConstructorSpy = createMapConstructorSpy(mapSpy);
 
     const fixture = TestBed.createComponent(TestApp);
     fixture.componentInstance.center = options.center;
@@ -142,7 +142,7 @@ describe('GoogleMap', () => {
       mapTypeId: DEFAULT_OPTIONS.mapTypeId,
     };
     mapSpy = createMapSpy(options);
-    mapConstructorSpy = createMapConstructorSpy(mapSpy).and.callThrough();
+    mapConstructorSpy = createMapConstructorSpy(mapSpy);
 
     const fixture = TestBed.createComponent(TestApp);
     fixture.componentInstance.options = options;
@@ -160,7 +160,7 @@ describe('GoogleMap', () => {
   it('should set a default center if the custom options do not provide one', () => {
     const options = {zoom: 7};
     mapSpy = createMapSpy(options);
-    mapConstructorSpy = createMapConstructorSpy(mapSpy).and.callThrough();
+    mapConstructorSpy = createMapConstructorSpy(mapSpy);
 
     const fixture = TestBed.createComponent(TestApp);
     fixture.componentInstance.options = options;
@@ -172,7 +172,7 @@ describe('GoogleMap', () => {
   it('should set a default zoom level if the custom options do not provide one', () => {
     const options = {};
     mapSpy = createMapSpy(options);
-    mapConstructorSpy = createMapConstructorSpy(mapSpy).and.callThrough();
+    mapConstructorSpy = createMapConstructorSpy(mapSpy);
 
     const fixture = TestBed.createComponent(TestApp);
     fixture.componentInstance.options = options;
@@ -184,7 +184,7 @@ describe('GoogleMap', () => {
   it('should not set a default zoom level if the custom options provide "zoom: 0"', () => {
     const options = {zoom: 0};
     mapSpy = createMapSpy(options);
-    mapConstructorSpy = createMapConstructorSpy(mapSpy).and.callThrough();
+    mapConstructorSpy = createMapConstructorSpy(mapSpy);
 
     const fixture = TestBed.createComponent(TestApp);
     fixture.componentInstance.options = options;
@@ -216,7 +216,7 @@ describe('GoogleMap', () => {
 
   it('exposes methods that change the configuration of the Google Map', () => {
     mapSpy = createMapSpy(DEFAULT_OPTIONS);
-    createMapConstructorSpy(mapSpy).and.callThrough();
+    createMapConstructorSpy(mapSpy);
 
     const fixture = TestBed.createComponent(TestApp);
     fixture.detectChanges();
@@ -238,7 +238,7 @@ describe('GoogleMap', () => {
 
   it('exposes methods that get information about the Google Map', () => {
     mapSpy = createMapSpy(DEFAULT_OPTIONS);
-    createMapConstructorSpy(mapSpy).and.callThrough();
+    createMapConstructorSpy(mapSpy);
 
     const fixture = TestBed.createComponent(TestApp);
     fixture.detectChanges();
@@ -275,7 +275,7 @@ describe('GoogleMap', () => {
 
   it('initializes event handlers that are set on the map', () => {
     mapSpy = createMapSpy(DEFAULT_OPTIONS);
-    createMapConstructorSpy(mapSpy).and.callThrough();
+    createMapConstructorSpy(mapSpy);
 
     const addSpy = mapSpy.addListener;
     const fixture = TestBed.createComponent(TestApp);
@@ -303,7 +303,7 @@ describe('GoogleMap', () => {
 
   it('should be able to add an event listener after init', () => {
     mapSpy = createMapSpy(DEFAULT_OPTIONS);
-    createMapConstructorSpy(mapSpy).and.callThrough();
+    createMapConstructorSpy(mapSpy);
 
     const addSpy = mapSpy.addListener;
     const fixture = TestBed.createComponent(TestApp);
@@ -321,7 +321,7 @@ describe('GoogleMap', () => {
 
   it('should set the map type', () => {
     mapSpy = createMapSpy(DEFAULT_OPTIONS);
-    mapConstructorSpy = createMapConstructorSpy(mapSpy).and.callThrough();
+    mapConstructorSpy = createMapConstructorSpy(mapSpy);
 
     const fixture = TestBed.createComponent(TestApp);
     fixture.componentInstance.mapTypeId = 'terrain' as unknown as google.maps.MapTypeId;
@@ -341,7 +341,7 @@ describe('GoogleMap', () => {
   it('sets mapTypeId through the options', () => {
     const options = {mapTypeId: 'satellite'};
     mapSpy = createMapSpy(options);
-    mapConstructorSpy = createMapConstructorSpy(mapSpy).and.callThrough();
+    mapConstructorSpy = createMapConstructorSpy(mapSpy);
     const fixture = TestBed.createComponent(TestApp);
     fixture.componentInstance.options = options;
     fixture.detectChanges();

--- a/src/google-maps/google-map/google-map.ts
+++ b/src/google-maps/google-map/google-map.ts
@@ -30,6 +30,7 @@ import {isPlatformBrowser} from '@angular/common';
 import {Observable} from 'rxjs';
 import {MapEventManager} from '../map-event-manager';
 import {take} from 'rxjs/operators';
+import {importLibrary} from '../import-library';
 
 interface GoogleMapsWindow extends Window {
   gm_authFailure?: () => void;
@@ -310,8 +311,7 @@ export class GoogleMap implements OnChanges, OnInit, OnDestroy {
       // user has subscribed to.
       this._ngZone.runOutsideAngular(async () => {
         const mapConstructor =
-          google.maps.Map ||
-          ((await google.maps.importLibrary('maps')) as google.maps.MapsLibrary).Map;
+          google.maps.Map || (await importLibrary<google.maps.Map>('maps', 'Map'));
         this.googleMap = new mapConstructor(this._mapEl, this._combineOptions());
         this._eventManager.setTarget(this.googleMap);
         this.mapInitialized.emit(this.googleMap);

--- a/src/google-maps/import-library.ts
+++ b/src/google-maps/import-library.ts
@@ -7,9 +7,8 @@
  */
 
 /** Imports a Google Maps library. */
-export async function importLibrary<T>(name: string, symbol: string): Promise<T> {
+export function importLibrary<T>(name: string, symbol: string): Promise<T> {
   // TODO(crisbeto): needs to cast to `any` to avoid some internal limitations around typings.
   // Should be cleaned up eventually.
-  const library = await (window as any).google.maps.importLibrary(name);
-  return library[symbol];
+  return (window as any).google.maps.importLibrary(name).then((library: any) => library[symbol]);
 }

--- a/src/google-maps/import-library.ts
+++ b/src/google-maps/import-library.ts
@@ -1,0 +1,15 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/** Imports a Google Maps library. */
+export async function importLibrary<T>(name: string, symbol: string): Promise<T> {
+  // TODO(crisbeto): needs to cast to `any` to avoid some internal limitations around typings.
+  // Should be cleaned up eventually.
+  const library = await (window as any).google.maps.importLibrary(name);
+  return library[symbol];
+}

--- a/src/google-maps/map-base-layer.ts
+++ b/src/google-maps/map-base-layer.ts
@@ -26,11 +26,11 @@ export class MapBaseLayer implements OnInit, OnDestroy {
 
   ngOnInit() {
     if (this._map._isBrowser) {
-      this._ngZone.runOutsideAngular(() => {
-        this._initializeObject();
+      this._ngZone.runOutsideAngular(async () => {
+        const map = await this._map._resolveMap();
+        await this._initializeObject();
+        this._setMap(map);
       });
-      this._assertInitialized();
-      this._setMap();
     }
   }
 
@@ -38,16 +38,7 @@ export class MapBaseLayer implements OnInit, OnDestroy {
     this._unsetMap();
   }
 
-  private _assertInitialized() {
-    if (!this._map.googleMap) {
-      throw Error(
-        'Cannot access Google Map information before the API has been initialized. ' +
-          'Please wait for the API to load before trying to interact with it.',
-      );
-    }
-  }
-
-  protected _initializeObject() {}
-  protected _setMap() {}
+  protected async _initializeObject() {}
+  protected _setMap(_map: google.maps.Map) {}
   protected _unsetMap() {}
 }

--- a/src/google-maps/map-base-layer.ts
+++ b/src/google-maps/map-base-layer.ts
@@ -26,11 +26,11 @@ export class MapBaseLayer implements OnInit, OnDestroy {
 
   ngOnInit() {
     if (this._map._isBrowser) {
-      this._ngZone.runOutsideAngular(async () => {
-        const map = await this._map._resolveMap();
-        await this._initializeObject();
-        this._setMap(map);
+      this._ngZone.runOutsideAngular(() => {
+        this._initializeObject();
       });
+      this._assertInitialized();
+      this._setMap();
     }
   }
 
@@ -38,7 +38,16 @@ export class MapBaseLayer implements OnInit, OnDestroy {
     this._unsetMap();
   }
 
-  protected async _initializeObject() {}
-  protected _setMap(_map: google.maps.Map) {}
+  private _assertInitialized() {
+    if (!this._map.googleMap) {
+      throw Error(
+        'Cannot access Google Map information before the API has been initialized. ' +
+          'Please wait for the API to load before trying to interact with it.',
+      );
+    }
+  }
+
+  protected _initializeObject() {}
+  protected _setMap() {}
   protected _unsetMap() {}
 }

--- a/src/google-maps/map-bicycling-layer/map-bicycling-layer.spec.ts
+++ b/src/google-maps/map-bicycling-layer/map-bicycling-layer.spec.ts
@@ -1,5 +1,5 @@
 import {Component} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
+import {TestBed, fakeAsync, flush} from '@angular/core/testing';
 
 import {DEFAULT_OPTIONS, GoogleMap} from '../google-map/google-map';
 import {
@@ -16,24 +16,23 @@ describe('MapBicyclingLayer', () => {
 
   beforeEach(() => {
     mapSpy = createMapSpy(DEFAULT_OPTIONS);
-    createMapConstructorSpy(mapSpy).and.callThrough();
+    createMapConstructorSpy(mapSpy);
   });
 
   afterEach(() => {
     (window.google as any) = undefined;
   });
 
-  it('initializes a Google Map Bicycling Layer', () => {
+  it('initializes a Google Map Bicycling Layer', fakeAsync(() => {
     const bicyclingLayerSpy = createBicyclingLayerSpy();
-    const bicyclingLayerConstructorSpy =
-      createBicyclingLayerConstructorSpy(bicyclingLayerSpy).and.callThrough();
-
+    const bicyclingLayerConstructorSpy = createBicyclingLayerConstructorSpy(bicyclingLayerSpy);
     const fixture = TestBed.createComponent(TestApp);
     fixture.detectChanges();
+    flush();
 
     expect(bicyclingLayerConstructorSpy).toHaveBeenCalled();
     expect(bicyclingLayerSpy.setMap).toHaveBeenCalledWith(mapSpy);
-  });
+  }));
 });
 
 @Component({

--- a/src/google-maps/map-bicycling-layer/map-bicycling-layer.ts
+++ b/src/google-maps/map-bicycling-layer/map-bicycling-layer.ts
@@ -12,6 +12,7 @@
 import {Directive, EventEmitter, Output} from '@angular/core';
 
 import {MapBaseLayer} from '../map-base-layer';
+import {importLibrary} from '../import-library';
 
 /**
  * Angular component that renders a Google Maps Bicycling Layer via the Google Maps JavaScript API.
@@ -38,7 +39,7 @@ export class MapBicyclingLayer extends MapBaseLayer {
   protected override async _initializeObject() {
     const layerConstructor =
       google.maps.BicyclingLayer ||
-      ((await google.maps.importLibrary('maps')) as google.maps.MapsLibrary).BicyclingLayer;
+      (await importLibrary<google.maps.BicyclingLayer>('maps', 'BicyclingLayer'));
     this.bicyclingLayer = new layerConstructor();
     this.bicyclingLayerInitialized.emit(this.bicyclingLayer);
   }

--- a/src/google-maps/map-circle/map-circle.spec.ts
+++ b/src/google-maps/map-circle/map-circle.spec.ts
@@ -1,5 +1,5 @@
 import {Component, ViewChild} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
+import {TestBed, fakeAsync, flush} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
 import {DEFAULT_OPTIONS, GoogleMap} from '../google-map/google-map';
@@ -31,64 +31,68 @@ describe('MapCircle', () => {
 
   beforeEach(() => {
     mapSpy = createMapSpy(DEFAULT_OPTIONS);
-    createMapConstructorSpy(mapSpy).and.callThrough();
+    createMapConstructorSpy(mapSpy);
   });
 
   afterEach(() => {
     (window.google as any) = undefined;
   });
 
-  it('initializes a Google Map Circle', () => {
+  it('initializes a Google Map Circle', fakeAsync(() => {
     const circleSpy = createCircleSpy({});
-    const circleConstructorSpy = createCircleConstructorSpy(circleSpy).and.callThrough();
+    const circleConstructorSpy = createCircleConstructorSpy(circleSpy);
 
     const fixture = TestBed.createComponent(TestApp);
     fixture.detectChanges();
+    flush();
 
     expect(circleConstructorSpy).toHaveBeenCalledWith({center: undefined, radius: undefined});
     expect(circleSpy.setMap).toHaveBeenCalledWith(mapSpy);
-  });
+  }));
 
-  it('sets center and radius from input', () => {
+  it('sets center and radius from input', fakeAsync(() => {
     const center: google.maps.LatLngLiteral = {lat: 3, lng: 5};
     const radius = 15;
     const options: google.maps.CircleOptions = {center, radius};
     const circleSpy = createCircleSpy(options);
-    const circleConstructorSpy = createCircleConstructorSpy(circleSpy).and.callThrough();
+    const circleConstructorSpy = createCircleConstructorSpy(circleSpy);
 
     const fixture = TestBed.createComponent(TestApp);
     fixture.componentInstance.center = center;
     fixture.componentInstance.radius = radius;
     fixture.detectChanges();
+    flush();
 
     expect(circleConstructorSpy).toHaveBeenCalledWith(options);
-  });
+  }));
 
-  it('gives precedence to other inputs over options', () => {
+  it('gives precedence to other inputs over options', fakeAsync(() => {
     const center: google.maps.LatLngLiteral = {lat: 3, lng: 5};
     const radius = 15;
     const expectedOptions: google.maps.CircleOptions = {...circleOptions, center, radius};
     const circleSpy = createCircleSpy(expectedOptions);
-    const circleConstructorSpy = createCircleConstructorSpy(circleSpy).and.callThrough();
+    const circleConstructorSpy = createCircleConstructorSpy(circleSpy);
 
     const fixture = TestBed.createComponent(TestApp);
     fixture.componentInstance.options = circleOptions;
     fixture.componentInstance.center = center;
     fixture.componentInstance.radius = radius;
     fixture.detectChanges();
+    flush();
 
     expect(circleConstructorSpy).toHaveBeenCalledWith(expectedOptions);
-  });
+  }));
 
-  it('exposes methods that provide information about the Circle', () => {
+  it('exposes methods that provide information about the Circle', fakeAsync(() => {
     const circleSpy = createCircleSpy(circleOptions);
-    createCircleConstructorSpy(circleSpy).and.callThrough();
+    createCircleConstructorSpy(circleSpy);
 
     const fixture = TestBed.createComponent(TestApp);
     const circleComponent = fixture.debugElement
       .query(By.directive(MapCircle))!
       .injector.get<MapCircle>(MapCircle);
     fixture.detectChanges();
+    flush();
 
     circleComponent.getCenter();
     expect(circleSpy.getCenter).toHaveBeenCalled();
@@ -104,15 +108,16 @@ describe('MapCircle', () => {
 
     circleSpy.getVisible.and.returnValue(true);
     expect(circleComponent.getVisible()).toBe(true);
-  });
+  }));
 
-  it('initializes Circle event handlers', () => {
+  it('initializes Circle event handlers', fakeAsync(() => {
     const circleSpy = createCircleSpy(circleOptions);
-    createCircleConstructorSpy(circleSpy).and.callThrough();
+    createCircleConstructorSpy(circleSpy);
 
     const addSpy = circleSpy.addListener;
     const fixture = TestBed.createComponent(TestApp);
     fixture.detectChanges();
+    flush();
 
     expect(addSpy).toHaveBeenCalledWith('center_changed', jasmine.any(Function));
     expect(addSpy).toHaveBeenCalledWith('click', jasmine.any(Function));
@@ -127,15 +132,16 @@ describe('MapCircle', () => {
     expect(addSpy).not.toHaveBeenCalledWith('mouseup', jasmine.any(Function));
     expect(addSpy).not.toHaveBeenCalledWith('radius_changed', jasmine.any(Function));
     expect(addSpy).toHaveBeenCalledWith('rightclick', jasmine.any(Function));
-  });
+  }));
 
-  it('should be able to add an event listener after init', () => {
+  it('should be able to add an event listener after init', fakeAsync(() => {
     const circleSpy = createCircleSpy(circleOptions);
-    createCircleConstructorSpy(circleSpy).and.callThrough();
+    createCircleConstructorSpy(circleSpy);
 
     const addSpy = circleSpy.addListener;
     const fixture = TestBed.createComponent(TestApp);
     fixture.detectChanges();
+    flush();
 
     expect(addSpy).not.toHaveBeenCalledWith('dragend', jasmine.any(Function));
 
@@ -145,7 +151,7 @@ describe('MapCircle', () => {
 
     expect(addSpy).toHaveBeenCalledWith('dragend', jasmine.any(Function));
     subscription.unsubscribe();
-  });
+  }));
 });
 
 @Component({

--- a/src/google-maps/map-circle/map-circle.ts
+++ b/src/google-maps/map-circle/map-circle.ts
@@ -24,6 +24,7 @@ import {map, take, takeUntil} from 'rxjs/operators';
 
 import {GoogleMap} from '../google-map/google-map';
 import {MapEventManager} from '../map-event-manager';
+import {importLibrary} from '../import-library';
 
 /**
  * Angular component that renders a Google Maps Circle via the Google Maps JavaScript API.
@@ -180,8 +181,7 @@ export class MapCircle implements OnInit, OnDestroy {
         this._ngZone.runOutsideAngular(async () => {
           const map = await this._map._resolveMap();
           const circleConstructor =
-            google.maps.Circle ||
-            ((await google.maps.importLibrary('maps')) as google.maps.MapsLibrary).Circle;
+            google.maps.Circle || (await importLibrary<google.maps.Circle>('maps', 'Circle'));
           this.circle = new circleConstructor(options);
           this._assertInitialized();
           this.circle.setMap(map);

--- a/src/google-maps/map-circle/map-circle.ts
+++ b/src/google-maps/map-circle/map-circle.ts
@@ -9,7 +9,16 @@
 // Workaround for: https://github.com/bazelbuild/rules_nodejs/issues/1265
 /// <reference types="google.maps" />
 
-import {Directive, Input, NgZone, OnDestroy, OnInit, Output, inject} from '@angular/core';
+import {
+  Directive,
+  EventEmitter,
+  Input,
+  NgZone,
+  OnDestroy,
+  OnInit,
+  Output,
+  inject,
+} from '@angular/core';
 import {BehaviorSubject, combineLatest, Observable, Subject} from 'rxjs';
 import {map, take, takeUntil} from 'rxjs/operators';
 
@@ -148,40 +157,48 @@ export class MapCircle implements OnInit, OnDestroy {
   @Output() readonly circleRightclick: Observable<google.maps.MapMouseEvent> =
     this._eventManager.getLazyEmitter<google.maps.MapMouseEvent>('rightclick');
 
+  /** Event emitted when the circle is initialized. */
+  @Output() readonly circleInitialized: EventEmitter<google.maps.Circle> =
+    new EventEmitter<google.maps.Circle>();
+
   constructor(
     private readonly _map: GoogleMap,
     private readonly _ngZone: NgZone,
   ) {}
 
   ngOnInit() {
-    if (this._map._isBrowser) {
-      this._combineOptions()
-        .pipe(take(1))
-        .subscribe(options => {
-          // Create the object outside the zone so its events don't trigger change detection.
-          // We'll bring it back in inside the `MapEventManager` only for the events that the
-          // user has subscribed to.
-          this._ngZone.runOutsideAngular(() => {
-            this.circle = new google.maps.Circle(options);
-          });
-          this._assertInitialized();
-          this.circle.setMap(this._map.googleMap!);
-          this._eventManager.setTarget(this.circle);
-        });
-
-      this._watchForOptionsChanges();
-      this._watchForCenterChanges();
-      this._watchForRadiusChanges();
+    if (!this._map._isBrowser) {
+      return;
     }
+
+    this._combineOptions()
+      .pipe(take(1))
+      .subscribe(options => {
+        // Create the object outside the zone so its events don't trigger change detection.
+        // We'll bring it back in inside the `MapEventManager` only for the events that the
+        // user has subscribed to.
+        this._ngZone.runOutsideAngular(async () => {
+          const map = await this._map._resolveMap();
+          const circleConstructor =
+            google.maps.Circle ||
+            ((await google.maps.importLibrary('maps')) as google.maps.MapsLibrary).Circle;
+          this.circle = new circleConstructor(options);
+          this._assertInitialized();
+          this.circle.setMap(map);
+          this._eventManager.setTarget(this.circle);
+          this.circleInitialized.emit(this.circle);
+          this._watchForOptionsChanges();
+          this._watchForCenterChanges();
+          this._watchForRadiusChanges();
+        });
+      });
   }
 
   ngOnDestroy() {
     this._eventManager.destroy();
     this._destroyed.next();
     this._destroyed.complete();
-    if (this.circle) {
-      this.circle.setMap(null);
-    }
+    this.circle?.setMap(null);
   }
 
   /**
@@ -278,12 +295,6 @@ export class MapCircle implements OnInit, OnDestroy {
 
   private _assertInitialized(): asserts this is {circle: google.maps.Circle} {
     if (typeof ngDevMode === 'undefined' || ngDevMode) {
-      if (!this._map.googleMap) {
-        throw Error(
-          'Cannot access Google Map information before the API has been initialized. ' +
-            'Please wait for the API to load before trying to interact with it.',
-        );
-      }
       if (!this.circle) {
         throw Error(
           'Cannot interact with a Google Map Circle before it has been ' +

--- a/src/google-maps/map-directions-renderer/map-directions-renderer.spec.ts
+++ b/src/google-maps/map-directions-renderer/map-directions-renderer.spec.ts
@@ -1,5 +1,5 @@
 import {Component, ViewChild} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
+import {TestBed, fakeAsync, flush} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {MapDirectionsRenderer} from './map-directions-renderer';
 import {DEFAULT_OPTIONS, GoogleMap} from '../google-map/google-map';
@@ -20,69 +20,72 @@ describe('MapDirectionsRenderer', () => {
 
   beforeEach(() => {
     mapSpy = createMapSpy(DEFAULT_OPTIONS);
-    createMapConstructorSpy(mapSpy).and.callThrough();
+    createMapConstructorSpy(mapSpy);
   });
 
   afterEach(() => {
     (window.google as any) = undefined;
   });
 
-  it('initializes a Google Maps DirectionsRenderer', () => {
+  it('initializes a Google Maps DirectionsRenderer', fakeAsync(() => {
     const directionsRendererSpy = createDirectionsRendererSpy({directions: DEFAULT_DIRECTIONS});
     const directionsRendererConstructorSpy =
-      createDirectionsRendererConstructorSpy(directionsRendererSpy).and.callThrough();
+      createDirectionsRendererConstructorSpy(directionsRendererSpy);
 
     const fixture = TestBed.createComponent(TestApp);
     fixture.componentInstance.options = {directions: DEFAULT_DIRECTIONS};
     fixture.detectChanges();
+    flush();
 
     expect(directionsRendererConstructorSpy).toHaveBeenCalledWith({
       directions: DEFAULT_DIRECTIONS,
       map: jasmine.any(Object),
     });
     expect(directionsRendererSpy.setMap).toHaveBeenCalledWith(mapSpy);
-  });
+  }));
 
-  it('sets directions from directions input', () => {
+  it('sets directions from directions input', fakeAsync(() => {
     const directionsRendererSpy = createDirectionsRendererSpy({directions: DEFAULT_DIRECTIONS});
     const directionsRendererConstructorSpy =
-      createDirectionsRendererConstructorSpy(directionsRendererSpy).and.callThrough();
+      createDirectionsRendererConstructorSpy(directionsRendererSpy);
 
     const fixture = TestBed.createComponent(TestApp);
     fixture.componentInstance.directions = DEFAULT_DIRECTIONS;
     fixture.detectChanges();
+    flush();
 
     expect(directionsRendererConstructorSpy).toHaveBeenCalledWith({
       directions: DEFAULT_DIRECTIONS,
       map: jasmine.any(Object),
     });
     expect(directionsRendererSpy.setMap).toHaveBeenCalledWith(mapSpy);
-  });
+  }));
 
-  it('gives precedence to directions over options', () => {
+  it('gives precedence to directions over options', fakeAsync(() => {
     const updatedDirections: google.maps.DirectionsResult = {
       geocoded_waypoints: [{partial_match: false, place_id: 'test', types: []}],
       routes: [],
     };
     const directionsRendererSpy = createDirectionsRendererSpy({directions: updatedDirections});
     const directionsRendererConstructorSpy =
-      createDirectionsRendererConstructorSpy(directionsRendererSpy).and.callThrough();
+      createDirectionsRendererConstructorSpy(directionsRendererSpy);
 
     const fixture = TestBed.createComponent(TestApp);
     fixture.componentInstance.options = {directions: DEFAULT_DIRECTIONS};
     fixture.componentInstance.directions = updatedDirections;
     fixture.detectChanges();
+    flush();
 
     expect(directionsRendererConstructorSpy).toHaveBeenCalledWith({
       directions: updatedDirections,
       map: jasmine.any(Object),
     });
     expect(directionsRendererSpy.setMap).toHaveBeenCalledWith(mapSpy);
-  });
+  }));
 
-  it('exposes methods that provide information from the DirectionsRenderer', () => {
+  it('exposes methods that provide information from the DirectionsRenderer', fakeAsync(() => {
     const directionsRendererSpy = createDirectionsRendererSpy({});
-    createDirectionsRendererConstructorSpy(directionsRendererSpy).and.callThrough();
+    createDirectionsRendererConstructorSpy(directionsRendererSpy);
 
     const fixture = TestBed.createComponent(TestApp);
 
@@ -90,6 +93,7 @@ describe('MapDirectionsRenderer', () => {
       .query(By.directive(MapDirectionsRenderer))!
       .injector.get<MapDirectionsRenderer>(MapDirectionsRenderer);
     fixture.detectChanges();
+    flush();
 
     directionsRendererSpy.getDirections.and.returnValue(DEFAULT_DIRECTIONS);
     expect(directionsRendererComponent.getDirections()).toBe(DEFAULT_DIRECTIONS);
@@ -99,20 +103,21 @@ describe('MapDirectionsRenderer', () => {
 
     directionsRendererSpy.getRouteIndex.and.returnValue(10);
     expect(directionsRendererComponent.getRouteIndex()).toBe(10);
-  });
+  }));
 
-  it('initializes DirectionsRenderer event handlers', () => {
+  it('initializes DirectionsRenderer event handlers', fakeAsync(() => {
     const directionsRendererSpy = createDirectionsRendererSpy({});
-    createDirectionsRendererConstructorSpy(directionsRendererSpy).and.callThrough();
+    createDirectionsRendererConstructorSpy(directionsRendererSpy);
 
     const fixture = TestBed.createComponent(TestApp);
     fixture.detectChanges();
+    flush();
 
     expect(directionsRendererSpy.addListener).toHaveBeenCalledWith(
       'directions_changed',
       jasmine.any(Function),
     );
-  });
+  }));
 });
 
 @Component({

--- a/src/google-maps/map-directions-renderer/map-directions-renderer.ts
+++ b/src/google-maps/map-directions-renderer/map-directions-renderer.ts
@@ -24,6 +24,7 @@ import {
 import {Observable} from 'rxjs';
 import {GoogleMap} from '../google-map/google-map';
 import {MapEventManager} from '../map-event-manager';
+import {importLibrary} from '../import-library';
 
 /**
  * Angular component that renders a Google Maps Directions Renderer via the Google Maps
@@ -88,8 +89,7 @@ export class MapDirectionsRenderer implements OnInit, OnChanges, OnDestroy {
         const map = await this._googleMap._resolveMap();
         const rendererConstructor =
           google.maps.DirectionsRenderer ||
-          ((await google.maps.importLibrary('routes')) as google.maps.RoutesLibrary)
-            .DirectionsRenderer;
+          (await importLibrary<google.maps.DirectionsRenderer>('routes', 'DirectionsRenderer'));
         this.directionsRenderer = new rendererConstructor(this._combineOptions());
         this._assertInitialized();
         this.directionsRenderer.setMap(map);

--- a/src/google-maps/map-directions-renderer/map-directions-service.spec.ts
+++ b/src/google-maps/map-directions-renderer/map-directions-service.spec.ts
@@ -12,8 +12,7 @@ describe('MapDirectionsService', () => {
 
   beforeEach(() => {
     directionsServiceSpy = createDirectionsServiceSpy();
-    directionsServiceConstructorSpy =
-      createDirectionsServiceConstructorSpy(directionsServiceSpy).and.callThrough();
+    directionsServiceConstructorSpy = createDirectionsServiceConstructorSpy(directionsServiceSpy);
     mapDirectionsService = TestBed.inject(MapDirectionsService);
   });
 

--- a/src/google-maps/map-directions-renderer/map-directions-service.ts
+++ b/src/google-maps/map-directions-renderer/map-directions-service.ts
@@ -48,14 +48,21 @@ export class MapDirectionsService {
     });
   }
 
-  private async _getService(): Promise<google.maps.DirectionsService> {
+  private _getService(): Promise<google.maps.DirectionsService> {
     if (!this._directionsService) {
-      const serviceConstructor =
-        google.maps.DirectionsService ||
-        (await importLibrary<google.maps.DirectionsService>('routes', 'DirectionsService'));
-      this._directionsService = new serviceConstructor();
+      if (google.maps.DirectionsService) {
+        this._directionsService = new google.maps.DirectionsService();
+      } else {
+        return importLibrary<typeof google.maps.DirectionsService>(
+          'routes',
+          'DirectionsService',
+        ).then(serviceConstructor => {
+          this._directionsService = new serviceConstructor();
+          return this._directionsService;
+        });
+      }
     }
 
-    return this._directionsService;
+    return Promise.resolve(this._directionsService);
   }
 }

--- a/src/google-maps/map-directions-renderer/map-directions-service.ts
+++ b/src/google-maps/map-directions-renderer/map-directions-service.ts
@@ -10,6 +10,7 @@
 /// <reference types="google.maps" />
 
 import {Injectable, NgZone} from '@angular/core';
+import {importLibrary} from '../import-library';
 import {Observable} from 'rxjs';
 
 export interface MapDirectionsResponse {
@@ -51,8 +52,7 @@ export class MapDirectionsService {
     if (!this._directionsService) {
       const serviceConstructor =
         google.maps.DirectionsService ||
-        ((await google.maps.importLibrary('routes')) as google.maps.RoutesLibrary)
-          .DirectionsService;
+        (await importLibrary<google.maps.DirectionsService>('routes', 'DirectionsService'));
       this._directionsService = new serviceConstructor();
     }
 

--- a/src/google-maps/map-geocoder/map-geocoder.spec.ts
+++ b/src/google-maps/map-geocoder/map-geocoder.spec.ts
@@ -9,7 +9,7 @@ describe('MapGeocoder', () => {
 
   beforeEach(() => {
     geocoderSpy = createGeocoderSpy();
-    geocoderConstructorSpy = createGeocoderConstructorSpy(geocoderSpy).and.callThrough();
+    geocoderConstructorSpy = createGeocoderConstructorSpy(geocoderSpy);
     geocoder = TestBed.inject(MapGeocoder);
   });
 

--- a/src/google-maps/map-geocoder/map-geocoder.ts
+++ b/src/google-maps/map-geocoder/map-geocoder.ts
@@ -10,6 +10,7 @@
 /// <reference types="google.maps" />
 
 import {Injectable, NgZone} from '@angular/core';
+import {importLibrary} from '../import-library';
 import {Observable} from 'rxjs';
 
 export interface MapGeocoderResponse {
@@ -47,7 +48,7 @@ export class MapGeocoder {
     if (!this._geocoder) {
       const geocoderConstructor =
         google.maps.Geocoder ||
-        ((await google.maps.importLibrary('geocoding')) as google.maps.GeocodingLibrary).Geocoder;
+        (await importLibrary<google.maps.Geocoder>('geocoding', 'Geocoder'));
       this._geocoder = new geocoderConstructor();
     }
 

--- a/src/google-maps/map-geocoder/map-geocoder.ts
+++ b/src/google-maps/map-geocoder/map-geocoder.ts
@@ -44,14 +44,20 @@ export class MapGeocoder {
     });
   }
 
-  private async _getGeocoder(): Promise<google.maps.Geocoder> {
+  private _getGeocoder(): Promise<google.maps.Geocoder> {
     if (!this._geocoder) {
-      const geocoderConstructor =
-        google.maps.Geocoder ||
-        (await importLibrary<google.maps.Geocoder>('geocoding', 'Geocoder'));
-      this._geocoder = new geocoderConstructor();
+      if (google.maps.Geocoder) {
+        this._geocoder = new google.maps.Geocoder();
+      } else {
+        return importLibrary<typeof google.maps.Geocoder>('geocoding', 'Geocoder').then(
+          geocoderConstructor => {
+            this._geocoder = new geocoderConstructor();
+            return this._geocoder;
+          },
+        );
+      }
     }
 
-    return this._geocoder;
+    return Promise.resolve(this._geocoder);
   }
 }

--- a/src/google-maps/map-ground-overlay/map-ground-overlay.spec.ts
+++ b/src/google-maps/map-ground-overlay/map-ground-overlay.spec.ts
@@ -1,5 +1,5 @@
 import {Component, ViewChild} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
+import {TestBed, fakeAsync, flush} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
 import {DEFAULT_OPTIONS, GoogleMap} from '../google-map/google-map';
@@ -22,17 +22,16 @@ describe('MapGroundOverlay', () => {
 
   beforeEach(() => {
     mapSpy = createMapSpy(DEFAULT_OPTIONS);
-    createMapConstructorSpy(mapSpy).and.callThrough();
+    createMapConstructorSpy(mapSpy);
   });
 
   afterEach(() => {
     (window.google as any) = undefined;
   });
 
-  it('initializes a Google Map Ground Overlay', () => {
+  it('initializes a Google Map Ground Overlay', fakeAsync(() => {
     const groundOverlaySpy = createGroundOverlaySpy(url, bounds, groundOverlayOptions);
-    const groundOverlayConstructorSpy =
-      createGroundOverlayConstructorSpy(groundOverlaySpy).and.callThrough();
+    const groundOverlayConstructorSpy = createGroundOverlayConstructorSpy(groundOverlaySpy);
 
     const fixture = TestBed.createComponent(TestApp);
     fixture.componentInstance.url = url;
@@ -40,14 +39,15 @@ describe('MapGroundOverlay', () => {
     fixture.componentInstance.clickable = clickable;
     fixture.componentInstance.opacity = opacity;
     fixture.detectChanges();
+    flush();
 
     expect(groundOverlayConstructorSpy).toHaveBeenCalledWith(url, bounds, groundOverlayOptions);
     expect(groundOverlaySpy.setMap).toHaveBeenCalledWith(mapSpy);
-  });
+  }));
 
-  it('exposes methods that provide information about the Ground Overlay', () => {
+  it('exposes methods that provide information about the Ground Overlay', fakeAsync(() => {
     const groundOverlaySpy = createGroundOverlaySpy(url, bounds, groundOverlayOptions);
-    createGroundOverlayConstructorSpy(groundOverlaySpy).and.callThrough();
+    createGroundOverlayConstructorSpy(groundOverlaySpy);
 
     const fixture = TestBed.createComponent(TestApp);
     const groundOverlayComponent = fixture.debugElement
@@ -57,6 +57,7 @@ describe('MapGroundOverlay', () => {
     fixture.componentInstance.bounds = bounds;
     fixture.componentInstance.opacity = opacity;
     fixture.detectChanges();
+    flush();
 
     groundOverlayComponent.getBounds();
     expect(groundOverlaySpy.getBounds).toHaveBeenCalled();
@@ -66,31 +67,33 @@ describe('MapGroundOverlay', () => {
 
     groundOverlaySpy.getUrl.and.returnValue(url);
     expect(groundOverlayComponent.getUrl()).toBe(url);
-  });
+  }));
 
-  it('initializes Ground Overlay event handlers', () => {
+  it('initializes Ground Overlay event handlers', fakeAsync(() => {
     const groundOverlaySpy = createGroundOverlaySpy(url, bounds, groundOverlayOptions);
-    createGroundOverlayConstructorSpy(groundOverlaySpy).and.callThrough();
+    createGroundOverlayConstructorSpy(groundOverlaySpy);
 
     const addSpy = groundOverlaySpy.addListener;
     const fixture = TestBed.createComponent(TestApp);
     fixture.componentInstance.url = url;
     fixture.componentInstance.bounds = bounds;
     fixture.detectChanges();
+    flush();
 
     expect(addSpy).toHaveBeenCalledWith('click', jasmine.any(Function));
     expect(addSpy).not.toHaveBeenCalledWith('dblclick', jasmine.any(Function));
-  });
+  }));
 
-  it('should be able to add an event listener after init', () => {
+  it('should be able to add an event listener after init', fakeAsync(() => {
     const groundOverlaySpy = createGroundOverlaySpy(url, bounds, groundOverlayOptions);
-    createGroundOverlayConstructorSpy(groundOverlaySpy).and.callThrough();
+    createGroundOverlayConstructorSpy(groundOverlaySpy);
 
     const addSpy = groundOverlaySpy.addListener;
     const fixture = TestBed.createComponent(TestApp);
     fixture.componentInstance.url = url;
     fixture.componentInstance.bounds = bounds;
     fixture.detectChanges();
+    flush();
 
     expect(addSpy).not.toHaveBeenCalledWith('dblclick', jasmine.any(Function));
 
@@ -100,12 +103,11 @@ describe('MapGroundOverlay', () => {
 
     expect(addSpy).toHaveBeenCalledWith('dblclick', jasmine.any(Function));
     subscription.unsubscribe();
-  });
+  }));
 
-  it('should be able to change the image after init', () => {
+  it('should be able to change the image after init', fakeAsync(() => {
     const groundOverlaySpy = createGroundOverlaySpy(url, bounds, groundOverlayOptions);
-    const groundOverlayConstructorSpy =
-      createGroundOverlayConstructorSpy(groundOverlaySpy).and.callThrough();
+    const groundOverlayConstructorSpy = createGroundOverlayConstructorSpy(groundOverlaySpy);
 
     const fixture = TestBed.createComponent(TestApp);
     fixture.componentInstance.url = url;
@@ -113,6 +115,7 @@ describe('MapGroundOverlay', () => {
     fixture.componentInstance.clickable = clickable;
     fixture.componentInstance.opacity = opacity;
     fixture.detectChanges();
+    flush();
 
     expect(groundOverlayConstructorSpy).toHaveBeenCalledWith(url, bounds, groundOverlayOptions);
     expect(groundOverlaySpy.setMap).toHaveBeenCalledWith(mapSpy);
@@ -125,23 +128,25 @@ describe('MapGroundOverlay', () => {
     expect(groundOverlaySpy.setMap).toHaveBeenCalledTimes(2);
     expect(groundOverlaySpy.setMap).toHaveBeenCalledWith(null);
     expect(groundOverlaySpy.setMap).toHaveBeenCalledWith(mapSpy);
-  });
+  }));
 
-  it('should recreate the ground overlay when the bounds change', () => {
+  it('should recreate the ground overlay when the bounds change', fakeAsync(() => {
     const groundOverlaySpy = createGroundOverlaySpy(url, bounds, groundOverlayOptions);
-    createGroundOverlayConstructorSpy(groundOverlaySpy).and.callThrough();
+    createGroundOverlayConstructorSpy(groundOverlaySpy);
 
     const fixture = TestBed.createComponent(TestApp);
     fixture.detectChanges();
+    flush();
 
     const oldOverlay = fixture.componentInstance.groundOverlay.groundOverlay;
     fixture.componentInstance.bounds = {...bounds};
     fixture.detectChanges();
+    flush();
 
     const newOverlay = fixture.componentInstance.groundOverlay.groundOverlay;
     expect(newOverlay).toBeTruthy();
     expect(newOverlay).not.toBe(oldOverlay);
-  });
+  }));
 });
 
 @Component({

--- a/src/google-maps/map-ground-overlay/map-ground-overlay.ts
+++ b/src/google-maps/map-ground-overlay/map-ground-overlay.ts
@@ -9,7 +9,16 @@
 // Workaround for: https://github.com/bazelbuild/rules_nodejs/issues/1265
 /// <reference types="google.maps" />
 
-import {Directive, Input, NgZone, OnDestroy, OnInit, Output, inject} from '@angular/core';
+import {
+  Directive,
+  EventEmitter,
+  Input,
+  NgZone,
+  OnDestroy,
+  OnInit,
+  Output,
+  inject,
+} from '@angular/core';
 import {BehaviorSubject, Observable, Subject} from 'rxjs';
 import {takeUntil} from 'rxjs/operators';
 
@@ -35,6 +44,7 @@ export class MapGroundOverlay implements OnInit, OnDestroy {
     google.maps.LatLngBounds | google.maps.LatLngBoundsLiteral | undefined
   >(undefined);
   private readonly _destroyed = new Subject<void>();
+  private _hasWatchers: boolean;
 
   /**
    * The underlying google.maps.GroundOverlay object.
@@ -82,6 +92,10 @@ export class MapGroundOverlay implements OnInit, OnDestroy {
   @Output() readonly mapDblclick: Observable<google.maps.MapMouseEvent> =
     this._eventManager.getLazyEmitter<google.maps.MapMouseEvent>('dblclick');
 
+  /** Event emitted when the ground overlay is initialized. */
+  @Output() readonly groundOverlayInitialized: EventEmitter<google.maps.GroundOverlay> =
+    new EventEmitter<google.maps.GroundOverlay>();
+
   constructor(
     private readonly _map: GoogleMap,
     private readonly _ngZone: NgZone,
@@ -98,24 +112,35 @@ export class MapGroundOverlay implements OnInit, OnDestroy {
           this.groundOverlay = undefined;
         }
 
+        if (!bounds) {
+          return;
+        }
+
         // Create the object outside the zone so its events don't trigger change detection.
         // We'll bring it back in inside the `MapEventManager` only for the events that the
         // user has subscribed to.
-        if (bounds) {
-          this._ngZone.runOutsideAngular(() => {
-            this.groundOverlay = new google.maps.GroundOverlay(this._url.getValue(), bounds, {
-              clickable: this.clickable,
-              opacity: this._opacity.value,
-            });
+        this._ngZone.runOutsideAngular(async () => {
+          const map = await this._map._resolveMap();
+          const overlayConstructor =
+            google.maps.GroundOverlay ||
+            ((await google.maps.importLibrary('maps')) as google.maps.MapsLibrary).GroundOverlay;
+          this.groundOverlay = new overlayConstructor(this._url.getValue(), bounds, {
+            clickable: this.clickable,
+            opacity: this._opacity.value,
           });
           this._assertInitialized();
-          this.groundOverlay.setMap(this._map.googleMap!);
+          this.groundOverlay.setMap(map);
           this._eventManager.setTarget(this.groundOverlay);
-        }
-      });
+          this.groundOverlayInitialized.emit(this.groundOverlay);
 
-      this._watchForOpacityChanges();
-      this._watchForUrlChanges();
+          // We only need to set up the watchers once.
+          if (!this._hasWatchers) {
+            this._hasWatchers = true;
+            this._watchForOpacityChanges();
+            this._watchForUrlChanges();
+          }
+        });
+      });
     }
   }
 
@@ -123,9 +148,7 @@ export class MapGroundOverlay implements OnInit, OnDestroy {
     this._eventManager.destroy();
     this._destroyed.next();
     this._destroyed.complete();
-    if (this.groundOverlay) {
-      this.groundOverlay.setMap(null);
-    }
+    this.groundOverlay?.setMap(null);
   }
 
   /**
@@ -161,32 +184,26 @@ export class MapGroundOverlay implements OnInit, OnDestroy {
   private _watchForOpacityChanges() {
     this._opacity.pipe(takeUntil(this._destroyed)).subscribe(opacity => {
       if (opacity != null) {
-        this._assertInitialized();
-        this.groundOverlay.setOpacity(opacity);
+        this.groundOverlay?.setOpacity(opacity);
       }
     });
   }
 
   private _watchForUrlChanges() {
     this._url.pipe(takeUntil(this._destroyed)).subscribe(url => {
-      this._assertInitialized();
       const overlay = this.groundOverlay;
-      overlay.set('url', url);
 
-      // Google Maps only redraws the overlay if we re-set the map.
-      overlay.setMap(null);
-      overlay.setMap(this._map.googleMap!);
+      if (overlay) {
+        overlay.set('url', url);
+        // Google Maps only redraws the overlay if we re-set the map.
+        overlay.setMap(null);
+        overlay.setMap(this._map.googleMap!);
+      }
     });
   }
 
   private _assertInitialized(): asserts this is {groundOverlay: google.maps.GroundOverlay} {
     if (typeof ngDevMode === 'undefined' || ngDevMode) {
-      if (!this._map.googleMap) {
-        throw Error(
-          'Cannot access Google Map information before the API has been initialized. ' +
-            'Please wait for the API to load before trying to interact with it.',
-        );
-      }
       if (!this.groundOverlay) {
         throw Error(
           'Cannot interact with a Google Map GroundOverlay before it has been initialized. ' +

--- a/src/google-maps/map-ground-overlay/map-ground-overlay.ts
+++ b/src/google-maps/map-ground-overlay/map-ground-overlay.ts
@@ -24,6 +24,7 @@ import {takeUntil} from 'rxjs/operators';
 
 import {GoogleMap} from '../google-map/google-map';
 import {MapEventManager} from '../map-event-manager';
+import {importLibrary} from '../import-library';
 
 /**
  * Angular component that renders a Google Maps Ground Overlay via the Google Maps JavaScript API.
@@ -123,7 +124,7 @@ export class MapGroundOverlay implements OnInit, OnDestroy {
           const map = await this._map._resolveMap();
           const overlayConstructor =
             google.maps.GroundOverlay ||
-            ((await google.maps.importLibrary('maps')) as google.maps.MapsLibrary).GroundOverlay;
+            (await importLibrary<google.maps.GroundOverlay>('maps', 'GroundOverlay'));
           this.groundOverlay = new overlayConstructor(this._url.getValue(), bounds, {
             clickable: this.clickable,
             opacity: this._opacity.value,

--- a/src/google-maps/map-heatmap-layer/README.md
+++ b/src/google-maps/map-heatmap-layer/README.md
@@ -5,24 +5,6 @@ a heatmap layer on the map when it is a content child of a `GoogleMap` component
 this directive offers an `options` input as well as a convenience input for passing in the `data`
 that is shown on the heatmap.
 
-## Requirements
-
-In order to render a heatmap, the Google Maps JavaScript API has to be loaded with the
-`visualization` library. To load the library, you have to add `&libraries=visualization` to the
-script that loads the Google Maps API. E.g.
-
-**Before:**
-```html
-<script src="https://maps.googleapis.com/maps/api/js?key=YOUR_API_KEY"></script>
-```
-
-**After:**
-```html
-<script src="https://maps.googleapis.com/maps/api/js?key=YOUR_API_KEY&libraries=visualization"></script>
-```
-
-More information: https://developers.google.com/maps/documentation/javascript/heatmaplayer
-
 ## Example
 
 ```typescript

--- a/src/google-maps/map-heatmap-layer/map-heatmap-layer.spec.ts
+++ b/src/google-maps/map-heatmap-layer/map-heatmap-layer.spec.ts
@@ -1,5 +1,5 @@
 import {Component, ViewChild} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
+import {TestBed, fakeAsync, flush} from '@angular/core/testing';
 
 import {DEFAULT_OPTIONS, GoogleMap} from '../google-map/google-map';
 
@@ -20,38 +20,40 @@ describe('MapHeatmapLayer', () => {
   beforeEach(() => {
     mapSpy = createMapSpy(DEFAULT_OPTIONS);
     latLngSpy = createLatLngSpy();
-    createMapConstructorSpy(mapSpy).and.callThrough();
-    createLatLngConstructorSpy(latLngSpy).and.callThrough();
+    createMapConstructorSpy(mapSpy);
+    createLatLngConstructorSpy(latLngSpy);
   });
 
   afterEach(() => {
     (window.google as any) = undefined;
   });
 
-  it('initializes a Google Map heatmap layer', () => {
+  it('initializes a Google Map heatmap layer', fakeAsync(() => {
     const heatmapSpy = createHeatmapLayerSpy();
-    const heatmapConstructorSpy = createHeatmapLayerConstructorSpy(heatmapSpy).and.callThrough();
+    const heatmapConstructorSpy = createHeatmapLayerConstructorSpy(heatmapSpy);
 
     const fixture = TestBed.createComponent(TestApp);
     fixture.detectChanges();
+    flush();
 
     expect(heatmapConstructorSpy).toHaveBeenCalledWith({
       data: [],
       map: mapSpy,
     });
-  });
+  }));
 
-  it('should throw if the `visualization` library has not been loaded', () => {
+  it('should throw if the `visualization` library has not been loaded', fakeAsync(() => {
     createHeatmapLayerConstructorSpy(createHeatmapLayerSpy());
     delete (window.google.maps as any).visualization;
 
     expect(() => {
       const fixture = TestBed.createComponent(TestApp);
       fixture.detectChanges();
+      flush();
     }).toThrowError(/Namespace `google.maps.visualization` not found, cannot construct heatmap/);
-  });
+  }));
 
-  it('sets heatmap inputs', () => {
+  it('sets heatmap inputs', fakeAsync(() => {
     const options: google.maps.visualization.HeatmapLayerOptions = {
       map: mapSpy,
       data: [
@@ -61,16 +63,17 @@ describe('MapHeatmapLayer', () => {
       ],
     };
     const heatmapSpy = createHeatmapLayerSpy();
-    const heatmapConstructorSpy = createHeatmapLayerConstructorSpy(heatmapSpy).and.callThrough();
+    const heatmapConstructorSpy = createHeatmapLayerConstructorSpy(heatmapSpy);
 
     const fixture = TestBed.createComponent(TestApp);
     fixture.componentInstance.data = options.data;
     fixture.detectChanges();
+    flush();
 
     expect(heatmapConstructorSpy).toHaveBeenCalledWith(options);
-  });
+  }));
 
-  it('sets heatmap options, ignoring map', () => {
+  it('sets heatmap options, ignoring map', fakeAsync(() => {
     const options: Partial<google.maps.visualization.HeatmapLayerOptions> = {
       radius: 5,
       dissipating: true,
@@ -81,31 +84,33 @@ describe('MapHeatmapLayer', () => {
       new google.maps.LatLng(37.782, -122.443),
     ];
     const heatmapSpy = createHeatmapLayerSpy();
-    const heatmapConstructorSpy = createHeatmapLayerConstructorSpy(heatmapSpy).and.callThrough();
+    const heatmapConstructorSpy = createHeatmapLayerConstructorSpy(heatmapSpy);
 
     const fixture = TestBed.createComponent(TestApp);
     fixture.componentInstance.data = data;
     fixture.componentInstance.options = options;
     fixture.detectChanges();
+    flush();
 
     expect(heatmapConstructorSpy).toHaveBeenCalledWith({...options, map: mapSpy, data});
-  });
+  }));
 
-  it('exposes methods that provide information about the heatmap', () => {
+  it('exposes methods that provide information about the heatmap', fakeAsync(() => {
     const heatmapSpy = createHeatmapLayerSpy();
-    createHeatmapLayerConstructorSpy(heatmapSpy).and.callThrough();
+    createHeatmapLayerConstructorSpy(heatmapSpy);
 
     const fixture = TestBed.createComponent(TestApp);
     fixture.detectChanges();
+    flush();
     const heatmap = fixture.componentInstance.heatmap;
 
     heatmapSpy.getData.and.returnValue([] as any);
     expect(heatmap.getData()).toEqual([]);
-  });
+  }));
 
-  it('should update the heatmap data when the input changes', () => {
+  it('should update the heatmap data when the input changes', fakeAsync(() => {
     const heatmapSpy = createHeatmapLayerSpy();
-    const heatmapConstructorSpy = createHeatmapLayerConstructorSpy(heatmapSpy).and.callThrough();
+    const heatmapConstructorSpy = createHeatmapLayerConstructorSpy(heatmapSpy);
     let data = [
       new google.maps.LatLng(1, 2),
       new google.maps.LatLng(3, 4),
@@ -115,6 +120,7 @@ describe('MapHeatmapLayer', () => {
     const fixture = TestBed.createComponent(TestApp);
     fixture.componentInstance.data = data;
     fixture.detectChanges();
+    flush();
 
     expect(heatmapConstructorSpy).toHaveBeenCalledWith(jasmine.objectContaining({data}));
     data = [
@@ -126,22 +132,23 @@ describe('MapHeatmapLayer', () => {
     fixture.detectChanges();
 
     expect(heatmapSpy.setData).toHaveBeenCalledWith(data);
-  });
+  }));
 
-  it('should create a LatLng object if a LatLngLiteral is passed in', () => {
-    const latLngConstructor = createLatLngConstructorSpy(latLngSpy).and.callThrough();
-    createHeatmapLayerConstructorSpy(createHeatmapLayerSpy()).and.callThrough();
+  it('should create a LatLng object if a LatLngLiteral is passed in', fakeAsync(() => {
+    const latLngConstructor = createLatLngConstructorSpy(latLngSpy);
+    createHeatmapLayerConstructorSpy(createHeatmapLayerSpy());
     const fixture = TestBed.createComponent(TestApp);
     fixture.componentInstance.data = [
       {lat: 1, lng: 2},
       {lat: 3, lng: 4},
     ];
     fixture.detectChanges();
+    flush();
 
     expect(latLngConstructor).toHaveBeenCalledWith(1, 2);
     expect(latLngConstructor).toHaveBeenCalledWith(3, 4);
     expect(latLngConstructor).toHaveBeenCalledTimes(2);
-  });
+  }));
 });
 
 @Component({

--- a/src/google-maps/map-heatmap-layer/map-heatmap-layer.ts
+++ b/src/google-maps/map-heatmap-layer/map-heatmap-layer.ts
@@ -22,6 +22,7 @@ import {
 } from '@angular/core';
 
 import {GoogleMap} from '../google-map/google-map';
+import {importLibrary} from '../import-library';
 
 /** Possible data that can be shown on a heatmap layer. */
 export type HeatmapData =
@@ -81,7 +82,7 @@ export class MapHeatmapLayer implements OnInit, OnChanges, OnDestroy {
     if (this._googleMap._isBrowser) {
       if (
         !window.google?.maps?.visualization &&
-        !window.google?.maps.importLibrary &&
+        !(window as any).google?.maps.importLibrary &&
         (typeof ngDevMode === 'undefined' || ngDevMode)
       ) {
         throw Error(
@@ -98,8 +99,10 @@ export class MapHeatmapLayer implements OnInit, OnChanges, OnDestroy {
         const map = await this._googleMap._resolveMap();
         const heatmapConstructor =
           google.maps.visualization?.HeatmapLayer ||
-          ((await google.maps.importLibrary('visualization')) as google.maps.VisualizationLibrary)
-            .HeatmapLayer;
+          (await importLibrary<google.maps.visualization.HeatmapLayer>(
+            'visualization',
+            'HeatmapLayer',
+          ));
         this.heatmap = new heatmapConstructor(this._combineOptions());
         this._assertInitialized();
         this.heatmap.setMap(map);

--- a/src/google-maps/map-info-window/map-info-window.spec.ts
+++ b/src/google-maps/map-info-window/map-info-window.spec.ts
@@ -1,5 +1,5 @@
 import {Component, ViewChild} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
+import {TestBed, fakeAsync, flush} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
 import {DEFAULT_OPTIONS, GoogleMap} from '../google-map/google-map';
@@ -18,17 +18,16 @@ describe('MapInfoWindow', () => {
 
   beforeEach(() => {
     mapSpy = createMapSpy(DEFAULT_OPTIONS);
-    createMapConstructorSpy(mapSpy).and.callThrough();
+    createMapConstructorSpy(mapSpy);
   });
 
   afterEach(() => {
     (window.google as any) = undefined;
   });
 
-  it('initializes a Google Map Info Window', () => {
+  it('initializes a Google Map Info Window', fakeAsync(() => {
     const infoWindowSpy = createInfoWindowSpy({});
-    const infoWindowConstructorSpy =
-      createInfoWindowConstructorSpy(infoWindowSpy).and.callThrough();
+    const infoWindowConstructorSpy = createInfoWindowConstructorSpy(infoWindowSpy);
 
     const fixture = TestBed.createComponent(TestApp);
     fixture.detectChanges();
@@ -37,45 +36,45 @@ describe('MapInfoWindow', () => {
       position: undefined,
       content: jasmine.any(Node),
     });
-  });
+  }));
 
-  it('sets position', () => {
+  it('sets position', fakeAsync(() => {
     const position: google.maps.LatLngLiteral = {lat: 5, lng: 7};
     const infoWindowSpy = createInfoWindowSpy({position});
-    const infoWindowConstructorSpy =
-      createInfoWindowConstructorSpy(infoWindowSpy).and.callThrough();
+    const infoWindowConstructorSpy = createInfoWindowConstructorSpy(infoWindowSpy);
 
     const fixture = TestBed.createComponent(TestApp);
     fixture.componentInstance.position = position;
     fixture.detectChanges();
+    flush();
 
     expect(infoWindowConstructorSpy).toHaveBeenCalledWith({
       position,
       content: jasmine.any(Node),
     });
-  });
+  }));
 
-  it('sets options', () => {
+  it('sets options', fakeAsync(() => {
     const options: google.maps.InfoWindowOptions = {
       position: {lat: 3, lng: 5},
       maxWidth: 50,
       disableAutoPan: true,
     };
     const infoWindowSpy = createInfoWindowSpy(options);
-    const infoWindowConstructorSpy =
-      createInfoWindowConstructorSpy(infoWindowSpy).and.callThrough();
+    const infoWindowConstructorSpy = createInfoWindowConstructorSpy(infoWindowSpy);
 
     const fixture = TestBed.createComponent(TestApp);
     fixture.componentInstance.options = options;
     fixture.detectChanges();
+    flush();
 
     expect(infoWindowConstructorSpy).toHaveBeenCalledWith({
       ...options,
       content: jasmine.any(Node),
     });
-  });
+  }));
 
-  it('gives preference to position over options', () => {
+  it('gives preference to position over options', fakeAsync(() => {
     const position: google.maps.LatLngLiteral = {lat: 5, lng: 7};
     const options: google.maps.InfoWindowOptions = {
       position: {lat: 3, lng: 5},
@@ -83,35 +82,36 @@ describe('MapInfoWindow', () => {
       disableAutoPan: true,
     };
     const infoWindowSpy = createInfoWindowSpy({...options, position});
-    const infoWindowConstructorSpy =
-      createInfoWindowConstructorSpy(infoWindowSpy).and.callThrough();
+    const infoWindowConstructorSpy = createInfoWindowConstructorSpy(infoWindowSpy);
 
     const fixture = TestBed.createComponent(TestApp);
     fixture.componentInstance.options = options;
     fixture.componentInstance.position = position;
     fixture.detectChanges();
+    flush();
 
     expect(infoWindowConstructorSpy).toHaveBeenCalledWith({
       ...options,
       position,
       content: jasmine.any(Node),
     });
-  });
+  }));
 
-  it('exposes methods that change the configuration of the info window', () => {
+  it('exposes methods that change the configuration of the info window', fakeAsync(() => {
     const fakeMarker = {} as unknown as google.maps.Marker;
     const fakeMarkerComponent = {
       marker: fakeMarker,
       getAnchor: () => fakeMarker,
     } as unknown as MapMarker;
     const infoWindowSpy = createInfoWindowSpy({});
-    createInfoWindowConstructorSpy(infoWindowSpy).and.callThrough();
+    createInfoWindowConstructorSpy(infoWindowSpy);
 
     const fixture = TestBed.createComponent(TestApp);
     const infoWindowComponent = fixture.debugElement
       .query(By.directive(MapInfoWindow))!
       .injector.get<MapInfoWindow>(MapInfoWindow);
     fixture.detectChanges();
+    flush();
 
     infoWindowComponent.close();
     expect(infoWindowSpy.close).toHaveBeenCalled();
@@ -124,22 +124,23 @@ describe('MapInfoWindow', () => {
         shouldFocus: undefined,
       }),
     );
-  });
+  }));
 
-  it('should not try to reopen info window multiple times for the same marker', () => {
+  it('should not try to reopen info window multiple times for the same marker', fakeAsync(() => {
     const fakeMarker = {} as unknown as google.maps.Marker;
     const fakeMarkerComponent = {
       marker: fakeMarker,
       getAnchor: () => fakeMarker,
     } as unknown as MapMarker;
     const infoWindowSpy = createInfoWindowSpy({});
-    createInfoWindowConstructorSpy(infoWindowSpy).and.callThrough();
+    createInfoWindowConstructorSpy(infoWindowSpy);
 
     const fixture = TestBed.createComponent(TestApp);
     const infoWindowComponent = fixture.debugElement
       .query(By.directive(MapInfoWindow))!
       .injector.get<MapInfoWindow>(MapInfoWindow);
     fixture.detectChanges();
+    flush();
 
     infoWindowComponent.open(fakeMarkerComponent);
     expect(infoWindowSpy.open).toHaveBeenCalledTimes(1);
@@ -150,17 +151,18 @@ describe('MapInfoWindow', () => {
     infoWindowComponent.close();
     infoWindowComponent.open(fakeMarkerComponent);
     expect(infoWindowSpy.open).toHaveBeenCalledTimes(2);
-  });
+  }));
 
-  it('exposes methods that provide information about the info window', () => {
+  it('exposes methods that provide information about the info window', fakeAsync(() => {
     const infoWindowSpy = createInfoWindowSpy({});
-    createInfoWindowConstructorSpy(infoWindowSpy).and.callThrough();
+    createInfoWindowConstructorSpy(infoWindowSpy);
 
     const fixture = TestBed.createComponent(TestApp);
     const infoWindowComponent = fixture.debugElement
       .query(By.directive(MapInfoWindow))!
       .injector.get<MapInfoWindow>(MapInfoWindow);
     fixture.detectChanges();
+    flush();
 
     infoWindowSpy.getContent.and.returnValue('test content');
     expect(infoWindowComponent.getContent()).toBe('test content');
@@ -170,30 +172,32 @@ describe('MapInfoWindow', () => {
 
     infoWindowSpy.getZIndex.and.returnValue(5);
     expect(infoWindowComponent.getZIndex()).toBe(5);
-  });
+  }));
 
-  it('initializes info window event handlers', () => {
+  it('initializes info window event handlers', fakeAsync(() => {
     const infoWindowSpy = createInfoWindowSpy({});
-    createInfoWindowConstructorSpy(infoWindowSpy).and.callThrough();
+    createInfoWindowConstructorSpy(infoWindowSpy);
 
     const addSpy = infoWindowSpy.addListener;
     const fixture = TestBed.createComponent(TestApp);
     fixture.detectChanges();
+    flush();
 
     expect(addSpy).toHaveBeenCalledWith('closeclick', jasmine.any(Function));
     expect(addSpy).not.toHaveBeenCalledWith('content_changed', jasmine.any(Function));
     expect(addSpy).not.toHaveBeenCalledWith('domready', jasmine.any(Function));
     expect(addSpy).not.toHaveBeenCalledWith('position_changed', jasmine.any(Function));
     expect(addSpy).not.toHaveBeenCalledWith('zindex_changed', jasmine.any(Function));
-  });
+  }));
 
-  it('should be able to add an event listener after init', () => {
+  it('should be able to add an event listener after init', fakeAsync(() => {
     const infoWindowSpy = createInfoWindowSpy({});
-    createInfoWindowConstructorSpy(infoWindowSpy).and.callThrough();
+    createInfoWindowConstructorSpy(infoWindowSpy);
 
     const addSpy = infoWindowSpy.addListener;
     const fixture = TestBed.createComponent(TestApp);
     fixture.detectChanges();
+    flush();
 
     expect(addSpy).not.toHaveBeenCalledWith('zindex_changed', jasmine.any(Function));
 
@@ -203,36 +207,38 @@ describe('MapInfoWindow', () => {
 
     expect(addSpy).toHaveBeenCalledWith('zindex_changed', jasmine.any(Function));
     subscription.unsubscribe();
-  });
+  }));
 
-  it('should be able to open an info window without passing in an anchor', () => {
+  it('should be able to open an info window without passing in an anchor', fakeAsync(() => {
     const infoWindowSpy = createInfoWindowSpy({});
-    createInfoWindowConstructorSpy(infoWindowSpy).and.callThrough();
+    createInfoWindowConstructorSpy(infoWindowSpy);
 
     const fixture = TestBed.createComponent(TestApp);
     const infoWindowComponent = fixture.debugElement
       .query(By.directive(MapInfoWindow))!
       .injector.get<MapInfoWindow>(MapInfoWindow);
     fixture.detectChanges();
+    flush();
 
     infoWindowComponent.open();
     expect(infoWindowSpy.open).toHaveBeenCalledTimes(1);
-  });
+  }));
 
-  it('should allow for the focus behavior to be changed when opening the info window', () => {
+  it('should allow for the focus behavior to be changed when opening the info window', fakeAsync(() => {
     const fakeMarker = {} as unknown as google.maps.Marker;
     const fakeMarkerComponent = {
       marker: fakeMarker,
       getAnchor: () => fakeMarker,
     } as unknown as MapMarker;
     const infoWindowSpy = createInfoWindowSpy({});
-    createInfoWindowConstructorSpy(infoWindowSpy).and.callThrough();
+    createInfoWindowConstructorSpy(infoWindowSpy);
 
     const fixture = TestBed.createComponent(TestApp);
     const infoWindowComponent = fixture.debugElement
       .query(By.directive(MapInfoWindow))!
       .injector.get<MapInfoWindow>(MapInfoWindow);
     fixture.detectChanges();
+    flush();
 
     infoWindowComponent.open(fakeMarkerComponent, false);
     expect(infoWindowSpy.open).toHaveBeenCalledWith(
@@ -240,7 +246,7 @@ describe('MapInfoWindow', () => {
         shouldFocus: false,
       }),
     );
-  });
+  }));
 });
 
 @Component({

--- a/src/google-maps/map-info-window/map-info-window.ts
+++ b/src/google-maps/map-info-window/map-info-window.ts
@@ -26,6 +26,7 @@ import {map, take, takeUntil} from 'rxjs/operators';
 import {GoogleMap} from '../google-map/google-map';
 import {MapEventManager} from '../map-event-manager';
 import {MapAnchorPoint} from '../map-anchor-point';
+import {importLibrary} from '../import-library';
 
 /**
  * Angular component that renders a Google Maps info window via the Google Maps JavaScript API.
@@ -122,7 +123,7 @@ export class MapInfoWindow implements OnInit, OnDestroy {
           this._ngZone.runOutsideAngular(async () => {
             const infoWindowConstructor =
               google.maps.InfoWindow ||
-              ((await google.maps.importLibrary('maps')) as google.maps.MapsLibrary).InfoWindow;
+              (await importLibrary<google.maps.InfoWindow>('maps', 'InfoWindow'));
             this.infoWindow = new infoWindowConstructor(options);
             this._eventManager.setTarget(this.infoWindow);
             this.infoWindowInitialized.emit(this.infoWindow);

--- a/src/google-maps/map-kml-layer/map-kml-layer.spec.ts
+++ b/src/google-maps/map-kml-layer/map-kml-layer.spec.ts
@@ -1,5 +1,5 @@
 import {Component, ViewChild} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
+import {TestBed, fakeAsync, flush} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
 import {DEFAULT_OPTIONS, GoogleMap} from '../google-map/google-map';
@@ -24,59 +24,63 @@ describe('MapKmlLayer', () => {
 
   beforeEach(() => {
     mapSpy = createMapSpy(DEFAULT_OPTIONS);
-    createMapConstructorSpy(mapSpy).and.callThrough();
+    createMapConstructorSpy(mapSpy);
   });
 
   afterEach(() => {
     (window.google as any) = undefined;
   });
 
-  it('initializes a Google Map Kml Layer', () => {
+  it('initializes a Google Map Kml Layer', fakeAsync(() => {
     const kmlLayerSpy = createKmlLayerSpy({});
-    const kmlLayerConstructorSpy = createKmlLayerConstructorSpy(kmlLayerSpy).and.callThrough();
+    const kmlLayerConstructorSpy = createKmlLayerConstructorSpy(kmlLayerSpy);
 
     const fixture = TestBed.createComponent(TestApp);
     fixture.detectChanges();
+    flush();
 
     expect(kmlLayerConstructorSpy).toHaveBeenCalledWith({url: undefined});
     expect(kmlLayerSpy.setMap).toHaveBeenCalledWith(mapSpy);
-  });
+  }));
 
-  it('sets url from input', () => {
+  it('sets url from input', fakeAsync(() => {
     const options: google.maps.KmlLayerOptions = {url: DEMO_URL};
     const kmlLayerSpy = createKmlLayerSpy(options);
-    const kmlLayerConstructorSpy = createKmlLayerConstructorSpy(kmlLayerSpy).and.callThrough();
+    const kmlLayerConstructorSpy = createKmlLayerConstructorSpy(kmlLayerSpy);
 
     const fixture = TestBed.createComponent(TestApp);
     fixture.componentInstance.url = DEMO_URL;
     fixture.detectChanges();
+    flush();
 
     expect(kmlLayerConstructorSpy).toHaveBeenCalledWith(options);
-  });
+  }));
 
-  it('gives precedence to url input over options', () => {
+  it('gives precedence to url input over options', fakeAsync(() => {
     const expectedUrl = 'www.realurl.kml';
     const expectedOptions: google.maps.KmlLayerOptions = {...DEFAULT_KML_OPTIONS, url: expectedUrl};
     const kmlLayerSpy = createKmlLayerSpy(expectedOptions);
-    const kmlLayerConstructorSpy = createKmlLayerConstructorSpy(kmlLayerSpy).and.callThrough();
+    const kmlLayerConstructorSpy = createKmlLayerConstructorSpy(kmlLayerSpy);
 
     const fixture = TestBed.createComponent(TestApp);
     fixture.componentInstance.options = DEFAULT_KML_OPTIONS;
     fixture.componentInstance.url = expectedUrl;
     fixture.detectChanges();
+    flush();
 
     expect(kmlLayerConstructorSpy).toHaveBeenCalledWith(expectedOptions);
-  });
+  }));
 
-  it('exposes methods that provide information about the KmlLayer', () => {
+  it('exposes methods that provide information about the KmlLayer', fakeAsync(() => {
     const kmlLayerSpy = createKmlLayerSpy(DEFAULT_KML_OPTIONS);
-    createKmlLayerConstructorSpy(kmlLayerSpy).and.callThrough();
+    createKmlLayerConstructorSpy(kmlLayerSpy);
 
     const fixture = TestBed.createComponent(TestApp);
     const kmlLayerComponent = fixture.debugElement
       .query(By.directive(MapKmlLayer))!
       .injector.get<MapKmlLayer>(MapKmlLayer);
     fixture.detectChanges();
+    flush();
 
     kmlLayerComponent.getDefaultViewport();
     expect(kmlLayerSpy.getDefaultViewport).toHaveBeenCalled();
@@ -103,28 +107,30 @@ describe('MapKmlLayer', () => {
 
     kmlLayerSpy.getZIndex.and.returnValue(3);
     expect(kmlLayerComponent.getZIndex()).toBe(3);
-  });
+  }));
 
-  it('initializes KmlLayer event handlers', () => {
+  it('initializes KmlLayer event handlers', fakeAsync(() => {
     const kmlLayerSpy = createKmlLayerSpy(DEFAULT_KML_OPTIONS);
-    createKmlLayerConstructorSpy(kmlLayerSpy).and.callThrough();
+    createKmlLayerConstructorSpy(kmlLayerSpy);
 
     const addSpy = kmlLayerSpy.addListener;
     const fixture = TestBed.createComponent(TestApp);
     fixture.detectChanges();
+    flush();
 
     expect(addSpy).toHaveBeenCalledWith('click', jasmine.any(Function));
     expect(addSpy).not.toHaveBeenCalledWith('defaultviewport_changed', jasmine.any(Function));
     expect(addSpy).toHaveBeenCalledWith('status_changed', jasmine.any(Function));
-  });
+  }));
 
-  it('should be able to add an event listener after init', () => {
+  it('should be able to add an event listener after init', fakeAsync(() => {
     const kmlLayerSpy = createKmlLayerSpy(DEFAULT_KML_OPTIONS);
-    createKmlLayerConstructorSpy(kmlLayerSpy).and.callThrough();
+    createKmlLayerConstructorSpy(kmlLayerSpy);
 
     const addSpy = kmlLayerSpy.addListener;
     const fixture = TestBed.createComponent(TestApp);
     fixture.detectChanges();
+    flush();
 
     expect(addSpy).not.toHaveBeenCalledWith('defaultviewport_changed', jasmine.any(Function));
 
@@ -134,7 +140,7 @@ describe('MapKmlLayer', () => {
 
     expect(addSpy).toHaveBeenCalledWith('defaultviewport_changed', jasmine.any(Function));
     subscription.unsubscribe();
-  });
+  }));
 });
 
 @Component({

--- a/src/google-maps/map-kml-layer/map-kml-layer.ts
+++ b/src/google-maps/map-kml-layer/map-kml-layer.ts
@@ -24,6 +24,7 @@ import {map, take, takeUntil} from 'rxjs/operators';
 
 import {GoogleMap} from '../google-map/google-map';
 import {MapEventManager} from '../map-event-manager';
+import {importLibrary} from '../import-library';
 
 /**
  * Angular component that renders a Google Maps KML Layer via the Google Maps JavaScript API.
@@ -100,7 +101,7 @@ export class MapKmlLayer implements OnInit, OnDestroy {
             const map = await this._map._resolveMap();
             const layerConstructor =
               google.maps.KmlLayer ||
-              ((await google.maps.importLibrary('maps')) as google.maps.MapsLibrary).KmlLayer;
+              (await importLibrary<google.maps.KmlLayer>('maps', 'KmlLayer'));
             this.kmlLayer = new layerConstructor(options);
             this._assertInitialized();
             this.kmlLayer.setMap(map);

--- a/src/google-maps/map-marker-clusterer/map-marker-clusterer.spec.ts
+++ b/src/google-maps/map-marker-clusterer/map-marker-clusterer.spec.ts
@@ -1,5 +1,5 @@
 import {Component, ViewChild} from '@angular/core';
-import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {ComponentFixture, TestBed, fakeAsync, flush} from '@angular/core/testing';
 
 import {DEFAULT_OPTIONS, GoogleMap} from '../google-map/google-map';
 import {MapMarker} from '../map-marker/map-marker';
@@ -30,7 +30,7 @@ describe('MapMarkerClusterer', () => {
 
   beforeEach(() => {
     mapSpy = createMapSpy(DEFAULT_OPTIONS);
-    createMapConstructorSpy(mapSpy).and.callThrough();
+    createMapConstructorSpy(mapSpy);
 
     const markerSpy = createMarkerSpy({});
     // The spy target function cannot be an arrow-function as this breaks when created
@@ -40,8 +40,7 @@ describe('MapMarkerClusterer', () => {
     });
 
     markerClustererSpy = createMarkerClustererSpy();
-    markerClustererConstructorSpy =
-      createMarkerClustererConstructorSpy(markerClustererSpy).and.callThrough();
+    markerClustererConstructorSpy = createMarkerClustererConstructorSpy(markerClustererSpy);
 
     fixture = TestBed.createComponent(TestApp);
   });
@@ -51,24 +50,19 @@ describe('MapMarkerClusterer', () => {
     (window as any).MarkerClusterer = undefined;
   });
 
-  it('throws an error if the clustering library has not been loaded', () => {
+  it('throws an error if the clustering library has not been loaded', fakeAsync(() => {
     (window as any).MarkerClusterer = undefined;
-    markerClustererConstructorSpy = createMarkerClustererConstructorSpy(
-      markerClustererSpy,
-      false,
-    ).and.callThrough();
+    markerClustererConstructorSpy = createMarkerClustererConstructorSpy(markerClustererSpy, false);
 
-    expect(() => fixture.detectChanges()).toThrow(
-      new Error(
-        'MarkerClusterer class not found, cannot construct a marker cluster. ' +
-          'Please install the MarkerClustererPlus library: ' +
-          'https://github.com/googlemaps/js-markerclustererplus',
-      ),
-    );
-  });
+    expect(() => {
+      fixture.detectChanges();
+      flush();
+    }).toThrowError(/MarkerClusterer class not found, cannot construct a marker cluster/);
+  }));
 
-  it('initializes a Google Map Marker Clusterer', () => {
+  it('initializes a Google Map Marker Clusterer', fakeAsync(() => {
     fixture.detectChanges();
+    flush();
 
     expect(markerClustererConstructorSpy).toHaveBeenCalledWith(mapSpy, [], {
       ariaLabelFn: undefined,
@@ -90,9 +84,9 @@ describe('MapMarkerClusterer', () => {
       zIndex: undefined,
       zoomOnClick: undefined,
     });
-  });
+  }));
 
-  it('sets marker clusterer inputs', () => {
+  it('sets marker clusterer inputs', fakeAsync(() => {
     fixture.componentInstance.ariaLabelFn = (testString: string) => testString;
     fixture.componentInstance.averageCenter = true;
     fixture.componentInstance.batchSize = 1;
@@ -110,6 +104,7 @@ describe('MapMarkerClusterer', () => {
     fixture.componentInstance.zIndex = 6;
     fixture.componentInstance.zoomOnClick = true;
     fixture.detectChanges();
+    flush();
 
     expect(markerClustererConstructorSpy).toHaveBeenCalledWith(mapSpy, [], {
       ariaLabelFn: jasmine.any(Function),
@@ -131,10 +126,11 @@ describe('MapMarkerClusterer', () => {
       zIndex: 6,
       zoomOnClick: true,
     });
-  });
+  }));
 
-  it('sets marker clusterer options', () => {
+  it('sets marker clusterer options', fakeAsync(() => {
     fixture.detectChanges();
+    flush();
     const options: MarkerClustererOptions = {
       enableRetinaIcons: true,
       gridSize: 1337,
@@ -144,10 +140,11 @@ describe('MapMarkerClusterer', () => {
     fixture.componentInstance.options = options;
     fixture.detectChanges();
     expect(markerClustererSpy.setOptions).toHaveBeenCalledWith(jasmine.objectContaining(options));
-  });
+  }));
 
-  it('gives precedence to specific inputs over options', () => {
+  it('gives precedence to specific inputs over options', fakeAsync(() => {
     fixture.detectChanges();
+    flush();
     const options: MarkerClustererOptions = {
       enableRetinaIcons: true,
       gridSize: 1337,
@@ -170,19 +167,21 @@ describe('MapMarkerClusterer', () => {
     expect(markerClustererSpy.setOptions).toHaveBeenCalledWith(
       jasmine.objectContaining(expectedOptions),
     );
-  });
+  }));
 
-  it('sets Google Maps Markers in the MarkerClusterer', () => {
+  it('sets Google Maps Markers in the MarkerClusterer', fakeAsync(() => {
     fixture.detectChanges();
+    flush();
 
     expect(markerClustererSpy.addMarkers).toHaveBeenCalledWith([
       anyMarkerMatcher,
       anyMarkerMatcher,
     ]);
-  });
+  }));
 
-  it('updates Google Maps Markers in the Marker Clusterer', () => {
+  it('updates Google Maps Markers in the Marker Clusterer', fakeAsync(() => {
     fixture.detectChanges();
+    flush();
 
     expect(markerClustererSpy.addMarkers).toHaveBeenCalledWith([
       anyMarkerMatcher,
@@ -191,6 +190,7 @@ describe('MapMarkerClusterer', () => {
 
     fixture.componentInstance.state = 'state2';
     fixture.detectChanges();
+    flush();
 
     expect(markerClustererSpy.addMarkers).toHaveBeenCalledWith([anyMarkerMatcher], true);
     expect(markerClustererSpy.removeMarkers).toHaveBeenCalledWith([anyMarkerMatcher], true);
@@ -198,6 +198,7 @@ describe('MapMarkerClusterer', () => {
 
     fixture.componentInstance.state = 'state0';
     fixture.detectChanges();
+    flush();
 
     expect(markerClustererSpy.addMarkers).toHaveBeenCalledWith([], true);
     expect(markerClustererSpy.removeMarkers).toHaveBeenCalledWith(
@@ -205,10 +206,11 @@ describe('MapMarkerClusterer', () => {
       true,
     );
     expect(markerClustererSpy.repaint).toHaveBeenCalledTimes(2);
-  });
+  }));
 
-  it('exposes marker clusterer methods', () => {
+  it('exposes marker clusterer methods', fakeAsync(() => {
     fixture.detectChanges();
+    flush();
     const markerClustererComponent = fixture.componentInstance.markerClusterer;
 
     markerClustererComponent.fitMapToMarkers(5);
@@ -275,10 +277,11 @@ describe('MapMarkerClusterer', () => {
 
     markerClustererSpy.getZoomOnClick.and.returnValue(true);
     expect(markerClustererComponent.getZoomOnClick()).toBe(true);
-  });
+  }));
 
-  it('initializes marker clusterer event handlers', () => {
+  it('initializes marker clusterer event handlers', fakeAsync(() => {
     fixture.detectChanges();
+    flush();
 
     expect(markerClustererSpy.addListener).toHaveBeenCalledWith(
       'clusteringbegin',
@@ -289,7 +292,7 @@ describe('MapMarkerClusterer', () => {
       jasmine.any(Function),
     );
     expect(markerClustererSpy.addListener).toHaveBeenCalledWith('click', jasmine.any(Function));
-  });
+  }));
 });
 
 @Component({

--- a/src/google-maps/map-marker-clusterer/map-marker-clusterer.ts
+++ b/src/google-maps/map-marker-clusterer/map-marker-clusterer.ts
@@ -14,6 +14,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   ContentChildren,
+  EventEmitter,
   Input,
   NgZone,
   OnChanges,
@@ -26,7 +27,7 @@ import {
   inject,
 } from '@angular/core';
 import {Observable, Subject} from 'rxjs';
-import {takeUntil} from 'rxjs/operators';
+import {take, takeUntil} from 'rxjs/operators';
 
 import {GoogleMap} from '../google-map/google-map';
 import {MapEventManager} from '../map-event-manager';
@@ -207,45 +208,56 @@ export class MapMarkerClusterer implements OnInit, AfterContentInit, OnChanges, 
    */
   markerClusterer?: MarkerClustererInstance;
 
+  /** Event emitted when the clusterer is initialized. */
+  @Output() readonly markerClustererInitialized: EventEmitter<MarkerClustererInstance> =
+    new EventEmitter<MarkerClustererInstance>();
+
   constructor(
     private readonly _googleMap: GoogleMap,
     private readonly _ngZone: NgZone,
   ) {
-    this._canInitialize = this._googleMap._isBrowser;
+    this._canInitialize = _googleMap._isBrowser;
   }
 
   ngOnInit() {
     if (this._canInitialize) {
-      if (
-        typeof MarkerClusterer !== 'function' &&
-        (typeof ngDevMode === 'undefined' || ngDevMode)
-      ) {
-        throw Error(
-          'MarkerClusterer class not found, cannot construct a marker cluster. ' +
-            'Please install the MarkerClustererPlus library: ' +
-            'https://github.com/googlemaps/js-markerclustererplus',
-        );
-      }
+      this._ngZone.runOutsideAngular(async () => {
+        const map = await this._googleMap._resolveMap();
 
-      // Create the object outside the zone so its events don't trigger change detection.
-      // We'll bring it back in inside the `MapEventManager` only for the events that the
-      // user has subscribed to.
-      this._ngZone.runOutsideAngular(() => {
-        this.markerClusterer = new MarkerClusterer(
-          this._googleMap.googleMap!,
-          [],
-          this._combineOptions(),
-        );
+        if (
+          typeof MarkerClusterer !== 'function' &&
+          (typeof ngDevMode === 'undefined' || ngDevMode)
+        ) {
+          throw Error(
+            'MarkerClusterer class not found, cannot construct a marker cluster. ' +
+              'Please install the MarkerClustererPlus library: ' +
+              'https://github.com/googlemaps/js-markerclustererplus',
+          );
+        }
+
+        // Create the object outside the zone so its events don't trigger change detection.
+        // We'll bring it back in inside the `MapEventManager` only for the events that the
+        // user has subscribed to.
+        this.markerClusterer = this._ngZone.runOutsideAngular(() => {
+          return new MarkerClusterer(map, [], this._combineOptions());
+        });
+
+        this._assertInitialized();
+        this._eventManager.setTarget(this.markerClusterer);
+        this.markerClustererInitialized.emit(this.markerClusterer);
       });
-
-      this._assertInitialized();
-      this._eventManager.setTarget(this.markerClusterer);
     }
   }
 
   ngAfterContentInit() {
     if (this._canInitialize) {
-      this._watchForMarkerChanges();
+      if (this.markerClusterer) {
+        this._watchForMarkerChanges();
+      } else {
+        this.markerClustererInitialized
+          .pipe(take(1), takeUntil(this._destroy))
+          .subscribe(() => this._watchForMarkerChanges());
+      }
     }
   }
 
@@ -333,9 +345,7 @@ export class MapMarkerClusterer implements OnInit, AfterContentInit, OnChanges, 
     this._destroy.next();
     this._destroy.complete();
     this._eventManager.destroy();
-    if (this.markerClusterer) {
-      this.markerClusterer.setMap(null);
-    }
+    this.markerClusterer?.setMap(null);
   }
 
   fitMapToMarkers(padding: number | google.maps.Padding) {
@@ -465,54 +475,56 @@ export class MapMarkerClusterer implements OnInit, AfterContentInit, OnChanges, 
 
   private _watchForMarkerChanges() {
     this._assertInitialized();
-    const initialMarkers: google.maps.Marker[] = [];
-    for (const marker of this._getInternalMarkers(this._markers.toArray())) {
-      this._currentMarkers.add(marker);
-      initialMarkers.push(marker);
-    }
-    this.markerClusterer.addMarkers(initialMarkers);
+
+    this._ngZone.runOutsideAngular(async () => {
+      const initialMarkers: google.maps.Marker[] = [];
+      const markers = await this._getInternalMarkers(this._markers);
+      for (const marker of markers) {
+        this._currentMarkers.add(marker);
+        initialMarkers.push(marker);
+      }
+      this.markerClusterer.addMarkers(initialMarkers);
+    });
 
     this._markers.changes
       .pipe(takeUntil(this._destroy))
       .subscribe((markerComponents: MapMarker[]) => {
         this._assertInitialized();
-        const newMarkers = new Set<google.maps.Marker>(this._getInternalMarkers(markerComponents));
-        const markersToAdd: google.maps.Marker[] = [];
-        const markersToRemove: google.maps.Marker[] = [];
-        for (const marker of Array.from(newMarkers)) {
-          if (!this._currentMarkers.has(marker)) {
-            this._currentMarkers.add(marker);
-            markersToAdd.push(marker);
+        this._ngZone.runOutsideAngular(async () => {
+          const newMarkers = new Set<google.maps.Marker>(
+            await this._getInternalMarkers(markerComponents),
+          );
+          const markersToAdd: google.maps.Marker[] = [];
+          const markersToRemove: google.maps.Marker[] = [];
+          for (const marker of Array.from(newMarkers)) {
+            if (!this._currentMarkers.has(marker)) {
+              this._currentMarkers.add(marker);
+              markersToAdd.push(marker);
+            }
           }
-        }
-        for (const marker of Array.from(this._currentMarkers)) {
-          if (!newMarkers.has(marker)) {
-            markersToRemove.push(marker);
+          for (const marker of Array.from(this._currentMarkers)) {
+            if (!newMarkers.has(marker)) {
+              markersToRemove.push(marker);
+            }
           }
-        }
-        this.markerClusterer.addMarkers(markersToAdd, true);
-        this.markerClusterer.removeMarkers(markersToRemove, true);
-        this.markerClusterer.repaint();
-        for (const marker of markersToRemove) {
-          this._currentMarkers.delete(marker);
-        }
+          this.markerClusterer.addMarkers(markersToAdd, true);
+          this.markerClusterer.removeMarkers(markersToRemove, true);
+          this.markerClusterer.repaint();
+          for (const marker of markersToRemove) {
+            this._currentMarkers.delete(marker);
+          }
+        });
       });
   }
 
-  private _getInternalMarkers(markers: MapMarker[]): google.maps.Marker[] {
-    return markers
-      .filter(markerComponent => !!markerComponent.marker)
-      .map(markerComponent => markerComponent.marker!);
+  private _getInternalMarkers(
+    markers: MapMarker[] | QueryList<MapMarker>,
+  ): Promise<google.maps.Marker[]> {
+    return Promise.all(markers.map(markerComponent => markerComponent._resolveMarker()));
   }
 
   private _assertInitialized(): asserts this is {markerClusterer: MarkerClustererInstance} {
     if (typeof ngDevMode === 'undefined' || ngDevMode) {
-      if (!this._googleMap.googleMap) {
-        throw Error(
-          'Cannot access Google Map information before the API has been initialized. ' +
-            'Please wait for the API to load before trying to interact with it.',
-        );
-      }
       if (!this.markerClusterer) {
         throw Error(
           'Cannot interact with a MarkerClusterer before it has been initialized. ' +

--- a/src/google-maps/map-marker/map-marker.spec.ts
+++ b/src/google-maps/map-marker/map-marker.spec.ts
@@ -1,5 +1,5 @@
 import {Component, ViewChild} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
+import {TestBed, fakeAsync, flush} from '@angular/core/testing';
 
 import {DEFAULT_OPTIONS, GoogleMap} from '../google-map/google-map';
 import {
@@ -15,19 +15,20 @@ describe('MapMarker', () => {
 
   beforeEach(() => {
     mapSpy = createMapSpy(DEFAULT_OPTIONS);
-    createMapConstructorSpy(mapSpy).and.callThrough();
+    createMapConstructorSpy(mapSpy);
   });
 
   afterEach(() => {
     (window.google as any) = undefined;
   });
 
-  it('initializes a Google Map marker', () => {
+  it('initializes a Google Map marker', fakeAsync(() => {
     const markerSpy = createMarkerSpy(DEFAULT_MARKER_OPTIONS);
-    const markerConstructorSpy = createMarkerConstructorSpy(markerSpy).and.callThrough();
+    const markerConstructorSpy = createMarkerConstructorSpy(markerSpy);
 
     const fixture = TestBed.createComponent(TestApp);
     fixture.detectChanges();
+    flush();
 
     expect(markerConstructorSpy).toHaveBeenCalledWith({
       ...DEFAULT_MARKER_OPTIONS,
@@ -38,9 +39,9 @@ describe('MapMarker', () => {
       visible: undefined,
       map: mapSpy,
     });
-  });
+  }));
 
-  it('sets marker inputs', () => {
+  it('sets marker inputs', fakeAsync(() => {
     const options: google.maps.MarkerOptions = {
       position: {lat: 3, lng: 5},
       title: 'marker title',
@@ -51,7 +52,7 @@ describe('MapMarker', () => {
       map: mapSpy,
     };
     const markerSpy = createMarkerSpy(options);
-    const markerConstructorSpy = createMarkerConstructorSpy(markerSpy).and.callThrough();
+    const markerConstructorSpy = createMarkerConstructorSpy(markerSpy);
 
     const fixture = TestBed.createComponent(TestApp);
     fixture.componentInstance.position = options.position;
@@ -61,11 +62,12 @@ describe('MapMarker', () => {
     fixture.componentInstance.icon = 'icon.png';
     fixture.componentInstance.visible = false;
     fixture.detectChanges();
+    flush();
 
     expect(markerConstructorSpy).toHaveBeenCalledWith(options);
-  });
+  }));
 
-  it('sets marker options, ignoring map', () => {
+  it('sets marker options, ignoring map', fakeAsync(() => {
     const options: google.maps.MarkerOptions = {
       position: {lat: 3, lng: 5},
       title: 'marker title',
@@ -75,16 +77,17 @@ describe('MapMarker', () => {
       visible: undefined,
     };
     const markerSpy = createMarkerSpy(options);
-    const markerConstructorSpy = createMarkerConstructorSpy(markerSpy).and.callThrough();
+    const markerConstructorSpy = createMarkerConstructorSpy(markerSpy);
 
     const fixture = TestBed.createComponent(TestApp);
     fixture.componentInstance.options = options;
     fixture.detectChanges();
+    flush();
 
     expect(markerConstructorSpy).toHaveBeenCalledWith({...options, map: mapSpy});
-  });
+  }));
 
-  it('gives precedence to specific inputs over options', () => {
+  it('gives precedence to specific inputs over options', fakeAsync(() => {
     const options: google.maps.MarkerOptions = {
       position: {lat: 3, lng: 5},
       title: 'marker title',
@@ -102,7 +105,7 @@ describe('MapMarker', () => {
       visible: undefined,
     };
     const markerSpy = createMarkerSpy(options);
-    const markerConstructorSpy = createMarkerConstructorSpy(markerSpy).and.callThrough();
+    const markerConstructorSpy = createMarkerConstructorSpy(markerSpy);
 
     const fixture = TestBed.createComponent(TestApp);
     fixture.componentInstance.position = expectedOptions.position;
@@ -111,16 +114,18 @@ describe('MapMarker', () => {
     fixture.componentInstance.clickable = expectedOptions.clickable;
     fixture.componentInstance.options = options;
     fixture.detectChanges();
+    flush();
 
     expect(markerConstructorSpy).toHaveBeenCalledWith(expectedOptions);
-  });
+  }));
 
-  it('exposes methods that provide information about the marker', () => {
+  it('exposes methods that provide information about the marker', fakeAsync(() => {
     const markerSpy = createMarkerSpy(DEFAULT_MARKER_OPTIONS);
-    createMarkerConstructorSpy(markerSpy).and.callThrough();
+    createMarkerConstructorSpy(markerSpy);
 
     const fixture = TestBed.createComponent(TestApp);
     fixture.detectChanges();
+    flush();
     const marker = fixture.componentInstance.marker;
 
     markerSpy.getAnimation.and.returnValue(null);
@@ -158,15 +163,16 @@ describe('MapMarker', () => {
 
     markerSpy.getZIndex.and.returnValue(2);
     expect(marker.getZIndex()).toBe(2);
-  });
+  }));
 
-  it('initializes marker event handlers', () => {
+  it('initializes marker event handlers', fakeAsync(() => {
     const markerSpy = createMarkerSpy(DEFAULT_MARKER_OPTIONS);
-    createMarkerConstructorSpy(markerSpy).and.callThrough();
+    createMarkerConstructorSpy(markerSpy);
 
     const addSpy = markerSpy.addListener;
     const fixture = TestBed.createComponent(TestApp);
     fixture.detectChanges();
+    flush();
 
     expect(addSpy).toHaveBeenCalledWith('click', jasmine.any(Function));
     expect(addSpy).toHaveBeenCalledWith('position_changed', jasmine.any(Function));
@@ -189,15 +195,16 @@ describe('MapMarker', () => {
     expect(addSpy).not.toHaveBeenCalledWith('title_changed', jasmine.any(Function));
     expect(addSpy).not.toHaveBeenCalledWith('visible_changed', jasmine.any(Function));
     expect(addSpy).not.toHaveBeenCalledWith('zindex_changed', jasmine.any(Function));
-  });
+  }));
 
-  it('should be able to add an event listener after init', () => {
+  it('should be able to add an event listener after init', fakeAsync(() => {
     const markerSpy = createMarkerSpy(DEFAULT_MARKER_OPTIONS);
-    createMarkerConstructorSpy(markerSpy).and.callThrough();
+    createMarkerConstructorSpy(markerSpy);
 
     const addSpy = markerSpy.addListener;
     const fixture = TestBed.createComponent(TestApp);
     fixture.detectChanges();
+    flush();
 
     expect(addSpy).not.toHaveBeenCalledWith('flat_changed', jasmine.any(Function));
 
@@ -207,7 +214,7 @@ describe('MapMarker', () => {
 
     expect(addSpy).toHaveBeenCalledWith('flat_changed', jasmine.any(Function));
     subscription.unsubscribe();
-  });
+  }));
 });
 
 @Component({

--- a/src/google-maps/map-marker/map-marker.ts
+++ b/src/google-maps/map-marker/map-marker.ts
@@ -27,6 +27,7 @@ import {take} from 'rxjs/operators';
 import {GoogleMap} from '../google-map/google-map';
 import {MapEventManager} from '../map-event-manager';
 import {MapAnchorPoint} from '../map-anchor-point';
+import {importLibrary} from '../import-library';
 
 /**
  * Default options for the Google Maps marker component. Displays a marker
@@ -293,8 +294,7 @@ export class MapMarker implements OnInit, OnChanges, OnDestroy, MapAnchorPoint {
     this._ngZone.runOutsideAngular(async () => {
       const map = await this._googleMap._resolveMap();
       const markerConstructor =
-        google.maps.Marker ||
-        ((await google.maps.importLibrary('marker')) as google.maps.MarkerLibrary).Marker;
+        google.maps.Marker || (await importLibrary<google.maps.Marker>('marker', 'Marker'));
 
       this.marker = new markerConstructor(this._combineOptions());
       this._assertInitialized();

--- a/src/google-maps/map-polygon/map-polygon.spec.ts
+++ b/src/google-maps/map-polygon/map-polygon.spec.ts
@@ -1,5 +1,5 @@
 import {Component, ViewChild} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
+import {TestBed, fakeAsync, flush} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
 import {DEFAULT_OPTIONS, GoogleMap} from '../google-map/google-map';
@@ -28,60 +28,64 @@ describe('MapPolygon', () => {
 
   beforeEach(() => {
     mapSpy = createMapSpy(DEFAULT_OPTIONS);
-    createMapConstructorSpy(mapSpy).and.callThrough();
+    createMapConstructorSpy(mapSpy);
   });
 
   afterEach(() => {
     (window.google as any) = undefined;
   });
 
-  it('initializes a Google Map Polygon', () => {
+  it('initializes a Google Map Polygon', fakeAsync(() => {
     const polygonSpy = createPolygonSpy({});
-    const polygonConstructorSpy = createPolygonConstructorSpy(polygonSpy).and.callThrough();
+    const polygonConstructorSpy = createPolygonConstructorSpy(polygonSpy);
 
     const fixture = TestBed.createComponent(TestApp);
     fixture.detectChanges();
+    flush();
 
     expect(polygonConstructorSpy).toHaveBeenCalledWith({paths: undefined});
     expect(polygonSpy.setMap).toHaveBeenCalledWith(mapSpy);
-  });
+  }));
 
-  it('sets path from input', () => {
+  it('sets path from input', fakeAsync(() => {
     const paths: google.maps.LatLngLiteral[] = [{lat: 3, lng: 5}];
     const options: google.maps.PolygonOptions = {paths};
     const polygonSpy = createPolygonSpy(options);
-    const polygonConstructorSpy = createPolygonConstructorSpy(polygonSpy).and.callThrough();
+    const polygonConstructorSpy = createPolygonConstructorSpy(polygonSpy);
 
     const fixture = TestBed.createComponent(TestApp);
     fixture.componentInstance.paths = paths;
     fixture.detectChanges();
+    flush();
 
     expect(polygonConstructorSpy).toHaveBeenCalledWith(options);
-  });
+  }));
 
-  it('gives precedence to path input over options', () => {
+  it('gives precedence to path input over options', fakeAsync(() => {
     const paths: google.maps.LatLngLiteral[] = [{lat: 3, lng: 5}];
     const expectedOptions: google.maps.PolygonOptions = {...polygonOptions, paths};
     const polygonSpy = createPolygonSpy(expectedOptions);
-    const polygonConstructorSpy = createPolygonConstructorSpy(polygonSpy).and.callThrough();
+    const polygonConstructorSpy = createPolygonConstructorSpy(polygonSpy);
 
     const fixture = TestBed.createComponent(TestApp);
     fixture.componentInstance.options = polygonOptions;
     fixture.componentInstance.paths = paths;
     fixture.detectChanges();
+    flush();
 
     expect(polygonConstructorSpy).toHaveBeenCalledWith(expectedOptions);
-  });
+  }));
 
-  it('exposes methods that provide information about the Polygon', () => {
+  it('exposes methods that provide information about the Polygon', fakeAsync(() => {
     const polygonSpy = createPolygonSpy(polygonOptions);
-    createPolygonConstructorSpy(polygonSpy).and.callThrough();
+    createPolygonConstructorSpy(polygonSpy);
 
     const fixture = TestBed.createComponent(TestApp);
     const polygonComponent = fixture.debugElement
       .query(By.directive(MapPolygon))!
       .injector.get<MapPolygon>(MapPolygon);
     fixture.detectChanges();
+    flush();
 
     polygonSpy.getDraggable.and.returnValue(true);
     expect(polygonComponent.getDraggable()).toBe(true);
@@ -97,15 +101,16 @@ describe('MapPolygon', () => {
 
     polygonSpy.getVisible.and.returnValue(true);
     expect(polygonComponent.getVisible()).toBe(true);
-  });
+  }));
 
-  it('initializes Polygon event handlers', () => {
+  it('initializes Polygon event handlers', fakeAsync(() => {
     const polygonSpy = createPolygonSpy(polygonOptions);
-    createPolygonConstructorSpy(polygonSpy).and.callThrough();
+    createPolygonConstructorSpy(polygonSpy);
 
     const addSpy = polygonSpy.addListener;
     const fixture = TestBed.createComponent(TestApp);
     fixture.detectChanges();
+    flush();
 
     expect(addSpy).toHaveBeenCalledWith('click', jasmine.any(Function));
     expect(addSpy).not.toHaveBeenCalledWith('dblclick', jasmine.any(Function));
@@ -118,15 +123,16 @@ describe('MapPolygon', () => {
     expect(addSpy).not.toHaveBeenCalledWith('mouseover', jasmine.any(Function));
     expect(addSpy).not.toHaveBeenCalledWith('mouseup', jasmine.any(Function));
     expect(addSpy).toHaveBeenCalledWith('rightclick', jasmine.any(Function));
-  });
+  }));
 
-  it('should be able to add an event listener after init', () => {
+  it('should be able to add an event listener after init', fakeAsync(() => {
     const polygonSpy = createPolygonSpy(polygonOptions);
-    createPolygonConstructorSpy(polygonSpy).and.callThrough();
+    createPolygonConstructorSpy(polygonSpy);
 
     const addSpy = polygonSpy.addListener;
     const fixture = TestBed.createComponent(TestApp);
     fixture.detectChanges();
+    flush();
 
     expect(addSpy).not.toHaveBeenCalledWith('dragend', jasmine.any(Function));
 
@@ -136,7 +142,7 @@ describe('MapPolygon', () => {
 
     expect(addSpy).toHaveBeenCalledWith('dragend', jasmine.any(Function));
     subscription.unsubscribe();
-  });
+  }));
 });
 
 @Component({

--- a/src/google-maps/map-polygon/map-polygon.ts
+++ b/src/google-maps/map-polygon/map-polygon.ts
@@ -24,6 +24,7 @@ import {map, take, takeUntil} from 'rxjs/operators';
 
 import {GoogleMap} from '../google-map/google-map';
 import {MapEventManager} from '../map-event-manager';
+import {importLibrary} from '../import-library';
 
 /**
  * Angular component that renders a Google Maps Polygon via the Google Maps JavaScript API.
@@ -157,8 +158,7 @@ export class MapPolygon implements OnInit, OnDestroy {
           this._ngZone.runOutsideAngular(async () => {
             const map = await this._map._resolveMap();
             const polygonConstructor =
-              google.maps.Polygon ||
-              ((await google.maps.importLibrary('maps')) as google.maps.MapsLibrary).Polygon;
+              google.maps.Polygon || (await importLibrary<google.maps.Polygon>('maps', 'Polygon'));
             this.polygon = new polygonConstructor(options);
             this._assertInitialized();
             this.polygon.setMap(map);

--- a/src/google-maps/map-polyline/map-polyline.spec.ts
+++ b/src/google-maps/map-polyline/map-polyline.spec.ts
@@ -1,5 +1,5 @@
 import {Component, ViewChild} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
+import {TestBed, fakeAsync, flush} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
 import {DEFAULT_OPTIONS, GoogleMap} from '../google-map/google-map';
@@ -32,60 +32,64 @@ describe('MapPolyline', () => {
 
   beforeEach(() => {
     mapSpy = createMapSpy(DEFAULT_OPTIONS);
-    createMapConstructorSpy(mapSpy).and.callThrough();
+    createMapConstructorSpy(mapSpy);
   });
 
   afterEach(() => {
     (window.google as any) = undefined;
   });
 
-  it('initializes a Google Map Polyline', () => {
+  it('initializes a Google Map Polyline', fakeAsync(() => {
     const polylineSpy = createPolylineSpy({});
-    const polylineConstructorSpy = createPolylineConstructorSpy(polylineSpy).and.callThrough();
+    const polylineConstructorSpy = createPolylineConstructorSpy(polylineSpy);
 
     const fixture = TestBed.createComponent(TestApp);
     fixture.detectChanges();
+    flush();
 
     expect(polylineConstructorSpy).toHaveBeenCalledWith({path: undefined});
     expect(polylineSpy.setMap).toHaveBeenCalledWith(mapSpy);
-  });
+  }));
 
-  it('sets path from input', () => {
+  it('sets path from input', fakeAsync(() => {
     const path: google.maps.LatLngLiteral[] = [{lat: 3, lng: 5}];
     const options: google.maps.PolylineOptions = {path};
     const polylineSpy = createPolylineSpy(options);
-    const polylineConstructorSpy = createPolylineConstructorSpy(polylineSpy).and.callThrough();
+    const polylineConstructorSpy = createPolylineConstructorSpy(polylineSpy);
 
     const fixture = TestBed.createComponent(TestApp);
     fixture.componentInstance.path = path;
     fixture.detectChanges();
+    flush();
 
     expect(polylineConstructorSpy).toHaveBeenCalledWith(options);
-  });
+  }));
 
-  it('gives precedence to path input over options', () => {
+  it('gives precedence to path input over options', fakeAsync(() => {
     const path: google.maps.LatLngLiteral[] = [{lat: 3, lng: 5}];
     const expectedOptions: google.maps.PolylineOptions = {...polylineOptions, path};
     const polylineSpy = createPolylineSpy(expectedOptions);
-    const polylineConstructorSpy = createPolylineConstructorSpy(polylineSpy).and.callThrough();
+    const polylineConstructorSpy = createPolylineConstructorSpy(polylineSpy);
 
     const fixture = TestBed.createComponent(TestApp);
     fixture.componentInstance.options = polylineOptions;
     fixture.componentInstance.path = path;
     fixture.detectChanges();
+    flush();
 
     expect(polylineConstructorSpy).toHaveBeenCalledWith(expectedOptions);
-  });
+  }));
 
-  it('exposes methods that provide information about the Polyline', () => {
+  it('exposes methods that provide information about the Polyline', fakeAsync(() => {
     const polylineSpy = createPolylineSpy(polylineOptions);
-    createPolylineConstructorSpy(polylineSpy).and.callThrough();
+    createPolylineConstructorSpy(polylineSpy);
 
     const fixture = TestBed.createComponent(TestApp);
     const polylineComponent = fixture.debugElement
       .query(By.directive(MapPolyline))!
       .injector.get<MapPolyline>(MapPolyline);
     fixture.detectChanges();
+    flush();
 
     polylineSpy.getDraggable.and.returnValue(true);
     expect(polylineComponent.getDraggable()).toBe(true);
@@ -98,15 +102,16 @@ describe('MapPolyline', () => {
 
     polylineSpy.getVisible.and.returnValue(true);
     expect(polylineComponent.getVisible()).toBe(true);
-  });
+  }));
 
-  it('initializes Polyline event handlers', () => {
+  it('initializes Polyline event handlers', fakeAsync(() => {
     const polylineSpy = createPolylineSpy(polylineOptions);
-    createPolylineConstructorSpy(polylineSpy).and.callThrough();
+    createPolylineConstructorSpy(polylineSpy);
 
     const addSpy = polylineSpy.addListener;
     const fixture = TestBed.createComponent(TestApp);
     fixture.detectChanges();
+    flush();
 
     expect(addSpy).toHaveBeenCalledWith('click', jasmine.any(Function));
     expect(addSpy).not.toHaveBeenCalledWith('dblclick', jasmine.any(Function));
@@ -119,15 +124,16 @@ describe('MapPolyline', () => {
     expect(addSpy).not.toHaveBeenCalledWith('mouseover', jasmine.any(Function));
     expect(addSpy).not.toHaveBeenCalledWith('mouseup', jasmine.any(Function));
     expect(addSpy).toHaveBeenCalledWith('rightclick', jasmine.any(Function));
-  });
+  }));
 
-  it('should be able to add an event listener after init', () => {
+  it('should be able to add an event listener after init', fakeAsync(() => {
     const polylineSpy = createPolylineSpy(polylineOptions);
-    createPolylineConstructorSpy(polylineSpy).and.callThrough();
+    createPolylineConstructorSpy(polylineSpy);
 
     const addSpy = polylineSpy.addListener;
     const fixture = TestBed.createComponent(TestApp);
     fixture.detectChanges();
+    flush();
 
     expect(addSpy).not.toHaveBeenCalledWith('dragend', jasmine.any(Function));
 
@@ -137,7 +143,7 @@ describe('MapPolyline', () => {
 
     expect(addSpy).toHaveBeenCalledWith('dragend', jasmine.any(Function));
     subscription.unsubscribe();
-  });
+  }));
 });
 
 @Component({

--- a/src/google-maps/map-polyline/map-polyline.ts
+++ b/src/google-maps/map-polyline/map-polyline.ts
@@ -9,7 +9,16 @@
 // Workaround for: https://github.com/bazelbuild/rules_nodejs/issues/1265
 /// <reference types="google.maps" />
 
-import {Directive, Input, OnDestroy, OnInit, Output, NgZone, inject} from '@angular/core';
+import {
+  Directive,
+  Input,
+  OnDestroy,
+  OnInit,
+  Output,
+  NgZone,
+  inject,
+  EventEmitter,
+} from '@angular/core';
 import {BehaviorSubject, combineLatest, Observable, Subject} from 'rxjs';
 import {map, take, takeUntil} from 'rxjs/operators';
 
@@ -126,6 +135,10 @@ export class MapPolyline implements OnInit, OnDestroy {
   @Output() readonly polylineRightclick: Observable<google.maps.PolyMouseEvent> =
     this._eventManager.getLazyEmitter<google.maps.PolyMouseEvent>('rightclick');
 
+  /** Event emitted when the polyline is initialized. */
+  @Output() readonly polylineInitialized: EventEmitter<google.maps.Polyline> =
+    new EventEmitter<google.maps.Polyline>();
+
   constructor(
     private readonly _map: GoogleMap,
     private _ngZone: NgZone,
@@ -139,14 +152,20 @@ export class MapPolyline implements OnInit, OnDestroy {
           // Create the object outside the zone so its events don't trigger change detection.
           // We'll bring it back in inside the `MapEventManager` only for the events that the
           // user has subscribed to.
-          this._ngZone.runOutsideAngular(() => (this.polyline = new google.maps.Polyline(options)));
-          this._assertInitialized();
-          this.polyline.setMap(this._map.googleMap!);
-          this._eventManager.setTarget(this.polyline);
+          this._ngZone.runOutsideAngular(async () => {
+            const map = await this._map._resolveMap();
+            const polylineConstructor =
+              google.maps.Polyline ||
+              ((await google.maps.importLibrary('maps')) as google.maps.MapsLibrary).Polyline;
+            this.polyline = new polylineConstructor(options);
+            this._assertInitialized();
+            this.polyline.setMap(map);
+            this._eventManager.setTarget(this.polyline);
+            this.polylineInitialized.emit(this.polyline);
+            this._watchForOptionsChanges();
+            this._watchForPathChanges();
+          });
         });
-
-      this._watchForOptionsChanges();
-      this._watchForPathChanges();
     }
   }
 
@@ -154,9 +173,7 @@ export class MapPolyline implements OnInit, OnDestroy {
     this._eventManager.destroy();
     this._destroyed.next();
     this._destroyed.complete();
-    if (this.polyline) {
-      this.polyline.setMap(null);
-    }
+    this.polyline?.setMap(null);
   }
 
   /**
@@ -222,12 +239,6 @@ export class MapPolyline implements OnInit, OnDestroy {
 
   private _assertInitialized(): asserts this is {polyline: google.maps.Polyline} {
     if (typeof ngDevMode === 'undefined' || ngDevMode) {
-      if (!this._map.googleMap) {
-        throw Error(
-          'Cannot access Google Map information before the API has been initialized. ' +
-            'Please wait for the API to load before trying to interact with it.',
-        );
-      }
       if (!this.polyline) {
         throw Error(
           'Cannot interact with a Google Map Polyline before it has been ' +

--- a/src/google-maps/map-polyline/map-polyline.ts
+++ b/src/google-maps/map-polyline/map-polyline.ts
@@ -24,6 +24,7 @@ import {map, take, takeUntil} from 'rxjs/operators';
 
 import {GoogleMap} from '../google-map/google-map';
 import {MapEventManager} from '../map-event-manager';
+import {importLibrary} from '../import-library';
 
 /**
  * Angular component that renders a Google Maps Polyline via the Google Maps JavaScript API.
@@ -156,7 +157,7 @@ export class MapPolyline implements OnInit, OnDestroy {
             const map = await this._map._resolveMap();
             const polylineConstructor =
               google.maps.Polyline ||
-              ((await google.maps.importLibrary('maps')) as google.maps.MapsLibrary).Polyline;
+              (await importLibrary<google.maps.Polyline>('maps', 'Polyline'));
             this.polyline = new polylineConstructor(options);
             this._assertInitialized();
             this.polyline.setMap(map);

--- a/src/google-maps/map-rectangle/map-rectangle.spec.ts
+++ b/src/google-maps/map-rectangle/map-rectangle.spec.ts
@@ -1,5 +1,5 @@
 import {Component, ViewChild} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
+import {TestBed, fakeAsync, flush} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
 import {DEFAULT_OPTIONS, GoogleMap} from '../google-map/google-map';
@@ -24,60 +24,64 @@ describe('MapRectangle', () => {
 
   beforeEach(() => {
     mapSpy = createMapSpy(DEFAULT_OPTIONS);
-    createMapConstructorSpy(mapSpy).and.callThrough();
+    createMapConstructorSpy(mapSpy);
   });
 
   afterEach(() => {
     (window.google as any) = undefined;
   });
 
-  it('initializes a Google Map Rectangle', () => {
+  it('initializes a Google Map Rectangle', fakeAsync(() => {
     const rectangleSpy = createRectangleSpy({});
-    const rectangleConstructorSpy = createRectangleConstructorSpy(rectangleSpy).and.callThrough();
+    const rectangleConstructorSpy = createRectangleConstructorSpy(rectangleSpy);
 
     const fixture = TestBed.createComponent(TestApp);
     fixture.detectChanges();
+    flush();
 
     expect(rectangleConstructorSpy).toHaveBeenCalledWith({bounds: undefined});
     expect(rectangleSpy.setMap).toHaveBeenCalledWith(mapSpy);
-  });
+  }));
 
-  it('sets bounds from input', () => {
+  it('sets bounds from input', fakeAsync(() => {
     const bounds: google.maps.LatLngBoundsLiteral = {east: 3, north: 5, west: -3, south: -5};
     const options: google.maps.RectangleOptions = {bounds};
     const rectangleSpy = createRectangleSpy(options);
-    const rectangleConstructorSpy = createRectangleConstructorSpy(rectangleSpy).and.callThrough();
+    const rectangleConstructorSpy = createRectangleConstructorSpy(rectangleSpy);
 
     const fixture = TestBed.createComponent(TestApp);
     fixture.componentInstance.bounds = bounds;
     fixture.detectChanges();
+    flush();
 
     expect(rectangleConstructorSpy).toHaveBeenCalledWith(options);
-  });
+  }));
 
-  it('gives precedence to bounds input over options', () => {
+  it('gives precedence to bounds input over options', fakeAsync(() => {
     const bounds: google.maps.LatLngBoundsLiteral = {east: 3, north: 5, west: -3, south: -5};
     const expectedOptions: google.maps.RectangleOptions = {...rectangleOptions, bounds};
     const rectangleSpy = createRectangleSpy(expectedOptions);
-    const rectangleConstructorSpy = createRectangleConstructorSpy(rectangleSpy).and.callThrough();
+    const rectangleConstructorSpy = createRectangleConstructorSpy(rectangleSpy);
 
     const fixture = TestBed.createComponent(TestApp);
     fixture.componentInstance.options = rectangleOptions;
     fixture.componentInstance.bounds = bounds;
     fixture.detectChanges();
+    flush();
 
     expect(rectangleConstructorSpy).toHaveBeenCalledWith(expectedOptions);
-  });
+  }));
 
-  it('exposes methods that provide information about the Rectangle', () => {
+  it('exposes methods that provide information about the Rectangle', fakeAsync(() => {
     const rectangleSpy = createRectangleSpy(rectangleOptions);
-    createRectangleConstructorSpy(rectangleSpy).and.callThrough();
+    createRectangleConstructorSpy(rectangleSpy);
 
     const fixture = TestBed.createComponent(TestApp);
     const rectangleComponent = fixture.debugElement
       .query(By.directive(MapRectangle))!
       .injector.get<MapRectangle>(MapRectangle);
     fixture.detectChanges();
+    flush();
 
     rectangleComponent.getBounds();
     expect(rectangleSpy.getBounds).toHaveBeenCalled();
@@ -90,15 +94,16 @@ describe('MapRectangle', () => {
 
     rectangleSpy.getVisible.and.returnValue(true);
     expect(rectangleComponent.getVisible()).toBe(true);
-  });
+  }));
 
-  it('initializes Rectangle event handlers', () => {
+  it('initializes Rectangle event handlers', fakeAsync(() => {
     const rectangleSpy = createRectangleSpy(rectangleOptions);
-    createRectangleConstructorSpy(rectangleSpy).and.callThrough();
+    createRectangleConstructorSpy(rectangleSpy);
 
     const addSpy = rectangleSpy.addListener;
     const fixture = TestBed.createComponent(TestApp);
     fixture.detectChanges();
+    flush();
 
     expect(addSpy).toHaveBeenCalledWith('bounds_changed', jasmine.any(Function));
     expect(addSpy).toHaveBeenCalledWith('click', jasmine.any(Function));
@@ -112,15 +117,16 @@ describe('MapRectangle', () => {
     expect(addSpy).not.toHaveBeenCalledWith('mouseover', jasmine.any(Function));
     expect(addSpy).not.toHaveBeenCalledWith('mouseup', jasmine.any(Function));
     expect(addSpy).toHaveBeenCalledWith('rightclick', jasmine.any(Function));
-  });
+  }));
 
-  it('should be able to add an event listener after init', () => {
+  it('should be able to add an event listener after init', fakeAsync(() => {
     const rectangleSpy = createRectangleSpy(rectangleOptions);
-    createRectangleConstructorSpy(rectangleSpy).and.callThrough();
+    createRectangleConstructorSpy(rectangleSpy);
 
     const addSpy = rectangleSpy.addListener;
     const fixture = TestBed.createComponent(TestApp);
     fixture.detectChanges();
+    flush();
 
     expect(addSpy).not.toHaveBeenCalledWith('dragend', jasmine.any(Function));
 
@@ -130,7 +136,7 @@ describe('MapRectangle', () => {
 
     expect(addSpy).toHaveBeenCalledWith('dragend', jasmine.any(Function));
     subscription.unsubscribe();
-  });
+  }));
 });
 
 @Component({

--- a/src/google-maps/map-rectangle/map-rectangle.ts
+++ b/src/google-maps/map-rectangle/map-rectangle.ts
@@ -24,6 +24,7 @@ import {map, take, takeUntil} from 'rxjs/operators';
 
 import {GoogleMap} from '../google-map/google-map';
 import {MapEventManager} from '../map-event-manager';
+import {importLibrary} from '../import-library';
 
 /**
  * Angular component that renders a Google Maps Rectangle via the Google Maps JavaScript API.
@@ -165,7 +166,7 @@ export class MapRectangle implements OnInit, OnDestroy {
             const map = await this._map._resolveMap();
             const rectangleConstructor =
               google.maps.Rectangle ||
-              ((await google.maps.importLibrary('maps')) as google.maps.MapsLibrary).Rectangle;
+              (await importLibrary<google.maps.Rectangle>('maps', 'Rectangle'));
             this.rectangle = new rectangleConstructor(options);
             this._assertInitialized();
             this.rectangle.setMap(map);

--- a/src/google-maps/map-traffic-layer/map-traffic-layer.spec.ts
+++ b/src/google-maps/map-traffic-layer/map-traffic-layer.spec.ts
@@ -1,5 +1,5 @@
 import {Component} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
+import {TestBed, fakeAsync, flush} from '@angular/core/testing';
 
 import {DEFAULT_OPTIONS, GoogleMap} from '../google-map/google-map';
 import {
@@ -17,25 +17,24 @@ describe('MapTrafficLayer', () => {
 
   beforeEach(() => {
     mapSpy = createMapSpy(DEFAULT_OPTIONS);
-    createMapConstructorSpy(mapSpy).and.callThrough();
+    createMapConstructorSpy(mapSpy);
   });
 
   afterEach(() => {
     (window.google as any) = undefined;
   });
 
-  it('initializes a Google Map Traffic Layer', () => {
+  it('initializes a Google Map Traffic Layer', fakeAsync(() => {
     const trafficLayerSpy = createTrafficLayerSpy(trafficLayerOptions);
-    const trafficLayerConstructorSpy =
-      createTrafficLayerConstructorSpy(trafficLayerSpy).and.callThrough();
-
+    const trafficLayerConstructorSpy = createTrafficLayerConstructorSpy(trafficLayerSpy);
     const fixture = TestBed.createComponent(TestApp);
     fixture.componentInstance.autoRefresh = false;
     fixture.detectChanges();
+    flush();
 
     expect(trafficLayerConstructorSpy).toHaveBeenCalledWith(trafficLayerOptions);
     expect(trafficLayerSpy.setMap).toHaveBeenCalledWith(mapSpy);
-  });
+  }));
 });
 
 @Component({

--- a/src/google-maps/map-traffic-layer/map-traffic-layer.ts
+++ b/src/google-maps/map-traffic-layer/map-traffic-layer.ts
@@ -9,7 +9,7 @@
 // Workaround for: https://github.com/bazelbuild/rules_nodejs/issues/1265
 /// <reference types="google.maps" />
 
-import {Directive, Input, NgZone, OnDestroy, OnInit} from '@angular/core';
+import {Directive, EventEmitter, Input, NgZone, OnDestroy, OnInit, Output} from '@angular/core';
 import {BehaviorSubject, Observable, Subject} from 'rxjs';
 import {map, take, takeUntil} from 'rxjs/operators';
 
@@ -44,6 +44,10 @@ export class MapTrafficLayer implements OnInit, OnDestroy {
     this._autoRefresh.next(autoRefresh);
   }
 
+  /** Event emitted when the traffic layer is initialized. */
+  @Output() readonly trafficLayerInitialized: EventEmitter<google.maps.TrafficLayer> =
+    new EventEmitter<google.maps.TrafficLayer>();
+
   constructor(
     private readonly _map: GoogleMap,
     private readonly _ngZone: NgZone,
@@ -54,24 +58,25 @@ export class MapTrafficLayer implements OnInit, OnDestroy {
       this._combineOptions()
         .pipe(take(1))
         .subscribe(options => {
-          // Create the object outside the zone so its events don't trigger change detection.
-          this._ngZone.runOutsideAngular(() => {
-            this.trafficLayer = new google.maps.TrafficLayer(options);
+          this._ngZone.runOutsideAngular(async () => {
+            const map = await this._map._resolveMap();
+            const layerConstructor =
+              google.maps.TrafficLayer ||
+              ((await google.maps.importLibrary('maps')) as google.maps.MapsLibrary).TrafficLayer;
+            this.trafficLayer = new layerConstructor(options);
+            this._assertInitialized();
+            this.trafficLayer.setMap(map);
+            this.trafficLayerInitialized.emit(this.trafficLayer);
+            this._watchForAutoRefreshChanges();
           });
-          this._assertInitialized();
-          this.trafficLayer.setMap(this._map.googleMap!);
         });
-
-      this._watchForAutoRefreshChanges();
     }
   }
 
   ngOnDestroy() {
     this._destroyed.next();
     this._destroyed.complete();
-    if (this.trafficLayer) {
-      this.trafficLayer.setMap(null);
-    }
+    this.trafficLayer?.setMap(null);
   }
 
   private _combineOptions(): Observable<google.maps.TrafficLayerOptions> {
@@ -93,12 +98,6 @@ export class MapTrafficLayer implements OnInit, OnDestroy {
   }
 
   private _assertInitialized(): asserts this is {trafficLayer: google.maps.TrafficLayer} {
-    if (!this._map.googleMap) {
-      throw Error(
-        'Cannot access Google Map information before the API has been initialized. ' +
-          'Please wait for the API to load before trying to interact with it.',
-      );
-    }
     if (!this.trafficLayer) {
       throw Error(
         'Cannot interact with a Google Map Traffic Layer before it has been initialized. ' +

--- a/src/google-maps/map-traffic-layer/map-traffic-layer.ts
+++ b/src/google-maps/map-traffic-layer/map-traffic-layer.ts
@@ -14,6 +14,7 @@ import {BehaviorSubject, Observable, Subject} from 'rxjs';
 import {map, take, takeUntil} from 'rxjs/operators';
 
 import {GoogleMap} from '../google-map/google-map';
+import {importLibrary} from '../import-library';
 
 /**
  * Angular component that renders a Google Maps Traffic Layer via the Google Maps JavaScript API.
@@ -62,7 +63,7 @@ export class MapTrafficLayer implements OnInit, OnDestroy {
             const map = await this._map._resolveMap();
             const layerConstructor =
               google.maps.TrafficLayer ||
-              ((await google.maps.importLibrary('maps')) as google.maps.MapsLibrary).TrafficLayer;
+              (await importLibrary<google.maps.TrafficLayer>('maps', 'TrafficLayer'));
             this.trafficLayer = new layerConstructor(options);
             this._assertInitialized();
             this.trafficLayer.setMap(map);

--- a/src/google-maps/map-transit-layer/map-transit-layer.spec.ts
+++ b/src/google-maps/map-transit-layer/map-transit-layer.spec.ts
@@ -1,5 +1,5 @@
 import {Component} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
+import {TestBed, fakeAsync, flush} from '@angular/core/testing';
 
 import {DEFAULT_OPTIONS, GoogleMap} from '../google-map/google-map';
 import {
@@ -16,24 +16,24 @@ describe('MapTransitLayer', () => {
 
   beforeEach(() => {
     mapSpy = createMapSpy(DEFAULT_OPTIONS);
-    createMapConstructorSpy(mapSpy).and.callThrough();
+    createMapConstructorSpy(mapSpy);
   });
 
   afterEach(() => {
     (window.google as any) = undefined;
   });
 
-  it('initializes a Google Map Transit Layer', () => {
+  it('initializes a Google Map Transit Layer', fakeAsync(() => {
     const transitLayerSpy = createTransitLayerSpy();
-    const transitLayerConstructorSpy =
-      createTransitLayerConstructorSpy(transitLayerSpy).and.callThrough();
+    const transitLayerConstructorSpy = createTransitLayerConstructorSpy(transitLayerSpy);
 
     const fixture = TestBed.createComponent(TestApp);
     fixture.detectChanges();
+    flush();
 
     expect(transitLayerConstructorSpy).toHaveBeenCalled();
     expect(transitLayerSpy.setMap).toHaveBeenCalledWith(mapSpy);
-  });
+  }));
 });
 
 @Component({

--- a/src/google-maps/map-transit-layer/map-transit-layer.ts
+++ b/src/google-maps/map-transit-layer/map-transit-layer.ts
@@ -12,6 +12,7 @@
 import {Directive, EventEmitter, Output} from '@angular/core';
 
 import {MapBaseLayer} from '../map-base-layer';
+import {importLibrary} from '../import-library';
 
 /**
  * Angular component that renders a Google Maps Transit Layer via the Google Maps JavaScript API.
@@ -38,7 +39,7 @@ export class MapTransitLayer extends MapBaseLayer {
   protected override async _initializeObject() {
     const layerConstructor =
       google.maps.TransitLayer ||
-      ((await google.maps.importLibrary('maps')) as google.maps.MapsLibrary).TransitLayer;
+      (await importLibrary<google.maps.TransitLayer>('maps', 'TransitLayer'));
     this.transitLayer = new layerConstructor();
     this.transitLayerInitialized.emit(this.transitLayer);
   }

--- a/src/google-maps/testing/fake-google-map-utils.ts
+++ b/src/google-maps/testing/fake-google-map-utils.ts
@@ -75,9 +75,11 @@ export function createMapConstructorSpy(
   apiLoaded = true,
 ): jasmine.Spy {
   // The spy target function cannot be an arrow-function as this breaks when created through `new`.
-  const mapConstructorSpy = jasmine.createSpy('Map constructor', function () {
-    return mapSpy;
-  });
+  const mapConstructorSpy = jasmine
+    .createSpy('Map constructor', function () {
+      return mapSpy;
+    })
+    .and.callThrough();
   const testingWindow: TestingWindow = window;
   if (apiLoaded) {
     testingWindow.google = {
@@ -119,9 +121,11 @@ export function createMarkerConstructorSpy(
   markerSpy: jasmine.SpyObj<google.maps.Marker>,
 ): jasmine.Spy {
   // The spy target function cannot be an arrow-function as this breaks when created through `new`.
-  const markerConstructorSpy = jasmine.createSpy('Marker constructor', function () {
-    return markerSpy;
-  });
+  const markerConstructorSpy = jasmine
+    .createSpy('Marker constructor', function () {
+      return markerSpy;
+    })
+    .and.callThrough();
   const testingWindow: TestingWindow = window;
   if (testingWindow.google && testingWindow.google.maps) {
     testingWindow.google.maps['Marker'] = markerConstructorSpy;
@@ -148,6 +152,8 @@ export function createInfoWindowSpy(
     'getZIndex',
     'open',
     'get',
+    'setOptions',
+    'setPosition',
   ]);
   infoWindowSpy.addListener.and.returnValue({remove: () => {}});
   infoWindowSpy.open.and.callFake((config: any) => (anchor = config.anchor));
@@ -161,9 +167,11 @@ export function createInfoWindowConstructorSpy(
   infoWindowSpy: jasmine.SpyObj<google.maps.InfoWindow>,
 ): jasmine.Spy {
   // The spy target function cannot be an arrow-function as this breaks when created through `new`.
-  const infoWindowConstructorSpy = jasmine.createSpy('InfoWindow constructor', function () {
-    return infoWindowSpy;
-  });
+  const infoWindowConstructorSpy = jasmine
+    .createSpy('InfoWindow constructor', function () {
+      return infoWindowSpy;
+    })
+    .and.callThrough();
   const testingWindow: TestingWindow = window;
   if (testingWindow.google && testingWindow.google.maps) {
     testingWindow.google.maps['InfoWindow'] = infoWindowConstructorSpy;
@@ -200,9 +208,11 @@ export function createPolylineConstructorSpy(
   polylineSpy: jasmine.SpyObj<google.maps.Polyline>,
 ): jasmine.Spy {
   // The spy target function cannot be an arrow-function as this breaks when created through `new`.
-  const polylineConstructorSpy = jasmine.createSpy('Polyline constructor', function () {
-    return polylineSpy;
-  });
+  const polylineConstructorSpy = jasmine
+    .createSpy('Polyline constructor', function () {
+      return polylineSpy;
+    })
+    .and.callThrough();
   const testingWindow: TestingWindow = window;
   if (testingWindow.google && testingWindow.google.maps) {
     testingWindow.google.maps['Polyline'] = polylineConstructorSpy;
@@ -230,6 +240,7 @@ export function createPolygonSpy(
     'setMap',
     'setOptions',
     'setPath',
+    'setPaths',
   ]);
   polygonSpy.addListener.and.returnValue({remove: () => {}});
   return polygonSpy;
@@ -240,9 +251,11 @@ export function createPolygonConstructorSpy(
   polygonSpy: jasmine.SpyObj<google.maps.Polygon>,
 ): jasmine.Spy {
   // The spy target function cannot be an arrow-function as this breaks when created through `new`.
-  const polygonConstructorSpy = jasmine.createSpy('Polygon constructor', function () {
-    return polygonSpy;
-  });
+  const polygonConstructorSpy = jasmine
+    .createSpy('Polygon constructor', function () {
+      return polygonSpy;
+    })
+    .and.callThrough();
   const testingWindow: TestingWindow = window;
   if (testingWindow.google && testingWindow.google.maps) {
     testingWindow.google.maps['Polygon'] = polygonConstructorSpy;
@@ -279,9 +292,11 @@ export function createRectangleConstructorSpy(
   rectangleSpy: jasmine.SpyObj<google.maps.Rectangle>,
 ): jasmine.Spy {
   // The spy target function cannot be an arrow-function as this breaks when created through `new`.
-  const rectangleConstructorSpy = jasmine.createSpy('Rectangle constructor', function () {
-    return rectangleSpy;
-  });
+  const rectangleConstructorSpy = jasmine
+    .createSpy('Rectangle constructor', function () {
+      return rectangleSpy;
+    })
+    .and.callThrough();
   const testingWindow: TestingWindow = window;
   if (testingWindow.google && testingWindow.google.maps) {
     testingWindow.google.maps['Rectangle'] = rectangleConstructorSpy;
@@ -320,9 +335,11 @@ export function createCircleConstructorSpy(
   circleSpy: jasmine.SpyObj<google.maps.Circle>,
 ): jasmine.Spy {
   // The spy target function cannot be an arrow-function as this breaks when created through `new`.
-  const circleConstructorSpy = jasmine.createSpy('Circle constructor', function () {
-    return circleSpy;
-  });
+  const circleConstructorSpy = jasmine
+    .createSpy('Circle constructor', function () {
+      return circleSpy;
+    })
+    .and.callThrough();
   const testingWindow: TestingWindow = window;
   if (testingWindow.google && testingWindow.google.maps) {
     testingWindow.google.maps['Circle'] = circleConstructorSpy;
@@ -362,9 +379,11 @@ export function createGroundOverlayConstructorSpy(
   groundOverlaySpy: jasmine.SpyObj<google.maps.GroundOverlay>,
 ): jasmine.Spy {
   // The spy target function cannot be an arrow-function as this breaks when created through `new`.
-  const groundOverlayConstructorSpy = jasmine.createSpy('GroundOverlay constructor', function () {
-    return groundOverlaySpy;
-  });
+  const groundOverlayConstructorSpy = jasmine
+    .createSpy('GroundOverlay constructor', function () {
+      return groundOverlaySpy;
+    })
+    .and.callThrough();
   const testingWindow: TestingWindow = window;
   if (testingWindow.google && testingWindow.google.maps) {
     testingWindow.google.maps['GroundOverlay'] = groundOverlayConstructorSpy;
@@ -402,9 +421,11 @@ export function createKmlLayerConstructorSpy(
   kmlLayerSpy: jasmine.SpyObj<google.maps.KmlLayer>,
 ): jasmine.Spy {
   // The spy target function cannot be an arrow-function as this breaks when created through `new`.
-  const kmlLayerConstructorSpy = jasmine.createSpy('KmlLayer constructor', function () {
-    return kmlLayerSpy;
-  });
+  const kmlLayerConstructorSpy = jasmine
+    .createSpy('KmlLayer constructor', function () {
+      return kmlLayerSpy;
+    })
+    .and.callThrough();
   const testingWindow: TestingWindow = window;
   if (testingWindow.google && testingWindow.google.maps) {
     testingWindow.google.maps['KmlLayer'] = kmlLayerConstructorSpy;
@@ -434,9 +455,11 @@ export function createTrafficLayerConstructorSpy(
   trafficLayerSpy: jasmine.SpyObj<google.maps.TrafficLayer>,
 ): jasmine.Spy {
   // The spy target function cannot be an arrow-function as this breaks when created through `new`.
-  const trafficLayerConstructorSpy = jasmine.createSpy('TrafficLayer constructor', function () {
-    return trafficLayerSpy;
-  });
+  const trafficLayerConstructorSpy = jasmine
+    .createSpy('TrafficLayer constructor', function () {
+      return trafficLayerSpy;
+    })
+    .and.callThrough();
   const testingWindow: TestingWindow = window;
   if (testingWindow.google && testingWindow.google.maps) {
     testingWindow.google.maps['TrafficLayer'] = trafficLayerConstructorSpy;
@@ -461,9 +484,11 @@ export function createTransitLayerConstructorSpy(
   transitLayerSpy: jasmine.SpyObj<google.maps.TransitLayer>,
 ): jasmine.Spy {
   // The spy target function cannot be an arrow-function as this breaks when created through `new`.
-  const transitLayerConstructorSpy = jasmine.createSpy('TransitLayer constructor', function () {
-    return transitLayerSpy;
-  });
+  const transitLayerConstructorSpy = jasmine
+    .createSpy('TransitLayer constructor', function () {
+      return transitLayerSpy;
+    })
+    .and.callThrough();
   const testingWindow: TestingWindow = window;
   if (testingWindow.google && testingWindow.google.maps) {
     testingWindow.google.maps['TransitLayer'] = transitLayerConstructorSpy;
@@ -488,9 +513,11 @@ export function createBicyclingLayerConstructorSpy(
   bicylingLayerSpy: jasmine.SpyObj<google.maps.BicyclingLayer>,
 ): jasmine.Spy {
   // The spy target function cannot be an arrow-function as this breaks when created through `new`.
-  const bicylingLayerConstructorSpy = jasmine.createSpy('BicyclingLayer constructor', function () {
-    return bicylingLayerSpy;
-  });
+  const bicylingLayerConstructorSpy = jasmine
+    .createSpy('BicyclingLayer constructor', function () {
+      return bicylingLayerSpy;
+    })
+    .and.callThrough();
   const testingWindow: TestingWindow = window;
   if (testingWindow.google && testingWindow.google.maps) {
     testingWindow.google.maps['BicyclingLayer'] = bicylingLayerConstructorSpy;
@@ -560,12 +587,11 @@ export function createMarkerClustererConstructorSpy(
   apiLoaded = true,
 ): jasmine.Spy {
   // The spy target function cannot be an arrow-function as this breaks when created through `new`.
-  const markerClustererConstructorSpy = jasmine.createSpy(
-    'MarkerClusterer constructor',
-    function () {
+  const markerClustererConstructorSpy = jasmine
+    .createSpy('MarkerClusterer constructor', function () {
       return markerClustererSpy;
-    },
-  );
+    })
+    .and.callThrough();
   if (apiLoaded) {
     const testingWindow: TestingWindow = window;
     testingWindow['MarkerClusterer'] = markerClustererConstructorSpy;
@@ -595,12 +621,11 @@ export function createDirectionsRendererConstructorSpy(
   directionsRendererSpy: jasmine.SpyObj<google.maps.DirectionsRenderer>,
 ): jasmine.Spy {
   // The spy target function cannot be an arrow-function as this breaks when created through `new`.
-  const directionsRendererConstructorSpy = jasmine.createSpy(
-    'DirectionsRenderer constructor',
-    function () {
+  const directionsRendererConstructorSpy = jasmine
+    .createSpy('DirectionsRenderer constructor', function () {
       return directionsRendererSpy;
-    },
-  );
+    })
+    .and.callThrough();
   const testingWindow: TestingWindow = window;
   if (testingWindow.google && testingWindow.google.maps) {
     testingWindow.google.maps['DirectionsRenderer'] = directionsRendererConstructorSpy;
@@ -625,12 +650,11 @@ export function createDirectionsServiceConstructorSpy(
   directionsServiceSpy: jasmine.SpyObj<google.maps.DirectionsService>,
 ): jasmine.Spy {
   // The spy target function cannot be an arrow-function as this breaks when created through `new`.
-  const directionsServiceConstructorSpy = jasmine.createSpy(
-    'DirectionsService constructor',
-    function () {
+  const directionsServiceConstructorSpy = jasmine
+    .createSpy('DirectionsService constructor', function () {
       return directionsServiceSpy;
-    },
-  );
+    })
+    .and.callThrough();
   const testingWindow: TestingWindow = window;
   if (testingWindow.google && testingWindow.google.maps) {
     testingWindow.google.maps['DirectionsService'] = directionsServiceConstructorSpy;
@@ -663,9 +687,11 @@ export function createHeatmapLayerConstructorSpy(
   heatmapLayerSpy: jasmine.SpyObj<google.maps.visualization.HeatmapLayer>,
 ): jasmine.Spy {
   // The spy target function cannot be an arrow-function as this breaks when created through `new`.
-  const heatmapLayerConstructorSpy = jasmine.createSpy('HeatmapLayer constructor', function () {
-    return heatmapLayerSpy;
-  });
+  const heatmapLayerConstructorSpy = jasmine
+    .createSpy('HeatmapLayer constructor', function () {
+      return heatmapLayerSpy;
+    })
+    .and.callThrough();
   const testingWindow: TestingWindow = window;
   if (testingWindow.google && testingWindow.google.maps) {
     if (!testingWindow.google.maps.visualization) {
@@ -694,9 +720,11 @@ export function createLatLngConstructorSpy(
   latLngSpy: jasmine.SpyObj<google.maps.LatLng>,
 ): jasmine.Spy {
   // The spy target function cannot be an arrow-function as this breaks when created through `new`.
-  const latLngConstructorSpy = jasmine.createSpy('LatLng constructor', function () {
-    return latLngSpy;
-  });
+  const latLngConstructorSpy = jasmine
+    .createSpy('LatLng constructor', function () {
+      return latLngSpy;
+    })
+    .and.callThrough();
   const testingWindow: TestingWindow = window;
   if (testingWindow.google && testingWindow.google.maps) {
     testingWindow.google.maps['LatLng'] = latLngConstructorSpy;
@@ -720,9 +748,11 @@ export function createGeocoderConstructorSpy(
   geocoderSpy: jasmine.SpyObj<google.maps.Geocoder>,
 ): jasmine.Spy {
   // The spy target function cannot be an arrow-function as this breaks when created through `new`.
-  const geocoderConstructorSpy = jasmine.createSpy('Geocoder constructor', function () {
-    return geocoderSpy;
-  });
+  const geocoderConstructorSpy = jasmine
+    .createSpy('Geocoder constructor', function () {
+      return geocoderSpy;
+    })
+    .and.callThrough();
   const testingWindow: TestingWindow = window;
   if (testingWindow.google && testingWindow.google.maps) {
     testingWindow.google.maps['Geocoder'] = geocoderConstructorSpy;

--- a/tools/public_api_guard/google-maps/google-maps.md
+++ b/tools/public_api_guard/google-maps/google-maps.md
@@ -107,6 +107,7 @@ export class GoogleMap implements OnChanges, OnInit, OnDestroy {
     panTo(latLng: google.maps.LatLng | google.maps.LatLngLiteral): void;
     panToBounds(latLngBounds: google.maps.LatLngBounds | google.maps.LatLngBoundsLiteral, padding?: number | google.maps.Padding): void;
     readonly projectionChanged: Observable<void>;
+    _resolveMap(): Promise<google.maps.Map>;
     readonly tilesloaded: Observable<void>;
     readonly tiltChanged: Observable<void>;
     width: string | number | null;
@@ -142,7 +143,7 @@ export interface MapAnchorPoint {
 export class MapBaseLayer implements OnInit, OnDestroy {
     constructor(_map: GoogleMap, _ngZone: NgZone);
     // (undocumented)
-    protected _initializeObject(): void;
+    protected _initializeObject(): Promise<void>;
     // (undocumented)
     protected readonly _map: GoogleMap;
     // (undocumented)
@@ -152,7 +153,7 @@ export class MapBaseLayer implements OnInit, OnDestroy {
     // (undocumented)
     protected readonly _ngZone: NgZone;
     // (undocumented)
-    protected _setMap(): void;
+    protected _setMap(_map: google.maps.Map): void;
     // (undocumented)
     protected _unsetMap(): void;
     // (undocumented)
@@ -164,14 +165,15 @@ export class MapBaseLayer implements OnInit, OnDestroy {
 // @public
 export class MapBicyclingLayer extends MapBaseLayer {
     bicyclingLayer?: google.maps.BicyclingLayer;
+    readonly bicyclingLayerInitialized: EventEmitter<google.maps.BicyclingLayer>;
     // (undocumented)
-    protected _initializeObject(): void;
+    protected _initializeObject(): Promise<void>;
     // (undocumented)
-    protected _setMap(): void;
+    protected _setMap(map: google.maps.Map): void;
     // (undocumented)
     protected _unsetMap(): void;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<MapBicyclingLayer, "map-bicycling-layer", ["mapBicyclingLayer"], {}, {}, never, never, true, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<MapBicyclingLayer, "map-bicycling-layer", ["mapBicyclingLayer"], {}, { "bicyclingLayerInitialized": "bicyclingLayerInitialized"; }, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MapBicyclingLayer, never>;
 }
@@ -194,6 +196,7 @@ export class MapCircle implements OnInit, OnDestroy {
     readonly circleDragend: Observable<google.maps.MapMouseEvent>;
     // (undocumented)
     readonly circleDragstart: Observable<google.maps.MapMouseEvent>;
+    readonly circleInitialized: EventEmitter<google.maps.Circle>;
     // (undocumented)
     readonly circleMousedown: Observable<google.maps.MapMouseEvent>;
     // (undocumented)
@@ -229,7 +232,7 @@ export class MapCircle implements OnInit, OnDestroy {
     // (undocumented)
     readonly radiusChanged: Observable<void>;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<MapCircle, "map-circle", ["mapCircle"], { "options": { "alias": "options"; "required": false; }; "center": { "alias": "center"; "required": false; }; "radius": { "alias": "radius"; "required": false; }; }, { "centerChanged": "centerChanged"; "circleClick": "circleClick"; "circleDblclick": "circleDblclick"; "circleDrag": "circleDrag"; "circleDragend": "circleDragend"; "circleDragstart": "circleDragstart"; "circleMousedown": "circleMousedown"; "circleMousemove": "circleMousemove"; "circleMouseout": "circleMouseout"; "circleMouseover": "circleMouseover"; "circleMouseup": "circleMouseup"; "radiusChanged": "radiusChanged"; "circleRightclick": "circleRightclick"; }, never, never, true, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<MapCircle, "map-circle", ["mapCircle"], { "options": { "alias": "options"; "required": false; }; "center": { "alias": "center"; "required": false; }; "radius": { "alias": "radius"; "required": false; }; }, { "centerChanged": "centerChanged"; "circleClick": "circleClick"; "circleDblclick": "circleDblclick"; "circleDrag": "circleDrag"; "circleDragend": "circleDragend"; "circleDragstart": "circleDragstart"; "circleMousedown": "circleMousedown"; "circleMousemove": "circleMousemove"; "circleMouseout": "circleMouseout"; "circleMouseover": "circleMouseover"; "circleMouseup": "circleMouseup"; "radiusChanged": "radiusChanged"; "circleRightclick": "circleRightclick"; "circleInitialized": "circleInitialized"; }, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MapCircle, never>;
 }
@@ -240,6 +243,7 @@ export class MapDirectionsRenderer implements OnInit, OnChanges, OnDestroy {
     set directions(directions: google.maps.DirectionsResult);
     readonly directionsChanged: Observable<void>;
     directionsRenderer?: google.maps.DirectionsRenderer;
+    readonly directionsRendererInitialized: EventEmitter<google.maps.DirectionsRenderer>;
     getDirections(): google.maps.DirectionsResult | null;
     getPanel(): Node | null;
     getRouteIndex(): number;
@@ -251,7 +255,7 @@ export class MapDirectionsRenderer implements OnInit, OnChanges, OnDestroy {
     ngOnInit(): void;
     set options(options: google.maps.DirectionsRendererOptions);
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<MapDirectionsRenderer, "map-directions-renderer", ["mapDirectionsRenderer"], { "directions": { "alias": "directions"; "required": false; }; "options": { "alias": "options"; "required": false; }; }, { "directionsChanged": "directionsChanged"; }, never, never, true, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<MapDirectionsRenderer, "map-directions-renderer", ["mapDirectionsRenderer"], { "directions": { "alias": "directions"; "required": false; }; "options": { "alias": "options"; "required": false; }; }, { "directionsChanged": "directionsChanged"; "directionsRendererInitialized": "directionsRendererInitialized"; }, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MapDirectionsRenderer, never>;
 }
@@ -310,6 +314,7 @@ export class MapGroundOverlay implements OnInit, OnDestroy {
     getOpacity(): number;
     getUrl(): string;
     groundOverlay?: google.maps.GroundOverlay;
+    readonly groundOverlayInitialized: EventEmitter<google.maps.GroundOverlay>;
     readonly mapClick: Observable<google.maps.MapMouseEvent>;
     readonly mapDblclick: Observable<google.maps.MapMouseEvent>;
     // (undocumented)
@@ -319,7 +324,7 @@ export class MapGroundOverlay implements OnInit, OnDestroy {
     set opacity(opacity: number);
     set url(url: string);
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<MapGroundOverlay, "map-ground-overlay", ["mapGroundOverlay"], { "url": { "alias": "url"; "required": false; }; "bounds": { "alias": "bounds"; "required": false; }; "clickable": { "alias": "clickable"; "required": false; }; "opacity": { "alias": "opacity"; "required": false; }; }, { "mapClick": "mapClick"; "mapDblclick": "mapDblclick"; }, never, never, true, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<MapGroundOverlay, "map-ground-overlay", ["mapGroundOverlay"], { "url": { "alias": "url"; "required": false; }; "bounds": { "alias": "bounds"; "required": false; }; "clickable": { "alias": "clickable"; "required": false; }; "opacity": { "alias": "opacity"; "required": false; }; }, { "mapClick": "mapClick"; "mapDblclick": "mapDblclick"; "groundOverlayInitialized": "groundOverlayInitialized"; }, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MapGroundOverlay, never>;
 }
@@ -330,6 +335,7 @@ export class MapHeatmapLayer implements OnInit, OnChanges, OnDestroy {
     set data(data: HeatmapData);
     getData(): HeatmapData;
     heatmap?: google.maps.visualization.HeatmapLayer;
+    readonly heatmapInitialized: EventEmitter<google.maps.visualization.HeatmapLayer>;
     // (undocumented)
     ngOnChanges(changes: SimpleChanges): void;
     // (undocumented)
@@ -338,7 +344,7 @@ export class MapHeatmapLayer implements OnInit, OnChanges, OnDestroy {
     ngOnInit(): void;
     set options(options: Partial<google.maps.visualization.HeatmapLayerOptions>);
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<MapHeatmapLayer, "map-heatmap-layer", ["mapHeatmapLayer"], { "data": { "alias": "data"; "required": false; }; "options": { "alias": "options"; "required": false; }; }, {}, never, never, true, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<MapHeatmapLayer, "map-heatmap-layer", ["mapHeatmapLayer"], { "data": { "alias": "data"; "required": false; }; "options": { "alias": "options"; "required": false; }; }, { "heatmapInitialized": "heatmapInitialized"; }, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MapHeatmapLayer, never>;
 }
@@ -354,6 +360,7 @@ export class MapInfoWindow implements OnInit, OnDestroy {
     getPosition(): google.maps.LatLng | null;
     getZIndex(): number;
     infoWindow?: google.maps.InfoWindow;
+    readonly infoWindowInitialized: EventEmitter<google.maps.InfoWindow>;
     // (undocumented)
     ngOnDestroy(): void;
     // (undocumented)
@@ -366,7 +373,7 @@ export class MapInfoWindow implements OnInit, OnDestroy {
     readonly positionChanged: Observable<void>;
     readonly zindexChanged: Observable<void>;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<MapInfoWindow, "map-info-window", ["mapInfoWindow"], { "options": { "alias": "options"; "required": false; }; "position": { "alias": "position"; "required": false; }; }, { "closeclick": "closeclick"; "contentChanged": "contentChanged"; "domready": "domready"; "positionChanged": "positionChanged"; "zindexChanged": "zindexChanged"; }, never, never, true, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<MapInfoWindow, "map-info-window", ["mapInfoWindow"], { "options": { "alias": "options"; "required": false; }; "position": { "alias": "position"; "required": false; }; }, { "closeclick": "closeclick"; "contentChanged": "contentChanged"; "domready": "domready"; "positionChanged": "positionChanged"; "zindexChanged": "zindexChanged"; "infoWindowInitialized": "infoWindowInitialized"; }, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MapInfoWindow, never>;
 }
@@ -382,6 +389,7 @@ export class MapKmlLayer implements OnInit, OnDestroy {
     getZIndex(): number;
     readonly kmlClick: Observable<google.maps.KmlMouseEvent>;
     kmlLayer?: google.maps.KmlLayer;
+    readonly kmlLayerInitialized: EventEmitter<google.maps.KmlLayer>;
     // (undocumented)
     ngOnDestroy(): void;
     // (undocumented)
@@ -392,7 +400,7 @@ export class MapKmlLayer implements OnInit, OnDestroy {
     // (undocumented)
     set url(url: string);
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<MapKmlLayer, "map-kml-layer", ["mapKmlLayer"], { "options": { "alias": "options"; "required": false; }; "url": { "alias": "url"; "required": false; }; }, { "kmlClick": "kmlClick"; "defaultviewportChanged": "defaultviewportChanged"; "statusChanged": "statusChanged"; }, never, never, true, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<MapKmlLayer, "map-kml-layer", ["mapKmlLayer"], { "options": { "alias": "options"; "required": false; }; "url": { "alias": "url"; "required": false; }; }, { "kmlClick": "kmlClick"; "defaultviewportChanged": "defaultviewportChanged"; "statusChanged": "statusChanged"; "kmlLayerInitialized": "kmlLayerInitialized"; }, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MapKmlLayer, never>;
 }
@@ -433,6 +441,7 @@ export class MapMarker implements OnInit, OnChanges, OnDestroy, MapAnchorPoint {
     readonly mapMouseup: Observable<google.maps.MapMouseEvent>;
     readonly mapRightclick: Observable<google.maps.MapMouseEvent>;
     marker?: google.maps.Marker;
+    readonly markerInitialized: EventEmitter<google.maps.Marker>;
     // (undocumented)
     ngOnChanges(changes: SimpleChanges): void;
     // (undocumented)
@@ -442,6 +451,7 @@ export class MapMarker implements OnInit, OnChanges, OnDestroy, MapAnchorPoint {
     set options(options: google.maps.MarkerOptions);
     set position(position: google.maps.LatLngLiteral | google.maps.LatLng);
     readonly positionChanged: Observable<void>;
+    _resolveMarker(): Promise<google.maps.Marker>;
     readonly shapeChanged: Observable<void>;
     set title(title: string);
     readonly titleChanged: Observable<void>;
@@ -449,7 +459,7 @@ export class MapMarker implements OnInit, OnChanges, OnDestroy, MapAnchorPoint {
     readonly visibleChanged: Observable<void>;
     readonly zindexChanged: Observable<void>;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<MapMarker, "map-marker", ["mapMarker"], { "title": { "alias": "title"; "required": false; }; "position": { "alias": "position"; "required": false; }; "label": { "alias": "label"; "required": false; }; "clickable": { "alias": "clickable"; "required": false; }; "options": { "alias": "options"; "required": false; }; "icon": { "alias": "icon"; "required": false; }; "visible": { "alias": "visible"; "required": false; }; }, { "animationChanged": "animationChanged"; "mapClick": "mapClick"; "clickableChanged": "clickableChanged"; "cursorChanged": "cursorChanged"; "mapDblclick": "mapDblclick"; "mapDrag": "mapDrag"; "mapDragend": "mapDragend"; "draggableChanged": "draggableChanged"; "mapDragstart": "mapDragstart"; "flatChanged": "flatChanged"; "iconChanged": "iconChanged"; "mapMousedown": "mapMousedown"; "mapMouseout": "mapMouseout"; "mapMouseover": "mapMouseover"; "mapMouseup": "mapMouseup"; "positionChanged": "positionChanged"; "mapRightclick": "mapRightclick"; "shapeChanged": "shapeChanged"; "titleChanged": "titleChanged"; "visibleChanged": "visibleChanged"; "zindexChanged": "zindexChanged"; }, never, never, true, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<MapMarker, "map-marker", ["mapMarker"], { "title": { "alias": "title"; "required": false; }; "position": { "alias": "position"; "required": false; }; "label": { "alias": "label"; "required": false; }; "clickable": { "alias": "clickable"; "required": false; }; "options": { "alias": "options"; "required": false; }; "icon": { "alias": "icon"; "required": false; }; "visible": { "alias": "visible"; "required": false; }; }, { "animationChanged": "animationChanged"; "mapClick": "mapClick"; "clickableChanged": "clickableChanged"; "cursorChanged": "cursorChanged"; "mapDblclick": "mapDblclick"; "mapDrag": "mapDrag"; "mapDragend": "mapDragend"; "draggableChanged": "draggableChanged"; "mapDragstart": "mapDragstart"; "flatChanged": "flatChanged"; "iconChanged": "iconChanged"; "mapMousedown": "mapMousedown"; "mapMouseout": "mapMouseout"; "mapMouseover": "mapMouseover"; "mapMouseup": "mapMouseup"; "positionChanged": "positionChanged"; "mapRightclick": "mapRightclick"; "shapeChanged": "shapeChanged"; "titleChanged": "titleChanged"; "visibleChanged": "visibleChanged"; "zindexChanged": "zindexChanged"; "markerInitialized": "markerInitialized"; }, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MapMarker, never>;
 }
@@ -525,6 +535,7 @@ export class MapMarkerClusterer implements OnInit, AfterContentInit, OnChanges, 
     // (undocumented)
     set imageSizes(imageSizes: number[]);
     markerClusterer?: MarkerClusterer;
+    readonly markerClustererInitialized: EventEmitter<MarkerClusterer>;
     // (undocumented)
     _markers: QueryList<MapMarker>;
     // (undocumented)
@@ -550,7 +561,7 @@ export class MapMarkerClusterer implements OnInit, AfterContentInit, OnChanges, 
     // (undocumented)
     set zoomOnClick(zoomOnClick: boolean);
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<MapMarkerClusterer, "map-marker-clusterer", ["mapMarkerClusterer"], { "ariaLabelFn": { "alias": "ariaLabelFn"; "required": false; }; "averageCenter": { "alias": "averageCenter"; "required": false; }; "batchSize": { "alias": "batchSize"; "required": false; }; "batchSizeIE": { "alias": "batchSizeIE"; "required": false; }; "calculator": { "alias": "calculator"; "required": false; }; "clusterClass": { "alias": "clusterClass"; "required": false; }; "enableRetinaIcons": { "alias": "enableRetinaIcons"; "required": false; }; "gridSize": { "alias": "gridSize"; "required": false; }; "ignoreHidden": { "alias": "ignoreHidden"; "required": false; }; "imageExtension": { "alias": "imageExtension"; "required": false; }; "imagePath": { "alias": "imagePath"; "required": false; }; "imageSizes": { "alias": "imageSizes"; "required": false; }; "maxZoom": { "alias": "maxZoom"; "required": false; }; "minimumClusterSize": { "alias": "minimumClusterSize"; "required": false; }; "styles": { "alias": "styles"; "required": false; }; "title": { "alias": "title"; "required": false; }; "zIndex": { "alias": "zIndex"; "required": false; }; "zoomOnClick": { "alias": "zoomOnClick"; "required": false; }; "options": { "alias": "options"; "required": false; }; }, { "clusteringbegin": "clusteringbegin"; "clusteringend": "clusteringend"; "clusterClick": "clusterClick"; }, ["_markers"], ["*"], true, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MapMarkerClusterer, "map-marker-clusterer", ["mapMarkerClusterer"], { "ariaLabelFn": { "alias": "ariaLabelFn"; "required": false; }; "averageCenter": { "alias": "averageCenter"; "required": false; }; "batchSize": { "alias": "batchSize"; "required": false; }; "batchSizeIE": { "alias": "batchSizeIE"; "required": false; }; "calculator": { "alias": "calculator"; "required": false; }; "clusterClass": { "alias": "clusterClass"; "required": false; }; "enableRetinaIcons": { "alias": "enableRetinaIcons"; "required": false; }; "gridSize": { "alias": "gridSize"; "required": false; }; "ignoreHidden": { "alias": "ignoreHidden"; "required": false; }; "imageExtension": { "alias": "imageExtension"; "required": false; }; "imagePath": { "alias": "imagePath"; "required": false; }; "imageSizes": { "alias": "imageSizes"; "required": false; }; "maxZoom": { "alias": "maxZoom"; "required": false; }; "minimumClusterSize": { "alias": "minimumClusterSize"; "required": false; }; "styles": { "alias": "styles"; "required": false; }; "title": { "alias": "title"; "required": false; }; "zIndex": { "alias": "zIndex"; "required": false; }; "zoomOnClick": { "alias": "zoomOnClick"; "required": false; }; "options": { "alias": "options"; "required": false; }; }, { "clusteringbegin": "clusteringbegin"; "clusteringend": "clusteringend"; "clusterClick": "clusterClick"; "markerClustererInitialized": "markerClustererInitialized"; }, ["_markers"], ["*"], true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MapMarkerClusterer, never>;
 }
@@ -577,6 +588,7 @@ export class MapPolygon implements OnInit, OnDestroy {
     readonly polygonDrag: Observable<google.maps.MapMouseEvent>;
     readonly polygonDragend: Observable<google.maps.MapMouseEvent>;
     readonly polygonDragstart: Observable<google.maps.MapMouseEvent>;
+    readonly polygonInitialized: EventEmitter<google.maps.Polygon>;
     readonly polygonMousedown: Observable<google.maps.PolyMouseEvent>;
     readonly polygonMousemove: Observable<google.maps.PolyMouseEvent>;
     readonly polygonMouseout: Observable<google.maps.PolyMouseEvent>;
@@ -584,7 +596,7 @@ export class MapPolygon implements OnInit, OnDestroy {
     readonly polygonMouseup: Observable<google.maps.PolyMouseEvent>;
     readonly polygonRightclick: Observable<google.maps.PolyMouseEvent>;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<MapPolygon, "map-polygon", ["mapPolygon"], { "options": { "alias": "options"; "required": false; }; "paths": { "alias": "paths"; "required": false; }; }, { "polygonClick": "polygonClick"; "polygonDblclick": "polygonDblclick"; "polygonDrag": "polygonDrag"; "polygonDragend": "polygonDragend"; "polygonDragstart": "polygonDragstart"; "polygonMousedown": "polygonMousedown"; "polygonMousemove": "polygonMousemove"; "polygonMouseout": "polygonMouseout"; "polygonMouseover": "polygonMouseover"; "polygonMouseup": "polygonMouseup"; "polygonRightclick": "polygonRightclick"; }, never, never, true, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<MapPolygon, "map-polygon", ["mapPolygon"], { "options": { "alias": "options"; "required": false; }; "paths": { "alias": "paths"; "required": false; }; }, { "polygonClick": "polygonClick"; "polygonDblclick": "polygonDblclick"; "polygonDrag": "polygonDrag"; "polygonDragend": "polygonDragend"; "polygonDragstart": "polygonDragstart"; "polygonMousedown": "polygonMousedown"; "polygonMousemove": "polygonMousemove"; "polygonMouseout": "polygonMouseout"; "polygonMouseover": "polygonMouseover"; "polygonMouseup": "polygonMouseup"; "polygonRightclick": "polygonRightclick"; "polygonInitialized": "polygonInitialized"; }, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MapPolygon, never>;
 }
@@ -610,6 +622,7 @@ export class MapPolyline implements OnInit, OnDestroy {
     readonly polylineDrag: Observable<google.maps.MapMouseEvent>;
     readonly polylineDragend: Observable<google.maps.MapMouseEvent>;
     readonly polylineDragstart: Observable<google.maps.MapMouseEvent>;
+    readonly polylineInitialized: EventEmitter<google.maps.Polyline>;
     readonly polylineMousedown: Observable<google.maps.PolyMouseEvent>;
     readonly polylineMousemove: Observable<google.maps.PolyMouseEvent>;
     readonly polylineMouseout: Observable<google.maps.PolyMouseEvent>;
@@ -617,7 +630,7 @@ export class MapPolyline implements OnInit, OnDestroy {
     readonly polylineMouseup: Observable<google.maps.PolyMouseEvent>;
     readonly polylineRightclick: Observable<google.maps.PolyMouseEvent>;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<MapPolyline, "map-polyline", ["mapPolyline"], { "options": { "alias": "options"; "required": false; }; "path": { "alias": "path"; "required": false; }; }, { "polylineClick": "polylineClick"; "polylineDblclick": "polylineDblclick"; "polylineDrag": "polylineDrag"; "polylineDragend": "polylineDragend"; "polylineDragstart": "polylineDragstart"; "polylineMousedown": "polylineMousedown"; "polylineMousemove": "polylineMousemove"; "polylineMouseout": "polylineMouseout"; "polylineMouseover": "polylineMouseover"; "polylineMouseup": "polylineMouseup"; "polylineRightclick": "polylineRightclick"; }, never, never, true, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<MapPolyline, "map-polyline", ["mapPolyline"], { "options": { "alias": "options"; "required": false; }; "path": { "alias": "path"; "required": false; }; }, { "polylineClick": "polylineClick"; "polylineDblclick": "polylineDblclick"; "polylineDrag": "polylineDrag"; "polylineDragend": "polylineDragend"; "polylineDragstart": "polylineDragstart"; "polylineMousedown": "polylineMousedown"; "polylineMousemove": "polylineMousemove"; "polylineMouseout": "polylineMouseout"; "polylineMouseover": "polylineMouseover"; "polylineMouseup": "polylineMouseup"; "polylineRightclick": "polylineRightclick"; "polylineInitialized": "polylineInitialized"; }, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MapPolyline, never>;
 }
@@ -644,6 +657,7 @@ export class MapRectangle implements OnInit, OnDestroy {
     readonly rectangleDrag: Observable<google.maps.MapMouseEvent>;
     readonly rectangleDragend: Observable<google.maps.MapMouseEvent>;
     readonly rectangleDragstart: Observable<google.maps.MapMouseEvent>;
+    readonly rectangleInitialized: EventEmitter<google.maps.Rectangle>;
     readonly rectangleMousedown: Observable<google.maps.MapMouseEvent>;
     readonly rectangleMousemove: Observable<google.maps.MapMouseEvent>;
     readonly rectangleMouseout: Observable<google.maps.MapMouseEvent>;
@@ -651,7 +665,7 @@ export class MapRectangle implements OnInit, OnDestroy {
     readonly rectangleMouseup: Observable<google.maps.MapMouseEvent>;
     readonly rectangleRightclick: Observable<google.maps.MapMouseEvent>;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<MapRectangle, "map-rectangle", ["mapRectangle"], { "options": { "alias": "options"; "required": false; }; "bounds": { "alias": "bounds"; "required": false; }; }, { "boundsChanged": "boundsChanged"; "rectangleClick": "rectangleClick"; "rectangleDblclick": "rectangleDblclick"; "rectangleDrag": "rectangleDrag"; "rectangleDragend": "rectangleDragend"; "rectangleDragstart": "rectangleDragstart"; "rectangleMousedown": "rectangleMousedown"; "rectangleMousemove": "rectangleMousemove"; "rectangleMouseout": "rectangleMouseout"; "rectangleMouseover": "rectangleMouseover"; "rectangleMouseup": "rectangleMouseup"; "rectangleRightclick": "rectangleRightclick"; }, never, never, true, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<MapRectangle, "map-rectangle", ["mapRectangle"], { "options": { "alias": "options"; "required": false; }; "bounds": { "alias": "bounds"; "required": false; }; }, { "boundsChanged": "boundsChanged"; "rectangleClick": "rectangleClick"; "rectangleDblclick": "rectangleDblclick"; "rectangleDrag": "rectangleDrag"; "rectangleDragend": "rectangleDragend"; "rectangleDragstart": "rectangleDragstart"; "rectangleMousedown": "rectangleMousedown"; "rectangleMousemove": "rectangleMousemove"; "rectangleMouseout": "rectangleMouseout"; "rectangleMouseover": "rectangleMouseover"; "rectangleMouseup": "rectangleMouseup"; "rectangleRightclick": "rectangleRightclick"; "rectangleInitialized": "rectangleInitialized"; }, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MapRectangle, never>;
 }
@@ -665,8 +679,9 @@ export class MapTrafficLayer implements OnInit, OnDestroy {
     // (undocumented)
     ngOnInit(): void;
     trafficLayer?: google.maps.TrafficLayer;
+    readonly trafficLayerInitialized: EventEmitter<google.maps.TrafficLayer>;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<MapTrafficLayer, "map-traffic-layer", ["mapTrafficLayer"], { "autoRefresh": { "alias": "autoRefresh"; "required": false; }; }, {}, never, never, true, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<MapTrafficLayer, "map-traffic-layer", ["mapTrafficLayer"], { "autoRefresh": { "alias": "autoRefresh"; "required": false; }; }, { "trafficLayerInitialized": "trafficLayerInitialized"; }, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MapTrafficLayer, never>;
 }
@@ -674,14 +689,15 @@ export class MapTrafficLayer implements OnInit, OnDestroy {
 // @public
 export class MapTransitLayer extends MapBaseLayer {
     // (undocumented)
-    protected _initializeObject(): void;
+    protected _initializeObject(): Promise<void>;
     // (undocumented)
-    protected _setMap(): void;
+    protected _setMap(map: google.maps.Map): void;
     transitLayer?: google.maps.TransitLayer;
+    readonly transitLayerInitialized: EventEmitter<google.maps.TransitLayer>;
     // (undocumented)
     protected _unsetMap(): void;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<MapTransitLayer, "map-transit-layer", ["mapTransitLayer"], {}, {}, never, never, true, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<MapTransitLayer, "map-transit-layer", ["mapTransitLayer"], {}, { "transitLayerInitialized": "transitLayerInitialized"; }, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MapTransitLayer, never>;
 }

--- a/tools/public_api_guard/google-maps/google-maps.md
+++ b/tools/public_api_guard/google-maps/google-maps.md
@@ -143,7 +143,7 @@ export interface MapAnchorPoint {
 export class MapBaseLayer implements OnInit, OnDestroy {
     constructor(_map: GoogleMap, _ngZone: NgZone);
     // (undocumented)
-    protected _initializeObject(): Promise<void>;
+    protected _initializeObject(): void;
     // (undocumented)
     protected readonly _map: GoogleMap;
     // (undocumented)
@@ -153,7 +153,7 @@ export class MapBaseLayer implements OnInit, OnDestroy {
     // (undocumented)
     protected readonly _ngZone: NgZone;
     // (undocumented)
-    protected _setMap(_map: google.maps.Map): void;
+    protected _setMap(): void;
     // (undocumented)
     protected _unsetMap(): void;
     // (undocumented)
@@ -163,15 +163,13 @@ export class MapBaseLayer implements OnInit, OnDestroy {
 }
 
 // @public
-export class MapBicyclingLayer extends MapBaseLayer {
+export class MapBicyclingLayer implements OnInit, OnDestroy {
     bicyclingLayer?: google.maps.BicyclingLayer;
     readonly bicyclingLayerInitialized: EventEmitter<google.maps.BicyclingLayer>;
     // (undocumented)
-    protected _initializeObject(): Promise<void>;
+    ngOnDestroy(): void;
     // (undocumented)
-    protected _setMap(map: google.maps.Map): void;
-    // (undocumented)
-    protected _unsetMap(): void;
+    ngOnInit(): void;
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<MapBicyclingLayer, "map-bicycling-layer", ["mapBicyclingLayer"], {}, { "bicyclingLayerInitialized": "bicyclingLayerInitialized"; }, never, never, true, never>;
     // (undocumented)
@@ -687,15 +685,13 @@ export class MapTrafficLayer implements OnInit, OnDestroy {
 }
 
 // @public
-export class MapTransitLayer extends MapBaseLayer {
+export class MapTransitLayer implements OnInit, OnDestroy {
     // (undocumented)
-    protected _initializeObject(): Promise<void>;
+    ngOnDestroy(): void;
     // (undocumented)
-    protected _setMap(map: google.maps.Map): void;
+    ngOnInit(): void;
     transitLayer?: google.maps.TransitLayer;
     readonly transitLayerInitialized: EventEmitter<google.maps.TransitLayer>;
-    // (undocumented)
-    protected _unsetMap(): void;
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<MapTransitLayer, "map-transit-layer", ["mapTransitLayer"], {}, { "transitLayerInitialized": "transitLayerInitialized"; }, never, never, true, never>;
     // (undocumented)


### PR DESCRIPTION
Currently the `@angular/google-maps` module is implemented on top of the legacy `<script>` API which is problematic, because:
1. It loads all of the JavaScript up-front, even if there are no maps on the page.
2. It requires the user to ensure that the API is fully loaded before the `<google-map>` component starts rendering. Lazy-loading in this scenario is error-prone and loading the API up-front leads to a lot of unused JavaScript being loaded.

These changes add support for the [Dynamic Library Import API](https://developers.google.com/maps/documentation/javascript/load-maps-js-api#dynamic-library-import) which requires a tiny script to be added up-front which then allows the `<google-map>` to load the chunks of the API it needs on-demand. The legacy API is still supported, but is no longer recommended.

All the components also now have `initialized` outputs to make it easier to know when the underlying Maps classes have been created and can be interacted with.