### PR TITLE
fix(cdk/drag-drop): reset pointer events on descendants

### DIFF
--- a/src/cdk/drag-drop/resets.scss
+++ b/src/cdk/drag-drop/resets.scss
@@ -6,3 +6,10 @@
     color: inherit;
   }
 }
+
+// These elements get `pointer-events: none` when they're created, but any descendants might
+// override it back to `auto`. Reset them here since they can affect the pointer position detection.
+.cdk-drag-placeholder *,
+.cdk-drag-preview * {
+  pointer-events: none !important;
+}


### PR DESCRIPTION
When we create the preview and placeholder, we set `pointer-events: none` on them so they don't interfere with the `elementFromPoint` calls, however descendants of the element could be resetting it back to `auto` for themselves. These changes update the reset to prevent it from happening.