### PR TITLE
Update next branch to reflect new release-train "v18.2.0-next.0".

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+<a name="18.1.0-rc.0"></a>
+# 18.1.0-rc.0 "zirconium-zoo" (2024-07-03)
+### material
+| Commit | Type | Description |
+| -- | -- | -- |
+| [674538b77](https://github.com/angular/components/commit/674538b778e75d229ada06d19c362752db3a18cc) | fix | **core:** add fallback if ripples get stuck ([#29323](https://github.com/angular/components/pull/29323)) |
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="18.0.6"></a>
 # 18.0.6 "gallium-grape" (2024-07-03)
 ### material

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "ci-notify-slack-failure": "node --no-warnings=ExperimentalWarning --loader ts-node/esm/transpile-only scripts/circleci/notify-slack-job-failure.mts",
     "prepare": "husky"
   },
-  "version": "18.1.0-next.4",
+  "version": "18.2.0-next.0",
   "dependencies": {
     "@angular/animations": "^18.1.0-next.3",
     "@angular/common": "^18.1.0-next.3",


### PR DESCRIPTION
The previous "next" release-train has moved into the release-candidate phase. This PR updates the next branch to the subsequent release-train.

Also this PR cherry-picks the changelog for v18.1.0-rc.0 into the main branch so that the changelog is up to date.