### PR TITLE
fix(cdk/listbox): make typeahead label nullable

### DIFF
--- a/src/cdk/listbox/listbox.ts
+++ b/src/cdk/listbox/listbox.ts
@@ -113,7 +113,7 @@ export class CdkOption<T = unknown> implements ListKeyManagerOption, Highlightab
    * The text used to locate this item during listbox typeahead. If not specified,
    * the `textContent` of the item will be used.
    */
-  @Input('cdkOptionTypeaheadLabel') typeaheadLabel: string;
+  @Input('cdkOptionTypeaheadLabel') typeaheadLabel: string | null;
 
   /** Whether this option is disabled. */
   @Input({alias: 'cdkOptionDisabled', transform: booleanAttribute})

--- a/tools/public_api_guard/cdk/listbox.md
+++ b/tools/public_api_guard/cdk/listbox.md
@@ -127,7 +127,7 @@ export class CdkOption<T = unknown> implements ListKeyManagerOption, Highlightab
     setActiveStyles(): void;
     setInactiveStyles(): void;
     toggle(): void;
-    typeaheadLabel: string;
+    typeaheadLabel: string | null;
     value: T;
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<CdkOption<any>, "[cdkOption]", ["cdkOption"], { "id": { "alias": "id"; "required": false; }; "value": { "alias": "cdkOption"; "required": false; }; "typeaheadLabel": { "alias": "cdkOptionTypeaheadLabel"; "required": false; }; "disabled": { "alias": "cdkOptionDisabled"; "required": false; }; "enabledTabIndex": { "alias": "tabindex"; "required": false; }; }, {}, never, never, true, never>;


### PR DESCRIPTION
Allows the `cdkOptionTypeaheadLabel` to be set to a nullable value.

Fixes #28464.