### PR TITLE
fix(material/snack-bar): Ensure snackbar enter/exit works with OnPush ancestor

### DIFF
--- a/src/material/snack-bar/snack-bar-container.ts
+++ b/src/material/snack-bar/snack-bar-container.ts
@@ -191,6 +191,9 @@ export class MatSnackBarContainer extends BasePortalOutlet implements OnDestroy 
   enter(): void {
     if (!this._destroyed) {
       this._animationState = 'visible';
+      // _animationState lives in host bindings and `detectChanges` does not refresh host bindings
+      // so we have to call `markForCheck` to ensure the host view is refreshed eventually.
+      this._changeDetectorRef.markForCheck();
       this._changeDetectorRef.detectChanges();
       this._screenReaderAnnounce();
     }
@@ -205,6 +208,7 @@ export class MatSnackBarContainer extends BasePortalOutlet implements OnDestroy 
       // where multiple snack bars are opened in quick succession (e.g. two consecutive calls to
       // `MatSnackBar.open`).
       this._animationState = 'hidden';
+      this._changeDetectorRef.markForCheck();
 
       // Mark this element with an 'exit' attribute to indicate that the snackbar has
       // been dismissed and will soon be removed from the DOM. This is used by the snackbar

--- a/src/material/snack-bar/snack-bar.spec.ts
+++ b/src/material/snack-bar/snack-bar.spec.ts
@@ -1,12 +1,14 @@
 import {LiveAnnouncer} from '@angular/cdk/a11y';
 import {OverlayContainer} from '@angular/cdk/overlay';
 import {
+  ChangeDetectionStrategy,
   Component,
   Directive,
   Inject,
   TemplateRef,
   ViewChild,
   ViewContainerRef,
+  signal,
 } from '@angular/core';
 import {ComponentFixture, fakeAsync, flush, inject, TestBed, tick} from '@angular/core/testing';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
@@ -358,7 +360,7 @@ describe('MatSnackBar', () => {
     viewContainerFixture.detectChanges();
     expect(overlayContainerElement.childElementCount).toBeGreaterThan(0);
 
-    viewContainerFixture.componentInstance.childComponentExists = false;
+    viewContainerFixture.componentInstance.childComponentExists.set(false);
     viewContainerFixture.detectChanges();
     flush();
 
@@ -403,6 +405,9 @@ describe('MatSnackBar', () => {
     const dismissCompleteSpy = jasmine.createSpy('dismiss complete spy');
 
     viewContainerFixture.detectChanges();
+
+    const containerElement = document.querySelector('mat-snack-bar-container')!;
+    expect(containerElement.classList).toContain('ng-animating');
     const container1 = snackBarRef.containerInstance as MatSnackBarContainer;
     expect(container1._animationState)
       .withContext(`Expected the animation state would be 'visible'.`)
@@ -1102,14 +1107,15 @@ class DirectiveWithViewContainer {
 
 @Component({
   selector: 'arbitrary-component',
-  template: `@if (childComponentExists) {<dir-with-view-container></dir-with-view-container>}`,
+  template: `@if (childComponentExists()) {<dir-with-view-container></dir-with-view-container>}`,
   standalone: true,
   imports: [DirectiveWithViewContainer],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 class ComponentWithChildViewContainer {
   @ViewChild(DirectiveWithViewContainer) childWithViewContainer: DirectiveWithViewContainer;
 
-  childComponentExists: boolean = true;
+  childComponentExists = signal(true);
 
   get childViewContainer() {
     return this.childWithViewContainer.viewContainerRef;


### PR DESCRIPTION
By updating the "arbitrary-component" to `OnPush`, the following test fails:
`MatSnackBar should set the old snack bar animation state to complete and the new snack bar animation`.

The assertion that fails is the `afterDismissed` spy, which never gets called. Adding `markForCheck` in the `exit` ensures the `_animationState` is applied to the host and completes. If this is not done, the following listener never executes, including the `_completeExist`: `'(@state.done)': 'onAnimationEnd($event)'`.