### PR TITLE
build: add missing yarn install block

### DIFF
--- a/.github/workflows/deploy-dev-app-main-push.yml
+++ b/.github/workflows/deploy-dev-app-main-push.yml
@@ -24,6 +24,8 @@ jobs:
         uses: angular/dev-infra/github-actions/bazel/setup@4b433074a806bbbd4d319264430740cd46e62f27
       - name: Setup Bazel RBE
         uses: angular/dev-infra/github-actions/bazel/configure-remote@4b433074a806bbbd4d319264430740cd46e62f27
+      - name: Install node modules
+        run: yarn install --frozen-lockfile
 
       - name: Building dev-app
         run: |


### PR DESCRIPTION
Looks like the action simply relied on caching.