### PR TITLE
fix(material/paginator): combobox items per page accessible label mis…

### DIFF
--- a/src/material/paginator/paginator.html
+++ b/src/material/paginator/paginator.html
@@ -14,6 +14,7 @@
             <mat-select
               [value]="pageSize"
               [disabled]="disabled"
+              [reverseLabelledByValueOrder]="true"
               [aria-labelledby]="_pageSizeLabelId"
               [panelClass]="selectConfig.panelClass || ''"
               [disableOptionCentering]="selectConfig.disableOptionCentering"

--- a/src/material/select/select.ts
+++ b/src/material/select/select.ts
@@ -140,6 +140,12 @@ export interface MatSelectConfig {
    * If set to null or an empty string, the panel will grow to match the longest option's text.
    */
   panelWidth?: string | number | null;
+
+  /**
+   * Whether form-field value order in aria-labelledby should be reversed,
+   * ie. b/286094434 Mat-paginator.
+   */
+  reverseLabelledByValueOrder?: boolean | false;
 }
 
 /** Injection token that can be used to provide the default options the select module. */
@@ -396,6 +402,9 @@ export class MatSelect
   /** Whether ripples in the select are disabled. */
   @Input({transform: booleanAttribute})
   disableRipple: boolean = false;
+
+  /** Whether aria-labelledby string should be reversed. */
+  @Input() reverseLabelledByValueOrder: boolean | false;
 
   /** Tab index of the select. */
   @Input({
@@ -1381,7 +1390,11 @@ export class MatSelect
     let value = (labelId ? labelId + ' ' : '') + this._valueId;
 
     if (this.ariaLabelledby) {
-      value += ' ' + this.ariaLabelledby;
+      if (this.reverseLabelledByValueOrder) {
+        value = this.ariaLabelledby + ' ' + value;
+      } else {
+        value += ' ' + this.ariaLabelledby;
+      }
     }
 
     return value;


### PR DESCRIPTION
…matches visual label

Fixes a bug in the Angular Material paginator component where the screenreader accessible label for the 'Items per page:' combobox does not match the UI visual label. This is because the Angular Material select component has a function which gets the aria-labelledby string and places the value before the label.

Fixes b/286094434