### PR TITLE
fix(material/core): export all available M3 palettes

### DIFF
--- a/guides/material-3.md
+++ b/guides/material-3.md
@@ -70,6 +70,7 @@ used with the `primary` and `tertiary` options:
 - `$magenta-palette`
 - `$orange-palette`
 - `$chartreuse-palette`
+- `$spring-green-palette`
 - `$azure-palette`
 - `$violet-palette`
 - `$rose-palette`

--- a/src/material/_index.scss
+++ b/src/material/_index.scss
@@ -8,7 +8,7 @@
   define-density;
 @forward './core/theming/palettes' show $red-palette, $green-palette, $blue-palette,
   $yellow-palette, $cyan-palette, $magenta-palette, $orange-palette,
-  $chartreuse-palette, $azure-palette, $violet-palette, $rose-palette;
+  $chartreuse-palette, $spring-green-palette, $azure-palette, $violet-palette, $rose-palette;
 @forward './core/theming/color-api-backwards-compatibility' show
   color-variants-backwards-compatibility;
 


### PR DESCRIPTION
Fixes that the `$spring-green-palette` wasn't being exported.

Fixes #28924.