### PR TITLE
Expose parameter to prevent menu from being pushed

### DIFF
--- a/src/material/menu/menu-trigger.ts
+++ b/src/material/menu/menu-trigger.ts
@@ -189,6 +189,11 @@ export class MatMenuTrigger implements AfterContentInit, OnDestroy {
    */
   @Input('matMenuTriggerRestoreFocus') restoreFocus: boolean = true;
 
+  /**
+   * Whether menu will reposition to fit in the viewport.
+  */
+  @Input('matMenuRepositionOverlay') reposition: boolean = true;
+
   /** Event emitted when the associated menu is opened. */
   @Output() readonly menuOpened: EventEmitter<void> = new EventEmitter<void>();
 
@@ -496,6 +501,7 @@ export class MatMenuTrigger implements AfterContentInit, OnDestroy {
         .flexibleConnectedTo(this._element)
         .withLockedPosition()
         .withGrowAfterOpen()
+        .withPush(this.reposition)
         .withTransformOriginOn('.mat-menu-panel, .mat-mdc-menu-panel'),
       backdropClass: menu.backdropClass || 'cdk-overlay-transparent-backdrop',
       panelClass: menu.overlayPanelClass,


### PR DESCRIPTION
When using the menu, there is a requirement in my work to not have the menu panel overlap on the item. This is happening when the screen size is small and the menu panel is big.

Adding of the input parameter into the PositionStrategy withPush() function allows the menu panel to stay in place and not be repositioned.