### PR TITLE
fix(cdk/table): support hydration

### DIFF
--- a/src/cdk/table/sticky-styler.ts
+++ b/src/cdk/table/sticky-styler.ts
@@ -258,10 +258,10 @@ export class StickyStyler {
       return;
     }
 
-    const tfoot = tableElement.querySelector('tfoot')!;
-
     // Coalesce with other sticky updates (and potentially other changes like column resize).
     this._coalescedStyleScheduler.schedule(() => {
+      const tfoot = tableElement.querySelector('tfoot')!;
+
       if (stickyStates.some(state => !state)) {
         this._removeStickyStyle(tfoot, ['bottom']);
       } else {

--- a/src/universal-app/kitchen-sink/kitchen-sink.html
+++ b/src/universal-app/kitchen-sink/kitchen-sink.html
@@ -380,35 +380,83 @@
 
 <h2>CDK Table</h2>
 
-<cdk-table #table [dataSource]="tableDataSource">
-  <ng-container cdkColumnDef="userId">
-    <cdk-header-cell *cdkHeaderCellDef>ID</cdk-header-cell>
-    <cdk-cell *cdkCellDef="let row">{{row.userId}}</cdk-cell>
+<cdk-table class="test-cdk-table" [dataSource]="tableDataSource">
+  <ng-container cdkColumnDef="position">
+    <cdk-header-cell *cdkHeaderCellDef>No.</cdk-header-cell>
+    <cdk-cell *cdkCellDef="let element">{{element.position}}</cdk-cell>
   </ng-container>
 
-  <cdk-header-row *cdkHeaderRowDef="tableColumns" ></cdk-header-row>
-  <cdk-row *cdkRowDef="let row; columns: tableColumns;"></cdk-row>
+  <ng-container cdkColumnDef="name">
+    <cdk-header-cell *cdkHeaderCellDef>Name</cdk-header-cell>
+    <cdk-cell *cdkCellDef="let element">{{element.name}}</cdk-cell>
+  </ng-container>
+
+  <ng-container cdkColumnDef="weight">
+    <cdk-header-cell *cdkHeaderCellDef>Weight</cdk-header-cell>
+    <cdk-cell *cdkCellDef="let element">{{element.weight}}</cdk-cell>
+  </ng-container>
+
+  <ng-container cdkColumnDef="symbol">
+    <cdk-header-cell *cdkHeaderCellDef>Symbol</cdk-header-cell>
+    <cdk-cell *cdkCellDef="let element">{{element.symbol}}</cdk-cell>
+  </ng-container>
+
+  <cdk-header-row *cdkHeaderRowDef="tableColumns"/>
+  <cdk-row *cdkRowDef="let row; columns: tableColumns;"/>
 </cdk-table>
 
 <h2>Material Table</h2>
 
 <mat-table [dataSource]="tableDataSource">
-  <ng-container matColumnDef="userId">
-    <mat-header-cell *matHeaderCellDef>ID</mat-header-cell>
-    <mat-cell *matCellDef="let row"> {{row.userId}} </mat-cell>
+  <ng-container matColumnDef="position">
+    <mat-header-cell *matHeaderCellDef>No.</mat-header-cell>
+    <mat-cell *matCellDef="let element">{{element.position}}</mat-cell>
   </ng-container>
 
-  <mat-header-row *matHeaderRowDef="tableColumns"></mat-header-row>
-  <mat-row *matRowDef="let row; columns: tableColumns;"></mat-row>
+  <ng-container matColumnDef="name">
+    <mat-header-cell *matHeaderCellDef>Name</mat-header-cell>
+    <mat-cell *matCellDef="let element">{{element.name}}</mat-cell>
+  </ng-container>
+
+  <ng-container matColumnDef="weight">
+    <mat-header-cell *matHeaderCellDef>Weight</mat-header-cell>
+    <mat-cell *matCellDef="let element">{{element.weight}}</mat-cell>
+  </ng-container>
+
+  <ng-container matColumnDef="symbol">
+    <mat-header-cell *matHeaderCellDef>Symbol</mat-header-cell>
+    <mat-cell *matCellDef="let element">{{element.symbol}}</mat-cell>
+  </ng-container>
+
+  <mat-header-row *matHeaderRowDef="tableColumns"/>
+  <mat-row *matRowDef="let row; columns: tableColumns;"/>
 </mat-table>
 
 <h2>Native table with sticky header and footer</h2>
 
 <table mat-table [dataSource]="tableDataSource">
-  <ng-container matColumnDef="userId">
-    <th mat-header-cell *matHeaderCellDef>ID</th>
-    <td mat-cell *matCellDef="let row">{{row.userId}}</td>
-    <td mat-footer-cell *matFooterCellDef>ID</td>
+  <ng-container matColumnDef="position">
+    <th mat-header-cell *matHeaderCellDef>No.</th>
+    <td mat-cell *matCellDef="let element">{{element.position}}</td>
+    <th mat-footer-cell *matFooterCellDef>No.</th>
+  </ng-container>
+
+  <ng-container matColumnDef="name">
+    <th mat-header-cell *matHeaderCellDef>Name</th>
+    <td mat-cell *matCellDef="let element">{{element.name}}</td>
+    <th mat-footer-cell *matFooterCellDef>Name</th>
+  </ng-container>
+
+  <ng-container matColumnDef="weight">
+    <th mat-header-cell *matHeaderCellDef>Weight</th>
+    <td mat-cell *matCellDef="let element">{{element.weight}}</td>
+    <th mat-footer-cell *matFooterCellDef>Weight</th>
+  </ng-container>
+
+  <ng-container matColumnDef="symbol">
+    <th mat-header-cell *matHeaderCellDef>Symbol</th>
+    <td mat-cell *matCellDef="let element">{{element.symbol}}</td>
+    <th mat-footer-cell *matFooterCellDef>Symbol</th>
   </ng-container>
 
   <tr mat-header-row *matHeaderRowDef="tableColumns; sticky: true"></tr>

--- a/src/universal-app/kitchen-sink/kitchen-sink.ts
+++ b/src/universal-app/kitchen-sink/kitchen-sink.ts
@@ -59,7 +59,18 @@ import {DOCUMENT} from '@angular/common';
 
 export class TableDataSource extends DataSource<any> {
   connect(): Observable<any> {
-    return observableOf([{userId: 1}, {userId: 2}]);
+    return observableOf([
+      {position: 1, name: 'Hydrogen', weight: 1.0079, symbol: 'H'},
+      {position: 2, name: 'Helium', weight: 4.0026, symbol: 'He'},
+      {position: 3, name: 'Lithium', weight: 6.941, symbol: 'Li'},
+      {position: 4, name: 'Beryllium', weight: 9.0122, symbol: 'Be'},
+      {position: 5, name: 'Boron', weight: 10.811, symbol: 'B'},
+      {position: 6, name: 'Carbon', weight: 12.0107, symbol: 'C'},
+      {position: 7, name: 'Nitrogen', weight: 14.0067, symbol: 'N'},
+      {position: 8, name: 'Oxygen', weight: 15.9994, symbol: 'O'},
+      {position: 9, name: 'Fluorine', weight: 18.9984, symbol: 'F'},
+      {position: 10, name: 'Neon', weight: 20.1797, symbol: 'Ne'},
+    ]);
   }
 
   disconnect() {}
@@ -81,6 +92,21 @@ export class TestEntryComponent {}
     .universal-viewport {
       height: 100px;
       border: 1px solid black;
+    }
+
+    .test-cdk-table {
+      display: table;
+      width: 100%;
+    }
+
+    .test-cdk-table .cdk-row,
+    .test-cdk-table .cdk-header-row {
+      display: table-row;
+    }
+
+    .test-cdk-table .cdk-cell,
+    .test-cdk-table .cdk-header-cell {
+      display: table-cell;
     }
   `,
   imports: [
@@ -144,7 +170,7 @@ export class TestEntryComponent {}
 })
 export class KitchenSink {
   /** List of columns for the CDK and Material table. */
-  tableColumns = ['userId'];
+  tableColumns = ['position', 'name', 'weight', 'symbol'];
 
   /** Data source for the CDK and Material table. */
   tableDataSource = new TableDataSource();

--- a/tools/public_api_guard/cdk/table.md
+++ b/tools/public_api_guard/cdk/table.md
@@ -75,7 +75,7 @@ export const CDK_ROW_TEMPLATE = "<ng-container cdkCellOutlet></ng-container>";
 export const CDK_TABLE: InjectionToken<any>;
 
 // @public
-export const CDK_TABLE_TEMPLATE = "\n  <ng-content select=\"caption\"></ng-content>\n  <ng-content select=\"colgroup, col\"></ng-content>\n  <ng-container headerRowOutlet></ng-container>\n  <ng-container rowOutlet></ng-container>\n  <ng-container noDataRowOutlet></ng-container>\n  <ng-container footerRowOutlet></ng-container>\n";
+export const CDK_TABLE_TEMPLATE = "\n  <ng-content select=\"caption\"/>\n  <ng-content select=\"colgroup, col\"/>\n\n  <!--\n    Unprojected content throws a hydration error so we need this to capture it.\n    It gets removed on the client so it doesn't affect the layout.\n  -->\n  @if (_isServer) {\n    <ng-content/>\n  }\n\n  @if (_isNativeHtmlTable) {\n    <thead role=\"rowgroup\">\n      <ng-container headerRowOutlet/>\n    </thead>\n    <tbody role=\"rowgroup\">\n      <ng-container rowOutlet/>\n      <ng-container noDataRowOutlet/>\n    </tbody>\n    <tfoot role=\"rowgroup\">\n      <ng-container footerRowOutlet/>\n    </tfoot>\n  } @else {\n    <ng-container headerRowOutlet/>\n    <ng-container rowOutlet/>\n    <ng-container noDataRowOutlet/>\n    <ng-container footerRowOutlet/>\n  }\n";
 
 // @public
 export class CdkCell extends BaseCdkCell {
@@ -323,6 +323,7 @@ export class CdkTable<T> implements AfterContentChecked, CollectionViewer, OnDes
     // (undocumented)
     _headerRowOutlet: HeaderRowOutlet;
     protected _isNativeHtmlTable: boolean;
+    protected _isServer: boolean;
     get multiTemplateDataRows(): boolean;
     set multiTemplateDataRows(value: boolean);
     // (undocumented)
@@ -343,6 +344,7 @@ export class CdkTable<T> implements AfterContentChecked, CollectionViewer, OnDes
     _noDataRow: CdkNoDataRow;
     // (undocumented)
     _noDataRowOutlet: NoDataRowOutlet;
+    _outletAssigned(): void;
     removeColumnDef(columnDef: CdkColumnDef): void;
     removeFooterRowDef(footerRowDef: CdkFooterRowDef): void;
     removeHeaderRowDef(headerRowDef: CdkHeaderRowDef): void;
@@ -366,7 +368,7 @@ export class CdkTable<T> implements AfterContentChecked, CollectionViewer, OnDes
     // (undocumented)
     protected readonly _viewRepeater: _ViewRepeater<T, RenderRow<T>, RowContext<T>>;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<CdkTable<any>, "cdk-table, table[cdk-table]", ["cdkTable"], { "trackBy": { "alias": "trackBy"; "required": false; }; "dataSource": { "alias": "dataSource"; "required": false; }; "multiTemplateDataRows": { "alias": "multiTemplateDataRows"; "required": false; }; "fixedLayout": { "alias": "fixedLayout"; "required": false; }; }, { "contentChanged": "contentChanged"; }, ["_noDataRow", "_contentColumnDefs", "_contentRowDefs", "_contentHeaderRowDefs", "_contentFooterRowDefs"], ["caption", "colgroup, col"], true, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<CdkTable<any>, "cdk-table, table[cdk-table]", ["cdkTable"], { "trackBy": { "alias": "trackBy"; "required": false; }; "dataSource": { "alias": "dataSource"; "required": false; }; "multiTemplateDataRows": { "alias": "multiTemplateDataRows"; "required": false; }; "fixedLayout": { "alias": "fixedLayout"; "required": false; }; }, { "contentChanged": "contentChanged"; }, ["_noDataRow", "_contentColumnDefs", "_contentRowDefs", "_contentHeaderRowDefs", "_contentFooterRowDefs"], ["caption", "colgroup, col", "*"], true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<CdkTable<any>, [null, null, null, { attribute: "role"; }, { optional: true; }, null, null, null, null, null, { optional: true; skipSelf: true; }, { optional: true; }]>;
 }

--- a/tools/public_api_guard/material/table.md
+++ b/tools/public_api_guard/material/table.md
@@ -27,7 +27,6 @@ import * as i1 from '@angular/material/core';
 import * as i2 from '@angular/cdk/table';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort } from '@angular/material/sort';
-import { OnInit } from '@angular/core';
 import { Subscription } from 'rxjs';
 
 // @public
@@ -156,13 +155,11 @@ export class MatRowDef<T> extends CdkRowDef<T> {
 }
 
 // @public (undocumented)
-export class MatTable<T> extends CdkTable<T> implements OnInit {
+export class MatTable<T> extends CdkTable<T> {
     protected needsPositionStickyOnElement: boolean;
-    // (undocumented)
-    ngOnInit(): void;
     protected stickyCssClass: string;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<MatTable<any>, "mat-table, table[mat-table]", ["matTable"], {}, {}, never, ["caption", "colgroup, col"], true, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MatTable<any>, "mat-table, table[mat-table]", ["matTable"], {}, {}, never, ["caption", "colgroup, col", "*"], true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatTable<any>, never>;
 }


### PR DESCRIPTION
Reworks the table so that it can support hydration. There were a few issues that broke hydration:
1. There wasn't a catch-all `ng-content` slot which meant that the comment nodes representing the table content were dropped, causing an error.
2. The table needs to conditionally wrap some content with native table sections (`thead`,  `tbody` etc.) which was done with direct DOM manipulation. This breaks hydration because Angular won't know about those elements.

The first issue is easily resolved by adding an `ng-content` element. It shouldn't affect existing tables, since all the projected content is composed of comment nodes.

The second issue is a bit trickier, because we were using content queries to resolve the individual table outlets. Wrapping them in a conditional breaks the query so we have to use something else to resolve them. I've worked around it by using DI which doesn't have the exact same timing, but it appears to be close enough.

Fixes #28355.