### PR TITLE
refactor(material/snack-bar): Remove NgZone.onMicrotaskEmpty dependency

### DIFF
--- a/src/material/snack-bar/snack-bar-container.ts
+++ b/src/material/snack-bar/snack-bar-container.ts
@@ -32,7 +32,6 @@ import {Observable, Subject} from 'rxjs';
 import {AriaLivePoliteness} from '@angular/cdk/a11y';
 import {Platform} from '@angular/cdk/platform';
 import {AnimationEvent} from '@angular/animations';
-import {take} from 'rxjs/operators';
 import {MatSnackBarConfig} from './snack-bar-config';
 
 let uniqueId = 0;
@@ -231,15 +230,13 @@ export class MatSnackBarContainer extends BasePortalOutlet implements OnDestroy 
   }
 
   /**
-   * Waits for the zone to settle before removing the element. Helps prevent
-   * errors where we end up removing an element which is in the middle of an animation.
+   * Removes the element in a microtask. Helps prevent errors where we end up
+   * removing an element which is in the middle of an animation.
    */
   private _completeExit() {
-    this._ngZone.onMicrotaskEmpty.pipe(take(1)).subscribe(() => {
-      this._ngZone.run(() => {
-        this._onExit.next();
-        this._onExit.complete();
-      });
+    queueMicrotask(() => {
+      this._onExit.next();
+      this._onExit.complete();
     });
   }
 


### PR DESCRIPTION
`onMicrotaskEmpty` will not emit when an application is using `NoopNgZone`. There wasn't a test around this bit of code when it was added so I can't be completely sure this doesn't break anything. It's unclear to me whether it's meant to wait for rendering or just meant to be async. It's possible that simply making the code execute in the microtask queue will have the same overall effect as before.