### PR TITLE
fix(material/datepicker): remove dependency on NgClass

### DIFF
--- a/src/material/datepicker/datepicker-base.ts
+++ b/src/material/datepicker/datepicker-base.ts
@@ -74,7 +74,7 @@ import {
   MatDateRangeSelectionStrategy,
 } from './date-range-selection-strategy';
 import {MatDatepickerIntl} from './datepicker-intl';
-import {DOCUMENT, NgClass} from '@angular/common';
+import {DOCUMENT} from '@angular/common';
 import {MatButton} from '@angular/material/button';
 import {CdkTrapFocus} from '@angular/cdk/a11y';
 
@@ -135,7 +135,7 @@ export const MAT_DATEPICKER_SCROLL_STRATEGY_FACTORY_PROVIDER = {
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: true,
-  imports: [CdkTrapFocus, MatCalendar, NgClass, CdkPortalOutlet, MatButton],
+  imports: [CdkTrapFocus, MatCalendar, CdkPortalOutlet, MatButton],
 })
 export class MatDatepickerContent<S, D = ExtractDateTypeFromSelection<S>>
   implements OnInit, AfterViewInit, OnDestroy
@@ -446,10 +446,7 @@ export abstract class MatDatepickerBase<
   /** Emits when the datepicker has been closed. */
   @Output('closed') readonly closedStream = new EventEmitter<void>();
 
-  /**
-   * Classes to be passed to the date picker panel.
-   * Supports string and string array values, similar to `ngClass`.
-   */
+  /** Classes to be passed to the date picker panel. */
   @Input()
   get panelClass(): string | string[] {
     return this._panelClass;

--- a/src/material/datepicker/datepicker-content.html
+++ b/src/material/datepicker/datepicker-content.html
@@ -8,7 +8,7 @@
   [class.mat-datepicker-content-container-with-actions]="_actionsPortal">
   <mat-calendar
     [id]="datepicker.id"
-    [ngClass]="datepicker.panelClass"
+    [class]="datepicker.panelClass"
     [startAt]="datepicker.startAt"
     [startView]="datepicker.startView"
     [minDate]="datepicker._getMinDate()"


### PR DESCRIPTION
We can set classes directly through `[class]` instead of having to import `NgClass`.