### PR TITLE
docs(material/chips): added an example that corresponds to the title static chips

### DIFF
--- a/src/components-examples/material/chips/chips-overview/chips-overview-example.html
+++ b/src/components-examples/material/chips/chips-overview/chips-overview-example.html
@@ -1,6 +1,6 @@
-<mat-chip-listbox aria-label="Fish selection">
-  <mat-chip-option>One fish</mat-chip-option>
-  <mat-chip-option>Two fish</mat-chip-option>
-  <mat-chip-option color="accent" selected>Accent fish</mat-chip-option>
-  <mat-chip-option color="warn">Warn fish</mat-chip-option>
-</mat-chip-listbox>
+<mat-chip-set aria-label="Fish selection">
+  <mat-chip>One fish</mat-chip>
+  <mat-chip>Two fish</mat-chip>
+  <mat-chip>Three fish</mat-chip>
+  <mat-chip disabled>Four fish</mat-chip>
+</mat-chip-set>


### PR DESCRIPTION
Fixes the documentation example in the Angular Material `chips` component. Previously the text description of static chips did not match code example

Fixes #28845