### PR TITLE
fix(cdk/table): error if outlets are assigned too early

### DIFF
--- a/src/cdk/table/sticky-styler.ts
+++ b/src/cdk/table/sticky-styler.ts
@@ -263,10 +263,12 @@ export class StickyStyler {
     this._coalescedStyleScheduler.schedule(() => {
       const tfoot = tableElement.querySelector('tfoot')!;
 
-      if (stickyStates.some(state => !state)) {
-        this._removeStickyStyle(tfoot, ['bottom']);
-      } else {
-        this._addStickyStyle(tfoot, 'bottom', 0, false);
+      if (tfoot) {
+        if (stickyStates.some(state => !state)) {
+          this._removeStickyStyle(tfoot, ['bottom']);
+        } else {
+          this._addStickyStyle(tfoot, 'bottom', 0, false);
+        }
       }
     });
   }

--- a/tools/public_api_guard/cdk/table.md
+++ b/tools/public_api_guard/cdk/table.md
@@ -5,6 +5,7 @@
 ```ts
 
 import { AfterContentChecked } from '@angular/core';
+import { AfterContentInit } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 import { ChangeDetectorRef } from '@angular/core';
 import { CollectionViewer } from '@angular/cdk/collections';
@@ -288,7 +289,7 @@ export class CdkRowDef<T> extends BaseRowDef {
 }
 
 // @public
-export class CdkTable<T> implements AfterContentChecked, CollectionViewer, OnDestroy, OnInit {
+export class CdkTable<T> implements AfterContentInit, AfterContentChecked, CollectionViewer, OnDestroy, OnInit {
     constructor(_differs: IterableDiffers, _changeDetectorRef: ChangeDetectorRef, _elementRef: ElementRef, role: string, _dir: Directionality, _document: any, _platform: Platform, _viewRepeater: _ViewRepeater<T, RenderRow<T>, RowContext<T>>, _coalescedStyleScheduler: _CoalescedStyleScheduler, _viewportRuler: ViewportRuler,
     _stickyPositioningListener: StickyPositioningListener,
     _ngZone?: NgZone | undefined);
@@ -336,6 +337,8 @@ export class CdkTable<T> implements AfterContentChecked, CollectionViewer, OnDes
     static ngAcceptInputType_multiTemplateDataRows: unknown;
     // (undocumented)
     ngAfterContentChecked(): void;
+    // (undocumented)
+    ngAfterContentInit(): void;
     // (undocumented)
     ngOnDestroy(): void;
     // (undocumented)


### PR DESCRIPTION
Fixes that the table was throwing an error if all outlets are assigned before `ngAfterContentInit`.

Fixes #28538.