### PR TITLE
build: remove unused dependencies on platform-browser-dynamic

### DIFF
--- a/src/components-examples/cdk/dialog/BUILD.bazel
+++ b/src/components-examples/cdk/dialog/BUILD.bazel
@@ -16,7 +16,6 @@ ng_module(
         "//src/cdk/dialog",
         "@npm//@angular/forms",
         "@npm//@angular/platform-browser",
-        "@npm//@angular/platform-browser-dynamic",
     ],
 )
 

--- a/src/components-examples/material/autocomplete/BUILD.bazel
+++ b/src/components-examples/material/autocomplete/BUILD.bazel
@@ -23,7 +23,6 @@ ng_module(
         "//src/material/slide-toggle",
         "@npm//@angular/forms",
         "@npm//@angular/platform-browser",
-        "@npm//@angular/platform-browser-dynamic",
         "@npm//@types/jasmine",
     ],
 )
@@ -47,7 +46,6 @@ ng_test_library(
         "//src/material/autocomplete",
         "//src/material/autocomplete/testing",
         "@npm//@angular/platform-browser",
-        "@npm//@angular/platform-browser-dynamic",
     ],
 )
 

--- a/src/components-examples/material/badge/BUILD.bazel
+++ b/src/components-examples/material/badge/BUILD.bazel
@@ -20,7 +20,6 @@ ng_module(
         "//src/material/button",
         "//src/material/icon",
         "@npm//@angular/platform-browser",
-        "@npm//@angular/platform-browser-dynamic",
         "@npm//@types/jasmine",
     ],
 )
@@ -43,7 +42,6 @@ ng_test_library(
         "//src/cdk/testing/testbed",
         "//src/material/badge",
         "//src/material/badge/testing",
-        "@npm//@angular/platform-browser-dynamic",
     ],
 )
 

--- a/src/components-examples/material/bottom-sheet/BUILD.bazel
+++ b/src/components-examples/material/bottom-sheet/BUILD.bazel
@@ -21,7 +21,6 @@ ng_module(
         "//src/material/button",
         "//src/material/list",
         "@npm//@angular/platform-browser",
-        "@npm//@angular/platform-browser-dynamic",
         "@npm//@types/jasmine",
     ],
 )
@@ -45,7 +44,6 @@ ng_test_library(
         "//src/material/bottom-sheet",
         "//src/material/bottom-sheet/testing",
         "@npm//@angular/platform-browser",
-        "@npm//@angular/platform-browser-dynamic",
     ],
 )
 

--- a/src/components-examples/material/button-toggle/BUILD.bazel
+++ b/src/components-examples/material/button-toggle/BUILD.bazel
@@ -19,7 +19,6 @@ ng_module(
         "//src/material/button-toggle/testing",
         "//src/material/icon",
         "@npm//@angular/platform-browser",
-        "@npm//@angular/platform-browser-dynamic",
         "@npm//@types/jasmine",
     ],
 )
@@ -42,7 +41,6 @@ ng_test_library(
         "//src/cdk/testing/testbed",
         "//src/material/button-toggle",
         "//src/material/button-toggle/testing",
-        "@npm//@angular/platform-browser-dynamic",
     ],
 )
 

--- a/src/components-examples/material/button/BUILD.bazel
+++ b/src/components-examples/material/button/BUILD.bazel
@@ -21,7 +21,6 @@ ng_module(
         "//src/material/icon",
         "//src/material/tooltip",
         "@npm//@angular/platform-browser",
-        "@npm//@angular/platform-browser-dynamic",
         "@npm//@types/jasmine",
     ],
 )
@@ -44,7 +43,6 @@ ng_test_library(
         "//src/cdk/testing/testbed",
         "//src/material/button",
         "//src/material/button/testing",
-        "@npm//@angular/platform-browser-dynamic",
     ],
 )
 

--- a/src/components-examples/material/card/BUILD.bazel
+++ b/src/components-examples/material/card/BUILD.bazel
@@ -22,7 +22,6 @@ ng_module(
         "//src/material/divider",
         "//src/material/progress-bar",
         "@npm//@angular/platform-browser",
-        "@npm//@angular/platform-browser-dynamic",
         "@npm//@types/jasmine",
     ],
 )
@@ -46,7 +45,6 @@ ng_test_library(
         "//src/material/button/testing",
         "//src/material/card",
         "//src/material/card/testing",
-        "@npm//@angular/platform-browser-dynamic",
     ],
 )
 

--- a/src/components-examples/material/checkbox/BUILD.bazel
+++ b/src/components-examples/material/checkbox/BUILD.bazel
@@ -21,7 +21,6 @@ ng_module(
         "//src/material/radio",
         "@npm//@angular/forms",
         "@npm//@angular/platform-browser",
-        "@npm//@angular/platform-browser-dynamic",
         "@npm//@types/jasmine",
     ],
 )
@@ -45,7 +44,6 @@ ng_test_library(
         "//src/material/checkbox",
         "//src/material/checkbox/testing",
         "@npm//@angular/forms",
-        "@npm//@angular/platform-browser-dynamic",
     ],
 )
 

--- a/src/components-examples/material/chips/BUILD.bazel
+++ b/src/components-examples/material/chips/BUILD.bazel
@@ -24,7 +24,6 @@ ng_module(
         "//src/material/icon",
         "@npm//@angular/forms",
         "@npm//@angular/platform-browser",
-        "@npm//@angular/platform-browser-dynamic",
         "@npm//@types/jasmine",
     ],
 )
@@ -48,7 +47,6 @@ ng_test_library(
         "//src/material/chips",
         "//src/material/chips/testing",
         "@npm//@angular/platform-browser",
-        "@npm//@angular/platform-browser-dynamic",
     ],
 )
 

--- a/src/components-examples/material/datepicker/BUILD.bazel
+++ b/src/components-examples/material/datepicker/BUILD.bazel
@@ -25,7 +25,6 @@ ng_module(
         "//src/material/input",
         "@npm//@angular/forms",
         "@npm//@angular/platform-browser",
-        "@npm//@angular/platform-browser-dynamic",
         "@npm//@types/jasmine",
         "@npm//moment",
     ],
@@ -52,7 +51,6 @@ ng_test_library(
         "//src/material/datepicker/testing",
         "@npm//@angular/forms",
         "@npm//@angular/platform-browser",
-        "@npm//@angular/platform-browser-dynamic",
     ],
 )
 

--- a/src/components-examples/material/dialog/BUILD.bazel
+++ b/src/components-examples/material/dialog/BUILD.bazel
@@ -22,7 +22,6 @@ ng_module(
         "//src/material/menu",
         "@npm//@angular/forms",
         "@npm//@angular/platform-browser",
-        "@npm//@angular/platform-browser-dynamic",
         "@npm//@types/jasmine",
     ],
 )
@@ -46,7 +45,6 @@ ng_test_library(
         "//src/material/dialog",
         "//src/material/dialog/testing",
         "@npm//@angular/platform-browser",
-        "@npm//@angular/platform-browser-dynamic",
     ],
 )
 

--- a/src/components-examples/material/divider/BUILD.bazel
+++ b/src/components-examples/material/divider/BUILD.bazel
@@ -19,7 +19,6 @@ ng_module(
         "//src/material/divider/testing",
         "//src/material/list",
         "@npm//@angular/platform-browser",
-        "@npm//@angular/platform-browser-dynamic",
         "@npm//@types/jasmine",
     ],
 )
@@ -42,7 +41,6 @@ ng_test_library(
         "//src/cdk/testing/testbed",
         "//src/material/divider",
         "//src/material/divider/testing",
-        "@npm//@angular/platform-browser-dynamic",
     ],
 )
 

--- a/src/components-examples/material/expansion/BUILD.bazel
+++ b/src/components-examples/material/expansion/BUILD.bazel
@@ -22,7 +22,6 @@ ng_module(
         "//src/material/icon",
         "//src/material/input",
         "@npm//@angular/platform-browser",
-        "@npm//@angular/platform-browser-dynamic",
         "@npm//@types/jasmine",
     ],
 )
@@ -46,7 +45,6 @@ ng_test_library(
         "//src/material/expansion",
         "//src/material/expansion/testing",
         "@npm//@angular/platform-browser",
-        "@npm//@angular/platform-browser-dynamic",
     ],
 )
 

--- a/src/components-examples/material/form-field/BUILD.bazel
+++ b/src/components-examples/material/form-field/BUILD.bazel
@@ -26,7 +26,6 @@ ng_module(
         "//src/material/select",
         "@npm//@angular/forms",
         "@npm//@angular/platform-browser",
-        "@npm//@angular/platform-browser-dynamic",
         "@npm//@types/jasmine",
     ],
 )
@@ -53,7 +52,6 @@ ng_test_library(
         "//src/material/input/testing",
         "@npm//@angular/forms",
         "@npm//@angular/platform-browser",
-        "@npm//@angular/platform-browser-dynamic",
     ],
 )
 

--- a/src/components-examples/material/grid-list/BUILD.bazel
+++ b/src/components-examples/material/grid-list/BUILD.bazel
@@ -18,7 +18,6 @@ ng_module(
         "//src/material/grid-list",
         "//src/material/grid-list/testing",
         "@npm//@angular/platform-browser",
-        "@npm//@angular/platform-browser-dynamic",
         "@npm//@types/jasmine",
     ],
 )
@@ -41,7 +40,6 @@ ng_test_library(
         "//src/cdk/testing/testbed",
         "//src/material/grid-list",
         "//src/material/grid-list/testing",
-        "@npm//@angular/platform-browser-dynamic",
     ],
 )
 

--- a/src/components-examples/material/icon/BUILD.bazel
+++ b/src/components-examples/material/icon/BUILD.bazel
@@ -18,7 +18,6 @@ ng_module(
         "//src/material/icon",
         "//src/material/icon/testing",
         "@npm//@angular/platform-browser",
-        "@npm//@angular/platform-browser-dynamic",
         "@npm//@types/jasmine",
     ],
 )
@@ -42,7 +41,6 @@ ng_test_library(
         "//src/material/icon",
         "//src/material/icon/testing",
         "@npm//@angular/platform-browser",
-        "@npm//@angular/platform-browser-dynamic",
     ],
 )
 

--- a/src/components-examples/material/input/BUILD.bazel
+++ b/src/components-examples/material/input/BUILD.bazel
@@ -21,7 +21,6 @@ ng_module(
         "//src/material/input/testing",
         "@npm//@angular/forms",
         "@npm//@angular/platform-browser",
-        "@npm//@angular/platform-browser-dynamic",
         "@npm//@types/jasmine",
     ],
 )
@@ -46,7 +45,6 @@ ng_test_library(
         "//src/material/input/testing",
         "@npm//@angular/forms",
         "@npm//@angular/platform-browser",
-        "@npm//@angular/platform-browser-dynamic",
     ],
 )
 

--- a/src/components-examples/material/list/BUILD.bazel
+++ b/src/components-examples/material/list/BUILD.bazel
@@ -19,7 +19,6 @@ ng_module(
         "//src/material/list",
         "//src/material/list/testing",
         "@npm//@angular/platform-browser",
-        "@npm//@angular/platform-browser-dynamic",
         "@npm//@types/jasmine",
     ],
 )
@@ -42,7 +41,6 @@ ng_test_library(
         "//src/cdk/testing/testbed",
         "//src/material/list",
         "//src/material/list/testing",
-        "@npm//@angular/platform-browser-dynamic",
     ],
 )
 

--- a/src/components-examples/material/menu/BUILD.bazel
+++ b/src/components-examples/material/menu/BUILD.bazel
@@ -21,7 +21,6 @@ ng_module(
         "//src/material/menu",
         "//src/material/menu/testing",
         "@npm//@angular/platform-browser",
-        "@npm//@angular/platform-browser-dynamic",
         "@npm//@types/jasmine",
     ],
 )
@@ -45,7 +44,6 @@ ng_test_library(
         "//src/material/menu",
         "//src/material/menu/testing",
         "@npm//@angular/platform-browser",
-        "@npm//@angular/platform-browser-dynamic",
     ],
 )
 

--- a/src/components-examples/material/paginator/BUILD.bazel
+++ b/src/components-examples/material/paginator/BUILD.bazel
@@ -24,7 +24,6 @@ ng_module(
         "//src/material/slide-toggle",
         "@npm//@angular/forms",
         "@npm//@angular/platform-browser",
-        "@npm//@angular/platform-browser-dynamic",
         "@npm//@types/jasmine",
     ],
 )
@@ -48,7 +47,6 @@ ng_test_library(
         "//src/material/paginator",
         "//src/material/paginator/testing",
         "@npm//@angular/platform-browser",
-        "@npm//@angular/platform-browser-dynamic",
     ],
 )
 

--- a/src/components-examples/material/progress-bar/BUILD.bazel
+++ b/src/components-examples/material/progress-bar/BUILD.bazel
@@ -22,7 +22,6 @@ ng_module(
         "//src/material/slider",
         "@npm//@angular/forms",
         "@npm//@angular/platform-browser",
-        "@npm//@angular/platform-browser-dynamic",
         "@npm//@types/jasmine",
     ],
 )
@@ -45,7 +44,6 @@ ng_test_library(
         "//src/cdk/testing/testbed",
         "//src/material/progress-bar",
         "//src/material/progress-bar/testing",
-        "@npm//@angular/platform-browser-dynamic",
     ],
 )
 

--- a/src/components-examples/material/progress-spinner/BUILD.bazel
+++ b/src/components-examples/material/progress-spinner/BUILD.bazel
@@ -22,7 +22,6 @@ ng_module(
         "//src/material/slider",
         "@npm//@angular/forms",
         "@npm//@angular/platform-browser",
-        "@npm//@angular/platform-browser-dynamic",
         "@npm//@types/jasmine",
     ],
 )
@@ -45,7 +44,6 @@ ng_test_library(
         "//src/cdk/testing/testbed",
         "//src/material/progress-spinner",
         "//src/material/progress-spinner/testing",
-        "@npm//@angular/platform-browser-dynamic",
     ],
 )
 

--- a/src/components-examples/material/radio/BUILD.bazel
+++ b/src/components-examples/material/radio/BUILD.bazel
@@ -19,7 +19,6 @@ ng_module(
         "//src/material/radio/testing",
         "@npm//@angular/forms",
         "@npm//@angular/platform-browser",
-        "@npm//@angular/platform-browser-dynamic",
         "@npm//@types/jasmine",
     ],
 )
@@ -43,7 +42,6 @@ ng_test_library(
         "//src/material/radio",
         "//src/material/radio/testing",
         "@npm//@angular/forms",
-        "@npm//@angular/platform-browser-dynamic",
     ],
 )
 

--- a/src/components-examples/material/select/BUILD.bazel
+++ b/src/components-examples/material/select/BUILD.bazel
@@ -22,7 +22,6 @@ ng_module(
         "//src/material/select/testing",
         "@npm//@angular/forms",
         "@npm//@angular/platform-browser",
-        "@npm//@angular/platform-browser-dynamic",
         "@npm//@types/jasmine",
     ],
 )
@@ -46,7 +45,6 @@ ng_test_library(
         "//src/material/select",
         "//src/material/select/testing",
         "@npm//@angular/platform-browser",
-        "@npm//@angular/platform-browser-dynamic",
     ],
 )
 

--- a/src/components-examples/material/sidenav/BUILD.bazel
+++ b/src/components-examples/material/sidenav/BUILD.bazel
@@ -19,15 +19,14 @@ ng_module(
         "//src/material/button",
         "//src/material/checkbox",
         "//src/material/icon",
+        "//src/material/input",
         "//src/material/list",
         "//src/material/radio",
         "//src/material/select",
         "//src/material/sidenav",
         "//src/material/toolbar",
-        "//src/material/input",
         "@npm//@angular/forms",
         "@npm//@angular/platform-browser",
-        "@npm//@angular/platform-browser-dynamic",
         "@npm//@types/jasmine",
     ],
 )
@@ -51,7 +50,6 @@ ng_test_library(
         "//src/material/sidenav",
         "//src/material/sidenav/testing",
         "@npm//@angular/platform-browser",
-        "@npm//@angular/platform-browser-dynamic",
     ],
 )
 

--- a/src/components-examples/material/slide-toggle/BUILD.bazel
+++ b/src/components-examples/material/slide-toggle/BUILD.bazel
@@ -23,7 +23,6 @@ ng_module(
         "//src/material/slide-toggle/testing",
         "@npm//@angular/forms",
         "@npm//@angular/platform-browser",
-        "@npm//@angular/platform-browser-dynamic",
         "@npm//@types/jasmine",
     ],
 )
@@ -47,7 +46,6 @@ ng_test_library(
         "//src/material/slide-toggle",
         "//src/material/slide-toggle/testing",
         "@npm//@angular/forms",
-        "@npm//@angular/platform-browser-dynamic",
     ],
 )
 

--- a/src/components-examples/material/slider/BUILD.bazel
+++ b/src/components-examples/material/slider/BUILD.bazel
@@ -22,7 +22,6 @@ ng_module(
         "//src/material/slider/testing",
         "@npm//@angular/forms",
         "@npm//@angular/platform-browser",
-        "@npm//@angular/platform-browser-dynamic",
         "@npm//@types/jasmine",
     ],
 )
@@ -45,7 +44,6 @@ ng_test_library(
         "//src/cdk/testing/testbed",
         "//src/material/slider",
         "//src/material/slider/testing",
-        "@npm//@angular/platform-browser-dynamic",
     ],
 )
 

--- a/src/components-examples/material/snack-bar/BUILD.bazel
+++ b/src/components-examples/material/snack-bar/BUILD.bazel
@@ -22,7 +22,6 @@ ng_module(
         "//src/material/snack-bar/testing",
         "@npm//@angular/forms",
         "@npm//@angular/platform-browser",
-        "@npm//@angular/platform-browser-dynamic",
         "@npm//@types/jasmine",
     ],
 )
@@ -46,7 +45,6 @@ ng_test_library(
         "//src/material/snack-bar",
         "//src/material/snack-bar/testing",
         "@npm//@angular/platform-browser",
-        "@npm//@angular/platform-browser-dynamic",
     ],
 )
 

--- a/src/components-examples/material/sort/BUILD.bazel
+++ b/src/components-examples/material/sort/BUILD.bazel
@@ -18,7 +18,6 @@ ng_module(
         "//src/material/sort",
         "//src/material/sort/testing",
         "@npm//@angular/platform-browser",
-        "@npm//@angular/platform-browser-dynamic",
         "@npm//@types/jasmine",
     ],
 )
@@ -42,7 +41,6 @@ ng_test_library(
         "//src/material/sort",
         "//src/material/sort/testing",
         "@npm//@angular/platform-browser",
-        "@npm//@angular/platform-browser-dynamic",
     ],
 )
 

--- a/src/components-examples/material/stepper/BUILD.bazel
+++ b/src/components-examples/material/stepper/BUILD.bazel
@@ -26,7 +26,6 @@ ng_module(
         "@npm//@angular/common",
         "@npm//@angular/forms",
         "@npm//@angular/platform-browser",
-        "@npm//@angular/platform-browser-dynamic",
         "@npm//@types/jasmine",
     ],
 )
@@ -51,7 +50,6 @@ ng_test_library(
         "//src/material/stepper/testing",
         "@npm//@angular/forms",
         "@npm//@angular/platform-browser",
-        "@npm//@angular/platform-browser-dynamic",
     ],
 )
 

--- a/src/components-examples/material/table/BUILD.bazel
+++ b/src/components-examples/material/table/BUILD.bazel
@@ -29,7 +29,6 @@ ng_module(
         "//src/material/table",
         "//src/material/table/testing",
         "@npm//@angular/platform-browser",
-        "@npm//@angular/platform-browser-dynamic",
         "@npm//@types/jasmine",
     ],
 )
@@ -52,7 +51,6 @@ ng_test_library(
         "//src/cdk/testing/testbed",
         "//src/material/table",
         "//src/material/table/testing",
-        "@npm//@angular/platform-browser-dynamic",
     ],
 )
 

--- a/src/components-examples/material/tabs/BUILD.bazel
+++ b/src/components-examples/material/tabs/BUILD.bazel
@@ -24,7 +24,6 @@ ng_module(
         "//src/material/tabs/testing",
         "@npm//@angular/forms",
         "@npm//@angular/platform-browser",
-        "@npm//@angular/platform-browser-dynamic",
         "@npm//@types/jasmine",
     ],
 )
@@ -48,7 +47,6 @@ ng_test_library(
         "//src/material/tabs",
         "//src/material/tabs/testing",
         "@npm//@angular/platform-browser",
-        "@npm//@angular/platform-browser-dynamic",
     ],
 )
 

--- a/src/components-examples/material/toolbar/BUILD.bazel
+++ b/src/components-examples/material/toolbar/BUILD.bazel
@@ -20,7 +20,6 @@ ng_module(
         "//src/material/toolbar",
         "//src/material/toolbar/testing",
         "@npm//@angular/platform-browser",
-        "@npm//@angular/platform-browser-dynamic",
         "@npm//@types/jasmine",
     ],
 )
@@ -44,7 +43,6 @@ ng_test_library(
         "//src/material/icon",
         "//src/material/toolbar",
         "//src/material/toolbar/testing",
-        "@npm//@angular/platform-browser-dynamic",
     ],
 )
 

--- a/src/components-examples/material/tooltip/BUILD.bazel
+++ b/src/components-examples/material/tooltip/BUILD.bazel
@@ -24,7 +24,6 @@ ng_module(
         "//src/material/tooltip/testing",
         "@npm//@angular/forms",
         "@npm//@angular/platform-browser",
-        "@npm//@angular/platform-browser-dynamic",
         "@npm//@types/jasmine",
     ],
 )
@@ -48,7 +47,6 @@ ng_test_library(
         "//src/material/tooltip",
         "//src/material/tooltip/testing",
         "@npm//@angular/platform-browser",
-        "@npm//@angular/platform-browser-dynamic",
     ],
 )
 

--- a/src/components-examples/material/tree/BUILD.bazel
+++ b/src/components-examples/material/tree/BUILD.bazel
@@ -23,7 +23,6 @@ ng_module(
         "//src/material/tree",
         "//src/material/tree/testing",
         "@npm//@angular/platform-browser",
-        "@npm//@angular/platform-browser-dynamic",
         "@npm//@types/jasmine",
     ],
 )
@@ -47,7 +46,6 @@ ng_test_library(
         "//src/material/icon",
         "//src/material/tree",
         "//src/material/tree/testing",
-        "@npm//@angular/platform-browser-dynamic",
     ],
 )
 

--- a/src/material/datepicker/BUILD.bazel
+++ b/src/material/datepicker/BUILD.bazel
@@ -123,7 +123,6 @@ ng_test_library(
         "@npm//@angular/common",
         "@npm//@angular/forms",
         "@npm//@angular/platform-browser",
-        "@npm//@angular/platform-browser-dynamic",
         "@npm//rxjs",
     ],
 )


### PR DESCRIPTION
A bunch of build targets were depending unnecessarily on `platform-browser-dynamic`. These changes clean them up.