### PR TITLE
fix(material/button): incorrect template for icon button anchor

### DIFF
--- a/src/material/button/icon-button.ts
+++ b/src/material/button/icon-button.ts
@@ -54,7 +54,7 @@ export class MatIconButton extends MatButtonBase {
  */
 @Component({
   selector: `a[mat-icon-button]`,
-  templateUrl: 'button.html',
+  templateUrl: 'icon-button.html',
   styleUrls: ['icon-button.css', 'button-high-contrast.css'],
   host: MAT_ANCHOR_HOST,
   exportAs: 'matButton, matAnchor',

--- a/tools/public_api_guard/material/button.md
+++ b/tools/public_api_guard/material/button.md
@@ -100,7 +100,7 @@ export interface MatFabDefaultOptions {
 export class MatIconAnchor extends MatAnchorBase {
     constructor(elementRef: ElementRef, platform: Platform, ngZone: NgZone, animationMode?: string);
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<MatIconAnchor, "a[mat-icon-button]", ["matButton", "matAnchor"], {}, {}, never, [".material-icons:not([iconPositionEnd]), mat-icon:not([iconPositionEnd]), [matButtonIcon]:not([iconPositionEnd])", "*", ".material-icons[iconPositionEnd], mat-icon[iconPositionEnd], [matButtonIcon][iconPositionEnd]"], true, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MatIconAnchor, "a[mat-icon-button]", ["matButton", "matAnchor"], {}, {}, never, ["*"], true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatIconAnchor, [null, null, null, { optional: true; }]>;
 }


### PR DESCRIPTION
Fixes that the icon button anchor was using the base button template instead of the icon button one.

Fixes #28990.