### PR TITLE
fix(material/datepicker): deprecate calendarLabel

### DIFF
--- a/src/material/datepicker/datepicker-intl.ts
+++ b/src/material/datepicker/datepicker-intl.ts
@@ -18,7 +18,11 @@ export class MatDatepickerIntl {
    */
   readonly changes: Subject<void> = new Subject<void>();
 
-  /** A label for the calendar popup (used by screen readers). */
+  /**
+   * A label for the calendar popup (used by screen readers).
+   * @deprecated Provide your own internationalization string.
+   * @breaking-change 20.0.0
+   */
   calendarLabel = 'Calendar';
 
   /** A label for the button used to open the calendar popup (used by screen readers). */

--- a/tools/public_api_guard/material/datepicker.md
+++ b/tools/public_api_guard/material/datepicker.md
@@ -479,6 +479,7 @@ export class MatDatepickerInputEvent<D, S = unknown> {
 
 // @public
 export class MatDatepickerIntl {
+    // @deprecated
     calendarLabel: string;
     readonly changes: Subject<void>;
     closeCalendarLabel: string;


### PR DESCRIPTION
Removed unused property `MatDatepickerIntl:calendarLabel`.

Remove dead code. Does not make behavior or visual change.

Fix #27935