### PR TITLE
fix(material/chips): simplify repeat chip removal prevention

### DIFF
--- a/src/material/chips/chip-grid.spec.ts
+++ b/src/material/chips/chip-grid.spec.ts
@@ -1,7 +1,6 @@
 import {animate, style, transition, trigger} from '@angular/animations';
 import {Direction, Directionality} from '@angular/cdk/bidi';
 import {
-  A,
   BACKSPACE,
   DELETE,
   END,
@@ -13,6 +12,8 @@ import {
   TAB,
 } from '@angular/cdk/keycodes';
 import {
+  createKeyboardEvent,
+  dispatchEvent,
   dispatchFakeEvent,
   dispatchKeyboardEvent,
   patchElementFocus,
@@ -789,28 +790,15 @@ describe('MDC-based MatChipGrid', () => {
         expectLastCellFocused();
       });
 
-      it(
-        'should not focus the last chip when pressing BACKSPACE after changing input, ' +
-          'until BACKSPACE is released and pressed again',
-        () => {
-          // Change the input
-          dispatchKeyboardEvent(nativeInput, 'keydown', A);
-
-          // It shouldn't focus until backspace is released and pressed again
-          dispatchKeyboardEvent(nativeInput, 'keydown', BACKSPACE);
-          dispatchKeyboardEvent(nativeInput, 'keydown', BACKSPACE);
-          dispatchKeyboardEvent(nativeInput, 'keydown', BACKSPACE);
-          expectNoCellFocused();
-
-          // Still not focused
-          dispatchKeyboardEvent(nativeInput, 'keyup', BACKSPACE);
-          expectNoCellFocused();
-
-          // Only now should it focus the last element
-          dispatchKeyboardEvent(nativeInput, 'keydown', BACKSPACE);
-          expectLastCellFocused();
-        },
-      );
+      it('should not focus the last chip when the BACKSPACE key is being repeated', () => {
+        // Only now should it focus the last element
+        const event = createKeyboardEvent('keydown', BACKSPACE);
+        Object.defineProperty(event, 'repeat', {
+          get: () => true,
+        });
+        dispatchEvent(nativeInput, event);
+        expectNoCellFocused();
+      });
 
       it('should focus last chip after pressing BACKSPACE after creating a chip', () => {
         // Create a chip

--- a/src/material/chips/chip-row.spec.ts
+++ b/src/material/chips/chip-row.spec.ts
@@ -123,7 +123,7 @@ describe('MDC-based Row Chips', () => {
 
           spyOn(testComponent, 'chipRemove');
 
-          chipInstance._handleKeydown(DELETE_EVENT);
+          dispatchEvent(chipNativeElement, DELETE_EVENT);
           fixture.detectChanges();
 
           expect(testComponent.chipRemove).toHaveBeenCalled();
@@ -134,10 +134,24 @@ describe('MDC-based Row Chips', () => {
 
           spyOn(testComponent, 'chipRemove');
 
-          chipInstance._handleKeydown(BACKSPACE_EVENT);
+          dispatchEvent(chipNativeElement, BACKSPACE_EVENT);
           fixture.detectChanges();
 
           expect(testComponent.chipRemove).toHaveBeenCalled();
+        });
+
+        it('should not remove for repeated BACKSPACE event', () => {
+          const BACKSPACE_EVENT = createKeyboardEvent('keydown', BACKSPACE);
+          Object.defineProperty(BACKSPACE_EVENT, 'repeat', {
+            get: () => true,
+          });
+
+          spyOn(testComponent, 'chipRemove');
+
+          dispatchEvent(chipNativeElement, BACKSPACE_EVENT);
+          fixture.detectChanges();
+
+          expect(testComponent.chipRemove).not.toHaveBeenCalled();
         });
       });
 
@@ -152,7 +166,7 @@ describe('MDC-based Row Chips', () => {
 
           spyOn(testComponent, 'chipRemove');
 
-          chipInstance._handleKeydown(DELETE_EVENT);
+          dispatchEvent(chipNativeElement, DELETE_EVENT);
           fixture.detectChanges();
 
           expect(testComponent.chipRemove).not.toHaveBeenCalled();
@@ -164,7 +178,7 @@ describe('MDC-based Row Chips', () => {
           spyOn(testComponent, 'chipRemove');
 
           // Use the delete to remove the chip
-          chipInstance._handleKeydown(BACKSPACE_EVENT);
+          dispatchEvent(chipNativeElement, BACKSPACE_EVENT);
           fixture.detectChanges();
 
           expect(testComponent.chipRemove).not.toHaveBeenCalled();

--- a/src/material/chips/chip.ts
+++ b/src/material/chips/chip.ts
@@ -336,7 +336,9 @@ export class MatChip implements OnInit, AfterViewInit, AfterContentInit, DoCheck
 
   /** Handles keyboard events on the chip. */
   _handleKeydown(event: KeyboardEvent) {
-    if (event.keyCode === BACKSPACE || event.keyCode === DELETE) {
+    // Ignore backspace events where the user is holding down the key
+    // so that we don't accidentally remove too many chips.
+    if ((event.keyCode === BACKSPACE && !event.repeat) || event.keyCode === DELETE) {
       event.preventDefault();
       this.remove();
     }

--- a/tools/public_api_guard/material/chips.md
+++ b/tools/public_api_guard/material/chips.md
@@ -249,7 +249,7 @@ export class MatChipGridChange {
 }
 
 // @public
-export class MatChipInput implements MatChipTextControl, AfterContentInit, OnChanges, OnDestroy {
+export class MatChipInput implements MatChipTextControl, OnChanges, OnDestroy {
     constructor(_elementRef: ElementRef<HTMLInputElement>, defaultOptions: MatChipsDefaultOptions, formField?: MatFormField);
     addOnBlur: boolean;
     _blur(): void;
@@ -269,14 +269,11 @@ export class MatChipInput implements MatChipTextControl, AfterContentInit, OnCha
     focused: boolean;
     id: string;
     readonly inputElement: HTMLInputElement;
-    _keydown(event?: KeyboardEvent): void;
-    _keyup(event: KeyboardEvent): void;
+    _keydown(event: KeyboardEvent): void;
     // (undocumented)
     static ngAcceptInputType_addOnBlur: unknown;
     // (undocumented)
     static ngAcceptInputType_disabled: unknown;
-    // (undocumented)
-    ngAfterContentInit(): void;
     // (undocumented)
     ngOnChanges(): void;
     // (undocumented)


### PR DESCRIPTION
We have some logic that prevents chip removal if the users is holding down the backspace key. It currently breaks down in the case where a value is pasted into the input via click.

These changes simplify our detection by using `KeyboardEvent.repeat` which also resolves the paste issue.