### PR TITLE
fix(material/core): throw better error when mixin doesn't support color variants

### DIFF
--- a/src/material/core/tokens/_token-utils.scss
+++ b/src/material/core/tokens/_token-utils.scss
@@ -203,9 +203,13 @@ $_component-prefix: null;
   }
   $overrides: map.get($tokens, list.append($prefix, $color-variant));
   @if $overrides == null {
-    @error #{'Invalid color variant: '}#{$color-variant}#{'. Supported color variants are: '}#{
-      _supported-color-variants($tokens, $prefix)
-    }#{'.'};
+    $variants: _supported-color-variants($tokens, $prefix);
+    $secondary-message: if($variants == (),
+      'Mixin does not support color variants',
+      'Supported color variants are: #{$variants}'
+    );
+
+    @error 'Invalid color variant: #{$color-variant}. #{$secondary-message}.';
   }
   @return if($emit-overrides-only, $overrides, map.merge($values, $overrides));
 }


### PR DESCRIPTION
Fixes that calling a theming mixin for a component that doesn't support color variants was throwing a cryptic error.

Fixes #28860.