### PR TITLE
fix(material/core): ripple loader not working in shadow DOM

### DIFF
--- a/src/material/button/button.spec.ts
+++ b/src/material/button/button.spec.ts
@@ -333,7 +333,7 @@ describe('MDC-based MatButton', () => {
     });
 
     // Ensure each of these events triggers the initialization of the button ripple.
-    for (const event of ['click', 'touchstart', 'mouseenter', 'focus']) {
+    for (const event of ['mousedown', 'touchstart', 'mouseenter', 'focus']) {
       it(`should render the ripple once a button has received a "${event}" event`, () => {
         const fab = fixture.debugElement.query(By.css('button[mat-fab]'))!;
         let ripple = fab.nativeElement.querySelector('.mat-mdc-button-ripple');


### PR DESCRIPTION
Fixes the following issues that prevented the button ripples from being loaded in the shadow DOM:
* We weren't resolving the event target properly.
* We were using `click` as a fallback which happens too late for the very first ripple. These changes switch to `mousedown`.

Fixes #29011.