### PR TITLE
refactor(cdk/table): remove mixin function usages

### DIFF
--- a/src/cdk/table/can-stick.ts
+++ b/src/cdk/table/can-stick.ts
@@ -21,9 +21,6 @@ export interface CanStick {
   /** Whether sticky positioning should be applied. */
   sticky: boolean;
 
-  /** Whether the sticky input has changed since it was last checked. */
-  _hasStickyChanged: boolean;
-
   /** Whether the sticky value has changed since this was last called. */
   hasStickyChanged(): boolean;
 

--- a/src/cdk/table/cell.ts
+++ b/src/cdk/table/cell.ts
@@ -16,7 +16,7 @@ import {
   TemplateRef,
   booleanAttribute,
 } from '@angular/core';
-import {CanStick, CanStickCtor, mixinHasStickyInput} from './can-stick';
+import {CanStick} from './can-stick';
 import {CDK_TABLE} from './tokens';
 
 /** Base interface for a cell definition. Captures a column's cell template definition. */
@@ -60,23 +60,18 @@ export class CdkFooterCellDef implements CellDef {
   constructor(/** @docs-private */ public template: TemplateRef<any>) {}
 }
 
-// Boilerplate for applying mixins to CdkColumnDef.
-/** @docs-private */
-class CdkColumnDefBase {}
-const _CdkColumnDefBase: CanStickCtor & typeof CdkColumnDefBase =
-  mixinHasStickyInput(CdkColumnDefBase);
-
 /**
  * Column definition for the CDK table.
  * Defines a set of cells available for a table column.
  */
 @Directive({
   selector: '[cdkColumnDef]',
-  inputs: ['sticky'],
   providers: [{provide: 'MAT_SORT_HEADER_COLUMN_DEF', useExisting: CdkColumnDef}],
   standalone: true,
 })
-export class CdkColumnDef extends _CdkColumnDefBase implements CanStick {
+export class CdkColumnDef implements CanStick {
+  private _hasStickyChanged = false;
+
   /** Unique name for this column. */
   @Input('cdkColumnDef')
   get name(): string {
@@ -86,6 +81,19 @@ export class CdkColumnDef extends _CdkColumnDefBase implements CanStick {
     this._setNameInput(name);
   }
   protected _name: string;
+
+  /** Whether the cell is sticky. */
+  @Input({transform: booleanAttribute})
+  get sticky(): boolean {
+    return this._sticky;
+  }
+  set sticky(value: boolean) {
+    if (value !== this._sticky) {
+      this._sticky = value;
+      this._hasStickyChanged = true;
+    }
+  }
+  private _sticky = false;
 
   /**
    * Whether this column should be sticky positioned on the end of the row. Should make sure
@@ -126,8 +134,18 @@ export class CdkColumnDef extends _CdkColumnDefBase implements CanStick {
    */
   _columnCssClassName: string[];
 
-  constructor(@Inject(CDK_TABLE) @Optional() public _table?: any) {
-    super();
+  constructor(@Inject(CDK_TABLE) @Optional() public _table?: any) {}
+
+  /** Whether the sticky state has changed. */
+  hasStickyChanged(): boolean {
+    const hasStickyChanged = this._hasStickyChanged;
+    this.resetStickyChanged();
+    return hasStickyChanged;
+  }
+
+  /** Resets the sticky changed state. */
+  resetStickyChanged(): void {
+    this._hasStickyChanged = false;
   }
 
   /**

--- a/src/cdk/table/row.ts
+++ b/src/cdk/table/row.ts
@@ -21,8 +21,10 @@ import {
   ViewEncapsulation,
   Inject,
   Optional,
+  Input,
+  booleanAttribute,
 } from '@angular/core';
-import {CanStick, CanStickCtor, mixinHasStickyInput} from './can-stick';
+import {CanStick} from './can-stick';
 import {CdkCellDef, CdkColumnDef} from './cell';
 import {CDK_TABLE} from './tokens';
 
@@ -80,22 +82,31 @@ export abstract class BaseRowDef implements OnChanges {
   }
 }
 
-// Boilerplate for applying mixins to CdkHeaderRowDef.
-/** @docs-private */
-class CdkHeaderRowDefBase extends BaseRowDef {}
-const _CdkHeaderRowDefBase: CanStickCtor & typeof CdkHeaderRowDefBase =
-  mixinHasStickyInput(CdkHeaderRowDefBase);
-
 /**
  * Header row definition for the CDK table.
  * Captures the header row's template and other header properties such as the columns to display.
  */
 @Directive({
   selector: '[cdkHeaderRowDef]',
-  inputs: ['columns: cdkHeaderRowDef', 'sticky: cdkHeaderRowDefSticky'],
+  inputs: [{name: 'columns', alias: 'cdkHeaderRowDef'}],
   standalone: true,
 })
-export class CdkHeaderRowDef extends _CdkHeaderRowDefBase implements CanStick, OnChanges {
+export class CdkHeaderRowDef extends BaseRowDef implements CanStick, OnChanges {
+  private _hasStickyChanged = false;
+
+  /** Whether the row is sticky. */
+  @Input({alias: 'cdkHeaderRowDefSticky', transform: booleanAttribute})
+  get sticky(): boolean {
+    return this._sticky;
+  }
+  set sticky(value: boolean) {
+    if (value !== this._sticky) {
+      this._sticky = value;
+      this._hasStickyChanged = true;
+    }
+  }
+  private _sticky = false;
+
   constructor(
     template: TemplateRef<any>,
     _differs: IterableDiffers,
@@ -109,13 +120,19 @@ export class CdkHeaderRowDef extends _CdkHeaderRowDefBase implements CanStick, O
   override ngOnChanges(changes: SimpleChanges): void {
     super.ngOnChanges(changes);
   }
-}
 
-// Boilerplate for applying mixins to CdkFooterRowDef.
-/** @docs-private */
-class CdkFooterRowDefBase extends BaseRowDef {}
-const _CdkFooterRowDefBase: CanStickCtor & typeof CdkFooterRowDefBase =
-  mixinHasStickyInput(CdkFooterRowDefBase);
+  /** Whether the sticky state has changed. */
+  hasStickyChanged(): boolean {
+    const hasStickyChanged = this._hasStickyChanged;
+    this.resetStickyChanged();
+    return hasStickyChanged;
+  }
+
+  /** Resets the sticky changed state. */
+  resetStickyChanged(): void {
+    this._hasStickyChanged = false;
+  }
+}
 
 /**
  * Footer row definition for the CDK table.
@@ -123,10 +140,25 @@ const _CdkFooterRowDefBase: CanStickCtor & typeof CdkFooterRowDefBase =
  */
 @Directive({
   selector: '[cdkFooterRowDef]',
-  inputs: ['columns: cdkFooterRowDef', 'sticky: cdkFooterRowDefSticky'],
+  inputs: [{name: 'columns', alias: 'cdkFooterRowDef'}],
   standalone: true,
 })
-export class CdkFooterRowDef extends _CdkFooterRowDefBase implements CanStick, OnChanges {
+export class CdkFooterRowDef extends BaseRowDef implements CanStick, OnChanges {
+  private _hasStickyChanged = false;
+
+  /** Whether the row is sticky. */
+  @Input({alias: 'cdkFooterRowDefSticky', transform: booleanAttribute})
+  get sticky(): boolean {
+    return this._sticky;
+  }
+  set sticky(value: boolean) {
+    if (value !== this._sticky) {
+      this._sticky = value;
+      this._hasStickyChanged = true;
+    }
+  }
+  private _sticky = false;
+
   constructor(
     template: TemplateRef<any>,
     _differs: IterableDiffers,
@@ -139,6 +171,18 @@ export class CdkFooterRowDef extends _CdkFooterRowDefBase implements CanStick, O
   // Explicitly define it so that the method is called as part of the Angular lifecycle.
   override ngOnChanges(changes: SimpleChanges): void {
     super.ngOnChanges(changes);
+  }
+
+  /** Whether the sticky state has changed. */
+  hasStickyChanged(): boolean {
+    const hasStickyChanged = this._hasStickyChanged;
+    this.resetStickyChanged();
+    return hasStickyChanged;
+  }
+
+  /** Resets the sticky changed state. */
+  resetStickyChanged(): void {
+    this._hasStickyChanged = false;
   }
 }
 
@@ -149,7 +193,10 @@ export class CdkFooterRowDef extends _CdkFooterRowDefBase implements CanStick, O
  */
 @Directive({
   selector: '[cdkRowDef]',
-  inputs: ['columns: cdkRowDefColumns', 'when: cdkRowDefWhen'],
+  inputs: [
+    {name: 'columns', alias: 'cdkRowDefColumns'},
+    {name: 'when', alias: 'cdkRowDefWhen'},
+  ],
   standalone: true,
 })
 export class CdkRowDef<T> extends BaseRowDef {

--- a/src/material/table/cell.ts
+++ b/src/material/table/cell.ts
@@ -56,7 +56,6 @@ export class MatFooterCellDef extends CdkFooterCellDef {}
  */
 @Directive({
   selector: '[matColumnDef]',
-  inputs: ['sticky'],
   providers: [
     {provide: CdkColumnDef, useExisting: MatColumnDef},
     {provide: 'MAT_SORT_HEADER_COLUMN_DEF', useExisting: MatColumnDef},

--- a/src/material/table/row.ts
+++ b/src/material/table/row.ts
@@ -16,7 +16,13 @@ import {
   CdkNoDataRow,
   CdkCellOutlet,
 } from '@angular/cdk/table';
-import {ChangeDetectionStrategy, Component, Directive, ViewEncapsulation} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Directive,
+  ViewEncapsulation,
+  booleanAttribute,
+} from '@angular/core';
 
 // We can't reuse `CDK_ROW_TEMPLATE` because it's incompatible with local compilation mode.
 const ROW_TEMPLATE = `<ng-container cdkCellOutlet></ng-container>`;
@@ -28,7 +34,10 @@ const ROW_TEMPLATE = `<ng-container cdkCellOutlet></ng-container>`;
 @Directive({
   selector: '[matHeaderRowDef]',
   providers: [{provide: CdkHeaderRowDef, useExisting: MatHeaderRowDef}],
-  inputs: ['columns: matHeaderRowDef', 'sticky: matHeaderRowDefSticky'],
+  inputs: [
+    {name: 'columns', alias: 'matHeaderRowDef'},
+    {name: 'sticky', alias: 'matHeaderRowDefSticky', transform: booleanAttribute},
+  ],
   standalone: true,
 })
 export class MatHeaderRowDef extends CdkHeaderRowDef {}
@@ -40,7 +49,10 @@ export class MatHeaderRowDef extends CdkHeaderRowDef {}
 @Directive({
   selector: '[matFooterRowDef]',
   providers: [{provide: CdkFooterRowDef, useExisting: MatFooterRowDef}],
-  inputs: ['columns: matFooterRowDef', 'sticky: matFooterRowDefSticky'],
+  inputs: [
+    {name: 'columns', alias: 'matFooterRowDef'},
+    {name: 'sticky', alias: 'matFooterRowDefSticky', transform: booleanAttribute},
+  ],
   standalone: true,
 })
 export class MatFooterRowDef extends CdkFooterRowDef {}
@@ -53,7 +65,10 @@ export class MatFooterRowDef extends CdkFooterRowDef {}
 @Directive({
   selector: '[matRowDef]',
   providers: [{provide: CdkRowDef, useExisting: MatRowDef}],
-  inputs: ['columns: matRowDefColumns', 'when: matRowDefWhen'],
+  inputs: [
+    {name: 'columns', alias: 'matRowDefColumns'},
+    {name: 'when', alias: 'matRowDefWhen'},
+  ],
   standalone: true,
 })
 export class MatRowDef<T> extends CdkRowDef<T> {}

--- a/tools/dgeni/common/directive-metadata.ts
+++ b/tools/dgeni/common/directive-metadata.ts
@@ -1,15 +1,4 @@
-import {
-  ArrayLiteralExpression,
-  CallExpression,
-  isCallExpression,
-  NodeArray,
-  ObjectLiteralExpression,
-  PropertyAssignment,
-  StringLiteral,
-  SyntaxKind,
-  getDecorators,
-  isClassDeclaration,
-} from 'typescript';
+import ts from 'typescript';
 import {CategorizedClassDoc} from './dgeni-definitions';
 
 /**
@@ -30,15 +19,15 @@ import {CategorizedClassDoc} from './dgeni-definitions';
 export function getDirectiveMetadata(classDoc: CategorizedClassDoc): Map<string, any> | null {
   const declaration = classDoc.symbol.valueDeclaration;
   const decorators =
-    declaration && isClassDeclaration(declaration) ? getDecorators(declaration) : null;
+    declaration && ts.isClassDeclaration(declaration) ? ts.getDecorators(declaration) : null;
 
   if (!decorators?.length) {
     return null;
   }
 
   const expression = decorators
-    .filter(decorator => decorator.expression && isCallExpression(decorator.expression))
-    .map(decorator => decorator.expression as CallExpression)
+    .filter(decorator => decorator.expression && ts.isCallExpression(decorator.expression))
+    .map(decorator => decorator.expression as ts.CallExpression)
     .find(
       callExpression =>
         callExpression.expression.getText() === 'Component' ||
@@ -55,25 +44,41 @@ export function getDirectiveMetadata(classDoc: CategorizedClassDoc): Map<string,
     return null;
   }
 
-  const objectExpression = expression.arguments[0] as ObjectLiteralExpression;
+  const objectExpression = expression.arguments[0] as ts.ObjectLiteralExpression;
   const resultMetadata = new Map<string, any>();
 
-  (objectExpression.properties as NodeArray<PropertyAssignment>).forEach(prop => {
+  (objectExpression.properties as ts.NodeArray<ts.PropertyAssignment>).forEach(prop => {
     // Support ArrayLiteralExpression assignments in the directive metadata.
-    if (prop.initializer.kind === SyntaxKind.ArrayLiteralExpression) {
-      const arrayData = (prop.initializer as ArrayLiteralExpression).elements.map(
-        literal => (literal as StringLiteral).text,
-      );
+    if (ts.isArrayLiteralExpression(prop.initializer)) {
+      const arrayData = prop.initializer.elements.map(literal => {
+        if (ts.isStringLiteralLike(literal)) {
+          return literal.text;
+        }
+
+        if (ts.isObjectLiteralExpression(literal)) {
+          return literal.properties.reduce(
+            (result, prop) => {
+              if (ts.isPropertyAssignment(prop)) {
+                result[prop.name.getText()] = ts.isStringLiteralLike(prop.initializer)
+                  ? prop.initializer.text
+                  : prop.initializer.getText();
+              }
+
+              return result;
+            },
+            {} as Record<string, string>,
+          );
+        }
+
+        return literal.getText();
+      });
 
       resultMetadata.set(prop.name.getText(), arrayData);
     }
 
     // Support normal StringLiteral and NoSubstitutionTemplateLiteral assignments
-    if (
-      prop.initializer.kind === SyntaxKind.StringLiteral ||
-      prop.initializer.kind === SyntaxKind.NoSubstitutionTemplateLiteral
-    ) {
-      resultMetadata.set(prop.name.getText(), (prop.initializer as StringLiteral).text);
+    if (ts.isStringLiteralLike(prop.initializer)) {
+      resultMetadata.set(prop.name.getText(), prop.initializer.text);
     }
   });
 

--- a/tools/dgeni/common/property-bindings.ts
+++ b/tools/dgeni/common/property-bindings.ts
@@ -40,13 +40,20 @@ function getBindingPropertyData(
   decoratorName: string,
 ) {
   if (metadata) {
-    const metadataValues: string[] = metadata.get(propertyName) || [];
-    const foundValue = metadataValues.find(value => value.split(':')[0] === doc.name);
+    const metadataValues: (string | {name: string; alias?: string})[] =
+      metadata.get(propertyName) || [];
+    const foundValue = metadataValues.find(value => {
+      const name = typeof value === 'string' ? value.split(':')[0] : value.name;
+      return name === doc.name;
+    });
 
     if (foundValue) {
       return {
         name: doc.name,
-        alias: foundValue.split(':')[1],
+        alias:
+          typeof foundValue === 'string'
+            ? foundValue.split(':')[1]
+            : foundValue.alias || foundValue.name,
       };
     }
   }

--- a/tools/public_api_guard/cdk/table.md
+++ b/tools/public_api_guard/cdk/table.md
@@ -61,7 +61,6 @@ export abstract class BaseRowDef implements OnChanges {
 // @public
 export interface CanStick {
     hasStickyChanged(): boolean;
-    _hasStickyChanged: boolean;
     resetStickyChanged(): void;
     sticky: boolean;
 }
@@ -138,20 +137,26 @@ export interface CdkCellOutletRowContext<T> {
 }
 
 // @public
-export class CdkColumnDef extends _CdkColumnDefBase implements CanStick {
+export class CdkColumnDef implements CanStick {
     constructor(_table?: any);
     cell: CdkCellDef;
     _columnCssClassName: string[];
     cssClassFriendlyName: string;
     footerCell: CdkFooterCellDef;
+    hasStickyChanged(): boolean;
     headerCell: CdkHeaderCellDef;
     get name(): string;
     set name(name: string);
     // (undocumented)
     protected _name: string;
     // (undocumented)
+    static ngAcceptInputType_sticky: unknown;
+    // (undocumented)
     static ngAcceptInputType_stickyEnd: unknown;
+    resetStickyChanged(): void;
     protected _setNameInput(value: string): void;
+    get sticky(): boolean;
+    set sticky(value: boolean);
     get stickyEnd(): boolean;
     set stickyEnd(value: boolean);
     // (undocumented)
@@ -160,7 +165,7 @@ export class CdkColumnDef extends _CdkColumnDefBase implements CanStick {
     _table?: any;
     protected _updateColumnCssClassName(): void;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkColumnDef, "[cdkColumnDef]", never, { "sticky": { "alias": "sticky"; "required": false; }; "name": { "alias": "cdkColumnDef"; "required": false; }; "stickyEnd": { "alias": "stickyEnd"; "required": false; }; }, {}, ["cell", "headerCell", "footerCell"], never, true, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkColumnDef, "[cdkColumnDef]", never, { "name": { "alias": "cdkColumnDef"; "required": false; }; "sticky": { "alias": "sticky"; "required": false; }; "stickyEnd": { "alias": "stickyEnd"; "required": false; }; }, {}, ["cell", "headerCell", "footerCell"], never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<CdkColumnDef, [{ optional: true; }]>;
 }
@@ -194,10 +199,16 @@ export class CdkFooterRow {
 }
 
 // @public
-export class CdkFooterRowDef extends _CdkFooterRowDefBase implements CanStick, OnChanges {
+export class CdkFooterRowDef extends BaseRowDef implements CanStick, OnChanges {
     constructor(template: TemplateRef<any>, _differs: IterableDiffers, _table?: any);
+    hasStickyChanged(): boolean;
+    // (undocumented)
+    static ngAcceptInputType_sticky: unknown;
     // (undocumented)
     ngOnChanges(changes: SimpleChanges): void;
+    resetStickyChanged(): void;
+    get sticky(): boolean;
+    set sticky(value: boolean);
     // (undocumented)
     _table?: any;
     // (undocumented)
@@ -235,10 +246,16 @@ export class CdkHeaderRow {
 }
 
 // @public
-export class CdkHeaderRowDef extends _CdkHeaderRowDefBase implements CanStick, OnChanges {
+export class CdkHeaderRowDef extends BaseRowDef implements CanStick, OnChanges {
     constructor(template: TemplateRef<any>, _differs: IterableDiffers, _table?: any);
+    hasStickyChanged(): boolean;
+    // (undocumented)
+    static ngAcceptInputType_sticky: unknown;
     // (undocumented)
     ngOnChanges(changes: SimpleChanges): void;
+    resetStickyChanged(): void;
+    get sticky(): boolean;
+    set sticky(value: boolean);
     // (undocumented)
     _table?: any;
     // (undocumented)

--- a/tools/public_api_guard/material/table.md
+++ b/tools/public_api_guard/material/table.md
@@ -51,7 +51,7 @@ export class MatColumnDef extends CdkColumnDef {
     set name(name: string);
     protected _updateColumnCssClassName(): void;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<MatColumnDef, "[matColumnDef]", never, { "sticky": { "alias": "sticky"; "required": false; }; "name": { "alias": "matColumnDef"; "required": false; }; }, {}, never, never, true, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<MatColumnDef, "[matColumnDef]", never, { "name": { "alias": "matColumnDef"; "required": false; }; }, {}, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatColumnDef, never>;
 }
@@ -82,6 +82,8 @@ export class MatFooterRow extends CdkFooterRow {
 
 // @public
 export class MatFooterRowDef extends CdkFooterRowDef {
+    // (undocumented)
+    static ngAcceptInputType_sticky: unknown;
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<MatFooterRowDef, "[matFooterRowDef]", never, { "columns": { "alias": "matFooterRowDef"; "required": false; }; "sticky": { "alias": "matFooterRowDefSticky"; "required": false; }; }, {}, never, never, true, never>;
     // (undocumented)
@@ -114,6 +116,8 @@ export class MatHeaderRow extends CdkHeaderRow {
 
 // @public
 export class MatHeaderRowDef extends CdkHeaderRowDef {
+    // (undocumented)
+    static ngAcceptInputType_sticky: unknown;
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<MatHeaderRowDef, "[matHeaderRowDef]", never, { "columns": { "alias": "matHeaderRowDef"; "required": false; }; "sticky": { "alias": "matHeaderRowDefSticky"; "required": false; }; }, {}, never, never, true, never>;
     // (undocumented)


### PR DESCRIPTION
Removes the final usages of TypeScript mixins in the CDK table by adding the sticky functionality to the individual usages. Ideally we'd have a base class for this, but that won't be usable in `CdkHeaderRowDef` and `CdkFooterRowDef` because they already inherit from `BaseRowDef` and we can't put the sticky functionality there, because `CdkRowDef` shouldn't support `sticky`. The logic is pretty basic so I think it's fine to duplicate it.