### PR TITLE
build: fix rootDir

### DIFF
--- a/src/material/tsconfig.json
+++ b/src/material/tsconfig.json
@@ -2,7 +2,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "rootDir": "..",
+    "rootDirs": ["..", "../../tools"],
     "baseUrl": ".",
     "paths": {
       "@angular/cdk": ["../cdk"],


### PR DESCRIPTION
The `tools/` directory was previously missing which caused red squigglies when we tried to import from the tools directory. e.g., in our theming tests: `import {createLocalAngularPackageImporter} from '../../../../../tools/sass/local-sass-importer';`