### PR TITLE
fix(material/menu): prevent divider styles from bleeding out

### DIFF
--- a/src/material/menu/menu.scss
+++ b/src/material/menu/menu.scss
@@ -63,17 +63,17 @@ mat-menu {
   @include cdk.high-contrast(active, off) {
     outline: solid 1px;
   }
-}
 
-.mat-divider {
-  // Use margin instead of padding since divider uses border-top for line
-  @include token-utils.use-tokens(
-    tokens-mat-menu.$prefix,
-    tokens-mat-menu.get-token-slots()
-  ) {
-    color: var(#{token-utils.get-token-variable(divider-color)});
-    margin-bottom: var(#{token-utils.get-token-variable(divider-bottom-spacing)});
-    margin-top: var(#{token-utils.get-token-variable(divider-top-spacing)});
+  .mat-divider {
+    // Use margin instead of padding since divider uses border-top to render out the line.
+    @include token-utils.use-tokens(
+      tokens-mat-menu.$prefix,
+      tokens-mat-menu.get-token-slots()
+    ) {
+      color: var(#{token-utils.get-token-variable(divider-color)});
+      margin-bottom: var(#{token-utils.get-token-variable(divider-bottom-spacing)});
+      margin-top: var(#{token-utils.get-token-variable(divider-top-spacing)});
+    }
   }
 }
 


### PR DESCRIPTION
Fixes that the styles for the menu divider were at the top level which means that they'll also affect dividers outside of the menu.

Fixes #29106.