### PR TITLE
fix(material/core): hide ripples inside drag&drop elements

### DIFF
--- a/src/material/core/ripple/_ripple.scss
+++ b/src/material/core/ripple/_ripple.scss
@@ -47,5 +47,11 @@
     @include cdk.high-contrast(active, off) {
       display: none;
     }
+
+    // Hide ripples inside cloned drag&drop elements since they won't go away.
+    .cdk-drag-preview &,
+    .cdk-drag-placeholder & {
+      display: none;
+    }
   }
 }


### PR DESCRIPTION
When we create previews and placeholders for the drag&drop module, we clone the DOM node in its current state. This means that if there are ripples, they'll be in the clone as well.

These changes add a default styles to hide the ripple in such cases since it'll never disappear.

Fixes #29159.