### PR TITLE
fix(cdk/observers): logs "ResizeObserver loop limit exceeded" errors

### DIFF
--- a/src/cdk/observers/private/shared-resize-observer.ts
+++ b/src/cdk/observers/private/shared-resize-observer.ts
@@ -15,7 +15,7 @@ import {filter, shareReplay, takeUntil} from 'rxjs/operators';
  * @param e The error
  */
 const loopLimitExceededErrorHandler = (e: unknown) => {
-  if (e instanceof Error && e.message === 'ResizeObserver loop limit exceeded') {
+  if (e instanceof ErrorEvent && e.message === 'ResizeObserver loop limit exceeded') {
     console.error(
       `${e.message}. This could indicate a performance issue with your app. See https://github.com/WICG/resize-observer/blob/master/explainer.md#error-handling`,
     );


### PR DESCRIPTION
The function `loopLimitExceededErrorHandler` never logs "ResizeObserver loop limit exceeded" errors because an [error event](https://developer.mozilla.org/en-US/docs/Web/API/Window/error_event) (fired by a `Window` object) is an instance of [`ErrorEvent`](https://developer.mozilla.org/en-US/docs/Web/API/ErrorEvent).
