### PR TITLE
fix(material/form-field): container height in lower densities

### DIFF
--- a/src/material/form-field/form-field.scss
+++ b/src/material/form-field/form-field.scss
@@ -144,7 +144,7 @@ $_icon-prefix-infix-padding: 4px;
   z-index: 1;
 
   & > .mat-icon {
-    padding: 12px;
+    padding: 0 12px;
     // It's common for apps to apply `box-sizing: border-box`
     // globally which will break the alignment.
     box-sizing: content-box;


### PR DESCRIPTION
* The 12px padding being applied to the mat-icon was preventing the form-field container height from condensing in lower densities.