### PR TITLE
build: fix missing elevation import

### DIFF
--- a/src/material/core/tokens/m2/mat/_app.scss
+++ b/src/material/core/tokens/m2/mat/_app.scss
@@ -3,6 +3,7 @@
 @use '../../token-utils';
 @use '../../../theming/inspection';
 @use '../../../style/sass-utils';
+@use '../../../style/elevation';
 
 // The prefix used to generate the fully qualified name for tokens in this file.
 $prefix: (mat, app);


### PR DESCRIPTION
Fixes a missing import when generating elevation tokens.