### PR TITLE
fix(cdk/drag-drop): make sure event is cancelable before calling "preventDefault"

### DIFF
--- a/src/cdk/drag-drop/drag-ref.ts
+++ b/src/cdk/drag-drop/drag-ref.ts
@@ -672,7 +672,9 @@ export class DragRef<T = any> {
         if (!container || (!container.isDragging() && !container.isReceiving())) {
           // Prevent the default action as soon as the dragging sequence is considered as
           // "started" since waiting for the next event can allow the device to begin scrolling.
-          event.preventDefault();
+          if (event.cancelable) {
+            event.preventDefault();
+          }
           this._hasStartedDragging = true;
           this._ngZone.run(() => this._startDragSequence(event));
         }
@@ -684,7 +686,9 @@ export class DragRef<T = any> {
     // We prevent the default action down here so that we know that dragging has started. This is
     // important for touch devices where doing this too early can unnecessarily block scrolling,
     // if there's a dragging delay.
-    event.preventDefault();
+    if (event.cancelable) {
+      event.preventDefault();
+    }
 
     const constrainedPointerPosition = this._getConstrainedPointerPosition(pointerPosition);
     this._hasMoved = true;


### PR DESCRIPTION
Fixes #18296

If you set a value for `dragStartThreshold` greater than 0, it will throw console errors saying: "[Intervention] Ignored attempt to cancel a touchmove event with cancelable=false, for example because scrolling is in progress and cannot be interrupted."

```ts
@Component({
  standalone: true,
  selector: 'app-carousel',
  changeDetection: ChangeDetectionStrategy.OnPush,
  imports: [CdkDrag],
  providers: [
    {
      provide: CDK_DRAG_CONFIG,
      useValue: {
        dragStartThreshold: 20,
      },
    },
  ],
```

![image](https://github.com/angular/components/assets/27731641/d928a94e-f482-4263-8829-964af17ffd64)

Adding a condition to check if the event is `cancelable` will prevent that error.

