### PR TITLE
fix(multiple): enable hydration in autocomplete, menu and select

### DIFF
--- a/src/material/autocomplete/autocomplete.ts
+++ b/src/material/autocomplete/autocomplete.ts
@@ -115,7 +115,6 @@ export function MAT_AUTOCOMPLETE_DEFAULT_OPTIONS_FACTORY(): MatAutocompleteDefau
   exportAs: 'matAutocomplete',
   host: {
     'class': 'mat-mdc-autocomplete',
-    'ngSkipHydration': '',
   },
   providers: [{provide: MAT_OPTION_PARENT_COMPONENT, useExisting: MatAutocomplete}],
   animations: [panelAnimation],

--- a/src/material/menu/menu.ts
+++ b/src/material/menu/menu.ts
@@ -105,7 +105,6 @@ export function MAT_MENU_DEFAULT_OPTIONS_FACTORY(): MatMenuDefaultOptions {
     '[attr.aria-label]': 'null',
     '[attr.aria-labelledby]': 'null',
     '[attr.aria-describedby]': 'null',
-    'ngSkipHydration': '',
   },
   animations: [matMenuAnimations.transformMenu, matMenuAnimations.fadeInItems],
   providers: [{provide: MAT_MENU_PANEL, useExisting: MatMenu}],

--- a/src/material/select/select.ts
+++ b/src/material/select/select.ts
@@ -190,7 +190,6 @@ export class MatSelectChange {
     '[attr.aria-disabled]': 'disabled.toString()',
     '[attr.aria-invalid]': 'errorState',
     '[attr.aria-activedescendant]': '_getAriaActiveDescendant()',
-    'ngSkipHydration': '',
     '[class.mat-mdc-select-disabled]': 'disabled',
     '[class.mat-mdc-select-invalid]': 'errorState',
     '[class.mat-mdc-select-required]': 'required',

--- a/tools/public_api_guard/material/select.md
+++ b/tools/public_api_guard/material/select.md
@@ -126,17 +126,29 @@ export class MatSelect implements AfterContentInit, OnChanges, OnDestroy, OnInit
     get multiple(): boolean;
     set multiple(value: boolean);
     // (undocumented)
-    static ngAcceptInputType_disabled: unknown;
+    static ngAcceptInputType_disabled:
+    /** Whether or not the overlay panel is open. */
+    unknown;
     // (undocumented)
-    static ngAcceptInputType_disableOptionCentering: unknown;
+    static ngAcceptInputType_disableOptionCentering:
+    /** Whether or not the overlay panel is open. */
+    unknown;
     // (undocumented)
-    static ngAcceptInputType_disableRipple: unknown;
+    static ngAcceptInputType_disableRipple:
+    /** Whether or not the overlay panel is open. */
+    unknown;
     // (undocumented)
-    static ngAcceptInputType_hideSingleSelectionIndicator: unknown;
+    static ngAcceptInputType_hideSingleSelectionIndicator:
+    /** Whether or not the overlay panel is open. */
+    unknown;
     // (undocumented)
-    static ngAcceptInputType_multiple: unknown;
+    static ngAcceptInputType_multiple:
+    /** Whether or not the overlay panel is open. */
+    unknown;
     // (undocumented)
-    static ngAcceptInputType_required: unknown;
+    static ngAcceptInputType_required:
+    /** Whether or not the overlay panel is open. */
+    unknown;
     // (undocumented)
     static ngAcceptInputType_tabIndex: unknown;
     // (undocumented)


### PR DESCRIPTION
Hydration was disabled for `mat-autocomplete`, `mat-menu` and `mat-select`, even though it currently seems to work. These changes enable it to allow for better initial performance.