### PR TITLE
Revert "perf(cdk/table): Use afterRender hooks (#28354)"

### DIFF
--- a/src/cdk-experimental/column-resize/resize-strategy.ts
+++ b/src/cdk-experimental/column-resize/resize-strategy.ts
@@ -55,12 +55,12 @@ export abstract class ResizeStrategy {
 
       this.styleScheduler.schedule(() => {
         tableElement.style.width = coerceCssPixelValue(tableWidth + this._pendingResizeDelta!);
+
         this._pendingResizeDelta = null;
       });
 
       this.styleScheduler.scheduleEnd(() => {
         this.table.updateStickyColumnStyles();
-        this.styleScheduler.flushAfterRender();
       });
     }
 

--- a/src/cdk-experimental/table-scroll-container/table-scroll-container.ts
+++ b/src/cdk-experimental/table-scroll-container/table-scroll-container.ts
@@ -72,34 +72,21 @@ export class CdkTableScrollContainer implements StickyPositioningListener, OnDes
   }
 
   stickyColumnsUpdated({sizes}: StickyUpdate): void {
-    if (arrayEquals(this._startSizes, sizes)) {
-      return;
-    }
     this._startSizes = sizes;
     this._updateScrollbar();
   }
 
   stickyEndColumnsUpdated({sizes}: StickyUpdate): void {
-    if (arrayEquals(this._endSizes, sizes)) {
-      return;
-    }
     this._endSizes = sizes;
     this._updateScrollbar();
   }
 
   stickyHeaderRowsUpdated({sizes}: StickyUpdate): void {
-    if (arrayEquals(this._headerSizes, sizes)) {
-      return;
-    }
     this._headerSizes = sizes;
     this._updateScrollbar();
   }
 
   stickyFooterRowsUpdated({sizes}: StickyUpdate): void {
-    console.log('sizes', this._footerSizes, sizes, arrayEquals(this._footerSizes, sizes));
-    if (arrayEquals(this._footerSizes, sizes)) {
-      return;
-    }
     this._footerSizes = sizes;
     this._updateScrollbar();
   }
@@ -143,13 +130,9 @@ export class CdkTableScrollContainer implements StickyPositioningListener, OnDes
   /** Updates the stylesheet with the specified scrollbar style. */
   private _applyCss(value: string) {
     this._clearCss();
+
     const selector = `.${this._uniqueClassName}::-webkit-scrollbar-track`;
     this._getStyleSheet().insertRule(`${selector} {margin: ${value}}`, 0);
-
-    // Force the scrollbar to paint.
-    const display = this._elementRef.nativeElement.style.display;
-    this._elementRef.nativeElement.style.display = 'none';
-    this._elementRef.nativeElement.style.display = display;
   }
 
   private _clearCss() {
@@ -169,21 +152,4 @@ function computeMargin(sizes: (number | null | undefined)[]): number {
     margin += size;
   }
   return margin;
-}
-
-function arrayEquals(a1: unknown[], a2: unknown[]) {
-  if (a1 === a2) {
-    return true;
-  }
-  if (a1.length !== a2.length) {
-    return false;
-  }
-
-  for (let index = 0; index < a1.length; index++) {
-    if (a1[index] !== a2[index]) {
-      return false;
-    }
-  }
-
-  return true;
 }

--- a/src/cdk/table/coalesced-style-scheduler.ts
+++ b/src/cdk/table/coalesced-style-scheduler.ts
@@ -6,14 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {
-  Injectable,
-  NgZone,
-  OnDestroy,
-  InjectionToken,
-  afterRender,
-  AfterRenderPhase,
-} from '@angular/core';
+import {Injectable, NgZone, OnDestroy, InjectionToken} from '@angular/core';
 import {from, Subject} from 'rxjs';
 import {take, takeUntil} from 'rxjs/operators';
 
@@ -42,46 +35,7 @@ export class _CoalescedStyleScheduler implements OnDestroy {
   private _currentSchedule: _Schedule | null = null;
   private readonly _destroyed = new Subject<void>();
 
-  private readonly _earlyReadTasks: (() => unknown)[] = [];
-  private readonly _writeTasks: (() => unknown)[] = [];
-  private readonly _readTasks: (() => unknown)[] = [];
-
-  constructor(private readonly _ngZone: NgZone) {
-    afterRender(() => flushTasks(this._earlyReadTasks), {phase: AfterRenderPhase.EarlyRead});
-    afterRender(() => flushTasks(this._writeTasks), {phase: AfterRenderPhase.Write});
-    afterRender(() => flushTasks(this._readTasks), {phase: AfterRenderPhase.Read});
-  }
-
-  /**
-   * Like afterNextRender(fn, AfterRenderPhase.EarlyRead), but can be called
-   * outside of injection context. Runs after current/next CD.
-   */
-  scheduleEarlyRead(task: () => unknown): void {
-    this._earlyReadTasks.push(task);
-  }
-
-  /**
-   * Like afterNextRender(fn, AfterRenderPhase.Write), but can be called
-   * outside of injection context. Runs after current/next CD.
-   */
-  scheduleWrite(task: () => unknown): void {
-    this._writeTasks.push(task);
-  }
-
-  /**
-   * Like afterNextRender(fn, AfterRenderPhase.Read), but can be called
-   * outside of injection context. Runs after current/next CD.
-   */
-  scheduleRead(task: () => unknown): void {
-    this._readTasks.push(task);
-  }
-
-  /** Greedily triggers pending EarlyRead, Write, and Read tasks, in that order. */
-  flushAfterRender() {
-    flushTasks(this._earlyReadTasks);
-    flushTasks(this._writeTasks);
-    flushTasks(this._readTasks);
-  }
+  constructor(private readonly _ngZone: NgZone) {}
 
   /**
    * Schedules the specified task to run at the end of the current VM turn.
@@ -143,16 +97,5 @@ export class _CoalescedStyleScheduler implements OnDestroy {
     return this._ngZone.isStable
       ? from(Promise.resolve(undefined))
       : this._ngZone.onStable.pipe(take(1));
-  }
-}
-
-/**
- * Runs and removes tasks from the passed array in order.
- * Tasks appended mid-flight will also be flushed.
- */
-function flushTasks(tasks: (() => unknown)[]) {
-  let task: (() => unknown) | undefined;
-  while ((task = tasks.shift())) {
-    task();
   }
 }

--- a/src/cdk/table/table.ts
+++ b/src/cdk/table/table.ts
@@ -727,11 +727,9 @@ export class CdkTable<T> implements AfterContentChecked, CollectionViewer, OnDes
     if (this._ngZone && NgZone.isInAngularZone()) {
       this._ngZone.onStable.pipe(take(1), takeUntil(this._onDestroy)).subscribe(() => {
         this.updateStickyColumnStyles();
-        this._coalescedStyleScheduler.flushAfterRender();
       });
     } else {
       this.updateStickyColumnStyles();
-      this._coalescedStyleScheduler.flushAfterRender();
     }
 
     this.contentChanged.next();

--- a/tools/public_api_guard/cdk/table.md
+++ b/tools/public_api_guard/cdk/table.md
@@ -423,13 +423,9 @@ export const _COALESCED_STYLE_SCHEDULER: InjectionToken<_CoalescedStyleScheduler
 // @public
 export class _CoalescedStyleScheduler implements OnDestroy {
     constructor(_ngZone: NgZone);
-    flushAfterRender(): void;
     ngOnDestroy(): void;
     schedule(task: () => unknown): void;
-    scheduleEarlyRead(task: () => unknown): void;
     scheduleEnd(task: () => unknown): void;
-    scheduleRead(task: () => unknown): void;
-    scheduleWrite(task: () => unknown): void;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<_CoalescedStyleScheduler, never>;
     // (undocumented)


### PR DESCRIPTION
This reverts commit 81cb5acc8b2545b5674362a6f4c0b1768136dd66.