### PR TITLE
feat(cdk/dialog, cdk/overlay): support open and close animations for overlay and backdrop

### DIFF
--- a/src/cdk/dialog/dialog-config.ts
+++ b/src/cdk/dialog/dialog-config.ts
@@ -16,6 +16,7 @@ import {
 import {Direction} from '@angular/cdk/bidi';
 import {PositionStrategy, ScrollStrategy} from '@angular/cdk/overlay';
 import {BasePortalOutlet} from '@angular/cdk/portal';
+import {animate, AnimationMetadata, style} from '@angular/animations';
 
 /** Options for where to set focus to automatically on dialog open */
 export type AutoFocusTarget = 'dialog' | 'first-tabbable' | 'first-heading';
@@ -168,4 +169,40 @@ export class DialogConfig<D = unknown, R = unknown, C extends BasePortalOutlet =
    * A function can be passed in to resolve the context lazily.
    */
   templateContext?: Record<string, any> | (() => Record<string, any>);
+
+  /**
+   * Animations applied to the overlay when dialog is opened.
+   * The default animation is based on the Material Design swift-ease-out.
+   */
+  overlayOpenAnimations?: AnimationMetadata | AnimationMetadata[] = [
+    style({opacity: 0}),
+    animate('400ms cubic-bezier(0.25, 0.8, 0.25, 1)', style({opacity: 1})),
+  ];
+
+  /**
+   * Animations applied to the backdrop when dialog is opened.
+   * The default animation is based on the Material Design swift-ease-out.
+   */
+  backdropOpenAnimations?: AnimationMetadata | AnimationMetadata[] = [
+    style({opacity: 0}),
+    animate('400ms cubic-bezier(0.25, 0.8, 0.25, 1)', style({opacity: 1})),
+  ];
+
+  /**
+   * Animations applied to the overlay when dialog is closed.
+   * The default animation is based on the Material Design swift-ease-in.
+   */
+  overlayCloseAnimations?: AnimationMetadata | AnimationMetadata[] = animate(
+    '300ms cubic-bezier(0.55, 0, 0.55, 0.2)',
+    style({opacity: 0}),
+  );
+
+  /**
+   * Animations applied to the backdrop when dialog is closed.
+   * The default animation is based on the Material Design swift-ease-in.
+   */
+  backdropCloseAnimations?: AnimationMetadata | AnimationMetadata[] = animate(
+    '300ms cubic-bezier(0.55, 0, 0.55, 0.2)',
+    style({opacity: 0}),
+  );
 }

--- a/src/cdk/dialog/dialog-ref.ts
+++ b/src/cdk/dialog/dialog-ref.ts
@@ -96,20 +96,23 @@ export class DialogRef<R = unknown, C = unknown> {
    * @param result Optional result to return to the dialog opener.
    * @param options Additional options to customize the closing behavior.
    */
-  close(result?: R, options?: DialogCloseOptions): void {
-    if (this.containerInstance) {
-      const closedSubject = this.closed as Subject<R | undefined>;
-      this.containerInstance._closeInteractionType = options?.focusOrigin || 'program';
-      // Drop the detach subscription first since it can be triggered by the
-      // `dispose` call and override the result of this closing sequence.
-      this._detachSubscription.unsubscribe();
-      this.overlayRef.dispose();
-      closedSubject.next(result);
-      closedSubject.complete();
-      (this as {componentInstance: C}).componentInstance = (
-        this as {containerInstance: BasePortalOutlet}
-      ).containerInstance = null!;
+  async close(result?: R, options?: DialogCloseOptions): Promise<void> {
+    if (!this.containerInstance) {
+      return Promise.resolve();
     }
+
+    const closedSubject = this.closed as Subject<R | undefined>;
+    this.containerInstance._closeInteractionType = options?.focusOrigin || 'program';
+    // Drop the detach subscription first since it can be triggered by the
+    // `dispose` call and override the result of this closing sequence.
+    this._detachSubscription.unsubscribe();
+
+    await this.overlayRef.dispose();
+    closedSubject.next(result);
+    closedSubject.complete();
+    (this as {componentInstance: C}).componentInstance = (
+      this as {containerInstance: BasePortalOutlet}
+    ).containerInstance = null!;
   }
 
   /** Updates the position of the dialog based on the current position strategy. */

--- a/src/cdk/dialog/dialog.ts
+++ b/src/cdk/dialog/dialog.ts
@@ -35,6 +35,7 @@ import {startWith} from 'rxjs/operators';
 
 import {DEFAULT_DIALOG_CONFIG, DIALOG_DATA, DIALOG_SCROLL_STRATEGY} from './dialog-injectors';
 import {CdkDialogContainer} from './dialog-container';
+import {AnimationBuilder} from '@angular/animations';
 
 /** Unique id for the created dialog. */
 let uniqueId = 0;
@@ -201,6 +202,10 @@ export class Dialog implements OnDestroy {
       width: config.width,
       height: config.height,
       disposeOnNavigation: config.closeOnNavigation,
+      paneOpenAnimations: config.overlayOpenAnimations,
+      backdropOpenAnimations: config.backdropOpenAnimations,
+      paneCloseAnimations: config.overlayCloseAnimations,
+      backdropCloseAnimations: config.backdropCloseAnimations,
     });
 
     if (config.backdropClass) {

--- a/src/cdk/overlay/BUILD.bazel
+++ b/src/cdk/overlay/BUILD.bazel
@@ -26,6 +26,7 @@ ng_module(
         "//src/cdk/platform",
         "//src/cdk/portal",
         "//src/cdk/scrolling",
+        "@npm//@angular/animations",
         "@npm//@angular/common",
         "@npm//@angular/core",
         "@npm//rxjs",

--- a/src/cdk/overlay/_index.scss
+++ b/src/cdk/overlay/_index.scss
@@ -8,10 +8,6 @@ $overlay-backdrop-z-index: 1000 !default;
 // Background color for all of the backdrops
 $overlay-backdrop-color: rgba(0, 0, 0, 0.32) !default;
 
-// Default backdrop animation is based on the Material Design swift-ease-out.
-$backdrop-animation-duration: 400ms !default;
-$backdrop-animation-timing-function: cubic-bezier(0.25, 0.8, 0.25, 1) !default;
-
 /// Emits structural styles required for cdk/overlay to function.
 @mixin overlay() {
   .cdk-overlay-container, .cdk-global-overlay-wrapper {
@@ -61,6 +57,8 @@ $backdrop-animation-timing-function: cubic-bezier(0.25, 0.8, 0.25, 1) !default;
     display: flex;
     max-width: 100%;
     max-height: 100%;
+
+    &.cdk-overlay-pane-showing {}
   }
 
   .cdk-overlay-backdrop {
@@ -74,12 +72,8 @@ $backdrop-animation-timing-function: cubic-bezier(0.25, 0.8, 0.25, 1) !default;
     z-index: $overlay-backdrop-z-index;
     pointer-events: auto;
     -webkit-tap-highlight-color: transparent;
-    transition: opacity $backdrop-animation-duration $backdrop-animation-timing-function;
-    opacity: 0;
 
     &.cdk-overlay-backdrop-showing {
-      opacity: 1;
-
       // Note that we can't import and use the `high-contrast` mixin from `_a11y.scss`, because
       // this file will be copied to the top-level `cdk` package when putting together the files
       // for npm. Any relative import paths we use here will become invalid once the file is copied.
@@ -96,23 +90,12 @@ $backdrop-animation-timing-function: cubic-bezier(0.25, 0.8, 0.25, 1) !default;
   }
 
   .cdk-overlay-transparent-backdrop {
-    // Define a transition on the visibility so that the `transitionend` event can fire immediately.
-    transition: visibility 1ms linear, opacity 1ms linear;
-    visibility: hidden;
-    opacity: 1;
-
     // Note: as of Firefox 57, having the backdrop be `background: none` will prevent it from
     // capturing the user's mouse scroll events. Since we also can't use something like
     // `rgba(0, 0, 0, 0)`, we work around the inconsistency by not setting the background at
     // all and using `opacity` to make the element transparent.
-    &.cdk-overlay-backdrop-showing {
-      opacity: 0;
-      visibility: visible;
-    }
-  }
-
-  .cdk-overlay-backdrop-noop-animation {
-    transition: none;
+    opacity: 0;
+    visibility: visible;
   }
 
   // Overlay parent element used with the connected position strategy. Used to constrain the

--- a/src/cdk/overlay/overlay-config.ts
+++ b/src/cdk/overlay/overlay-config.ts
@@ -9,6 +9,7 @@
 import {PositionStrategy} from './position/position-strategy';
 import {Direction, Directionality} from '@angular/cdk/bidi';
 import {ScrollStrategy, NoopScrollStrategy} from './scroll/index';
+import {AnimationMetadata} from '@angular/animations';
 
 /** Initial configuration used when creating an overlay. */
 export class OverlayConfig {
@@ -57,6 +58,18 @@ export class OverlayConfig {
    * the `HashLocationStrategy`).
    */
   disposeOnNavigation?: boolean = false;
+
+  /** Animations applied to the pane when overlay is opened. */
+  paneOpenAnimations?: AnimationMetadata | AnimationMetadata[];
+
+  /** Animations applied to the backdrop when overlay is opened. */
+  backdropOpenAnimations?: AnimationMetadata | AnimationMetadata[];
+
+  /** Animations applied to the pane when overlay is closed. */
+  paneCloseAnimations?: AnimationMetadata | AnimationMetadata[];
+
+  /** Animations applied to the backdrop when overlay is closed. */
+  backdropCloseAnimations?: AnimationMetadata | AnimationMetadata[];
 
   constructor(config?: OverlayConfig) {
     if (config) {

--- a/src/cdk/overlay/overlay.ts
+++ b/src/cdk/overlay/overlay.ts
@@ -27,6 +27,7 @@ import {OverlayContainer} from './overlay-container';
 import {OverlayRef} from './overlay-ref';
 import {OverlayPositionBuilder} from './position/overlay-position-builder';
 import {ScrollStrategyOptions} from './scroll/index';
+import {AnimationBuilder} from '@angular/animations';
 
 /** Next overlay unique ID. */
 let nextUniqueId = 0;
@@ -59,7 +60,7 @@ export class Overlay {
     private _directionality: Directionality,
     private _location: Location,
     private _outsideClickDispatcher: OverlayOutsideClickDispatcher,
-    @Inject(ANIMATION_MODULE_TYPE) @Optional() private _animationsModuleType?: string,
+    private _animationBuilder: AnimationBuilder,
   ) {}
 
   /**
@@ -85,8 +86,8 @@ export class Overlay {
       this._document,
       this._location,
       this._outsideClickDispatcher,
-      this._animationsModuleType === 'NoopAnimations',
       this._injector.get(EnvironmentInjector),
+      this._animationBuilder,
     );
   }
 

--- a/src/cdk/portal/dom-portal-outlet.ts
+++ b/src/cdk/portal/dom-portal-outlet.ts
@@ -176,9 +176,10 @@ export class DomPortalOutlet extends BasePortalOutlet {
   /**
    * Clears out a portal from the DOM.
    */
-  override dispose(): void {
+  override dispose(): Promise<void> {
     super.dispose();
     this.outletElement.remove();
+    return Promise.resolve();
   }
 
   /** Gets the root HTMLElement for an instantiated component. */

--- a/src/cdk/portal/portal.ts
+++ b/src/cdk/portal/portal.ts
@@ -183,7 +183,7 @@ export interface PortalOutlet {
   detach(): any;
 
   /** Performs cleanup before the outlet is destroyed. */
-  dispose(): void;
+  dispose(): Promise<void>;
 
   /** Whether there is currently a portal attached to this outlet. */
   hasAttached(): boolean;
@@ -269,13 +269,14 @@ export abstract class BasePortalOutlet implements PortalOutlet {
   }
 
   /** Permanently dispose of this portal host. */
-  dispose(): void {
+  dispose(): Promise<void> {
     if (this.hasAttached()) {
       this.detach();
     }
 
     this._invokeDisposeFn();
     this._isDisposed = true;
+    return Promise.resolve();
   }
 
   /** @docs-private */

--- a/src/material/dialog/dialog.ts
+++ b/src/material/dialog/dialog.ts
@@ -213,6 +213,12 @@ export class MatDialog implements OnDestroy {
           {provide: this._dialogRefConstructor, useValue: dialogRef},
         ];
       },
+      // material ui still uses its own animation system,
+      // so we disable cdk-dialog animations to prevent any interference
+      overlayOpenAnimations: undefined,
+      backdropOpenAnimations: undefined,
+      overlayCloseAnimations: undefined,
+      backdropCloseAnimations: undefined,
     });
 
     // This can't be assigned in the `providers` callback, because


### PR DESCRIPTION
This PR removes the CSS based opening animations for the backdrop of cdk/overlay and replaces it with the options to define opening and closing angular animations for the cdk/overlay overlay and backdrop.

Closing animations are currently not possible as the disposal does not wait for animations to finish, this PR fixes this and adds more flexibility and ease of use.

It also adds default animations for all cases for the cdk/dialog, but disables them for the material ui dialog to prevent any interference with the custom material ui dialog animations.

Fixes #28878 

Demo:

https://github.com/angular/components/assets/11254522/6561b60d-2d12-4fac-9115-af164ccd7194