### PR TITLE
refactor(material/core): simplify token calls

### DIFF
--- a/src/material/button/_button-base.scss
+++ b/src/material/button/_button-base.scss
@@ -139,14 +139,24 @@
 
 @mixin mat-private-button-horizontal-layout($prefix, $slots, $has-with-icon-padding) {
   @include token-utils.use-tokens($prefix, $slots) {
+<<<<<<< Updated upstream
     $icon-spacing: token-utils.get-token-variable-reference(icon-spacing, true);
     $icon-offset: token-utils.get-token-variable-reference(icon-offset, true);
     $horizontal-padding: token-utils.get-token-variable-reference(horizontal-padding, true);
+=======
+    $icon-spacing: token-utils.get-token-variable(icon-spacing);
+    $icon-offset: token-utils.get-token-variable(icon-offset);
+    $horizontal-padding: token-utils.get-token-variable(horizontal-padding);
+>>>>>>> Stashed changes
     padding: 0 $horizontal-padding;
 
     @if ($has-with-icon-padding) {
       $with-icon-horizontal-padding:
+<<<<<<< Updated upstream
         token-utils.get-token-variable-reference(with-icon-horizontal-padding, true);
+=======
+        token-utils.get-token-variable(with-icon-horizontal-padding);
+>>>>>>> Stashed changes
 
       // stylelint-disable-next-line selector-class-pattern
       &:has(.material-icons, mat-icon, [matButtonIcon]) {

--- a/src/material/core/tokens/_token-utils.scss
+++ b/src/material/core/tokens/_token-utils.scss
@@ -69,8 +69,8 @@ $_component-prefix: null;
 }
 
 // Combines a prefix and a string to generate a CSS variable name for a token.
-@function _get-css-variable($prefix, $name) {
-  @if $prefix == null or $name == null {
+@function _create-var-name($prefix, $token) {
+  @if $prefix == null or $token == null {
     @error 'Must specify both prefix and name when generating token';
   }
 
@@ -81,36 +81,45 @@ $_component-prefix: null;
     $string-prefix: if($string-prefix == '', $part, '#{$string-prefix}-#{$part}');
   }
 
-  @return string.unquote('--#{$string-prefix}-#{$name}');
+  @return string.unquote('--#{$string-prefix}-#{$token}');
 }
 
-// Emits a slot for the given token, provided that it has a non-null value in the token map passed
-// to `use-tokens`.
-@mixin create-token-slot($property, $token, $emit-fallback: false) {
+// Gets the value of the token given the current global context state.
+@function _get-token-value($token, $fallback) {
+  $var-name: _create-var-name($_component-prefix, $token);
+  @if ($fallback) {
+    @return var($var-name, $fallback);
+  } @else {
+    @return var($var-name);
+  }
+}
+
+// Assertion mixin that throws an error if the global state has not been set up by wrapping
+// calls with `use-tokens`.
+@function _assert-use-tokens($token) {
   @if $_component-prefix == null or $_tokens == null {
-    @error '`create-token-slot` must be used within `use-tokens`';
+    @error 'Was not called within a wrapping call of `use-tokens`';
   }
   @if not map.has-key($_tokens, $token) {
     @error 'Token #{$token} does not exist. Configured tokens are: #{map.keys($_tokens)}';
   }
+
+  @return true;
+}
+
+// Emits a slot for the given token, provided that it has a non-null value in the token map passed
+// to `use-tokens`.
+// Accepts an optional fallback parameter to include in the CSS variable.
+@mixin create-token-slot($property, $token, $fallback: null) {
+  $_assert: _assert-use-tokens($token);
   @if map.get($_tokens, $token) != null {
-    $fallback: null;
-
-    @if ($emit-fallback == true) {
-      $fallback: map.get($_tokens, $token);
-    }
-    @else if ($emit-fallback) {
-      $fallback: $emit-fallback;
-    }
-
-    $var-name: _get-css-variable($_component-prefix, $token);
-    $var-reference: if($fallback == null, var(#{$var-name}), var(#{$var-name}, #{$fallback}));
-    #{$property}: #{$var-reference};
+    #{$property}: #{_get-token-value($token, $fallback)};
   }
 }
 
 // Returns the name of a token including the current prefix. Intended to be used in calculations
 // involving tokens. `create-token-slot` should be used when outputting tokens.
+<<<<<<< Updated upstream
 @function get-token-variable($token) {
   @if $_component-prefix == null or $_tokens == null {
     @error '`get-token-variable` must be used within `use-tokens`';
@@ -120,11 +129,17 @@ $_component-prefix: null;
   }
 
   @return _get-css-variable($_component-prefix, $token);
+=======
+@function get-token-variable-name($token) {
+  $_assert: _assert-use-tokens($token);
+  @return _create-var-name($_component-prefix, $token);
+>>>>>>> Stashed changes
 }
 
 // TODO(crisbeto): should be able to replace the usages of `get-token-variable` with this.
 // Returns a `var()` reference to a specific token. Intended for declarations
 // where the token has to be referenced as a part of a larger expression.
+<<<<<<< Updated upstream
 @function get-token-variable-reference($token, $emit-fallback: false) {
   @if $_component-prefix == null or $_tokens == null {
     @error '`get-token-variable-reference` must be used within `use-tokens`';
@@ -142,6 +157,12 @@ $_component-prefix: null;
   @else {
     @return var($var);
   }
+=======
+// Accepts an optional fallback parameter to include in the CSS variable.
+@function get-token-variable($token, $fallback: null) {
+  $_assert: _assert-use-tokens($token);
+  @return _get-token-value($token, $fallback);
+>>>>>>> Stashed changes
 }
 
 // Outputs a map of tokens under a specific prefix.
@@ -149,7 +170,7 @@ $_component-prefix: null;
   @if $tokens != null {
     @each $key, $value in $tokens {
       @if $value != null {
-        #{_get-css-variable($prefix, $key)}: #{$value};
+        #{_create-var-name($prefix, $key)}: #{$value};
       }
     }
   }

--- a/src/material/dialog/dialog.scss
+++ b/src/material/dialog/dialog.scss
@@ -1,3 +1,4 @@
+@use 'sass:map';
 @use '@angular/cdk';
 @use '../core/tokens/m2/mdc/dialog' as tokens-mdc-dialog;
 @use '../core/tokens/m2/mat/dialog' as tokens-mat-dialog;
@@ -48,14 +49,11 @@ $_emit-fallbacks: true;
 // This needs extra specificity so it doesn't get overwritten by the CDK structural styles.
 .cdk-overlay-pane.mat-mdc-dialog-panel {
   @include _use-mat-tokens {
-    @include token-utils.create-token-slot(max-width, container-max-width,
-      $_emit-fallbacks);
-    @include token-utils.create-token-slot(min-width, container-min-width,
-      $_emit-fallbacks);
+    @include token-utils.create-token-slot(max-width, container-max-width);
+    @include token-utils.create-token-slot(min-width, container-min-width);
 
     @media (variables.$xsmall) {
-      @include token-utils.create-token-slot(max-width, container-small-max-width,
-        $_emit-fallbacks);
+      @include token-utils.create-token-slot(max-width, container-small-max-width);
     }
   }
 }
@@ -134,13 +132,12 @@ $_emit-fallbacks: true;
   }
 
   @include _use-mat-tokens {
-    @include token-utils.create-token-slot(box-shadow, container-elevation-shadow,
-      $_emit-fallbacks);
+    @include token-utils.create-token-slot(box-shadow, container-elevation-shadow);
   }
 
   @include _use-mdc-tokens {
-    @include token-utils.create-token-slot(border-radius, container-shape, $_emit-fallbacks);
-    @include token-utils.create-token-slot(background-color, container-color, $_emit-fallbacks);
+    @include token-utils.create-token-slot(border-radius, container-shape);
+    @include token-utils.create-token-slot(background-color, container-color);
   }
 }
 
@@ -167,18 +164,18 @@ $_emit-fallbacks: true;
   }
 
   @include _use-mat-tokens {
-    @include token-utils.create-token-slot(padding, headline-padding, $_emit-fallbacks);
+    @include token-utils.create-token-slot(padding, headline-padding);
   }
 
   // Nested to maintain the old specificity.
   .mat-mdc-dialog-container & {
     @include _use-mdc-tokens {
-      @include token-utils.create-token-slot(color, subhead-color, $_emit-fallbacks);
-      @include token-utils.create-token-slot(font-family, subhead-font, $_emit-fallbacks);
-      @include token-utils.create-token-slot(line-height, subhead-line-height, $_emit-fallbacks);
-      @include token-utils.create-token-slot(font-size, subhead-size, $_emit-fallbacks);
-      @include token-utils.create-token-slot(font-weight, subhead-weight, $_emit-fallbacks);
-      @include token-utils.create-token-slot(letter-spacing, subhead-tracking, $_emit-fallbacks);
+      @include token-utils.create-token-slot(color, subhead-color);
+      @include token-utils.create-token-slot(font-family, subhead-font);
+      @include token-utils.create-token-slot(line-height, subhead-line-height);
+      @include token-utils.create-token-slot(font-size, subhead-size);
+      @include token-utils.create-token-slot(font-weight, subhead-weight);
+      @include token-utils.create-token-slot(letter-spacing, subhead-tracking);
     }
   }
 }
@@ -202,28 +199,25 @@ $_emit-fallbacks: true;
   // Nested to maintain the old specificity.
   .mat-mdc-dialog-container & {
     @include _use-mdc-tokens {
-      @include token-utils.create-token-slot(color, supporting-text-color, $_emit-fallbacks);
-      @include token-utils.create-token-slot(font-family, supporting-text-font, $_emit-fallbacks);
-      @include token-utils.create-token-slot(line-height, supporting-text-line-height,
-        $_emit-fallbacks);
-      @include token-utils.create-token-slot(font-size, supporting-text-size, $_emit-fallbacks);
-      @include token-utils.create-token-slot(font-weight, supporting-text-weight, $_emit-fallbacks);
-      @include token-utils.create-token-slot(letter-spacing, supporting-text-tracking,
-        $_emit-fallbacks);
+      @include token-utils.create-token-slot(color, supporting-text-color);
+      @include token-utils.create-token-slot(font-family, supporting-text-font);
+      @include token-utils.create-token-slot(line-height, supporting-text-line-height);
+      @include token-utils.create-token-slot(font-size, supporting-text-size);
+      @include token-utils.create-token-slot(font-weight, supporting-text-weight);
+      @include token-utils.create-token-slot(letter-spacing, supporting-text-tracking);
     }
   }
 
   @include _use-mat-tokens {
     // These styles need a bit more specificity.
     .mat-mdc-dialog-container & {
-      @include token-utils.create-token-slot(padding, content-padding, $_emit-fallbacks);
+      @include token-utils.create-token-slot(padding, content-padding);
     }
 
     // Note: we can achieve this with a `:has` selector, but it results in an
     // increased specificity which breaks a lot of internal clients.
     .mat-mdc-dialog-container-with-actions & {
-      @include token-utils.create-token-slot(padding, with-actions-content-padding,
-        $_emit-fallbacks);
+      @include token-utils.create-token-slot(padding, with-actions-content-padding);
     }
   }
 
@@ -252,8 +246,8 @@ $_emit-fallbacks: true;
   // For backwards compatibility, actions align at start by default. MDC usually
   // aligns actions at the end of the container.
   @include _use-mat-tokens {
-    @include token-utils.create-token-slot(padding, actions-padding, $_emit-fallbacks);
-    @include token-utils.create-token-slot(justify-content, actions-alignment, $_emit-fallbacks);
+    @include token-utils.create-token-slot(padding, actions-padding);
+    @include token-utils.create-token-slot(justify-content, actions-alignment);
   }
 
   // .mat-mdc-dialog-actions-align-{start|center|end} are set by directive input "align"

--- a/src/material/table/table.scss
+++ b/src/material/table/table.scss
@@ -11,8 +11,8 @@
 }
 
 @mixin _cell-border {
-  @include token-utils.create-token-slot(border-bottom-color, row-item-outline-color, true);
-  @include token-utils.create-token-slot(border-bottom-width, row-item-outline-width, true);
+  @include token-utils.create-token-slot(border-bottom-color, row-item-outline-color);
+  @include token-utils.create-token-slot(border-bottom-width, row-item-outline-width);
   border-bottom-style: solid;
 }
 
@@ -52,8 +52,8 @@
   .mat-mdc-header-row {
     @include vendor-prefixes.smooth-font;
     @include token-utils.create-token-slot(height, header-container-height, 56px);
-    @include token-utils.create-token-slot(color, header-headline-color, true);
-    @include token-utils.create-token-slot(font-family, header-headline-font, true);
+    @include token-utils.create-token-slot(color, header-headline-color);
+    @include token-utils.create-token-slot(font-family, header-headline-font);
     @include token-utils.create-token-slot(line-height, header-headline-line-height);
     @include token-utils.create-token-slot(font-size, header-headline-size, 14px);
     @include token-utils.create-token-slot(font-weight, header-headline-weight, 500);
@@ -61,7 +61,7 @@
 
   .mat-mdc-row {
     @include token-utils.create-token-slot(height, row-item-container-height, 52px);
-    @include token-utils.create-token-slot(color, row-item-label-text-color, true);
+    @include token-utils.create-token-slot(color, row-item-label-text-color);
   }
 
   // Note that while it's redundant to apply the typography both to the row
@@ -71,7 +71,7 @@
   .mat-mdc-row,
   .mdc-data-table__content {
     @include vendor-prefixes.smooth-font;
-    @include token-utils.create-token-slot(font-family, row-item-label-text-font, true);
+    @include token-utils.create-token-slot(font-family, row-item-label-text-font);
     @include token-utils.create-token-slot(line-height, row-item-label-text-line-height);
     @include token-utils.create-token-slot(font-size, row-item-label-text-size, 14px);
     @include token-utils.create-token-slot(font-weight, row-item-label-text-weight);
@@ -80,8 +80,8 @@
   .mat-mdc-footer-row {
     @include vendor-prefixes.smooth-font;
     @include token-utils.create-token-slot(height, footer-container-height, 52px);
-    @include token-utils.create-token-slot(color, row-item-label-text-color, true);
-    @include token-utils.create-token-slot(font-family, footer-supporting-text-font, true);
+    @include token-utils.create-token-slot(color, row-item-label-text-color);
+    @include token-utils.create-token-slot(font-family, footer-supporting-text-font);
     @include token-utils.create-token-slot(line-height, footer-supporting-text-line-height);
     @include token-utils.create-token-slot(font-size, footer-supporting-text-size, 14px);
     @include token-utils.create-token-slot(font-weight, footer-supporting-text-weight);


### PR DESCRIPTION
Using this to see what happens if we don't fallback to token values in the dialog, table, and button