### PR TITLE
fix(material/autocomplete): not closing when clicking on hint area

### DIFF
--- a/src/material/autocomplete/autocomplete-trigger.ts
+++ b/src/material/autocomplete/autocomplete-trigger.ts
@@ -407,7 +407,9 @@ export class MatAutocompleteTrigger
         // If we're in the Shadow DOM, the event target will be the shadow root, so we have to
         // fall back to check the first element in the path of the click event.
         const clickTarget = _getEventTarget<HTMLElement>(event)!;
-        const formField = this._formField ? this._formField._elementRef.nativeElement : null;
+        const formField = this._formField
+          ? this._formField.getConnectedOverlayOrigin().nativeElement
+          : null;
         const customOrigin = this.connectedTo ? this.connectedTo.elementRef.nativeElement : null;
 
         return (


### PR DESCRIPTION
Fixes that the autocomplete was ignoring clicks on the entire form field area, including hints, rather than just the form field inner container.

Fixes #28271.