### PR TITLE
fix(material/tabs): avoid pagination infinite loop in safari

### DIFF
--- a/src/material/tabs/paginated-tab-header.ts
+++ b/src/material/tabs/paginated-tab-header.ts
@@ -550,18 +550,27 @@ export abstract class MatPaginatedTabHeader
     if (this.disablePagination) {
       this._showPaginationControls = false;
     } else {
-      const isEnabled =
-        this._tabListInner.nativeElement.scrollWidth > this._elementRef.nativeElement.offsetWidth;
+      const scrollWidth = this._tabListInner.nativeElement.scrollWidth;
+      const containerWidth = this._elementRef.nativeElement.offsetWidth;
+
+      // Usually checking that the scroll width is greater than the container width should be
+      // enough, but on Safari at specific widths the browser ends up rounding up when there's
+      // no pagination and rounding down once the pagination is added. This can throw the component
+      // into an infinite loop where the pagination shows up and disappears constantly. We work
+      // around it by adding a threshold to the calculation. From manual testing the threshold
+      // can be lowered to 2px and still resolve the issue, but we set a higher one to be safe.
+      // This shouldn't cause any content to be clipped, because tabs have a 24px horizontal
+      // padding. See b/316395154 for more information.
+      const isEnabled = scrollWidth - containerWidth >= 5;
 
       if (!isEnabled) {
         this.scrollDistance = 0;
       }
 
       if (isEnabled !== this._showPaginationControls) {
+        this._showPaginationControls = isEnabled;
         this._changeDetectorRef.markForCheck();
       }
-
-      this._showPaginationControls = isEnabled;
     }
   }
 


### PR DESCRIPTION
Fixes a bug reported internally where the tabs pagination was going into an infinite loop at some widths.

The root cause is a bit unclear, but it looks like in some cases Safari rounds up the `scrollWidth` and in some it doesn't which we end up hitting when adding/removing the pagination.

These changes work around it by adding a 5px threshold that needs to be crossed before we start showing the pagination. The threshold shouldn't be noticable for users since the tabs have a 24px padding on each side.