### PR TITLE
fix(material/dialog): input option is not binded to element when dialog is scrolled

### DIFF
--- a/src/material/dialog/dialog-container.html
+++ b/src/material/dialog/dialog-container.html
@@ -1,4 +1,4 @@
-<div class="mdc-dialog__container">
+<div class="mdc-dialog__container" cdkScrollable>
   <div class="mat-mdc-dialog-surface mdc-dialog__surface">
     <ng-template cdkPortalOutlet />
   </div>


### PR DESCRIPTION
Fixes the bug in the Angular Material 'dialog' component. 
The input in the dialog, in this case autocomplete does not stay attached when scrolled 
The solution implemented was by adding the cdkScrollable attribute to mat-dialog-content

Fixes #28936