### PR TITLE
feat(material/core): add option to configure prefix of system variables

### DIFF
--- a/src/material/core/theming/_config-validation.scss
+++ b/src/material/core/theming/_config-validation.scss
@@ -89,7 +89,7 @@
   @if $err {
     @return (#{'$config should be a color configuration object. Got:'} $config);
   }
-  $allowed: (theme-type, primary, tertiary, use-system-variables);
+  $allowed: (theme-type, primary, tertiary, use-system-variables, system-variables-prefix);
   $err: validation.validate-allowed-values(map.keys($config or ()), $allowed...);
   @if $err {
     @return (
@@ -134,7 +134,8 @@
     bold-weight,
     medium-weight,
     regular-weight,
-    use-system-variables
+    use-system-variables,
+    system-variables-prefix
   );
   $err: validation.validate-allowed-values(map.keys($config or ()), $allowed...);
   @if $err {

--- a/src/material/core/theming/_definition.scss
+++ b/src/material/core/theming/_definition.scss
@@ -40,6 +40,7 @@ $theme-version: 1;
   $type: map.get($config, theme-type) or light;
   $primary: map.get($config, primary) or palettes.$violet-palette;
   $tertiary: map.get($config, tertiary) or $primary;
+  $system-variables-prefix: map.get($config, system-variables-prefix) or sys;
   sass-utils.$use-system-color-variables: map.get($config, use-system-variables) or false;
 
   @return (
@@ -55,7 +56,7 @@ $theme-version: 1;
         error: map.get($primary, error),
       ),
       color-tokens: m3-tokens.generate-color-tokens(
-          $type, $primary, $tertiary, map.get($primary, error))
+          $type, $primary, $tertiary, map.get($primary, error), $system-variables-prefix)
     )
   );
 }
@@ -74,6 +75,7 @@ $theme-version: 1;
   $bold: map.get($config, bold-weight) or 700;
   $medium: map.get($config, medium-weight) or 500;
   $regular: map.get($config, regular-weight) or 400;
+  $system-variables-prefix: map.get($config, system-variables-prefix) or sys;
   sass-utils.$use-system-typography-variables: map.get($config, use-system-variables) or false;
 
   @return (
@@ -87,7 +89,7 @@ $theme-version: 1;
         regular: $regular,
       ),
       typography-tokens: m3-tokens.generate-typography-tokens(
-          $brand, $plain, $bold, $medium, $regular)
+          $brand, $plain, $bold, $medium, $regular, $system-variables-prefix)
     )
   );
 }

--- a/src/material/core/tokens/_m3-tokens.scss
+++ b/src/material/core/tokens/_m3-tokens.scss
@@ -135,6 +135,7 @@ $_cached-token-slots: null;
   );
 
   $type: map.get($theme, _mat-theming-internals-do-not-access, theme-type);
+  $system-variables-prefix: map.get($theme, system-variables-prefix) or sys;
   $primary: map.merge(map.get($palettes, primary), $base-palettes);
   $tertiary: map.merge(map.get($palettes, tertiary), $base-palettes);
   $error: map.get($palettes, error);
@@ -148,7 +149,7 @@ $_cached-token-slots: null;
     mdc-tokens.md-sys-color-values-light($ref));
 
   @each $name, $value in $sys-colors {
-    --sys-#{$name}: #{map.get($overrides, $name) or $value};
+    --#{$system-variables-prefix}-#{$name}: #{map.get($overrides, $name) or $value};
   }
 }
 
@@ -159,7 +160,7 @@ $_cached-token-slots: null;
   $bold: map.get($font-definition, bold);
   $medium: map.get($font-definition, medium);
   $regular: map.get($font-definition, regular);
-
+  $system-variables-prefix: map.get($theme, system-variables-prefix) or sys;
   $ref: (
     md-ref-typeface: _generate-ref-typeface-tokens($brand, $plain, $bold, $medium, $regular)
   );
@@ -167,168 +168,180 @@ $_cached-token-slots: null;
   $sys-typescale: mdc-tokens.md-sys-typescale-values($ref);
 
   @each $name, $value in $sys-typescale {
-    --sys-#{$name}: #{map.get($overrides, $name) or $value};
+    --#{$system-variables-prefix}-#{$name}: #{map.get($overrides, $name) or $value};
   }
 }
 
-@function _get-sys-color($type, $ref) {
+@function create-map($keys, $prefix) {
+  $result: ();
+  @each $key in $keys {
+    $result: map-merge($result, ($key: var(--#{$prefix}-#{$key})));
+  }
+  @return $result;
+}
+
+@function _get-sys-color($type, $ref, $prefix) {
   $mdc-sys-color: if($type == dark,
     mdc-tokens.md-sys-color-values-dark($ref),
     mdc-tokens.md-sys-color-values-light($ref));
 
   @if (sass-utils.$use-system-color-variables) {
-    @return (
-      'background': var(--sys-background),
-      'error': var(--sys-error),
-      'error-container': var(--sys-error-container),
-      'inverse-on-surface': var(--sys-inverse-on-surface),
-      'inverse-primary': var(--sys-inverse-primary),
-      'inverse-surface': var(--sys-inverse-surface),
-      'on-background': var(--sys-on-background),
-      'on-error': var(--sys-on-error),
-      'on-error-container': var(--sys-on-error-container),
-      'on-primary': var(--sys-on-primary),
-      'on-primary-container': var(--sys-on-primary-container),
-      'on-primary-fixed': var(--sys-on-primary-fixed),
-      'on-primary-fixed-variant': var(--sys-on-primary-fixed-variant),
-      'on-secondary': var(--sys-on-secondary),
-      'on-secondary-container': var(--sys-on-secondary-container),
-      'on-secondary-fixed': var(--sys-on-secondary-fixed),
-      'on-secondary-fixed-variant': var(--sys-on-secondary-fixed-variant),
-      'on-surface': var(--sys-on-surface),
-      'on-surface-variant': var(--sys-on-surface-variant),
-      'on-tertiary': var(--sys-on-tertiary),
-      'on-tertiary-container': var(--sys-on-tertiary-container),
-      'on-tertiary-fixed': var(--sys-on-tertiary-fixed),
-      'on-tertiary-fixed-variant': var(--sys-on-tertiary-fixed-variant),
-      'outline': var(--sys-outline),
-      'outline-variant': var(--sys-outline-variant),
-      'primary': var(--sys-primary),
-      'primary-container': var(--sys-primary-container),
-      'primary-fixed': var(--sys-primary-fixed),
-      'primary-fixed-dim': var(--sys-primary-fixed-dim),
-      'scrim': var(--sys-scrim),
-      'secondary': var(--sys-secondary),
-      'secondary-container': var(--sys-secondary-container),
-      'secondary-fixed': var(--sys-secondary-fixed),
-      'secondary-fixed-dim': var(--sys-secondary-fixed-dim),
-      'shadow': map.get($mdc-sys-color, shadow),
-      'surface': var(--sys-surface),
-      'surface-bright': var(--sys-surface-bright),
-      'surface-container': var(--sys-surface-container),
-      'surface-container-high': var(--sys-surface-container-high),
-      'surface-container-highest': var(--sys-surface-container-highest),
-      'surface-container-low': var(--sys-surface-container-low),
-      'surface-container-lowest': var(--sys-surface-container-lowest),
-      'surface-dim': var(--sys-surface-dim),
-      'surface-tint': var(--sys-surface-tint),
-      'surface-variant': var(--sys-surface-variant),
-      'tertiary': var(--sys-tertiary),
-      'tertiary-container': var(--sys-tertiary-container),
-      'tertiary-fixed': var(--sys-tertiary-fixed),
-      'tertiary-fixed-dim': var(--sys-tertiary-fixed-dim),
+    $keys: (
+            'background',
+            'error',
+            'error-container',
+            'inverse-on-surface',
+            'inverse-primary',
+            'inverse-surface',
+            'on-background',
+            'on-error',
+            'on-error-container',
+            'on-primary',
+            'on-primary-container',
+            'on-primary-fixed',
+            'on-primary-fixed-variant',
+            'on-secondary',
+            'on-secondary-container',
+            'on-secondary-fixed',
+            'on-secondary-fixed-variant',
+            'on-surface',
+            'on-surface-variant',
+            'on-tertiary',
+            'on-tertiary-container',
+            'on-tertiary-fixed',
+            'on-tertiary-fixed-variant',
+            'outline',
+            'outline-variant',
+            'primary',
+            'primary-container',
+            'primary-fixed',
+            'primary-fixed-dim',
+            'scrim',
+            'secondary',
+            'secondary-container',
+            'secondary-fixed',
+            'secondary-fixed-dim',
+            'surface',
+            'surface-bright',
+            'surface-container',
+            'surface-container-high',
+            'surface-container-highest',
+            'surface-container-low',
+            'surface-container-lowest',
+            'surface-dim',
+            'surface-tint',
+            'surface-variant',
+            'tertiary',
+            'tertiary-container',
+            'tertiary-fixed',
+            'tertiary-fixed-dim'
     );
+    @return map-merge(create-map($keys, $prefix), (
+            shadow: map.get($mdc-sys-color, shadow)
+    ));
   }
 
   @return $mdc-sys-color;
 }
 
-@function _get-sys-typeface($ref) {
+@function _get-sys-typeface($ref, $prefix) {
   @if (sass-utils.$use-system-typography-variables) {
-    @return (
-      'body-large': var(--sys-body-large),
-      'body-large-font': var(--sys-body-large-font),
-      'body-large-line-height': var(--sys-body-large-line-height),
-      'body-large-size': var(--sys-body-large-size),
-      'body-large-tracking': var(--sys-body-large-tracking),
-      'body-large-weight': var(--sys-body-large-weight),
-      'body-medium': var(--sys-body-medium),
-      'body-medium-font': var(--sys-body-medium-font),
-      'body-medium-line-height': var(--sys-body-medium-line-height),
-      'body-medium-size': var(--sys-body-medium-size),
-      'body-medium-tracking': var(--sys-body-medium-tracking),
-      'body-medium-weight': var(--sys-body-medium-weight),
-      'body-small': var(--sys-body-small),
-      'body-small-font': var(--sys-body-small-font),
-      'body-small-line-height': var(--sys-body-small-line-height),
-      'body-small-size': var(--sys-body-small-size),
-      'body-small-tracking': var(--sys-body-small-tracking),
-      'body-small-weight': var(--sys-body-small-weight),
-      'display-large': var(--sys-display-large),
-      'display-large-font': var(--sys-display-large-font),
-      'display-large-line-height': var(--sys-display-large-line-height),
-      'display-large-size': var(--sys-display-large-size),
-      'display-large-tracking': var(--sys-display-large-tracking),
-      'display-large-weight': var(--sys-display-large-weight),
-      'display-medium': var(--sys-display-medium),
-      'display-medium-font': var(--sys-display-medium-font),
-      'display-medium-line-height': var(--sys-display-medium-line-height),
-      'display-medium-size': var(--sys-display-medium-size),
-      'display-medium-tracking': var(--sys-display-medium-tracking),
-      'display-medium-weight': var(--sys-display-medium-weight),
-      'display-small': var(--sys-display-small),
-      'display-small-font': var(--sys-display-small-font),
-      'display-small-line-height': var(--sys-display-small-line-height),
-      'display-small-size': var(--sys-display-small-size),
-      'display-small-tracking': var(--sys-display-small-tracking),
-      'display-small-weight': var(--sys-display-small-weight),
-      'headline-large': var(--sys-headline-large),
-      'headline-large-font': var(--sys-headline-large-font),
-      'headline-large-line-height': var(--sys-headline-large-line-height),
-      'headline-large-size': var(--sys-headline-large-size),
-      'headline-large-tracking': var(--sys-headline-large-tracking),
-      'headline-large-weight': var(--sys-headline-large-weight),
-      'headline-medium': var(--sys-headline-medium),
-      'headline-medium-font': var(--sys-headline-medium-font),
-      'headline-medium-line-height': var(--sys-headline-medium-line-height),
-      'headline-medium-size': var(--sys-headline-medium-size),
-      'headline-medium-tracking': var(--sys-headline-medium-tracking),
-      'headline-medium-weight': var(--sys-headline-medium-weight),
-      'headline-small': var(--sys-headline-small),
-      'headline-small-font': var(--sys-headline-small-font),
-      'headline-small-line-height': var(--sys-headline-small-line-height),
-      'headline-small-size': var(--sys-headline-small-size),
-      'headline-small-tracking': var(--sys-headline-small-tracking),
-      'headline-small-weight': var(--sys-headline-small-weight),
-      'label-large': var(--sys-label-large),
-      'label-large-font': var(--sys-label-large-font),
-      'label-large-line-height': var(--sys-label-large-line-height),
-      'label-large-size': var(--sys-label-large-size),
-      'label-large-tracking': var(--sys-label-large-tracking),
-      'label-large-weight': var(--sys-label-large-weight),
-      'label-large-weight-prominent': var(--sys-label-large-weight-prominent),
-      'label-medium': var(--sys-label-medium),
-      'label-medium-font': var(--sys-label-medium-font),
-      'label-medium-line-height': var(--sys-label-medium-line-height),
-      'label-medium-size': var(--sys-label-medium-size),
-      'label-medium-tracking': var(--sys-label-medium-tracking),
-      'label-medium-weight': var(--sys-label-medium-weight),
-      'label-medium-weight-prominent': var(--sys-label-medium-weight-prominent),
-      'label-small': var(--sys-label-small),
-      'label-small-font': var(--sys-label-small-font),
-      'label-small-line-height': var(--sys-label-small-line-height),
-      'label-small-size': var(--sys-label-small-size),
-      'label-small-tracking': var(--sys-label-small-tracking),
-      'label-small-weight': var(--sys-label-small-weight),
-      'title-large': var(--sys-title-large),
-      'title-large-font': var(--sys-title-large-font),
-      'title-large-line-height': var(--sys-title-large-line-height),
-      'title-large-size': var(--sys-title-large-size),
-      'title-large-tracking': var(--sys-title-large-tracking),
-      'title-large-weight': var(--sys-title-large-weight),
-      'title-medium': var(--sys-title-medium),
-      'title-medium-font': var(--sys-title-medium-font),
-      'title-medium-line-height': var(--sys-title-medium-line-height),
-      'title-medium-size': var(--sys-title-medium-size),
-      'title-medium-tracking': var(--sys-title-medium-tracking),
-      'title-medium-weight': var(--sys-title-medium-weight),
-      'title-small': var(--sys-title-small),
-      'title-small-font': var(--sys-title-small-font),
-      'title-small-line-height': var(--sys-title-small-line-height),
-      'title-small-size': var(--sys-title-small-size),
-      'title-small-tracking': var(--sys-title-small-tracking),
-      'title-small-weight': var(--sys-title-small-weight),
+    $keys: (
+            'body-large',
+            'body-large-font',
+            'body-large-line-height',
+            'body-large-size',
+            'body-large-tracking',
+            'body-large-weight',
+            'body-medium',
+            'body-medium-font',
+            'body-medium-line-height',
+            'body-medium-size',
+            'body-medium-tracking',
+            'body-medium-weight',
+            'body-small',
+            'body-small-font',
+            'body-small-line-height',
+            'body-small-size',
+            'body-small-tracking',
+            'body-small-weight',
+            'display-large',
+            'display-large-font',
+            'display-large-line-height',
+            'display-large-size',
+            'display-large-tracking',
+            'display-large-weight',
+            'display-medium',
+            'display-medium-font',
+            'display-medium-line-height',
+            'display-medium-size',
+            'display-medium-tracking',
+            'display-medium-weight',
+            'display-small',
+            'display-small-font',
+            'display-small-line-height',
+            'display-small-size',
+            'display-small-tracking',
+            'display-small-weight',
+            'headline-large',
+            'headline-large-font',
+            'headline-large-line-height',
+            'headline-large-size',
+            'headline-large-tracking',
+            'headline-large-weight',
+            'headline-medium',
+            'headline-medium-font',
+            'headline-medium-line-height',
+            'headline-medium-size',
+            'headline-medium-tracking',
+            'headline-medium-weight',
+            'headline-small',
+            'headline-small-font',
+            'headline-small-line-height',
+            'headline-small-size',
+            'headline-small-tracking',
+            'headline-small-weight',
+            'label-large',
+            'label-large-font',
+            'label-large-line-height',
+            'label-large-size',
+            'label-large-tracking',
+            'label-large-weight',
+            'label-large-weight-prominent',
+            'label-medium',
+            'label-medium-font',
+            'label-medium-line-height',
+            'label-medium-size',
+            'label-medium-tracking',
+            'label-medium-weight',
+            'label-medium-weight-prominent',
+            'label-small',
+            'label-small-font',
+            'label-small-line-height',
+            'label-small-size',
+            'label-small-tracking',
+            'label-small-weight',
+            'title-large',
+            'title-large-font',
+            'title-large-line-height',
+            'title-large-size',
+            'title-large-tracking',
+            'title-large-weight',
+            'title-medium',
+            'title-medium-font',
+            'title-medium-line-height',
+            'title-medium-size',
+            'title-medium-tracking',
+            'title-medium-weight',
+            'title-small',
+            'title-small-font',
+            'title-small-line-height',
+            'title-small-size',
+            'title-small-tracking',
+            'title-small-weight'
     );
+
+    @return create-map($keys, $prefix);
   }
   @return mdc-tokens.md-sys-typescale-values($ref);
 }
@@ -338,13 +351,14 @@ $_cached-token-slots: null;
 /// @param {Map} $primary The primary palette
 /// @param {Map} $tertiary The tertiary palette
 /// @param {Map} $error The error palette
+/// @param {String} $system-variables-prefix The prefix of system tokens
 /// @return {Map} A map of namespaced color tokens
-@function generate-color-tokens($type, $primary, $tertiary, $error) {
+@function generate-color-tokens($type, $primary, $tertiary, $error, $system-variables-prefix) {
   $ref: (
     md-ref-palette: _generate-ref-palette-tokens($primary, $tertiary, $error)
   );
 
-  $sys-color: _get-sys-color($type, $ref);
+  $sys-color: _get-sys-color($type, $ref, $system-variables-prefix);
 
   @return _generate-tokens(map.merge($ref, (
     md-sys-color: $sys-color,
@@ -365,12 +379,14 @@ $_cached-token-slots: null;
 /// @param {String|Number} $bold The bold font-weight
 /// @param {String|Number} $medium The medium font-weight
 /// @param {String|Number} $regular The regular font-weight
+/// @param {String} $system-variables-prefix The prefix of system tokens
 /// @return {Map} A map of namespaced typography tokens
-@function generate-typography-tokens($brand, $plain, $bold, $medium, $regular) {
+@function generate-typography-tokens($brand, $plain, $bold, $medium, $regular,
+$system-variables-prefix) {
   $ref: (
     md-ref-typeface: _generate-ref-typeface-tokens($brand, $plain, $bold, $medium, $regular)
   );
-  $sys-typeface: _get-sys-typeface($ref);
+  $sys-typeface: _get-sys-typeface($ref, $system-variables-prefix);
   @return _generate-tokens((
     md-sys-typescale: $sys-typeface
   ));

--- a/src/material/schematics/ng-generate/m3-theme/README.md
+++ b/src/material/schematics/ng-generate/m3-theme/README.md
@@ -23,6 +23,10 @@ If you're using the system variables option, you should remember to either provi
 system variables (all prefixed with `--sys-`), or to include the `system-level-colors` and
 `system-level-typography` mixins which will generate the values based on your theme.
 
+The default prefix for system variables is `--sys-`. This prefix can be customized. For
+example, to change the prefix to `--md-sys-`, use the following configuration at the color or typography level:
+`system-prefix: md-sys`.
+
 ```scss
 @use '@angular/material' as mat;
 @use './path/to/my-theme';


### PR DESCRIPTION
The component tokens (CSS variables) can reference the system variables abstraction with the configuration use-system-variables at the color and typography options level. 

With this PR, you can replace the `--sys-` prefix with, for example, `--md-sys-`. This makes it more flexible to adopt your own tokens, which are based on the Material 3 naming scheme but include a custom design system prefix, e.g., `--labs-sys-`. This saves additional mapping.

Demo configuration:
```scss
// Create a theme with the specified color type and density.
@function create-theme($type: light, $density: 0) {
  @return mat.define-theme((
    color: (
      theme-type: $type,
      primary: mat.$azure-palette,
      tertiary: mat.$blue-palette,
      use-system-variables: true,
      system-variables-prefix: md-sys,
    ),
    typography: (use-system-variables: true, system-variables-prefix: md-sys),
    density: (
      scale: $density
    ),
  ));
}
```


I made a small optimization to the map with the tokens, as the key and value were the same and only the --sys- prefix was added.


The result:
<img width="699" alt="image" src="https://github.com/angular/components/assets/1221055/a7a5bd40-740e-4e26-8f51-dc7f12c792c7">
