### PR TITLE
fix(material/select): Remove disableOptionCentering Input

### DIFF
--- a/src/material/paginator/paginator.html
+++ b/src/material/paginator/paginator.html
@@ -17,7 +17,6 @@
               [disabled]="disabled"
               [aria-labelledby]="_pageSizeLabelId"
               [panelClass]="selectConfig.panelClass || ''"
-              [disableOptionCentering]="selectConfig.disableOptionCentering"
               (selectionChange)="_changePageSize($event.value)"
               hideSingleSelectionIndicator>
               @for (pageSizeOption of _displayedPageSizeOptions; track pageSizeOption) {

--- a/src/material/paginator/paginator.spec.ts
+++ b/src/material/paginator/paginator.spec.ts
@@ -225,16 +225,13 @@ describe('MDC-based MatPaginator', () => {
     fixture.detectChanges();
     const select: MatSelect = fixture.debugElement.query(By.directive(MatSelect)).componentInstance;
 
-    expect(select.disableOptionCentering).toBe(false);
     expect(select.panelClass).toBeFalsy();
 
     fixture.componentInstance.selectConfig = {
-      disableOptionCentering: true,
       panelClass: 'custom-class',
     };
     fixture.detectChanges();
 
-    expect(select.disableOptionCentering).toBe(true);
     expect(select.panelClass).toBe('custom-class');
   });
 

--- a/src/material/paginator/paginator.ts
+++ b/src/material/paginator/paginator.ts
@@ -35,9 +35,6 @@ const DEFAULT_PAGE_SIZE = 50;
 
 /** Object that can used to configure the underlying `MatSelect` inside a `MatPaginator`. */
 export interface MatPaginatorSelectConfig {
-  /** Whether to center the active option over the trigger. */
-  disableOptionCentering?: boolean;
-
   /** Classes to be passed to the select panel. */
   panelClass?: string | string[] | Set<string> | {[key: string]: any};
 }

--- a/src/material/select/select.spec.ts
+++ b/src/material/select/select.spec.ts
@@ -3915,37 +3915,6 @@ describe('MDC-based MatSelect', () => {
     );
   });
 
-  describe('with option centering disabled', () => {
-    beforeEach(waitForAsync(() => configureMatSelectTestingModule([SelectWithoutOptionCentering])));
-
-    let fixture: ComponentFixture<SelectWithoutOptionCentering>;
-    let trigger: HTMLElement;
-
-    beforeEach(fakeAsync(() => {
-      fixture = TestBed.createComponent(SelectWithoutOptionCentering);
-      fixture.detectChanges();
-      trigger = fixture.debugElement.query(By.css('.mat-mdc-select-trigger'))!.nativeElement;
-    }));
-
-    it('should not align the active option with the trigger if centering is disabled', fakeAsync(() => {
-      trigger.click();
-      fixture.detectChanges();
-      flush();
-
-      const scrollContainer = document.querySelector('.cdk-overlay-pane .mat-mdc-select-panel')!;
-
-      // The panel should be scrolled to 0 because centering the option disabled.
-      // The panel should be scrolled to 0 because centering the option disabled.
-      expect(scrollContainer.scrollTop)
-        .withContext(`Expected panel not to be scrolled.`)
-        .toEqual(0);
-      // The trigger should contain 'Pizza' because it was preselected
-      expect(trigger.textContent).toContain('Pizza');
-      // The selected index should be 1 because it was preselected
-      expect(fixture.componentInstance.options.toArray()[1].selected).toBe(true);
-    }));
-  });
-
   describe('positioning', () => {
     beforeEach(waitForAsync(() => configureMatSelectTestingModule([BasicSelect])));
 
@@ -4469,7 +4438,6 @@ describe('MDC-based MatSelect', () => {
         {
           provide: MAT_SELECT_CONFIG,
           useValue: {
-            disableOptionCentering: true,
             typeaheadDebounceInterval: 1337,
             overlayPanelClass: 'test-panel-class',
             panelWidth: null,
@@ -4484,7 +4452,6 @@ describe('MDC-based MatSelect', () => {
     fixture.detectChanges();
     flush();
 
-    expect(select.disableOptionCentering).toBe(true);
     expect(select.typeaheadDebounceInterval).toBe(1337);
     expect(document.querySelector('.cdk-overlay-pane')?.classList).toContain('test-panel-class');
     expect(select.panelWidth).toBeNull();
@@ -5331,35 +5298,6 @@ class SingleSelectWithPreselectedArrayValues {
   ];
 
   selectedFoods = this.foods[1].value;
-
-  @ViewChild(MatSelect) select: MatSelect;
-  @ViewChildren(MatOption) options: QueryList<MatOption>;
-}
-
-@Component({
-  selector: 'select-without-option-centering',
-  template: `
-    <mat-form-field>
-      <mat-select placeholder="Food" [formControl]="control" disableOptionCentering>
-        @for (food of foods; track food) {
-          <mat-option [value]="food.value">{{ food.viewValue }}</mat-option>
-        }
-      </mat-select>
-    </mat-form-field>
-  `,
-})
-class SelectWithoutOptionCentering {
-  foods: any[] = [
-    {value: 'steak-0', viewValue: 'Steak'},
-    {value: 'pizza-1', viewValue: 'Pizza'},
-    {value: 'tacos-2', viewValue: 'Tacos'},
-    {value: 'sandwich-3', viewValue: 'Sandwich'},
-    {value: 'chips-4', viewValue: 'Chips'},
-    {value: 'eggs-5', viewValue: 'Eggs'},
-    {value: 'pasta-6', viewValue: 'Pasta'},
-    {value: 'sushi-7', viewValue: 'Sushi'},
-  ];
-  control = new FormControl('pizza-1');
 
   @ViewChild(MatSelect) select: MatSelect;
   @ViewChildren(MatOption) options: QueryList<MatOption>;

--- a/src/material/select/select.ts
+++ b/src/material/select/select.ts
@@ -123,9 +123,6 @@ export function MAT_SELECT_SCROLL_STRATEGY_PROVIDER_FACTORY(
 
 /** Object that can be used to configure the default options for the select module. */
 export interface MatSelectConfig {
-  /** Whether option centering should be disabled. */
-  disableOptionCentering?: boolean;
-
   /** Time to wait in milliseconds after the last keystroke before moving focus to an item. */
   typeaheadDebounceInterval?: number;
 
@@ -456,10 +453,6 @@ export class MatSelect
     this._multiple = value;
   }
   private _multiple: boolean = false;
-
-  /** Whether to center the active option over the trigger. */
-  @Input({transform: booleanAttribute})
-  disableOptionCentering = this._defaultOptions?.disableOptionCentering ?? false;
 
   /**
    * Function to compare the option values with the selected values. The first argument

--- a/tools/public_api_guard/material/paginator.md
+++ b/tools/public_api_guard/material/paginator.md
@@ -123,7 +123,6 @@ export class MatPaginatorModule {
 
 // @public
 export interface MatPaginatorSelectConfig {
-    disableOptionCentering?: boolean;
     panelClass?: string | string[] | Set<string> | {
         [key: string]: any;
     };

--- a/tools/public_api_guard/material/select.md
+++ b/tools/public_api_guard/material/select.md
@@ -104,7 +104,6 @@ export class MatSelect implements AfterContentInit, OnChanges, OnDestroy, OnInit
     protected readonly _destroy: Subject<void>;
     readonly disableAutomaticLabeling = true;
     disabled: boolean;
-    disableOptionCentering: boolean;
     disableRipple: boolean;
     // (undocumented)
     readonly _elementRef: ElementRef;
@@ -129,8 +128,6 @@ export class MatSelect implements AfterContentInit, OnChanges, OnDestroy, OnInit
     set multiple(value: boolean);
     // (undocumented)
     static ngAcceptInputType_disabled: unknown;
-    // (undocumented)
-    static ngAcceptInputType_disableOptionCentering: unknown;
     // (undocumented)
     static ngAcceptInputType_disableRipple: unknown;
     // (undocumented)
@@ -216,7 +213,7 @@ export class MatSelect implements AfterContentInit, OnChanges, OnDestroy, OnInit
     protected _viewportRuler: ViewportRuler;
     writeValue(value: any): void;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<MatSelect, "mat-select", ["matSelect"], { "userAriaDescribedBy": { "alias": "aria-describedby"; "required": false; }; "panelClass": { "alias": "panelClass"; "required": false; }; "disabled": { "alias": "disabled"; "required": false; }; "disableRipple": { "alias": "disableRipple"; "required": false; }; "tabIndex": { "alias": "tabIndex"; "required": false; }; "hideSingleSelectionIndicator": { "alias": "hideSingleSelectionIndicator"; "required": false; }; "placeholder": { "alias": "placeholder"; "required": false; }; "required": { "alias": "required"; "required": false; }; "multiple": { "alias": "multiple"; "required": false; }; "disableOptionCentering": { "alias": "disableOptionCentering"; "required": false; }; "compareWith": { "alias": "compareWith"; "required": false; }; "value": { "alias": "value"; "required": false; }; "ariaLabel": { "alias": "aria-label"; "required": false; }; "ariaLabelledby": { "alias": "aria-labelledby"; "required": false; }; "errorStateMatcher": { "alias": "errorStateMatcher"; "required": false; }; "typeaheadDebounceInterval": { "alias": "typeaheadDebounceInterval"; "required": false; }; "sortComparator": { "alias": "sortComparator"; "required": false; }; "id": { "alias": "id"; "required": false; }; "panelWidth": { "alias": "panelWidth"; "required": false; }; }, { "openedChange": "openedChange"; "_openedStream": "opened"; "_closedStream": "closed"; "selectionChange": "selectionChange"; "valueChange": "valueChange"; }, ["customTrigger", "options", "optionGroups"], ["mat-select-trigger", "*"], true, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MatSelect, "mat-select", ["matSelect"], { "userAriaDescribedBy": { "alias": "aria-describedby"; "required": false; }; "panelClass": { "alias": "panelClass"; "required": false; }; "disabled": { "alias": "disabled"; "required": false; }; "disableRipple": { "alias": "disableRipple"; "required": false; }; "tabIndex": { "alias": "tabIndex"; "required": false; }; "hideSingleSelectionIndicator": { "alias": "hideSingleSelectionIndicator"; "required": false; }; "placeholder": { "alias": "placeholder"; "required": false; }; "required": { "alias": "required"; "required": false; }; "multiple": { "alias": "multiple"; "required": false; }; "compareWith": { "alias": "compareWith"; "required": false; }; "value": { "alias": "value"; "required": false; }; "ariaLabel": { "alias": "aria-label"; "required": false; }; "ariaLabelledby": { "alias": "aria-labelledby"; "required": false; }; "errorStateMatcher": { "alias": "errorStateMatcher"; "required": false; }; "typeaheadDebounceInterval": { "alias": "typeaheadDebounceInterval"; "required": false; }; "sortComparator": { "alias": "sortComparator"; "required": false; }; "id": { "alias": "id"; "required": false; }; "panelWidth": { "alias": "panelWidth"; "required": false; }; }, { "openedChange": "openedChange"; "_openedStream": "opened"; "_closedStream": "closed"; "selectionChange": "selectionChange"; "valueChange": "valueChange"; }, ["customTrigger", "options", "optionGroups"], ["mat-select-trigger", "*"], true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatSelect, [null, null, null, null, null, { optional: true; }, { optional: true; }, { optional: true; }, { optional: true; }, { optional: true; self: true; }, { attribute: "tabindex"; }, null, null, { optional: true; }]>;
 }
@@ -238,7 +235,6 @@ export class MatSelectChange {
 
 // @public
 export interface MatSelectConfig {
-    disableOptionCentering?: boolean;
     hideSingleSelectionIndicator?: boolean;
     overlayPanelClass?: string | string[];
     panelWidth?: string | number | null;


### PR DESCRIPTION
Removes the `disableOptionCentering` field since the option centering functionality is no longer working in the mat-select component.

Fixes #28303