### PR TITLE
M3-related density fixes

### DIFF
--- a/src/dev-app/theme-m3.scss
+++ b/src/dev-app/theme-m3.scss
@@ -147,7 +147,7 @@ html {
 }
 
 // Emit density styles for each scale.
-@each $scale in (maximum, 0, -1, -2, -3, minimum) {
+@each $scale in (maximum, 0, -1, -2, -3, -4, minimum) {
   $scale-theme: matx.define-theme(map.set($m3-base-config, density, scale, $scale));
 
   .demo-density-#{$scale} {

--- a/src/material-experimental/theming/_config-validation.scss
+++ b/src/material-experimental/theming/_config-validation.scss
@@ -154,7 +154,7 @@
     @return (#{'$config has unexpected properties. Valid properties are: scale. Found:'} $err);
   }
   @if $config and map.has-key($config, scale) {
-    $allowed-scales: (0, -1, -2, -3, -4 -5, minimum, maximum);
+    $allowed-scales: (0, -1, -2, -3, -4, -5, minimum, maximum);
     @if mat.private-validate-allowed-values(map.get($config, scale), $allowed-scales...) {
       @return (
         #{'Expected $config.scale to be one of: #{$allowed-scales}. Got:'}

--- a/src/material/paginator/_paginator-theme.scss
+++ b/src/material/paginator/_paginator-theme.scss
@@ -1,7 +1,7 @@
 @use 'sass:map';
 @use 'sass:meta';
 @use '../core/tokens/m2/mat/paginator' as tokens-mat-paginator;
-@use '../core/tokens/m2/mat/form-field' as tokens-mat-form-field;
+@use '../form-field/form-field-theme';
 @use '../core/style/sass-utils';
 @use '../core/typography/typography';
 @use '../core/theming/theming';
@@ -40,30 +40,24 @@
 }
 
 @mixin density($theme) {
+  $density-scale: inspection.get-theme-density($theme);
+  $form-field-density: if((meta.type-of($density-scale) == 'number' and $density-scale >= -4) or
+    $density-scale == maximum, -4, $density-scale);
+
   @if inspection.get-theme-version($theme) == 1 {
     @include _theme-from-tokens(inspection.get-theme-tokens($theme, density));
   }
   @else {
-    $density-scale: inspection.get-theme-density($theme);
-
     @include sass-utils.current-selector-or-root() {
       @include token-utils.create-token-values(tokens-mat-paginator.$prefix,
         tokens-mat-paginator.get-density-tokens($theme));
     }
+  }
 
-    .mat-mdc-paginator {
-      // We need the form field to be narrower in order to fit into the paginator,
-      // so we set its density to be -4 or denser.
-      @if ((meta.type-of($density-scale) == 'number' and $density-scale >= -4) or
-         $density-scale == maximum) {
-        @include token-utils.create-token-values(tokens-mat-form-field.$prefix,
-          tokens-mat-form-field.get-density-tokens((density: -4)));
-      }
-      @else {
-        @include token-utils.create-token-values(tokens-mat-form-field.$prefix,
-          tokens-mat-form-field.get-density-tokens((density: $density-scale)));
-      }
-    }
+  // We need the form field to be narrower in order to fit into the paginator,
+  // so we set its density to be -4 or denser.
+  .mat-mdc-paginator {
+    @include form-field-theme.density((density: $form-field-density));
   }
 }
 


### PR DESCRIPTION
Includes a couple of M3-related density fixes:
1. We weren't validating density scales correctly, because of a missing comma.
2. We weren't setting the density of the form field in the paginator in M3.