### PR TITLE
fix(material/core): add fallback if ripples get stuck

### DIFF
--- a/src/material/slider/slider.spec.ts
+++ b/src/material/slider/slider.spec.ts
@@ -691,8 +691,8 @@ describe('MDC-based MatSlider', () => {
     it('should show the active ripple on pointerdown', fakeAsync(() => {
       expect(isRippleVisible('active')).toBeFalse();
       pointerdown();
-      flush();
       expect(isRippleVisible('active')).toBeTrue();
+      flush();
     }));
 
     it('should hide the active ripple on pointerup', fakeAsync(() => {
@@ -1831,7 +1831,7 @@ function setValueByClick(
   input.focus();
   dispatchPointerEvent(inputElement, 'pointerup', x, y);
   dispatchEvent(input._hostElement, new Event('change'));
-  tick();
+  flush();
 }
 
 /** Slides the MatSlider's thumb to the given value. */


### PR DESCRIPTION
Currently ripples assume that after the transition is started, either a `transitionend` or `transitioncancel` event will occur. That doesn't seem to be the case in some browser/OS combinations and when there's a high load on the browser.

These changes add a fallback timer that will clear the ripples if they get stuck.

Fixes #29159.