### PR TITLE
fix(cdk/drag-drop): optionally inject parent drag in preview and placeholder

### DIFF
--- a/src/cdk/drag-drop/directives/drag-placeholder.ts
+++ b/src/cdk/drag-drop/directives/drag-placeholder.ts
@@ -26,16 +26,16 @@ export const CDK_DRAG_PLACEHOLDER = new InjectionToken<CdkDragPlaceholder>('CdkD
   providers: [{provide: CDK_DRAG_PLACEHOLDER, useExisting: CdkDragPlaceholder}],
 })
 export class CdkDragPlaceholder<T = any> implements OnDestroy {
-  private _drag = inject(CDK_DRAG_PARENT);
+  private _drag = inject(CDK_DRAG_PARENT, {optional: true});
 
   /** Context data to be added to the placeholder template instance. */
   @Input() data: T;
 
   constructor(public templateRef: TemplateRef<T>) {
-    this._drag._setPlaceholderTemplate(this);
+    this._drag?._setPlaceholderTemplate(this);
   }
 
   ngOnDestroy(): void {
-    this._drag._resetPlaceholderTemplate(this);
+    this._drag?._resetPlaceholderTemplate(this);
   }
 }

--- a/src/cdk/drag-drop/directives/drag-preview.ts
+++ b/src/cdk/drag-drop/directives/drag-preview.ts
@@ -34,7 +34,7 @@ export const CDK_DRAG_PREVIEW = new InjectionToken<CdkDragPreview>('CdkDragPrevi
   providers: [{provide: CDK_DRAG_PREVIEW, useExisting: CdkDragPreview}],
 })
 export class CdkDragPreview<T = any> implements OnDestroy {
-  private _drag = inject(CDK_DRAG_PARENT);
+  private _drag = inject(CDK_DRAG_PARENT, {optional: true});
 
   /** Context data to be added to the preview template instance. */
   @Input() data: T;
@@ -43,10 +43,10 @@ export class CdkDragPreview<T = any> implements OnDestroy {
   @Input({transform: booleanAttribute}) matchSize: boolean = false;
 
   constructor(public templateRef: TemplateRef<T>) {
-    this._drag._setPreviewTemplate(this);
+    this._drag?._setPreviewTemplate(this);
   }
 
   ngOnDestroy(): void {
-    this._drag._resetPreviewTemplate(this);
+    this._drag?._resetPreviewTemplate(this);
   }
 }


### PR DESCRIPTION
Fixes a regression from #28633 where using `cdkDragPlaceholder` or `cdkDragPreview` without a `cdkDrag` would throw. Technically this is a no-op, but it appears that folks started depending on the old behavior so these changes bring it back.

Fixes #28744.