### PR TITLE
fix(material/paginator): items per page accessible label doesn't matc…

### DIFF
--- a/src/material/paginator/paginator.html
+++ b/src/material/paginator/paginator.html
@@ -14,7 +14,7 @@
             <mat-select
               [value]="pageSize"
               [disabled]="disabled"
-              [aria-labelledby]="_pageSizeLabelId"
+              [aria-label]="_intl.itemsPerPageLabel + pageSize"
               [panelClass]="selectConfig.panelClass || ''"
               [disableOptionCentering]="selectConfig.disableOptionCentering"
               (selectionChange)="_changePageSize($event.value)"


### PR DESCRIPTION
…h visual label

Fixes a bug in the Angular Material paginator component where the screenreader accessible label does not match the UI visual label. This is because previously the mat-select aria-labelledby value was inserting the selected value before the
 label.

Fixes b/286094434