### PR TITLE
fix(material/form-field): mat-label disappears when density < -1

### DIFF
--- a/src/material-experimental/theming/_m3-density.scss
+++ b/src/material-experimental/theming/_m3-density.scss
@@ -85,10 +85,11 @@ $_density-tokens: (
   ),
   (mat, form-field): (
     container-height: (56px, 52px, 48px, 44px, 40px, 36px),
-    filled-label-display: (block, block, none, none, none, none),
+    filled-label-display: (block, block, block, block, block, block),
     container-vertical-padding: (16px, 14px, 12px, 10px, 8px, 6px),
     filled-with-label-container-padding-top: (24px, 22px, 12px, 10px, 8px, 6px),
     filled-with-label-container-padding-bottom: (8px, 6px, 12px, 10px, 8px, 6px),
+    filled-with-label-position-top: (28px, 27px, 26px, 25px, 24px, 23px),
   ),
   (mat, grid-list): (),
   (mat, icon): (),

--- a/src/material/core/tokens/m2/mat/_form-field.scss
+++ b/src/material/core/tokens/m2/mat/_form-field.scss
@@ -141,6 +141,7 @@ $prefix: (mat, form-field);
   $filled-with-label-padding-top: 24px - $vertical-deduction;
   $filled-with-label-padding-bottom: 8px - $vertical-deduction;
   $vertical-padding: 16px - $vertical-deduction;
+  $filled-with-label-position-top: 28px - math.div($vertical-deduction, 2);
 
   @return (
     container-height: $height,
@@ -150,6 +151,7 @@ $prefix: (mat, form-field);
       if($hide-label, $vertical-padding, $filled-with-label-padding-top),
     filled-with-label-container-padding-bottom:
       if($hide-label, $vertical-padding, $filled-with-label-padding-bottom),
+    filled-with-label-position-top: $filled-with-label-position-top,
   );
 }
 

--- a/src/material/form-field/_mdc-text-field-density-overrides.scss
+++ b/src/material/form-field/_mdc-text-field-density-overrides.scss
@@ -52,8 +52,7 @@
     // For the outline appearance, we re-create the active floating label transform. This is
     // necessary because the transform for docked floating labels can be updated to account for
     // the width of prefix container.
-    .mat-mdc-text-field-wrapper.mdc-text-field--outlined .mdc-notched-outline--upgraded
-      .mdc-floating-label--float-above {
+    .mat-mdc-text-field-wrapper.mdc-text-field--outlined .mdc-notched-outline--upgraded .mdc-floating-label--float-above {
       // Needs to be in a string form to work around an internal check that incorrectly flags this
       // interpolation in `calc` as unnecessary. If we don't have it, Sass won't evaluate it.
       $translate: 'calc(#{mdc-textfield.get-outlined-label-position-y(var(#{$height}))} * -1)';

--- a/src/material/form-field/_mdc-text-field-density-overrides.scss
+++ b/src/material/form-field/_mdc-text-field-density-overrides.scss
@@ -39,6 +39,7 @@
       top: calc(var(#{$height}) / 2);
     }
 
+    // We need to adjust the floating label position for filled text-fields to support showing label in all densities.
     .mat-mdc-text-field-wrapper .mat-mdc-form-field-flex .mat-mdc-floating-label.mdc-floating-label--float-above {
       top: var(#{token-utils.get-token-variable(filled-with-label-position-top)}, 28px);
     }

--- a/src/material/form-field/_mdc-text-field-density-overrides.scss
+++ b/src/material/form-field/_mdc-text-field-density-overrides.scss
@@ -52,7 +52,8 @@
     // For the outline appearance, we re-create the active floating label transform. This is
     // necessary because the transform for docked floating labels can be updated to account for
     // the width of prefix container.
-    .mat-mdc-text-field-wrapper.mdc-text-field--outlined .mdc-notched-outline--upgraded .mdc-floating-label--float-above {
+    .mat-mdc-text-field-wrapper.mdc-text-field--outlined .mdc-notched-outline--upgraded 
+    .mdc-floating-label--float-above {
       // Needs to be in a string form to work around an internal check that incorrectly flags this
       // interpolation in `calc` as unnecessary. If we don't have it, Sass won't evaluate it.
       $translate: 'calc(#{mdc-textfield.get-outlined-label-position-y(var(#{$height}))} * -1)';

--- a/src/material/form-field/_mdc-text-field-density-overrides.scss
+++ b/src/material/form-field/_mdc-text-field-density-overrides.scss
@@ -39,6 +39,10 @@
       top: calc(var(#{$height}) / 2);
     }
 
+    .mat-mdc-text-field-wrapper .mat-mdc-form-field-flex .mat-mdc-floating-label.mdc-floating-label--float-above {
+      top: var(#{token-utils.get-token-variable(filled-with-label-position-top)}, 28px);
+    }
+
     // We need to conditionally hide the floating label based on the height of the form field.
     .mdc-text-field--filled .mat-mdc-floating-label {
       display: var(#{token-utils.get-token-variable(filled-label-display)}, block);
@@ -48,7 +52,7 @@
     // necessary because the transform for docked floating labels can be updated to account for
     // the width of prefix container.
     .mat-mdc-text-field-wrapper.mdc-text-field--outlined .mdc-notched-outline--upgraded
-    .mdc-floating-label--float-above {
+      .mdc-floating-label--float-above {
       // Needs to be in a string form to work around an internal check that incorrectly flags this
       // interpolation in `calc` as unnecessary. If we don't have it, Sass won't evaluate it.
       $translate: 'calc(#{mdc-textfield.get-outlined-label-position-y(var(#{$height}))} * -1)';


### PR DESCRIPTION
Fixes a bug in the Angular Material `form-field` where the floating
label is not presented in densities more compact than -1

Fixes https://github.com/angular/components/issues/26579