### PR TITLE
docs(material/sidenav): drawer width in documenation example has content squeezed

### DIFF
--- a/src/components-examples/material/sidenav/sidenav-drawer-overview/sidenav-drawer-overview-example.css
+++ b/src/components-examples/material/sidenav/sidenav-drawer-overview/sidenav-drawer-overview-example.css
@@ -1,6 +1,8 @@
 .example-container {
-  width: 400px;
+  width: auto;
   height: 200px;
   margin: 10px;
   border: 1px solid #555;
+  /* The background property is added to clearly distinguish the borders between drawer and main content */
+  background: #eee;
 }


### PR DESCRIPTION
Fixes the documentation example in the Angular Material 'sidenav' component. 
The drawer width in the example does not adequately contain the content
This was fixed by updating the width to auto and adding background color to distinguish drawers

Fixes #28885