### PR TITLE
[Cherry pick] fix(material/schematics): schema error in mdc migration

### DIFF
--- a/src/material/schematics/ng-generate/mdc-migration/schema.json
+++ b/src/material/schematics/ng-generate/mdc-migration/schema.json
@@ -8,7 +8,6 @@
       "type": "string",
       "format": "path",
       "description": "Workspace-relative path to a directory which will be migrated.",
-      "alias": "d",
       "x-prompt": "Limit the migration to a specific directory? (Enter the relative path such as 'src/app/shared' or leave blank for all directories)"
     },
     "components": {


### PR DESCRIPTION
Cherry-picks the fix for the MDC migration to the 16.2.x branch.

[A recent change in the CLI](https://github.com/angular/angular-cli/pull/26685) added a `-d` flag to `ng generate` which is the same as the alias for `--directory` in the MDC migration. This caused an error, because the default boolean value from the CLI was being picked up and was failing the schema validation.

These changes remove the alias since it isn't really necessary.

Fixes #28510.