### PR TITLE
fix(multiple): import ANIMATION_MODULE_TYPE from core

### DIFF
--- a/src/cdk/clipboard/BUILD.bazel
+++ b/src/cdk/clipboard/BUILD.bazel
@@ -10,6 +10,7 @@ ng_module(
     ),
     assets = glob(["**/*.html"]),
     deps = [
+        "@npm//@angular/common",
         "@npm//@angular/core",
         "@npm//rxjs",
     ],

--- a/src/cdk/observers/private/BUILD.bazel
+++ b/src/cdk/observers/private/BUILD.bazel
@@ -15,6 +15,7 @@ ng_module(
     ),
     deps = [
         "//src:dev_mode_types",
+        "@npm//@angular/core",
         "@npm//rxjs",
     ],
 )

--- a/src/cdk/portal/BUILD.bazel
+++ b/src/cdk/portal/BUILD.bazel
@@ -16,6 +16,7 @@ ng_module(
     ),
     deps = [
         "//src:dev_mode_types",
+        "@npm//@angular/common",
         "@npm//@angular/core",
     ],
 )

--- a/src/dev-app/checkbox/checkbox-demo.ts
+++ b/src/dev-app/checkbox/checkbox-demo.ts
@@ -6,9 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, Directive} from '@angular/core';
+import {Component, Directive, ANIMATION_MODULE_TYPE} from '@angular/core';
 import {MatCheckboxModule, MAT_CHECKBOX_DEFAULT_OPTIONS} from '@angular/material/checkbox';
-import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {MatPseudoCheckboxModule, ThemePalette} from '@angular/material/core';
 import {MatInputModule} from '@angular/material/input';

--- a/src/material/badge/badge.ts
+++ b/src/material/badge/badge.ts
@@ -26,9 +26,9 @@ import {
   Optional,
   Renderer2,
   ViewEncapsulation,
+  ANIMATION_MODULE_TYPE,
 } from '@angular/core';
 import {ThemePalette} from '@angular/material/core';
-import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 
 let nextId = 0;
 

--- a/src/material/button/button.ts
+++ b/src/material/button/button.ts
@@ -15,8 +15,8 @@ import {
   NgZone,
   Optional,
   ViewEncapsulation,
+  ANIMATION_MODULE_TYPE,
 } from '@angular/core';
-import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 
 import {MAT_ANCHOR_HOST, MAT_BUTTON_HOST, MatAnchorBase, MatButtonBase} from './button-base';
 

--- a/src/material/button/fab.ts
+++ b/src/material/button/fab.ts
@@ -18,8 +18,8 @@ import {
   Optional,
   ViewEncapsulation,
   booleanAttribute,
+  ANIMATION_MODULE_TYPE,
 } from '@angular/core';
-import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 
 import {MatAnchor} from './button';
 import {MAT_ANCHOR_HOST, MAT_BUTTON_HOST, MatButtonBase} from './button-base';

--- a/src/material/button/icon-button.ts
+++ b/src/material/button/icon-button.ts
@@ -15,8 +15,8 @@ import {
   NgZone,
   Optional,
   ViewEncapsulation,
+  ANIMATION_MODULE_TYPE,
 } from '@angular/core';
-import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 import {MAT_ANCHOR_HOST, MAT_BUTTON_HOST, MatAnchorBase, MatButtonBase} from './button-base';
 
 /**

--- a/src/material/checkbox/checkbox.ts
+++ b/src/material/checkbox/checkbox.ts
@@ -26,6 +26,7 @@ import {
   SimpleChanges,
   ViewChild,
   ViewEncapsulation,
+  ANIMATION_MODULE_TYPE,
 } from '@angular/core';
 import {
   AbstractControl,
@@ -36,7 +37,6 @@ import {
   Validator,
 } from '@angular/forms';
 import {_MatInternalFormField, MatRipple} from '@angular/material/core';
-import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 import {FocusableOption} from '@angular/cdk/a11y';
 import {
   MAT_CHECKBOX_DEFAULT_OPTIONS,

--- a/src/material/chips/chip-row.ts
+++ b/src/material/chips/chip-row.ts
@@ -7,7 +7,6 @@
  */
 
 import {ENTER} from '@angular/cdk/keycodes';
-import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 import {
   AfterViewInit,
   Attribute,
@@ -24,6 +23,7 @@ import {
   Output,
   ViewChild,
   ViewEncapsulation,
+  ANIMATION_MODULE_TYPE,
 } from '@angular/core';
 import {DOCUMENT} from '@angular/common';
 import {MAT_RIPPLE_GLOBAL_OPTIONS, RippleGlobalOptions} from '@angular/material/core';

--- a/src/material/chips/chip.ts
+++ b/src/material/chips/chip.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 import {
   AfterViewInit,
   AfterContentInit,
@@ -32,6 +31,7 @@ import {
   inject,
   booleanAttribute,
   numberAttribute,
+  ANIMATION_MODULE_TYPE,
 } from '@angular/core';
 import {DOCUMENT} from '@angular/common';
 import {

--- a/src/material/core/ripple/ripple.ts
+++ b/src/material/core/ripple/ripple.ts
@@ -17,10 +17,10 @@ import {
   OnDestroy,
   OnInit,
   Optional,
+  ANIMATION_MODULE_TYPE,
 } from '@angular/core';
 import {RippleAnimationConfig, RippleConfig, RippleRef} from './ripple-ref';
 import {RippleRenderer, RippleTarget} from './ripple-renderer';
-import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 
 /** Configurable options for `matRipple`. */
 export interface RippleGlobalOptions {

--- a/src/material/core/selection/pseudo-checkbox/pseudo-checkbox.ts
+++ b/src/material/core/selection/pseudo-checkbox/pseudo-checkbox.ts
@@ -13,8 +13,8 @@ import {
   ChangeDetectionStrategy,
   Inject,
   Optional,
+  ANIMATION_MODULE_TYPE,
 } from '@angular/core';
-import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 
 /**
  * Possible states for a pseudo checkbox.

--- a/src/material/dialog/dialog-container.ts
+++ b/src/material/dialog/dialog-container.ts
@@ -20,9 +20,9 @@ import {
   OnDestroy,
   Optional,
   ViewEncapsulation,
+  ANIMATION_MODULE_TYPE,
 } from '@angular/core';
 import {MatDialogConfig} from './dialog-config';
-import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 import {CdkDialogContainer} from '@angular/cdk/dialog';
 import {coerceNumberProperty} from '@angular/cdk/coercion';
 import {CdkPortalOutlet, ComponentPortal} from '@angular/cdk/portal';

--- a/src/material/expansion/expansion-panel-header.ts
+++ b/src/material/expansion/expansion-panel-header.ts
@@ -23,8 +23,8 @@ import {
   OnDestroy,
   Optional,
   ViewEncapsulation,
+  ANIMATION_MODULE_TYPE,
 } from '@angular/core';
-import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 import {EMPTY, merge, Subscription} from 'rxjs';
 import {filter} from 'rxjs/operators';
 import {MatAccordionTogglePosition} from './accordion-base';

--- a/src/material/expansion/expansion-panel.ts
+++ b/src/material/expansion/expansion-panel.ts
@@ -33,8 +33,8 @@ import {
   ViewContainerRef,
   ViewEncapsulation,
   booleanAttribute,
+  ANIMATION_MODULE_TYPE,
 } from '@angular/core';
-import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 import {Subject} from 'rxjs';
 import {distinctUntilChanged, filter, startWith, take} from 'rxjs/operators';
 import {MatAccordionBase, MatAccordionTogglePosition, MAT_ACCORDION} from './accordion-base';

--- a/src/material/form-field/form-field.ts
+++ b/src/material/form-field/form-field.ts
@@ -26,10 +26,10 @@ import {
   QueryList,
   ViewChild,
   ViewEncapsulation,
+  ANIMATION_MODULE_TYPE,
 } from '@angular/core';
 import {AbstractControlDirective} from '@angular/forms';
 import {ThemePalette} from '@angular/material/core';
-import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 import {merge, Subject} from 'rxjs';
 import {takeUntil} from 'rxjs/operators';
 import {MAT_ERROR, MatError} from './directives/error';

--- a/src/material/list/list-base.ts
+++ b/src/material/list/list-base.ts
@@ -20,6 +20,7 @@ import {
   OnDestroy,
   Optional,
   QueryList,
+  ANIMATION_MODULE_TYPE,
 } from '@angular/core';
 import {
   MAT_RIPPLE_GLOBAL_OPTIONS,
@@ -28,7 +29,6 @@ import {
   RippleRenderer,
   RippleTarget,
 } from '@angular/material/core';
-import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 import {Subscription, merge} from 'rxjs';
 import {
   MatListItemLine,

--- a/src/material/list/list.ts
+++ b/src/material/list/list.ts
@@ -20,9 +20,9 @@ import {
   ViewChild,
   ViewEncapsulation,
   InjectionToken,
+  ANIMATION_MODULE_TYPE,
 } from '@angular/core';
 import {MAT_RIPPLE_GLOBAL_OPTIONS, RippleGlobalOptions} from '@angular/material/core';
-import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 import {MatListBase, MatListItemBase} from './list-base';
 import {MatListItemLine, MatListItemMeta, MatListItemTitle} from './list-item-sections';
 import {coerceBooleanProperty} from '@angular/cdk/coercion';

--- a/src/material/progress-bar/progress-bar.ts
+++ b/src/material/progress-bar/progress-bar.ts
@@ -23,10 +23,10 @@ import {
   InjectionToken,
   inject,
   numberAttribute,
+  ANIMATION_MODULE_TYPE,
 } from '@angular/core';
 import {DOCUMENT} from '@angular/common';
 import {ThemePalette} from '@angular/material/core';
-import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 
 /** Last animation end data. */
 export interface ProgressAnimationEnd {

--- a/src/material/progress-spinner/progress-spinner.ts
+++ b/src/material/progress-spinner/progress-spinner.ts
@@ -17,9 +17,9 @@ import {
   ViewChild,
   ViewEncapsulation,
   numberAttribute,
+  ANIMATION_MODULE_TYPE,
 } from '@angular/core';
 import {ThemePalette} from '@angular/material/core';
-import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 import {NgTemplateOutlet} from '@angular/common';
 
 /** Possible mode for a progress spinner. */

--- a/src/material/radio/radio.ts
+++ b/src/material/radio/radio.ts
@@ -31,11 +31,11 @@ import {
   QueryList,
   ViewChild,
   ViewEncapsulation,
+  ANIMATION_MODULE_TYPE,
 } from '@angular/core';
 import {_MatInternalFormField, MatRipple, ThemePalette} from '@angular/material/core';
 import {FocusMonitor, FocusOrigin} from '@angular/cdk/a11y';
 import {UniqueSelectionDispatcher} from '@angular/cdk/collections';
-import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
 import {Subscription} from 'rxjs';
 

--- a/src/material/sidenav/drawer.ts
+++ b/src/material/sidenav/drawer.ts
@@ -42,6 +42,7 @@ import {
   QueryList,
   ViewChild,
   ViewEncapsulation,
+  ANIMATION_MODULE_TYPE,
 } from '@angular/core';
 import {fromEvent, merge, Observable, Subject} from 'rxjs';
 import {
@@ -55,7 +56,6 @@ import {
   mapTo,
 } from 'rxjs/operators';
 import {matDrawerAnimations} from './drawer-animations';
-import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 
 /**
  * Throws an exception when two MatDrawer are matching the same position.

--- a/src/material/slide-toggle/slide-toggle.ts
+++ b/src/material/slide-toggle/slide-toggle.ts
@@ -26,6 +26,7 @@ import {
   SimpleChanges,
   ViewChild,
   ViewEncapsulation,
+  ANIMATION_MODULE_TYPE,
 } from '@angular/core';
 import {
   AbstractControl,
@@ -35,7 +36,6 @@ import {
   ValidationErrors,
   Validator,
 } from '@angular/forms';
-import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 import {FocusMonitor} from '@angular/cdk/a11y';
 import {
   MAT_SLIDE_TOGGLE_DEFAULT_OPTIONS,

--- a/src/material/slider/slider.ts
+++ b/src/material/slider/slider.ts
@@ -28,9 +28,9 @@ import {
   ViewChild,
   ViewChildren,
   ViewEncapsulation,
+  ANIMATION_MODULE_TYPE,
 } from '@angular/core';
 import {MAT_RIPPLE_GLOBAL_OPTIONS, RippleGlobalOptions, ThemePalette} from '@angular/material/core';
-import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 import {Subscription} from 'rxjs';
 import {
   _MatThumb,

--- a/src/material/tabs/paginated-tab-header.ts
+++ b/src/material/tabs/paginated-tab-header.ts
@@ -23,6 +23,7 @@ import {
   booleanAttribute,
   numberAttribute,
   Output,
+  ANIMATION_MODULE_TYPE,
 } from '@angular/core';
 import {Direction, Directionality} from '@angular/cdk/bidi';
 import {ViewportRuler} from '@angular/cdk/scrolling';
@@ -40,7 +41,6 @@ import {
 } from 'rxjs';
 import {take, switchMap, startWith, skip, takeUntil, filter} from 'rxjs/operators';
 import {Platform, normalizePassiveListenerOptions} from '@angular/cdk/platform';
-import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 
 /** Config used to bind passive event listeners */
 const passiveEventListenerOptions = normalizePassiveListenerOptions({

--- a/src/material/tabs/tab-group.ts
+++ b/src/material/tabs/tab-group.ts
@@ -26,8 +26,8 @@ import {
   booleanAttribute,
   inject,
   numberAttribute,
+  ANIMATION_MODULE_TYPE,
 } from '@angular/core';
-import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 import {MAT_TAB_GROUP, MatTab} from './tab';
 import {MatTabHeader} from './tab-header';
 import {ThemePalette, MatRipple} from '@angular/material/core';

--- a/src/material/tabs/tab-header.ts
+++ b/src/material/tabs/tab-header.ts
@@ -24,11 +24,11 @@ import {
   ViewChild,
   ViewEncapsulation,
   booleanAttribute,
+  ANIMATION_MODULE_TYPE,
 } from '@angular/core';
 import {ViewportRuler} from '@angular/cdk/scrolling';
 import {Platform} from '@angular/cdk/platform';
 import {Directionality} from '@angular/cdk/bidi';
-import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 import {MatTabLabelWrapper} from './tab-label-wrapper';
 import {MatInkBar} from './ink-bar';
 import {MatPaginatedTabHeader} from './paginated-tab-header';

--- a/src/material/tabs/tab-nav-bar/tab-nav-bar.ts
+++ b/src/material/tabs/tab-nav-bar/tab-nav-bar.ts
@@ -26,8 +26,8 @@ import {
   QueryList,
   ViewChild,
   ViewEncapsulation,
+  ANIMATION_MODULE_TYPE,
 } from '@angular/core';
-import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 import {
   MAT_RIPPLE_GLOBAL_OPTIONS,
   MatRipple,

--- a/src/material/tooltip/tooltip.ts
+++ b/src/material/tooltip/tooltip.ts
@@ -30,10 +30,10 @@ import {
   ViewContainerRef,
   ViewEncapsulation,
   inject,
+  ANIMATION_MODULE_TYPE,
 } from '@angular/core';
 import {DOCUMENT, NgClass} from '@angular/common';
 import {normalizePassiveListenerOptions, Platform} from '@angular/cdk/platform';
-import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 import {AriaDescriber, FocusMonitor} from '@angular/cdk/a11y';
 import {Directionality} from '@angular/cdk/bidi';
 import {

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -143,7 +143,6 @@ def ng_module(
     local_deps = [
         # Add tslib because we use import helpers for all public packages.
         "@npm//tslib",
-        "@npm//@angular/platform-browser",
     ]
 
     # Append given deps only if they're not in the default set of deps


### PR DESCRIPTION
Moves all imports of `ANIMATION_MODULE_TYPE` from `platform-browser/animations` to `core` to reduce our dependence on the animations module and to avoid potential issues when lazy-loading animations.