### PR TITLE
fix(material/dialog): Make autofocus work with animations disabled

### DIFF
--- a/src/material/dialog/dialog-container.ts
+++ b/src/material/dialog/dialog-container.ts
@@ -94,8 +94,6 @@ export class MatDialogContainer extends CdkDialogContainer<MatDialogConfig> impl
   /** Current timer for dialog animations. */
   private _animationTimer: ReturnType<typeof setTimeout> | null = null;
 
-  private _isDestroyed = false;
-
   constructor(
     elementRef: ElementRef,
     focusTrapFactory: FocusTrapFactory,
@@ -264,10 +262,6 @@ export class MatDialogContainer extends CdkDialogContainer<MatDialogConfig> impl
    * be called by sub-classes that use different animation implementations.
    */
   protected _openAnimationDone(totalTime: number) {
-    if (this._isDestroyed) {
-      return;
-    }
-
     if (this._config.delayFocusTrap) {
       this._trapFocus();
     }
@@ -281,8 +275,6 @@ export class MatDialogContainer extends CdkDialogContainer<MatDialogConfig> impl
     if (this._animationTimer !== null) {
       clearTimeout(this._animationTimer);
     }
-
-    this._isDestroyed = true;
   }
 
   override attachComponentPortal<T>(portal: ComponentPortal<T>): ComponentRef<T> {

--- a/src/material/dialog/dialog.spec.ts
+++ b/src/material/dialog/dialog.spec.ts
@@ -30,8 +30,8 @@ import {
   ViewEncapsulation,
   createNgModuleRef,
   forwardRef,
-  signal,
   provideZoneChangeDetection,
+  signal,
 } from '@angular/core';
 import {
   ComponentFixture,
@@ -1041,7 +1041,8 @@ describe('MDC-based MatDialog', () => {
         });
 
         viewContainerFixture.detectChanges();
-        flushMicrotasks();
+        flush();
+        viewContainerFixture.detectChanges();
 
         let backdrop = overlayContainerElement.querySelector(
           '.cdk-overlay-backdrop',
@@ -1209,7 +1210,8 @@ describe('MDC-based MatDialog', () => {
       });
 
       viewContainerFixture.detectChanges();
-      flushMicrotasks();
+      flush();
+      viewContainerFixture.detectChanges();
 
       let container = overlayContainerElement.querySelector(
         '.mat-mdc-dialog-container',
@@ -1245,7 +1247,8 @@ describe('MDC-based MatDialog', () => {
       });
 
       viewContainerFixture.detectChanges();
-      flushMicrotasks();
+      flush();
+      viewContainerFixture.detectChanges();
 
       let firstParagraph = overlayContainerElement.querySelector(
         'p[tabindex="-1"]',


### PR DESCRIPTION
fixes #29194, blocked on https://github.com/angular/components/pull/29203