### PR TITLE
fix(material/input): Number input not changing on wheel interaction

### DIFF
--- a/src/dev-app/input/BUILD.bazel
+++ b/src/dev-app/input/BUILD.bazel
@@ -21,6 +21,7 @@ ng_module(
         "//src/material/input",
         "//src/material/tabs",
         "//src/material/toolbar",
+        "//src/material/tooltip",
         "@npm//@angular/forms",
     ],
 )

--- a/src/dev-app/input/input-demo.html
+++ b/src/dev-app/input/input-demo.html
@@ -58,6 +58,19 @@
   </mat-card-content>
 </mat-card>
 
+<mat-card class="demo-card demo-number-input-tooltip">
+  <mat-toolbar color="primary">Number Input + Tooltip</mat-toolbar>
+  <mat-card-content>
+    <form>
+      <mat-form-field>
+        <mat-label>Pump Flow</mat-label>
+        <input matNativeControl value="10" type="number"><!--  -->
+        <span matSuffix matTooltip="Milliliter per Minute">ml/min</span>
+      </mat-form-field>
+    </form>
+  </mat-card-content>
+</mat-card>
+
 <mat-card class="demo-card demo-basic">
   <mat-toolbar color="primary">Error messages</mat-toolbar>
   <mat-card-content>

--- a/src/dev-app/input/input-demo.ts
+++ b/src/dev-app/input/input-demo.ts
@@ -28,6 +28,7 @@ import {MatCheckboxModule} from '@angular/material/checkbox';
 import {MatIconModule} from '@angular/material/icon';
 import {MatTabsModule} from '@angular/material/tabs';
 import {MatToolbarModule} from '@angular/material/toolbar';
+import {MatTooltipModule} from '@angular/material/tooltip';
 
 let max = 5;
 
@@ -55,6 +56,7 @@ const EMAIL_REGEX = /^[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA
     FormFieldCustomControlExample,
     MyTelInput,
     ReactiveFormsModule,
+    MatTooltipModule,
   ],
 })
 export class InputDemo {

--- a/tools/public_api_guard/material/input.md
+++ b/tools/public_api_guard/material/input.md
@@ -47,7 +47,7 @@ export { MatHint }
 
 // @public (undocumented)
 export class MatInput implements MatFormFieldControl<any>, OnChanges, OnDestroy, AfterViewInit, DoCheck {
-    constructor(_elementRef: ElementRef<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>, _platform: Platform, ngControl: NgControl, parentForm: NgForm, parentFormGroup: FormGroupDirective, defaultErrorStateMatcher: ErrorStateMatcher, inputValueAccessor: any, _autofillMonitor: AutofillMonitor, ngZone: NgZone, _formField?: MatFormField | undefined);
+    constructor(_elementRef: ElementRef<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>, _platform: Platform, ngControl: NgControl, parentForm: NgForm, parentFormGroup: FormGroupDirective, defaultErrorStateMatcher: ErrorStateMatcher, inputValueAccessor: any, _autofillMonitor: AutofillMonitor, _ngZone: NgZone, _formField?: MatFormField | undefined);
     autofilled: boolean;
     controlType: string;
     protected _dirtyCheckNativeValue(): void;


### PR DESCRIPTION
In blink and webkit browsers the default behavior of increasing or decreasing a focused number input on wheel events is broken until a wheel event listener is explicitly added.

Fixes #29074