### PR TITLE
fix(material/paginator): fix issue with paginator focus

### DIFF
--- a/src/material/paginator/paginator.ts
+++ b/src/material/paginator/paginator.ts
@@ -11,7 +11,6 @@ import {
   ChangeDetectorRef,
   Component,
   EventEmitter,
-  HostListener,
   Inject,
   InjectionToken,
   Input,

--- a/src/material/paginator/paginator.ts
+++ b/src/material/paginator/paginator.ts
@@ -123,6 +123,12 @@ export class MatPaginator implements OnInit, OnDestroy {
   /** ID for the DOM node containing the paginator's items per page label. */
   readonly _pageSizeLabelId = `mat-paginator-page-size-label-${nextUniqueId++}`;
 
+  /** MDC class names of paginator buttons. */
+  readonly _pageNext = 'mat-mdc-paginator-navigation-next';
+  readonly _pagePrevious = 'mat-mdc-paginator-navigation-previous';
+  readonly _pageFirst = 'mat-mdc-paginator-navigation-first';
+  readonly _pageLast = 'mat-mdc-paginator-navigation-last';
+
   private _intlChanges: Subscription;
   private _isInitialized = false;
   private _initializedStream = new ReplaySubject<void>(1);
@@ -311,29 +317,20 @@ export class MatPaginator implements OnInit, OnDestroy {
 
       setTimeout(() => {
         event.preventDefault();
-        if (
-          currentElement.disabled &&
-          currentElement.classList.contains('mat-mdc-paginator-navigation-next')
-        ) {
+        if (currentElement.disabled && currentElement.classList.contains(this._pageNext)) {
           const previousElement = currentElement.previousElementSibling as HTMLButtonElement;
           previousElement?.focus();
         } else if (
           currentElement.disabled &&
-          currentElement.classList.contains('mat-mdc-paginator-navigation-previous')
+          currentElement.classList.contains(this._pagePrevious)
         ) {
           const nextElement = currentElement.nextElementSibling as HTMLButtonElement;
           nextElement?.focus();
-        } else if (
-          currentElement.disabled &&
-          currentElement.classList.contains('mat-mdc-paginator-navigation-first')
-        ) {
+        } else if (currentElement.disabled && currentElement.classList.contains(this._pageFirst)) {
           const nextElement = currentElement.nextElementSibling
             ?.nextElementSibling as HTMLButtonElement;
           nextElement?.focus();
-        } else if (
-          currentElement.disabled &&
-          currentElement.classList.contains('mat-mdc-paginator-navigation-last')
-        ) {
+        } else if (currentElement.disabled && currentElement.classList.contains(this._pageLast)) {
           const previousElement = currentElement.previousElementSibling
             ?.previousElementSibling as HTMLButtonElement;
           previousElement?.focus();

--- a/src/material/paginator/paginator.ts
+++ b/src/material/paginator/paginator.ts
@@ -316,7 +316,8 @@ export class MatPaginator implements OnInit, OnDestroy {
     if (event.key === 'Enter') {
       const currentElement = event.target as HTMLButtonElement;
 
-      /** setTimeout is used to give DOM time to update currentElement (paginator buttons)
+      /**
+       * setTimeout is used to give DOM time to update currentElement (paginator buttons)
        * to see if it's disabled or not.
        */
       setTimeout(() => {

--- a/src/material/paginator/paginator.ts
+++ b/src/material/paginator/paginator.ts
@@ -11,6 +11,7 @@ import {
   ChangeDetectorRef,
   Component,
   EventEmitter,
+  HostListener,
   Inject,
   InjectionToken,
   Input,
@@ -112,6 +113,10 @@ let nextUniqueId = 0;
   imports: [MatFormField, MatSelect, MatOption, MatIconButton, MatTooltip],
 })
 export class MatPaginator implements OnInit, OnDestroy {
+  /** Listener to know when to focus on previous button when next button is disabled */
+  @HostListener('keydown', ['$event']) focusPreviousIfDisabledFunc(event: KeyboardEvent) {
+    this.focusPreviousOrNextIfDisabled(event);
+  }
   /** If set, styles the "page size" form field with the designated style. */
   _formFieldAppearance?: MatFormFieldAppearance;
 
@@ -298,6 +303,43 @@ export class MatPaginator implements OnInit, OnDestroy {
     }
 
     return Math.ceil(this.length / this.pageSize);
+  }
+
+  focusPreviousOrNextIfDisabled(event: KeyboardEvent) {
+    if (event.key === 'Enter') {
+      const currentElement = event.target as HTMLButtonElement;
+
+      setTimeout(() => {
+        event.preventDefault();
+        if (
+          currentElement.disabled &&
+          currentElement.classList.contains('mat-mdc-paginator-navigation-next')
+        ) {
+          const previousElement = currentElement.previousElementSibling as HTMLButtonElement;
+          previousElement?.focus();
+        } else if (
+          currentElement.disabled &&
+          currentElement.classList.contains('mat-mdc-paginator-navigation-previous')
+        ) {
+          const nextElement = currentElement.nextElementSibling as HTMLButtonElement;
+          nextElement?.focus();
+        } else if (
+          currentElement.disabled &&
+          currentElement.classList.contains('mat-mdc-paginator-navigation-first')
+        ) {
+          const nextElement = currentElement.nextElementSibling
+            ?.nextElementSibling as HTMLButtonElement;
+          nextElement?.focus();
+        } else if (
+          currentElement.disabled &&
+          currentElement.classList.contains('mat-mdc-paginator-navigation-last')
+        ) {
+          const previousElement = currentElement.previousElementSibling
+            ?.previousElementSibling as HTMLButtonElement;
+          previousElement?.focus();
+        }
+      }, 100);
+    }
   }
 
   /**

--- a/src/material/paginator/paginator.ts
+++ b/src/material/paginator/paginator.ts
@@ -106,6 +106,7 @@ let nextUniqueId = 0;
   host: {
     'class': 'mat-mdc-paginator',
     'role': 'group',
+    '(keydown)': '_focusPreviousOrNextIfDisabled($event)',
   },
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
@@ -113,10 +114,6 @@ let nextUniqueId = 0;
   imports: [MatFormField, MatSelect, MatOption, MatIconButton, MatTooltip],
 })
 export class MatPaginator implements OnInit, OnDestroy {
-  /** Listener to know when to focus on previous button when next button is disabled */
-  @HostListener('keydown', ['$event']) focusPreviousIfDisabledFunc(event: KeyboardEvent) {
-    this.focusPreviousOrNextIfDisabled(event);
-  }
   /** If set, styles the "page size" form field with the designated style. */
   _formFieldAppearance?: MatFormFieldAppearance;
 
@@ -311,10 +308,18 @@ export class MatPaginator implements OnInit, OnDestroy {
     return Math.ceil(this.length / this.pageSize);
   }
 
-  focusPreviousOrNextIfDisabled(event: KeyboardEvent) {
+  /**
+   * Handle keyboard Enter event for the Paginator. Keeps focus on appropriate paginator button
+   * whenever next, previous, first, or last button becomes disabled.
+   * @param event The keyboard event to be handled.
+   */
+  _focusPreviousOrNextIfDisabled(event: KeyboardEvent) {
     if (event.key === 'Enter') {
       const currentElement = event.target as HTMLButtonElement;
 
+      /** setTimeout is used to give DOM time to update currentElement (paginator buttons)
+       * to see if it's disabled or not.
+       */
       setTimeout(() => {
         event.preventDefault();
         if (currentElement.disabled && currentElement.classList.contains(this._pageNext)) {

--- a/tools/public_api_guard/material/paginator.md
+++ b/tools/public_api_guard/material/paginator.md
@@ -40,6 +40,7 @@ export class MatPaginator implements OnInit, OnDestroy {
     disabled: boolean;
     _displayedPageSizeOptions: number[];
     firstPage(): void;
+    _focusPreviousOrNextIfDisabled(event: KeyboardEvent): void;
     _formFieldAppearance?: MatFormFieldAppearance;
     getNumberOfPages(): number;
     hasNextPage(): boolean;
@@ -70,8 +71,15 @@ export class MatPaginator implements OnInit, OnDestroy {
     // (undocumented)
     ngOnInit(): void;
     readonly page: EventEmitter<PageEvent>;
+    // (undocumented)
+    readonly _pageFirst = "mat-mdc-paginator-navigation-first";
     get pageIndex(): number;
     set pageIndex(value: number);
+    // (undocumented)
+    readonly _pageLast = "mat-mdc-paginator-navigation-last";
+    readonly _pageNext = "mat-mdc-paginator-navigation-next";
+    // (undocumented)
+    readonly _pagePrevious = "mat-mdc-paginator-navigation-previous";
     get pageSize(): number;
     set pageSize(value: number);
     readonly _pageSizeLabelId: string;


### PR DESCRIPTION
Fixes an issue where focus is lost and goes back to the body when on the next, previous, first, or last buttons are disabled. Changed to where focus will now jump to the next appropriate button instead of focusing to body.

Before:
[Screen recording 2024-05-07 9.22.24 AM.webm](https://github.com/angular/components/assets/42016383/5a71521f-ae34-4faa-b812-233d9a609a9d)

After: 
[Screen recording 2024-05-07 9.19.26 AM.webm](https://github.com/angular/components/assets/42016383/21f877a4-d836-4f3f-9282-14bfd4c4c20e)


Fixes b/286098030