### PR TITLE
fix(material/slider): safari value correction bug

### DIFF
--- a/src/material/slider/slider-input.ts
+++ b/src/material/slider/slider-input.ts
@@ -456,7 +456,7 @@ export class MatSliderThumb implements _MatSliderThumb, OnDestroy, ControlValueA
       return;
     }
 
-    this.value = value;
+    this._setValue(value + '');
     this.valueChange.emit(this.value);
     this._onChangeFn?.(this.value);
     this._slider._onValueChange(this);


### PR DESCRIPTION
* Fixes an issue where the slider value would sometimes not get immediately corrected on pointerdown in safari.
* This bug only gets triggered when the user triggers a user begins dragging directly on the hidden native inputs slider thumb.