### PR TITLE
Add a zoneless toggle to the dev-app

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
 # Generated files for infrastructure.
 .yarn/releases/*.cjs
+.prettierrc
 
 # These schematic ng-generate files are template files that cannot be formatted.
 src/material/schematics/ng-generate/*/files/**/*

--- a/.prettierrc
+++ b/.prettierrc
@@ -5,5 +5,12 @@
   "quoteProps": "preserve",
   "bracketSpacing": false,
   "arrowParens": "avoid",
-  "embeddedLanguageFormatting": "off"
-}
+  "embeddedLanguageFormatting": "off",
+  "overrides": [
+    {
+      "files": "*.html",
+      "options": {
+        "parser": "angular"
+      }
+    }
+  ]}

--- a/src/components-examples/example-module.d.ts
+++ b/src/components-examples/example-module.d.ts
@@ -1,0 +1,20 @@
+interface LiveExample {
+  /** Title of the example. */
+  title: string;
+  /** Name of the example component. */
+  componentName: string;
+  /** Selector to match the component of this example. */
+  selector: string;
+  /** Name of the primary file of this example. */
+  primaryFile: string;
+  /** List of files which are part of the example. */
+  files: string[];
+  /** Path to the directory containing the example. */
+  packagePath: string;
+  /** List of additional components which are part of the example. */
+  additionalComponents: string[];
+  /** Path from which to import the xample. */
+  importPath: string;
+}
+
+export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample};

--- a/src/dev-app/autocomplete/autocomplete-demo.ts
+++ b/src/dev-app/autocomplete/autocomplete-demo.ts
@@ -6,16 +6,16 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, inject, ViewChild} from '@angular/core';
-import {FormControl, NgModel, FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {CommonModule} from '@angular/common';
+import {ChangeDetectionStrategy, Component, inject, ViewChild} from '@angular/core';
+import {FormControl, FormsModule, NgModel, ReactiveFormsModule} from '@angular/forms';
 import {MatAutocompleteModule} from '@angular/material/autocomplete';
 import {MatButtonModule} from '@angular/material/button';
 import {MatCardModule} from '@angular/material/card';
 import {MatCheckboxModule} from '@angular/material/checkbox';
-import {MatInputModule} from '@angular/material/input';
 import {ThemePalette} from '@angular/material/core';
 import {MatDialog, MatDialogRef} from '@angular/material/dialog';
+import {MatInputModule} from '@angular/material/input';
 
 export interface State {
   code: string;
@@ -45,6 +45,7 @@ type DisableStateOption = 'none' | 'first-middle-last' | 'all';
     MatInputModule,
     ReactiveFormsModule,
   ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AutocompleteDemo {
   stateCtrl = new FormControl();
@@ -246,6 +247,7 @@ export class AutocompleteDemo {
   `,
   standalone: true,
   imports: [CommonModule, FormsModule, MatAutocompleteModule, MatButtonModule, MatInputModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AutocompleteDemoExampleDialog {
   constructor(public dialogRef: MatDialogRef<AutocompleteDemoExampleDialog>) {}

--- a/src/dev-app/badge/badge-demo.ts
+++ b/src/dev-app/badge/badge-demo.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component} from '@angular/core';
 import {CommonModule} from '@angular/common';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {MatBadgeModule} from '@angular/material/badge';
 import {MatButtonModule} from '@angular/material/button';
@@ -19,6 +19,7 @@ import {MatIconModule} from '@angular/material/icon';
   styleUrl: 'badge-demo.css',
   standalone: true,
   imports: [CommonModule, FormsModule, MatBadgeModule, MatButtonModule, MatIconModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class BadgeDemo {
   visible = true;

--- a/src/dev-app/baseline/baseline-demo.ts
+++ b/src/dev-app/baseline/baseline-demo.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component} from '@angular/core';
 import {CommonModule} from '@angular/common';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {MatCardModule} from '@angular/material/card';
 import {MatCheckboxModule} from '@angular/material/checkbox';
 import {MatFormFieldModule} from '@angular/material/form-field';
@@ -31,6 +31,7 @@ import {MatToolbarModule} from '@angular/material/toolbar';
     MatSelectModule,
     MatToolbarModule,
   ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class BaselineDemo {
   name: string;

--- a/src/dev-app/bottom-sheet/bottom-sheet-demo.ts
+++ b/src/dev-app/bottom-sheet/bottom-sheet-demo.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, TemplateRef, ViewChild} from '@angular/core';
 import {CommonModule} from '@angular/common';
+import {ChangeDetectionStrategy, Component, TemplateRef, ViewChild} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {
   MatBottomSheet,
@@ -44,6 +44,7 @@ const defaultConfig = new MatBottomSheetConfig();
     MatSelectModule,
     MatListModule,
   ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class BottomSheetDemo {
   config: MatBottomSheetConfig = {
@@ -80,6 +81,7 @@ export class BottomSheetDemo {
   `,
   standalone: true,
   imports: [CommonModule, MatListModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ExampleBottomSheet {
   constructor(private _bottomSheet: MatBottomSheetRef) {}

--- a/src/dev-app/button-toggle/button-toggle-demo.ts
+++ b/src/dev-app/button-toggle/button-toggle-demo.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component} from '@angular/core';
 import {CommonModule} from '@angular/common';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {MatButtonToggleModule} from '@angular/material/button-toggle';
 import {MatCheckboxModule} from '@angular/material/checkbox';
@@ -19,6 +19,7 @@ import {MatIconModule} from '@angular/material/icon';
   styleUrl: 'button-toggle-demo.css',
   standalone: true,
   imports: [CommonModule, FormsModule, MatButtonToggleModule, MatCheckboxModule, MatIconModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ButtonToggleDemo {
   isVertical = false;

--- a/src/dev-app/button/button-demo.ts
+++ b/src/dev-app/button/button-demo.ts
@@ -6,21 +6,21 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component} from '@angular/core';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {
-  MatButton,
   MatAnchor,
-  MatFabButton,
+  MatButton,
   MatFabAnchor,
-  MatIconButton,
+  MatFabButton,
   MatIconAnchor,
-  MatMiniFabButton,
+  MatIconButton,
   MatMiniFabAnchor,
+  MatMiniFabButton,
 } from '@angular/material/button';
+import {MatCheckbox} from '@angular/material/checkbox';
 import {MatIcon} from '@angular/material/icon';
 import {MatTooltip} from '@angular/material/tooltip';
-import {MatCheckbox} from '@angular/material/checkbox';
 
 @Component({
   selector: 'button-demo',
@@ -41,6 +41,7 @@ import {MatCheckbox} from '@angular/material/checkbox';
     MatCheckbox,
     FormsModule,
   ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ButtonDemo {
   isDisabled = false;

--- a/src/dev-app/card/card-demo.ts
+++ b/src/dev-app/card/card-demo.ts
@@ -6,10 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, ViewEncapsulation} from '@angular/core';
-import {MatCardAppearance, MatCardModule} from '@angular/material/card';
+import {ChangeDetectionStrategy, Component, ViewEncapsulation} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {MatButtonModule} from '@angular/material/button';
+import {MatCardAppearance, MatCardModule} from '@angular/material/card';
 import {MatCheckboxModule} from '@angular/material/checkbox';
 
 @Component({
@@ -19,6 +19,7 @@ import {MatCheckboxModule} from '@angular/material/checkbox';
   encapsulation: ViewEncapsulation.None,
   standalone: true,
   imports: [MatCardModule, MatButtonModule, MatCheckboxModule, FormsModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class CardDemo {
   appearance: MatCardAppearance = 'raised';

--- a/src/dev-app/cdk-dialog/dialog-demo.ts
+++ b/src/dev-app/cdk-dialog/dialog-demo.ts
@@ -6,8 +6,17 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, Inject, TemplateRef, ViewChild, ViewEncapsulation} from '@angular/core';
-import {DIALOG_DATA, Dialog, DialogConfig, DialogRef, DialogModule} from '@angular/cdk/dialog';
+import {DIALOG_DATA, Dialog, DialogConfig, DialogModule, DialogRef} from '@angular/cdk/dialog';
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  Inject,
+  TemplateRef,
+  ViewChild,
+  ViewEncapsulation,
+  inject,
+} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 
 const defaultDialogConfig = new DialogConfig();
@@ -19,6 +28,7 @@ const defaultDialogConfig = new DialogConfig();
   encapsulation: ViewEncapsulation.None,
   standalone: true,
   imports: [DialogModule, FormsModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DialogDemo {
   dialogRef: DialogRef<string> | null;
@@ -43,6 +53,8 @@ export class DialogDemo {
 
   @ViewChild(TemplateRef) template: TemplateRef<any>;
 
+  readonly cdr = inject(ChangeDetectorRef);
+
   constructor(public dialog: Dialog) {}
 
   openJazz() {
@@ -51,12 +63,19 @@ export class DialogDemo {
     this.dialogRef.closed.subscribe(result => {
       this.result = result!;
       this.dialogRef = null;
+      this.cdr.markForCheck();
     });
   }
 
   openTemplate() {
     this.numTemplateOpens++;
-    this.dialog.open(this.template, this.config);
+    this.dialogRef = this.dialog.open(this.template, this.config);
+
+    this.dialogRef.closed.subscribe(result => {
+      this.result = result!;
+      this.dialogRef = null;
+      this.cdr.markForCheck();
+    });
   }
 }
 
@@ -92,6 +111,7 @@ export class DialogDemo {
     }
   `,
   standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class JazzDialog {
   private _dimensionToggle = false;

--- a/src/dev-app/cdk-experimental-combobox/cdk-combobox-demo.ts
+++ b/src/dev-app/cdk-experimental-combobox/cdk-combobox-demo.ts
@@ -6,13 +6,14 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component} from '@angular/core';
 import {CdkComboboxModule} from '@angular/cdk-experimental/combobox';
 import {CommonModule} from '@angular/common';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 
 @Component({
   templateUrl: 'cdk-combobox-demo.html',
   standalone: true,
   imports: [CdkComboboxModule, CommonModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class CdkComboboxDemo {}

--- a/src/dev-app/cdk-menu/cdk-menu-demo.ts
+++ b/src/dev-app/cdk-menu/cdk-menu-demo.ts
@@ -6,18 +6,18 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component} from '@angular/core';
-import {ConnectedPosition} from '@angular/cdk/overlay';
 import {CdkMenuModule} from '@angular/cdk/menu';
+import {ConnectedPosition} from '@angular/cdk/overlay';
 import {CommonModule} from '@angular/common';
 import {
+  CdkMenuContextExample,
+  CdkMenuInlineExample,
+  CdkMenuMenubarExample,
+  CdkMenuNestedContextExample,
   CdkMenuStandaloneMenuExample,
   CdkMenuStandaloneStatefulMenuExample,
-  CdkMenuMenubarExample,
-  CdkMenuInlineExample,
-  CdkMenuContextExample,
-  CdkMenuNestedContextExample,
 } from '@angular/components-examples/cdk/menu';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 
 @Component({
   templateUrl: 'cdk-menu-demo.html',
@@ -33,6 +33,7 @@ import {
     CdkMenuContextExample,
     CdkMenuNestedContextExample,
   ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class CdkMenuDemo {
   customPosition = [

--- a/src/dev-app/checkbox/checkbox-demo.ts
+++ b/src/dev-app/checkbox/checkbox-demo.ts
@@ -6,13 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, Directive, ANIMATION_MODULE_TYPE} from '@angular/core';
-import {MatCheckboxModule, MAT_CHECKBOX_DEFAULT_OPTIONS} from '@angular/material/checkbox';
+import {CommonModule} from '@angular/common';
+import {ANIMATION_MODULE_TYPE, ChangeDetectionStrategy, Component, Directive} from '@angular/core';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
+import {MAT_CHECKBOX_DEFAULT_OPTIONS, MatCheckboxModule} from '@angular/material/checkbox';
 import {MatPseudoCheckboxModule, ThemePalette} from '@angular/material/core';
 import {MatInputModule} from '@angular/material/input';
 import {MatSelectModule} from '@angular/material/select';
-import {CommonModule} from '@angular/common';
 
 export interface Task {
   name: string;
@@ -51,6 +51,7 @@ export class AnimationsNoop {}
   templateUrl: 'nested-checklist.html',
   standalone: true,
   imports: [CommonModule, MatCheckboxModule, FormsModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MatCheckboxDemoNestedChecklist {
   tasks: Task[] = [
@@ -114,6 +115,7 @@ export class MatCheckboxDemoNestedChecklist {
     ClickActionCheck,
     AnimationsNoop,
   ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class CheckboxDemo {
   isIndeterminate: boolean = false;

--- a/src/dev-app/chips/chips-demo.ts
+++ b/src/dev-app/chips/chips-demo.ts
@@ -6,19 +6,19 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, inject} from '@angular/core';
+import {LiveAnnouncer} from '@angular/cdk/a11y';
 import {COMMA, ENTER} from '@angular/cdk/keycodes';
 import {CommonModule} from '@angular/common';
-import {ThemePalette} from '@angular/material/core';
-import {MatChipInputEvent, MatChipEditedEvent, MatChipsModule} from '@angular/material/chips';
+import {ChangeDetectionStrategy, Component, inject} from '@angular/core';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {MatButtonModule} from '@angular/material/button';
 import {MatCardModule} from '@angular/material/card';
 import {MatCheckboxModule} from '@angular/material/checkbox';
+import {MatChipEditedEvent, MatChipInputEvent, MatChipsModule} from '@angular/material/chips';
+import {ThemePalette} from '@angular/material/core';
 import {MatFormFieldModule} from '@angular/material/form-field';
-import {MatToolbarModule} from '@angular/material/toolbar';
 import {MatIconModule} from '@angular/material/icon';
-import {LiveAnnouncer} from '@angular/cdk/a11y';
+import {MatToolbarModule} from '@angular/material/toolbar';
 
 export interface Person {
   name: string;
@@ -46,6 +46,7 @@ export interface DemoColor {
     MatToolbarModule,
     ReactiveFormsModule,
   ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ChipsDemo {
   visible = true;

--- a/src/dev-app/clipboard/clipboard-demo.ts
+++ b/src/dev-app/clipboard/clipboard-demo.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component} from '@angular/core';
 import {Clipboard, ClipboardModule} from '@angular/cdk/clipboard';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 
 @Component({
@@ -16,6 +16,7 @@ import {FormsModule} from '@angular/forms';
   templateUrl: 'clipboard-demo.html',
   standalone: true,
   imports: [ClipboardModule, FormsModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ClipboardDemo {
   attempts = 3;

--- a/src/dev-app/column-resize/column-resize-home.ts
+++ b/src/dev-app/column-resize/column-resize-home.ts
@@ -6,12 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component} from '@angular/core';
 import {
   DefaultEnabledColumnResizeExample,
   DefaultEnabledColumnResizeFlexExample,
   OptInColumnResizeExample,
 } from '@angular/components-examples/material-experimental/column-resize';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {MatExpansionModule} from '@angular/material/expansion';
 
 @Component({
@@ -23,5 +23,6 @@ import {MatExpansionModule} from '@angular/material/expansion';
     DefaultEnabledColumnResizeFlexExample,
     OptInColumnResizeExample,
   ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ColumnResizeHome {}

--- a/src/dev-app/connected-overlay/connected-overlay-demo.ts
+++ b/src/dev-app/connected-overlay/connected-overlay-demo.ts
@@ -19,6 +19,7 @@ import {TemplatePortal} from '@angular/cdk/portal';
 import {CommonModule} from '@angular/common';
 import {CdkOverlayBasicExample} from '@angular/components-examples/cdk/overlay';
 import {
+  ChangeDetectionStrategy,
   Component,
   TemplateRef,
   ViewChild,
@@ -45,6 +46,7 @@ import {MatRadioModule} from '@angular/material/radio';
     MatRadioModule,
     OverlayModule,
   ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ConnectedOverlayDemo {
   @ViewChild(CdkOverlayOrigin) _overlayOrigin: CdkOverlayOrigin;

--- a/src/dev-app/datepicker/datepicker-demo.ts
+++ b/src/dev-app/datepicker/datepicker-demo.ts
@@ -6,30 +6,30 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {CommonModule} from '@angular/common';
 import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
+  Directive,
   Inject,
+  Injectable,
   OnDestroy,
   Optional,
   ViewChild,
   ViewEncapsulation,
-  Directive,
-  Injectable,
 } from '@angular/core';
-import {CommonModule} from '@angular/common';
 import {FormControl, FormGroup, FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {MatButtonModule} from '@angular/material/button';
 import {MatCheckboxModule} from '@angular/material/checkbox';
 import {DateAdapter, MAT_DATE_FORMATS, MatDateFormats, ThemePalette} from '@angular/material/core';
 import {
+  DateRange,
+  MAT_DATE_RANGE_SELECTION_STRATEGY,
   MatCalendar,
   MatCalendarHeader,
-  MatDatepickerInputEvent,
-  MAT_DATE_RANGE_SELECTION_STRATEGY,
   MatDateRangeSelectionStrategy,
-  DateRange,
+  MatDatepickerInputEvent,
   MatDatepickerModule,
 } from '@angular/material/datepicker';
 import {MatFormFieldModule} from '@angular/material/form-field';
@@ -146,7 +146,7 @@ export class CustomHeader<D> implements OnDestroy {
 }
 
 @Component({
-  selector: 'customer-header-ng-content',
+  selector: 'custom-header-ng-content',
   template: `
       <mat-calendar-header #header>
         <button mat-button type="button" (click)="todayClicked()">TODAY</button>
@@ -154,6 +154,7 @@ export class CustomHeader<D> implements OnDestroy {
     `,
   standalone: true,
   imports: [MatDatepickerModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class CustomHeaderNgContent<D> {
   @ViewChild(MatCalendarHeader)
@@ -238,8 +239,8 @@ export class DatepickerDemo {
     return !(date.getFullYear() % 2) && Boolean(date.getMonth() % 2) && !(date.getDate() % 2);
   };
 
-  onDateInput = (e: MatDatepickerInputEvent<Date>) => (this.lastDateInput = e.value);
-  onDateChange = (e: MatDatepickerInputEvent<Date>) => (this.lastDateChange = e.value);
+  onDateInput = (e: MatDatepickerInputEvent<Date, Date | null>) => (this.lastDateInput = e.value);
+  onDateChange = (e: MatDatepickerInputEvent<Date, Date | null>) => (this.lastDateChange = e.value);
 
   // pass custom header component type as input
   customHeader = CustomHeader;

--- a/src/dev-app/dev-app.ts
+++ b/src/dev-app/dev-app.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, ViewEncapsulation} from '@angular/core';
+import {ChangeDetectionStrategy, Component, ViewEncapsulation} from '@angular/core';
 import {RouterModule} from '@angular/router';
 import {DevAppLayout} from './dev-app/dev-app-layout';
 
@@ -17,5 +17,6 @@ import {DevAppLayout} from './dev-app/dev-app-layout';
   encapsulation: ViewEncapsulation.None,
   standalone: true,
   imports: [DevAppLayout, RouterModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DevApp {}

--- a/src/dev-app/dev-app/dev-app-404.ts
+++ b/src/dev-app/dev-app/dev-app-404.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component} from '@angular/core';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {MatButtonModule} from '@angular/material/button';
 import {RouterModule} from '@angular/router';
 
@@ -19,5 +19,6 @@ import {RouterModule} from '@angular/router';
   host: {'class': 'mat-typography'},
   standalone: true,
   imports: [MatButtonModule, RouterModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DevApp404 {}

--- a/src/dev-app/dev-app/dev-app-home.ts
+++ b/src/dev-app/dev-app/dev-app-home.ts
@@ -7,7 +7,7 @@
  */
 
 /** Home component which includes a welcome message for the dev-app. */
-import {Component} from '@angular/core';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 
 @Component({
   template: `
@@ -15,5 +15,6 @@ import {Component} from '@angular/core';
     <p>Open the sidenav to select a demo.</p>
   `,
   standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DevAppHome {}

--- a/src/dev-app/dev-app/dev-app-layout.html
+++ b/src/dev-app/dev-app/dev-app-layout.html
@@ -8,22 +8,18 @@
           routerLinkActive
           #routerLinkActiveInstance="routerLinkActive"
           [attr.tabindex]="routerLinkActiveInstance.isActive ? 0 : -1"
-          [routerLink]="[navItem.route]">{{navItem.name}}</a>
+          [routerLink]="[navItem.route]"
+          >{{navItem.name}}</a
+        >
       }
 
       <mat-divider></mat-divider>
 
-      <a mat-list-item
-          tabindex="-1"
-          (click)="navigation.close()"
-          [routerLink]="['/baseline']">
+      <a mat-list-item tabindex="-1" (click)="navigation.close()" [routerLink]="['/baseline']">
         Baseline
       </a>
 
-      <a mat-list-item
-         tabindex="-1"
-         (click)="navigation.close()"
-         [routerLink]="['/performance']">
+      <a mat-list-item tabindex="-1" (click)="navigation.close()" [routerLink]="['/performance']">
         Performance
       </a>
     </mat-nav-list>
@@ -47,22 +43,21 @@
         <div class="demo-config-buttons">
           @if (state.m3Enabled) {
             <button
-                mat-icon-button
-                (click)="toggleColorApiBackCompat()"
-                matTooltip="{{state.colorApiBackCompat ? 'Disable' : 'Enable'}} color API back-compat">
+              mat-icon-button
+              (click)="toggleColorApiBackCompat()"
+              matTooltip="{{state.colorApiBackCompat ? 'Disable' : 'Enable'}} color API back-compat"
+            >
               <mat-icon>colorize</mat-icon>
             </button>
           }
-          <button
-            mat-icon-button
-            (click)="toggleFullscreen()"
-            matTooltip="Toggle fullscreen">
+          <button mat-icon-button (click)="toggleFullscreen()" matTooltip="Toggle fullscreen">
             <mat-icon>fullscreen</mat-icon>
           </button>
           <button
             mat-icon-button
             (click)="toggleM3()"
-            [matTooltip]="state.m3Enabled ? 'Use M2 theme' : 'Use M3 theme'">
+            [matTooltip]="state.m3Enabled ? 'Use M2 theme' : 'Use M3 theme'"
+          >
             @if (state.m3Enabled) {
               <mat-icon>invert_colors_off</mat-icon>
             } @else {
@@ -71,8 +66,20 @@
           </button>
           <button
             mat-icon-button
+            (click)="toggleZoneless()"
+            [matTooltip]="isZoneless ? 'Use zones' : 'Use zoneless'"
+          >
+            @if (isZoneless) {
+              <mat-icon>visibility</mat-icon>
+            } @else {
+              <mat-icon>visibility_off</mat-icon>
+            }
+          </button>
+          <button
+            mat-icon-button
             (click)="toggleAnimations()"
-            [matTooltip]="state.animations ? 'Disable animations' : 'Enable animations'">
+            [matTooltip]="state.animations ? 'Disable animations' : 'Enable animations'"
+          >
             @if (state.animations) {
               <mat-icon>pause_circle</mat-icon>
             } @else {
@@ -82,7 +89,8 @@
           <button
             mat-icon-button
             (click)="toggleTheme()"
-            [matTooltip]="state.darkTheme ? 'Switch to light theme' : 'Switch to dark theme'">
+            [matTooltip]="state.darkTheme ? 'Switch to light theme' : 'Switch to dark theme'"
+          >
             @if (state.darkTheme) {
               <mat-icon>light_mode</mat-icon>
             } @else {
@@ -92,7 +100,8 @@
           <button
             mat-icon-button
             (click)="toggleRippleDisabled()"
-            [matTooltip]="state.rippleDisabled ? 'Enable ripples' : 'Disable ripples'">
+            [matTooltip]="state.rippleDisabled ? 'Enable ripples' : 'Disable ripples'"
+          >
             @if (state.rippleDisabled) {
               <mat-icon>waves</mat-icon>
             } @else {
@@ -102,7 +111,8 @@
           <button
             mat-icon-button
             (click)="toggleStrongFocus()"
-            [matTooltip]="state.strongFocusEnabled ? 'Disable strong focus' : 'Enable strong focus'">
+            [matTooltip]="state.strongFocusEnabled ? 'Disable strong focus' : 'Enable strong focus'"
+          >
             @if (state.strongFocusEnabled) {
               <mat-icon>not_accessible</mat-icon>
             } @else {
@@ -112,7 +122,8 @@
           <button
             mat-icon-button
             (click)="toggleDirection()"
-            [matTooltip]="state.direction === 'rtl' ? 'Switch to LTR' : 'Switch to RTL'">
+            [matTooltip]="state.direction === 'rtl' ? 'Switch to LTR' : 'Switch to RTL'"
+          >
             @if (state.direction === 'rtl') {
               <mat-icon>west</mat-icon>
             } @else {
@@ -123,7 +134,8 @@
             #densityTooltip="matTooltip"
             mat-icon-button
             (click)="toggleDensity(undefined, densityTooltip)"
-            [matTooltip]="'Density: ' + state.density">
+            [matTooltip]="'Density: ' + state.density"
+          >
             <mat-icon>grid_on</mat-icon>
           </button>
         </div>

--- a/src/dev-app/dev-app/dev-app-layout.ts
+++ b/src/dev-app/dev-app/dev-app-layout.ts
@@ -6,19 +6,26 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ChangeDetectorRef, Component, ElementRef, Inject, ViewEncapsulation} from '@angular/core';
-import {CommonModule, DOCUMENT} from '@angular/common';
 import {Direction, Directionality} from '@angular/cdk/bidi';
-import {MatSidenavModule} from '@angular/material/sidenav';
-import {MatListModule} from '@angular/material/list';
+import {CommonModule, DOCUMENT} from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  ElementRef,
+  Inject,
+  ViewEncapsulation,
+} from '@angular/core';
 import {MatButtonModule} from '@angular/material/button';
-import {RouterModule} from '@angular/router';
 import {MatIconModule, MatIconRegistry} from '@angular/material/icon';
+import {MatListModule} from '@angular/material/list';
+import {MatSidenavModule} from '@angular/material/sidenav';
 import {MatToolbarModule} from '@angular/material/toolbar';
 import {MatTooltip, MatTooltipModule} from '@angular/material/tooltip';
+import {RouterModule} from '@angular/router';
 import {DevAppDirectionality} from './dev-app-directionality';
-import {DevAppRippleOptions} from './ripple-options';
 import {getAppState, setAppState} from './dev-app-state';
+import {DevAppRippleOptions} from './ripple-options';
 
 /** Root component for the dev-app demos. */
 @Component({
@@ -37,6 +44,7 @@ import {getAppState, setAppState} from './dev-app-state';
     MatTooltipModule,
     RouterModule,
   ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DevAppLayout {
   state = getAppState();

--- a/src/dev-app/dev-app/dev-app-layout.ts
+++ b/src/dev-app/dev-app/dev-app-layout.ts
@@ -14,7 +14,10 @@ import {
   Component,
   ElementRef,
   Inject,
+  NgZone,
   ViewEncapsulation,
+  inject,
+  ɵNoopNgZone,
 } from '@angular/core';
 import {MatButtonModule} from '@angular/material/button';
 import {MatIconModule, MatIconRegistry} from '@angular/material/icon';
@@ -112,6 +115,10 @@ export class DevAppLayout {
   /** List of possible global density scale values. */
   private _densityScales = [0, -1, -2, -3, -4, 'minimum', 'maximum'];
 
+  private _ngZone = inject(NgZone);
+
+  readonly isZoneless = this._ngZone instanceof ɵNoopNgZone;
+
   constructor(
     private _element: ElementRef<HTMLElement>,
     private _rippleOptions: DevAppRippleOptions,
@@ -143,6 +150,12 @@ export class DevAppLayout {
     this.state.strongFocusEnabled = value;
     this._document.body.classList.toggle('demo-strong-focus', value);
     setAppState(this.state);
+  }
+
+  toggleZoneless(value = !this.isZoneless) {
+    this.state.zoneless = value;
+    setAppState(this.state);
+    location.reload();
   }
 
   toggleAnimations() {

--- a/src/dev-app/dev-app/dev-app-state.ts
+++ b/src/dev-app/dev-app/dev-app-state.ts
@@ -14,6 +14,7 @@ const KEY = 'MAT_DEV_APP_STATE';
 export interface DevAppState {
   density: string | number;
   animations: boolean;
+  zoneless: boolean;
   darkTheme: boolean;
   rippleDisabled: boolean;
   strongFocusEnabled: boolean;
@@ -39,6 +40,7 @@ export function getAppState(): DevAppState {
     value = {
       density: 0,
       animations: true,
+      zoneless: false,
       darkTheme: false,
       rippleDisabled: false,
       strongFocusEnabled: false,
@@ -56,7 +58,9 @@ export function getAppState(): DevAppState {
 /** Saves the state of the dev app apperance in local storage. */
 export function setAppState(newState: DevAppState): void {
   const currentState = getAppState();
-  const keys = Object.keys(currentState) as (keyof DevAppState)[];
+  const keys = new Set([...Object.keys(currentState), ...Object.keys(newState)]) as Set<
+    keyof DevAppState
+  >;
 
   // Only write to storage if something actually changed.
   for (const key of keys) {

--- a/src/dev-app/dialog/dialog-demo.html
+++ b/src/dev-app/dialog/dialog-demo.html
@@ -25,33 +25,33 @@
     <p>
       <mat-form-field>
         <mat-label>Width</mat-label>
-        <input matInput [(ngModel)]="config.width">
+        <input matInput [(ngModel)]="config.width" />
       </mat-form-field>
       <mat-form-field>
         <mat-label>Height</mat-label>
-        <input matInput [(ngModel)]="config.height">
+        <input matInput [(ngModel)]="config.height" />
       </mat-form-field>
     </p>
 
     <p>
       <mat-form-field>
         <mat-label>Min width</mat-label>
-        <input matInput [(ngModel)]="config.minWidth">
+        <input matInput [(ngModel)]="config.minWidth" />
       </mat-form-field>
       <mat-form-field>
         <mat-label>Min height</mat-label>
-        <input matInput [(ngModel)]="config.minHeight">
+        <input matInput [(ngModel)]="config.minHeight" />
       </mat-form-field>
     </p>
 
     <p>
       <mat-form-field>
         <mat-label>Max width</mat-label>
-        <input matInput [(ngModel)]="config.maxWidth">
+        <input matInput [(ngModel)]="config.maxWidth" />
       </mat-form-field>
       <mat-form-field>
         <mat-label>Max height</mat-label>
-        <input matInput [(ngModel)]="config.maxHeight">
+        <input matInput [(ngModel)]="config.maxHeight" />
       </mat-form-field>
     </p>
 
@@ -60,22 +60,22 @@
     <p>
       <mat-form-field>
         <mat-label>Top</mat-label>
-        <input matInput [(ngModel)]="config.position.top" (change)="config.position.bottom = ''">
+        <input matInput [(ngModel)]="config.position.top" (change)="config.position.bottom = ''" />
       </mat-form-field>
       <mat-form-field>
         <mat-label>Bottom</mat-label>
-        <input matInput [(ngModel)]="config.position.bottom" (change)="config.position.top = ''">
+        <input matInput [(ngModel)]="config.position.bottom" (change)="config.position.top = ''" />
       </mat-form-field>
     </p>
 
     <p>
       <mat-form-field>
         <mat-label>Left</mat-label>
-        <input matInput [(ngModel)]="config.position.left" (change)="config.position.right = ''">
+        <input matInput [(ngModel)]="config.position.left" (change)="config.position.right = ''" />
       </mat-form-field>
       <mat-form-field>
         <mat-label>Right</mat-label>
-        <input matInput [(ngModel)]="config.position.right" (change)="config.position.left = ''">
+        <input matInput [(ngModel)]="config.position.right" (change)="config.position.left = ''" />
       </mat-form-field>
     </p>
 
@@ -84,7 +84,7 @@
     <p>
       <mat-form-field>
         <mat-label>Backdrop class</mat-label>
-        <input matInput [(ngModel)]="config.backdropClass">
+        <input matInput [(ngModel)]="config.backdropClass" />
       </mat-form-field>
     </p>
 
@@ -106,7 +106,7 @@
     <p>
       <mat-form-field>
         <mat-label>Dialog message</mat-label>
-        <input matInput [(ngModel)]="config.data.message">
+        <input matInput [(ngModel)]="config.data.message" />
       </mat-form-field>
     </p>
 
@@ -116,15 +116,15 @@
   </mat-card-content>
 </mat-card>
 
-<p>Last afterClosed result: {{lastAfterClosedResult}}</p>
-<p>Last beforeClose result: {{lastBeforeCloseResult}}</p>
+<p>Last afterClosed result: {{lastAfterClosedResult | json}}</p>
+<p>Last beforeClose result: {{lastBeforeCloseResult | json}}</p>
 
 <ng-template let-data let-dialogRef="dialogRef">
   <p>Order printer ink refills.</p>
 
   <mat-form-field>
     <mat-label>How many?</mat-label>
-    <input matInput #howMuch>
+    <input matInput #howMuch />
   </mat-form-field>
 
   <mat-form-field>
@@ -138,16 +138,22 @@
     </mat-select>
   </mat-form-field>
 
-  <p> {{ data.message }} </p>
+  <p>{{ data.message }}</p>
 
   <p>I'm a template dialog. I've been opened {{numTemplateOpens}} times!</p>
 
-  <button type="button" class="demo-dialog-button" cdkFocusInitial
-          (click)="dialogRef.close({ quantity: howMuch.value, color: whatColor.value })">
+  <button
+    type="button"
+    class="demo-dialog-button"
+    cdkFocusInitial
+    (click)="dialogRef.close({ quantity: howMuch.value, color: whatColor.value })"
+  >
     Close dialog
   </button>
-  <button (click)="dialogRef.updateSize('500px', '500px').updatePosition({top: '25px', left: '25px'});"
-          class="demo-dialog-button">
+  <button
+    (click)="dialogRef.updateSize('500px', '500px').updatePosition({top: '25px', left: '25px'});"
+    class="demo-dialog-button"
+  >
     Change dimensions
   </button>
 </ng-template>

--- a/src/dev-app/dialog/dialog-demo.ts
+++ b/src/dev-app/dialog/dialog-demo.ts
@@ -6,8 +6,22 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {DOCUMENT} from '@angular/common';
-import {Component, Inject, TemplateRef, ViewChild, ViewEncapsulation} from '@angular/core';
+import {DragDropModule} from '@angular/cdk/drag-drop';
+import {DOCUMENT, JsonPipe} from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  Inject,
+  TemplateRef,
+  ViewChild,
+  ViewEncapsulation,
+  inject,
+} from '@angular/core';
+import {FormsModule} from '@angular/forms';
+import {MatButtonModule} from '@angular/material/button';
+import {MatCardModule} from '@angular/material/card';
+import {MatCheckboxModule} from '@angular/material/checkbox';
 import {
   MAT_DIALOG_DATA,
   MatDialog,
@@ -18,14 +32,9 @@ import {
   MatDialogRef,
   MatDialogTitle,
 } from '@angular/material/dialog';
-import {FormsModule} from '@angular/forms';
-import {MatButtonModule} from '@angular/material/button';
-import {MatCardModule} from '@angular/material/card';
-import {MatCheckboxModule} from '@angular/material/checkbox';
 import {MatFormFieldModule} from '@angular/material/form-field';
 import {MatInputModule} from '@angular/material/input';
 import {MatSelectModule} from '@angular/material/select';
-import {DragDropModule} from '@angular/cdk/drag-drop';
 
 @Component({
   selector: 'dialog-demo',
@@ -43,7 +52,9 @@ import {DragDropModule} from '@angular/cdk/drag-drop';
     MatFormFieldModule,
     MatInputModule,
     MatSelectModule,
+    JsonPipe,
   ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DialogDemo {
   dialogRef: MatDialogRef<JazzDialog> | null;
@@ -77,6 +88,8 @@ export class DialogDemo {
 
   @ViewChild(TemplateRef) template: TemplateRef<any>;
 
+  readonly cdr = inject(ChangeDetectorRef);
+
   constructor(
     public dialog: MatDialog,
     @Inject(DOCUMENT) doc: any,
@@ -99,10 +112,12 @@ export class DialogDemo {
 
     this.dialogRef.beforeClosed().subscribe((result: string) => {
       this.lastBeforeCloseResult = result;
+      this.cdr.markForCheck();
     });
     this.dialogRef.afterClosed().subscribe((result: string) => {
       this.lastAfterClosedResult = result;
       this.dialogRef = null;
+      this.cdr.markForCheck();
     });
   }
 
@@ -162,6 +177,7 @@ export class DialogDemo {
   styles: `.hidden-dialog { opacity: 0; }`,
   standalone: true,
   imports: [DragDropModule, MatInputModule, MatSelectModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class JazzDialog {
   private _dimensionToggle = false;
@@ -239,6 +255,7 @@ export class JazzDialog {
   `,
   standalone: true,
   imports: [MatButtonModule, MatDialogTitle, MatDialogContent, MatDialogClose, MatDialogActions],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ContentElementDialog {
   actionsAlignment?: 'start' | 'center' | 'end';
@@ -275,5 +292,6 @@ export class ContentElementDialog {
   `,
   standalone: true,
   imports: [MatButtonModule, MatDialogTitle, MatDialogContent, MatDialogClose, MatDialogActions],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class IFrameDialog {}

--- a/src/dev-app/drawer/drawer-demo.ts
+++ b/src/dev-app/drawer/drawer-demo.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component} from '@angular/core';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {MatButtonModule} from '@angular/material/button';
 import {MatListModule} from '@angular/material/list';
 import {MatSidenavModule} from '@angular/material/sidenav';
@@ -17,6 +17,7 @@ import {MatSidenavModule} from '@angular/material/sidenav';
   styleUrl: 'drawer-demo.css',
   standalone: true,
   imports: [MatButtonModule, MatListModule, MatSidenavModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DrawerDemo {
   invert = false;

--- a/src/dev-app/example/example-list.ts
+++ b/src/dev-app/example/example-list.ts
@@ -9,7 +9,7 @@
 import {BooleanInput, coerceBooleanProperty} from '@angular/cdk/coercion';
 import {CommonModule} from '@angular/common';
 import {EXAMPLE_COMPONENTS} from '@angular/components-examples';
-import {Component, Input} from '@angular/core';
+import {ChangeDetectionStrategy, Component, Input} from '@angular/core';
 import {MatExpansionModule} from '@angular/material/expansion';
 import {Example} from './example';
 
@@ -58,6 +58,7 @@ import {Example} from './example';
       font-size: 12px;
     }
   `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ExampleList {
   /** Type of examples being displayed. */

--- a/src/dev-app/example/example.ts
+++ b/src/dev-app/example/example.ts
@@ -11,6 +11,7 @@ import {CommonModule} from '@angular/common';
 import {EXAMPLE_COMPONENTS} from '@angular/components-examples';
 import {loadExample} from '@angular/components-examples/private';
 import {
+  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   Injector,
@@ -57,6 +58,7 @@ import {
       white-space: pre;
     }
   `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class Example implements OnInit {
   /** ID of the material example to display. */
@@ -84,6 +86,6 @@ export class Example implements OnInit {
 
     const example = await loadExample(this.id, this._injector);
     this._viewContainerRef.createComponent(example.component, {injector: example.injector});
-    this._changeDetectorRef.detectChanges();
+    this._changeDetectorRef.markForCheck();
   }
 }

--- a/src/dev-app/examples-page/examples-page.ts
+++ b/src/dev-app/examples-page/examples-page.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component} from '@angular/core';
 import {EXAMPLE_COMPONENTS} from '@angular/components-examples';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {ExampleList} from '../example/example-list';
 
 /** Renders all material examples listed in the generated EXAMPLE_COMPONENTS. */
@@ -15,6 +15,7 @@ import {ExampleList} from '../example/example-list';
   template: `<material-example-list [ids]="examples"></material-example-list>`,
   standalone: true,
   imports: [ExampleList],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ExamplesPage {
   examples = Object.keys(EXAMPLE_COMPONENTS);

--- a/src/dev-app/expansion/expansion-demo.ts
+++ b/src/dev-app/expansion/expansion-demo.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, ViewChild} from '@angular/core';
 import {CdkAccordionModule} from '@angular/cdk/accordion';
 import {CommonModule} from '@angular/common';
+import {ChangeDetectionStrategy, Component, ViewChild} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {MatButtonModule} from '@angular/material/button';
 import {MatCheckboxModule} from '@angular/material/checkbox';
@@ -40,6 +40,7 @@ import {MatSlideToggleModule} from '@angular/material/slide-toggle';
     MatRadioModule,
     MatSlideToggleModule,
   ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ExpansionDemo {
   @ViewChild(MatAccordion) accordion: MatAccordion;

--- a/src/dev-app/focus-origin/focus-origin-demo.ts
+++ b/src/dev-app/focus-origin/focus-origin-demo.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component} from '@angular/core';
 import {A11yModule, FocusMonitor} from '@angular/cdk/a11y';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 
 @Component({
   selector: 'focus-origin-demo',
@@ -15,6 +15,7 @@ import {A11yModule, FocusMonitor} from '@angular/cdk/a11y';
   styleUrl: 'focus-origin-demo.css',
   standalone: true,
   imports: [A11yModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class FocusOriginDemo {
   constructor(public fom: FocusMonitor) {}

--- a/src/dev-app/focus-trap/focus-trap-demo.ts
+++ b/src/dev-app/focus-trap/focus-trap-demo.ts
@@ -6,16 +6,23 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {A11yModule, CdkTrapFocus} from '@angular/cdk/a11y';
+import {_supportsShadowDom} from '@angular/cdk/platform';
+import {CommonModule} from '@angular/common';
 import {
   AfterViewInit,
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
   Component,
   ElementRef,
-  ViewChild,
-  ViewEncapsulation,
-  ViewChildren,
   QueryList,
+  ViewChild,
+  ViewChildren,
+  ViewEncapsulation,
+  inject,
 } from '@angular/core';
-import {A11yModule, CdkTrapFocus} from '@angular/cdk/a11y';
+import {MatButtonModule} from '@angular/material/button';
+import {MatCardModule} from '@angular/material/card';
 import {
   MatDialog,
   MatDialogActions,
@@ -23,10 +30,6 @@ import {
   MatDialogContent,
   MatDialogTitle,
 } from '@angular/material/dialog';
-import {_supportsShadowDom} from '@angular/cdk/platform';
-import {CommonModule} from '@angular/common';
-import {MatButtonModule} from '@angular/material/button';
-import {MatCardModule} from '@angular/material/card';
 import {MatToolbarModule} from '@angular/material/toolbar';
 
 @Component({
@@ -35,6 +38,7 @@ import {MatToolbarModule} from '@angular/material/toolbar';
   host: {'class': 'demo-focus-trap-shadow-root'},
   encapsulation: ViewEncapsulation.ShadowDom,
   standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class FocusTrapShadowDomDemo {}
 
@@ -51,6 +55,7 @@ export class FocusTrapShadowDomDemo {}
     MatToolbarModule,
     FocusTrapShadowDomDemo,
   ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class FocusTrapDemo implements AfterViewInit {
   @ViewChild('newElements')
@@ -61,6 +66,8 @@ export class FocusTrapDemo implements AfterViewInit {
 
   _supportsShadowDom = _supportsShadowDom();
 
+  readonly cdr = inject(ChangeDetectorRef);
+
   constructor(public dialog: MatDialog) {}
 
   ngAfterViewInit() {
@@ -68,6 +75,7 @@ export class FocusTrapDemo implements AfterViewInit {
     // the view will result in "changed after checked" errors so we defer it to the next tick.
     setTimeout(() => {
       this._focusTraps.forEach(trap => (trap.enabled = false));
+      this.cdr.markForCheck();
     });
   }
 
@@ -97,6 +105,7 @@ let dialogCount = 0;
   templateUrl: 'focus-trap-dialog-demo.html',
   standalone: true,
   imports: [MatDialogTitle, MatDialogContent, MatDialogClose, MatDialogActions],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class FocusTrapDialogDemo {
   id = dialogCount++;

--- a/src/dev-app/google-map/google-map-demo.ts
+++ b/src/dev-app/google-map/google-map-demo.ts
@@ -7,9 +7,16 @@
  */
 
 import {CommonModule} from '@angular/common';
-import {Component, ViewChild} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  ViewChild,
+  inject,
+} from '@angular/core';
 import {
   GoogleMap,
+  MapAdvancedMarker,
   MapBicyclingLayer,
   MapCircle,
   MapDirectionsRenderer,
@@ -25,7 +32,6 @@ import {
   MapRectangle,
   MapTrafficLayer,
   MapTransitLayer,
-  MapAdvancedMarker,
 } from '@angular/google-maps';
 
 const POLYLINE_PATH: google.maps.LatLngLiteral[] = [
@@ -80,6 +86,7 @@ let apiLoadingPromise: Promise<unknown> | null = null;
     MapTrafficLayer,
     MapTransitLayer,
   ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class GoogleMapDemo {
   @ViewChild(MapInfoWindow) infoWindow: MapInfoWindow;
@@ -87,6 +94,7 @@ export class GoogleMapDemo {
   @ViewChild(MapPolygon) polygon: MapPolygon;
   @ViewChild(MapRectangle) rectangle: MapRectangle;
   @ViewChild(MapCircle) circle: MapCircle;
+  readonly cdr = inject(ChangeDetectorRef);
 
   center = {lat: 24, lng: 12};
   mapAdvancedMarkerPosition = {lat: 22, lng: 21};
@@ -278,6 +286,7 @@ export class GoogleMapDemo {
       };
       this._mapDirectionsService.route(request).subscribe(response => {
         this.directionsResult = response.result;
+        this.cdr.markForCheck();
       });
     }
   }
@@ -310,7 +319,10 @@ export class GoogleMapDemo {
     }
 
     apiLoadingPromise.then(
-      () => (this.hasLoaded = true),
+      () => {
+        this.hasLoaded = true;
+        this.cdr.markForCheck();
+      },
       error => console.error('Failed to load Google Maps API', error),
     );
   }

--- a/src/dev-app/grid-list/grid-list-demo.ts
+++ b/src/dev-app/grid-list/grid-list-demo.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component} from '@angular/core';
 import {CommonModule} from '@angular/common';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {MatButtonModule} from '@angular/material/button';
 import {MatCardModule} from '@angular/material/card';
@@ -27,6 +27,7 @@ import {MatIconModule} from '@angular/material/icon';
     MatGridListModule,
     MatIconModule,
   ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class GridListDemo {
   tiles: {text: string; cols: number; rows: number; color: string}[] = [

--- a/src/dev-app/icon/icon-demo.ts
+++ b/src/dev-app/icon/icon-demo.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component} from '@angular/core';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {MatIconModule, MatIconRegistry} from '@angular/material/icon';
 import {DomSanitizer} from '@angular/platform-browser';
 
@@ -16,6 +16,7 @@ import {DomSanitizer} from '@angular/platform-browser';
   styleUrl: 'icon-demo.css',
   standalone: true,
   imports: [MatIconModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class IconDemo {
   constructor(iconRegistry: MatIconRegistry, sanitizer: DomSanitizer) {

--- a/src/dev-app/input-modality/input-modality-detector-demo.ts
+++ b/src/dev-app/input-modality/input-modality-detector-demo.ts
@@ -6,17 +6,24 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, OnDestroy, NgZone} from '@angular/core';
 import {A11yModule, InputModality, InputModalityDetector} from '@angular/cdk/a11y';
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  NgZone,
+  OnDestroy,
+  inject,
+} from '@angular/core';
 
-import {Subject} from 'rxjs';
-import {takeUntil} from 'rxjs/operators';
 import {CommonModule} from '@angular/common';
 import {MatButtonModule} from '@angular/material/button';
 import {MatFormFieldModule} from '@angular/material/form-field';
 import {MatInputModule} from '@angular/material/input';
 import {MatRadioModule} from '@angular/material/radio';
 import {MatSelectModule} from '@angular/material/select';
+import {Subject} from 'rxjs';
+import {takeUntil} from 'rxjs/operators';
 
 @Component({
   selector: 'input-modality-detector-demo',
@@ -31,15 +38,18 @@ import {MatSelectModule} from '@angular/material/select';
     MatRadioModule,
     MatSelectModule,
   ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class InputModalityDetectorDemo implements OnDestroy {
   _modality: InputModality = null;
   _destroyed = new Subject<void>();
+  readonly cdr = inject(ChangeDetectorRef);
 
   constructor(inputModalityDetector: InputModalityDetector, ngZone: NgZone) {
     inputModalityDetector.modalityChanged.pipe(takeUntil(this._destroyed)).subscribe(modality =>
       ngZone.run(() => {
         this._modality = modality;
+        this.cdr.markForCheck();
       }),
     );
   }

--- a/src/dev-app/layout/layout-demo.ts
+++ b/src/dev-app/layout/layout-demo.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {BreakpointObserverOverviewExample} from '@angular/components-examples/cdk/layout';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 
 @Component({
   selector: 'layout-demo',
@@ -16,5 +16,6 @@ import {BreakpointObserverOverviewExample} from '@angular/components-examples/cd
   styleUrl: 'layout-demo.css',
   standalone: true,
   imports: [CommonModule, BreakpointObserverOverviewExample],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class LayoutDemo {}

--- a/src/dev-app/list/BUILD.bazel
+++ b/src/dev-app/list/BUILD.bazel
@@ -13,6 +13,7 @@ ng_module(
         "//src/material/button",
         "//src/material/icon",
         "//src/material/list",
+        "@npm//@angular/router",
     ],
 )
 

--- a/src/dev-app/list/list-demo.ts
+++ b/src/dev-app/list/list-demo.ts
@@ -6,12 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {ChangeDetectionStrategy, ChangeDetectorRef, Component, inject} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {MatButtonModule} from '@angular/material/button';
-import {MatListModule, MatListOptionTogglePosition} from '@angular/material/list';
 import {MatIconModule} from '@angular/material/icon';
-import {CommonModule} from '@angular/common';
+import {MatListModule, MatListOptionTogglePosition} from '@angular/material/list';
+import {ActivatedRoute} from '@angular/router';
 
 interface Link {
   name: string;
@@ -24,6 +25,7 @@ interface Link {
   styleUrl: 'list-demo.css',
   standalone: true,
   imports: [CommonModule, FormsModule, MatButtonModule, MatIconModule, MatListModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ListDemo {
   items: string[] = ['Pepper', 'Salt', 'Paprika'];
@@ -74,6 +76,15 @@ export class ListDemo {
   selectedOptions: string[] = ['apples'];
   changeEventCount = 0;
   modelChangeEventCount = 0;
+
+  readonly cdr = inject(ChangeDetectorRef);
+  readonly activatedRoute = inject(ActivatedRoute);
+
+  constructor() {
+    this.activatedRoute.url.subscribe(() => {
+      this.cdr.markForCheck();
+    });
+  }
 
   onSelectedOptionsChange(values: string[]) {
     this.selectedOptions = values;

--- a/src/dev-app/live-announcer/live-announcer-demo.ts
+++ b/src/dev-app/live-announcer/live-announcer-demo.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, TemplateRef, ViewChild} from '@angular/core';
 import {A11yModule, LiveAnnouncer} from '@angular/cdk/a11y';
+import {ChangeDetectionStrategy, Component, TemplateRef, ViewChild} from '@angular/core';
 import {MatButtonModule} from '@angular/material/button';
 import {MatDialog} from '@angular/material/dialog';
 
@@ -16,6 +16,7 @@ import {MatDialog} from '@angular/material/dialog';
   templateUrl: 'live-announcer-demo.html',
   standalone: true,
   imports: [A11yModule, MatButtonModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class LiveAnnouncerDemo {
   constructor(

--- a/src/dev-app/main.ts
+++ b/src/dev-app/main.ts
@@ -9,21 +9,25 @@
 // Load `$localize` for examples using it.
 import '@angular/localize/init';
 
-import {importProvidersFrom} from '@angular/core';
 import {HttpClientModule} from '@angular/common/http';
+import {
+  importProvidersFrom,
+  provideZoneChangeDetection,
+  ɵprovideZonelessChangeDetection,
+} from '@angular/core';
+import {bootstrapApplication} from '@angular/platform-browser';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {RouterModule} from '@angular/router';
-import {bootstrapApplication} from '@angular/platform-browser';
 
-import {MAT_RIPPLE_GLOBAL_OPTIONS, provideNativeDateAdapter} from '@angular/material/core';
 import {Directionality} from '@angular/cdk/bidi';
-import {OverlayContainer, FullscreenOverlayContainer} from '@angular/cdk/overlay';
+import {FullscreenOverlayContainer, OverlayContainer} from '@angular/cdk/overlay';
+import {MAT_RIPPLE_GLOBAL_OPTIONS, provideNativeDateAdapter} from '@angular/material/core';
 
 import {DevApp} from './dev-app';
 import {DevAppDirectionality} from './dev-app/dev-app-directionality';
+import {getAppState} from './dev-app/dev-app-state';
 import {DevAppRippleOptions} from './dev-app/ripple-options';
 import {DEV_APP_ROUTES} from './routes';
-import {getAppState} from './dev-app/dev-app-state';
 
 // We need to insert this stylesheet manually since it depends on the value from the app state.
 // It uses a different file, instead of toggling a class, to avoid other styles from bleeding in.
@@ -47,5 +51,8 @@ bootstrapApplication(DevApp, {
     {provide: OverlayContainer, useClass: FullscreenOverlayContainer},
     {provide: MAT_RIPPLE_GLOBAL_OPTIONS, useExisting: DevAppRippleOptions},
     {provide: Directionality, useClass: DevAppDirectionality},
+    cachedAppState.zoneless
+      ? ɵprovideZonelessChangeDetection()
+      : provideZoneChangeDetection({eventCoalescing: true}),
   ],
 });

--- a/src/dev-app/menu/menu-demo.ts
+++ b/src/dev-app/menu/menu-demo.ts
@@ -6,13 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component} from '@angular/core';
 import {CommonModule} from '@angular/common';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
+import {MatButtonModule} from '@angular/material/button';
+import {MatDividerModule} from '@angular/material/divider';
+import {MatIconModule} from '@angular/material/icon';
 import {MatMenuModule} from '@angular/material/menu';
 import {MatToolbarModule} from '@angular/material/toolbar';
-import {MatIconModule} from '@angular/material/icon';
-import {MatDividerModule} from '@angular/material/divider';
-import {MatButtonModule} from '@angular/material/button';
 
 @Component({
   selector: 'menu-demo',
@@ -27,6 +27,7 @@ import {MatButtonModule} from '@angular/material/button';
     MatIconModule,
     MatDividerModule,
   ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MenuDemo {
   selected = '';

--- a/src/dev-app/menubar/mat-menubar-demo.ts
+++ b/src/dev-app/menubar/mat-menubar-demo.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, ViewEncapsulation} from '@angular/core';
-import {CdkMenu, CdkMenuItem, CdkMenuGroup, CDK_MENU, CdkMenuModule} from '@angular/cdk/menu';
+import {CDK_MENU, CdkMenu, CdkMenuGroup, CdkMenuItem, CdkMenuModule} from '@angular/cdk/menu';
+import {ChangeDetectionStrategy, Component, ViewEncapsulation} from '@angular/core';
 import {MatMenuBarModule} from '@angular/material-experimental/menubar';
 
 // TODO: Remove the fake when mat-menu is re-built with CdkMenu directives
@@ -29,6 +29,7 @@ import {MatMenuBarModule} from '@angular/material-experimental/menubar';
   styleUrl: 'mat-menubar-demo.css',
   encapsulation: ViewEncapsulation.None,
   standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DemoMenu extends CdkMenu {}
 
@@ -47,6 +48,7 @@ export class DemoMenu extends CdkMenu {}
   styleUrl: 'mat-menubar-demo.css',
   encapsulation: ViewEncapsulation.None,
   standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DemoMenuItem extends CdkMenuItem {}
 
@@ -54,5 +56,6 @@ export class DemoMenuItem extends CdkMenuItem {}
   templateUrl: 'mat-menubar-demo.html',
   standalone: true,
   imports: [CdkMenuModule, MatMenuBarModule, DemoMenu, DemoMenuItem],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MatMenuBarDemo {}

--- a/src/dev-app/paginator/paginator-demo.ts
+++ b/src/dev-app/paginator/paginator-demo.ts
@@ -6,18 +6,18 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component} from '@angular/core';
-import {MatPaginatorModule, PageEvent} from '@angular/material/paginator';
 import {CommonModule} from '@angular/common';
+import {
+  PaginatorConfigurableExample,
+  PaginatorOverviewExample,
+} from '@angular/components-examples/material/paginator';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {MatCardModule} from '@angular/material/card';
 import {MatFormFieldModule} from '@angular/material/form-field';
 import {MatInputModule} from '@angular/material/input';
+import {MatPaginatorModule, PageEvent} from '@angular/material/paginator';
 import {MatSlideToggleModule} from '@angular/material/slide-toggle';
-import {
-  PaginatorOverviewExample,
-  PaginatorConfigurableExample,
-} from '@angular/components-examples/material/paginator';
 
 @Component({
   selector: 'paginator-demo',
@@ -35,6 +35,7 @@ import {
     PaginatorOverviewExample,
     PaginatorConfigurableExample,
   ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class PaginatorDemo {
   length = 50;

--- a/src/dev-app/performance/performance-demo.ts
+++ b/src/dev-app/performance/performance-demo.ts
@@ -6,15 +6,17 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {CommonModule} from '@angular/common';
 import {
   afterNextRender,
   AfterViewInit,
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
   Component,
   inject,
   Injector,
   ViewChild,
 } from '@angular/core';
-import {CommonModule} from '@angular/common';
 import {FormsModule} from '@angular/forms';
 
 import {MatButtonModule} from '@angular/material/button';
@@ -43,6 +45,7 @@ import {MatTableDataSource, MatTableModule} from '@angular/material/table';
     MatSelectModule,
     MatTableModule,
   ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class PerformanceDemo implements AfterViewInit {
   /** Controls the rendering of components. */
@@ -73,6 +76,8 @@ export class PerformanceDemo implements AfterViewInit {
   componentArray = [].constructor(this.componentCount);
 
   private _injector = inject(Injector);
+
+  readonly cdr = inject(ChangeDetectorRef);
 
   /** The standard deviation of the recorded samples. */
   get stdev(): number | undefined {
@@ -123,6 +128,7 @@ export class PerformanceDemo implements AfterViewInit {
     this.allSamples.push(...samples);
     this.isRunningBenchmark = false;
     this.computedResults = this.getTotalRenderTime();
+    this.cdr.markForCheck();
   }
 
   clearMetrics() {
@@ -135,11 +141,13 @@ export class PerformanceDemo implements AfterViewInit {
     return new Promise(res => {
       setTimeout(() => {
         this.show = true;
+        this.cdr.markForCheck();
         const start = performance.now();
         afterNextRender(
           () => {
             const end = performance.now();
             this.show = false;
+            this.cdr.markForCheck();
             res(end - start);
           },
           {injector: this._injector},

--- a/src/dev-app/platform/platform-demo.ts
+++ b/src/dev-app/platform/platform-demo.ts
@@ -6,15 +6,16 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component} from '@angular/core';
 import {Platform, getSupportedInputTypes} from '@angular/cdk/platform';
 import {CommonModule} from '@angular/common';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 
 @Component({
   selector: 'platform-demo',
   templateUrl: 'platform-demo.html',
   standalone: true,
   imports: [CommonModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class PlatformDemo {
   supportedInputTypes = getSupportedInputTypes();

--- a/src/dev-app/popover-edit/popover-edit-demo.ts
+++ b/src/dev-app/popover-edit/popover-edit-demo.ts
@@ -6,21 +6,21 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component} from '@angular/core';
-import {FormsModule} from '@angular/forms';
 import {
-  CdkPopoverEditCdkTableFlexExample,
   CdkPopoverEditCdkTableExample,
+  CdkPopoverEditCdkTableFlexExample,
   CdkPopoverEditCellSpanVanillaTableExample,
   CdkPopoverEditTabOutVanillaTableExample,
   CdkPopoverEditVanillaTableExample,
 } from '@angular/components-examples/cdk-experimental/popover-edit';
 import {
   PopoverEditCellSpanMatTableExample,
-  PopoverEditMatTableFlexExample,
   PopoverEditMatTableExample,
+  PopoverEditMatTableFlexExample,
   PopoverEditTabOutMatTableExample,
 } from '@angular/components-examples/material-experimental/popover-edit';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
+import {FormsModule} from '@angular/forms';
 
 @Component({
   template: `
@@ -58,5 +58,6 @@ import {
     PopoverEditTabOutMatTableExample,
     FormsModule,
   ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class PopoverEditDemo {}

--- a/src/dev-app/portal/portal-demo.ts
+++ b/src/dev-app/portal/portal-demo.ts
@@ -6,13 +6,21 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ComponentPortal, Portal, CdkPortal, DomPortal, PortalModule} from '@angular/cdk/portal';
-import {Component, QueryList, ViewChildren, ElementRef, ViewChild} from '@angular/core';
+import {CdkPortal, ComponentPortal, DomPortal, Portal, PortalModule} from '@angular/cdk/portal';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  QueryList,
+  ViewChild,
+  ViewChildren,
+} from '@angular/core';
 
 @Component({
   selector: 'science-joke',
   template: `<p> 100 kilopascals go into a bar. </p>`,
   standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ScienceJoke {}
 
@@ -22,6 +30,7 @@ export class ScienceJoke {}
   styleUrl: 'portal-demo.css',
   standalone: true,
   imports: [PortalModule, ScienceJoke],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class PortalDemo {
   @ViewChildren(CdkPortal) templatePortals: QueryList<Portal<any>>;

--- a/src/dev-app/progress-bar/progress-bar-demo.ts
+++ b/src/dev-app/progress-bar/progress-bar-demo.ts
@@ -6,13 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component} from '@angular/core';
-import {ThemePalette} from '@angular/material/core';
 import {CommonModule} from '@angular/common';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {FormsModule} from '@angular/forms';
-import {MatProgressBarModule} from '@angular/material/progress-bar';
 import {MatButtonModule} from '@angular/material/button';
 import {MatButtonToggleModule} from '@angular/material/button-toggle';
+import {ThemePalette} from '@angular/material/core';
+import {MatProgressBarModule} from '@angular/material/progress-bar';
 
 @Component({
   selector: 'progress-bar-demo',
@@ -26,6 +26,7 @@ import {MatButtonToggleModule} from '@angular/material/button-toggle';
     MatButtonModule,
     MatButtonToggleModule,
   ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ProgressBarDemo {
   color: ThemePalette = 'primary';

--- a/src/dev-app/progress-spinner/progress-spinner-demo.ts
+++ b/src/dev-app/progress-spinner/progress-spinner-demo.ts
@@ -6,13 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component} from '@angular/core';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
+import {FormsModule} from '@angular/forms';
+import {MatButtonModule} from '@angular/material/button';
+import {MatButtonToggleModule} from '@angular/material/button-toggle';
+import {MatCheckboxModule} from '@angular/material/checkbox';
 import {ThemePalette} from '@angular/material/core';
 import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
-import {MatButtonModule} from '@angular/material/button';
-import {MatCheckboxModule} from '@angular/material/checkbox';
-import {MatButtonToggleModule} from '@angular/material/button-toggle';
-import {FormsModule} from '@angular/forms';
 
 @Component({
   selector: 'progress-spinner-demo',
@@ -26,6 +26,7 @@ import {FormsModule} from '@angular/forms';
     FormsModule,
     MatProgressSpinnerModule,
   ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ProgressSpinnerDemo {
   progressValue = 60;

--- a/src/dev-app/radio/radio-demo.ts
+++ b/src/dev-app/radio/radio-demo.ts
@@ -6,12 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component} from '@angular/core';
-import {MatRadioModule} from '@angular/material/radio';
+import {CommonModule} from '@angular/common';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {MatButtonModule} from '@angular/material/button';
 import {MatCheckboxModule} from '@angular/material/checkbox';
-import {CommonModule} from '@angular/common';
+import {MatRadioModule} from '@angular/material/radio';
 
 @Component({
   selector: 'radio-demo',
@@ -19,6 +19,7 @@ import {CommonModule} from '@angular/common';
   styleUrl: 'radio-demo.css',
   standalone: true,
   imports: [CommonModule, MatRadioModule, FormsModule, MatButtonModule, MatCheckboxModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class RadioDemo {
   isAlignEnd: boolean = false;

--- a/src/dev-app/ripple/ripple-demo.ts
+++ b/src/dev-app/ripple/ripple-demo.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, ViewChild} from '@angular/core';
 import {RippleOverviewExample} from '@angular/components-examples/material/core';
+import {ChangeDetectionStrategy, Component, ViewChild} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {MatButtonModule} from '@angular/material/button';
 import {MatCheckboxModule} from '@angular/material/checkbox';
@@ -28,6 +28,7 @@ import {MatInputModule} from '@angular/material/input';
     MatIconModule,
     MatInputModule,
   ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class RippleDemo {
   @ViewChild(MatRipple) ripple: MatRipple;

--- a/src/dev-app/screen-type/screen-type-demo.ts
+++ b/src/dev-app/screen-type/screen-type-demo.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component} from '@angular/core';
-import {BreakpointObserver, Breakpoints, BreakpointState, LayoutModule} from '@angular/cdk/layout';
+import {BreakpointObserver, BreakpointState, Breakpoints, LayoutModule} from '@angular/cdk/layout';
 import {CommonModule} from '@angular/common';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {MatGridListModule} from '@angular/material/grid-list';
 import {MatIconModule} from '@angular/material/icon';
 import {Observable} from 'rxjs';
@@ -19,6 +19,7 @@ import {Observable} from 'rxjs';
   styleUrl: 'screen-type-demo.css',
   standalone: true,
   imports: [CommonModule, LayoutModule, MatGridListModule, MatIconModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ScreenTypeDemo {
   isHandset: Observable<BreakpointState>;

--- a/src/dev-app/select/select-demo.ts
+++ b/src/dev-app/select/select-demo.ts
@@ -6,17 +6,17 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component} from '@angular/core';
-import {FormControl, Validators, FormsModule, ReactiveFormsModule} from '@angular/forms';
-import {ErrorStateMatcher, ThemePalette} from '@angular/material/core';
-import {MatSelectChange, MatSelectModule} from '@angular/material/select';
-import {FloatLabelType} from '@angular/material/form-field';
 import {CommonModule} from '@angular/common';
-import {MatCardModule} from '@angular/material/card';
-import {MatIconModule} from '@angular/material/icon';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
+import {FormControl, FormsModule, ReactiveFormsModule, Validators} from '@angular/forms';
 import {MatButtonModule} from '@angular/material/button';
-import {MatInputModule} from '@angular/material/input';
+import {MatCardModule} from '@angular/material/card';
 import {MatCheckboxModule} from '@angular/material/checkbox';
+import {ErrorStateMatcher, ThemePalette} from '@angular/material/core';
+import {FloatLabelType} from '@angular/material/form-field';
+import {MatIconModule} from '@angular/material/icon';
+import {MatInputModule} from '@angular/material/input';
+import {MatSelectChange, MatSelectModule} from '@angular/material/select';
 
 /** Error any time control is invalid */
 export class MyErrorStateMatcher implements ErrorStateMatcher {
@@ -46,6 +46,7 @@ type DisableDrinkOption = 'none' | 'first-middle-last' | 'all';
     MatSelectModule,
     ReactiveFormsModule,
   ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SelectDemo {
   drinksRequired = false;

--- a/src/dev-app/selection/selection-demo.ts
+++ b/src/dev-app/selection/selection-demo.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component} from '@angular/core';
 import {
   CdkSelectionColumnExample,
   CdkSelectionListExample,
@@ -15,6 +14,7 @@ import {
   MatSelectionColumnExample,
   MatSelectionListExample,
 } from '@angular/components-examples/material-experimental/selection';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 
 @Component({
@@ -39,5 +39,6 @@ import {FormsModule} from '@angular/forms';
     MatSelectionListExample,
     FormsModule,
   ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SelectionDemo {}

--- a/src/dev-app/sidenav/sidenav-demo.ts
+++ b/src/dev-app/sidenav/sidenav-demo.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component} from '@angular/core';
 import {CommonModule} from '@angular/common';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {MatButtonModule} from '@angular/material/button';
 import {MatCheckboxModule} from '@angular/material/checkbox';
@@ -27,6 +27,7 @@ import {MatToolbarModule} from '@angular/material/toolbar';
     MatSidenavModule,
     MatToolbarModule,
   ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SidenavDemo {
   isLaunched = false;

--- a/src/dev-app/slide-toggle/slide-toggle-demo.ts
+++ b/src/dev-app/slide-toggle/slide-toggle-demo.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component} from '@angular/core';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {MatButtonModule} from '@angular/material/button';
 import {MatSlideToggleModule} from '@angular/material/slide-toggle';
@@ -17,6 +17,7 @@ import {MatSlideToggleModule} from '@angular/material/slide-toggle';
   styleUrl: 'slide-toggle-demo.css',
   standalone: true,
   imports: [FormsModule, MatButtonModule, MatSlideToggleModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SlideToggleDemo {
   firstToggle: boolean = false;

--- a/src/dev-app/slider/slider-demo.ts
+++ b/src/dev-app/slider/slider-demo.ts
@@ -6,20 +6,20 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, Inject} from '@angular/core';
+import {ChangeDetectionStrategy, Component, Inject} from '@angular/core';
 import {FormControl, FormsModule, ReactiveFormsModule} from '@angular/forms';
-import {MatSliderModule} from '@angular/material/slider';
-import {MatTabsModule} from '@angular/material/tabs';
+import {MatButtonModule} from '@angular/material/button';
 import {MatButtonToggleModule} from '@angular/material/button-toggle';
 import {MatCheckboxModule} from '@angular/material/checkbox';
-import {
-  MatDialog,
-  MAT_DIALOG_DATA,
-  MatDialogTitle,
-  MatDialogContent,
-} from '@angular/material/dialog';
-import {MatButtonModule} from '@angular/material/button';
 import {ThemePalette} from '@angular/material/core';
+import {
+  MAT_DIALOG_DATA,
+  MatDialog,
+  MatDialogContent,
+  MatDialogTitle,
+} from '@angular/material/dialog';
+import {MatSliderModule} from '@angular/material/slider';
+import {MatTabsModule} from '@angular/material/tabs';
 
 interface DialogData {
   color: ThemePalette;
@@ -41,13 +41,13 @@ interface DialogData {
     ReactiveFormsModule,
   ],
   styleUrl: 'slider-demo.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SliderDemo {
   discrete = true;
   showTickMarks = true;
   colorModel: ThemePalette = 'primary';
 
-  noop = () => {};
   min = '0';
   max = '100';
   step = '0';
@@ -136,6 +136,7 @@ export class SliderDemo {
   `,
   standalone: true,
   imports: [MatSliderModule, MatDialogTitle, MatDialogContent],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SliderDialogDemo {
   constructor(@Inject(MAT_DIALOG_DATA) public data: DialogData) {}

--- a/src/dev-app/snack-bar/snack-bar-demo.ts
+++ b/src/dev-app/snack-bar/snack-bar-demo.ts
@@ -7,19 +7,25 @@
  */
 
 import {Directionality} from '@angular/cdk/bidi';
-import {Component, TemplateRef, ViewChild, ViewEncapsulation} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  TemplateRef,
+  ViewChild,
+  ViewEncapsulation,
+} from '@angular/core';
+import {FormsModule} from '@angular/forms';
+import {MatButtonModule} from '@angular/material/button';
+import {MatCheckboxModule} from '@angular/material/checkbox';
+import {MatInputModule} from '@angular/material/input';
+import {MatSelectModule} from '@angular/material/select';
 import {
   MatSnackBar,
   MatSnackBarConfig,
   MatSnackBarHorizontalPosition,
   MatSnackBarVerticalPosition,
 } from '@angular/material/snack-bar';
-import {CommonModule} from '@angular/common';
-import {FormsModule} from '@angular/forms';
-import {MatButtonModule} from '@angular/material/button';
-import {MatCheckboxModule} from '@angular/material/checkbox';
-import {MatInputModule} from '@angular/material/input';
-import {MatSelectModule} from '@angular/material/select';
 
 @Component({
   selector: 'snack-bar-demo',
@@ -35,6 +41,7 @@ import {MatSelectModule} from '@angular/material/select';
     MatInputModule,
     MatSelectModule,
   ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SnackBarDemo {
   @ViewChild('template') template: TemplateRef<any>;

--- a/src/dev-app/stepper/stepper-demo.ts
+++ b/src/dev-app/stepper/stepper-demo.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, inject} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {ChangeDetectionStrategy, Component, inject} from '@angular/core';
 import {
   AbstractControl,
   FormBuilder,
@@ -14,10 +15,9 @@ import {
   ReactiveFormsModule,
   Validators,
 } from '@angular/forms';
-import {ThemePalette} from '@angular/material/core';
-import {CommonModule} from '@angular/common';
 import {MatButtonModule} from '@angular/material/button';
 import {MatCheckboxModule} from '@angular/material/checkbox';
+import {ThemePalette} from '@angular/material/core';
 import {MatFormFieldModule} from '@angular/material/form-field';
 import {MatInputModule} from '@angular/material/input';
 import {MatSelectModule} from '@angular/material/select';
@@ -38,6 +38,7 @@ import {MatStepperModule} from '@angular/material/stepper';
     MatSelectModule,
     ReactiveFormsModule,
   ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class StepperDemo {
   private _formBuilder = inject(FormBuilder);

--- a/src/dev-app/table-scroll-container/table-scroll-container-demo.ts
+++ b/src/dev-app/table-scroll-container/table-scroll-container-demo.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component} from '@angular/core';
-import {CommonModule} from '@angular/common';
 import {CdkTableScrollContainerModule} from '@angular/cdk-experimental/table-scroll-container';
+import {CommonModule} from '@angular/common';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {MatButtonModule} from '@angular/material/button';
 import {MatButtonToggleGroup, MatButtonToggleModule} from '@angular/material/button-toggle';
 import {MatTableModule} from '@angular/material/table';
@@ -28,6 +28,7 @@ import {MatTableModule} from '@angular/material/table';
     MatButtonToggleModule,
     MatTableModule,
   ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TableScrollContainerDemo {
   displayedColumns: string[] = [];

--- a/src/dev-app/table/table-demo.ts
+++ b/src/dev-app/table/table-demo.ts
@@ -6,46 +6,46 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component} from '@angular/core';
 import {
-  CdkTableFlexBasicExample,
   CdkTableBasicExample,
   CdkTableFixedLayoutExample,
+  CdkTableFlexBasicExample,
   CdkTableRecycleRowsExample,
 } from '@angular/components-examples/cdk/table';
 import {
-  TableFlexBasicExample,
   TableBasicExample,
+  TableColumnStylingExample,
+  TableDynamicArrayDataExample,
   TableDynamicColumnsExample,
+  TableDynamicObservableDataExample,
   TableExpandableRowsExample,
   TableFilteringExample,
+  TableFlexBasicExample,
+  TableFlexLargeRowExample,
   TableFooterRowExample,
+  TableGeneratedColumnsExample,
+  TableHarnessExample,
   TableHttpExample,
   TableMultipleHeaderFooterExample,
   TableOverviewExample,
   TablePaginationExample,
+  TableRecycleRowsExample,
+  TableReorderableExample,
+  TableRowBindingExample,
   TableRowContextExample,
   TableSelectionExample,
   TableSortingExample,
   TableStickyColumnsExample,
-  TableStickyComplexFlexExample,
   TableStickyComplexExample,
+  TableStickyComplexFlexExample,
   TableStickyFooterExample,
   TableStickyHeaderExample,
   TableTextColumnAdvancedExample,
   TableTextColumnExample,
-  TableWrappedExample,
-  TableReorderableExample,
-  TableRecycleRowsExample,
-  TableHarnessExample,
   TableWithRipplesExample,
-  TableColumnStylingExample,
-  TableRowBindingExample,
-  TableDynamicArrayDataExample,
-  TableDynamicObservableDataExample,
-  TableGeneratedColumnsExample,
-  TableFlexLargeRowExample,
+  TableWrappedExample,
 } from '@angular/components-examples/material/table';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 
 @Component({
   templateUrl: './table-demo.html',
@@ -87,5 +87,6 @@ import {
     TableGeneratedColumnsExample,
     TableFlexLargeRowExample,
   ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TableDemo {}

--- a/src/dev-app/tabs/tabs-demo.ts
+++ b/src/dev-app/tabs/tabs-demo.ts
@@ -6,27 +6,27 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component} from '@angular/core';
-import {MatTabsModule} from '@angular/material/tabs';
 import {
-  TabGroupInkBarExample,
-  TabGroupInvertedExample,
-  TabGroupPaginatedExample,
-  TabNavBarBasicExample,
-  TabGroupThemeExample,
-  TabGroupStretchedExample,
-  TabGroupPreserveContentExample,
-  TabGroupLazyLoadedExample,
-  TabGroupHeaderBelowExample,
-  TabGroupDynamicExample,
-  TabGroupHarnessExample,
   TabGroupAlignExample,
   TabGroupAnimationsExample,
   TabGroupAsyncExample,
   TabGroupBasicExample,
   TabGroupCustomLabelExample,
+  TabGroupDynamicExample,
   TabGroupDynamicHeightExample,
+  TabGroupHarnessExample,
+  TabGroupHeaderBelowExample,
+  TabGroupInkBarExample,
+  TabGroupInvertedExample,
+  TabGroupLazyLoadedExample,
+  TabGroupPaginatedExample,
+  TabGroupPreserveContentExample,
+  TabGroupStretchedExample,
+  TabGroupThemeExample,
+  TabNavBarBasicExample,
 } from '@angular/components-examples/material/tabs';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
+import {MatTabsModule} from '@angular/material/tabs';
 
 @Component({
   selector: 'tabs-demo',
@@ -52,5 +52,6 @@ import {
     TabGroupDynamicHeightExample,
     MatTabsModule,
   ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TabsDemo {}

--- a/src/dev-app/toolbar/toolbar-demo.ts
+++ b/src/dev-app/toolbar/toolbar-demo.ts
@@ -6,13 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component} from '@angular/core';
 import {
   ToolbarBasicExample,
+  ToolbarHarnessExample,
   ToolbarMultirowExample,
   ToolbarOverviewExample,
-  ToolbarHarnessExample,
 } from '@angular/components-examples/material/toolbar';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {MatButtonModule} from '@angular/material/button';
 import {MatIconModule} from '@angular/material/icon';
 import {MatToolbarModule} from '@angular/material/toolbar';
@@ -31,5 +31,6 @@ import {MatToolbarModule} from '@angular/material/toolbar';
     ToolbarOverviewExample,
     ToolbarHarnessExample,
   ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ToolbarDemo {}

--- a/src/dev-app/tooltip/tooltip-demo.ts
+++ b/src/dev-app/tooltip/tooltip-demo.ts
@@ -5,20 +5,20 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {Component} from '@angular/core';
 import {
   TooltipAutoHideExample,
   TooltipCustomClassExample,
   TooltipDelayExample,
   TooltipDisabledExample,
+  TooltipHarnessExample,
   TooltipManualExample,
   TooltipMessageExample,
   TooltipModifiedDefaultsExample,
   TooltipOverviewExample,
-  TooltipPositionExample,
   TooltipPositionAtOriginExample,
-  TooltipHarnessExample,
+  TooltipPositionExample,
 } from '@angular/components-examples/material/tooltip';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 
 @Component({
   selector: 'tooltip-demo',
@@ -37,5 +37,6 @@ import {
     TooltipPositionAtOriginExample,
     TooltipHarnessExample,
   ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TooltipDemo {}

--- a/src/dev-app/tree/tree-demo.ts
+++ b/src/dev-app/tree/tree-demo.ts
@@ -5,7 +5,6 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {Component} from '@angular/core';
 import {CdkTreeModule} from '@angular/cdk/tree';
 import {CommonModule} from '@angular/common';
 import {CdkTreeFlatExample, CdkTreeNestedExample} from '@angular/components-examples/cdk/tree';
@@ -16,6 +15,7 @@ import {
   TreeLoadmoreExample,
   TreeNestedOverviewExample,
 } from '@angular/components-examples/material/tree';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {MatButtonModule} from '@angular/material/button';
 import {MatCheckboxModule} from '@angular/material/checkbox';
@@ -51,5 +51,6 @@ import {MatTreeModule} from '@angular/material/tree';
     MatTreeModule,
     MatProgressBarModule,
   ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TreeDemo {}

--- a/src/dev-app/typography/typography-demo.ts
+++ b/src/dev-app/typography/typography-demo.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component} from '@angular/core';
-import {MatCheckboxModule} from '@angular/material/checkbox';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {FormsModule} from '@angular/forms';
+import {MatCheckboxModule} from '@angular/material/checkbox';
 
 @Component({
   selector: 'typography-demo',
@@ -16,5 +16,6 @@ import {FormsModule} from '@angular/forms';
   styleUrl: 'typography-demo.css',
   imports: [MatCheckboxModule, FormsModule],
   standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TypographyDemo {}

--- a/src/dev-app/youtube-player/youtube-player-demo.ts
+++ b/src/dev-app/youtube-player/youtube-player-demo.ts
@@ -8,6 +8,7 @@
 
 import {
   AfterViewInit,
+  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   ElementRef,
@@ -15,9 +16,9 @@ import {
   ViewChild,
 } from '@angular/core';
 import {FormsModule} from '@angular/forms';
+import {MatCheckboxModule} from '@angular/material/checkbox';
 import {MatRadioModule} from '@angular/material/radio';
 import {PlaceholderImageQuality, YouTubePlayer} from '@angular/youtube-player';
-import {MatCheckboxModule} from '@angular/material/checkbox';
 
 interface Video {
   id: string;
@@ -79,6 +80,7 @@ const VIDEOS: Video[] = [
   styleUrl: 'youtube-player-demo.css',
   standalone: true,
   imports: [FormsModule, MatRadioModule, MatCheckboxModule, YouTubePlayer],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class YouTubePlayerDemo implements AfterViewInit, OnDestroy {
   @ViewChild('demoYouTubePlayer') demoYouTubePlayer: ElementRef<HTMLDivElement>;
@@ -106,7 +108,7 @@ export class YouTubePlayerDemo implements AfterViewInit, OnDestroy {
     // Automatically expand the video to fit the page up to 1200px x 720px
     this.videoWidth = Math.min(this.demoYouTubePlayer.nativeElement.clientWidth, 1200);
     this.videoHeight = this.videoWidth * 0.6;
-    this._changeDetectorRef.detectChanges();
+    this._changeDetectorRef.markForCheck();
   };
 
   ngOnDestroy(): void {

--- a/tslint.json
+++ b/tslint.json
@@ -90,41 +90,65 @@
     "validate-decorators": [
       true,
       {
-        "Component": {
-          "argument": 0,
-          "properties": {
-            "!preserveWhitespaces": ".*",
-            "!styles": ".*",
-            "!moduleId": ".*",
-            "changeDetection": "\\.OnPush$",
-            "encapsulation": "\\.None$",
-            "standalone": "^true$"
+        "Component": [
+          {
+            "argument": 0,
+            "properties": {
+              "!preserveWhitespaces": ".*",
+              "!styles": ".*",
+              "!moduleId": ".*",
+              "encapsulation": "\\.None$"
+            },
+            "excludeFiles": ["**/dev-app/**"]
+          },
+          // Enforce OnPush & standalone even in the dev-app.
+          {
+            "argument": 0,
+            "properties": {
+              "changeDetection": "\\.OnPush$",
+              "standalone": "^true$"
+            }
           }
-        },
-        "Directive": {
-          "argument": 0,
-          "properties": {
-            "!host": "\\[class\\]",
-            "standalone": "^true$"
+        ],
+        "Directive": [
+          {
+            "argument": 0,
+            "properties": {
+              "!host": "\\[class\\]"
+            },
+            "excludeFiles": ["**/dev-app/**"]
+          },
+          // Enforce standalone even in the dev-app.
+          {
+            "argument": 0,
+            "properties": {
+              "standalone": "^true$"
+            }
           }
-        },
-        "NgModule": {
-          "argument": 0,
-          "properties": {
-            "*": "^(?!\\s*$).+"
+        ],
+        "NgModule": [
+          {
+            "argument": 0,
+            "properties": {
+              "*": "^(?!\\s*$).+"
+            },
+            "excludeFiles": ["**/dev-app/**"]
           }
-        },
-        "ContentChildren": {
-          "argument": 1,
-          "required": true,
-          "properties": {
-            "descendants": "^(true|false)$"
+        ],
+        "ContentChildren": [
+          {
+            "argument": 1,
+            "required": true,
+            "properties": {
+              "descendants": "^(true|false)$"
+            },
+            "excludeFiles": ["**/dev-app/**"]
           }
-        }
+        ]
       },
       [
         // Internal code that doesn't need to follow the same standards.
-        "**/+(e2e-app|components-examples|universal-app|dev-app|integration)/**",
+        "**/+(e2e-app|components-examples|universal-app|integration)/**",
         "**/*.spec.ts"
       ]
     ],


### PR DESCRIPTION
This PR:
- Expands the scope of the decorator lint to enforce `standalone` and `OnPush` in the dev-app
- Converts all dev-app components to `OnPush`
- Adds a toggle to the dev-app to enable zoneless

Based on manual testing of the dev-app, all features seem to work fine in zoneless, with the exception of virtual scrolling. Virtual scrolling works in zoneless, but is noticeably buggier than in the zone app.