### PR TITLE
fix(material/sidenav): not closing on escape key press

### DIFF
--- a/src/material/sidenav/drawer.ts
+++ b/src/material/sidenav/drawer.ts
@@ -322,6 +322,7 @@ export class MatDrawer implements AfterViewInit, AfterContentChecked, OnDestroy 
   readonly _modeChanged = new Subject<void>();
 
   private _injector = inject(Injector);
+  private _changeDetectorRef = inject(ChangeDetectorRef);
 
   constructor(
     private _elementRef: ElementRef<HTMLElement>,
@@ -593,6 +594,8 @@ export class MatDrawer implements AfterViewInit, AfterContentChecked, OnDestroy 
       }
     }
 
+    // Needed to ensure that the closing sequence fires off correctly.
+    this._changeDetectorRef.markForCheck();
     this._updateFocusTrapState();
 
     return new Promise<MatDrawerToggleResult>(resolve => {


### PR DESCRIPTION
Fixes that the sidenav wasn't triggering change detection when closing via a escape key press.