### PR TITLE
feat(material-date-fns-adapter): support date-fns 3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
     "browser-sync": "2.26.13",
     "chalk": "^4.1.0",
     "cross-env": "^7.0.3",
-    "date-fns": "^2.28.0",
+    "date-fns": "^3.0.6",
     "dgeni": "^0.4.14",
     "dgeni-packages": "^0.29.5",
     "esbuild": "^0.17.5",

--- a/src/material-date-fns-adapter/adapter/date-fns-adapter.ts
+++ b/src/material-date-fns-adapter/adapter/date-fns-adapter.ts
@@ -54,7 +54,7 @@ const DAY_OF_WEEK_FORMATS = {
 export class DateFnsAdapter extends DateAdapter<Date, Locale> {
   constructor(@Optional() @Inject(MAT_DATE_LOCALE) matDateLocale: {}) {
     super();
-    this.setLocale(matDateLocale);
+    this.setLocale(matDateLocale as Locale);
   }
 
   getYear(date: Date): number {

--- a/src/material-date-fns-adapter/package.json
+++ b/src/material-date-fns-adapter/package.json
@@ -14,7 +14,7 @@
   "peerDependencies": {
     "@angular/material": "0.0.0-PLACEHOLDER",
     "@angular/core": "0.0.0-NG",
-    "date-fns": "^2.23.0"
+    "date-fns": ">2.20.0 <4.0"
   },
   "dependencies": {
     "tslib": "0.0.0-TSLIB"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7803,10 +7803,10 @@ data-uri-to-buffer@^4.0.0:
   resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz#b5db46aea50f6176428ac05b73be39a57701a64b"
   integrity sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==
 
-date-fns@^2.28.0:
-  version "2.28.0"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.28.0.tgz#9570d656f5fc13143e50c975a3b6bbeb46cd08b2"
-  integrity sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==
+date-fns@^3.0.6:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-3.0.6.tgz#fe3aeb7592d359f075ffc41cb16139828810ca83"
+  integrity sha512-W+G99rycpKMMF2/YD064b2lE7jJGUe+EjOES7Q8BIGY8sbNdbgcs9XFTZwvzc9Jx1f3k7LB7gZaZa7f8Agzljg==
 
 date-format@^4.0.7:
   version "4.0.7"


### PR DESCRIPTION
Adds support for `date-fns` 3 to the date adapter.

Fixes #28357.