### PR TITLE
fix(material/core): mark fields on HasErrorState as nullable

### DIFF
--- a/src/material/core/common-behaviors/error-state.ts
+++ b/src/material/core/common-behaviors/error-state.ts
@@ -33,14 +33,14 @@ type CanUpdateErrorStateCtor = Constructor<CanUpdateErrorState> &
 
 /** @docs-private */
 interface HasErrorState {
-  _parentFormGroup: FormGroupDirective;
-  _parentForm: NgForm;
+  _parentFormGroup: FormGroupDirective | null;
+  _parentForm: NgForm | null;
   _defaultErrorStateMatcher: ErrorStateMatcher;
 
   // These properties are defined as per the `MatFormFieldControl` interface. Since
   // this mixin is commonly used with custom form-field controls, we respect the
   // properties (also with the public name they need according to `MatFormFieldControl`).
-  ngControl: NgControl;
+  ngControl: NgControl | null;
   stateChanges: Subject<void>;
 }
 


### PR DESCRIPTION
Updates a couple of the fields on `HasErrorState` to be nullable to align them with the `_ErrorStateTracker`.

Fixes #28688.