### PR TITLE
fix(material/chips): increase chip remove touch target size

### DIFF
--- a/src/material/chips/chip.scss
+++ b/src/material/chips/chip.scss
@@ -534,7 +534,7 @@ $_avatar-trailing-padding: 8px;
     }
 
     &::after {
-      @include token-utils.create-token-slot(background, trailing-action-state-layer-color);
+      @include token-utils.create-token-slot(background-color, trailing-action-state-layer-color);
     }
 
     &:hover::after {
@@ -548,7 +548,7 @@ $_avatar-trailing-padding: 8px;
 
   .mat-mdc-chip-selected .mat-mdc-chip-remove::after,
   .mat-mdc-chip-highlighted .mat-mdc-chip-remove::after {
-    @include token-utils.create-token-slot(background, selected-trailing-action-state-layer-color);
+    @include token-utils.create-token-slot(background-color, selected-trailing-action-state-layer-color);
   }
 }
 
@@ -691,7 +691,9 @@ $_avatar-trailing-padding: 8px;
 
   // Used as a state overlay.
   &::after {
-    $offset: 2px;
+    $_touch-target-size: 48px;
+    $_ripple-size: 24px;
+    $offset: 3px;
     content: '';
     display: block;
     opacity: 0;
@@ -701,6 +703,11 @@ $_avatar-trailing-padding: 8px;
     left: 8px - $offset;
     right: 8px - $offset;
     border-radius: 50%;
+    box-sizing: border-box;
+    padding: calc(($_touch-target-size - $_ripple-size)/2);
+    margin: calc((($_touch-target-size - $_ripple-size)/2) * -1);
+    // stylelint-disable material/no-prefixes
+    background-clip: content-box;
   }
 
   .mat-icon {

--- a/src/material/chips/chip.scss
+++ b/src/material/chips/chip.scss
@@ -548,7 +548,8 @@ $_avatar-trailing-padding: 8px;
 
   .mat-mdc-chip-selected .mat-mdc-chip-remove::after,
   .mat-mdc-chip-highlighted .mat-mdc-chip-remove::after {
-    @include token-utils.create-token-slot(background-color, selected-trailing-action-state-layer-color);
+    @include token-utils.create-token-slot(background-color,
+      selected-trailing-action-state-layer-color);
   }
 }
 


### PR DESCRIPTION
Fixes Angular Components Chips component accessibility issue where the touch target is too small. Updates the chips' remove button ::after margin and padding styles to create a larger touch target to meet the minimum 48px x 48px size.

[Before screenshot](https://screenshot.googleplex.com/LY4J6jk4b3TFyQo)
[After screenshot](https://screenshot.googleplex.com/7Nwr6gzbWkwBwum)

Fixes b/286959517