### PR TITLE
fix(material/dialog): autofocus should wait for rendering to complete

### DIFF
--- a/src/material/dialog/dialog-container.ts
+++ b/src/material/dialog/dialog-container.ts
@@ -92,7 +92,6 @@ export class MatDialogContainer extends CdkDialogContainer<MatDialogConfig> impl
     : 0;
   /** Current timer for dialog animations. */
   private _animationTimer: ReturnType<typeof setTimeout> | null = null;
-  private readonly _injector = inject(Injector);
 
   constructor(
     elementRef: ElementRef,

--- a/src/material/dialog/dialog.spec.ts
+++ b/src/material/dialog/dialog.spec.ts
@@ -30,6 +30,7 @@ import {
   ViewContainerRef,
   ViewEncapsulation,
   forwardRef,
+  ApplicationRef,
 } from '@angular/core';
 import {
   ComponentFixture,
@@ -1090,7 +1091,7 @@ describe('MDC-based MatDialog', () => {
   it(
     'should recapture focus to the first element that matches the css selector when ' +
       'clicking on the backdrop with autoFocus set to a css selector',
-    fakeAsync(() => {
+    async () => {
       viewContainerFixture.autoDetectChanges();
       TestBed.inject(NgZone).run(() => {
         // Queueing a microtask prevents synchronous change detection after zone.run
@@ -1108,7 +1109,7 @@ describe('MDC-based MatDialog', () => {
         });
       });
 
-      flushMicrotasks();
+      await viewContainerFixture.whenStable();
 
       let backdrop = overlayContainerElement.querySelector('.cdk-overlay-backdrop') as HTMLElement;
       let firstButton = overlayContainerElement.querySelector(
@@ -1121,12 +1122,12 @@ describe('MDC-based MatDialog', () => {
 
       firstButton.blur(); // Programmatic clicks might not move focus so we simulate it.
       backdrop.click();
-      flush();
+      await viewContainerFixture.whenStable();
 
       expect(document.activeElement)
         .withContext('Expected first button to stay focused after click')
         .toBe(firstButton);
-    }),
+    },
   );
 
   describe('hasBackdrop option', () => {


### PR DESCRIPTION
The current implementation of the dialog's `finishDialogOpen`, which includes autofocus, only waits for a microtask before executing. This only works in the tests because of the synchronous call to `detectChanges` after opening the dialog, ensuring that change detection runs before the microtask. In an application, this is not guaranteed because `NgZone` will only run change detection when the microtask queue empties, which includes the microtask created by the dialog container.

This commit updates the implementation to wait for the next render to coplete, _then_ queues a microtask that will finish the open process and perform autofocus.