### PR TITLE
fix(material/chip-set): fixed chips-avatar-example

### DIFF
--- a/src/components-examples/material/chips/chips-avatar/chips-avatar-example.html
+++ b/src/components-examples/material/chips/chips-avatar/chips-avatar-example.html
@@ -1,4 +1,4 @@
-<mat-chip-listbox aria-label="Dog selection">
+<mat-chip-set aria-label="Dog selection">
   <mat-chip>
     <img matChipAvatar src="https://material.angular.io/assets/img/examples/shiba1.jpg" alt="Photo of a Shiba Inu"/>
     Dog one
@@ -11,4 +11,4 @@
     <img matChipAvatar src="https://material.angular.io/assets/img/examples/shiba1.jpg" alt="Photo of a Shiba Inu"/>
     Dog three
   </mat-chip>
-</mat-chip-listbox>
+</mat-chip-set>


### PR DESCRIPTION
 since using mat-chip inside mat-chip-listbox is unsupported (#28210)