### PR TITLE
fix(material/menu): prevent icon from collapsing when text is long

### DIFF
--- a/src/material/menu/menu.scss
+++ b/src/material/menu/menu.scss
@@ -128,6 +128,7 @@ mat-menu {
   }
 
   .mat-icon {
+    flex-shrink: 0;
     margin-right: mdc-list-variables.$side-padding;
   }
 


### PR DESCRIPTION
Fixes that the icon the menu item was collapsing if the menu item text was too long.

Fixes #28502.