### PR TITLE
fix(cdk/a11y): support signals in ListKeyManager

### DIFF
--- a/tools/public_api_guard/cdk/a11y.md
+++ b/tools/public_api_guard/cdk/a11y.md
@@ -13,12 +13,14 @@ import { EventEmitter } from '@angular/core';
 import * as i0 from '@angular/core';
 import * as i1 from '@angular/cdk/observers';
 import { InjectionToken } from '@angular/core';
+import { Injector } from '@angular/core';
 import { NgZone } from '@angular/core';
 import { Observable } from 'rxjs';
 import { OnChanges } from '@angular/core';
 import { OnDestroy } from '@angular/core';
 import { Platform } from '@angular/cdk/platform';
 import { QueryList } from '@angular/core';
+import { Signal } from '@angular/core';
 import { SimpleChanges } from '@angular/core';
 import { Subject } from 'rxjs';
 
@@ -347,7 +349,8 @@ export class IsFocusableConfig {
 
 // @public
 export class ListKeyManager<T extends ListKeyManagerOption> {
-    constructor(_items: QueryList<T> | T[]);
+    constructor(items: QueryList<T> | T[] | readonly T[]);
+    constructor(items: Signal<T[]> | Signal<readonly T[]>, injector: Injector);
     get activeItem(): T | null;
     get activeItemIndex(): number | null;
     cancelTypeahead(): this;


### PR DESCRIPTION
Updates the `ListKeyManager` to support passing in a signal. Also expands the type to allow readonly arrays.

Fixes #28710.