### PR TITLE
fix(material/progress-bar): avoid CSP issues for apps not using buffer mode

### DIFF
--- a/src/material/progress-bar/progress-bar.html
+++ b/src/material/progress-bar/progress-bar.html
@@ -6,7 +6,10 @@
   <div
     class="mdc-linear-progress__buffer-bar"
     [style.flex-basis]="_getBufferBarFlexBasis()"></div>
-  <div class="mdc-linear-progress__buffer-dots"></div>
+  <!-- Remove the dots outside of buffer mode since they can cause CSP issues (see #28938) -->
+  @if (mode === 'buffer') {
+    <div class="mdc-linear-progress__buffer-dots"></div>
+  }
 </div>
 <div
   class="mdc-linear-progress__bar mdc-linear-progress__primary-bar"


### PR DESCRIPTION
The `buffer` mode requires an element that uses a `data:` URI in its styles. This can be problematic for CSP.

Fixes #28938.