### PR TITLE
build: fix patch deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,9 +50,9 @@
     "integration-tests:mdc-migration": "bazel test --test_output=streamed //integration/mdc-migration/...",
     "check-tooling-setup": "yarn tsc --project tools/tsconfig.json && yarn tsc --project scripts/tsconfig.json && yarn tsc --project .ng-dev/tsconfig.json",
     "tsc": "node ./node_modules/typescript/bin/tsc",
-    "ci-push-deploy-docs-app": "ts-node --esm --project scripts/tsconfig.json scripts/docs-deploy/deploy-ci-push.mts",
-    "ci-docs-monitor-test": "ts-node --esm --project scripts/tsconfig.json scripts/docs-deploy/monitoring/ci-test.mts",
-    "ci-notify-slack-failure": "ts-node --esm --project scripts/tsconfig.json scripts/circleci/notify-slack-job-failure.mts",
+    "ci-push-deploy-docs-app": "node --no-warnings=ExperimentalWarning --loader ts-node/esm/transpile-only scripts/docs-deploy/deploy-ci-push.mts",
+    "ci-docs-monitor-test": "node --no-warnings=ExperimentalWarning --loader ts-node/esm/transpile-only scripts/docs-deploy/monitoring/ci-test.mts",
+    "ci-notify-slack-failure": "node --no-warnings=ExperimentalWarning --loader ts-node/esm/transpile-only scripts/circleci/notify-slack-job-failure.mts",
     "prepare": "husky install"
   },
   "version": "17.3.5",


### PR DESCRIPTION
Updates the patch deployment scripts to avoid a ts-node error.