### PR TITLE
refactor(multiple): use object literal syntax in inputs array

### DIFF
--- a/src/cdk-experimental/popover-edit/lens-directives.ts
+++ b/src/cdk-experimental/popover-edit/lens-directives.ts
@@ -25,9 +25,9 @@ export type PopoverEditClickOutBehavior = 'close' | 'submit' | 'noop';
 @Directive({
   selector: 'form[cdkEditControl]',
   inputs: [
-    'clickOutBehavior: cdkEditControlClickOutBehavior',
-    'preservedFormValue: cdkEditControlPreservedFormValue',
-    'ignoreSubmitUnlessValid: cdkEditControlIgnoreSubmitUnlessValid',
+    {name: 'clickOutBehavior', alias: 'cdkEditControlClickOutBehavior'},
+    {name: 'preservedFormValue', alias: 'cdkEditControlPreservedFormValue'},
+    {name: 'ignoreSubmitUnlessValid', alias: 'cdkEditControlIgnoreSubmitUnlessValid'},
   ],
   outputs: ['preservedFormValueChange: cdkEditControlPreservedFormValueChange'],
   providers: [EditRef],

--- a/src/cdk-experimental/popover-edit/table-directives.ts
+++ b/src/cdk-experimental/popover-edit/table-directives.ts
@@ -161,10 +161,10 @@ const POPOVER_EDIT_HOST_BINDINGS = {
 };
 
 const POPOVER_EDIT_INPUTS = [
-  'template: cdkPopoverEdit',
-  'context: cdkPopoverEditContext',
-  'colspan: cdkPopoverEditColspan',
-  'disabled: cdkPopoverEditDisabled',
+  {name: 'template', alias: 'cdkPopoverEdit'},
+  {name: 'context', alias: 'cdkPopoverEditContext'},
+  {name: 'colspan', alias: 'cdkPopoverEditColspan'},
+  {name: 'disabled', alias: 'cdkPopoverEditDisabled'},
 ];
 
 /**

--- a/src/cdk/menu/context-menu-trigger.ts
+++ b/src/cdk/menu/context-menu-trigger.ts
@@ -63,9 +63,9 @@ export type ContextMenuCoordinates = {x: number; y: number};
     '(contextmenu)': '_openOnContextMenu($event)',
   },
   inputs: [
-    'menuTemplateRef: cdkContextMenuTriggerFor',
-    'menuPosition: cdkContextMenuPosition',
-    'menuData: cdkContextMenuTriggerData',
+    {name: 'menuTemplateRef', alias: 'cdkContextMenuTriggerFor'},
+    {name: 'menuPosition', alias: 'cdkContextMenuPosition'},
+    {name: 'menuData', alias: 'cdkContextMenuTriggerData'},
   ],
   outputs: ['opened: cdkContextMenuOpened', 'closed: cdkContextMenuClosed'],
   providers: [

--- a/src/cdk/menu/menu-trigger.ts
+++ b/src/cdk/menu/menu-trigger.ts
@@ -56,9 +56,9 @@ import {eventDispatchesNativeClick} from './event-detection';
     '(click)': '_handleClick()',
   },
   inputs: [
-    'menuTemplateRef: cdkMenuTriggerFor',
-    'menuPosition: cdkMenuPosition',
-    'menuData: cdkMenuTriggerData',
+    {name: 'menuTemplateRef', alias: 'cdkMenuTriggerFor'},
+    {name: 'menuPosition', alias: 'cdkMenuPosition'},
+    {name: 'menuData', alias: 'cdkMenuTriggerData'},
   ],
   outputs: ['opened: cdkMenuOpened', 'closed: cdkMenuClosed'],
   providers: [

--- a/src/cdk/portal/portal-directives.ts
+++ b/src/cdk/portal/portal-directives.ts
@@ -19,6 +19,7 @@ import {
   TemplateRef,
   ViewContainerRef,
   Inject,
+  Input,
 } from '@angular/core';
 import {DOCUMENT} from '@angular/common';
 import {BasePortalOutlet, ComponentPortal, Portal, TemplatePortal, DomPortal} from './portal';
@@ -70,7 +71,6 @@ export type CdkPortalOutletAttachedRef = ComponentRef<any> | EmbeddedViewRef<any
 @Directive({
   selector: '[cdkPortalOutlet]',
   exportAs: 'cdkPortalOutlet',
-  inputs: ['portal: cdkPortalOutlet'],
   standalone: true,
 })
 export class CdkPortalOutlet extends BasePortalOutlet implements OnInit, OnDestroy {
@@ -97,6 +97,7 @@ export class CdkPortalOutlet extends BasePortalOutlet implements OnInit, OnDestr
   }
 
   /** Portal associated with the Portal outlet. */
+  @Input('cdkPortalOutlet')
   get portal(): Portal<any> | null {
     return this._attachedPortal;
   }
@@ -251,7 +252,7 @@ export class CdkPortalOutlet extends BasePortalOutlet implements OnInit, OnDestr
 @Directive({
   selector: '[cdkPortalHost], [portalHost]',
   exportAs: 'cdkPortalHost',
-  inputs: ['portal: cdkPortalHost'],
+  inputs: [{name: 'portal', alias: 'cdkPortalHost'}],
   providers: [
     {
       provide: CdkPortalOutlet,

--- a/src/cdk/tree/node.ts
+++ b/src/cdk/tree/node.ts
@@ -33,7 +33,7 @@ export class CdkTreeNodeOutletContext<T> {
  */
 @Directive({
   selector: '[cdkTreeNodeDef]',
-  inputs: ['when: cdkTreeNodeDefWhen'],
+  inputs: [{name: 'when', alias: 'cdkTreeNodeDefWhen'}],
   standalone: true,
 })
 export class CdkTreeNodeDef<T> {

--- a/src/material-experimental/column-resize/resizable-directives/common.ts
+++ b/src/material-experimental/column-resize/resizable-directives/common.ts
@@ -27,6 +27,6 @@ export const RESIZABLE_HOST_BINDINGS = {
 };
 
 export const RESIZABLE_INPUTS = [
-  'minWidthPx: matResizableMinWidthPx',
-  'maxWidthPx: matResizableMaxWidthPx',
+  {name: 'minWidthPx', alias: 'matResizableMinWidthPx'},
+  {name: 'maxWidthPx', alias: 'matResizableMaxWidthPx'},
 ];

--- a/src/material-experimental/popover-edit/lens-directives.ts
+++ b/src/material-experimental/popover-edit/lens-directives.ts
@@ -27,9 +27,9 @@ import {
     'class': 'mat-edit-lens',
   },
   inputs: [
-    'clickOutBehavior: matEditLensClickOutBehavior',
-    'preservedFormValue: matEditLensPreservedFormValue',
-    'ignoreSubmitUnlessValid: matEditLensIgnoreSubmitUnlessValid',
+    {name: 'clickOutBehavior', alias: 'matEditLensClickOutBehavior'},
+    {name: 'preservedFormValue', alias: 'matEditLensPreservedFormValue'},
+    {name: 'ignoreSubmitUnlessValid', alias: 'matEditLensIgnoreSubmitUnlessValid'},
   ],
   outputs: ['preservedFormValueChange: matEditLensPreservedFormValueChange'],
   providers: [EditRef],

--- a/src/material-experimental/popover-edit/table-directives.ts
+++ b/src/material-experimental/popover-edit/table-directives.ts
@@ -22,10 +22,10 @@ const POPOVER_EDIT_HOST_BINDINGS = {
 };
 
 const POPOVER_EDIT_INPUTS = [
-  'template: matPopoverEdit',
-  'context: matPopoverEditContext',
-  'colspan: matPopoverEditColspan',
-  'disabled: matPopoverEditDisabled',
+  {name: 'template', alias: 'matPopoverEdit'},
+  {name: 'context', alias: 'matPopoverEditContext'},
+  {name: 'colspan', alias: 'matPopoverEditColspan'},
+  {name: 'disabled', alias: 'matPopoverEditDisabled'},
 ];
 
 const EDIT_PANE_CLASS = 'mat-edit-pane';

--- a/src/material-experimental/selection/row-selection.ts
+++ b/src/material-experimental/selection/row-selection.ts
@@ -23,7 +23,7 @@ import {Input, Directive} from '@angular/core';
     '[attr.aria-selected]': '_selection.isSelected(this.value, this.index)',
   },
   providers: [{provide: CdkRowSelection, useExisting: MatRowSelection}],
-  inputs: ['index: matRowSelectionIndex'],
+  inputs: [{name: 'index', alias: 'matRowSelectionIndex'}],
   standalone: true,
 })
 export class MatRowSelection<T> extends CdkRowSelection<T> {

--- a/src/material-experimental/selection/selection-toggle.ts
+++ b/src/material-experimental/selection/selection-toggle.ts
@@ -22,7 +22,7 @@ import {Directive, Input} from '@angular/core';
 @Directive({
   selector: '[matSelectionToggle]',
   exportAs: 'matSelectionToggle',
-  inputs: ['index: matSelectionToggleIndex'],
+  inputs: [{name: 'index', alias: 'matSelectionToggleIndex'}],
   providers: [{provide: CdkSelectionToggle, useExisting: MatSelectionToggle}],
   standalone: true,
 })

--- a/src/material/tabs/ink-bar.ts
+++ b/src/material/tabs/ink-bar.ts
@@ -14,8 +14,8 @@ import {
   OnDestroy,
   OnInit,
   QueryList,
+  booleanAttribute,
   inject,
-  numberAttribute,
 } from '@angular/core';
 
 /**
@@ -79,7 +79,7 @@ export abstract class InkBarItem implements OnInit, OnDestroy {
   private _fitToContent = false;
 
   /** Whether the ink bar should fit to the entire tab or just its content. */
-  @Input({transform: numberAttribute})
+  @Input({transform: booleanAttribute})
   get fitInkBarToContent(): boolean {
     return this._fitToContent;
   }

--- a/src/material/tabs/tab-label-wrapper.ts
+++ b/src/material/tabs/tab-label-wrapper.ts
@@ -15,7 +15,6 @@ import {InkBarItem} from './ink-bar';
  */
 @Directive({
   selector: '[matTabLabelWrapper]',
-  inputs: ['fitInkBarToContent'],
   host: {
     '[class.mat-mdc-tab-disabled]': 'disabled',
     '[attr.aria-disabled]': '!!disabled',

--- a/src/material/tree/node.ts
+++ b/src/material/tree/node.ts
@@ -75,7 +75,7 @@ export class MatTreeNode<T, K = T> extends CdkTreeNode<T, K> implements OnInit, 
  */
 @Directive({
   selector: '[matTreeNodeDef]',
-  inputs: ['when: matTreeNodeDefWhen'],
+  inputs: [{name: 'when', alias: 'matTreeNodeDefWhen'}],
   providers: [{provide: CdkTreeNodeDef, useExisting: MatTreeNodeDef}],
   standalone: true,
 })

--- a/src/material/tree/toggle.ts
+++ b/src/material/tree/toggle.ts
@@ -15,7 +15,7 @@ import {Directive} from '@angular/core';
 @Directive({
   selector: '[matTreeNodeToggle]',
   providers: [{provide: CdkTreeNodeToggle, useExisting: MatTreeNodeToggle}],
-  inputs: ['recursive: matTreeNodeToggleRecursive'],
+  inputs: [{name: 'recursive', alias: 'matTreeNodeToggleRecursive'}],
   standalone: true,
 })
 export class MatTreeNodeToggle<T, K = T> extends CdkTreeNodeToggle<T, K> {}

--- a/tools/public_api_guard/material/tabs.md
+++ b/tools/public_api_guard/material/tabs.md
@@ -393,7 +393,7 @@ export class MatTabLabelWrapper extends InkBarItem {
     // (undocumented)
     static ngAcceptInputType_disabled: unknown;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<MatTabLabelWrapper, "[matTabLabelWrapper]", never, { "fitInkBarToContent": { "alias": "fitInkBarToContent"; "required": false; }; "disabled": { "alias": "disabled"; "required": false; }; }, {}, never, never, true, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<MatTabLabelWrapper, "[matTabLabelWrapper]", never, { "disabled": { "alias": "disabled"; "required": false; }; }, {}, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatTabLabelWrapper, never>;
 }


### PR DESCRIPTION
Switches to using the object literal syntax in the `inputs` array which is a bit more readable than the string syntax. This shouldn't have an effect on users.