### PR TITLE
build: temporarily force local spawn strategy during release builds

### DIFF
--- a/scripts/build-packages-dist.mts
+++ b/scripts/build-packages-dist.mts
@@ -64,7 +64,8 @@ function buildReleasePackages(distPath: string, isSnapshotBuild: boolean): Built
   // version placeholder is populated in the release output.
   const stampConfigArg = `--config=${isSnapshotBuild ? 'snapshot-build' : 'release'}`;
 
-  exec(`${bazelCmd} build ${stampConfigArg} ${targets.join(' ')}`);
+  // TODO(josephperrott): Figure out why we can't use workers right now.
+  exec(`${bazelCmd} build --spawn_strategy=local ${stampConfigArg} ${targets.join(' ')}`);
 
   // Delete the distribution directory so that the output is guaranteed to be clean. Re-create
   // the empty directory so that we can copy the release packages into it later.


### PR DESCRIPTION
Temporarily force the local spawn strategy for building during release due to seeing unexpected and yet to be traced failures in the Sass compiler within workers.