### PR TITLE
docs: fix broken links

### DIFF
--- a/guides/material-2.md
+++ b/guides/material-2.md
@@ -932,7 +932,7 @@ The following example demonstrates usage of the typography styles emitted by the
 #### Reading typography values from a config
 
 It is possible to read typography properties from a theme for use in your own components. For more
-information about this see our section on [Theming your own components](https://material.angular.io/guide/material-2#theming-your-components),
+information about this see our section on [Theming your own components](https://material.angular.io/guide/material-2-theming#theming-your-components),
 
 ### Step-by-step example
 

--- a/guides/theming-your-components.md
+++ b/guides/theming-your-components.md
@@ -5,7 +5,7 @@ You can use Angular Material's Sass-based theming system for your own custom com
 **Note: The information on this page is specific to Material 3, for Material 2
 information on how to theme your components see the [Material 2 guide][material-2].**
 
-[material-2]: https://material.angular.io/guide/material-2#theming-your-components
+[material-2]: https://material.angular.io/guide/material-2-theming#theming-your-components
 
 ## Reading values from a theme
 

--- a/guides/theming.md
+++ b/guides/theming.md
@@ -14,7 +14,7 @@ see [Angular Material Typography][mat-typography]. For guidance on building comp
 customizable with this system, see [Theming your own components][theme-your-own].
 
 [material-design-theming]: https://m3.material.io/
-[material-2]: https://material.angular.io/guide/material-2
+[material-2]: https://material.angular.io/guide/material-2-theming
 [mat-typography]: https://material.angular.io/guide/typography
 [theme-your-own]: https://material.angular.io/guide/theming-your-components
 
@@ -576,7 +576,7 @@ above can be applied to any checkbox _or_ any element that contains checkboxes, 
 of all checkboxes within that element.
 
 While you should prefer applying the mixins with color variants explicitly, if migrating from M2 to
-M3 you can alternatively use [the provided backwards compatibility mixins](https://material.angular.io/guide/material-2#how-to-migrate-an-app-from-material-2-to-material-3)
+M3 you can alternatively use [the provided backwards compatibility mixins](https://material.angular.io/guide/material-2-theming#how-to-migrate-an-app-from-material-2-to-material-3)
 that apply styles directly to the existing CSS classes (`mat-primary`, `mat-accent`, and
 `mat-warn`).
 


### PR DESCRIPTION
Fixes some broken links to the M2 guide.

Fixes #29101.