### PR TITLE
fix(material/tabs): prevent page scroll on space press

### DIFF
--- a/src/material/tabs/tab-nav-bar/tab-nav-bar.ts
+++ b/src/material/tabs/tab-nav-bar/tab-nav-bar.ts
@@ -372,6 +372,12 @@ export class MatTabLink
       if (this.disabled) {
         event.preventDefault();
       } else if (this._tabNavBar.tabPanel) {
+        // Only prevent the default action on space since it can scroll the page.
+        // Don't prevent enter since it can break link navigation.
+        if (event.keyCode === SPACE) {
+          event.preventDefault();
+        }
+
         this.elementRef.nativeElement.click();
       }
     }


### PR DESCRIPTION
This appears to be a regression from #27862 where the `preventDefault` was removed both from space and enter presses. We still need it on space so that the page doesn't scroll.

Fixes #28392.