### PR TITLE
fix(cdk): handle signal based items in list key manager

### DIFF
--- a/src/cdk/a11y/key-manager/list-key-manager.ts
+++ b/src/cdk/a11y/key-manager/list-key-manager.ts
@@ -366,7 +366,7 @@ export class ListKeyManager<T extends ListKeyManagerOption> {
 
   /** Sets the active item to the last enabled item in the list. */
   setLastItemActive(): void {
-    this._setActiveItemByIndex(this._items.length - 1, -1);
+    this._setActiveItemByIndex(this._getItemsArray().length - 1, -1);
   }
 
   /** Sets the active item to the next enabled item in the list. */


### PR DESCRIPTION
The `setLastItemActive` method of the `ListKeyManager` used the items input directly to determine the length without checking if it is a `Signal` instead of a `QueryList`.

The fix uses the already present `_getItemsArray` for safe access.