### PR TITLE
fix(material/tooltip): Tooltip should mark for check when visibility …

### DIFF
--- a/src/material/tooltip/tooltip.ts
+++ b/src/material/tooltip/tooltip.ts
@@ -1105,7 +1105,10 @@ export class TooltipComponent implements OnDestroy {
     const hideClass = this._hideAnimation;
     tooltip.classList.remove(isVisible ? hideClass : showClass);
     tooltip.classList.add(isVisible ? showClass : hideClass);
-    this._isVisible = isVisible;
+    if (this._isVisible !== isVisible) {
+      this._isVisible = isVisible;
+      this._changeDetectorRef.markForCheck();
+    }
 
     // It's common for internal apps to disable animations using `* { animation: none !important }`
     // which can break the opening sequence. Try to detect such cases and work around them.


### PR DESCRIPTION
…changes

This commit fixes an error in the tooltip component where it updates a value used in a host binding without calling `markForCheck`. This does not currently throw an error because `checkNoChanges` is broken for `OnPush` components. However, the error was surfaced when testing an "exhaustive" check that will check _all_ views, regardless of their dirty state. The issue also doesn't really produce a _visible_ problem because it occurs when the tooltip is hidden so the fact that the zoom never updates doesn't make a real difference.