### PR TITLE
Clean up Google Maps advanced marker

### DIFF
--- a/src/dev-app/google-map/BUILD.bazel
+++ b/src/dev-app/google-map/BUILD.bazel
@@ -11,6 +11,7 @@ ng_module(
     ],
     deps = [
         "//src/google-maps",
+        "@npm//@angular/forms",
     ],
 )
 

--- a/src/dev-app/google-map/google-map-demo.html
+++ b/src/dev-app/google-map/google-map-demo.html
@@ -98,7 +98,7 @@
     <div>
       <label for="polyline-checkbox">
         Toggle Polyline
-        <input type="checkbox" (click)="togglePolylineDisplay()">
+        <input type="checkbox" [(ngModel)]="isPolylineDisplayed">
       </label>
     </div>
     <div>
@@ -106,14 +106,15 @@
         Toggle Editable Polyline
         <input type="checkbox"
               [disabled]="!isPolylineDisplayed"
-              (click)="toggleEditablePolyline()">
+              [ngModel]="polylineOptions.editable"
+              (ngModelChange)="editablePolylineChanged($event)">
       </label>
     </div>
 
     <div>
       <label for="polygon-checkbox">
         Toggle Polygon
-        <input type="checkbox" (click)="togglePolygonDisplay()">
+        <input type="checkbox" [(ngModel)]="isPolygonDisplayed">
       </label>
     </div>
     <div>
@@ -121,14 +122,15 @@
         Toggle Editable Polygon
         <input type="checkbox"
               [disabled]="!isPolygonDisplayed"
-              (click)="toggleEditablePolygon()">
+              [ngModel]="polygonOptions.editable"
+              (ngModelChange)="editablePolygonChanged($event)">
       </label>
     </div>
 
     <div>
       <label for="rectangle-checkbox">
         Toggle Rectangle
-        <input type="checkbox" (click)="toggleRectangleDisplay()">
+        <input type="checkbox" [(ngModel)]="isRectangleDisplayed">
       </label>
     </div>
     <div>
@@ -136,27 +138,32 @@
         Toggle Editable Rectangle
         <input type="checkbox"
               [disabled]="!isRectangleDisplayed"
-              (click)="toggleEditableRectangle()">
+              [ngModel]="rectangleOptions.editable"
+              (ngModelChange)="editableRectangleChanged($event)">
       </label>
     </div>
 
     <div>
       <label for="circle-checkbox">
         Toggle Circle
-        <input type="checkbox" (click)="toggleCircleDisplay()">
+        <input type="checkbox" [(ngModel)]="isCircleDisplayed">
       </label>
     </div>
     <div>
       <label for="editable-circle-checkbox">
         Toggle Editable Circle
-        <input type="checkbox" [disabled]="!isCircleDisplayed" (click)="toggleEditableCircle()">
+        <input
+          type="checkbox"
+          [disabled]="!isCircleDisplayed"
+          [ngModel]="circleOptions.editable"
+          (ngModelChange)="editableCircleChanged($event)">
       </label>
     </div>
 
     <div>
       <label for="ground-overlay-checkbox">
         Toggle Ground Overlay
-        <input type="checkbox" (click)="toggleGroundOverlayDisplay()">
+        <input type="checkbox" [(ngModel)]="isGroundOverlayDisplayed">
       </label>
     </div>
 
@@ -164,7 +171,7 @@
       <label for="ground-overlay-image">
         Ground Overlay image
 
-        <select id="ground-overlay-image" (change)="groundOverlayUrlChanged($event)">
+        <select id="ground-overlay-image" [(ngModel)]="groundOverlayUrl">
           @for (image of groundOverlayImages; track image) {
             <option [value]="image.url">{{image.title}}</option>
           }
@@ -175,28 +182,28 @@
     <div>
       <label for="kml-layer-checkbox">
         Toggle KML Layer
-        <input type="checkbox" (click)="toggleKmlLayerDisplay()">
+        <input type="checkbox" [(ngModel)]="isKmlLayerDisplayed">
       </label>
     </div>
 
     <div>
       <label for="traffic-layer-checkbox">
         Toggle Traffic Layer
-        <input type="checkbox" (click)="toggleTrafficLayerDisplay()">
+        <input type="checkbox" [(ngModel)]="isTrafficLayerDisplayed">
       </label>
     </div>
 
     <div>
       <label for="transit-layer-checkbox">
         Toggle Transit Layer
-        <input type="checkbox" (click)="toggleTransitLayerDisplay()">
+        <input type="checkbox" [(ngModel)]="isTransitLayerDisplayed">
       </label>
     </div>
 
     <div>
       <label for="bicycling-layer-checkbox">
         Toggle Bicycling Layer
-        <input type="checkbox" (click)="toggleBicyclingLayerDisplay()">
+        <input type="checkbox" [(ngModel)]="isBicyclingLayerDisplayed">
       </label>
     </div>
 
@@ -210,14 +217,17 @@
     <div>
       <label>
         Toggle Advanced Marker
-        <input type="checkbox" (click)="toggleAdvancedMarker()">
+        <input type="checkbox" [(ngModel)]="hasAdvancedMarker">
       </label>
     </div>
 
     <div>
       <label>
         Toggle custom content for Advanced Marker
-        <input type="checkbox" (click)="toggleAdvancedMarkerCustomContent()">
+        <input
+          type="checkbox"
+          [(ngModel)]="hasAdvancedMarkerCustomContent"
+          [disabled]="!hasAdvancedMarker">
       </label>
     </div>
 

--- a/src/dev-app/google-map/google-map-demo.html
+++ b/src/dev-app/google-map/google-map-demo.html
@@ -8,38 +8,39 @@
                 (mapClick)="handleClick($event)"
                 (mapMousemove)="handleMove($event)"
                 (mapRightclick)="handleRightclick()"
-                [mapTypeId]="mapTypeId">
+                [mapTypeId]="mapTypeId"
+                [mapId]="mapId">
       <map-marker-clusterer [imagePath]="markerClustererImagePath">
         <map-marker #firstMarker="mapMarker"
                     [position]="center"
-                    (mapClick)="clickMarker(firstMarker)"></map-marker>
+                    (mapClick)="infoWindow.open(firstMarker)"></map-marker>
         @for (markerPosition of markerPositions; track markerPosition) {
           <map-marker #marker="mapMarker"
             [position]="markerPosition"
             [options]="markerOptions"
-            (mapClick)="clickMarker(marker)"></map-marker>
+            (mapClick)="infoWindow.open(marker)"></map-marker>
         }
       </map-marker-clusterer>
       @if (hasAdvancedMarker) {
         <map-advanced-marker
           #secondMarker="mapAdvancedMarker"
-          (mapClick)="clickAdvancedMarker(secondMarker)"
+          (mapClick)="infoWindow.open(secondMarker)"
           title="Advanced Marker"
           [gmpDraggable]="false"
-          [content]="advancedMarkerContent"
+          [content]="hasAdvancedMarkerCustomContent ? advancedMarkerContent : null"
           [position]="mapAdvancedMarkerPosition">
 
           <svg #advancedMarkerContent fill="oklch(69.02% .277 332.77)" viewBox="0 0 960 960" width="50px" height="50px" xml:space="preserve">
             <g>
-              <polygon points="562.6,109.8 804.1,629.5 829.2,233.1 	"/>
-              <polygon points="624.9,655.9 334.3,655.9 297.2,745.8 479.6,849.8 662,745.8 	"/>
-              <polygon points="384.1,539.3 575.2,539.3 479.6,307 	"/>
-              <polygon points="396.6,109.8 130,233.1 155.1,629.5 	"/>
+              <polygon points="562.6,109.8 804.1,629.5 829.2,233.1"/>
+              <polygon points="624.9,655.9 334.3,655.9 297.2,745.8 479.6,849.8 662,745.8"/>
+              <polygon points="384.1,539.3 575.2,539.3 479.6,307"/>
+              <polygon points="396.6,109.8 130,233.1 155.1,629.5"/>
             </g>
           </svg>
         </map-advanced-marker>
       }
-      <map-info-window>Testing 1 2 3</map-info-window>
+      <map-info-window #infoWindow="mapInfoWindow">Testing 1 2 3</map-info-window>
       @if (isPolylineDisplayed) {
         <map-polyline [options]="polylineOptions"></map-polyline>
       }
@@ -210,6 +211,13 @@
       <label>
         Toggle Advanced Marker
         <input type="checkbox" (click)="toggleAdvancedMarker()">
+      </label>
+    </div>
+
+    <div>
+      <label>
+        Toggle custom content for Advanced Marker
+        <input type="checkbox" (click)="toggleAdvancedMarkerCustomContent()">
       </label>
     </div>
 

--- a/src/dev-app/google-map/google-map-demo.ts
+++ b/src/dev-app/google-map/google-map-demo.ts
@@ -89,7 +89,6 @@ let apiLoadingPromise: Promise<unknown> | null = null;
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class GoogleMapDemo {
-  @ViewChild(MapInfoWindow) infoWindow: MapInfoWindow;
   @ViewChild(MapPolyline) polyline: MapPolyline;
   @ViewChild(MapPolygon) polygon: MapPolygon;
   @ViewChild(MapRectangle) rectangle: MapRectangle;
@@ -154,6 +153,9 @@ export class GoogleMapDemo {
   isTransitLayerDisplayed = false;
   isBicyclingLayerDisplayed = false;
   hasAdvancedMarker = false;
+  hasAdvancedMarkerCustomContent = true;
+  // This is necessary for testing advanced markers. It seems like any value works locally.
+  mapId = '123';
 
   mapTypeId: google.maps.MapTypeId;
   mapTypeIds = ['hybrid', 'roadmap', 'satellite', 'terrain'] as google.maps.MapTypeId[];
@@ -179,17 +181,6 @@ export class GoogleMapDemo {
 
   handleMove(event: google.maps.MapMouseEvent) {
     this.display = event.latLng?.toJSON();
-  }
-
-  clickMarker(marker: MapMarker) {
-    this.infoWindow.open(marker);
-  }
-
-  clickAdvancedMarker(advancedMarker: MapAdvancedMarker) {
-    this.infoWindow.openAdvancedMarkerElement(
-      advancedMarker.advancedMarker,
-      advancedMarker.advancedMarker.title,
-    );
   }
 
   handleRightclick() {
@@ -275,6 +266,10 @@ export class GoogleMapDemo {
 
   toggleAdvancedMarker() {
     this.hasAdvancedMarker = !this.hasAdvancedMarker;
+  }
+
+  toggleAdvancedMarkerCustomContent() {
+    this.hasAdvancedMarkerCustomContent = !this.hasAdvancedMarkerCustomContent;
   }
 
   calculateDirections() {

--- a/src/dev-app/google-map/google-map-demo.ts
+++ b/src/dev-app/google-map/google-map-demo.ts
@@ -14,6 +14,7 @@ import {
   ViewChild,
   inject,
 } from '@angular/core';
+import {FormsModule} from '@angular/forms';
 import {
   GoogleMap,
   MapAdvancedMarker,
@@ -85,6 +86,7 @@ let apiLoadingPromise: Promise<unknown> | null = null;
     MapRectangle,
     MapTrafficLayer,
     MapTransitLayer,
+    FormsModule,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
@@ -187,50 +189,34 @@ export class GoogleMapDemo {
     this.markerPositions.pop();
   }
 
-  togglePolylineDisplay() {
-    this.isPolylineDisplayed = !this.isPolylineDisplayed;
-  }
-
-  toggleEditablePolyline() {
+  editablePolylineChanged(editable: boolean) {
     this.polylineOptions = {
       ...this.polylineOptions,
-      editable: !this.polylineOptions.editable,
+      editable,
       path: this.polyline.getPath(),
     };
   }
 
-  togglePolygonDisplay() {
-    this.isPolygonDisplayed = !this.isPolygonDisplayed;
-  }
-
-  toggleEditablePolygon() {
+  editablePolygonChanged(editable: boolean) {
     this.polygonOptions = {
       ...this.polygonOptions,
-      editable: !this.polygonOptions.editable,
+      editable,
       paths: this.polygon.getPaths(),
     };
   }
 
-  toggleRectangleDisplay() {
-    this.isRectangleDisplayed = !this.isRectangleDisplayed;
-  }
-
-  toggleEditableRectangle() {
+  editableRectangleChanged(editable: boolean) {
     this.rectangleOptions = {
       ...this.rectangleOptions,
-      editable: !this.rectangleOptions.editable,
+      editable,
       bounds: this.rectangle.getBounds(),
     };
   }
 
-  toggleCircleDisplay() {
-    this.isCircleDisplayed = !this.isCircleDisplayed;
-  }
-
-  toggleEditableCircle() {
+  editableCircleChanged(editable: boolean) {
     this.circleOptions = {
       ...this.circleOptions,
-      editable: !this.circleOptions.editable,
+      editable,
       center: this.circle.getCenter(),
       radius: this.circle.getRadius(),
     };
@@ -238,38 +224,6 @@ export class GoogleMapDemo {
 
   mapTypeChanged(event: Event) {
     this.mapTypeId = (event.target as HTMLSelectElement).value as unknown as google.maps.MapTypeId;
-  }
-
-  toggleGroundOverlayDisplay() {
-    this.isGroundOverlayDisplayed = !this.isGroundOverlayDisplayed;
-  }
-
-  groundOverlayUrlChanged(event: Event) {
-    this.groundOverlayUrl = (event.target as HTMLSelectElement).value;
-  }
-
-  toggleKmlLayerDisplay() {
-    this.isKmlLayerDisplayed = !this.isKmlLayerDisplayed;
-  }
-
-  toggleTrafficLayerDisplay() {
-    this.isTrafficLayerDisplayed = !this.isTrafficLayerDisplayed;
-  }
-
-  toggleTransitLayerDisplay() {
-    this.isTransitLayerDisplayed = !this.isTransitLayerDisplayed;
-  }
-
-  toggleBicyclingLayerDisplay() {
-    this.isBicyclingLayerDisplayed = !this.isBicyclingLayerDisplayed;
-  }
-
-  toggleAdvancedMarker() {
-    this.hasAdvancedMarker = !this.hasAdvancedMarker;
-  }
-
-  toggleAdvancedMarkerCustomContent() {
-    this.hasAdvancedMarkerCustomContent = !this.hasAdvancedMarkerCustomContent;
   }
 
   calculateDirections() {

--- a/src/google-maps/map-advanced-marker/map-advanced-marker.ts
+++ b/src/google-maps/map-advanced-marker/map-advanced-marker.ts
@@ -25,6 +25,7 @@ import {
 import {GoogleMap} from '../google-map/google-map';
 import {MapEventManager} from '../map-event-manager';
 import {Observable} from 'rxjs';
+import {MapAnchorPoint} from '../map-anchor-point';
 
 /**
  * Default options for the Google Maps marker component. Displays a marker
@@ -44,7 +45,7 @@ export const DEFAULT_MARKER_OPTIONS = {
   exportAs: 'mapAdvancedMarker',
   standalone: true,
 })
-export class MapAdvancedMarker implements OnInit, OnChanges, OnDestroy {
+export class MapAdvancedMarker implements OnInit, OnChanges, OnDestroy, MapAnchorPoint {
   private _eventManager = new MapEventManager(inject(NgZone));
 
   /**
@@ -80,10 +81,10 @@ export class MapAdvancedMarker implements OnInit, OnChanges, OnDestroy {
    * See: https://developers.google.com/maps/documentation/javascript/reference/advanced-markers#AdvancedMarkerElementOptions.content
    */
   @Input()
-  set content(content: Node | google.maps.marker.PinElement) {
+  set content(content: Node | google.maps.marker.PinElement | null) {
     this._content = content;
   }
-  private _content: Node;
+  private _content: Node | null;
 
   /**
    * If true, the AdvancedMarkerElement can be dragged.
@@ -229,6 +230,11 @@ export class MapAdvancedMarker implements OnInit, OnChanges, OnDestroy {
     if (this.advancedMarker) {
       this.advancedMarker.map = null;
     }
+  }
+
+  getAnchor(): google.maps.marker.AdvancedMarkerElement {
+    this._assertInitialized();
+    return this.advancedMarker;
   }
 
   /** Creates a combined options object using the passed-in options and the individual inputs. */

--- a/src/google-maps/map-anchor-point.ts
+++ b/src/google-maps/map-anchor-point.ts
@@ -10,5 +10,5 @@
 /// <reference types="google.maps" />
 
 export interface MapAnchorPoint {
-  getAnchor(): google.maps.MVCObject;
+  getAnchor(): google.maps.MVCObject | google.maps.marker.AdvancedMarkerElement;
 }

--- a/src/google-maps/map-info-window/README.md
+++ b/src/google-maps/map-info-window/README.md
@@ -36,14 +36,17 @@ export class GoogleMapDemo {
 
 ```html
 <!-- google-maps-demo.component.html -->
-<google-map 
+<google-map
   height="400px"
   width="750px"
   [center]="center"
   [zoom]="zoom"
   (mapClick)="addMarker($event)">
     @for (position of markerPositions; track position) {
-      <map-marker #marker="mapMarker" [position]="position" (mapClick)="openInfoWindow(marker)" />
+      <map-advanced-marker
+        #marker="mapMarker"
+        [position]="position"
+        (mapClick)="openInfoWindow(marker)" />
     }
     <map-info-window>Info Window content</map-info-window>
 </google-map>

--- a/src/google-maps/map-marker/README.md
+++ b/src/google-maps/map-marker/README.md
@@ -2,6 +2,8 @@
 
 The `MapMarker` component wraps the [`google.maps.Marker` class](https://developers.google.com/maps/documentation/javascript/reference/marker#Marker) from the Google Maps JavaScript API. The `MapMarker` component displays a marker on the map when it is a content child of a `GoogleMap` component. Like `GoogleMap`, this component offers an `options` input as well as convenience inputs for `position`, `title`, `label`, and `clickable`, and supports all `google.maps.Marker` events as outputs.
 
+**Note:** As of 2024, Google Maps has deprecated the `Marker` class. Consider using the `map-advanced-marker` instead.
+
 ## Example
 
 ```typescript
@@ -29,7 +31,7 @@ export class GoogleMapDemo {
 
 ```html
 <!-- google-map-demo.component.html -->
-<google-map 
+<google-map
   height="400px"
   width="750px"
   [center]="center"

--- a/src/universal-app/kitchen-sink/kitchen-sink.html
+++ b/src/universal-app/kitchen-sink/kitchen-sink.html
@@ -585,8 +585,9 @@
 
 <h2>Google Map</h2>
 <!-- position: relative prevents the "Map failed to load" element from leaving the container -->
-<google-map height="400px" width="750px" style="position: relative">
+<google-map height="400px" width="750px" mapId="123" style="position: relative">
   <map-marker [position]="{lat: 24, lng: 12}"></map-marker>
+  <map-advanced-marker [position]="{lat: 12, lng: 12}"></map-advanced-marker>
   <map-info-window>Hello</map-info-window>
   <map-polyline
     [options]="{

--- a/src/universal-app/kitchen-sink/kitchen-sink.ts
+++ b/src/universal-app/kitchen-sink/kitchen-sink.ts
@@ -22,6 +22,7 @@ import {
   MapRectangle,
   MapTrafficLayer,
   MapTransitLayer,
+  MapAdvancedMarker,
 } from '@angular/google-maps';
 import {MatAutocompleteModule} from '@angular/material/autocomplete';
 import {MatBadgeModule} from '@angular/material/badge';
@@ -196,6 +197,7 @@ export class TestEntryComponent {}
     MapInfoWindow,
     MapKmlLayer,
     MapMarker,
+    MapAdvancedMarker,
     MapMarkerClusterer,
     MapPolygon,
     MapPolyline,

--- a/tools/public_api_guard/google-maps/google-maps.md
+++ b/tools/public_api_guard/google-maps/google-maps.md
@@ -135,10 +135,12 @@ export class GoogleMapsModule {
 export type HeatmapData = google.maps.MVCArray<google.maps.LatLng | google.maps.visualization.WeightedLocation | google.maps.LatLngLiteral> | (google.maps.LatLng | google.maps.visualization.WeightedLocation | google.maps.LatLngLiteral)[];
 
 // @public
-export class MapAdvancedMarker implements OnInit, OnChanges, OnDestroy {
+export class MapAdvancedMarker implements OnInit, OnChanges, OnDestroy, MapAnchorPoint {
     constructor(_googleMap: GoogleMap, _ngZone: NgZone);
     advancedMarker: google.maps.marker.AdvancedMarkerElement;
-    set content(content: Node | google.maps.marker.PinElement);
+    set content(content: Node | google.maps.marker.PinElement | null);
+    // (undocumented)
+    getAnchor(): google.maps.marker.AdvancedMarkerElement;
     set gmpDraggable(draggable: boolean);
     readonly mapClick: Observable<google.maps.MapMouseEvent>;
     readonly mapDrag: Observable<google.maps.MapMouseEvent>;
@@ -164,7 +166,7 @@ export class MapAdvancedMarker implements OnInit, OnChanges, OnDestroy {
 // @public
 export interface MapAnchorPoint {
     // (undocumented)
-    getAnchor(): google.maps.MVCObject;
+    getAnchor(): google.maps.MVCObject | google.maps.marker.AdvancedMarkerElement;
 }
 
 // @public (undocumented)
@@ -391,7 +393,8 @@ export class MapInfoWindow implements OnInit, OnDestroy {
     ngOnDestroy(): void;
     // (undocumented)
     ngOnInit(): void;
-    open(anchor?: MapAnchorPoint, shouldFocus?: boolean): void;
+    open(anchor?: MapAnchorPoint, shouldFocus?: boolean, content?: string | Element | Text): void;
+    // @deprecated
     openAdvancedMarkerElement(advancedMarkerElement: google.maps.marker.AdvancedMarkerElement, content?: string | Element | Text): void;
     // (undocumented)
     set options(options: google.maps.InfoWindowOptions);


### PR DESCRIPTION
Includes a couple of changes:

### fix(google-maps): make info window open method compatible with advanced marker
Currently the info window has two methods: one for any `MapAnchorPoint` and one for an advanced marker. These changes deprecate the latter and make the former compatible with advanced markers.

### build: use ngModel in google map demo 
Adding new options to the Google Maps demo has been a bit cumbersome, because it's using `click` handlers on checkboxes to manage the state. These changes switch to using `ngModel`.