### PR TITLE
fix(cdk/dialog): CDK Dialog docs missing explanation on how to access dialogRef when using a TemplateRef

### DIFF
--- a/src/cdk/dialog/dialog.md
+++ b/src/cdk/dialog/dialog.md
@@ -159,6 +159,14 @@ If you're using a `TemplateRef` for your dialog content, the data is available i
 </ng-template>
 ```
 
+If you're using a `DialogRef`, you can use:
+
+```html
+<ng-template let-data let-dialogRef="dialogRef">
+    Hello, {{data.name}}
+</ng-template>
+```
+
 <!-- example(cdk-dialog-data) -->
 
 ### Accessibility

--- a/src/cdk/dialog/dialog.md
+++ b/src/cdk/dialog/dialog.md
@@ -159,7 +159,7 @@ If you're using a `TemplateRef` for your dialog content, the data is available i
 </ng-template>
 ```
 
-If you're using a `DialogRef`, you can use:
+If you're using a `TemplateRef` and need to access the `DialogRef`, you can use the following:
 
 ```html
 <ng-template let-data let-dialogRef="dialogRef">


### PR DESCRIPTION
Updated the dialog in the cdk to add an example on accessing the dialogRef when using TemplateRef

Fixes #26193