### PR TITLE
Avoid extra styles for text-align

### DIFF
--- a/src/material/datepicker/calendar-body.scss
+++ b/src/material/datepicker/calendar-body.scss
@@ -57,7 +57,7 @@ $_tokens: (tokens-mat-datepicker.$prefix, tokens-mat-datepicker.get-token-slots(
 .mat-calendar-body-label {
   height: 0;
   line-height: 0;
-  text-align: left;
+  text-align: start;
   padding-left: $calendar-body-label-side-padding;
   padding-right: $calendar-body-label-side-padding;
 
@@ -422,11 +422,5 @@ $_tokens: (tokens-mat-datepicker.$prefix, tokens-mat-datepicker.get-token-slots(
       border-right: 0;
       border-left: $comparison-range-border;
     }
-  }
-}
-
-[dir='rtl'] {
-  .mat-calendar-body-label {
-    text-align: right;
   }
 }

--- a/src/material/list/list.scss
+++ b/src/material/list/list.scss
@@ -186,11 +186,7 @@ mat-action-list button {
   font: inherit;
   outline: inherit;
   -webkit-tap-highlight-color: transparent;
-  text-align: left;
-
-  [dir='rtl'] & {
-    text-align: right;
-  }
+  text-align: start;
 
   &::-moz-focus-inner {
     border: 0;

--- a/src/material/progress-bar/progress-bar.scss
+++ b/src/material/progress-bar/progress-bar.scss
@@ -16,11 +16,7 @@
   display: block;
 
   // Explicitly set a `text-align` so that the content isn't affected by the parent (see #27613).
-  text-align: left;
-
-  [dir='rtl'] & {
-    text-align: right;
-  }
+  text-align: start;
 
   // Inverts the progress bar horizontally in `query` mode.
   &[mode='query'] {


### PR DESCRIPTION
Updates all the places where we have to invert `text-align` manually to use `text-align: start`.

Fixes https://github.com/angular/components/issues/28572.