### PR TITLE
ci: add missing google sync config entry

### DIFF
--- a/.ng-dev/google-sync-config.json
+++ b/.ng-dev/google-sync-config.json
@@ -35,5 +35,6 @@
     "src/material/expansion/index.ts",
     "src/material-experimental/theming/_format-tokens.scss",
     "**/*import.scss"
-  ]
+  ],
+  "separateFilePatterns": []
 }


### PR DESCRIPTION
For the primitives sync in FW, a new field was added, that is apparently not optional. This commit adds it now.