### PR TITLE
test(menu): remove provideZoneChangeDetection for all menu tests

### DIFF
--- a/src/cdk/menu/context-menu-trigger.spec.ts
+++ b/src/cdk/menu/context-menu-trigger.spec.ts
@@ -1,12 +1,4 @@
-import {
-  Component,
-  ViewChild,
-  ElementRef,
-  Type,
-  ViewChildren,
-  QueryList,
-  provideZoneChangeDetection,
-} from '@angular/core';
+import {Component, ViewChild, ElementRef, Type, ViewChildren, QueryList} from '@angular/core';
 import {CdkMenuModule} from './menu-module';
 import {TestBed, waitForAsync, ComponentFixture} from '@angular/core/testing';
 import {CdkMenu} from './menu';
@@ -26,7 +18,6 @@ describe('CdkContextMenuTrigger', () => {
       TestBed.configureTestingModule({
         imports: [CdkMenuModule],
         declarations: [SimpleContextMenu],
-        providers: [provideZoneChangeDetection()],
       }).compileComponents();
     }));
 
@@ -160,7 +151,6 @@ describe('CdkContextMenuTrigger', () => {
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [CdkMenuModule],
-        providers: [provideZoneChangeDetection()],
         declarations: [NestedContextMenu],
       }).compileComponents();
     }));
@@ -223,6 +213,7 @@ describe('CdkContextMenuTrigger', () => {
         ' is disabled',
       () => {
         fixture.componentInstance.copyMenuDisabled = true;
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
         openCopyContextMenu();
 
@@ -410,7 +401,6 @@ describe('CdkContextMenuTrigger', () => {
     function createComponent<T>(componentClass: Type<T>) {
       TestBed.configureTestingModule({
         imports: [CdkMenuModule],
-        providers: [provideZoneChangeDetection()],
         declarations: [componentClass],
       }).compileComponents();
 

--- a/src/cdk/menu/context-menu-trigger.ts
+++ b/src/cdk/menu/context-menu-trigger.ts
@@ -6,7 +6,15 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {booleanAttribute, Directive, inject, Injectable, Input, OnDestroy} from '@angular/core';
+import {
+  booleanAttribute,
+  ChangeDetectorRef,
+  Directive,
+  inject,
+  Injectable,
+  Input,
+  OnDestroy,
+} from '@angular/core';
 import {Directionality} from '@angular/cdk/bidi';
 import {
   FlexibleConnectedPositionStrategy,
@@ -83,6 +91,8 @@ export class CdkContextMenuTrigger extends CdkMenuTriggerBase implements OnDestr
   /** The app's context menu tracking registry */
   private readonly _contextMenuTracker = inject(ContextMenuTracker);
 
+  private readonly _changeDetectorRef = inject(ChangeDetectorRef);
+
   /** Whether the context menu is disabled. */
   @Input({alias: 'cdkContextMenuDisabled', transform: booleanAttribute}) disabled: boolean = false;
 
@@ -97,6 +107,7 @@ export class CdkContextMenuTrigger extends CdkMenuTriggerBase implements OnDestr
    */
   open(coordinates: ContextMenuCoordinates) {
     this._open(null, coordinates);
+    this._changeDetectorRef.markForCheck();
   }
 
   /** Close the currently opened context menu. */

--- a/src/cdk/menu/menu-item-checkbox.spec.ts
+++ b/src/cdk/menu/menu-item-checkbox.spec.ts
@@ -1,4 +1,4 @@
-import {Component, ElementRef, provideZoneChangeDetection} from '@angular/core';
+import {Component, ElementRef} from '@angular/core';
 import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {CdkMenuModule} from './menu-module';
@@ -16,7 +16,6 @@ describe('MenuItemCheckbox', () => {
     TestBed.configureTestingModule({
       imports: [CdkMenuModule, SingleCheckboxButton],
       providers: [
-        provideZoneChangeDetection(),
         {provide: CDK_MENU, useClass: CdkMenu},
         {provide: MENU_STACK, useClass: MenuStack},
         // View engine can't figure out the ElementRef to inject so we need to provide a fake
@@ -43,6 +42,7 @@ describe('MenuItemCheckbox', () => {
     expect(checkboxElement.getAttribute('aria-disabled')).toBeNull();
 
     checkbox.disabled = true;
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
 
     expect(checkboxElement.getAttribute('aria-disabled')).toBe('true');

--- a/src/cdk/menu/menu-item-radio.spec.ts
+++ b/src/cdk/menu/menu-item-radio.spec.ts
@@ -1,4 +1,4 @@
-import {Component, ElementRef, provideZoneChangeDetection} from '@angular/core';
+import {Component, ElementRef} from '@angular/core';
 import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {UniqueSelectionDispatcher} from '@angular/cdk/collections';
@@ -19,7 +19,6 @@ describe('MenuItemRadio', () => {
     TestBed.configureTestingModule({
       imports: [CdkMenuModule, SimpleRadioButton],
       providers: [
-        provideZoneChangeDetection(),
         {provide: UniqueSelectionDispatcher, useValue: selectionDispatcher},
         {provide: CDK_MENU, useClass: CdkMenu},
         {provide: MENU_STACK, useClass: MenuStack},
@@ -47,6 +46,7 @@ describe('MenuItemRadio', () => {
     expect(radioElement.getAttribute('aria-disabled')).toBeNull();
 
     radioButton.disabled = true;
+    fixture.componentRef.changeDetectorRef.markForCheck();
     fixture.detectChanges();
 
     expect(radioElement.getAttribute('aria-disabled')).toBe('true');

--- a/src/cdk/menu/menu-item.spec.ts
+++ b/src/cdk/menu/menu-item.spec.ts
@@ -1,4 +1,4 @@
-import {Component, Type, ElementRef, provideZoneChangeDetection} from '@angular/core';
+import {Component, Type, ElementRef} from '@angular/core';
 import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 import {dispatchKeyboardEvent} from '@angular/cdk/testing/private';
 import {By} from '@angular/platform-browser';
@@ -20,7 +20,6 @@ describe('MenuItem', () => {
         imports: [CdkMenuModule],
         declarations: [SingleMenuItem],
         providers: [
-          provideZoneChangeDetection(),
           {provide: CDK_MENU, useClass: CdkMenu},
           {provide: MENU_STACK, useClass: MenuStack},
           // View engine can't figure out the ElementRef to inject so we need to provide a fake
@@ -49,11 +48,13 @@ describe('MenuItem', () => {
       expect(nativeButton.hasAttribute('aria-disabled')).toBeFalse();
 
       menuItem.disabled = true;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       expect(nativeButton.getAttribute('aria-disabled')).toBe('true');
 
       menuItem.disabled = false;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       expect(nativeButton.hasAttribute('aria-disabled')).toBeFalse();
@@ -83,7 +84,6 @@ describe('MenuItem', () => {
       TestBed.configureTestingModule({
         imports: [CdkMenuModule, MatIcon],
         providers: [
-          provideZoneChangeDetection(),
           {provide: CDK_MENU, useClass: CdkMenu},
           {provide: MENU_STACK, useClass: MenuStack},
           // View engine can't figure out the ElementRef to inject so we need to provide a fake
@@ -108,6 +108,7 @@ describe('MenuItem', () => {
       const fixture = createComponent(MenuItemWithIcon);
       expect(menuItem.getLabel()).toEqual('unicorn Click me!');
       fixture.componentInstance.typeahead = 'Click me!';
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(menuItem.getLabel()).toEqual('Click me!');
     });
@@ -119,6 +120,7 @@ describe('MenuItem', () => {
         const fixture = createComponent(MenuItemWithIconClass);
         expect(menuItem.getLabel()).toEqual('unicorn Click me!');
         fixture.componentInstance.typeahead = 'Click me!';
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
         expect(menuItem.getLabel()).toEqual('Click me!');
       },
@@ -136,6 +138,7 @@ describe('MenuItem', () => {
         const fixture = createComponent(MenuItemWithMultipleNestings);
         expect(menuItem.getLabel()).toEqual('unicorn Click menume!');
         fixture.componentInstance.typeahead = 'Click me!';
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
         expect(menuItem.getLabel()).toEqual('Click me!');
       },

--- a/src/cdk/menu/menu-trigger.spec.ts
+++ b/src/cdk/menu/menu-trigger.spec.ts
@@ -1,12 +1,4 @@
-import {
-  Component,
-  ViewChildren,
-  QueryList,
-  ElementRef,
-  ViewChild,
-  Type,
-  provideZoneChangeDetection,
-} from '@angular/core';
+import {Component, ViewChildren, QueryList, ElementRef, ViewChild, Type} from '@angular/core';
 import {ComponentFixture, TestBed, fakeAsync, tick, waitForAsync} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {dispatchKeyboardEvent} from '../../cdk/testing/private';
@@ -27,7 +19,6 @@ describe('MenuTrigger', () => {
       TestBed.configureTestingModule({
         imports: [CdkMenuModule],
         declarations: [TriggerForEmptyMenu],
-        providers: [provideZoneChangeDetection()],
       }).compileComponents();
     }));
 
@@ -51,6 +42,7 @@ describe('MenuTrigger', () => {
       expect(menuItemElement.getAttribute('aria-disabled')).toBeNull();
 
       menuItem.disabled = true;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       expect(menuItemElement.getAttribute('aria-disabled')).toBe('true');
@@ -60,6 +52,7 @@ describe('MenuTrigger', () => {
       expect(menuItemElement.getAttribute('aria-haspopup')).toEqual('menu');
 
       fixture.componentInstance.trigger.menuTemplateRef = null;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       expect(menuItemElement.hasAttribute('aria-haspopup')).toBe(false);
@@ -69,6 +62,7 @@ describe('MenuTrigger', () => {
       expect(menuItem.hasMenu).toBeTrue();
 
       fixture.componentInstance.trigger.menuTemplateRef = null;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       expect(menuItem.hasMenu).toBeFalse();
@@ -83,6 +77,7 @@ describe('MenuTrigger', () => {
       expect(menuItemElement.getAttribute('aria-expanded')).toBe('false');
 
       fixture.componentInstance.trigger.menuTemplateRef = null;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       expect(menuItemElement.hasAttribute('aria-expanded')).toBeFalse();

--- a/src/cdk/menu/pointer-focus-tracker.spec.ts
+++ b/src/cdk/menu/pointer-focus-tracker.spec.ts
@@ -1,11 +1,4 @@
-import {
-  Component,
-  QueryList,
-  ElementRef,
-  ViewChildren,
-  AfterViewInit,
-  provideZoneChangeDetection,
-} from '@angular/core';
+import {Component, QueryList, ElementRef, ViewChildren, AfterViewInit} from '@angular/core';
 import {waitForAsync, ComponentFixture, TestBed} from '@angular/core/testing';
 import {createMouseEvent, dispatchEvent} from '../../cdk/testing/private';
 import {Observable} from 'rxjs';
@@ -26,7 +19,6 @@ describe('FocusMouseManger', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      providers: [provideZoneChangeDetection()],
       imports: [MultiElementWithConditionalComponent, MockWrapper],
     }).compileComponents();
   }));
@@ -68,6 +60,7 @@ describe('FocusMouseManger', () => {
 
     expect(mockElements.length).toBe(2);
     fixture.componentInstance.showThird = true;
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     getComponentsForTesting();
 


### PR DESCRIPTION
This removes 'provideZoneChangeDetection' from menu tests. Change summary:

* Many tests set inputs directly. This isn't really how it happens in applications - inputs set from the template automatically mark components for check. When tests set inputs directly like this, they need to call `markForCheck` manually (or something similar).
* One test seems to be calling a public API (`CdkContextMenuTrigger.open`) that failed to call `markForCheck` so that was added to the implementation
* `fakeAsync` had an additional timer so I just added `flush` to make it work.