### PR TITLE
docs: release notes for the v18.1.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,94 @@
+<a name="18.1.2"></a>
+# 18.1.2 "velvet-violin" (2024-07-24)
+## Breaking Changes
+### material
+-  updates chip remove button touch target to increase accessibility of the button especially on touch/mobile devices.
+  
+  * refactor(material/chips): chip remove touch target size is insufficient
+  
+  Updates fix to Autocomplete Component Chips component where the
+  touch target size is too small and fails minimum accessibility
+  size of 48x48 px. Addresses nit fixes from PR review.
+  
+  Fixes b/286959517
+- updates padding size of remove touch target to
+  satisfy minimum 48x48 accessibility size.
+  
+  * fix(material/chip): remove button is too small
+  
+  Fixes Angular Components Chip component where the touch target of the
+  remove button of a chip is too small. Updates .mat-mdc-chip-remove to
+  target more specific styles to override original style of padding: 8px
+  so that the user has a larger touch target particularly on mobile
+  devices.
+  
+  Fixes b/286959517
+  
+  * refactor(material/chips): remove button is too small
+  
+  Fixes lint errors from previous commit for Angular Components
+  Chip component where the remove button touch target is too small,
+  particularly for touch/mobile devices. Increases padding on all
+  sides.
+  
+  Fixes b/286959517
+  
+  * fix(material/chips): increase chip remove button touch target size
+  
+  Fixes issue with Angular Component Chip's touch target size by
+  increasing the padding on chips with a trailing icon that has
+  an action.
+  
+  Fixes b/286959517
+-  updates chip remove button touch target to increase accessibility of the button especially on touch/mobile devices.
+  
+  * fix(material/chips): chips remove touch target is too small to be accessible
+  
+  Updates Angular Components Chips component by increasing its
+  .mat-mdc-chip-remove::after styles to increase the size of the
+  touch target to make it more accessible/clickable.
+  
+  Fixes b/286959517
+  
+  * refactor(material/chips): fix lint errors
+  
+  Updates fix for Angular Components Chips component where there
+  were lint formatting errors.
+  
+  * refactor(material/chips): replace px with _trailing-icon-size variable
+  
+  Updates previous Angular Components Chip component fix and makes it
+  adaptable by swapping the hard-coded 18px offset to equal the
+  variable for -icon-size.
+  
+  * refactor(material/chips): updates touch target centering method
+  
+  Updates previous Angular Component Chip component fix which
+  added padding to the ::after pseudo-element and attempted to
+  calculate centering. Changes calculation based on using
+   with padding values countered
+  with margin negative values to center the touch target.
+  
+  * refactor(material/chips): updates ::after styles and fix lint errors
+  
+  Updates Angular Component Chips component fix to change ::after
+  background property changes to be background-color specifically to
+  avoid overriding background-clip styles. Suppresses lint warning
+  material/no-prefixes for background-clip since it's majority
+  compatible with browsers.
+  
+  Fixes b/286959517
+  
+  (cherry picked from commit d6aed804460d4b75082d7d04e051f2cae9b4f8f6)
+### material
+| Commit | Type | Description |
+| -- | -- | -- |
+| [cf61af53bd](https://github.com/angular/components/commit/cf61af53bdb5178cfc80157b9abae2ca1819f4b0) | fix | **chips:** remove button is too small ([#29351](https://github.com/angular/components/pull/29351)) |
+| [c79ec264aa](https://github.com/angular/components/commit/c79ec264aa454b31f6cefa6a1b032884c565ae2e) | fix | **form-field:** hiding a label after it has been ([#29461](https://github.com/angular/components/pull/29461)) |
+| [15238d255f](https://github.com/angular/components/commit/15238d255f563348677fd81690735a708d3bda5c) | fix | **input:** Number input not changing on wheel interaction ([#29449](https://github.com/angular/components/pull/29449)) |
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="18.1.1"></a>
 # 18.1.1 "tantalum-tale" (2024-07-17)
 ### cdk


### PR DESCRIPTION
Cherry-picks the changelog from the "18.1.x" branch to the next branch (main).