### PR TITLE
Fixing indexOf usage bug when selection-list handles changes in items.

### DIFF
--- a/src/material/list/selection-list.spec.ts
+++ b/src/material/list/selection-list.spec.ts
@@ -1319,6 +1319,21 @@ describe('MDC-based MatSelectionList with forms', () => {
         .toBe(1);
     }));
 
+    it('should focus the first option when the list items are changed', fakeAsync(() => {
+      fixture.componentInstance.options = ['first option', 'second option'];
+      fixture.detectChanges();
+
+      tick();
+
+      const listElements = fixture.debugElement
+        .queryAll(By.directive(MatListOption))
+        .map(optionDebugEl => optionDebugEl.nativeElement);
+
+      expect(listElements.length).toBe(2);
+      expect(listElements[0].tabIndex).toBe(0);
+      expect(listElements[1].tabIndex).toBe(-1);
+    }));
+
     it('should not mark the model as touched when the list is blurred', fakeAsync(() => {
       expect(ngModel.touched)
         .withContext('Expected the selection-list to be untouched by default.')

--- a/src/material/list/selection-list.ts
+++ b/src/material/list/selection-list.ts
@@ -429,7 +429,7 @@ export class MatSelectionList
     this._items.changes.pipe(takeUntil(this._destroyed)).subscribe(() => {
       const activeItem = this._keyManager.activeItem;
 
-      if (!activeItem || !this._items.toArray().indexOf(activeItem)) {
+      if (!activeItem || this._items.toArray().indexOf(activeItem) === -1) {
         this._resetActiveOption();
       }
     });


### PR DESCRIPTION
The buggy logic was using a truthiness check for checking for presence in a list; this check needs to compare against -1 instead.  This bug causes mismanagement of tabIndex, which caused an accessibility bug where, if the list of items changed, the selection list could not be tab selected until the selection list was focused.