### PR TITLE
fix(cdk/drag-drop): resolve helper directives with DI for proper hostDirectives support

### DIFF
--- a/src/cdk/drag-drop/directives/drag-handle.ts
+++ b/src/cdk/drag-drop/directives/drag-handle.ts
@@ -18,6 +18,7 @@ import {
   booleanAttribute,
 } from '@angular/core';
 import {Subject} from 'rxjs';
+import type {CdkDrag} from './drag';
 import {CDK_DRAG_PARENT} from '../drag-parent';
 import {assertElementNode} from './assertions';
 
@@ -38,9 +39,6 @@ export const CDK_DRAG_HANDLE = new InjectionToken<CdkDragHandle>('CdkDragHandle'
   providers: [{provide: CDK_DRAG_HANDLE, useExisting: CdkDragHandle}],
 })
 export class CdkDragHandle implements OnDestroy {
-  /** Closest parent draggable instance. */
-  _parentDrag: {} | undefined;
-
   /** Emits when the state of the handle has changed. */
   readonly _stateChanges = new Subject<CdkDragHandle>();
 
@@ -57,16 +55,17 @@ export class CdkDragHandle implements OnDestroy {
 
   constructor(
     public element: ElementRef<HTMLElement>,
-    @Inject(CDK_DRAG_PARENT) @Optional() @SkipSelf() parentDrag?: any,
+    @Inject(CDK_DRAG_PARENT) @Optional() @SkipSelf() private _parentDrag?: CdkDrag,
   ) {
     if (typeof ngDevMode === 'undefined' || ngDevMode) {
       assertElementNode(element.nativeElement, 'cdkDragHandle');
     }
 
-    this._parentDrag = parentDrag;
+    _parentDrag?._addHandle(this);
   }
 
   ngOnDestroy() {
+    this._parentDrag?._removeHandle(this);
     this._stateChanges.complete();
   }
 }

--- a/src/cdk/drag-drop/directives/drag-placeholder.ts
+++ b/src/cdk/drag-drop/directives/drag-placeholder.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, TemplateRef, Input, InjectionToken} from '@angular/core';
+import {Directive, TemplateRef, Input, InjectionToken, inject, OnDestroy} from '@angular/core';
+import {CDK_DRAG_PARENT} from '../drag-parent';
 
 /**
  * Injection token that can be used to reference instances of `CdkDragPlaceholder`. It serves as
@@ -24,8 +25,17 @@ export const CDK_DRAG_PLACEHOLDER = new InjectionToken<CdkDragPlaceholder>('CdkD
   standalone: true,
   providers: [{provide: CDK_DRAG_PLACEHOLDER, useExisting: CdkDragPlaceholder}],
 })
-export class CdkDragPlaceholder<T = any> {
+export class CdkDragPlaceholder<T = any> implements OnDestroy {
+  private _drag = inject(CDK_DRAG_PARENT);
+
   /** Context data to be added to the placeholder template instance. */
   @Input() data: T;
-  constructor(public templateRef: TemplateRef<T>) {}
+
+  constructor(public templateRef: TemplateRef<T>) {
+    this._drag._setPlaceholderTemplate(this);
+  }
+
+  ngOnDestroy(): void {
+    this._drag._resetPlaceholderTemplate(this);
+  }
 }

--- a/src/cdk/drag-drop/directives/drag-preview.ts
+++ b/src/cdk/drag-drop/directives/drag-preview.ts
@@ -6,7 +6,16 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, InjectionToken, Input, TemplateRef, booleanAttribute} from '@angular/core';
+import {
+  Directive,
+  InjectionToken,
+  Input,
+  OnDestroy,
+  TemplateRef,
+  booleanAttribute,
+  inject,
+} from '@angular/core';
+import {CDK_DRAG_PARENT} from '../drag-parent';
 
 /**
  * Injection token that can be used to reference instances of `CdkDragPreview`. It serves as
@@ -24,12 +33,20 @@ export const CDK_DRAG_PREVIEW = new InjectionToken<CdkDragPreview>('CdkDragPrevi
   standalone: true,
   providers: [{provide: CDK_DRAG_PREVIEW, useExisting: CdkDragPreview}],
 })
-export class CdkDragPreview<T = any> {
+export class CdkDragPreview<T = any> implements OnDestroy {
+  private _drag = inject(CDK_DRAG_PARENT);
+
   /** Context data to be added to the preview template instance. */
   @Input() data: T;
 
   /** Whether the preview should preserve the same size as the item that is being dragged. */
   @Input({transform: booleanAttribute}) matchSize: boolean = false;
 
-  constructor(public templateRef: TemplateRef<T>) {}
+  constructor(public templateRef: TemplateRef<T>) {
+    this._drag._setPreviewTemplate(this);
+  }
+
+  ngOnDestroy(): void {
+    this._drag._resetPreviewTemplate(this);
+  }
 }

--- a/src/cdk/drag-drop/drag-parent.ts
+++ b/src/cdk/drag-drop/drag-parent.ts
@@ -7,6 +7,7 @@
  */
 
 import {InjectionToken} from '@angular/core';
+import type {CdkDrag} from './directives/drag';
 
 /**
  * Injection token that can be used for a `CdkDrag` to provide itself as a parent to the
@@ -14,4 +15,4 @@ import {InjectionToken} from '@angular/core';
  * to avoid circular imports.
  * @docs-private
  */
-export const CDK_DRAG_PARENT = new InjectionToken<{}>('CDK_DRAG_PARENT');
+export const CDK_DRAG_PARENT = new InjectionToken<CdkDrag>('CDK_DRAG_PARENT');

--- a/tools/public_api_guard/cdk/drag-drop.md
+++ b/tools/public_api_guard/cdk/drag-drop.md
@@ -18,7 +18,6 @@ import { NumberInput } from '@angular/cdk/coercion';
 import { Observable } from 'rxjs';
 import { OnChanges } from '@angular/core';
 import { OnDestroy } from '@angular/core';
-import { QueryList } from '@angular/core';
 import { ScrollDispatcher } from '@angular/cdk/scrolling';
 import { SimpleChanges } from '@angular/core';
 import { Subject } from 'rxjs';
@@ -33,7 +32,7 @@ export const CDK_DRAG_CONFIG: InjectionToken<DragDropConfig>;
 export const CDK_DRAG_HANDLE: InjectionToken<CdkDragHandle>;
 
 // @public
-export const CDK_DRAG_PARENT: InjectionToken<{}>;
+export const CDK_DRAG_PARENT: InjectionToken<CdkDrag<any>>;
 
 // @public
 export const CDK_DRAG_PLACEHOLDER: InjectionToken<CdkDragPlaceholder<any>>;
@@ -53,6 +52,8 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
     element: ElementRef<HTMLElement>,
     dropContainer: CdkDropList,
     _document: any, _ngZone: NgZone, _viewContainerRef: ViewContainerRef, config: DragDropConfig, _dir: Directionality, dragDrop: DragDrop, _changeDetectorRef: ChangeDetectorRef, _selfHandle?: CdkDragHandle | undefined, _parentDrag?: CdkDrag<any> | undefined);
+    // (undocumented)
+    _addHandle(handle: CdkDragHandle): void;
     boundaryElement: string | ElementRef<HTMLElement> | HTMLElement;
     constrainPosition?: (userPointerPosition: Point, dragRef: DragRef, dimensions: DOMRect, pickupPositionInElement: Point) => Point;
     data: T;
@@ -70,7 +71,6 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
     getFreeDragPosition(): Readonly<Point>;
     getPlaceholderElement(): HTMLElement;
     getRootElement(): HTMLElement;
-    _handles: QueryList<CdkDragHandle>;
     lockAxis: DragAxis;
     readonly moved: Observable<CdkDragMove<T>>;
     // (undocumented)
@@ -81,17 +81,25 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
     ngOnChanges(changes: SimpleChanges): void;
     // (undocumented)
     ngOnDestroy(): void;
-    _placeholderTemplate: CdkDragPlaceholder;
     previewClass: string | string[];
     previewContainer: PreviewContainer;
-    _previewTemplate: CdkDragPreview;
     readonly released: EventEmitter<CdkDragRelease>;
+    // (undocumented)
+    _removeHandle(handle: CdkDragHandle): void;
     reset(): void;
+    // (undocumented)
+    _resetPlaceholderTemplate(placeholder: CdkDragPlaceholder): void;
+    // (undocumented)
+    _resetPreviewTemplate(preview: CdkDragPreview): void;
     rootElementSelector: string;
     setFreeDragPosition(value: Point): void;
+    // (undocumented)
+    _setPlaceholderTemplate(placeholder: CdkDragPlaceholder): void;
+    // (undocumented)
+    _setPreviewTemplate(preview: CdkDragPreview): void;
     readonly started: EventEmitter<CdkDragStart>;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkDrag<any>, "[cdkDrag]", ["cdkDrag"], { "data": { "alias": "cdkDragData"; "required": false; }; "lockAxis": { "alias": "cdkDragLockAxis"; "required": false; }; "rootElementSelector": { "alias": "cdkDragRootElement"; "required": false; }; "boundaryElement": { "alias": "cdkDragBoundary"; "required": false; }; "dragStartDelay": { "alias": "cdkDragStartDelay"; "required": false; }; "freeDragPosition": { "alias": "cdkDragFreeDragPosition"; "required": false; }; "disabled": { "alias": "cdkDragDisabled"; "required": false; }; "constrainPosition": { "alias": "cdkDragConstrainPosition"; "required": false; }; "previewClass": { "alias": "cdkDragPreviewClass"; "required": false; }; "previewContainer": { "alias": "cdkDragPreviewContainer"; "required": false; }; }, { "started": "cdkDragStarted"; "released": "cdkDragReleased"; "ended": "cdkDragEnded"; "entered": "cdkDragEntered"; "exited": "cdkDragExited"; "dropped": "cdkDragDropped"; "moved": "cdkDragMoved"; }, ["_previewTemplate", "_placeholderTemplate", "_handles"], never, true, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkDrag<any>, "[cdkDrag]", ["cdkDrag"], { "data": { "alias": "cdkDragData"; "required": false; }; "lockAxis": { "alias": "cdkDragLockAxis"; "required": false; }; "rootElementSelector": { "alias": "cdkDragRootElement"; "required": false; }; "boundaryElement": { "alias": "cdkDragBoundary"; "required": false; }; "dragStartDelay": { "alias": "cdkDragStartDelay"; "required": false; }; "freeDragPosition": { "alias": "cdkDragFreeDragPosition"; "required": false; }; "disabled": { "alias": "cdkDragDisabled"; "required": false; }; "constrainPosition": { "alias": "cdkDragConstrainPosition"; "required": false; }; "previewClass": { "alias": "cdkDragPreviewClass"; "required": false; }; "previewContainer": { "alias": "cdkDragPreviewContainer"; "required": false; }; }, { "started": "cdkDragStarted"; "released": "cdkDragReleased"; "ended": "cdkDragEnded"; "entered": "cdkDragEntered"; "exited": "cdkDragExited"; "dropped": "cdkDragDropped"; "moved": "cdkDragMoved"; }, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<CdkDrag<any>, [null, { optional: true; skipSelf: true; }, null, null, null, { optional: true; }, { optional: true; }, null, null, { optional: true; self: true; }, { optional: true; skipSelf: true; }]>;
 }
@@ -144,7 +152,7 @@ export interface CdkDragExit<T = any, I = T> {
 
 // @public
 export class CdkDragHandle implements OnDestroy {
-    constructor(element: ElementRef<HTMLElement>, parentDrag?: any);
+    constructor(element: ElementRef<HTMLElement>, _parentDrag?: CdkDrag<any> | undefined);
     get disabled(): boolean;
     set disabled(value: boolean);
     // (undocumented)
@@ -153,7 +161,6 @@ export class CdkDragHandle implements OnDestroy {
     static ngAcceptInputType_disabled: unknown;
     // (undocumented)
     ngOnDestroy(): void;
-    _parentDrag: {} | undefined;
     readonly _stateChanges: Subject<CdkDragHandle>;
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<CdkDragHandle, "[cdkDragHandle]", never, { "disabled": { "alias": "cdkDragHandleDisabled"; "required": false; }; }, {}, never, never, true, never>;
@@ -180,9 +187,11 @@ export interface CdkDragMove<T = any> {
 }
 
 // @public
-export class CdkDragPlaceholder<T = any> {
+export class CdkDragPlaceholder<T = any> implements OnDestroy {
     constructor(templateRef: TemplateRef<T>);
     data: T;
+    // (undocumented)
+    ngOnDestroy(): void;
     // (undocumented)
     templateRef: TemplateRef<T>;
     // (undocumented)
@@ -192,12 +201,14 @@ export class CdkDragPlaceholder<T = any> {
 }
 
 // @public
-export class CdkDragPreview<T = any> {
+export class CdkDragPreview<T = any> implements OnDestroy {
     constructor(templateRef: TemplateRef<T>);
     data: T;
     matchSize: boolean;
     // (undocumented)
     static ngAcceptInputType_matchSize: unknown;
+    // (undocumented)
+    ngOnDestroy(): void;
     // (undocumented)
     templateRef: TemplateRef<T>;
     // (undocumented)


### PR DESCRIPTION
Currently `CdkDrag` resolves its helper directives (e.g. handle or preview) using a content query, but that doesn't work when it's applied as a host directive, because no content is being projected.

These changes switch to having the helper directives inject the closest drag directive and register themselves manually.

Fixes #28614.