### PR TITLE
fix(material/autocomplete): typos and unresolved variables in tests

### DIFF
--- a/src/material/autocomplete/autocomplete.spec.ts
+++ b/src/material/autocomplete/autocomplete.spec.ts
@@ -175,7 +175,7 @@ describe('MDC-based MatAutocomplete', () => {
         .toEqual('');
     }));
 
-    it('should close the panel when the user clicks away via auxilliary button', waitForAsync(async () => {
+    it('should close the panel when the user clicks away via auxiliary button', waitForAsync(async () => {
       dispatchFakeEvent(input, 'focusin');
       fixture.detectChanges();
       await new Promise(r => setTimeout(r));
@@ -1609,7 +1609,7 @@ describe('MDC-based MatAutocomplete', () => {
         fixture.detectChanges();
 
         expect(event.defaultPrevented)
-          .withContext(`Expected autocompete not to block ${name} key`)
+          .withContext(`Expected autocomplete not to block ${name} key`)
           .toBe(false);
       });
     });
@@ -3440,7 +3440,7 @@ describe('MDC-based MatAutocomplete', () => {
     widthFixture.detectChanges();
 
     const overlayPane = overlayContainerElement.querySelector('.cdk-overlay-pane') as HTMLElement;
-    // Firefox, edge return a decimal value for width, so we need to parse and round it to verify
+    // Firefox, Edge return a decimal value for width, so we need to parse and round it to verify
     expect(Math.ceil(parseFloat(overlayPane.style.width as string))).toBe(300);
 
     widthFixture.componentInstance.trigger.closePanel();
@@ -3453,7 +3453,7 @@ describe('MDC-based MatAutocomplete', () => {
     widthFixture.componentInstance.trigger.openPanel();
     widthFixture.detectChanges();
 
-    // Firefox, edge return a decimal value for width, so we need to parse and round it to verify
+    // Firefox, Edge return a decimal value for width, so we need to parse and round it to verify
     expect(Math.ceil(parseFloat(overlayPane.style.width as string))).toBe(500);
   });
 
@@ -3850,7 +3850,7 @@ describe('MDC-based MatAutocomplete', () => {
       dispatchFakeEvent(document.querySelector('mat-option')!, 'click');
       fixture.detectChanges();
 
-      const selectedOption = document.querySelector('mat-option[aria-selected="true"');
+      const selectedOption = document.querySelector('mat-option[aria-selected="true"]');
       expect(selectedOption).withContext('Expected an option to be selected.').not.toBeNull();
       expect(selectedOption?.querySelector('.mat-pseudo-checkbox.mat-pseudo-checkbox-minimal'))
         .withContext(
@@ -3876,7 +3876,7 @@ describe('MDC-based MatAutocomplete', () => {
       dispatchFakeEvent(document.querySelector('mat-option')!, 'click');
       fixture.detectChanges();
 
-      const selectedOption = document.querySelector('mat-option[aria-selected="true"');
+      const selectedOption = document.querySelector('mat-option[aria-selected="true"]');
       expect(selectedOption).withContext('Expected an option to be selected.').not.toBeNull();
       expect(document.querySelectorAll('.mat-pseudo-checkbox').length).toBe(0);
     });
@@ -4212,7 +4212,7 @@ class AutocompleteWithoutPanel {
 
     <mat-autocomplete #auto="matAutocomplete">
       @for (group of stateGroups; track group) {
-        <mat-optgroup [label]="group.label">
+        <mat-optgroup [label]="group.title">
           @for (state of group.states; track state) {
             <mat-option [value]="state">
               <span>{{ state }}</span>
@@ -4251,7 +4251,7 @@ class AutocompleteWithGroups {
     <mat-autocomplete #auto="matAutocomplete">
       @if (true) {
         @for (group of stateGroups; track group) {
-          <mat-optgroup [label]="group.label">
+          <mat-optgroup [label]="group.title">
             @for (state of group.states; track state) {
               <mat-option [value]="state">
                 <span>{{ state }}</span>


### PR DESCRIPTION
Fix typos in comments and test descriptions, fix query selectors and unresolved variables