### PR TITLE
refactor(multiple): replace hasError() with errors

### DIFF
--- a/src/components-examples/cdk/listbox/cdk-listbox-forms-validation/cdk-listbox-forms-validation-example.ts
+++ b/src/components-examples/cdk/listbox/cdk-listbox-forms-validation/cdk-listbox-forms-validation-example.ts
@@ -42,13 +42,13 @@ export class CdkListboxFormsValidationExample {
 
   getErrors() {
     const errors = [];
-    if (this.signCtrl.hasError('required')) {
+    if (this.signCtrl.errors?.['required']) {
       errors.push('You must enter your zodiac sign');
     }
-    if (this.signCtrl.hasError('cdkListboxUnexpectedMultipleValues')) {
+    if (this.signCtrl.errors?.['cdkListboxUnexpectedMultipleValues']) {
       errors.push('You can only select one zodiac sign');
     }
-    if (this.signCtrl.hasError('cdkListboxUnexpectedOptionValues')) {
+    if (this.signCtrl.errors?.['cdkListboxUnexpectedOptionValues']) {
       const invalidOptions = this.signCtrl.getError('cdkListboxUnexpectedOptionValues').values;
       errors.push(`You entered an invalid zodiac sign: ${invalidOptions[0]}`);
     }

--- a/src/components-examples/material/datepicker/date-range-picker-forms/date-range-picker-forms-example.html
+++ b/src/components-examples/material/datepicker/date-range-picker-forms/date-range-picker-forms-example.html
@@ -8,10 +8,10 @@
   <mat-datepicker-toggle matIconSuffix [for]="picker"></mat-datepicker-toggle>
   <mat-date-range-picker #picker></mat-date-range-picker>
 
-  @if (range.controls.start.hasError('matStartDateInvalid')) {
+  @if (range.controls.start.errors?.['matStartDateInvalid']) {
     <mat-error>Invalid start date</mat-error>
   }
-  @if (range.controls.end.hasError('matEndDateInvalid')) {
+  @if (range.controls.end.errors?.['matEndDateInvalid']) {
     <mat-error>Invalid end date</mat-error>
   }
 </mat-form-field>

--- a/src/components-examples/material/form-field/form-field-error/form-field-error-example.ts
+++ b/src/components-examples/material/form-field/form-field-error/form-field-error-example.ts
@@ -25,9 +25,9 @@ export class FormFieldErrorExample {
   }
 
   updateErrorMessage() {
-    if (this.email.hasError('required')) {
+    if (this.email.errors?.['required']) {
       this.errorMessage = 'You must enter a value';
-    } else if (this.email.hasError('email')) {
+    } else if (this.email.errors?.['email']) {
       this.errorMessage = 'Not a valid email';
     } else {
       this.errorMessage = '';

--- a/src/components-examples/material/input/input-error-state-matcher/input-error-state-matcher-example.html
+++ b/src/components-examples/material/input/input-error-state-matcher/input-error-state-matcher-example.html
@@ -4,10 +4,10 @@
     <input type="email" matInput [formControl]="emailFormControl" [errorStateMatcher]="matcher"
            placeholder="Ex. pat@example.com">
     <mat-hint>Errors appear instantly!</mat-hint>
-    @if (emailFormControl.hasError('email') && !emailFormControl.hasError('required')) {
+    @if (emailFormControl.errors?.['email'] && !emailFormControl.errors?.['required']) {
       <mat-error>Please enter a valid email address</mat-error>
     }
-    @if (emailFormControl.hasError('required')) {
+    @if (emailFormControl.errors?.['required']) {
       <mat-error>Email is <strong>required</strong></mat-error>
     }
   </mat-form-field>

--- a/src/components-examples/material/input/input-errors/input-errors-example.html
+++ b/src/components-examples/material/input/input-errors/input-errors-example.html
@@ -2,10 +2,10 @@
   <mat-form-field class="example-full-width">
     <mat-label>Email</mat-label>
     <input type="email" matInput [formControl]="emailFormControl" placeholder="Ex. pat@example.com">
-    @if (emailFormControl.hasError('email') && !emailFormControl.hasError('required')) {
+    @if (emailFormControl.errors?.['email'] && !emailFormControl.errors?.['required']) {
       <mat-error>Please enter a valid email address</mat-error>
     }
-    @if (emailFormControl.hasError('required')) {
+    @if (emailFormControl.errors?.['required']) {
       <mat-error>Email is <strong>required</strong></mat-error>
     }
   </mat-form-field>

--- a/src/components-examples/material/select/select-error-state-matcher/select-error-state-matcher-example.html
+++ b/src/components-examples/material/select/select-error-state-matcher/select-error-state-matcher-example.html
@@ -7,10 +7,10 @@
     <mat-option value="invalid">Invalid option</mat-option>
   </mat-select>
   <mat-hint>Errors appear instantly!</mat-hint>
-  @if (selected.hasError('required')) {
+  @if (selected.errors?.['required']) {
     <mat-error>You must make a selection</mat-error>
   }
-  @if (selected.hasError('pattern') && !selected.hasError('required')) {
+  @if (selected.errors?.['pattern'] && !selected.errors?.['required']) {
     <mat-error>Your selection is invalid</mat-error>
   }
 </mat-form-field>
@@ -23,10 +23,10 @@
     <option value="valid" selected>Valid option</option>
     <option value="invalid">Invalid option</option>
   </select>
-  @if (nativeSelectFormControl.hasError('required')) {
+  @if (nativeSelectFormControl.errors?.['required']) {
     <mat-error>You must make a selection</mat-error>
   }
-  @if (nativeSelectFormControl.hasError('pattern') && !nativeSelectFormControl.hasError('required')) {
+  @if (nativeSelectFormControl.errors?.['pattern'] && !nativeSelectFormControl.errors?.['required']) {
     <mat-error>Your selection is invalid</mat-error>
   }
 </mat-form-field>

--- a/src/components-examples/material/select/select-hint-error/select-hint-error-example.html
+++ b/src/components-examples/material/select/select-hint-error/select-hint-error-example.html
@@ -7,7 +7,7 @@
       <mat-option [value]="animal">{{animal.name}}</mat-option>
     }
   </mat-select>
-  @if (animalControl.hasError('required')) {
+  @if (animalControl.errors?.['required']) {
     <mat-error>Please choose an animal</mat-error>
   }
   <mat-hint>{{animalControl.value?.sound}}</mat-hint>
@@ -22,7 +22,7 @@
     <option value="mercedes">Mercedes</option>
     <option value="audi">Audi</option>
   </select>
-  @if (selectFormControl.hasError('required')) {
+  @if (selectFormControl.errors?.['required']) {
     <mat-error>This field is required</mat-error>
   }
   <mat-hint>You can pick up your favorite car here</mat-hint>

--- a/src/dev-app/datepicker/datepicker-demo.html
+++ b/src/dev-app/datepicker/datepicker-demo.html
@@ -91,18 +91,18 @@
         </mat-datepicker-actions>
       }
     </mat-datepicker>
-    @if (resultPickerModel.hasError('matDatepickerParse')) {
+    @if (resultPickerModel.errors?.['matDatepickerParse']) {
       <mat-error>
         "{{resultPickerModel.getError('matDatepickerParse').text}}" is not a valid date!
       </mat-error>
     }
-    @if (resultPickerModel.hasError('matDatepickerMin')) {
+    @if (resultPickerModel.errors?.['matDatepickerMin']) {
       <mat-error>Too early!</mat-error>
     }
-    @if (resultPickerModel.hasError('matDatepickerMax')) {
+    @if (resultPickerModel.errors?.['matDatepickerMax']) {
       <mat-error>Too late!</mat-error>
     }
-    @if (resultPickerModel.hasError('matDatepickerFilter')) {
+    @if (resultPickerModel.errors?.['matDatepickerFilter']) {
       <mat-error>Date unavailable!</mat-error>
     }
   </mat-form-field>

--- a/src/dev-app/input/input-demo.html
+++ b/src/dev-app/input/input-demo.html
@@ -73,10 +73,10 @@
       <mat-form-field>
         <mat-label>Email</mat-label>
         <input matInput [formControl]="emailFormControl">
-        @if (emailFormControl.hasError('required')) {
+        @if (emailFormControl.errors?.['required']) {
           <mat-error>This field is required</mat-error>
         }
-        @if (emailFormControl.hasError('pattern')) {
+        @if (emailFormControl.errors?.['pattern']) {
           <mat-error>Please enter a valid email address</mat-error>
         }
       </mat-form-field>

--- a/src/dev-app/select/select-demo.html
+++ b/src/dev-app/select/select-demo.html
@@ -356,7 +356,7 @@ Space above cards: <input type="number" [formControl]="topHeightCtrl">
           <option value="mercedes">Mercedes</option>
           <option value="audi">Audi</option>
         </select>
-        @if (selectFormControl.hasError('required')) {
+        @if (selectFormControl.errors?.['required']) {
           <mat-error>This field is required</mat-error>
         }
         <mat-hint>You can pick up your favorite car here</mat-hint>
@@ -371,7 +371,7 @@ Space above cards: <input type="number" [formControl]="topHeightCtrl">
           <option value="mercedes">Mercedes</option>
           <option value="audi">Audi</option>
         </select>
-        @if (selectFormControl.hasError('required')) {
+        @if (selectFormControl.errors?.['required']) {
           <mat-error>This field is required</mat-error>
         }
         <mat-hint>You can pick up your favorite car here</mat-hint>

--- a/src/material/datepicker/datepicker.spec.ts
+++ b/src/material/datepicker/datepicker.spec.ts
@@ -1163,12 +1163,12 @@ describe('MatDatepicker', () => {
       it('should set the matDatepickerParse error when an invalid value is typed for the first time', () => {
         const formControl = fixture.componentInstance.formControl;
 
-        expect(formControl.hasError('matDatepickerParse')).toBe(false);
+        expect(formControl.errors?.['matDatepickerParse']).toBe(false);
 
         typeInElement(fixture.nativeElement.querySelector('input'), 'Today');
         fixture.detectChanges();
 
-        expect(formControl.hasError('matDatepickerParse')).toBe(true);
+        expect(formControl.errors?.['matDatepickerParse']).toBe(true);
       });
     });
 

--- a/src/material/schematics/ng-generate/address-form/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.html.template
+++ b/src/material/schematics/ng-generate/address-form/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.html.template
@@ -15,7 +15,7 @@
         <div class="col">
           <mat-form-field class="full-width">
             <input matInput placeholder="First name" formControlName="firstName">
-            @if (addressForm.controls['firstName'].hasError('required')) {
+            @if (addressForm.controls['firstName'].errors?.['required']) {
               <mat-error>First name is <strong>required</strong></mat-error>
             }
           </mat-form-field>
@@ -23,7 +23,7 @@
         <div class="col">
           <mat-form-field class="full-width">
             <input matInput placeholder="Last name" formControlName="lastName">
-            @if (addressForm.controls['lastName'].hasError('required')) {
+            @if (addressForm.controls['lastName'].errors?.['required']) {
               <mat-error>Last name is <strong>required</strong></mat-error>
             }
           </mat-form-field>
@@ -33,7 +33,7 @@
         <div class="col">
           <mat-form-field class="full-width">
             <textarea matInput placeholder="Address" formControlName="address"></textarea>
-            @if (addressForm.controls['address'].hasError('required')) {
+            @if (addressForm.controls['address'].errors?.['required']) {
               <mat-error>Address is <strong>required</strong></mat-error>
             }
           </mat-form-field>
@@ -56,7 +56,7 @@
         <div class="col">
           <mat-form-field class="full-width">
             <input matInput placeholder="City" formControlName="city">
-            @if (addressForm.controls['city'].hasError('required')) {
+            @if (addressForm.controls['city'].errors?.['required']) {
               <mat-error>City is <strong>required</strong></mat-error>
             }
           </mat-form-field>
@@ -68,7 +68,7 @@
                 <mat-option [value]="state.abbreviation">{{ state.name }}</mat-option>
               }
             </mat-select>
-            @if (addressForm.controls['state'].hasError('required')) {
+            @if (addressForm.controls['state'].errors?.['required']) {
               <mat-error>State is <strong>required</strong></mat-error>
             }
           </mat-form-field>


### PR DESCRIPTION
Angular documentation use errors instead of hasError. Since the function is called in the template and it's not recommended to call functions within a template, we replaced it with errors.

related issue #28883