### PR TITLE
doc-bug(cdk/listbox): remove forms validation and validation example

### DIFF
--- a/src/cdk/listbox/listbox.md
+++ b/src/cdk/listbox/listbox.md
@@ -120,23 +120,6 @@ The CDK Listbox supports both template driven forms and reactive forms.
   "region": "listbox"
 }) -->
 
-#### Forms validation
-
-The CDK listbox integrates with Angular's form validation API and has the following built-in
-validation errors:
-
-- `cdkListboxUnexpectedOptionValues` - Raised when the bound value contains values that do not
-  appear as option value in the listbox. The validation error contains a `values` property that
-  lists the invalid values
-- `cdkListboxUnexpectedMultipleValues` - Raised when a single-selection listbox is bound to a value
-  containing multiple selected options.
-
-<!-- example({
-  "example": "cdk-listbox-forms-validation",
-  "file": "cdk-listbox-forms-validation-example.ts",
-  "region": "errors"
-}) -->
-
 ### Disabling options
 
 You can disable options for selection by setting `cdkOptionDisabled`.

--- a/src/components-examples/cdk/listbox/cdk-listbox-forms-validation/cdk-listbox-forms-validation-example.html
+++ b/src/components-examples/cdk/listbox/cdk-listbox-forms-validation/cdk-listbox-forms-validation-example.html
@@ -20,8 +20,5 @@
 }
 <p>
   Your zodiac sign is: <strong>{{signCtrl.value | json}}</strong>&nbsp;
-  <button (click)="signCtrl.setValue(['Cat'])">Set: Cat</button>&nbsp;
-  <button (click)="signCtrl.setValue(['Dragon', 'Snake'])">Set: Dragon, Snake</button>&nbsp;
-  <button (click)="signCtrl.setValue(['Cat', 'Rat'])">Set: Cat, Rat</button>&nbsp;
   <button (click)="signCtrl.setValue([])">Clear</button>
 </p>

--- a/src/components-examples/cdk/listbox/cdk-listbox-forms-validation/cdk-listbox-forms-validation-example.ts
+++ b/src/components-examples/cdk/listbox/cdk-listbox-forms-validation/cdk-listbox-forms-validation-example.ts
@@ -45,13 +45,7 @@ export class CdkListboxFormsValidationExample {
     if (this.signCtrl.hasError('required')) {
       errors.push('You must enter your zodiac sign');
     }
-    if (this.signCtrl.hasError('cdkListboxUnexpectedMultipleValues')) {
-      errors.push('You can only select one zodiac sign');
-    }
-    if (this.signCtrl.hasError('cdkListboxUnexpectedOptionValues')) {
-      const invalidOptions = this.signCtrl.getError('cdkListboxUnexpectedOptionValues').values;
-      errors.push(`You entered an invalid zodiac sign: ${invalidOptions[0]}`);
-    }
+
     return errors.length ? errors : null;
   }
   // #enddocregion errors


### PR DESCRIPTION
CDK listbox doc have wrong part about forms-validation
https://material.angular.io/cdk/listbox/overview#forms-validation


`cdkListboxUnexpectedOptionValues` and `cdkListboxUnexpectedMultipleValues `  have removed in this PR https://github.com/angular/components/pull/25856, but doc not updated.

This PR is remove forms-validation from cdk listbox doc.