### PR TITLE
docs(material/theming-your-component): Typo in code-block example

### DIFF
--- a/guides/theming-your-components.md
+++ b/guides/theming-your-components.md
@@ -136,7 +136,7 @@ See the below example of reading the density scale from a theme:
 ```scss
 $theme: mat.define-dark-theme(...);
 
-$density-scale: mat.get-theme-desity($theme);
+$density-scale: mat.get-theme-density($theme);
 ```
 
 ### Checking what dimensions are configured for a theme


### PR DESCRIPTION
Fixes a typo which is used in a code block as an example. The typo is "desity" instead of "density", and thus is a code block that does not work.

No breaking changes, just a doc change.