### PR TITLE
docs(cdk/dialog): add initial setup instructions for CDK dialogs

### DIFF
--- a/src/cdk/dialog/dialog.md
+++ b/src/cdk/dialog/dialog.md
@@ -1,6 +1,16 @@
 The `Dialog` service can be used to open unstyled modal dialogs and to build your own dialog
 services.
 
+### Initial setup
+The CDK dialogs depend on a small set of structural styles to work correctly. If you're using
+Angular Material, these styles have been included together with the theme, otherwise if you're
+using the CDK on its own, you'll have to include the styles yourself. You can do so by importing
+the prebuilt styles in your global stylesheet:
+
+```scss
+@import '@angular/cdk/overlay-prebuilt.css';
+```
+
 <!-- example(cdk-dialog-overview) -->
 
 You can open a dialog by calling the `open` method either with a component or with a `TemplateRef`

--- a/src/cdk/dialog/dialog.md
+++ b/src/cdk/dialog/dialog.md
@@ -11,6 +11,14 @@ the prebuilt styles in your global stylesheet:
 @import '@angular/cdk/overlay-prebuilt.css';
 ```
 
+Alternatively, you can include the styles using the `cdk.overlay` mixin in your Sass file. You can import the mixin as follows:
+
+```scss
+@use '@angular/cdk' as cdk;
+
+@include cdk.overlay();
+```
+
 <!-- example(cdk-dialog-overview) -->
 
 You can open a dialog by calling the `open` method either with a component or with a `TemplateRef`


### PR DESCRIPTION
Added instructions for including structural styles required by CDK dialogs. Noted that without importing `@angular/cdk/overlay-prebuilt.css` in the global stylesheet, CDK dialogs did not work correctly.