### PR TITLE
fix(material/dialog): dialog actions overflow and are unreachable

### DIFF
--- a/src/material/dialog/dialog.scss
+++ b/src/material/dialog/dialog.scss
@@ -12,6 +12,9 @@ $mat-dialog-content-max-height: 65vh !default;
 // Dialog button horizontal margin. This has been extracted from MDC as they
 // don't expose this value as variable.
 $mat-dialog-button-horizontal-margin: 8px !default;
+// Dialog container max height. This has been given a default value so the
+// flex-children can be calculated and not overflow on smaller screens.
+$mat-dialog-container-max-height: 95vh !default;
 
 // Whether to emit fallback values for the structural styles. Previously MDC was emitting
 // paddings in the static styles which meant that users would get them even if they didn't


### PR DESCRIPTION
Fixes a bug in the Angular Material dialog component where buttons/actions are unreachable due to dialog overflowing because of unspecified max-height for the mat-dialog-container parent flexbox.

Fixes #24785