### PR TITLE
fix(material/datepicker): unable to distinguish disabled buttons in the calendar

### DIFF
--- a/src/material/datepicker/calendar.scss
+++ b/src/material/datepicker/calendar.scss
@@ -92,9 +92,8 @@ $_tokens: tokens-mat-datepicker.$prefix, tokens-mat-datepicker.get-token-slots()
   position: relative;
 
   @include token-utils.use-tokens($_tokens...) {
-
     // Needs need a bit more specificity to avoid being overwritten by the .mat-icon-button.
-    .mat-datepicker-content & {
+    .mat-datepicker-content &:not(.mat-mdc-button-disabled) {
       @include token-utils.create-token-slot(color, calendar-navigation-button-icon-color);
     }
   }


### PR DESCRIPTION
Fixes that at some point during the tokens transition the disabled state of the calendar buttons started being overwritten by the enabled state.