### PR TITLE
fix(material/theming): Expose the `theme-remove` Sass function

### DIFF
--- a/src/material/_index.scss
+++ b/src/material/_index.scss
@@ -151,4 +151,4 @@
 
 // New theming APIs:
 @forward './core/theming/inspection' show get-theme-version, get-theme-type, get-theme-color,
-  get-theme-typography, get-theme-density, theme-has;
+  get-theme-typography, get-theme-density, theme-has, theme-remove;


### PR DESCRIPTION
We intended to expose this function along with the other theme inspection APIs, but forgot to add it to the list. It is necessary for users to be able to create their own versions of mixins like `all-component-colors`