### PR TITLE
docs-bug(mat-table): Example suggesting to use max-width to set column width is misleading

### DIFF
--- a/src/components-examples/material/table/table-http/table-http-example.css
+++ b/src/components-examples/material/table/table-http/table-http-example.css
@@ -35,9 +35,9 @@ table {
 /* Column Widths */
 .mat-column-number,
 .mat-column-state {
-  max-width: 64px;
+  width: 64px;
 }
 
 .mat-column-created {
-  max-width: 124px;
+  width: 124px;
 }


### PR DESCRIPTION
The fix is to use the width property instead of max-width since this can be misleading as though the width will never exceed the max-width provided.

Fixes #29294