### PR TITLE
docs(material/slide-toggle): add examples with labelPosition="before"

### DIFF
--- a/src/components-examples/material/slide-toggle/slide-toggle-overview/slide-toggle-overview-example.html
+++ b/src/components-examples/material/slide-toggle/slide-toggle-overview/slide-toggle-overview-example.html
@@ -1,1 +1,2 @@
-<mat-slide-toggle>Slide me!</mat-slide-toggle>
+<p><mat-slide-toggle>Slide me!</mat-slide-toggle></p>
+<p><mat-slide-toggle labelPosition="before">...and slide me too!</mat-slide-toggle></p>

--- a/src/dev-app/slide-toggle/slide-toggle-demo.html
+++ b/src/dev-app/slide-toggle/slide-toggle-demo.html
@@ -4,6 +4,13 @@
   <mat-slide-toggle [disabled]="firstToggle">Disable Bound</mat-slide-toggle>
   <mat-slide-toggle hideIcon [(ngModel)]="firstToggle">No icon</mat-slide-toggle>
 
+  <p>With label before the slide toggle.</p>
+
+  <mat-slide-toggle labelPosition="before" color="primary" [(ngModel)]="firstToggle">Default Slide Toggle</mat-slide-toggle>
+  <mat-slide-toggle labelPosition="before" [(ngModel)]="firstToggle" disabled>Disabled Slide Toggle</mat-slide-toggle>
+  <mat-slide-toggle labelPosition="before" [disabled]="firstToggle">Disable Bound</mat-slide-toggle>
+  <mat-slide-toggle labelPosition="before" hideIcon [(ngModel)]="firstToggle">No icon</mat-slide-toggle>
+
   <p>Example where the slide toggle is required inside of a form.</p>
 
   <form #form="ngForm" (ngSubmit)="onFormSubmit()">


### PR DESCRIPTION
Add examples of using the slide toggle with labelPosition="before". This renders the label before the toggle button.

Allow testing of issues when label is before the toggle button (#26880).

Relates to #26880