### PR TITLE
build: remove ie-based lint rule

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -104,10 +104,6 @@
     "declaration-block-semicolon-newline-before": "never-multi-line",
     "declaration-block-semicolon-newline-after": "always-multi-line",
     "declaration-colon-space-after": "always-single-line",
-    "declaration-property-value-disallowed-list": [
-      {"/.*/": ["initial"]},
-      {"message": "The `initial` value is not supported in IE."}
-    ],
 
     "block-closing-brace-newline-after": [
       "always",


### PR DESCRIPTION
Enables the use of `initial` for CSS values

IE is no longer tested against for Angular Material