### PR TITLE
fix(material/menu): invert arrow in RTL

### DIFF
--- a/src/material/core/style/_menu-common.scss
+++ b/src/material/core/style/_menu-common.scss
@@ -63,12 +63,18 @@ $icon-margin: 16px !default;
   width: $icon-size;
   height: 10px;
   fill: currentColor;
+
+  // We use `padding` here, because the margin can collapse depending on the other content.
   padding-left: $item-spacing;
 
   [dir='rtl'] & {
-    right: auto;
     padding-right: $item-spacing;
     padding-left: 0;
+
+    // Invert the arrow direction.
+    polygon {
+      transform: scaleX(-1);
+    }
   }
 
   // Fix for Chromium-based browsers blending in the `currentColor` with the background.


### PR DESCRIPTION
Fixes a regression from #28470 where the nested menu icon isn't being inverted in RTL anymore.

Fixes #28813.