### PR TITLE
fix(multiple): change fallbacks to use m3

### DIFF
--- a/src/material/core/_core.scss
+++ b/src/material/core/_core.scss
@@ -7,6 +7,14 @@
 
 // Mixin that renders all of the core styles that are not theme-dependent.
 @mixin core() {
+  // TODO: Move ripple styles to be dynamically loaded instead of in core.
+  // This variable is used as a fallback for the ripple element's
+  // background color. However, if it isn't defined anywhere, then MSS
+  // complains in its verification stage.
+  html {
+    --mat-app-on-surface: initial;
+  }
+
   @include ripple.ripple();
   @include cdk.a11y-visually-hidden();
   @include cdk.overlay();

--- a/src/material/core/tokens/_token-utils.scss
+++ b/src/material/core/tokens/_token-utils.scss
@@ -113,11 +113,7 @@ $_system-fallbacks: m3-tokens.create-system-fallbacks();
     @return _create-var($sys-fallback, $fallback);
   }
 
-  // TODO(mat-app-theme): Return the system-level fallback.
-  // Changing this will affect clients that do not properly call theme mixins since the tokens
-  // will be undefined and now default to M3 system values, causing a number of screenshot failures.
-  // @return $sys-fallback;
-  @return $fallback;
+  @return $sys-fallback;
 }
 
 // Outputs a map of tokens under a specific prefix.


### PR DESCRIPTION
When possible, use token fallbacks defined by the MDC system tokens instead of the M2 hardcoded values (or nothing).

This will affect the appearance of applications that are incorrectly lacking calls to component theme mixins, since all of these fallbacks should be ignored in favor of the fine-grained token values.

Applications that have styles changed from this should ensure that they are calling component theme mixins, e.g. `mat.button-theme()` if a button is used. 

For example, here's the change for expansion panel expanded height:
```
.mat-expansion-panel-header.mat-expanded {
    // Before: 
    height: var(--mat-expansion-header-expanded-state-height);

    // After:
    height: var(--mat-expansion-header-expanded-state-height, 64px);
}
```