### PR TITLE
fix(material/slider): resolve duplicate key warnings

### DIFF
--- a/src/material/slider/slider.html
+++ b/src/material/slider/slider.html
@@ -10,7 +10,7 @@
   @if (showTickMarks) {
     <div class="mdc-slider__tick-marks" #tickMarkContainer>
       @if (_cachedWidth) {
-        @for (tickMark of _tickMarks; track tickMark; let i = $index) {
+        @for (tickMark of _tickMarks; track i; let i = $index) {
           <div
             [class]="tickMark === 0 ? 'mdc-slider__tick-mark--active' : 'mdc-slider__tick-mark--inactive'"
             [style.transform]="_calcTickMarkTransform(i)"></div>


### PR DESCRIPTION
Fixes that the slider was logging a bunch of warnings because we were using duplicated keys to render out the tick marks.