### PR TITLE
fix(material-experimental/theming): incorrect track color for alternate progress bar palettes

### DIFF
--- a/src/material-experimental/theming/_custom-tokens.scss
+++ b/src/material-experimental/theming/_custom-tokens.scss
@@ -1505,12 +1505,15 @@
     primary: (), // Default, no overrides needed
     secondary: (
       active-indicator-color: map.get($systems, md-sys-color, secondary),
+      track-color: map.get($systems, md-sys-color, secondary-container),
     ),
     tertiary: (
       active-indicator-color: map.get($systems, md-sys-color, tertiary),
+      track-color: map.get($systems, md-sys-color, tertiary-container),
     ),
     error: (
       active-indicator-color: map.get($systems, md-sys-color, error),
+      track-color: map.get($systems, md-sys-color, error-container),
     ),
   );
 }


### PR DESCRIPTION
Fixes that the track color for the progress bar didn't match the palette color.