### PR TITLE
fix(material/divider): non-text color contrast issues

### DIFF
--- a/src/dev-app/list/list-demo.scss
+++ b/src/dev-app/list/list-demo.scss
@@ -3,7 +3,7 @@
   flex-flow: row wrap;
 
   .mat-mdc-list-base {
-    border: 1px solid rgba(0, 0, 0, 0.12);
+    border: 1px solid var(--mat-divider-color);
     width: 350px;
     margin: 20px 20px 0 0;
   }

--- a/src/material/core/tokens/m3/mat/_divider.scss
+++ b/src/material/core/tokens/m3/mat/_divider.scss
@@ -12,7 +12,7 @@ $prefix: (mat, divider);
 @function get-tokens($systems, $exclude-hardcoded, $token-slots) {
   $tokens: (
     width: token-utils.hardcode(1px, $exclude-hardcoded),
-    color: map.get($systems, md-sys-color, outline-variant),
+    color: map.get($systems, md-sys-color, outline),
   );
 
   @return token-utils.namespace-tokens($prefix, $tokens, $token-slots);

--- a/src/material/core/tokens/m3/mat/_expansion.scss
+++ b/src/material/core/tokens/m3/mat/_expansion.scss
@@ -20,7 +20,7 @@ $prefix: (mat, expansion);
       header-indicator-display: token-utils.hardcode(inline-block, $exclude-hardcoded),
       container-background-color: map.get($systems, md-sys-color, surface),
       container-text-color: map.get($systems, md-sys-color, on-surface),
-      actions-divider-color: map.get($systems, md-sys-color, outline-variant),
+      actions-divider-color: map.get($systems, md-sys-color, outline),
       header-hover-state-layer-color: sass-utils.safe-color-change(
         map.get($systems, md-sys-color, on-surface),
         $alpha: map.get($systems, md-sys-state, hover-state-layer-opacity)

--- a/src/material/core/tokens/m3/mat/_stepper.scss
+++ b/src/material/core/tokens/m3/mat/_stepper.scss
@@ -14,7 +14,7 @@ $prefix: (mat, stepper);
   $tokens: (
     (
       container-color: map.get($systems, md-sys-color, surface),
-      line-color: map.get($systems, md-sys-color, outline-variant),
+      line-color: map.get($systems, md-sys-color, outline),
       header-hover-state-layer-color: sass-utils.safe-color-change(
         map.get($systems, md-sys-color, inverse-surface),
         $alpha: map.get($systems, md-sys-state, hover-state-layer-opacity)

--- a/src/material/core/tokens/m3/mat/_table.scss
+++ b/src/material/core/tokens/m3/mat/_table.scss
@@ -20,7 +20,7 @@ $prefix: (mat, table);
       background-color: map.get($systems, md-sys-color, surface),
       header-headline-color: map.get($systems, md-sys-color, on-surface),
       row-item-label-text-color: map.get($systems, md-sys-color, on-surface),
-      row-item-outline-color: map.get($systems, md-sys-color, outline-variant),
+      row-item-outline-color: map.get($systems, md-sys-color, outline),
     ),
   );
 


### PR DESCRIPTION
Fixes color contrast issues with non-text elements, including divider. Changed from "outline-variant" to "outline" colors to pass 3:1 ratio between light/dark mode backgrounds. Also changing for expansion, stepper, and table so they can also pass not-text color contrast.

Before (Light mode):
FG- #c4c6d0 (neutral-variant80)
BG- #fff
Ratio: 1.70:1
Screenshot: 
![image](https://github.com/angular/components/assets/42016383/46f243b8-04d1-45fc-a825-deef998361e6)


After (Light mode):
FG- #747775 (neutral-variant50)
BG- #fff
Ratio: 4.52:1
Screenshot: 
![image](https://github.com/angular/components/assets/42016383/3fce70e4-6484-4093-a3e0-4e3226572975)

Before (Dark mode):
FG- #44474E (neutral-variant30)
BG- #1f1f1f
Ratio: 1.77:1
Screenshot: 
![image](https://github.com/angular/components/assets/42016383/d3e15de8-b2cd-4534-8136-04bbf39605e8)


After (Dark mode):
FG- #8e9099 (neutral-variant60)
BG- #1f1f1f
Ratio: 5.17:1
Screenshot: 
![image](https://github.com/angular/components/assets/42016383/786f92b4-1db8-44fa-820f-e14ccb0c37fb)

Fixes b/291964002