### PR TITLE
Update portal.spec.ts DOM text reinterpreted as HTML

### DIFF
--- a/src/cdk/portal/portal.spec.ts
+++ b/src/cdk/portal/portal.spec.ts
@@ -176,7 +176,7 @@ describe('Portals', () => {
       testAppComponent.selectedPortal = domPortal;
       fixture.detectChanges();
 
-      parent.innerHTML = '';
+      parent.innerText = '';
 
       expect(() => {
         testAppComponent.selectedPortal = undefined;


### PR DESCRIPTION
By using innerText, it will avoid the risk of HTML injection, as these properties automatically escape any HTML special characters in the provided text. This helps prevent cross-site scripting (XSS) vulnerabilities by treating the input as plain text rather than interpreted HTML.