### PR TITLE
fix(material/core): require theme for option typography

### DIFF
--- a/src/material/core/tokens/m2/mat/_optgroup.scss
+++ b/src/material/core/tokens/m2/mat/_optgroup.scss
@@ -1,7 +1,6 @@
 @use '../../token-utils';
 @use '../../../theming/inspection';
 @use '../../../style/sass-utils';
-@use '../../../mdc-helpers/mdc-helpers';
 
 // The prefix used to generate the fully qualified name for tokens in this file.
 $prefix: (mat, optgroup);
@@ -21,14 +20,6 @@ $prefix: (mat, optgroup);
 
 // Tokens that can be configured through Angular Material's typography theming API.
 @function get-typography-tokens($theme) {
-  // TODO(crisbeto): The earlier implementation of the option used MDC's APIs to create the
-  // typography tokens. As a result, we unintentionally allowed `null` typography configs to be
-  // passed in. Since there a lot of apps that now depend on this pattern, we need this temporary
-  // fallback.
-  @if ($theme == null) {
-    $theme: mdc-helpers.private-fallback-typography-from-mdc();
-  }
-
   @return (
     label-text-font: inspection.get-theme-typography($theme, body-1, font-family),
     label-text-line-height: inspection.get-theme-typography($theme, body-1, line-height),

--- a/src/material/core/tokens/m2/mat/_option.scss
+++ b/src/material/core/tokens/m2/mat/_option.scss
@@ -1,7 +1,6 @@
 @use '../../token-utils';
 @use '../../../theming/inspection';
 @use '../../../style/sass-utils';
-@use '../../../mdc-helpers/mdc-helpers';
 
 // The prefix used to generate the fully qualified name for tokens in this file.
 $prefix: (mat, option);
@@ -29,14 +28,6 @@ $prefix: (mat, option);
 
 // Tokens that can be configured through Angular Material's typography theming API.
 @function get-typography-tokens($theme) {
-  // TODO(crisbeto): The earlier implementation of the option used MDC's APIs to create the
-  // typography tokens. As a result, we unintentionally allowed `null` typography configs to be
-  // passed in. Since there a lot of apps that now depend on this pattern, we need this temporary
-  // fallback.
-  @if ($theme == null) {
-    $theme: mdc-helpers.private-fallback-typography-from-mdc();
-  }
-
   @return (
     label-text-font: inspection.get-theme-typography($theme, body-1, font-family),
     label-text-line-height: inspection.get-theme-typography($theme, body-1, line-height),


### PR DESCRIPTION
Removes the fallback for generating typography tokens for `mat-option` and `mat-optgroup` even if there's no theme. This isn't a supported configuration and the previous setup was temporary.