### PR TITLE
fix(material/sort): clear aria description on destroy

### DIFF
--- a/src/material/sort/sort-header.ts
+++ b/src/material/sort/sort-header.ts
@@ -230,6 +230,10 @@ export class MatSortHeader implements MatSortable, OnDestroy, OnInit, AfterViewI
     this._focusMonitor.stopMonitoring(this._elementRef);
     this._sort.deregister(this);
     this._rerenderSubscription.unsubscribe();
+
+    if (this._sortButton) {
+      this._ariaDescriber?.removeDescription(this._sortButton, this._sortActionDescription);
+    }
   }
 
   /**


### PR DESCRIPTION
Fixes that the sort header wasn't clearing its ARIA description when it gets destroyed, causing a memory leak.