### PR TITLE
fix(material/radio): avoid error if destroyed quickly

### DIFF
--- a/src/material/radio/radio.ts
+++ b/src/material/radio/radio.ts
@@ -671,7 +671,8 @@ export class MatRadioButton implements OnInit, AfterViewInit, DoCheck, OnDestroy
   }
 
   ngOnDestroy() {
-    this._inputElement.nativeElement.removeEventListener('click', this._onInputClick);
+    // We need to null check in case the button was destroyed before `ngAfterViewInit`.
+    this._inputElement?.nativeElement.removeEventListener('click', this._onInputClick);
     this._focusMonitor.stopMonitoring(this._elementRef);
     this._removeUniqueSelectionListener();
   }
@@ -713,7 +714,7 @@ export class MatRadioButton implements OnInit, AfterViewInit, DoCheck, OnDestroy
     if (!this.disabled || this.disabledInteractive) {
       // Normally the input should be focused already, but if the click
       // comes from the touch target, then we might have to focus it ourselves.
-      this._inputElement.nativeElement.focus();
+      this._inputElement?.nativeElement.focus();
     }
   }
 


### PR DESCRIPTION
Fixes an error that can happen if a radio button is destroyed before `ngAfterViewInit` has run.