### PR TITLE
feat(material/slider): Support for multi word thumb label text #28599

### DIFF
--- a/src/material/slider/slider.scss
+++ b/src/material/slider/slider.scss
@@ -105,6 +105,11 @@ $_mat-slots: (tokens-mat-slider.$prefix, tokens-mat-slider.get-token-slots());
   pointer-events: none;
   position: absolute;
   transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 8px;
+  box-sizing: border-box;
 
   @include token-utils.use-tokens($_mat-slots...) {
     @include token-utils.create-token-slot(transform, value-indicator-container-transform);
@@ -125,6 +130,10 @@ $_mat-slots: (tokens-mat-slider.$prefix, tokens-mat-slider.get-token-slots());
   transform-origin: bottom;
   opacity: 1;
   transition: transform 100ms cubic-bezier(0.4, 0, 1, 1);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
 
   // Stop parent word-break from altering
   // the word-break of the value indicator.


### PR DESCRIPTION
**Fix Text Overflow in Value Indicator Container**

Fixes #28599

Before:

<img width="290" alt="Screenshot 2024-07-26 at 08 26 28" src="https://github.com/user-attachments/assets/ccaf3c12-6fd5-489b-946c-aad50164caf8">

After:

<img width="244" alt="Screenshot 2024-07-26 at 08 27 14" src="https://github.com/user-attachments/assets/456c68dd-89a8-4441-8d74-e2c131ed6190">
