### PR TITLE
fix(formfield):Formfield password suffix icon docs example show/hide not working #29356

### DIFF
--- a/src/components-examples/material/form-field/form-field-prefix-suffix/form-field-prefix-suffix-example.ts
+++ b/src/components-examples/material/form-field/form-field-prefix-suffix/form-field-prefix-suffix-example.ts
@@ -16,7 +16,7 @@ import {MatInputModule} from '@angular/material/input';
 export class FormFieldPrefixSuffixExample {
   hide = signal(true);
   clickEvent(event: MouseEvent) {
-    this.hide.set(!this.hide);
+    this.hide.set(!this.hide());
     event.stopPropagation();
   }
 }


### PR DESCRIPTION
Updated the show hide functionality of the button suffix when clicking the password show/hide icon

Fixes https://github.com/angular/components/issues/29356