### PR TITLE
fix: unable to toggle icon in demo file

### DIFF
--- a/src/components-examples/material/form-field/form-field-prefix-suffix/form-field-prefix-suffix-example.ts
+++ b/src/components-examples/material/form-field/form-field-prefix-suffix/form-field-prefix-suffix-example.ts
@@ -16,7 +16,7 @@ import {MatInputModule} from '@angular/material/input';
 export class FormFieldPrefixSuffixExample {
   hide = signal(true);
   clickEvent(event: MouseEvent) {
-    this.hide.set(!this.hide);
+    this.hide.set(!this.hide());
     event.stopPropagation();
   }
 }


### PR DESCRIPTION
Fixes minor bug in demo file where icon cannot be toggled. This is because `signal` was not called correctly