### PR TITLE
fix(material/chips): fix focus issue

### DIFF
--- a/src/material/chips/chip-grid.ts
+++ b/src/material/chips/chip-grid.ts
@@ -340,7 +340,7 @@ export class MatChipGrid
       // Delay until the next tick, because this can cause a "changed after checked"
       // error if the input does something on focus (e.g. opens an autocomplete).
       Promise.resolve().then(() => this._chipInput.focus());
-    } else if (this._chips.length) {
+    } else if (this._chips.length && this._keyManager.activeItemIndex !== 0) {
       this._keyManager.setFirstItemActive();
     }
 


### PR DESCRIPTION
Fixed an issue to where users can get stuck in a focus trap in mat-grid. If a user were to try to navigate backwards out of the chip grid, the user gets stuck.

fixes b/290959510