### PR TITLE
fix(material/chips): use concrete value for remove icon size

### DIFF
--- a/src/material/chips/chip.scss
+++ b/src/material/chips/chip.scss
@@ -366,9 +366,9 @@
   }
 
   .mat-icon {
-    width: inherit;
-    height: inherit;
-    font-size: inherit;
+    width: mdc-chip-theme.$trailing-action-size;
+    height: mdc-chip-theme.$trailing-action-size;
+    font-size: mdc-chip-theme.$trailing-action-size;
     box-sizing: content-box;
   }
 }


### PR DESCRIPTION
Currently the remove icon is a bit brittle, because the size is set to `inherit` which only works if there's a `button` around it. These changes set the specific width instead.

Fixes #28467.