### PR TITLE
docs: provide example for global `ErrorStateMatcher` for standalone apps

### DIFF
--- a/src/material/input/input.md
+++ b/src/material/input/input.md
@@ -65,11 +65,23 @@ applies to all inputs. For convenience, `ShowOnDirtyErrorStateMatcher` is availa
 globally cause input errors to show when the input is dirty and invalid.
 
 ```ts
+// Module applications
 @NgModule({
   providers: [
     {provide: ErrorStateMatcher, useClass: ShowOnDirtyErrorStateMatcher}
   ]
 })
+
+// Standalone applications
+export const appConfig: ApplicationConfig = {
+  providers: [
+    {provide: ErrorStateMatcher, useClass: ShowOnDirtyErrorStateMatcher}
+  ]
+};
+```
+
+```ts
+
 ```
 
 ### Auto-resizing `<textarea>` elements

--- a/src/material/input/input.md
+++ b/src/material/input/input.md
@@ -65,7 +65,7 @@ applies to all inputs. For convenience, `ShowOnDirtyErrorStateMatcher` is availa
 globally cause input errors to show when the input is dirty and invalid.
 
 ```ts
-// Module applications
+// NgModule applications
 @NgModule({
   providers: [
     {provide: ErrorStateMatcher, useClass: ShowOnDirtyErrorStateMatcher}
@@ -78,10 +78,6 @@ export const appConfig: ApplicationConfig = {
     {provide: ErrorStateMatcher, useClass: ShowOnDirtyErrorStateMatcher}
   ]
 };
-```
-
-```ts
-
 ```
 
 ### Auto-resizing `<textarea>` elements

--- a/src/material/select/select.md
+++ b/src/material/select/select.md
@@ -130,11 +130,19 @@ applies to all inputs. For convenience, `ShowOnDirtyErrorStateMatcher` is availa
 globally cause input errors to show when the input is dirty and invalid.
 
 ```ts
+// NgModule applications
 @NgModule({
   providers: [
     {provide: ErrorStateMatcher, useClass: ShowOnDirtyErrorStateMatcher}
   ]
 })
+
+// Standalone applications
+export const appConfig: ApplicationConfig = {
+  providers: [
+    {provide: ErrorStateMatcher, useClass: ShowOnDirtyErrorStateMatcher}
+  ]
+};
 ```
 
 ### Keyboard interaction


### PR DESCRIPTION
Relevant documentation page: https://material.angular.io/components/input/overview#changing-when-error-messages-are-shown
Edit: other page https://material.angular.io/components/select/overview#changing-when-error-messages-are-shown

`ErrorStateMatcher` is very useful, especially when added globally. This PR would add an example on how to use it globally in standalone applications.