### PR TITLE
refactor(multiple): remove references to deprecated ClientRect

### DIFF
--- a/src/cdk/drag-drop/directives/drag.spec.ts
+++ b/src/cdk/drag-drop/directives/drag.spec.ts
@@ -567,7 +567,7 @@ describe('CdkDrag', () => {
       fixture.componentInstance.dragInstance.constrainPosition = (
         {x, y}: Point,
         _dragRef: DragRef,
-        _dimensions: ClientRect,
+        _dimensions: DOMRect,
         pickup: Point,
       ) => {
         x -= pickup.x;
@@ -610,7 +610,7 @@ describe('CdkDrag', () => {
       fixture.componentInstance.dragInstance.constrainPosition = (
         {x, y}: Point,
         _dragRef: DragRef,
-        _dimensions: ClientRect,
+        _dimensions: DOMRect,
         pickup: Point,
       ) => {
         x -= pickup.x;
@@ -1007,7 +1007,7 @@ describe('CdkDrag', () => {
       fixture.componentInstance.dragInstance.constrainPosition = (
         {x, y}: Point,
         _dragRef: DragRef,
-        _dimensions: ClientRect,
+        _dimensions: DOMRect,
         pickup: Point,
       ) => {
         x -= pickup.x;

--- a/src/cdk/drag-drop/directives/drag.ts
+++ b/src/cdk/drag-drop/directives/drag.ts
@@ -143,7 +143,7 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
   @Input('cdkDragConstrainPosition') constrainPosition?: (
     userPointerPosition: Point,
     dragRef: DragRef,
-    dimensions: ClientRect,
+    dimensions: DOMRect,
     pickupPositionInElement: Point,
   ) => Point;
 

--- a/src/cdk/drag-drop/dom/dom-rect.ts
+++ b/src/cdk/drag-drop/dom/dom-rect.ts
@@ -6,45 +6,45 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-/** Gets a mutable version of an element's bounding `ClientRect`. */
-export function getMutableClientRect(element: Element): ClientRect {
-  const clientRect = element.getBoundingClientRect();
+/** Gets a mutable version of an element's bounding `DOMRect`. */
+export function getMutableClientRect(element: Element): DOMRect {
+  const rect = element.getBoundingClientRect();
 
   // We need to clone the `clientRect` here, because all the values on it are readonly
   // and we need to be able to update them. Also we can't use a spread here, because
-  // the values on a `ClientRect` aren't own properties. See:
+  // the values on a `DOMRect` aren't own properties. See:
   // https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect#Notes
   return {
-    top: clientRect.top,
-    right: clientRect.right,
-    bottom: clientRect.bottom,
-    left: clientRect.left,
-    width: clientRect.width,
-    height: clientRect.height,
-    x: clientRect.x,
-    y: clientRect.y,
-  } as ClientRect;
+    top: rect.top,
+    right: rect.right,
+    bottom: rect.bottom,
+    left: rect.left,
+    width: rect.width,
+    height: rect.height,
+    x: rect.x,
+    y: rect.y,
+  } as DOMRect;
 }
 
 /**
- * Checks whether some coordinates are within a `ClientRect`.
- * @param clientRect ClientRect that is being checked.
+ * Checks whether some coordinates are within a `DOMRect`.
+ * @param clientRect DOMRect that is being checked.
  * @param x Coordinates along the X axis.
  * @param y Coordinates along the Y axis.
  */
-export function isInsideClientRect(clientRect: ClientRect, x: number, y: number) {
+export function isInsideClientRect(clientRect: DOMRect, x: number, y: number) {
   const {top, bottom, left, right} = clientRect;
   return y >= top && y <= bottom && x >= left && x <= right;
 }
 
 /**
- * Updates the top/left positions of a `ClientRect`, as well as their bottom/right counterparts.
- * @param clientRect `ClientRect` that should be updated.
+ * Updates the top/left positions of a `DOMRect`, as well as their bottom/right counterparts.
+ * @param domRect `DOMRect` that should be updated.
  * @param top Amount to add to the `top` position.
  * @param left Amount to add to the `left` position.
  */
-export function adjustClientRect(
-  clientRect: {
+export function adjustDomRect(
+  domRect: {
     top: number;
     bottom: number;
     left: number;
@@ -55,22 +55,22 @@ export function adjustClientRect(
   top: number,
   left: number,
 ) {
-  clientRect.top += top;
-  clientRect.bottom = clientRect.top + clientRect.height;
+  domRect.top += top;
+  domRect.bottom = domRect.top + domRect.height;
 
-  clientRect.left += left;
-  clientRect.right = clientRect.left + clientRect.width;
+  domRect.left += left;
+  domRect.right = domRect.left + domRect.width;
 }
 
 /**
- * Checks whether the pointer coordinates are close to a ClientRect.
- * @param rect ClientRect to check against.
- * @param threshold Threshold around the ClientRect.
+ * Checks whether the pointer coordinates are close to a DOMRect.
+ * @param rect DOMRect to check against.
+ * @param threshold Threshold around the DOMRect.
  * @param pointerX Coordinates along the X axis.
  * @param pointerY Coordinates along the Y axis.
  */
-export function isPointerNearClientRect(
-  rect: ClientRect,
+export function isPointerNearDomRect(
+  rect: DOMRect,
   threshold: number,
   pointerX: number,
   pointerY: number,

--- a/src/cdk/drag-drop/dom/parent-position-tracker.ts
+++ b/src/cdk/drag-drop/dom/parent-position-tracker.ts
@@ -7,7 +7,7 @@
  */
 
 import {_getEventTarget} from '@angular/cdk/platform';
-import {getMutableClientRect, adjustClientRect} from './client-rect';
+import {getMutableClientRect, adjustDomRect} from './dom-rect';
 
 /** Object holding the scroll position of something. */
 interface ScrollPosition {
@@ -22,7 +22,7 @@ export class ParentPositionTracker {
     Document | HTMLElement,
     {
       scrollPosition: ScrollPosition;
-      clientRect?: ClientRect;
+      clientRect?: DOMRect;
     }
   >();
 
@@ -77,7 +77,7 @@ export class ParentPositionTracker {
     // parents that are inside the element that was scrolled.
     this.positions.forEach((position, node) => {
       if (position.clientRect && target !== node && target.contains(node)) {
-        adjustClientRect(position.clientRect, topDifference, leftDifference);
+        adjustDomRect(position.clientRect, topDifference, leftDifference);
       }
     });
 

--- a/src/cdk/drag-drop/drop-list-ref.ts
+++ b/src/cdk/drag-drop/drop-list-ref.ts
@@ -15,7 +15,7 @@ import {Subject, Subscription, interval, animationFrameScheduler} from 'rxjs';
 import {takeUntil} from 'rxjs/operators';
 import {DragDropRegistry} from './drag-drop-registry';
 import type {DragRef, Point} from './drag-ref';
-import {isPointerNearClientRect, isInsideClientRect} from './dom/client-rect';
+import {isPointerNearDomRect, isInsideClientRect} from './dom/dom-rect';
 import {ParentPositionTracker} from './dom/parent-position-tracker';
 import {DragCSSStyleDeclaration} from './dom/styling';
 import {DropListSortStrategy} from './sorting/drop-list-sort-strategy';
@@ -148,8 +148,8 @@ export class DropListRef<T = any> {
   /** Strategy being used to sort items within the list. */
   private _sortStrategy: DropListSortStrategy<DragRef>;
 
-  /** Cached `ClientRect` of the drop list. */
-  private _clientRect: ClientRect | undefined;
+  /** Cached `DOMRect` of the drop list. */
+  private _domRect: DOMRect | undefined;
 
   /** Draggable items in the container. */
   private _draggables: readonly DragRef[] = [];
@@ -410,8 +410,8 @@ export class DropListRef<T = any> {
     // Don't sort the item if sorting is disabled or it's out of range.
     if (
       this.sortingDisabled ||
-      !this._clientRect ||
-      !isPointerNearClientRect(this._clientRect, DROP_PROXIMITY_THRESHOLD, pointerX, pointerY)
+      !this._domRect ||
+      !isPointerNearDomRect(this._domRect, DROP_PROXIMITY_THRESHOLD, pointerX, pointerY)
     ) {
       return;
     }
@@ -451,9 +451,7 @@ export class DropListRef<T = any> {
         return;
       }
 
-      if (
-        isPointerNearClientRect(position.clientRect, DROP_PROXIMITY_THRESHOLD, pointerX, pointerY)
-      ) {
+      if (isPointerNearDomRect(position.clientRect, DROP_PROXIMITY_THRESHOLD, pointerX, pointerY)) {
         [verticalScrollDirection, horizontalScrollDirection] = getElementScrollDirections(
           element as HTMLElement,
           position.clientRect,
@@ -470,16 +468,16 @@ export class DropListRef<T = any> {
     // Otherwise check if we can start scrolling the viewport.
     if (!verticalScrollDirection && !horizontalScrollDirection) {
       const {width, height} = this._viewportRuler.getViewportSize();
-      const clientRect = {
+      const domRect = {
         width,
         height,
         top: 0,
         right: width,
         bottom: height,
         left: 0,
-      } as ClientRect;
-      verticalScrollDirection = getVerticalScrollDirection(clientRect, pointerY);
-      horizontalScrollDirection = getHorizontalScrollDirection(clientRect, pointerX);
+      } as DOMRect;
+      verticalScrollDirection = getVerticalScrollDirection(domRect, pointerY);
+      horizontalScrollDirection = getHorizontalScrollDirection(domRect, pointerX);
       scrollNode = window;
     }
 
@@ -529,8 +527,8 @@ export class DropListRef<T = any> {
     this._parentPositions.cache(this._scrollableElements);
 
     // The list element is always in the `scrollableElements`
-    // so we can take advantage of the cached `ClientRect`.
-    this._clientRect = this._parentPositions.positions.get(element)!.clientRect!;
+    // so we can take advantage of the cached `DOMRect`.
+    this._domRect = this._parentPositions.positions.get(element)!.clientRect!;
   }
 
   /** Resets the container to its initial state. */
@@ -577,7 +575,7 @@ export class DropListRef<T = any> {
    * @param y Pointer position along the Y axis.
    */
   _isOverContainer(x: number, y: number): boolean {
-    return this._clientRect != null && isInsideClientRect(this._clientRect, x, y);
+    return this._domRect != null && isInsideClientRect(this._domRect, x, y);
   }
 
   /**
@@ -599,8 +597,8 @@ export class DropListRef<T = any> {
    */
   _canReceive(item: DragRef, x: number, y: number): boolean {
     if (
-      !this._clientRect ||
-      !isInsideClientRect(this._clientRect, x, y) ||
+      !this._domRect ||
+      !isInsideClientRect(this._domRect, x, y) ||
       !this.enterPredicate(item, this)
     ) {
       return false;
@@ -616,7 +614,7 @@ export class DropListRef<T = any> {
 
     const nativeElement = coerceElement(this.element);
 
-    // The `ClientRect`, that we're using to find the container over which the user is
+    // The `DOMRect`, that we're using to find the container over which the user is
     // hovering, doesn't give us any information on whether the element has been scrolled
     // out of the view or whether it's overlapping with other containers. This means that
     // we could end up transferring the item into a container that's invisible or is positioned
@@ -712,7 +710,7 @@ export class DropListRef<T = any> {
  * @param clientRect Dimensions of the node.
  * @param pointerY Position of the user's pointer along the y axis.
  */
-function getVerticalScrollDirection(clientRect: ClientRect, pointerY: number) {
+function getVerticalScrollDirection(clientRect: DOMRect, pointerY: number) {
   const {top, bottom, height} = clientRect;
   const yThreshold = height * SCROLL_PROXIMITY_THRESHOLD;
 
@@ -730,7 +728,7 @@ function getVerticalScrollDirection(clientRect: ClientRect, pointerY: number) {
  * @param clientRect Dimensions of the node.
  * @param pointerX Position of the user's pointer along the x axis.
  */
-function getHorizontalScrollDirection(clientRect: ClientRect, pointerX: number) {
+function getHorizontalScrollDirection(clientRect: DOMRect, pointerX: number) {
   const {left, right, width} = clientRect;
   const xThreshold = width * SCROLL_PROXIMITY_THRESHOLD;
 
@@ -753,7 +751,7 @@ function getHorizontalScrollDirection(clientRect: ClientRect, pointerX: number) 
  */
 function getElementScrollDirections(
   element: HTMLElement,
-  clientRect: ClientRect,
+  clientRect: DOMRect,
   pointerX: number,
   pointerY: number,
 ): [AutoScrollVerticalDirection, AutoScrollHorizontalDirection] {

--- a/src/cdk/drag-drop/sorting/single-axis-sort-strategy.ts
+++ b/src/cdk/drag-drop/sorting/single-axis-sort-strategy.ts
@@ -12,7 +12,7 @@ import {coerceElement} from '@angular/cdk/coercion';
 import {DragDropRegistry} from '../drag-drop-registry';
 import {moveItemInArray} from '../drag-utils';
 import {combineTransforms} from '../dom/styling';
-import {adjustClientRect, getMutableClientRect, isInsideClientRect} from '../dom/client-rect';
+import {adjustDomRect, getMutableClientRect, isInsideClientRect} from '../dom/dom-rect';
 import {
   DropListSortStrategy,
   DropListSortStrategyItem,
@@ -27,7 +27,7 @@ interface CachedItemPosition<T> {
   /** Instance of the drag item. */
   drag: T;
   /** Dimensions of the item. */
-  clientRect: ClientRect;
+  clientRect: DOMRect;
   /** Amount by which the item has been moved since dragging started. */
   offset: number;
   /** Inline transform that the drag item had when dragging started. */
@@ -146,13 +146,13 @@ export class SingleAxisSortStrategy<T extends DropListSortStrategyItem>
           `translate3d(${Math.round(sibling.offset)}px, 0, 0)`,
           sibling.initialTransform,
         );
-        adjustClientRect(sibling.clientRect, 0, offset);
+        adjustDomRect(sibling.clientRect, 0, offset);
       } else {
         elementToOffset.style.transform = combineTransforms(
           `translate3d(0, ${Math.round(sibling.offset)}px, 0)`,
           sibling.initialTransform,
         );
-        adjustClientRect(sibling.clientRect, offset, 0);
+        adjustDomRect(sibling.clientRect, offset, 0);
       }
     });
 
@@ -286,7 +286,7 @@ export class SingleAxisSortStrategy<T extends DropListSortStrategyItem>
     // we can avoid inconsistent behavior where we might be measuring the element before
     // its position has changed.
     this._itemPositions.forEach(({clientRect}) => {
-      adjustClientRect(clientRect, topDifference, leftDifference);
+      adjustDomRect(clientRect, topDifference, leftDifference);
     });
 
     // We need two loops for this, because we want all of the cached
@@ -327,7 +327,7 @@ export class SingleAxisSortStrategy<T extends DropListSortStrategyItem>
    * @param newPosition Position of the item where the current item should be moved.
    * @param delta Direction in which the user is moving.
    */
-  private _getItemOffsetPx(currentPosition: ClientRect, newPosition: ClientRect, delta: 1 | -1) {
+  private _getItemOffsetPx(currentPosition: DOMRect, newPosition: DOMRect, delta: 1 | -1) {
     const isHorizontal = this.orientation === 'horizontal';
     let itemOffset = isHorizontal
       ? newPosition.left - currentPosition.left

--- a/src/cdk/overlay/position/flexible-connected-position-strategy.spec.ts
+++ b/src/cdk/overlay/position/flexible-connected-position-strategy.spec.ts
@@ -2416,20 +2416,20 @@ describe('FlexibleConnectedPositionStrategy', () => {
 
       const originalGetBoundingClientRect = overlayRef.overlayElement.getBoundingClientRect;
 
-      // The browser may return a `ClientRect` with sub-pixel deviations if the screen is zoomed in.
+      // The browser may return a `DOMRect` with sub-pixel deviations if the screen is zoomed in.
       // Since there's no way for us to zoom in the screen programmatically, we simulate the effect
       // by patching `getBoundingClientRect` to return a slightly different value.
       overlayRef.overlayElement.getBoundingClientRect = function () {
-        const clientRect = originalGetBoundingClientRect.apply(this);
+        const domRect = originalGetBoundingClientRect.apply(this);
         const zoomOffset = 0.1;
 
         return {
-          top: clientRect.top,
-          right: clientRect.right + zoomOffset,
-          bottom: clientRect.bottom + zoomOffset,
-          left: clientRect.left,
-          width: clientRect.width + zoomOffset,
-          height: clientRect.height + zoomOffset,
+          top: domRect.top,
+          right: domRect.right + zoomOffset,
+          bottom: domRect.bottom + zoomOffset,
+          left: domRect.left,
+          width: domRect.width + zoomOffset,
+          height: domRect.height + zoomOffset,
         } as any;
       };
 

--- a/src/cdk/overlay/position/flexible-connected-position-strategy.ts
+++ b/src/cdk/overlay/position/flexible-connected-position-strategy.ts
@@ -41,8 +41,8 @@ export type FlexibleConnectedPositionStrategyOrigin =
       height?: number;
     });
 
-/** Equivalent of `ClientRect` without some of the properties we don't care about. */
-type Dimensions = Omit<ClientRect, 'x' | 'y' | 'toJSON'>;
+/** Equivalent of `DOMRect` without some of the properties we don't care about. */
+type Dimensions = Omit<DOMRect, 'x' | 'y' | 'toJSON'>;
 
 /**
  * A strategy for positioning overlays. Using this strategy, an overlay is given an
@@ -768,7 +768,7 @@ export class FlexibleConnectedPositionStrategy implements PositionStrategy {
     } else if (position.overlayY === 'bottom') {
       // Overlay is opening "upward" and thus is bound by the top viewport edge. We need to add
       // the viewport margin back in, because the viewport rect is narrowed down to remove the
-      // margin, whereas the `origin` position is calculated based on its `ClientRect`.
+      // margin, whereas the `origin` position is calculated based on its `DOMRect`.
       bottom = viewport.height - origin.y + this._viewportMargin * 2;
       height = viewport.height - bottom + this._viewportMargin;
     } else {
@@ -1155,7 +1155,7 @@ export class FlexibleConnectedPositionStrategy implements PositionStrategy {
     }
   }
 
-  /** Returns the ClientRect of the current origin. */
+  /** Returns the DOMRect of the current origin. */
   private _getOriginRect(): Dimensions {
     const origin = this._origin;
 
@@ -1273,9 +1273,9 @@ function getPixelValue(input: number | string | null | undefined): number | null
 }
 
 /**
- * Gets a version of an element's bounding `ClientRect` where all the values are rounded down to
+ * Gets a version of an element's bounding `DOMRect` where all the values are rounded down to
  * the nearest pixel. This allows us to account for the cases where there may be sub-pixel
- * deviations in the `ClientRect` returned by the browser (e.g. when zoomed in with a percentage
+ * deviations in the `DOMRect` returned by the browser (e.g. when zoomed in with a percentage
  * size, see #21350).
  */
 function getRoundedBoundingClientRect(clientRect: Dimensions): Dimensions {

--- a/src/cdk/overlay/position/scroll-clip.ts
+++ b/src/cdk/overlay/position/scroll-clip.ts
@@ -9,8 +9,8 @@
 // TODO(jelbourn): move this to live with the rest of the scrolling code
 // TODO(jelbourn): someday replace this with IntersectionObservers
 
-/** Equivalent of `ClientRect` without some of the properties we don't care about. */
-type Dimensions = Omit<ClientRect, 'x' | 'y' | 'toJSON'>;
+/** Equivalent of `DOMRect` without some of the properties we don't care about. */
+type Dimensions = Omit<DOMRect, 'x' | 'y' | 'toJSON'>;
 
 /**
  * Gets whether an element is scrolled outside of view by any of its parent scrolling containers.

--- a/src/cdk/scrolling/viewport-ruler.ts
+++ b/src/cdk/scrolling/viewport-ruler.ts
@@ -90,7 +90,7 @@ export class ViewportRuler implements OnDestroy {
     return output;
   }
 
-  /** Gets a ClientRect for the viewport's bounds. */
+  /** Gets a DOMRect for the viewport's bounds. */
   getViewportRect() {
     // Use the document element's bounding rect rather than the window scroll properties
     // (e.g. pageYOffset, scrollY) due to in issue in Chrome and IE where window scroll

--- a/src/cdk/scrolling/virtual-scrollable.ts
+++ b/src/cdk/scrolling/virtual-scrollable.ts
@@ -38,7 +38,7 @@ export abstract class CdkVirtualScrollable extends CdkScrollable {
   }
 
   /**
-   * Measure the bounding ClientRect size including the scroll offset.
+   * Measure the bounding DOMRect size including the scroll offset.
    *
    * @param from The edge to measure from.
    */

--- a/src/dev-app/drag-drop/drag-drop-demo.ts
+++ b/src/dev-app/drag-drop/drag-drop-demo.ts
@@ -77,12 +77,7 @@ export class DragAndDropDemo {
     }
   }
 
-  constrainPosition(
-    {x, y}: Point,
-    _dragRef: DragRef,
-    _dimensions: ClientRect,
-    pickup: Point,
-  ): Point {
+  constrainPosition({x, y}: Point, _dragRef: DragRef, _dimensions: DOMRect, pickup: Point): Point {
     // Just returning the original top left corner to not modify position
     x -= pickup.x;
     y -= pickup.y;

--- a/src/material/core/ripple/ripple-renderer.ts
+++ b/src/material/core/ripple/ripple-renderer.ts
@@ -95,7 +95,7 @@ export class RippleRenderer implements EventListenerObject {
    * Cached dimensions of the ripple container. Set when the first
    * ripple is shown and cleared once no more ripples are visible.
    */
-  private _containerRect: ClientRect | null;
+  private _containerRect: DOMRect | null;
 
   private static _eventManager = new RippleEventManager();
 
@@ -441,7 +441,7 @@ export class RippleRenderer implements EventListenerObject {
 /**
  * Returns the distance from the point (x, y) to the furthest corner of a rectangle.
  */
-function distanceToFurthestCorner(x: number, y: number, rect: ClientRect) {
+function distanceToFurthestCorner(x: number, y: number, rect: DOMRect) {
   const distX = Math.max(Math.abs(x - rect.left), Math.abs(x - rect.right));
   const distY = Math.max(Math.abs(y - rect.top), Math.abs(y - rect.bottom));
   return Math.sqrt(distX * distX + distY * distY);

--- a/src/material/tabs/ink-bar.ts
+++ b/src/material/tabs/ink-bar.ts
@@ -15,7 +15,7 @@ import {ElementRef, InjectionToken, OnDestroy, OnInit, QueryList} from '@angular
  */
 export interface MatInkBarItem extends OnInit, OnDestroy {
   elementRef: ElementRef<HTMLElement>;
-  activateInkBar(previousIndicatorClientRect?: ClientRect): void;
+  activateInkBar(previousIndicatorClientRect?: DOMRect): void;
   deactivateInkBar(): void;
   fitInkBarToContent: boolean;
 }
@@ -53,10 +53,10 @@ export class MatInkBar {
     currentItem?.deactivateInkBar();
 
     if (correspondingItem) {
-      const clientRect = currentItem?.elementRef.nativeElement.getBoundingClientRect?.();
+      const domRect = currentItem?.elementRef.nativeElement.getBoundingClientRect?.();
 
-      // The ink bar won't animate unless we give it the `ClientRect` of the previous item.
-      correspondingItem.activateInkBar(clientRect);
+      // The ink bar won't animate unless we give it the `DOMRect` of the previous item.
+      correspondingItem.activateInkBar(domRect);
       this._currentItem = correspondingItem;
     }
   }
@@ -97,7 +97,7 @@ export function mixinInkBarItem<
     }
 
     /** Aligns the ink bar to the current item. */
-    activateInkBar(previousIndicatorClientRect?: ClientRect) {
+    activateInkBar(previousIndicatorClientRect?: DOMRect) {
       const element = this.elementRef.nativeElement;
 
       // Early exit if no indicator is present to handle cases where an indicator

--- a/tools/public_api_guard/cdk/drag-drop.md
+++ b/tools/public_api_guard/cdk/drag-drop.md
@@ -54,7 +54,7 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
     dropContainer: CdkDropList,
     _document: any, _ngZone: NgZone, _viewContainerRef: ViewContainerRef, config: DragDropConfig, _dir: Directionality, dragDrop: DragDrop, _changeDetectorRef: ChangeDetectorRef, _selfHandle?: CdkDragHandle | undefined, _parentDrag?: CdkDrag<any> | undefined);
     boundaryElement: string | ElementRef<HTMLElement> | HTMLElement;
-    constrainPosition?: (userPointerPosition: Point, dragRef: DragRef, dimensions: ClientRect, pickupPositionInElement: Point) => Point;
+    constrainPosition?: (userPointerPosition: Point, dragRef: DragRef, dimensions: DOMRect, pickupPositionInElement: Point) => Point;
     data: T;
     get disabled(): boolean;
     set disabled(value: boolean);
@@ -366,7 +366,7 @@ export class DragDropRegistry<I extends {
 export class DragRef<T = any> {
     constructor(element: ElementRef<HTMLElement> | HTMLElement, _config: DragRefConfig, _document: Document, _ngZone: NgZone, _viewportRuler: ViewportRuler, _dragDropRegistry: DragDropRegistry<DragRef, DropListRef>);
     readonly beforeStarted: Subject<void>;
-    constrainPosition?: (userPointerPosition: Point, dragRef: DragRef, dimensions: ClientRect, pickupPositionInElement: Point) => Point;
+    constrainPosition?: (userPointerPosition: Point, dragRef: DragRef, dimensions: DOMRect, pickupPositionInElement: Point) => Point;
     data: T;
     get disabled(): boolean;
     set disabled(value: boolean);


### PR DESCRIPTION
The `ClientRect` type is deprecated in favor of `DOMRect`. These changes replace all the references.