### PR TITLE
build: remove engines field from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   },
   "license": "MIT",
   "engines": {
-    "node": "^18.19.1 || >=20.11.1",
     "yarn": "^1.22.17",
     "npm": "Please use Yarn instead of NPM to install dependencies. See: https://yarnpkg.com/lang/en/docs/install/"
   },


### PR DESCRIPTION
As discussed, these changes remove the `engines` enforcement since it can be annoying given that our project isn't sensitive to Node version changes.