### PR TITLE
fix(material/datepicker): datepicker row count inaccurate for screen …

### DIFF
--- a/src/material/datepicker/month-view.html
+++ b/src/material/datepicker/month-view.html
@@ -8,7 +8,7 @@
         </th>
       }
     </tr>
-    <tr><th aria-hidden="true" class="mat-calendar-table-header-divider" colspan="7"></th></tr>
+    <tr aria-hidden="true"><th class="mat-calendar-table-header-divider" colspan="7"></th></tr>
   </thead>
   <tbody mat-calendar-body
          [label]="_monthLabel"


### PR DESCRIPTION
…reader

Fixes a bug in the Angular Material datepicker component where the divider row is being counted as a row. This is because the 'aria-hidden=true' was placed on its child th tag as opposed to the divider tr tag.

Fixes #28476