### PR TITLE
build: fix deprecated husky install command

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "ci-push-deploy-docs-app": "node --no-warnings=ExperimentalWarning --loader ts-node/esm/transpile-only scripts/docs-deploy/deploy-ci-push.mts",
     "ci-docs-monitor-test": "node --no-warnings=ExperimentalWarning --loader ts-node/esm/transpile-only scripts/docs-deploy/monitoring/ci-test.mts",
     "ci-notify-slack-failure": "node --no-warnings=ExperimentalWarning --loader ts-node/esm/transpile-only scripts/circleci/notify-slack-job-failure.mts",
-    "prepare": "husky install"
+    "prepare": "husky"
   },
   "version": "18.1.0-next.0",
   "dependencies": {


### PR DESCRIPTION
husky v9 deprecated `husky install` command. We need to use `husky` command instead to avoid the below warning when running `yarn`.

```
$ husky install
install command is deprecated
```

Husky v9 changelog(https://github.com/typicode/husky/releases/tag/v9.0.1):

> Removed husky install. Use husky or husky some/dir for the same functionality (deprecation notice to be added).

