### PR TITLE
fix(material/dialog): `mat-dialog-title` should work under `OnPush` `viewContainerRef`

### DIFF
--- a/src/cdk/dialog/dialog-container.ts
+++ b/src/cdk/dialog/dialog-container.ts
@@ -25,6 +25,7 @@ import {
 import {DOCUMENT} from '@angular/common';
 import {
   ChangeDetectionStrategy,
+  ChangeDetectorRef,
   Component,
   ComponentRef,
   ElementRef,
@@ -35,6 +36,7 @@ import {
   Optional,
   ViewChild,
   ViewEncapsulation,
+  inject,
 } from '@angular/core';
 import {DialogConfig} from './dialog-config';
 
@@ -97,6 +99,8 @@ export class CdkDialogContainer<C extends DialogConfig = DialogConfig>
    */
   _ariaLabelledByQueue: string[] = [];
 
+  protected readonly _changeDetectorRef = inject(ChangeDetectorRef);
+
   constructor(
     protected _elementRef: ElementRef,
     protected _focusTrapFactory: FocusTrapFactory,
@@ -113,6 +117,20 @@ export class CdkDialogContainer<C extends DialogConfig = DialogConfig>
 
     if (this._config.ariaLabelledBy) {
       this._ariaLabelledByQueue.push(this._config.ariaLabelledBy);
+    }
+  }
+
+  _addAriaLabelledBy(id: string) {
+    this._ariaLabelledByQueue.push(id);
+    this._changeDetectorRef.markForCheck();
+  }
+
+  _removeAriaLabelledBy(id: string) {
+    const index = this._ariaLabelledByQueue.indexOf(id);
+
+    if (index > -1) {
+      this._ariaLabelledByQueue.splice(index, 1);
+      this._changeDetectorRef.markForCheck();
     }
   }
 

--- a/src/material/bottom-sheet/bottom-sheet-container.ts
+++ b/src/material/bottom-sheet/bottom-sheet-container.ts
@@ -14,7 +14,6 @@ import {OverlayRef} from '@angular/cdk/overlay';
 import {DOCUMENT} from '@angular/common';
 import {
   ChangeDetectionStrategy,
-  ChangeDetectorRef,
   Component,
   ElementRef,
   EventEmitter,
@@ -77,7 +76,6 @@ export class MatBottomSheetContainer extends CdkDialogContainer implements OnDes
     ngZone: NgZone,
     overlayRef: OverlayRef,
     breakpointObserver: BreakpointObserver,
-    private _changeDetectorRef: ChangeDetectorRef,
     focusMonitor?: FocusMonitor,
   ) {
     super(

--- a/src/material/dialog/dialog-content-directives.ts
+++ b/src/material/dialog/dialog-content-directives.ts
@@ -120,23 +120,19 @@ export class MatDialogTitle implements OnInit, OnDestroy {
       Promise.resolve().then(() => {
         // Note: we null check the queue, because there are some internal
         // tests that are mocking out `MatDialogRef` incorrectly.
-        this._dialogRef._containerInstance?._ariaLabelledByQueue?.push(this.id);
+        this._dialogRef._containerInstance?._addAriaLabelledBy?.(this.id);
       });
     }
   }
 
   ngOnDestroy() {
-    // Note: we null check the queue, because there are some internal
+    // Note: we null check because there are some internal
     // tests that are mocking out `MatDialogRef` incorrectly.
-    const queue = this._dialogRef?._containerInstance?._ariaLabelledByQueue;
+    const instance = this._dialogRef?._containerInstance;
 
-    if (queue) {
+    if (instance) {
       Promise.resolve().then(() => {
-        const index = queue.indexOf(this.id);
-
-        if (index > -1) {
-          queue.splice(index, 1);
-        }
+        instance._removeAriaLabelledBy?.(this.id);
       });
     }
   }

--- a/tools/public_api_guard/cdk/dialog.md
+++ b/tools/public_api_guard/cdk/dialog.md
@@ -6,6 +6,7 @@
 
 import { BasePortalOutlet } from '@angular/cdk/portal';
 import { CdkPortalOutlet } from '@angular/cdk/portal';
+import { ChangeDetectorRef } from '@angular/core';
 import { ComponentFactoryResolver } from '@angular/core';
 import { ComponentPortal } from '@angular/cdk/portal';
 import { ComponentRef } from '@angular/core';
@@ -45,12 +46,16 @@ export type AutoFocusTarget = 'dialog' | 'first-tabbable' | 'first-heading';
 // @public
 export class CdkDialogContainer<C extends DialogConfig = DialogConfig> extends BasePortalOutlet implements OnDestroy {
     constructor(_elementRef: ElementRef, _focusTrapFactory: FocusTrapFactory, _document: any, _config: C, _interactivityChecker: InteractivityChecker, _ngZone: NgZone, _overlayRef: OverlayRef, _focusMonitor?: FocusMonitor | undefined);
+    // (undocumented)
+    _addAriaLabelledBy(id: string): void;
     _ariaLabelledByQueue: string[];
     attachComponentPortal<T>(portal: ComponentPortal<T>): ComponentRef<T>;
     // @deprecated
     attachDomPortal: (portal: DomPortal) => void;
     attachTemplatePortal<T>(portal: TemplatePortal<T>): EmbeddedViewRef<T>;
     protected _captureInitialFocus(): void;
+    // (undocumented)
+    protected readonly _changeDetectorRef: ChangeDetectorRef;
     _closeInteractionType: FocusOrigin | null;
     // (undocumented)
     readonly _config: C;
@@ -68,6 +73,8 @@ export class CdkDialogContainer<C extends DialogConfig = DialogConfig> extends B
     protected _ngZone: NgZone;
     _portalOutlet: CdkPortalOutlet;
     _recaptureFocus(): void;
+    // (undocumented)
+    _removeAriaLabelledBy(id: string): void;
     protected _trapFocus(): void;
     // (undocumented)
     static ɵcmp: i0.ɵɵComponentDeclaration<CdkDialogContainer<any>, "cdk-dialog-container", never, {}, {}, never, never, true, never>;

--- a/tools/public_api_guard/material/bottom-sheet.md
+++ b/tools/public_api_guard/material/bottom-sheet.md
@@ -8,7 +8,6 @@ import { AnimationEvent as AnimationEvent_2 } from '@angular/animations';
 import { AnimationTriggerMetadata } from '@angular/animations';
 import { BreakpointObserver } from '@angular/cdk/layout';
 import { CdkDialogContainer } from '@angular/cdk/dialog';
-import { ChangeDetectorRef } from '@angular/core';
 import { ComponentRef } from '@angular/core';
 import { ComponentType } from '@angular/cdk/portal';
 import { DialogConfig } from '@angular/cdk/dialog';
@@ -83,7 +82,7 @@ export class MatBottomSheetConfig<D = any> {
 
 // @public
 export class MatBottomSheetContainer extends CdkDialogContainer implements OnDestroy {
-    constructor(elementRef: ElementRef, focusTrapFactory: FocusTrapFactory, document: any, config: DialogConfig, checker: InteractivityChecker, ngZone: NgZone, overlayRef: OverlayRef, breakpointObserver: BreakpointObserver, _changeDetectorRef: ChangeDetectorRef, focusMonitor?: FocusMonitor);
+    constructor(elementRef: ElementRef, focusTrapFactory: FocusTrapFactory, document: any, config: DialogConfig, checker: InteractivityChecker, ngZone: NgZone, overlayRef: OverlayRef, breakpointObserver: BreakpointObserver, focusMonitor?: FocusMonitor);
     _animationState: 'void' | 'visible' | 'hidden';
     _animationStateChanged: EventEmitter<AnimationEvent_2>;
     // (undocumented)
@@ -99,7 +98,7 @@ export class MatBottomSheetContainer extends CdkDialogContainer implements OnDes
     // (undocumented)
     static ɵcmp: i0.ɵɵComponentDeclaration<MatBottomSheetContainer, "mat-bottom-sheet-container", never, {}, {}, never, never, true, never>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<MatBottomSheetContainer, [null, null, { optional: true; }, null, null, null, null, null, null, null]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MatBottomSheetContainer, [null, null, { optional: true; }, null, null, null, null, null, null]>;
 }
 
 // @public (undocumented)


### PR DESCRIPTION
The `mat-dialog-title` directive updates state in a microtask and should call `ChangeDetectorRef.markForCheck`. Failing to do this will cause the component tree to not be checked if it lives under an `OnPush` component that has not otherwise been marked for check.