### PR TITLE
fix(material/dialog): invalid font-family declaration

### DIFF
--- a/src/material/dialog/dialog.scss
+++ b/src/material/dialog/dialog.scss
@@ -174,7 +174,8 @@ $_emit-fallbacks: true;
   .mat-mdc-dialog-container & {
     @include _use-mdc-tokens {
       @include token-utils.create-token-slot(color, subhead-color, $_emit-fallbacks);
-      @include token-utils.create-token-slot(font-family, subhead-font, $_emit-fallbacks);
+      @include token-utils.create-token-slot(font-family, subhead-font,
+        if($_emit-fallbacks, inherit, null));
       @include token-utils.create-token-slot(line-height, subhead-line-height, $_emit-fallbacks);
       @include token-utils.create-token-slot(font-size, subhead-size, $_emit-fallbacks);
       @include token-utils.create-token-slot(font-weight, subhead-weight, $_emit-fallbacks);
@@ -203,7 +204,8 @@ $_emit-fallbacks: true;
   .mat-mdc-dialog-container & {
     @include _use-mdc-tokens {
       @include token-utils.create-token-slot(color, supporting-text-color, $_emit-fallbacks);
-      @include token-utils.create-token-slot(font-family, supporting-text-font, $_emit-fallbacks);
+      @include token-utils.create-token-slot(font-family, supporting-text-font,
+        if($_emit-fallbacks, inherit, null));
       @include token-utils.create-token-slot(line-height, supporting-text-line-height,
         $_emit-fallbacks);
       @include token-utils.create-token-slot(font-size, supporting-text-size, $_emit-fallbacks);


### PR DESCRIPTION
We were emitting a font family value like `var(--mat-dialog-font, Roboto, sans-serif)` which is invalid. These changes remove the fallback since it was primarily there to make it easier to land the MDC changes.