### PR TITLE
fix(cdk/drag-drop): remove preview after animate to placeholder animation completes

### DIFF
--- a/src/cdk/drag-drop/drag-ref.ts
+++ b/src/cdk/drag-drop/drag-ref.ts
@@ -1106,7 +1106,9 @@ export class DragRef<T = any> {
         const handler = ((event: TransitionEvent) => {
           if (
             !event ||
-            (_getEventTarget(event) === this._preview && event.propertyName === 'transform')
+            (this._preview &&
+              _getEventTarget(event) === this._preview.element &&
+              event.propertyName === 'transform')
           ) {
             this._preview?.removeEventListener('transitionend', handler);
             resolve();

--- a/src/cdk/drag-drop/preview-ref.ts
+++ b/src/cdk/drag-drop/preview-ref.ts
@@ -39,6 +39,10 @@ export class PreviewRef {
   /** Reference to the preview element. */
   private _preview: HTMLElement;
 
+  public get element(): HTMLElement {
+    return this._preview;
+  }
+
   constructor(
     private _document: Document,
     private _rootElement: HTMLElement,

--- a/src/cdk/drag-drop/preview-ref.ts
+++ b/src/cdk/drag-drop/preview-ref.ts
@@ -39,7 +39,7 @@ export class PreviewRef {
   /** Reference to the preview element. */
   private _preview: HTMLElement;
 
-  public get element(): HTMLElement {
+  get element(): HTMLElement {
     return this._preview;
   }
 


### PR DESCRIPTION
The comparison between the event target element and this._preview never returned true because this._preview is a class, and we need to compare its element instead. This regression was introduced in commit https://github.com/angular/components/commit/ebab924601c3d93933aed2698b4db96b4cafa3d4#diff-65b82ba5c290701d792881e9e389e8f1961848abb740bb20940d4383dfae4eacL121-R117.