### PR TITLE
fix(material/slide-toggle): trigger `this.change` on toggle

### DIFF
--- a/src/material/slide-toggle/slide-toggle.ts
+++ b/src/material/slide-toggle/slide-toggle.ts
@@ -277,6 +277,7 @@ export class MatSlideToggle
   toggle(): void {
     this.checked = !this.checked;
     this._onChange(this.checked);
+    this.change.emit(this._createChangeEvent(this.checked));
   }
 
   /**


### PR DESCRIPTION
I was wondering why there were no updates on the `(change)` output while using the `toggle` function until I saw that the `change` output simply isn't being triggered.
Hopefully this PR should fix this issue and is acceptable. Sorry if the format is wrong or if the contribution is invalid.
