### PR TITLE
fix(material/slide-toggle): remove divs from button

### DIFF
--- a/src/material/slide-toggle/slide-toggle.html
+++ b/src/material/slide-toggle/slide-toggle.html
@@ -18,20 +18,20 @@
     [attr.aria-checked]="checked"
     (click)="_handleClick()"
     #switch>
-    <div class="mdc-switch__track"></div>
-    <div class="mdc-switch__handle-track">
-      <div class="mdc-switch__handle">
-        <div class="mdc-switch__shadow">
-          <div class="mdc-elevation-overlay"></div>
-        </div>
-        <div class="mdc-switch__ripple">
-          <div class="mat-mdc-slide-toggle-ripple mat-mdc-focus-indicator" mat-ripple
+    <span class="mdc-switch__track"></span>
+    <span class="mdc-switch__handle-track">
+      <span class="mdc-switch__handle">
+        <span class="mdc-switch__shadow">
+          <span class="mdc-elevation-overlay"></span>
+        </span>
+        <span class="mdc-switch__ripple">
+          <span class="mat-mdc-slide-toggle-ripple mat-mdc-focus-indicator" mat-ripple
             [matRippleTrigger]="switch"
             [matRippleDisabled]="disableRipple || disabled"
-            [matRippleCentered]="true"></div>
-        </div>
+            [matRippleCentered]="true"></span>
+        </span>
         @if (!hideIcon) {
-          <div class="mdc-switch__icons">
+          <span class="mdc-switch__icons">
             <svg
               class="mdc-switch__icon mdc-switch__icon--on"
               viewBox="0 0 24 24"
@@ -44,10 +44,10 @@
               aria-hidden="true">
               <path d="M20 13H4v-2h16v2z" />
             </svg>
-          </div>
+          </span>
         }
-      </div>
-    </div>
+      </span>
+    </span>
   </button>
 
   <!--


### PR DESCRIPTION
Replaces `div` nodes inside the `button` with `span` since the former trigger some automated checkers.

Fixes #29484.