### PR TITLE
fixed show scrollbar in preview of the last element

### DIFF
--- a/src/components-examples/cdk/drag-drop/cdk-drag-drop-sorting/cdk-drag-drop-sorting-example.css
+++ b/src/components-examples/cdk/drag-drop/cdk-drag-drop-sorting/cdk-drag-drop-sorting-example.css
@@ -24,6 +24,7 @@
 }
 
 .cdk-drag-preview {
+  border: none;
   box-sizing: border-box;
   border-radius: 4px;
   box-shadow: 0 5px 5px -3px rgba(0, 0, 0, 0.2),


### PR DESCRIPTION

The style `border-bottom: solid 1px #ccc;` was initially applied to all elements with the class `example-box`, except for the last child which had its border removed with `border: none`. However, when the last element was dragged, it lost the `border: none` style and regained the `border-bottom: 1px solid #ccc`, causing the scrollbar to appear.

To fix this issue, I applied `border: none` to the class `cdk-drag-preview`. This ensures that all dragged elements lose their `border-bottom`, preventing the scrollbar from appearing during the drag operation.

Fixes #29419 
