### PR TITLE
feat(cdk/drag-drop): add the ability to specify an alternate drop list container

### DIFF
--- a/src/cdk/drag-drop/directives/drop-list-shared.spec.ts
+++ b/src/cdk/drag-drop/directives/drop-list-shared.spec.ts
@@ -4709,6 +4709,61 @@ export function defineCommonDropListTests(config: {
       expect(event.stopPropagation).toHaveBeenCalled();
     }));
   });
+
+  describe('with an alternate element container', () => {
+    it('should move the placeholder into the alternate container of an empty list', fakeAsync(() => {
+      const fixture = createComponent(ConnectedDropZonesWithAlternateContainer);
+      fixture.detectChanges();
+
+      const dropZones = fixture.componentInstance.dropInstances.map(d => d.element.nativeElement);
+      const item = fixture.componentInstance.groupedDragItems[0][1];
+      const sourceContainer = dropZones[0].querySelector('.inner-container')!;
+      const targetContainer = dropZones[1].querySelector('.inner-container')!;
+      const targetRect = targetContainer.getBoundingClientRect();
+
+      startDraggingViaMouse(fixture, item.element.nativeElement);
+
+      const placeholder = dropZones[0].querySelector('.cdk-drag-placeholder')!;
+
+      expect(placeholder).toBeTruthy();
+      expect(placeholder.parentNode)
+        .withContext('Expected placeholder to be inside the first container.')
+        .toBe(sourceContainer);
+
+      dispatchMouseEvent(document, 'mousemove', targetRect.left + 1, targetRect.top + 1);
+      fixture.detectChanges();
+
+      expect(placeholder.parentNode)
+        .withContext('Expected placeholder to be inside second container.')
+        .toBe(targetContainer);
+    }));
+
+    it('should throw if the items are not inside of the alternate container', fakeAsync(() => {
+      const fixture = createComponent(DraggableWithInvalidAlternateContainer);
+      fixture.detectChanges();
+
+      expect(() => {
+        const item = fixture.componentInstance.dragItems.first.element.nativeElement;
+        startDraggingViaMouse(fixture, item);
+        tick();
+      }).toThrowError(
+        /Invalid DOM structure for drop list\. All items must be placed directly inside of the element container/,
+      );
+    }));
+
+    it('should throw if the alternate container cannot be found', fakeAsync(() => {
+      const fixture = createComponent(DraggableWithMissingAlternateContainer);
+      fixture.detectChanges();
+
+      expect(() => {
+        const item = fixture.componentInstance.dragItems.first.element.nativeElement;
+        startDraggingViaMouse(fixture, item);
+        tick();
+      }).toThrowError(
+        /CdkDropList could not find an element container matching the selector "does-not-exist"/,
+      );
+    }));
+  });
 }
 
 export function assertStartToEndSorting(
@@ -5890,4 +5945,99 @@ class DraggableWithRadioInputsInDropZone {
     {id: 2, checked: false},
     {id: 3, checked: true},
   ];
+}
+
+@Component({
+  encapsulation: ViewEncapsulation.ShadowDom,
+  styles: [...CONNECTED_DROP_ZONES_STYLES, `.inner-container {min-height: 50px;}`],
+  template: `
+    <div
+      cdkDropList
+      #todoZone="cdkDropList"
+      [cdkDropListData]="todo"
+      [cdkDropListConnectedTo]="[doneZone]"
+      (cdkDropListDropped)="droppedSpy($event)"
+      (cdkDropListEntered)="enteredSpy($event)"
+      cdkDropListElementContainer=".inner-container">
+      <div class="inner-container">
+        @for (item of todo; track item) {
+          <div
+            [cdkDragData]="item"
+            (cdkDragEntered)="itemEnteredSpy($event)"
+            cdkDrag>{{item}}</div>
+        }
+      </div>
+    </div>
+
+    <div
+      cdkDropList
+      #doneZone="cdkDropList"
+      [cdkDropListData]="done"
+      [cdkDropListConnectedTo]="[todoZone]"
+      (cdkDropListDropped)="droppedSpy($event)"
+      (cdkDropListEntered)="enteredSpy($event)"
+      cdkDropListElementContainer=".inner-container">
+      <div class="inner-container">
+        @for (item of done; track item) {
+          <div
+            [cdkDragData]="item"
+            (cdkDragEntered)="itemEnteredSpy($event)"
+            cdkDrag>{{item}}</div>
+        }
+      </div>
+    </div>
+  `,
+  standalone: true,
+  imports: [CdkDropList, CdkDrag],
+})
+class ConnectedDropZonesWithAlternateContainer extends ConnectedDropZones {
+  override done: string[] = [];
+}
+
+@Component({
+  template: `
+    <div
+      cdkDropList
+      cdkDropListElementContainer=".element-container"
+      style="width: 100px; background: pink;">
+      <div class="element-container"></div>
+
+      @for (item of items; track $index) {
+        <div
+          cdkDrag
+          [cdkDragData]="item"
+          style="width: 100%; height: 50px; background: red;">{{item}}</div>
+      }
+    </div>
+  `,
+  standalone: true,
+  imports: [CdkDropList, CdkDrag],
+})
+class DraggableWithInvalidAlternateContainer {
+  @ViewChildren(CdkDrag) dragItems: QueryList<CdkDrag>;
+  @ViewChild(CdkDropList) dropInstance: CdkDropList;
+  items = ['Zero', 'One', 'Two', 'Three'];
+}
+
+@Component({
+  template: `
+    <div
+      cdkDropList
+      cdkDropListElementContainer="does-not-exist"
+      style="width: 100px; background: pink;">
+      @for (item of items; track $index) {
+        <div
+          cdkDrag
+          [cdkDragData]="item"
+          style="width: 100%; height: 50px; background: red;">{{item}}</div>
+      }
+    </div>
+  `,
+  standalone: true,
+  imports: [CdkDropList, CdkDrag],
+})
+class DraggableWithMissingAlternateContainer {
+  @ViewChildren(CdkDrag) dragItems: QueryList<CdkDrag>;
+  @ViewChild(CdkDropList) dropInstance: CdkDropList;
+  items = ['Zero', 'One', 'Two', 'Three'];
 }

--- a/src/cdk/drag-drop/directives/drop-list.ts
+++ b/src/cdk/drag-drop/directives/drop-list.ts
@@ -127,6 +127,22 @@ export class CdkDropList<T = any> implements OnDestroy {
   @Input('cdkDropListAutoScrollStep')
   autoScrollStep: NumberInput;
 
+  /**
+   * Selector that will be used to resolve an alternate element container for the drop list.
+   * Passing an alternate container is useful for the cases where one might not have control
+   * over the parent node of the draggable items within the list (e.g. due to content projection).
+   * This allows for usages like:
+   *
+   * ```
+   * <div cdkDropList cdkDropListElementContainer=".inner">
+   *   <div class="inner">
+   *     <div cdkDrag></div>
+   *   </div>
+   * </div>
+   * ```
+   */
+  @Input('cdkDropListElementContainer') elementContainerSelector: string | null;
+
   /** Emits when the user drops an item inside the container. */
   @Output('cdkDropListDropped')
   readonly dropped: EventEmitter<CdkDragDrop<T, any>> = new EventEmitter<CdkDragDrop<T, any>>();
@@ -293,6 +309,18 @@ export class CdkDropList<T = any> implements OnDestroy {
         // Only do this once since it involves traversing the DOM and the parents
         // shouldn't be able to change without the drop list being destroyed.
         this._scrollableParentsResolved = true;
+      }
+
+      if (this.elementContainerSelector) {
+        const container = this.element.nativeElement.querySelector(this.elementContainerSelector);
+
+        if (!container && (typeof ngDevMode === 'undefined' || ngDevMode)) {
+          throw new Error(
+            `CdkDropList could not find an element container matching the selector "${this.elementContainerSelector}"`,
+          );
+        }
+
+        ref.withElementContainer(container as HTMLElement);
       }
 
       ref.disabled = this.disabled;

--- a/src/cdk/drag-drop/sorting/drop-list-sort-strategy.ts
+++ b/src/cdk/drag-drop/sorting/drop-list-sort-strategy.ts
@@ -29,6 +29,7 @@ export interface DropListSortStrategy {
   enter(item: DragRef, pointerX: number, pointerY: number, index?: number): void;
   withItems(items: readonly DragRef[]): void;
   withSortPredicate(predicate: SortPredicate<DragRef>): void;
+  withElementContainer(container: HTMLElement): void;
   reset(): void;
   getActiveItemsSnapshot(): readonly DragRef[];
   getItemIndex(item: DragRef): number;

--- a/src/cdk/drag-drop/sorting/mixed-sort-strategy.ts
+++ b/src/cdk/drag-drop/sorting/mixed-sort-strategy.ts
@@ -18,6 +18,9 @@ import type {DragRef} from '../drag-ref';
  * @docs-private
  */
 export class MixedSortStrategy implements DropListSortStrategy {
+  /** Root element container of the drop list. */
+  private _element: HTMLElement;
+
   /** Function used to determine if an item can be sorted into a specific index. */
   private _sortPredicate: SortPredicate<DragRef>;
 
@@ -50,7 +53,6 @@ export class MixedSortStrategy implements DropListSortStrategy {
   private _relatedNodes: [node: Node, nextSibling: Node | null][] = [];
 
   constructor(
-    private _element: HTMLElement,
     private _document: Document,
     private _dragDropRegistry: DragDropRegistry<DragRef, unknown>,
   ) {}
@@ -229,6 +231,13 @@ export class MixedSortStrategy implements DropListSortStrategy {
         item._sortFromLastPointerPosition();
       }
     });
+  }
+
+  withElementContainer(container: HTMLElement): void {
+    if (container !== this._element) {
+      this._element = container;
+      this._rootNode = undefined;
+    }
   }
 
   /**

--- a/src/cdk/drag-drop/sorting/single-axis-sort-strategy.ts
+++ b/src/cdk/drag-drop/sorting/single-axis-sort-strategy.ts
@@ -35,6 +35,9 @@ interface CachedItemPosition<T> {
  * @docs-private
  */
 export class SingleAxisSortStrategy implements DropListSortStrategy {
+  /** Root element container of the drop list. */
+  private _element: HTMLElement;
+
   /** Function used to determine if an item can be sorted into a specific index. */
   private _sortPredicate: SortPredicate<DragRef>;
 
@@ -54,10 +57,7 @@ export class SingleAxisSortStrategy implements DropListSortStrategy {
   /** Layout direction of the drop list. */
   direction: Direction;
 
-  constructor(
-    private _element: HTMLElement,
-    private _dragDropRegistry: DragDropRegistry<DragRef, unknown>,
-  ) {}
+  constructor(private _dragDropRegistry: DragDropRegistry<DragRef, unknown>) {}
 
   /**
    * Keeps track of the item that was last swapped with the dragged item, as well as what direction
@@ -235,7 +235,7 @@ export class SingleAxisSortStrategy implements DropListSortStrategy {
   /** Resets the strategy to its initial state before dragging was started. */
   reset() {
     // TODO(crisbeto): may have to wait for the animations to finish.
-    this._activeDraggables.forEach(item => {
+    this._activeDraggables?.forEach(item => {
       const rootElement = item.getRootElement();
 
       if (rootElement) {
@@ -291,6 +291,10 @@ export class SingleAxisSortStrategy implements DropListSortStrategy {
         drag._sortFromLastPointerPosition();
       }
     });
+  }
+
+  withElementContainer(container: HTMLElement): void {
+    this._element = container;
   }
 
   /** Refreshes the position cache of the items and sibling containers. */

--- a/tools/public_api_guard/cdk/drag-drop.md
+++ b/tools/public_api_guard/cdk/drag-drop.md
@@ -251,6 +251,7 @@ export class CdkDropList<T = any> implements OnDestroy {
     _dropListRef: DropListRef<CdkDropList<T>>;
     readonly dropped: EventEmitter<CdkDragDrop<T, any>>;
     element: ElementRef<HTMLElement>;
+    elementContainerSelector: string | null;
     readonly entered: EventEmitter<CdkDragEnter<T>>;
     enterPredicate: (drag: CdkDrag, drop: CdkDropList) => boolean;
     readonly exited: EventEmitter<CdkDragExit<T>>;
@@ -271,7 +272,7 @@ export class CdkDropList<T = any> implements OnDestroy {
     sortingDisabled: boolean;
     sortPredicate: (index: number, drag: CdkDrag, drop: CdkDropList) => boolean;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkDropList<any>, "[cdkDropList], cdk-drop-list", ["cdkDropList"], { "connectedTo": { "alias": "cdkDropListConnectedTo"; "required": false; }; "data": { "alias": "cdkDropListData"; "required": false; }; "orientation": { "alias": "cdkDropListOrientation"; "required": false; }; "id": { "alias": "id"; "required": false; }; "lockAxis": { "alias": "cdkDropListLockAxis"; "required": false; }; "disabled": { "alias": "cdkDropListDisabled"; "required": false; }; "sortingDisabled": { "alias": "cdkDropListSortingDisabled"; "required": false; }; "enterPredicate": { "alias": "cdkDropListEnterPredicate"; "required": false; }; "sortPredicate": { "alias": "cdkDropListSortPredicate"; "required": false; }; "autoScrollDisabled": { "alias": "cdkDropListAutoScrollDisabled"; "required": false; }; "autoScrollStep": { "alias": "cdkDropListAutoScrollStep"; "required": false; }; }, { "dropped": "cdkDropListDropped"; "entered": "cdkDropListEntered"; "exited": "cdkDropListExited"; "sorted": "cdkDropListSorted"; }, never, never, true, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkDropList<any>, "[cdkDropList], cdk-drop-list", ["cdkDropList"], { "connectedTo": { "alias": "cdkDropListConnectedTo"; "required": false; }; "data": { "alias": "cdkDropListData"; "required": false; }; "orientation": { "alias": "cdkDropListOrientation"; "required": false; }; "id": { "alias": "id"; "required": false; }; "lockAxis": { "alias": "cdkDropListLockAxis"; "required": false; }; "disabled": { "alias": "cdkDropListDisabled"; "required": false; }; "sortingDisabled": { "alias": "cdkDropListSortingDisabled"; "required": false; }; "enterPredicate": { "alias": "cdkDropListEnterPredicate"; "required": false; }; "sortPredicate": { "alias": "cdkDropListSortPredicate"; "required": false; }; "autoScrollDisabled": { "alias": "cdkDropListAutoScrollDisabled"; "required": false; }; "autoScrollStep": { "alias": "cdkDropListAutoScrollStep"; "required": false; }; "elementContainerSelector": { "alias": "cdkDropListElementContainer"; "required": false; }; }, { "dropped": "cdkDropListDropped"; "entered": "cdkDropListEntered"; "exited": "cdkDropListExited"; "sorted": "cdkDropListSorted"; }, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<CdkDropList<any>, [null, null, null, null, { optional: true; }, { optional: true; skipSelf: true; }, { optional: true; }]>;
 }
@@ -543,6 +544,7 @@ export class DropListRef<T = any> {
     _stopReceiving(sibling: DropListRef): void;
     _stopScrolling(): void;
     withDirection(direction: Direction): this;
+    withElementContainer(container: HTMLElement): this;
     withItems(items: DragRef[]): this;
     withOrientation(orientation: DropListOrientation): this;
     withScrollableParents(elements: HTMLElement[]): this;


### PR DESCRIPTION
Adds the new `cdkDropListElementContainer` input that allows users to specify a different element that should be considered the root of the drop list. This is useful in the cases where the user might not have full control over the DOM between the drop list and the items, like when making a tab list draggable.

Fixes #29140.