### PR TITLE
feat(material/radio): add the ability to interact with disabled radio buttons

### DIFF
--- a/src/dev-app/radio/BUILD.bazel
+++ b/src/dev-app/radio/BUILD.bazel
@@ -13,6 +13,7 @@ ng_module(
         "//src/material/button",
         "//src/material/checkbox",
         "//src/material/radio",
+        "//src/material/tooltip",
         "@npm//@angular/forms",
     ],
 )

--- a/src/dev-app/radio/radio-demo.html
+++ b/src/dev-app/radio/radio-demo.html
@@ -63,3 +63,21 @@
   </mat-radio-group>
   <p>Your favorite season is: {{favoriteSeason}}</p>
 </section>
+
+<h1>Disabled interactive group</h1>
+<section class="demo-section">
+  <mat-radio-group
+    disabled
+    [disabledInteractive]="disabledInteractive"
+    [(ngModel)]="favoriteSeason">
+    @for (season of seasonOptions; track season) {
+      <mat-radio-button [value]="season" matTooltip="This is a tooltip" matTooltipPosition="above">
+        {{season}}
+      </mat-radio-button>
+    }
+  </mat-radio-group>
+
+  <div>
+    <mat-checkbox [(ngModel)]="disabledInteractive">Disabled interactive</mat-checkbox>
+  </div>
+</section>

--- a/src/dev-app/radio/radio-demo.ts
+++ b/src/dev-app/radio/radio-demo.ts
@@ -6,25 +6,34 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {CommonModule} from '@angular/common';
 import {ChangeDetectionStrategy, Component} from '@angular/core';
+import {CommonModule} from '@angular/common';
 import {FormsModule} from '@angular/forms';
 import {MatButtonModule} from '@angular/material/button';
 import {MatCheckboxModule} from '@angular/material/checkbox';
 import {MatRadioModule} from '@angular/material/radio';
+import {MatTooltip} from '@angular/material/tooltip';
 
 @Component({
   selector: 'radio-demo',
   templateUrl: 'radio-demo.html',
   styleUrl: 'radio-demo.css',
   standalone: true,
-  imports: [CommonModule, MatRadioModule, FormsModule, MatButtonModule, MatCheckboxModule],
+  imports: [
+    CommonModule,
+    MatRadioModule,
+    FormsModule,
+    MatButtonModule,
+    MatCheckboxModule,
+    MatTooltip,
+  ],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class RadioDemo {
-  isAlignEnd: boolean = false;
-  isDisabled: boolean = false;
-  isRequired: boolean = false;
-  favoriteSeason: string = 'Autumn';
+  isAlignEnd = false;
+  isDisabled = false;
+  isRequired = false;
+  disabledInteractive = true;
+  favoriteSeason = 'Autumn';
   seasonOptions = ['Winter', 'Spring', 'Summer', 'Autumn'];
 }

--- a/src/material/checkbox/checkbox.spec.ts
+++ b/src/material/checkbox/checkbox.spec.ts
@@ -466,6 +466,19 @@ describe('MDC-based MatCheckbox', () => {
       expect(inputElement.disabled).toBe(false);
     }));
 
+    it('should not change the checked state if disabled and interactive', fakeAsync(() => {
+      testComponent.isDisabled = testComponent.disabledInteractive = true;
+      fixture.changeDetectorRef.markForCheck();
+      fixture.detectChanges();
+
+      expect(inputElement.checked).toBe(false);
+
+      inputElement.click();
+      fixture.detectChanges();
+
+      expect(inputElement.checked).toBe(false);
+    }));
+
     describe('ripple elements', () => {
       it('should show ripples on label mousedown', fakeAsync(() => {
         const rippleSelector = '.mat-ripple-element:not(.mat-checkbox-persistent-ripple)';

--- a/src/material/radio/_radio-common.scss
+++ b/src/material/radio/_radio-common.scss
@@ -219,9 +219,27 @@ $_icon-size: 20px;
     }
   }
 
-  .mdc-radio--disabled {
-    cursor: default;
-    pointer-events: none;
+  @if ($is-interactive) {
+    &.mat-mdc-radio-disabled-interactive .mdc-radio--disabled {
+      pointer-events: auto;
+
+      @include token-utils.use-tokens($tokens...) {
+        .mdc-radio__native-control:not(:checked) + .mdc-radio__background .mdc-radio__outer-circle {
+          @include token-utils.create-token-slot(border-color, disabled-unselected-icon-color);
+          @include token-utils.create-token-slot(opacity, disabled-unselected-icon-opacity);
+        }
+
+        &:hover .mdc-radio__native-control:checked + .mdc-radio__background,
+        .mdc-radio__native-control:checked:focus + .mdc-radio__background,
+        .mdc-radio__native-control + .mdc-radio__background {
+          .mdc-radio__inner-circle,
+          .mdc-radio__outer-circle {
+            @include token-utils.create-token-slot(border-color, disabled-selected-icon-color);
+            @include token-utils.create-token-slot(opacity, disabled-selected-icon-opacity);
+          }
+        }
+      }
+    }
   }
 }
 

--- a/src/material/radio/radio.html
+++ b/src/material/radio/radio.html
@@ -5,13 +5,14 @@
     <input #input class="mdc-radio__native-control" type="radio"
            [id]="inputId"
            [checked]="checked"
-           [disabled]="disabled"
+           [disabled]="disabled && !disabledInteractive"
            [attr.name]="name"
            [attr.value]="value"
            [required]="required"
            [attr.aria-label]="ariaLabel"
            [attr.aria-labelledby]="ariaLabelledby"
            [attr.aria-describedby]="ariaDescribedby"
+           [attr.aria-disabled]="disabled && disabledInteractive ? 'true' : null"
            (change)="_onInputInteraction($event)">
     <div class="mdc-radio__background">
       <div class="mdc-radio__outer-circle"></div>

--- a/src/material/radio/radio.scss
+++ b/src/material/radio/radio.scss
@@ -12,28 +12,22 @@
     .mdc-radio__background::before {
       @include token-utils.create-token-slot(background-color, ripple-color);
     }
-  }
 
-  &.mat-mdc-radio-checked {
-    @include token-utils.use-tokens(
-      tokens-mat-radio.$prefix,
-      tokens-mat-radio.get-token-slots()
-    ) {
+    &.mat-mdc-radio-checked {
+      .mat-ripple-element,
       .mdc-radio__background::before {
         @include token-utils.create-token-slot(background-color, checked-ripple-color);
       }
+    }
 
-      .mat-ripple-element {
-        @include token-utils.create-token-slot(background-color, checked-ripple-color);
+    &.mat-mdc-radio-disabled-interactive .mdc-radio--disabled {
+      .mat-ripple-element,
+      .mdc-radio__background::before {
+        @include token-utils.create-token-slot(background-color, ripple-color);
       }
     }
-  }
 
-  .mat-internal-form-field {
-    @include token-utils.use-tokens(
-      tokens-mat-radio.$prefix,
-      tokens-mat-radio.get-token-slots()
-    ) {
+    .mat-internal-form-field {
       @include token-utils.create-token-slot(color, label-text-color);
       @include token-utils.create-token-slot(font-family, label-text-font);
       @include token-utils.create-token-slot(line-height, label-text-line-height);
@@ -41,14 +35,8 @@
       @include token-utils.create-token-slot(letter-spacing, label-text-tracking);
       @include token-utils.create-token-slot(font-weight, label-text-weight);
     }
-  }
 
-  // MDC should set the disabled color on the label, but doesn't, so we do it here instead.
-  .mdc-radio--disabled + label {
-    @include token-utils.use-tokens(
-      tokens-mat-radio.$prefix,
-      tokens-mat-radio.get-token-slots()
-    ) {
+    .mdc-radio--disabled + label {
       @include token-utils.create-token-slot(color, disabled-label-color);
     }
   }
@@ -81,6 +69,15 @@
   // the hidden input is focused (slightly different for each control).
   &.cdk-focused .mat-mdc-focus-indicator::before {
     content: '';
+  }
+}
+
+.mat-mdc-radio-disabled {
+  cursor: default;
+  pointer-events: none;
+
+  &.mat-mdc-radio-disabled-interactive {
+    pointer-events: auto;
   }
 }
 

--- a/src/material/radio/radio.spec.ts
+++ b/src/material/radio/radio.spec.ts
@@ -132,6 +132,29 @@ describe('MDC-based MatRadio', () => {
       }
     });
 
+    it('should make all disabled buttons interactive if the group is marked as disabledInteractive', () => {
+      testComponent.isGroupDisabledInteractive = true;
+      fixture.changeDetectorRef.markForCheck();
+      fixture.detectChanges();
+      expect(radioInstances.every(radio => radio.disabledInteractive)).toBe(true);
+    });
+
+    it('should prevent the click action when disabledInteractive and disabled', () => {
+      testComponent.isGroupDisabled = true;
+      testComponent.isGroupDisabledInteractive = true;
+      fixture.changeDetectorRef.markForCheck();
+      fixture.detectChanges();
+
+      // We can't monitor the `defaultPrevented` state on the
+      // native `click` so we dispatch an extra one.
+      const fakeEvent = dispatchFakeEvent(radioInputElements[0], 'click');
+      radioInputElements[0].click();
+      fixture.detectChanges();
+
+      expect(fakeEvent.defaultPrevented).toBe(true);
+      expect(radioInstances[0].checked).toBe(false);
+    });
+
     it('should set required to each radio button when the group is required', () => {
       testComponent.isGroupRequired = true;
       fixture.changeDetectorRef.markForCheck();
@@ -675,6 +698,7 @@ describe('MDC-based MatRadio', () => {
     let fixture: ComponentFixture<DisableableRadioButton>;
     let radioInstance: MatRadioButton;
     let radioNativeElement: HTMLInputElement;
+    let radioHost: HTMLElement;
     let testComponent: DisableableRadioButton;
 
     beforeEach(() => {
@@ -683,8 +707,9 @@ describe('MDC-based MatRadio', () => {
 
       testComponent = fixture.debugElement.componentInstance;
       const radioDebugElement = fixture.debugElement.query(By.directive(MatRadioButton))!;
+      radioHost = radioDebugElement.nativeElement;
       radioInstance = radioDebugElement.injector.get<MatRadioButton>(MatRadioButton);
-      radioNativeElement = radioDebugElement.nativeElement.querySelector('input');
+      radioNativeElement = radioHost.querySelector('input')!;
     });
 
     it('should toggle the disabled state', () => {
@@ -702,6 +727,24 @@ describe('MDC-based MatRadio', () => {
       fixture.detectChanges();
       expect(radioInstance.disabled).toBeFalsy();
       expect(radioNativeElement.disabled).toBeFalsy();
+    });
+
+    it('should keep the button interactive if disabledInteractive is enabled', () => {
+      testComponent.disabled = true;
+      fixture.changeDetectorRef.markForCheck();
+      fixture.detectChanges();
+
+      expect(radioNativeElement.disabled).toBe(true);
+      expect(radioNativeElement.hasAttribute('aria-disabled')).toBe(false);
+      expect(radioHost.classList).not.toContain('mat-mdc-radio-disabled-interactive');
+
+      testComponent.disabledInteractive = true;
+      fixture.changeDetectorRef.markForCheck();
+      fixture.detectChanges();
+
+      expect(radioNativeElement.disabled).toBe(false);
+      expect(radioNativeElement.getAttribute('aria-disabled')).toBe('true');
+      expect(radioHost.classList).toContain('mat-mdc-radio-disabled-interactive');
     });
   });
 
@@ -1031,11 +1074,13 @@ describe('MatRadioDefaultOverrides', () => {
 
 @Component({
   template: `
-  <mat-radio-group [disabled]="isGroupDisabled"
-                  [labelPosition]="labelPos"
-                  [required]="isGroupRequired"
-                  [value]="groupValue"
-                  name="test-name">
+  <mat-radio-group
+    [disabled]="isGroupDisabled"
+    [labelPosition]="labelPos"
+    [required]="isGroupRequired"
+    [value]="groupValue"
+    [disabledInteractive]="isGroupDisabledInteractive"
+    name="test-name">
     @if (isFirstShown) {
       <mat-radio-button value="fire" [disableRipple]="disableRipple" [disabled]="isFirstDisabled"
                       [color]="color">
@@ -1058,6 +1103,7 @@ class RadiosInsideRadioGroup {
   isFirstDisabled = false;
   isGroupDisabled = false;
   isGroupRequired = false;
+  isGroupDisabledInteractive = false;
   groupValue: string | null = null;
   disableRipple = false;
   color: string | null;
@@ -1130,16 +1176,18 @@ class RadioGroupWithNgModel {
 }
 
 @Component({
-  template: `<mat-radio-button>One</mat-radio-button>`,
+  template: `
+    <mat-radio-button
+      [disabled]="disabled"
+      [disabledInteractive]="disabledInteractive">One</mat-radio-button>`,
   standalone: true,
   imports: [MatRadioModule, FormsModule, ReactiveFormsModule, CommonModule],
 })
 class DisableableRadioButton {
-  @ViewChild(MatRadioButton) matRadioButton: MatRadioButton;
+  disabled = false;
+  disabledInteractive = false;
 
-  set disabled(value: boolean) {
-    this.matRadioButton.disabled = value;
-  }
+  @ViewChild(MatRadioButton) matRadioButton: MatRadioButton;
 }
 
 @Component({

--- a/tools/public_api_guard/material/radio.md
+++ b/tools/public_api_guard/material/radio.md
@@ -37,7 +37,7 @@ export const MAT_RADIO_GROUP_CONTROL_VALUE_ACCESSOR: any;
 
 // @public (undocumented)
 export class MatRadioButton implements OnInit, AfterViewInit, DoCheck, OnDestroy {
-    constructor(radioGroup: MatRadioGroup, _elementRef: ElementRef, _changeDetector: ChangeDetectorRef, _focusMonitor: FocusMonitor, _radioDispatcher: UniqueSelectionDispatcher, animationMode?: string, _providerOverride?: MatRadioDefaultOptions | undefined, tabIndex?: string);
+    constructor(radioGroup: MatRadioGroup, _elementRef: ElementRef, _changeDetector: ChangeDetectorRef, _focusMonitor: FocusMonitor, _radioDispatcher: UniqueSelectionDispatcher, animationMode?: string, _defaultOptions?: MatRadioDefaultOptions | undefined, tabIndex?: string);
     ariaDescribedby: string;
     ariaLabel: string;
     ariaLabelledby: string;
@@ -48,6 +48,8 @@ export class MatRadioButton implements OnInit, AfterViewInit, DoCheck, OnDestroy
     set color(newValue: ThemePalette);
     get disabled(): boolean;
     set disabled(value: boolean);
+    get disabledInteractive(): boolean;
+    set disabledInteractive(value: boolean);
     disableRipple: boolean;
     // (undocumented)
     protected _elementRef: ElementRef;
@@ -66,6 +68,8 @@ export class MatRadioButton implements OnInit, AfterViewInit, DoCheck, OnDestroy
     // (undocumented)
     static ngAcceptInputType_disabled: unknown;
     // (undocumented)
+    static ngAcceptInputType_disabledInteractive: unknown;
+    // (undocumented)
     static ngAcceptInputType_disableRipple: unknown;
     // (undocumented)
     static ngAcceptInputType_required: unknown;
@@ -80,8 +84,6 @@ export class MatRadioButton implements OnInit, AfterViewInit, DoCheck, OnDestroy
     // (undocumented)
     ngOnInit(): void;
     _noopAnimations: boolean;
-    // (undocumented)
-    _onInputClick(event: Event): void;
     _onInputInteraction(event: Event): void;
     _onTouchTargetClick(event: Event): void;
     radioGroup: MatRadioGroup;
@@ -93,7 +95,7 @@ export class MatRadioButton implements OnInit, AfterViewInit, DoCheck, OnDestroy
     get value(): any;
     set value(value: any);
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<MatRadioButton, "mat-radio-button", ["matRadioButton"], { "id": { "alias": "id"; "required": false; }; "name": { "alias": "name"; "required": false; }; "ariaLabel": { "alias": "aria-label"; "required": false; }; "ariaLabelledby": { "alias": "aria-labelledby"; "required": false; }; "ariaDescribedby": { "alias": "aria-describedby"; "required": false; }; "disableRipple": { "alias": "disableRipple"; "required": false; }; "tabIndex": { "alias": "tabIndex"; "required": false; }; "checked": { "alias": "checked"; "required": false; }; "value": { "alias": "value"; "required": false; }; "labelPosition": { "alias": "labelPosition"; "required": false; }; "disabled": { "alias": "disabled"; "required": false; }; "required": { "alias": "required"; "required": false; }; "color": { "alias": "color"; "required": false; }; }, { "change": "change"; }, never, ["*"], true, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MatRadioButton, "mat-radio-button", ["matRadioButton"], { "id": { "alias": "id"; "required": false; }; "name": { "alias": "name"; "required": false; }; "ariaLabel": { "alias": "aria-label"; "required": false; }; "ariaLabelledby": { "alias": "aria-labelledby"; "required": false; }; "ariaDescribedby": { "alias": "aria-describedby"; "required": false; }; "disableRipple": { "alias": "disableRipple"; "required": false; }; "tabIndex": { "alias": "tabIndex"; "required": false; }; "checked": { "alias": "checked"; "required": false; }; "value": { "alias": "value"; "required": false; }; "labelPosition": { "alias": "labelPosition"; "required": false; }; "disabled": { "alias": "disabled"; "required": false; }; "required": { "alias": "required"; "required": false; }; "color": { "alias": "color"; "required": false; }; "disabledInteractive": { "alias": "disabledInteractive"; "required": false; }; }, { "change": "change"; }, never, ["*"], true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatRadioButton, [{ optional: true; }, null, null, null, null, { optional: true; }, { optional: true; }, { attribute: "tabindex"; }]>;
 }
@@ -110,6 +112,7 @@ export class MatRadioChange {
 // @public (undocumented)
 export interface MatRadioDefaultOptions {
     color: ThemePalette;
+    disabledInteractive?: boolean;
 }
 
 // @public
@@ -122,6 +125,8 @@ export class MatRadioGroup implements AfterContentInit, OnDestroy, ControlValueA
     _controlValueAccessorChangeFn: (value: any) => void;
     get disabled(): boolean;
     set disabled(value: boolean);
+    get disabledInteractive(): boolean;
+    set disabledInteractive(value: boolean);
     _emitChangeEvent(): void;
     get labelPosition(): 'before' | 'after';
     set labelPosition(v: 'before' | 'after');
@@ -131,6 +136,8 @@ export class MatRadioGroup implements AfterContentInit, OnDestroy, ControlValueA
     set name(value: string);
     // (undocumented)
     static ngAcceptInputType_disabled: unknown;
+    // (undocumented)
+    static ngAcceptInputType_disabledInteractive: unknown;
     // (undocumented)
     static ngAcceptInputType_required: unknown;
     ngAfterContentInit(): void;
@@ -150,7 +157,7 @@ export class MatRadioGroup implements AfterContentInit, OnDestroy, ControlValueA
     set value(newValue: any);
     writeValue(value: any): void;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<MatRadioGroup, "mat-radio-group", ["matRadioGroup"], { "color": { "alias": "color"; "required": false; }; "name": { "alias": "name"; "required": false; }; "labelPosition": { "alias": "labelPosition"; "required": false; }; "value": { "alias": "value"; "required": false; }; "selected": { "alias": "selected"; "required": false; }; "disabled": { "alias": "disabled"; "required": false; }; "required": { "alias": "required"; "required": false; }; }, { "change": "change"; }, ["_radios"], never, true, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<MatRadioGroup, "mat-radio-group", ["matRadioGroup"], { "color": { "alias": "color"; "required": false; }; "name": { "alias": "name"; "required": false; }; "labelPosition": { "alias": "labelPosition"; "required": false; }; "value": { "alias": "value"; "required": false; }; "selected": { "alias": "selected"; "required": false; }; "disabled": { "alias": "disabled"; "required": false; }; "required": { "alias": "required"; "required": false; }; "disabledInteractive": { "alias": "disabledInteractive"; "required": false; }; }, { "change": "change"; }, ["_radios"], never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatRadioGroup, never>;
 }


### PR DESCRIPTION
Adds the `disabledInteractive` input that allows users to opt into being able to interact with a disabled radio button (e.g. focus or show a tooltip).

Also fixes that we weren't setting `pointer-events: none` on the entire container when it's disabled.