### PR TITLE
docs(material-3): fix typography config

### DIFF
--- a/guides/material-3.md
+++ b/guides/material-3.md
@@ -38,8 +38,8 @@ $theme: matx.define-theme((
     primary: matx.$m3-violet-palette,
   ),
   typography: (
-    brand: 'Comic Sans',
-    bold: 900
+    brand-family: 'Comic Sans',
+    bold-weight: 900
   ),
   density: (
     scale: -1


### PR DESCRIPTION
Encountering an error with $config.typography in the provided Angular Material 3 example.

![image](https://github.com/angular/components/assets/55021051/852f6349-2ce3-48b3-9794-697f2ee07530)

I believe that `brand` and `bold` should be replaced with `brand-family` and `bold-weight` .
