### PR TITLE
fix(material/bottom-sheet): changed after checked error with zoneless

### DIFF
--- a/src/material/bottom-sheet/bottom-sheet-container.ts
+++ b/src/material/bottom-sheet/bottom-sheet-container.ts
@@ -92,15 +92,17 @@ export class MatBottomSheetContainer extends CdkDialogContainer implements OnDes
     this._breakpointSubscription = breakpointObserver
       .observe([Breakpoints.Medium, Breakpoints.Large, Breakpoints.XLarge])
       .subscribe(() => {
-        this._toggleClass(
+        const classList = (this._elementRef.nativeElement as HTMLElement).classList;
+
+        classList.toggle(
           'mat-bottom-sheet-container-medium',
           breakpointObserver.isMatched(Breakpoints.Medium),
         );
-        this._toggleClass(
+        classList.toggle(
           'mat-bottom-sheet-container-large',
           breakpointObserver.isMatched(Breakpoints.Large),
         );
-        this._toggleClass(
+        classList.toggle(
           'mat-bottom-sheet-container-xlarge',
           breakpointObserver.isMatched(Breakpoints.XLarge),
         );
@@ -111,6 +113,7 @@ export class MatBottomSheetContainer extends CdkDialogContainer implements OnDes
   enter(): void {
     if (!this._destroyed) {
       this._animationState = 'visible';
+      this._changeDetectorRef.markForCheck();
       this._changeDetectorRef.detectChanges();
     }
   }
@@ -142,8 +145,4 @@ export class MatBottomSheetContainer extends CdkDialogContainer implements OnDes
   }
 
   protected override _captureInitialFocus(): void {}
-
-  private _toggleClass(cssClass: string, add: boolean) {
-    this._elementRef.nativeElement.classList.toggle(cssClass, add);
-  }
 }


### PR DESCRIPTION
Fixes that when closing and immediately reopening bottom sheet in a zoneless app, we were causing a "changed after checked" error to be thrown. It seems to be because we were calling `detectChanges` without marking for check first.

Fixes #29258.