### PR TITLE
refactor(cdk/a11y): only call currentResolve if defined

### DIFF
--- a/src/cdk/a11y/live-announcer/live-announcer.ts
+++ b/src/cdk/a11y/live-announcer/live-announcer.ts
@@ -135,7 +135,9 @@ export class LiveAnnouncer implements OnDestroy {
           this._previousTimeout = setTimeout(() => this.clear(), duration);
         }
 
-        this._currentResolve!();
+        // For some reason in tests this can be undefined
+        // Probably related to ZoneJS and every other thing that patches browser APIs in tests
+        this._currentResolve?.();
         this._currentPromise = this._currentResolve = undefined;
       }, 100);
 


### PR DESCRIPTION
Should it be possible for it to be undefined within the timeout body? No. But ZoneJS and test environments do weird things so it's better to be safe.