### PR TITLE
fix(material/card): Adds original padding for a card footer

### DIFF
--- a/src/material/card/card.scss
+++ b/src/material/card/card.scss
@@ -98,6 +98,8 @@ $mat-card-default-padding: 16px !default;
   }
 }
 
+
+
 // Header section at the top of a card. MDC does not have a pre-made header section for cards.
 // Maintained here for backwards compatibility with the previous generation MatCard.
 .mat-mdc-card-header {
@@ -107,6 +109,16 @@ $mat-card-default-padding: 16px !default;
   display: flex;
 
   // Apply default padding for the header region. Omit any bottom padding because we assume
+  // this region will be followed by another region that includes top padding.
+  padding: $mat-card-default-padding $mat-card-default-padding 0;
+}
+
+// Footer section at the bottom of a card. MDC does not have a pre-made footer section for cards.
+// Maintained here for backwards compatibility with the previous generation MatCard.
+.mat-mdc-card-header {
+  display: flex;
+
+  // Apply default padding for the footer region. Omit any bottom padding because we assume
   // this region will be followed by another region that includes top padding.
   padding: $mat-card-default-padding $mat-card-default-padding 0;
 }


### PR DESCRIPTION
The mat-progress-bar overflows when placed in the mat-card-footer. Content should not extend beyond the borders of the card

Fixes #28785