### PR TITLE
fix(material/tooltip): remove aria-describedby when disabled

### DIFF
--- a/src/material/tooltip/tooltip.ts
+++ b/src/material/tooltip/tooltip.ts
@@ -205,6 +205,7 @@ export class MatTooltip implements OnDestroy, AfterViewInit {
   private _viewportMargin = 8;
   private _currentPosition: TooltipPosition;
   private readonly _cssClassPrefix: string = 'mat-mdc';
+  private _ariaDescriptionPending: boolean;
 
   /** Allows the user to define the position of the tooltip relative to the parent element */
   @Input('matTooltipPosition')
@@ -246,13 +247,19 @@ export class MatTooltip implements OnDestroy, AfterViewInit {
   }
 
   set disabled(value: BooleanInput) {
-    this._disabled = coerceBooleanProperty(value);
+    const isDisabled = coerceBooleanProperty(value);
 
-    // If tooltip is disabled, hide immediately.
-    if (this._disabled) {
-      this.hide(0);
-    } else {
-      this._setupPointerEnterEventsIfNeeded();
+    if (this._disabled !== isDisabled) {
+      this._disabled = isDisabled;
+
+      // If tooltip is disabled, hide immediately.
+      if (isDisabled) {
+        this.hide(0);
+      } else {
+        this._setupPointerEnterEventsIfNeeded();
+      }
+
+      this._syncAriaDescription(this.message);
     }
   }
 
@@ -307,7 +314,7 @@ export class MatTooltip implements OnDestroy, AfterViewInit {
   }
 
   set message(value: string | null | undefined) {
-    this._ariaDescriber.removeDescription(this._elementRef.nativeElement, this._message, 'tooltip');
+    const oldMessage = this._message;
 
     // If the message is not a string (e.g. number), convert it to a string and trim it.
     // Must convert with `String(value)`, not `${value}`, otherwise Closure Compiler optimises
@@ -319,16 +326,9 @@ export class MatTooltip implements OnDestroy, AfterViewInit {
     } else {
       this._setupPointerEnterEventsIfNeeded();
       this._updateTooltipMessage();
-      this._ngZone.runOutsideAngular(() => {
-        // The `AriaDescriber` has some functionality that avoids adding a description if it's the
-        // same as the `aria-label` of an element, however we can't know whether the tooltip trigger
-        // has a data-bound `aria-label` or when it'll be set for the first time. We can avoid the
-        // issue by deferring the description by a tick so Angular has time to set the `aria-label`.
-        Promise.resolve().then(() => {
-          this._ariaDescriber.describe(this._elementRef.nativeElement, this.message, 'tooltip');
-        });
-      });
     }
+
+    this._syncAriaDescription(oldMessage);
   }
 
   private _message = '';
@@ -903,6 +903,30 @@ export class MatTooltip implements OnDestroy, AfterViewInit {
       style.touchAction = 'none';
       (style as any).webkitTapHighlightColor = 'transparent';
     }
+  }
+
+  /** Updates the tooltip's ARIA description based on it current state. */
+  private _syncAriaDescription(oldMessage: string): void {
+    if (this._ariaDescriptionPending) {
+      return;
+    }
+
+    this._ariaDescriptionPending = true;
+    this._ariaDescriber.removeDescription(this._elementRef.nativeElement, oldMessage, 'tooltip');
+
+    this._ngZone.runOutsideAngular(() => {
+      // The `AriaDescriber` has some functionality that avoids adding a description if it's the
+      // same as the `aria-label` of an element, however we can't know whether the tooltip trigger
+      // has a data-bound `aria-label` or when it'll be set for the first time. We can avoid the
+      // issue by deferring the description by a tick so Angular has time to set the `aria-label`.
+      Promise.resolve().then(() => {
+        this._ariaDescriptionPending = false;
+
+        if (this.message && !this.disabled) {
+          this._ariaDescriber.describe(this._elementRef.nativeElement, this.message, 'tooltip');
+        }
+      });
+    });
   }
 }
 


### PR DESCRIPTION
Fixes that we were setting an `aria-describedby` even if the tooltip won't show up because it's disabled.

Fixes #29501.