### PR TITLE
fix(material/chips): remove button is too small

### DIFF
--- a/src/material/chips/chip.scss
+++ b/src/material/chips/chip.scss
@@ -695,7 +695,7 @@ $_avatar-trailing-padding: 8px;
 
   // Used as a state overlay.
   &::after {
-    $offset: 18px; /*size of the remove icon*/
+    $offset: 18px; // size of the remove icon
     content: '';
     display: block;
     opacity: 0;
@@ -705,7 +705,7 @@ $_avatar-trailing-padding: 8px;
     left: 12 - $offset;
     right: 12 - $offset;
     border-radius: 50%;
-    // Increases touch target to improve accessibility and fix b/286959517
+    // Increases touch target size to improve accessibility and fix b/286959517
     z-index: 100;
     pointer-events: all;
     height: 48px;

--- a/src/material/chips/chip.scss
+++ b/src/material/chips/chip.scss
@@ -715,7 +715,7 @@ $_avatar-trailing-padding: 8px;
   }
 }
 
-//Increases mdc-dhip-remove trailing icon action touch-target in order to fix b/286959517
+// Increases mdc-chip-remove trailing icon action touch-target in order to fix b/286959517
 .mat-mdc-chip-trailing-icon.mdc-evolution-chip__action--trailing,
 .mat-mdc-chip-trailing-icon.mdc-evolution-chip__icon--trailing,
 .mdc-evolution-chip--with-primary-graphic.mdc-evolution-chip--with-trailing-action {

--- a/src/material/chips/chip.scss
+++ b/src/material/chips/chip.scss
@@ -695,7 +695,7 @@ $_avatar-trailing-padding: 8px;
 
   // Used as a state overlay.
   &::after {
-    $offset: 18px; // size of the remove icon
+    $offset: $_trailing-icon-size; // size of the remove icon
     content: '';
     display: block;
     opacity: 0;

--- a/src/material/chips/chip.scss
+++ b/src/material/chips/chip.scss
@@ -713,6 +713,12 @@ $_avatar-trailing-padding: 8px;
     font-size: $_trailing-icon-size;
     box-sizing: content-box;
   }
+  /** Increases mdc-dhip-remove trailing icon action touch-target
+    in order to fix b/286959517. */
+  &.mat-mdc-chip-trailing-icon.mdc-evolution-chip__action--trailing,
+  &.mat-mdc-chip-trailing-icon.mdc-evolution-chip__icon--trailing {
+    padding: 24px 12px;
+  }
 }
 
 // Increases mdc-chip-remove trailing icon action touch-target in order to fix b/286959517

--- a/src/material/chips/chip.scss
+++ b/src/material/chips/chip.scss
@@ -695,21 +695,20 @@ $_avatar-trailing-padding: 8px;
 
   // Used as a state overlay.
   &::after {
-    $offset: $_trailing-icon-size; // size of the remove icon
+    $_touch-target-size: 48px;
+    $_ripple-size: 24px;
     content: '';
     display: block;
     opacity: 0;
     position: absolute;
-    top: 2 - $offset;
-    bottom: 2 - $offset;
-    left: 12 - $offset;
-    right: 12 - $offset;
-    border-radius: 50%;
     // Increases touch target size to improve accessibility and fix b/286959517
     z-index: 100;
     pointer-events: all;
-    height: 48px;
-    width: 48px;
+    box-sizing: border-box;
+    padding: calc(($_touch-target-size - $_ripple-size)/2);
+    margin: calc((($_touch-target-size - $_ripple-size)/2) * -1);
+    -webkit-background-clip: content-box;
+    background-clip: content-box;
   }
 
   .mat-icon {

--- a/src/material/chips/chip.scss
+++ b/src/material/chips/chip.scss
@@ -695,16 +695,21 @@ $_avatar-trailing-padding: 8px;
 
   // Used as a state overlay.
   &::after {
-    $offset: 2px;
+    $offset: 18px; /*size of the remove icon*/
     content: '';
     display: block;
     opacity: 0;
     position: absolute;
-    top: 0 - $offset;
-    bottom: 0 - $offset;
-    left: 8px - $offset;
-    right: 8px - $offset;
+    top: 2 - $offset;
+    bottom: 2 - $offset;
+    left: 12 - $offset;
+    right: 12 - $offset;
     border-radius: 50%;
+    // Increases touch target to improve accessibility and fix b/286959517
+    z-index: 100;
+    pointer-events: all;
+    height: 48px;
+    width: 48px;
   }
 
   .mat-icon {
@@ -712,28 +717,6 @@ $_avatar-trailing-padding: 8px;
     height: $_trailing-icon-size;
     font-size: $_trailing-icon-size;
     box-sizing: content-box;
-  }
-}
-
-//Increases mdc-dhip-remove trailing icon action touch-target in order to fix b/286959517
-.mat-mdc-chip-trailing-icon.mdc-evolution-chip__action--trailing,
-.mat-mdc-chip-trailing-icon.mdc-evolution-chip__icon--trailing,
-.mdc-evolution-chip--with-primary-graphic.mdc-evolution-chip--with-trailing-action {
-  &.mat-mdc-chip-remove,
-  &.mat-mdc-standard-chip .mdc-evolution-chip__action--trailing,
-  &.mdc-evolution-chip--with-avatar .mdc-evolution-chip__action--trailing {
-    padding: 16px;
-  }
-}
-
-// Increases mdc-chip-remove trailing icon action touch-target in order to fix b/286959517
-.mat-mdc-chip-trailing-icon.mdc-evolution-chip__action--trailing,
-.mat-mdc-chip-trailing-icon.mdc-evolution-chip__icon--trailing,
-.mdc-evolution-chip--with-primary-graphic.mdc-evolution-chip--with-trailing-action {
-  &.mat-mdc-chip-remove,
-  &.mat-mdc-standard-chip .mdc-evolution-chip__action--trailing,
-  &.mdc-evolution-chip--with-avatar .mdc-evolution-chip__action--trailing {
-    padding: 16px;
   }
 }
 

--- a/src/material/chips/chip.scss
+++ b/src/material/chips/chip.scss
@@ -713,10 +713,16 @@ $_avatar-trailing-padding: 8px;
     font-size: $_trailing-icon-size;
     box-sizing: content-box;
   }
-  //Increases mdc-dhip-remove trailing icon action touch-target in order to fix b/286959517
-  &.mat-mdc-chip-trailing-icon.mdc-evolution-chip__action--trailing,
-  &.mat-mdc-chip-trailing-icon.mdc-evolution-chip__icon--trailing {
-    padding: 24px 12px;
+}
+
+//Increases mdc-dhip-remove trailing icon action touch-target in order to fix b/286959517
+.mat-mdc-chip-trailing-icon.mdc-evolution-chip__action--trailing,
+.mat-mdc-chip-trailing-icon.mdc-evolution-chip__icon--trailing,
+.mdc-evolution-chip--with-primary-graphic.mdc-evolution-chip--with-trailing-action {
+  &.mat-mdc-chip-remove,
+  &.mat-mdc-standard-chip .mdc-evolution-chip__action--trailing,
+  &.mdc-evolution-chip--with-avatar .mdc-evolution-chip__action--trailing {
+    padding: 16px;
   }
 }
 

--- a/src/material/chips/chip.scss
+++ b/src/material/chips/chip.scss
@@ -713,8 +713,7 @@ $_avatar-trailing-padding: 8px;
     font-size: $_trailing-icon-size;
     box-sizing: content-box;
   }
-  /** Increases mdc-dhip-remove trailing icon action touch-target
-    in order to fix b/286959517. */
+  //Increases mdc-dhip-remove trailing icon action touch-target in order to fix b/286959517
   &.mat-mdc-chip-trailing-icon.mdc-evolution-chip__action--trailing,
   &.mat-mdc-chip-trailing-icon.mdc-evolution-chip__icon--trailing {
     padding: 24px 12px;

--- a/src/material/chips/chip.scss
+++ b/src/material/chips/chip.scss
@@ -538,7 +538,7 @@ $_avatar-trailing-padding: 8px;
     }
 
     &::after {
-      @include token-utils.create-token-slot(background, trailing-action-state-layer-color);
+      @include token-utils.create-token-slot(background-color, trailing-action-state-layer-color);
     }
 
     &:hover::after {
@@ -552,7 +552,8 @@ $_avatar-trailing-padding: 8px;
 
   .mat-mdc-chip-selected .mat-mdc-chip-remove::after,
   .mat-mdc-chip-highlighted .mat-mdc-chip-remove::after {
-    @include token-utils.create-token-slot(background, selected-trailing-action-state-layer-color);
+    @include token-utils.create-token-slot(background-color,
+      selected-trailing-action-state-layer-color);
   }
 }
 
@@ -697,17 +698,20 @@ $_avatar-trailing-padding: 8px;
   &::after {
     $_touch-target-size: 48px;
     $_ripple-size: 24px;
+    $offset: 3px;
     content: '';
     display: block;
     opacity: 0;
     position: absolute;
-    // Increases touch target size to improve accessibility and fix b/286959517
-    z-index: 100;
-    pointer-events: all;
+    top: 0 - $offset;
+    bottom: 0 - $offset;
+    left: 8px - $offset;
+    right: 8px - $offset;
+    border-radius: 50%;
     box-sizing: border-box;
     padding: calc(($_touch-target-size - $_ripple-size)/2);
     margin: calc((($_touch-target-size - $_ripple-size)/2) * -1);
-    -webkit-background-clip: content-box;
+    // stylelint-disable material/no-prefixes
     background-clip: content-box;
   }
 

--- a/src/material/chips/chip.scss
+++ b/src/material/chips/chip.scss
@@ -713,6 +713,12 @@ $_avatar-trailing-padding: 8px;
     font-size: $_trailing-icon-size;
     box-sizing: content-box;
   }
+  /** Increases mdc-dhip-remove trailing icon action touch-target
+    in order to fix b/286959517. */
+  &.mat-mdc-chip-trailing-icon.mdc-evolution-chip__action--trailing,
+  &.mat-mdc-chip-trailing-icon.mdc-evolution-chip__icon--trailing {
+    padding: 24px 12px;
+  }
 }
 
 .mat-chip-edit-input {


### PR DESCRIPTION
Fixes Angular Components Chip component where the touch target of the remove button of a chip is too small. Updates .mat-mdc-chip-remove to target more specific styles to override original style of padding: 8px so that the user has a larger touch target particularly on mobile devices.

Fixes b/286959517

Before [screenshot](https://screenshot.googleplex.com/LY4J6jk4b3TFyQo)
After [screenshot](https://screenshot.googleplex.com/5zpHzNya7CxhMnx)

BREAKING CHANGE: updates chip remove button touch target to increase accessibility of the button especially on touch/mobile devices.