### PR TITLE
Avoid emitting position change event unnecessarily and emit inside the zone

### DIFF
--- a/src/cdk/overlay/overlay-directives.spec.ts
+++ b/src/cdk/overlay/overlay-directives.spec.ts
@@ -1,4 +1,4 @@
-import {Component, ElementRef, ViewChild} from '@angular/core';
+import {Component, ElementRef, NgZone, ViewChild} from '@angular/core';
 import {By} from '@angular/platform-browser';
 import {
   ComponentFixture,
@@ -616,6 +616,18 @@ describe('Overlay directives', () => {
       expect(latestCall.args[0] instanceof ConnectedOverlayPositionChange)
         .withContext(`Expected directive to emit an instance of ConnectedOverlayPositionChange.`)
         .toBe(true);
+    });
+
+    it('should emit the position change handler inside the zone', () => {
+      let callsInZone: boolean[] = [];
+
+      fixture.componentInstance.positionChangeHandler.and.callFake(() => {
+        callsInZone.push(NgZone.isInAngularZone());
+      });
+      fixture.componentInstance.isOpen = true;
+      fixture.detectChanges();
+
+      expect(callsInZone).toEqual([true]);
     });
 
     it('should emit when attached', () => {

--- a/src/cdk/overlay/overlay-directives.ts
+++ b/src/cdk/overlay/overlay-directives.ts
@@ -16,6 +16,7 @@ import {
   Inject,
   InjectionToken,
   Input,
+  NgZone,
   OnChanges,
   OnDestroy,
   Optional,
@@ -116,6 +117,7 @@ export class CdkConnectedOverlay implements OnDestroy, OnChanges {
   private _position: FlexibleConnectedPositionStrategy;
   private _scrollStrategyFactory: () => ScrollStrategy;
   private _disposeOnNavigation = false;
+  private _ngZone = inject(NgZone);
 
   /** Origin for the connected overlay. */
   @Input('cdkConnectedOverlayOrigin')
@@ -421,7 +423,7 @@ export class CdkConnectedOverlay implements OnDestroy, OnChanges {
       this._positionSubscription = this._position.positionChanges
         .pipe(takeWhile(() => this.positionChange.observers.length > 0))
         .subscribe(position => {
-          this.positionChange.emit(position);
+          this._ngZone.run(() => this.positionChange.emit(position));
 
           if (this.positionChange.observers.length === 0) {
             this._positionSubscription.unsubscribe();


### PR DESCRIPTION
Includes the following fixes:

### fix(cdk/overlay): only emit positionChanges when position is different
Currently we emit the `positionChanges` event whenever a position is recalculcated which can be on each scroll event. These changes switch to doing so only if either the actual position or the scrolled state has changed.

### fix(cdk/overlay): run positionChange event inside the zone

Fixes that the `positionChange` event of the `CdkConnectedOverlay` directive was running outside the zone.

Fixes #28568.