### PR TITLE
fix(material/datepicker): mark for check when focus state is updated

### DIFF
--- a/src/material/datepicker/date-range-input.ts
+++ b/src/material/datepicker/date-range-input.ts
@@ -6,39 +6,39 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {CdkMonitorFocus, FocusOrigin} from '@angular/cdk/a11y';
 import {
-  Component,
-  ChangeDetectionStrategy,
-  ViewEncapsulation,
-  Input,
-  Optional,
-  OnDestroy,
-  ContentChild,
   AfterContentInit,
+  ChangeDetectionStrategy,
   ChangeDetectorRef,
-  Self,
+  Component,
+  ContentChild,
   ElementRef,
   Inject,
+  Input,
   OnChanges,
+  OnDestroy,
+  Optional,
+  Self,
   SimpleChanges,
+  ViewEncapsulation,
   booleanAttribute,
 } from '@angular/core';
-import {MatFormFieldControl, MAT_FORM_FIELD} from '@angular/material/form-field';
-import {ThemePalette, DateAdapter} from '@angular/material/core';
-import {NgControl, ControlContainer, Validators} from '@angular/forms';
-import {Subject, merge, Subscription} from 'rxjs';
-import {FocusOrigin, CdkMonitorFocus} from '@angular/cdk/a11y';
+import {ControlContainer, NgControl, Validators} from '@angular/forms';
+import {DateAdapter, ThemePalette} from '@angular/material/core';
+import {MAT_FORM_FIELD, MatFormFieldControl} from '@angular/material/form-field';
+import {Subject, Subscription, merge} from 'rxjs';
 import {
-  MatStartDate,
-  MatEndDate,
-  MatDateRangeInputParent,
   MAT_DATE_RANGE_INPUT_PARENT,
+  MatDateRangeInputParent,
+  MatEndDate,
+  MatStartDate,
 } from './date-range-input-parts';
-import {MatDatepickerControl, MatDatepickerPanel} from './datepicker-base';
-import {createMissingDateImplError} from './datepicker-errors';
-import {DateFilterFn, dateInputsHaveChanged, _MatFormFieldPartial} from './datepicker-input-base';
 import {MatDateRangePickerInput} from './date-range-picker';
 import {DateRange, MatDateSelectionModel} from './date-selection-model';
+import {MatDatepickerControl, MatDatepickerPanel} from './datepicker-base';
+import {createMissingDateImplError} from './datepicker-errors';
+import {DateFilterFn, _MatFormFieldPartial, dateInputsHaveChanged} from './datepicker-input-base';
 
 let nextUniqueId = 0;
 
@@ -407,6 +407,7 @@ export class MatDateRangeInput<D>
   _updateFocus(origin: FocusOrigin) {
     this.focused = origin !== null;
     this.stateChanges.next();
+    this._changeDetectorRef.markForCheck();
   }
 
   /** Re-runs the validators on the start/end inputs. */


### PR DESCRIPTION
Currently this works without the `markForCheck` call because `CdkFocusMonitor` emits the event inside `NgZone.run` which triggers a change detection. However, to make sure this continues working in the future, we should explicitly mark for check.