### PR TITLE
docs(material/list): fix m3 demo trailing icon color

### DIFF
--- a/src/dev-app/list/list-demo.scss
+++ b/src/dev-app/list/list-demo.scss
@@ -12,10 +12,6 @@
     margin-top: 20px;
   }
 
-  .mat-mdc-icon-button {
-    color: rgba(0, 0, 0, 0.12);
-  }
-
   &.demo-show-boxes .mat-mdc-list-item {
     border: 1px solid grey;
   }


### PR DESCRIPTION
Fix trailing icon color in M3 List demo. Fix icon color by removing style override in List demo.