### PR TITLE
fix(material/autocomplete): prevent hidden overlay from blocking clicks

### DIFF
--- a/src/material/autocomplete/autocomplete.scss
+++ b/src/material/autocomplete/autocomplete.scss
@@ -46,6 +46,7 @@ div.mat-mdc-autocomplete-panel {
 
   &.mat-mdc-autocomplete-hidden {
     visibility: hidden;
+    pointer-events: none;
   }
 }
 


### PR DESCRIPTION
The autocomplete hides its dropdown if there are no options, but it is still clickable. These changes add `pointer-events: none` to prevent it from blocking interactions.

Fixes #28670.