### PR TITLE
fix(material/select): required attribute not being read by TalkBack

### DIFF
--- a/src/material/input/input.ts
+++ b/src/material/input/input.ts
@@ -63,6 +63,7 @@ let nextUniqueId = 0;
     '[id]': 'id',
     '[disabled]': 'disabled',
     '[required]': 'required',
+    '[attr.required]': 'required',
     '[attr.name]': 'name || null',
     '[attr.readonly]': 'readonly && !_isNativeSelect || null',
     // Only mark the input as invalid for assistive technology if it has a value since the

--- a/src/material/select/select.ts
+++ b/src/material/select/select.ts
@@ -187,6 +187,7 @@ export class MatSelectChange {
     '[attr.aria-expanded]': 'panelOpen',
     '[attr.aria-label]': 'ariaLabel || null',
     '[attr.aria-required]': 'required.toString()',
+    '[attr.required]': 'required',
     '[attr.aria-disabled]': 'disabled.toString()',
     '[attr.aria-invalid]': 'errorState',
     '[attr.aria-activedescendant]': '_getAriaActiveDescendant()',


### PR DESCRIPTION
Fixes Angular Components form field components Input and Select which do not have the required attribute being read by TalkBack. Provides required value to html attribute required creating required=true if required exists.

Fixes b/285947676