### PR TITLE
Allow undefined & null values in [matTooltip] explicitly

### DIFF
--- a/src/material/tooltip/tooltip.spec.ts
+++ b/src/material/tooltip/tooltip.spec.ts
@@ -413,12 +413,12 @@ describe('MDC-based MatTooltip', () => {
     it('should not show tooltip if message is not present or empty', () => {
       assertTooltipInstance(tooltipDirective, false);
 
-      tooltipDirective.message = undefined!;
+      tooltipDirective.message = undefined;
       fixture.detectChanges();
       tooltipDirective.show();
       assertTooltipInstance(tooltipDirective, false);
 
-      tooltipDirective.message = null!;
+      tooltipDirective.message = null;
       fixture.detectChanges();
       tooltipDirective.show();
       assertTooltipInstance(tooltipDirective, false);

--- a/src/material/tooltip/tooltip.ts
+++ b/src/material/tooltip/tooltip.ts
@@ -300,7 +300,7 @@ export class MatTooltip implements OnDestroy, AfterViewInit {
     return this._message;
   }
 
-  set message(value: string) {
+  set message(value: string | null | undefined) {
     this._ariaDescriber.removeDescription(this._elementRef.nativeElement, this._message, 'tooltip');
 
     // If the message is not a string (e.g. number), convert it to a string and trim it.

--- a/src/material/tooltip/tooltip.ts
+++ b/src/material/tooltip/tooltip.ts
@@ -296,7 +296,7 @@ export class MatTooltip implements OnDestroy, AfterViewInit {
 
   /** The message to be displayed in the tooltip */
   @Input('matTooltip')
-  get message() {
+  get message(): string {
     return this._message;
   }
 

--- a/tools/public_api_guard/material/tooltip.md
+++ b/tools/public_api_guard/material/tooltip.md
@@ -76,7 +76,7 @@ export class MatTooltip implements OnDestroy, AfterViewInit {
     set hideDelay(value: NumberInput);
     _isTooltipVisible(): boolean;
     get message(): string;
-    set message(value: string);
+    set message(value: string | null | undefined);
     // (undocumented)
     ngAfterViewInit(): void;
     ngOnDestroy(): void;


### PR DESCRIPTION
We have tests that already set these values (but used to use nullness assertions to overcome the build failures) and protect against it by treating these values as empty strings (and thus we hide the tooltip), but we don't allow anyone who uses templates with strict type checking to set optional values unless they add their own nullness assertion.
