### PR TITLE
fix(cdk/drag-drop): defer loading reset styles

### DIFF
--- a/src/cdk/drag-drop/drag-drop.ts
+++ b/src/cdk/drag-drop/drag-drop.ts
@@ -6,19 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {
-  Injectable,
-  Inject,
-  NgZone,
-  ElementRef,
-  Component,
-  ViewEncapsulation,
-  ChangeDetectionStrategy,
-  ApplicationRef,
-  inject,
-  createComponent,
-  EnvironmentInjector,
-} from '@angular/core';
+import {Injectable, Inject, NgZone, ElementRef} from '@angular/core';
 import {DOCUMENT} from '@angular/common';
 import {ViewportRuler} from '@angular/cdk/scrolling';
 import {DragRef, DragRefConfig} from './drag-ref';
@@ -31,31 +19,11 @@ const DEFAULT_CONFIG = {
   pointerDirectionChangeThreshold: 5,
 };
 
-/** Keeps track of the apps currently containing badges. */
-const activeApps = new Set<ApplicationRef>();
-
-/**
- * Component used to load the drag&drop reset styles.
- * @docs-private
- */
-@Component({
-  standalone: true,
-  styleUrl: 'resets.css',
-  encapsulation: ViewEncapsulation.None,
-  template: '',
-  changeDetection: ChangeDetectionStrategy.OnPush,
-  host: {'cdk-drag-resets-container': ''},
-})
-export class _ResetsLoader {}
-
 /**
  * Service that allows for drag-and-drop functionality to be attached to DOM elements.
  */
 @Injectable({providedIn: 'root'})
 export class DragDrop {
-  private _appRef = inject(ApplicationRef);
-  private _environmentInjector = inject(EnvironmentInjector);
-
   constructor(
     @Inject(DOCUMENT) private _document: any,
     private _ngZone: NgZone,
@@ -72,7 +40,6 @@ export class DragDrop {
     element: ElementRef<HTMLElement> | HTMLElement,
     config: DragRefConfig = DEFAULT_CONFIG,
   ): DragRef<T> {
-    this._loadResets();
     return new DragRef<T>(
       element,
       config,
@@ -95,24 +62,5 @@ export class DragDrop {
       this._ngZone,
       this._viewportRuler,
     );
-  }
-
-  // TODO(crisbeto): abstract this away into something reusable.
-  /** Loads the CSS resets needed for the module to work correctly. */
-  private _loadResets() {
-    if (!activeApps.has(this._appRef)) {
-      activeApps.add(this._appRef);
-
-      const componentRef = createComponent(_ResetsLoader, {
-        environmentInjector: this._environmentInjector,
-      });
-
-      this._appRef.onDestroy(() => {
-        activeApps.delete(this._appRef);
-        if (activeApps.size === 0) {
-          componentRef.destroy();
-        }
-      });
-    }
   }
 }

--- a/src/cdk/drag-drop/public-api.ts
+++ b/src/cdk/drag-drop/public-api.ts
@@ -14,7 +14,7 @@ export {CDK_DRAG_PARENT} from './drag-parent';
 export * from './drag-events';
 export * from './drag-utils';
 export * from './drag-drop-module';
-export * from './drag-drop-registry';
+export {DragDropRegistry} from './drag-drop-registry';
 
 export {CdkDropList} from './directives/drop-list';
 export * from './directives/config';


### PR DESCRIPTION
Currently we load the reset styles for the preview up-front which seems to break some Jest tests since Jest's CSS parser doesn't understand layers.

These changes switch to loading the styles only once dragging has started.

Fixes #29053.