### PR TITLE
fix(material/dialog): dialog name on mac only using aria-label

### DIFF
--- a/src/cdk/dialog/dialog-container.ts
+++ b/src/cdk/dialog/dialog-container.ts
@@ -75,7 +75,7 @@ export class CdkDialogContainer<C extends DialogConfig = DialogConfig>
   extends BasePortalOutlet
   implements OnDestroy
 {
-  public _platform = inject(Platform);
+  protected _platform = inject(Platform);
   protected _document: Document;
 
   /** The portal outlet inside of this container into which the dialog content will be loaded. */

--- a/src/cdk/dialog/dialog-container.ts
+++ b/src/cdk/dialog/dialog-container.ts
@@ -75,7 +75,7 @@ export class CdkDialogContainer<C extends DialogConfig = DialogConfig>
   extends BasePortalOutlet
   implements OnDestroy
 {
-  private _platform = inject(Platform);
+  public _platform = inject(Platform);
   protected _document: Document;
 
   /** The portal outlet inside of this container into which the dialog content will be loaded. */

--- a/src/cdk/platform/platform.ts
+++ b/src/cdk/platform/platform.ts
@@ -86,6 +86,13 @@ export class Platform {
   /** Whether the current browser is Safari. */
   SAFARI: boolean = this.isBrowser && /safari/i.test(navigator.userAgent) && this.WEBKIT;
 
+  /** Whether the device is a Mac device/OS. */
+  MAC: boolean =
+    !this.isBrowser && /(macintosh|macintel|macppc|mac68k|macos)/i.test(navigator.userAgent);
+
+  /** Whether the device is a Windows device/OS. */
+  WINDOWS: boolean = !this.isBrowser && /(win32|win64|windows|wince)/i.test(navigator.userAgent);
+
   /** Backwards-compatible constructor. */
   constructor(..._args: unknown[]);
 

--- a/src/cdk/platform/platform.ts
+++ b/src/cdk/platform/platform.ts
@@ -87,7 +87,7 @@ export class Platform {
   SAFARI: boolean = this.isBrowser && /safari/i.test(navigator.userAgent) && this.WEBKIT;
 
   /** Whether the device is a Mac device/OS. */
-  MAC: boolean =
+  MAC_OS: boolean =
     !this.isBrowser && /(macintosh|macintel|macppc|mac68k|macos)/i.test(navigator.userAgent);
 
   /** Whether the device is a Windows device/OS. */

--- a/src/dev-app/dialog/dialog-demo.ts
+++ b/src/dev-app/dialog/dialog-demo.ts
@@ -73,6 +73,7 @@ export class DialogDemo {
     minHeight: '',
     maxWidth: '',
     maxHeight: '',
+    ariaLabelledBy: 'jazz-title',
     position: {
       top: '',
       bottom: '',
@@ -146,7 +147,7 @@ export class DialogDemo {
   selector: 'demo-jazz-dialog',
   template: `
     <div cdkDrag cdkDragRootElement=".cdk-overlay-pane">
-      <p>Order printer ink refills.</p>
+      <p id="jazz-title">Order printer ink refills.</p>
 
       <mat-form-field>
         <mat-label>How many?</mat-label>
@@ -213,7 +214,7 @@ export class JazzDialog {
     }
   `,
   template: `
-    <h2 mat-dialog-title>Neptune</h2>
+    <h2 id="jazz-title" mat-dialog-title>Neptune</h2>
 
     <mat-dialog-content>
       <p>
@@ -276,7 +277,7 @@ export class ContentElementDialog {
     }
   `,
   template: `
-    <h2 mat-dialog-title>Neptune</h2>
+    <h2 id="jazz-title" mat-dialog-title>Neptune</h2>
 
     <mat-dialog-content>
       <iframe style="border: 0" src="https://en.wikipedia.org/wiki/Neptune"></iframe>

--- a/src/material/dialog/dialog-container.ts
+++ b/src/material/dialog/dialog-container.ts
@@ -103,7 +103,6 @@ export class MatDialogContainer
 
   constructor(
     elementRef: ElementRef,
-    _platform: Platform,
     focusTrapFactory: FocusTrapFactory,
     @Optional() @Inject(DOCUMENT) _document: any,
     dialogConfig: MatDialogConfig,
@@ -125,24 +124,6 @@ export class MatDialogContainer
     );
   }
 
-  /** Get userAgent to check for useragent operating system */
-  private _getUserPlatform = (): string => {
-    let os = '';
-
-    if (this._platform.MAC) {
-      os = 'macos';
-    } else if (this._platform.IOS) {
-      os = 'ios';
-    } else if (this._platform.WINDOWS) {
-      os = 'windows';
-    } else if (this._platform.ANDROID) {
-      os = 'android';
-    } else if (this._platform.LINUX) {
-      os = 'linux';
-    }
-    return os;
-  };
-
   /** Get Dialog name from aria attributes */
   private _getDialogName = (): string => {
     // _ariaLabelledByQueue is created if ariaLabelledBy values are applied
@@ -160,8 +141,10 @@ export class MatDialogContainer
   };
 
   private _setAriaLabel = (): void => {
-    const os = this._getUserPlatform();
-    if (os === 'macos' || os === 'ios') {
+    /* Check for platform's operating system & provide
+      aria-labelledby value or default text as dialog
+      name if platform is MAC_OS or IOS. Fixes b/274674581 */
+    if (this._platform.MAC_OS || this._platform.IOS) {
       this._config.ariaLabel = this._getDialogName();
     }
     return;

--- a/src/material/dialog/dialog-container.ts
+++ b/src/material/dialog/dialog-container.ts
@@ -142,7 +142,6 @@ export class MatDialogContainer
     } else if (!os && /linux/.test(userAgent)) {
       os = 'linux';
     }
-    // const platform = window.navigator.userAgent.platform
     return os;
   };
 
@@ -172,6 +171,7 @@ export class MatDialogContainer
     }
     return;
   };
+
   ngOnInit() {
     this._setAriaLabel();
   }

--- a/src/material/dialog/dialog-container.ts
+++ b/src/material/dialog/dialog-container.ts
@@ -145,27 +145,24 @@ export class MatDialogContainer
 
   /** Get Dialog name from aria attributes */
   private _getDialogName = (): string => {
-    // _ariaLabelledByQueue and _ariaDescribedByQueue are created if ariaLabelledBy
-    // or ariaDescribedBy values are applied to the dialog config
+    // _ariaLabelledByQueue is created if ariaLabelledBy values are applied
+    // to the dialog config
     const ariaLabelledByRefId = this._ariaLabelledByQueue[0];
-    const ariaDescribedByRefId = this._ariaDescribedByQueue[0];
-    // Get Element to get name/title from if ariaLabelledBy or ariaDescribedBy
-    const dialogNameElement =
-      document.getElementById(ariaLabelledByRefId) || document.getElementById(ariaDescribedByRefId);
+    // Get Element to get name/title from if ariaLabelledBy
+    const dialogNameElement = document.getElementById(ariaLabelledByRefId);
     const dialogNameInnerText =
-      // If no ariaLabelledBy, ariaDescribedBy, or ariaLabel, create default aria label
+      // If no ariaLabelledBy or ariaLabel, create default aria label
       !dialogNameElement && !this._config.ariaLabel
         ? 'Dialog Modal'
         : // : Otherwise prioritize use of ariaLabel
           this._config.ariaLabel || dialogNameElement?.innerText || dialogNameElement?.ariaLabel;
-    this._config.ariaLabel = dialogNameInnerText || 'Dialog Modal';
-    return this._config.ariaLabel;
+    return dialogNameInnerText || 'Dialog Modal';
   };
 
   private _setAriaLabel = (): void => {
     const os = this._getUserPlatform();
     if (os === 'macos' || os === 'ios') {
-      this._getDialogName();
+      this._config.ariaLabel = this._getDialogName();
     }
     return;
   };

--- a/src/material/dialog/dialog-container.ts
+++ b/src/material/dialog/dialog-container.ts
@@ -142,10 +142,6 @@ export class MatDialogContainer
     } else if (!os && /linux/.test(userAgent)) {
       os = 'linux';
     }
-    console.log('userAgent:');
-    console.log(userAgent);
-    console.log(`os:`);
-    console.log(os);
     // const platform = window.navigator.userAgent.platform
     return os;
   };
@@ -156,8 +152,6 @@ export class MatDialogContainer
     // or ariaDescribedBy values are applied to the dialog config
     const ariaLabelledByRefId = this._ariaLabelledByQueue[0];
     const ariaDescribedByRefId = this._ariaDescribedByQueue[0];
-    console.log(`ariaLabelledByRefId: ${ariaLabelledByRefId}`);
-    console.log(`ariaDescribedByRefId: ${ariaDescribedByRefId}`);
     // Get Element to get name/title from if ariaLabelledBy or ariaDescribedBy
     const dialogNameElement =
       document.getElementById(ariaLabelledByRefId) || document.getElementById(ariaDescribedByRefId);
@@ -168,8 +162,6 @@ export class MatDialogContainer
         : // : Otherwise prioritize use of ariaLabel
           this._config.ariaLabel || dialogNameElement?.innerText || dialogNameElement?.ariaLabel;
     this._config.ariaLabel = dialogNameInnerText || 'Dialog Modal';
-    console.log(`getDialogName this.config.ariaLabel: `);
-    console.log(this._config.ariaLabel);
     return this._config.ariaLabel;
   };
 

--- a/src/material/dialog/dialog-container.ts
+++ b/src/material/dialog/dialog-container.ts
@@ -27,7 +27,6 @@ import {
 import {MatDialogConfig} from './dialog-config';
 import {CdkDialogContainer} from '@angular/cdk/dialog';
 import {coerceNumberProperty} from '@angular/cdk/coercion';
-import {Platform} from '@angular/cdk/platform';
 import {CdkPortalOutlet, ComponentPortal} from '@angular/cdk/portal';
 
 /** Event that captures the state of dialog container animations. */

--- a/src/material/dialog/dialog-container.ts
+++ b/src/material/dialog/dialog-container.ts
@@ -175,7 +175,7 @@ export class MatDialogContainer
 
   private _setAriaLabel = (): void => {
     const os = this._getUserPlatform();
-    if (os === 'mac') {
+    if (os === 'macos') {
       this._getDialogName();
     }
     return;

--- a/src/material/dialog/dialog-container.ts
+++ b/src/material/dialog/dialog-container.ts
@@ -27,6 +27,7 @@ import {
 import {MatDialogConfig} from './dialog-config';
 import {CdkDialogContainer} from '@angular/cdk/dialog';
 import {coerceNumberProperty} from '@angular/cdk/coercion';
+import {Platform} from '@angular/cdk/platform';
 import {CdkPortalOutlet, ComponentPortal} from '@angular/cdk/portal';
 
 /** Event that captures the state of dialog container animations. */
@@ -105,6 +106,7 @@ export class MatDialogContainer
 
   constructor(
     elementRef: ElementRef,
+    _platform: Platform,
     focusTrapFactory: FocusTrapFactory,
     @Optional() @Inject(DOCUMENT) _document: any,
     dialogConfig: MatDialogConfig,
@@ -129,6 +131,9 @@ export class MatDialogContainer
   /** Get userAgent to check for useragent operating system */
   private _getUserPlatform = (): string => {
     const window = this._getWindow();
+    console.log('Testing Platform CDK');
+    console.log('this._platform:');
+    console.log(this._platform);
     let userAgent = window.navigator.userAgent.toLowerCase(),
       macosPlatforms = /(macintosh|macintel|macppc|mac68k|macos)/i,
       windowsPlatforms = /(win32|win64|windows|wince)/i,

--- a/src/material/dialog/dialog-container.ts
+++ b/src/material/dialog/dialog-container.ts
@@ -134,8 +134,7 @@ export class MatDialogContainer
       // If no ariaLabelledBy or ariaLabel, create default aria label
       !dialogNameElement && !this._config.ariaLabel
         ? 'Dialog Modal'
-        : // : Otherwise prioritize use of ariaLabel
-          this._config.ariaLabel || dialogNameElement?.innerText || dialogNameElement?.ariaLabel;
+        : dialogNameElement?.innerText || dialogNameElement?.ariaLabel || this._config.ariaLabel;
     return dialogNameInnerText || 'Dialog Modal';
   };
 

--- a/src/material/dialog/dialog-container.ts
+++ b/src/material/dialog/dialog-container.ts
@@ -99,6 +99,9 @@ export class MatDialogContainer
     : 0;
   /** Current timer for dialog animations. */
   private _animationTimer: ReturnType<typeof setTimeout> | null = null;
+  private _getWindow(): Window {
+    return this._document?.defaultView || window;
+  }
 
   constructor(
     elementRef: ElementRef,
@@ -166,7 +169,7 @@ export class MatDialogContainer
 
   private _setAriaLabel = (): void => {
     const os = this._getUserPlatform();
-    if (os === 'macos') {
+    if (os === 'macos' || os === 'ios') {
       this._getDialogName();
     }
     return;

--- a/src/material/dialog/dialog-container.ts
+++ b/src/material/dialog/dialog-container.ts
@@ -120,6 +120,31 @@ export class MatDialogContainer extends CdkDialogContainer<MatDialogConfig> impl
     );
   }
 
+  /** Get Dialog name from aria attributes */
+  private _getDialogName = async (): Promise<string> => {
+    const configData = this._config;
+    /**_ariaLabelledByQueue and _ariaDescribedByQueue are created if ariaLabelledBy
+        or ariaDescribedBy values are applied to the dialog config */
+    const ariaLabelledByRefId = await this._ariaLabelledByQueue[0];
+    const ariaDescribedByRefId = await this._ariaDescribedByQueue[0];
+    /** Get Element to get name/title from if ariaLabelledBy or ariaDescribedBy */
+    const dialogNameElement =
+      document.getElementById(ariaLabelledByRefId) || document.getElementById(ariaDescribedByRefId);
+    const dialogNameInnerText =
+      /** If no ariaLabelledBy, ariaDescribedBy, or ariaLabel, create default aria label */
+      !dialogNameElement && !this._config.ariaLabel
+        ? 'Dialog Modal'
+        : /** Otherwise prioritize use of ariaLabel */
+          this._config.ariaLabel || dialogNameElement?.innerText || dialogNameElement?.ariaLabel;
+    this._config.ariaLabel = dialogNameInnerText || 'Dialog Modal';
+    console.log(`getDialogName this.config.ariaLabel: `);
+    console.log(this._config.ariaLabel);
+    return this._config.ariaLabel;
+  };
+  ngAfterViewInit() {
+    this._getDialogName();
+  }
+
   protected override _contentAttached(): void {
     // Delegate to the original dialog-container initialization (i.e. saving the
     // previous element, setting up the focus trap and moving focus to the container).

--- a/src/material/dialog/dialog-container.ts
+++ b/src/material/dialog/dialog-container.ts
@@ -100,9 +100,6 @@ export class MatDialogContainer
     : 0;
   /** Current timer for dialog animations. */
   private _animationTimer: ReturnType<typeof setTimeout> | null = null;
-  private _getWindow(): Window {
-    return this._document?.defaultView || window;
-  }
 
   constructor(
     elementRef: ElementRef,
@@ -130,24 +127,17 @@ export class MatDialogContainer
 
   /** Get userAgent to check for useragent operating system */
   private _getUserPlatform = (): string => {
-    const window = this._getWindow();
-    console.log('Testing Platform CDK');
-    console.log('this._platform:');
-    console.log(this._platform);
-    let userAgent = window.navigator.userAgent.toLowerCase(),
-      macosPlatforms = /(macintosh|macintel|macppc|mac68k|macos)/i,
-      windowsPlatforms = /(win32|win64|windows|wince)/i,
-      iosPlatforms = /(iphone|ipad|ipod)/i,
-      os = '';
-    if (macosPlatforms.test(userAgent)) {
+    let os = '';
+
+    if (this._platform.MAC) {
       os = 'macos';
-    } else if (iosPlatforms.test(userAgent)) {
+    } else if (this._platform.IOS) {
       os = 'ios';
-    } else if (windowsPlatforms.test(userAgent)) {
+    } else if (this._platform.WINDOWS) {
       os = 'windows';
-    } else if (/android/.test(userAgent)) {
+    } else if (this._platform.ANDROID) {
       os = 'android';
-    } else if (!os && /linux/.test(userAgent)) {
+    } else if (this._platform.LINUX) {
       os = 'linux';
     }
     return os;

--- a/src/material/dialog/dialog-content-directives.ts
+++ b/src/material/dialog/dialog-content-directives.ts
@@ -34,8 +34,6 @@ let dialogElementUid = 0;
   host: {
     '(click)': '_onButtonClick($event)',
     '[attr.aria-label]': 'ariaLabel || null',
-    '[attr.aria-labelledby]': 'ariaLabelledBy || null',
-    '[attr.aria-describedby]': 'ariaDescribedBy || null',
     '[attr.type]': 'type',
   },
 })

--- a/src/material/dialog/dialog-content-directives.ts
+++ b/src/material/dialog/dialog-content-directives.ts
@@ -34,6 +34,8 @@ let dialogElementUid = 0;
   host: {
     '(click)': '_onButtonClick($event)',
     '[attr.aria-label]': 'ariaLabel || null',
+    '[attr.aria-labelledby]': 'ariaLabelledBy || null',
+    '[attr.aria-describedby]': 'ariaDescribedBy || null',
     '[attr.type]': 'type',
   },
 })

--- a/src/material/dialog/dialog.md
+++ b/src/material/dialog/dialog.md
@@ -40,6 +40,7 @@ export class YourDialog {
 ```
 
 ### Specifying global configuration defaults
+
 Default dialog options can be specified by providing an instance of `MatDialogConfig` for
 MAT_DIALOG_DEFAULT_OPTIONS in your application's root module.
 
@@ -52,6 +53,7 @@ MAT_DIALOG_DEFAULT_OPTIONS in your application's root module.
 ```
 
 ### Sharing data with the Dialog component.
+
 If you want to share data with your dialog, you can use the `data`
 option to pass information to the dialog component.
 
@@ -88,16 +90,18 @@ will be available implicitly in the template:
 <!-- example(dialog-data) -->
 
 ### Dialog content
+
 Several directives are available to make it easier to structure your dialog content:
 
-| Name                   | Description                                                                                                   |
-|------------------------|---------------------------------------------------------------------------------------------------------------|
-| `mat-dialog-title`     | \[Attr] Dialog title, applied to a heading element (e.g., `<h1>`, `<h2>`)                                     |
-| `<mat-dialog-content>` | Primary scrollable content of the dialog.                                                                     |
-| `<mat-dialog-actions>` | Container for action buttons at the bottom of the dialog. Button alignment can be controlled via the `align` attribute which can be set to `end` and `center`.                                                      |
-| `mat-dialog-close`     | \[Attr] Added to a `<button>`, makes the button close the dialog with an optional result from the bound value.|
+| Name                   | Description                                                                                                                                                    |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `mat-dialog-title`     | \[Attr] Dialog title, applied to a heading element (e.g., `<h1>`, `<h2>`)                                                                                      |
+| `<mat-dialog-content>` | Primary scrollable content of the dialog.                                                                                                                      |
+| `<mat-dialog-actions>` | Container for action buttons at the bottom of the dialog. Button alignment can be controlled via the `align` attribute which can be set to `end` and `center`. |
+| `mat-dialog-close`     | \[Attr] Added to a `<button>`, makes the button close the dialog with an optional result from the bound value.                                                 |
 
 For example:
+
 ```html
 <h2 mat-dialog-title>Delete all elements?</h2>
 <mat-dialog-content>This will delete all elements that are currently on this page and cannot be undone.</mat-dialog-content>
@@ -119,6 +123,7 @@ You can control which elements are tab stops with the `tabindex` attribute
 <!-- example(dialog-content) -->
 
 ### Controlling the dialog animation
+
 You can control the duration of the dialog's enter and exit animations using the
 `enterAnimationDuration` and `exitAnimationDuration` options. If you want to disable the dialog's
 animation completely, you can do so by setting the properties to `0ms`.
@@ -130,11 +135,10 @@ animation completely, you can do so by setting the properties to `0ms`.
 `MatDialog` creates modal dialogs that implements the ARIA `role="dialog"` pattern by default.
 You can change the dialog's role to `alertdialog` via `MatDialogConfig`.
 
-You should provide an accessible label to this root dialog element by setting the `ariaLabel` or
-`ariaLabelledBy` properties of `MatDialogConfig`. You can additionally specify a description element
-ID via the `ariaDescribedBy` property of `MatDialogConfig`.
+In order to make your dialog title/name known and read by all screenreaders regardless of OS or browser, you should provide an accessible label to this root dialog element. You can do so either by setting the dialog name/title as a value to the `ariaLabel` property of `MatDialogConfig` or providing the id of the respective element with the dialog name as `ariaLabelledBy` property of `MatDialogConfig`. You can additionally specify a description element ID via the `ariaDescribedBy` property of `MatDialogConfig`. If none of these properties (`ariaLabel`,`ariaLabelledBy`, or `ariaDescribedBy`) are applied to `MatDialogConfig` the default aria-label value will be "Dialog Modal".
 
 #### Keyboard interaction
+
 By default, the escape key closes `MatDialog`. While you can disable this behavior via
 the `disableClose` property of `MatDialogConfig`, doing this breaks the expected interaction
 pattern for the ARIA `role="dialog"` pattern.
@@ -146,12 +150,12 @@ When opened, `MatDialog` traps browser focus such that it cannot escape the root
 You can customize which element receives focus with the `autoFocus` property of
 `MatDialogConfig`, which supports the following values.
 
-| Value            | Behavior                                                                 |
-|------------------|--------------------------------------------------------------------------|
-| `first-tabbable` | Focus the first tabbable element. This is the default setting.           |
-| `first-header`   | Focus the first header element (`role="heading"`, `h1` through `h6`)     |
-| `dialog`         | Focus the root `role="dialog"` element.                                  |
-| Any CSS selector | Focus the first element matching the given selector.                     |
+| Value            | Behavior                                                             |
+| ---------------- | -------------------------------------------------------------------- |
+| `first-tabbable` | Focus the first tabbable element. This is the default setting.       |
+| `first-header`   | Focus the first header element (`role="heading"`, `h1` through `h6`) |
+| `dialog`         | Focus the root `role="dialog"` element.                              |
+| Any CSS selector | Focus the first element matching the given selector.                 |
 
 While the default setting applies the best behavior for most applications, special cases may benefit
 from these alternatives. Always test your application to verify the behavior that works best for


### PR DESCRIPTION
Fixes bug with Angular Components Dialog component on Mac whether using Chrome or Firefox the screenreader does not read the dialog name/title unless it is using an aria-label. Updates the dialog-content-directives to read/apply the aria- labelledby and aria-describedby values if they exist.

Fixes b/274674581