### PR TITLE
Remove usages of the initialized mixin

### DIFF
--- a/tools/public_api_guard/material/paginator.md
+++ b/tools/public_api_guard/material/paginator.md
@@ -6,13 +6,13 @@
 
 import { ChangeDetectorRef } from '@angular/core';
 import { EventEmitter } from '@angular/core';
-import { HasInitialized } from '@angular/material/core';
 import * as i0 from '@angular/core';
 import * as i1 from '@angular/material/button';
 import * as i2 from '@angular/material/select';
 import * as i3 from '@angular/material/tooltip';
 import { InjectionToken } from '@angular/core';
 import { MatFormFieldAppearance } from '@angular/material/form-field';
+import { Observable } from 'rxjs';
 import { OnDestroy } from '@angular/core';
 import { OnInit } from '@angular/core';
 import { Optional } from '@angular/core';
@@ -33,7 +33,7 @@ export const MAT_PAGINATOR_INTL_PROVIDER: {
 export function MAT_PAGINATOR_INTL_PROVIDER_FACTORY(parentIntl: MatPaginatorIntl): MatPaginatorIntl;
 
 // @public
-export class MatPaginator extends _MatPaginatorMixinBase implements OnInit, OnDestroy, HasInitialized {
+export class MatPaginator implements OnInit, OnDestroy {
     constructor(_intl: MatPaginatorIntl, _changeDetectorRef: ChangeDetectorRef, defaults?: MatPaginatorDefaultOptions);
     _changePageSize(pageSize: number): void;
     color: ThemePalette;
@@ -45,6 +45,7 @@ export class MatPaginator extends _MatPaginatorMixinBase implements OnInit, OnDe
     hasNextPage(): boolean;
     hasPreviousPage(): boolean;
     hidePageSize: boolean;
+    initialized: Observable<void>;
     // (undocumented)
     _intl: MatPaginatorIntl;
     lastPage(): void;

--- a/tools/public_api_guard/material/sort.md
+++ b/tools/public_api_guard/material/sort.md
@@ -11,10 +11,10 @@ import { ChangeDetectorRef } from '@angular/core';
 import { ElementRef } from '@angular/core';
 import { EventEmitter } from '@angular/core';
 import { FocusMonitor } from '@angular/cdk/a11y';
-import { HasInitialized } from '@angular/material/core';
 import * as i0 from '@angular/core';
 import * as i1 from '@angular/material/core';
 import { InjectionToken } from '@angular/core';
+import { Observable } from 'rxjs';
 import { OnChanges } from '@angular/core';
 import { OnDestroy } from '@angular/core';
 import { OnInit } from '@angular/core';
@@ -46,7 +46,7 @@ export const MAT_SORT_HEADER_INTL_PROVIDER: {
 export function MAT_SORT_HEADER_INTL_PROVIDER_FACTORY(parentIntl: MatSortHeaderIntl): MatSortHeaderIntl;
 
 // @public
-export class MatSort extends _MatSortBase implements HasInitialized, OnChanges, OnDestroy, OnInit {
+export class MatSort implements OnChanges, OnDestroy, OnInit {
     constructor(_defaultOptions?: MatSortDefaultOptions | undefined);
     active: string;
     deregister(sortable: MatSortable): void;
@@ -55,6 +55,7 @@ export class MatSort extends _MatSortBase implements HasInitialized, OnChanges, 
     disableClear: boolean;
     disabled: boolean;
     getNextSortDirection(sortable: MatSortable): SortDirection;
+    initialized: Observable<void>;
     // (undocumented)
     static ngAcceptInputType_disableClear: unknown;
     // (undocumented)


### PR DESCRIPTION
Removes the `mixinInitialized` from the sort header and paginator.