### PR TITLE
test: remove compileComponent calls

### DIFF
--- a/src/cdk-experimental/combobox/combobox.spec.ts
+++ b/src/cdk-experimental/combobox/combobox.spec.ts
@@ -26,7 +26,7 @@ describe('Combobox', () => {
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [CdkComboboxModule, ComboboxToggle],
-      }).compileComponents();
+      });
     }));
 
     beforeEach(() => {
@@ -192,7 +192,7 @@ describe('Combobox', () => {
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [CdkComboboxModule, ComboboxToggle],
-      }).compileComponents();
+      });
     }));
 
     beforeEach(() => {
@@ -262,7 +262,7 @@ describe('Combobox', () => {
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [CdkComboboxModule, ComboboxToggle],
-      }).compileComponents();
+      });
     }));
 
     beforeEach(() => {

--- a/src/cdk-experimental/popover-edit/popover-edit.spec.ts
+++ b/src/cdk-experimental/popover-edit/popover-edit.spec.ts
@@ -397,7 +397,7 @@ describe('CDK Popover Edit', () => {
         TestBed.configureTestingModule({
           imports: [CdkTableModule, CdkPopoverEditModule, CommonModule, FormsModule, BidiModule],
           declarations: [componentClass],
-        }).compileComponents();
+        });
         fixture = TestBed.createComponent<BaseTestComponent>(componentClass);
         component = fixture.componentInstance;
         fixture.detectChanges();

--- a/src/cdk-experimental/scrolling/virtual-scroll-viewport.spec.ts
+++ b/src/cdk-experimental/scrolling/virtual-scroll-viewport.spec.ts
@@ -12,7 +12,7 @@ describe('CdkVirtualScrollViewport', () => {
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [ScrollingModule, ExperimentalScrollingModule, AutoSizeVirtualScroll],
-      }).compileComponents();
+      });
     }));
 
     beforeEach(() => {

--- a/src/cdk-experimental/selection/selection.spec.ts
+++ b/src/cdk-experimental/selection/selection.spec.ts
@@ -14,7 +14,7 @@ describe('CdkSelection', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [CdkSelectionModule, ListWithMultiSelection],
-    }).compileComponents();
+    });
   }));
 
   beforeEach(() => {
@@ -240,7 +240,7 @@ describe('CdkSelection with multiple = false', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [CdkSelectionModule, ListWithSingleSelection],
-    }).compileComponents();
+    });
   }));
 
   beforeEach(() => {
@@ -305,7 +305,7 @@ describe('cdkSelectionColumn', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [CdkSelectionModule, CdkTableModule, MultiSelectTableWithSelectionColumn],
-    }).compileComponents();
+    });
   }));
 
   beforeEach(() => {
@@ -399,7 +399,7 @@ describe('cdkSelectionColumn with multiple = false', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [CdkSelectionModule, CdkTableModule, SingleSelectTableWithSelectionColumn],
-    }).compileComponents();
+    });
   }));
 
   beforeEach(() => {

--- a/src/cdk-experimental/table-scroll-container/table-scroll-container.spec.ts
+++ b/src/cdk-experimental/table-scroll-container/table-scroll-container.spec.ts
@@ -24,7 +24,7 @@ describe('CdkTableScrollContainer', () => {
   ): ComponentFixture<T> {
     TestBed.configureTestingModule({
       imports: [CdkTableModule, CdkTableScrollContainerModule, componentType, ...declarations],
-    }).compileComponents();
+    });
 
     return TestBed.createComponent<T>(componentType);
   }

--- a/src/cdk/a11y/aria-describer/aria-describer.spec.ts
+++ b/src/cdk/a11y/aria-describer/aria-describer.spec.ts
@@ -12,7 +12,7 @@ describe('AriaDescriber', () => {
     TestBed.configureTestingModule({
       imports: [A11yModule, TestApp],
       providers: [AriaDescriber, ...providers],
-    }).compileComponents();
+    });
 
     fixture = TestBed.createComponent(TestApp);
     component = fixture.componentInstance;

--- a/src/cdk/a11y/focus-monitor/focus-monitor.spec.ts
+++ b/src/cdk/a11y/focus-monitor/focus-monitor.spec.ts
@@ -59,7 +59,7 @@ describe('FocusMonitor', () => {
           },
         },
       ],
-    }).compileComponents();
+    });
   });
 
   beforeEach(inject([FocusMonitor], (fm: FocusMonitor) => {
@@ -478,7 +478,7 @@ describe('FocusMonitor with "eventual" detection', () => {
           },
         },
       ],
-    }).compileComponents();
+    });
   });
 
   beforeEach(inject([FocusMonitor], (fm: FocusMonitor) => {
@@ -515,7 +515,7 @@ describe('cdkMonitorFocus', () => {
         FocusMonitorOnCommentNode,
         ExportedFocusMonitor,
       ],
-    }).compileComponents();
+    });
   });
 
   describe('button with cdkMonitorElementFocus', () => {
@@ -827,7 +827,7 @@ describe('FocusMonitor observable stream', () => {
     TestBed.configureTestingModule({
       imports: [A11yModule, PlainButton],
       providers: [{provide: Platform, useValue: fakePlatform}],
-    }).compileComponents();
+    });
   });
 
   beforeEach(inject([FocusMonitor], (fm: FocusMonitor) => {
@@ -864,7 +864,7 @@ describe('FocusMonitor input label detection', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [A11yModule, CheckboxWithLabel],
-    }).compileComponents();
+    });
   });
 
   beforeEach(inject([FocusMonitor], (fm: FocusMonitor) => {

--- a/src/cdk/a11y/focus-monitor/focus-monitor.zone.spec.ts
+++ b/src/cdk/a11y/focus-monitor/focus-monitor.zone.spec.ts
@@ -16,7 +16,7 @@ describe('FocusMonitor observable stream Zone.js integration', () => {
     TestBed.configureTestingModule({
       imports: [A11yModule, PlainButton],
       providers: [{provide: Platform, useValue: fakePlatform}, provideZoneChangeDetection()],
-    }).compileComponents();
+    });
   });
 
   beforeEach(inject([FocusMonitor], (fm: FocusMonitor) => {

--- a/src/cdk/a11y/focus-trap/configurable-focus-trap.spec.ts
+++ b/src/cdk/a11y/focus-trap/configurable-focus-trap.spec.ts
@@ -95,7 +95,7 @@ function createComponent<T>(
   TestBed.configureTestingModule({
     imports: [A11yModule, componentType],
     providers: providers,
-  }).compileComponents();
+  });
 
   return TestBed.createComponent<T>(componentType);
 }

--- a/src/cdk/a11y/focus-trap/event-listener-inert-strategy.spec.ts
+++ b/src/cdk/a11y/focus-trap/event-listener-inert-strategy.spec.ts
@@ -64,7 +64,7 @@ function createComponent<T>(
   TestBed.configureTestingModule({
     imports: [A11yModule, componentType],
     providers: providers,
-  }).compileComponents();
+  });
 
   return TestBed.createComponent<T>(componentType);
 }

--- a/src/cdk/a11y/focus-trap/focus-trap.spec.ts
+++ b/src/cdk/a11y/focus-trap/focus-trap.spec.ts
@@ -28,8 +28,6 @@ describe('FocusTrap', () => {
         FocusTrapWithAutoCaptureInShadowDom,
       ],
     });
-
-    TestBed.compileComponents();
   }));
 
   describe('with default element', () => {

--- a/src/cdk/accordion/accordion-item.spec.ts
+++ b/src/cdk/accordion/accordion-item.spec.ts
@@ -15,7 +15,6 @@ describe('CdkAccordionItem', () => {
         ItemGroupWithAccordion,
       ],
     });
-    TestBed.compileComponents();
   }));
 
   describe('single item', () => {

--- a/src/cdk/accordion/accordion.spec.ts
+++ b/src/cdk/accordion/accordion.spec.ts
@@ -11,7 +11,6 @@ describe('CdkAccordion', () => {
     TestBed.configureTestingModule({
       imports: [BrowserAnimationsModule, CdkAccordionModule, SetOfItems, NestedItems],
     });
-    TestBed.compileComponents();
   }));
 
   it('should ensure only one item is expanded at a time', () => {

--- a/src/cdk/bidi/directionality.spec.ts
+++ b/src/cdk/bidi/directionality.spec.ts
@@ -18,7 +18,7 @@ describe('Directionality', () => {
         ElementWithPredefinedUppercaseDir,
       ],
       providers: [{provide: DIR_DOCUMENT, useFactory: () => fakeDocument}],
-    }).compileComponents();
+    });
   }));
 
   describe('Service', () => {

--- a/src/cdk/clipboard/copy-to-clipboard.spec.ts
+++ b/src/cdk/clipboard/copy-to-clipboard.spec.ts
@@ -31,8 +31,6 @@ describe('CdkCopyToClipboard', () => {
     TestBed.configureTestingModule({
       imports: [ClipboardModule, CopyToClipboardHost],
     });
-
-    TestBed.compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/cdk/dialog/dialog.spec.ts
+++ b/src/cdk/dialog/dialog.spec.ts
@@ -69,8 +69,6 @@ describe('Dialog', () => {
       ],
     });
 
-    TestBed.compileComponents();
-
     dialog = TestBed.inject(Dialog);
     mockLocation = TestBed.inject(Location) as SpyLocation;
     overlay = TestBed.inject(Overlay);
@@ -1131,7 +1129,6 @@ describe('Dialog with a parent Dialog', () => {
       ],
     });
 
-    TestBed.compileComponents();
     parentDialog = TestBed.inject(Dialog);
     fixture = TestBed.createComponent(ComponentThatProvidesMatDialog);
     childDialog = fixture.componentInstance.dialog;

--- a/src/cdk/drag-drop/directives/test-utils.spec.ts
+++ b/src/cdk/drag-drop/directives/test-utils.spec.ts
@@ -46,7 +46,6 @@ export function createComponent<T>(
     });
   }
 
-  TestBed.compileComponents();
   return TestBed.createComponent<T>(componentType);
 }
 

--- a/src/cdk/drag-drop/drag-drop-registry.spec.ts
+++ b/src/cdk/drag-drop/drag-drop-registry.spec.ts
@@ -17,7 +17,7 @@ describe('DragDropRegistry', () => {
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
       imports: [DragDropModule, BlankComponent],
-    }).compileComponents();
+    });
 
     fixture = TestBed.createComponent(BlankComponent);
     fixture.detectChanges();

--- a/src/cdk/drag-drop/drag-drop.spec.ts
+++ b/src/cdk/drag-drop/drag-drop.spec.ts
@@ -13,7 +13,6 @@ describe('DragDrop', () => {
       imports: [DragDropModule, TestComponent],
     });
 
-    TestBed.compileComponents();
     service = TestBed.inject(DragDrop);
   }));
 

--- a/src/cdk/listbox/listbox.spec.ts
+++ b/src/cdk/listbox/listbox.spec.ts
@@ -21,7 +21,7 @@ function setupComponent<T, O = string>(component: Type<T>, imports: any[] = []) 
   TestBed.configureTestingModule({
     imports: [CdkListboxModule, ...imports],
     declarations: [component],
-  }).compileComponents();
+  });
   const fixture = TestBed.createComponent(component);
   fixture.detectChanges();
 

--- a/src/cdk/menu/context-menu-trigger.spec.ts
+++ b/src/cdk/menu/context-menu-trigger.spec.ts
@@ -18,7 +18,7 @@ describe('CdkContextMenuTrigger', () => {
       TestBed.configureTestingModule({
         imports: [CdkMenuModule],
         declarations: [SimpleContextMenu],
-      }).compileComponents();
+      });
     }));
 
     beforeEach(() => {
@@ -152,7 +152,7 @@ describe('CdkContextMenuTrigger', () => {
       TestBed.configureTestingModule({
         imports: [CdkMenuModule],
         declarations: [NestedContextMenu],
-      }).compileComponents();
+      });
     }));
 
     beforeEach(() => {
@@ -267,7 +267,7 @@ describe('CdkContextMenuTrigger', () => {
       TestBed.configureTestingModule({
         imports: [CdkMenuModule],
         declarations: [ContextMenuWithSubmenu],
-      }).compileComponents();
+      });
     }));
 
     beforeEach(() => {
@@ -298,7 +298,7 @@ describe('CdkContextMenuTrigger', () => {
       TestBed.configureTestingModule({
         imports: [CdkMenuModule],
         declarations: [ContextMenuWithMenuBarAndInlineMenu],
-      }).compileComponents();
+      });
     }));
 
     beforeEach(() => {
@@ -402,7 +402,7 @@ describe('CdkContextMenuTrigger', () => {
       TestBed.configureTestingModule({
         imports: [CdkMenuModule],
         declarations: [componentClass],
-      }).compileComponents();
+      });
 
       const fixture = TestBed.createComponent(componentClass);
       fixture.detectChanges();
@@ -428,7 +428,7 @@ describe('CdkContextMenuTrigger', () => {
     TestBed.configureTestingModule({
       imports: [CdkMenuModule],
       declarations: [ContextTriggerWithData],
-    }).compileComponents();
+    });
 
     const fixture = TestBed.createComponent(ContextTriggerWithData);
     fixture.componentInstance.menuData = {message: 'Hello!'};

--- a/src/cdk/menu/menu-bar.spec.ts
+++ b/src/cdk/menu/menu-bar.spec.ts
@@ -47,7 +47,7 @@ describe('MenuBar', () => {
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [CdkMenuModule, MenuBarRadioGroup],
-      }).compileComponents();
+      });
 
       fixture = TestBed.createComponent(MenuBarRadioGroup);
       fixture.detectChanges();
@@ -107,7 +107,7 @@ describe('MenuBar', () => {
       beforeEach(waitForAsync(() => {
         TestBed.configureTestingModule({
           imports: [CdkMenuModule, MultiMenuWithSubmenu],
-        }).compileComponents();
+        });
       }));
 
       beforeEach(() => {
@@ -531,7 +531,7 @@ describe('MenuBar', () => {
       beforeEach(waitForAsync(() => {
         TestBed.configureTestingModule({
           imports: [CdkMenuModule, MultiMenuWithSubmenu],
-        }).compileComponents();
+        });
       }));
 
       beforeEach(() => {
@@ -658,7 +658,7 @@ describe('MenuBar', () => {
       beforeEach(waitForAsync(() => {
         TestBed.configureTestingModule({
           imports: [CdkMenuModule, MenuWithCheckboxes],
-        }).compileComponents();
+        });
       }));
 
       beforeEach(() => {
@@ -724,7 +724,7 @@ describe('MenuBar', () => {
       beforeEach(waitForAsync(() => {
         TestBed.configureTestingModule({
           imports: [CdkMenuModule, MenuWithRadioButtons],
-        }).compileComponents();
+        });
       }));
 
       beforeEach(() => {
@@ -779,7 +779,7 @@ describe('MenuBar', () => {
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [CdkMenuModule, MenuBarWithMenusAndInlineMenu],
-      }).compileComponents();
+      });
     }));
 
     beforeEach(() => {
@@ -898,7 +898,7 @@ describe('MenuBar', () => {
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [CdkMenuModule, MultiMenuWithSubmenu],
-      }).compileComponents();
+      });
     }));
 
     beforeEach(() => {

--- a/src/cdk/menu/menu-group.spec.ts
+++ b/src/cdk/menu/menu-group.spec.ts
@@ -14,7 +14,7 @@ describe('MenuGroup', () => {
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [CdkMenuModule, CheckboxMenu],
-      }).compileComponents();
+      });
 
       fixture = TestBed.createComponent(CheckboxMenu);
       fixture.detectChanges();
@@ -41,7 +41,7 @@ describe('MenuGroup', () => {
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [CdkMenuModule, MenuWithMultipleRadioGroups],
-      }).compileComponents();
+      });
 
       fixture = TestBed.createComponent(MenuWithMultipleRadioGroups);
       fixture.detectChanges();

--- a/src/cdk/menu/menu-item-checkbox.spec.ts
+++ b/src/cdk/menu/menu-item-checkbox.spec.ts
@@ -21,7 +21,7 @@ describe('MenuItemCheckbox', () => {
         // View engine can't figure out the ElementRef to inject so we need to provide a fake
         {provide: ElementRef, useValue: new ElementRef<null>(null)},
       ],
-    }).compileComponents();
+    });
   }));
 
   beforeEach(() => {

--- a/src/cdk/menu/menu-item-radio.spec.ts
+++ b/src/cdk/menu/menu-item-radio.spec.ts
@@ -25,7 +25,7 @@ describe('MenuItemRadio', () => {
         // View engine can't figure out the ElementRef to inject so we need to provide a fake
         {provide: ElementRef, useValue: new ElementRef<null>(null)},
       ],
-    }).compileComponents();
+    });
   }));
 
   beforeEach(() => {

--- a/src/cdk/menu/menu-item.spec.ts
+++ b/src/cdk/menu/menu-item.spec.ts
@@ -25,7 +25,7 @@ describe('MenuItem', () => {
           // View engine can't figure out the ElementRef to inject so we need to provide a fake
           {provide: ElementRef, useValue: new ElementRef<null>(null)},
         ],
-      }).compileComponents();
+      });
     }));
 
     beforeEach(() => {
@@ -90,7 +90,7 @@ describe('MenuItem', () => {
           {provide: ElementRef, useValue: new ElementRef<null>(null)},
         ],
         declarations: [componentClass],
-      }).compileComponents();
+      });
 
       fixture = TestBed.createComponent(componentClass);
       fixture.detectChanges();

--- a/src/cdk/menu/menu-stack.spec.ts
+++ b/src/cdk/menu/menu-stack.spec.ts
@@ -23,7 +23,7 @@ describe('MenuStack', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [CdkMenuModule, MultiMenuWithSubmenu],
-    }).compileComponents();
+    });
   }));
 
   beforeEach(() => {

--- a/src/cdk/menu/menu-trigger.spec.ts
+++ b/src/cdk/menu/menu-trigger.spec.ts
@@ -19,7 +19,7 @@ describe('MenuTrigger', () => {
       TestBed.configureTestingModule({
         imports: [CdkMenuModule],
         declarations: [TriggerForEmptyMenu],
-      }).compileComponents();
+      });
     }));
 
     beforeEach(() => {
@@ -114,7 +114,7 @@ describe('MenuTrigger', () => {
       TestBed.configureTestingModule({
         imports: [CdkMenuModule],
         declarations: [MenuBarWithNestedSubMenus],
-      }).compileComponents();
+      });
     }));
 
     beforeEach(() => {
@@ -334,7 +334,7 @@ describe('MenuTrigger', () => {
       TestBed.configureTestingModule({
         imports: [CdkMenuModule],
         declarations: [componentClass],
-      }).compileComponents();
+      });
 
       const fixture = TestBed.createComponent(componentClass);
       fixture.detectChanges();
@@ -407,7 +407,7 @@ describe('MenuTrigger', () => {
       TestBed.configureTestingModule({
         imports: [CdkMenuModule],
         declarations: [StandaloneTriggerWithInlineMenu],
-      }).compileComponents();
+      });
     }));
 
     beforeEach(() => {
@@ -490,7 +490,7 @@ describe('MenuTrigger', () => {
     TestBed.configureTestingModule({
       imports: [CdkMenuModule],
       declarations: [TriggerWithData],
-    }).compileComponents();
+    });
 
     const fixture = TestBed.createComponent(TriggerWithData);
     fixture.componentInstance.menuData = {message: 'Hello!'};
@@ -510,7 +510,7 @@ describe('MenuTrigger', () => {
       TestBed.configureTestingModule({
         imports: [CdkMenuModule],
         declarations: [TriggerWithNullValue],
-      }).compileComponents();
+      });
     }));
 
     beforeEach(() => {
@@ -549,7 +549,7 @@ describe('MenuTrigger', () => {
     TestBed.configureTestingModule({
       imports: [CdkMenuModule],
       declarations: [TriggersWithSameMenuDifferentMenuBars],
-    }).compileComponents();
+    });
 
     const fixture = TestBed.createComponent(TriggersWithSameMenuDifferentMenuBars);
     fixture.detectChanges();

--- a/src/cdk/menu/menu.spec.ts
+++ b/src/cdk/menu/menu.spec.ts
@@ -28,7 +28,7 @@ describe('Menu', () => {
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [CdkMenuModule, MenuCheckboxGroup],
-      }).compileComponents();
+      });
 
       fixture = TestBed.createComponent(MenuCheckboxGroup);
       fixture.detectChanges();
@@ -63,7 +63,7 @@ describe('Menu', () => {
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [CdkMenuModule, InlineMenu],
-      }).compileComponents();
+      });
     }));
 
     beforeEach(() => {
@@ -138,7 +138,7 @@ describe('Menu', () => {
       beforeEach(waitForAsync(() => {
         TestBed.configureTestingModule({
           imports: [CdkMenuModule, WithComplexNestedMenus],
-        }).compileComponents();
+        });
       }));
 
       beforeEach(() => {
@@ -329,7 +329,7 @@ describe('Menu', () => {
       beforeEach(waitForAsync(() => {
         TestBed.configureTestingModule({
           imports: [CdkMenuModule, WithComplexNestedMenusOnBottom],
-        }).compileComponents();
+        });
       }));
 
       beforeEach(() => {

--- a/src/cdk/menu/pointer-focus-tracker.spec.ts
+++ b/src/cdk/menu/pointer-focus-tracker.spec.ts
@@ -20,7 +20,7 @@ describe('FocusMouseManger', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [MultiElementWithConditionalComponent, MockWrapper],
-    }).compileComponents();
+    });
   }));
 
   beforeEach(() => {

--- a/src/cdk/observers/observe-content.spec.ts
+++ b/src/cdk/observers/observe-content.spec.ts
@@ -15,8 +15,6 @@ describe('Observe content directive', () => {
       TestBed.configureTestingModule({
         imports: [ObserversModule, ComponentWithTextContent, ComponentWithChildTextContent],
       });
-
-      TestBed.compileComponents();
     }));
 
     it('should trigger the callback when the content of the element changes', done => {
@@ -108,8 +106,6 @@ describe('Observe content directive', () => {
         ],
       });
 
-      TestBed.compileComponents();
-
       fixture = TestBed.createComponent(ComponentWithDebouncedListener);
       fixture.detectChanges();
     }));
@@ -151,8 +147,6 @@ describe('ContentObserver injectable', () => {
           },
         ],
       });
-
-      TestBed.compileComponents();
     }));
 
     beforeEach(inject([ContentObserver], (co: ContentObserver) => {
@@ -213,7 +207,6 @@ describe('ContentObserver injectable', () => {
         imports: [ObserversModule, UnobservedComponentWithTextContent],
       });
 
-      TestBed.compileComponents();
       const fixture = TestBed.createComponent(UnobservedComponentWithTextContent);
       fixture.autoDetectChanges();
       spy = jasmine.createSpy('content observer');

--- a/src/cdk/overlay/fullscreen-overlay-container.spec.ts
+++ b/src/cdk/overlay/fullscreen-overlay-container.spec.ts
@@ -56,7 +56,7 @@ describe('FullscreenOverlayContainer', () => {
           },
         },
       ],
-    }).compileComponents();
+    });
   }));
 
   beforeEach(inject([Overlay], (o: Overlay) => {

--- a/src/cdk/overlay/overlay-container.spec.ts
+++ b/src/cdk/overlay/overlay-container.spec.ts
@@ -10,7 +10,7 @@ describe('OverlayContainer', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [OverlayTestModule],
-    }).compileComponents();
+    });
   }));
 
   beforeEach(inject([Overlay, OverlayContainer], (o: Overlay, oc: OverlayContainer) => {

--- a/src/cdk/overlay/overlay.spec.ts
+++ b/src/cdk/overlay/overlay.spec.ts
@@ -59,7 +59,7 @@ describe('Overlay', () => {
           useClass: SpyLocation,
         },
       ],
-    }).compileComponents();
+    });
 
     overlay = TestBed.inject(Overlay);
     overlayContainer = TestBed.inject(OverlayContainer);

--- a/src/cdk/overlay/scroll/block-scroll-strategy.spec.ts
+++ b/src/cdk/overlay/scroll/block-scroll-strategy.spec.ts
@@ -21,7 +21,7 @@ describe('BlockScrollStrategy', () => {
 
     TestBed.configureTestingModule({
       imports: [OverlayModule, PortalModule, FocacciaMsg],
-    }).compileComponents();
+    });
   }));
 
   beforeEach(inject(

--- a/src/cdk/overlay/scroll/close-scroll-strategy.spec.ts
+++ b/src/cdk/overlay/scroll/close-scroll-strategy.spec.ts
@@ -31,8 +31,6 @@ describe('CloseScrollStrategy', () => {
         },
       ],
     });
-
-    TestBed.compileComponents();
   }));
 
   beforeEach(inject([Overlay], (overlay: Overlay) => {

--- a/src/cdk/overlay/scroll/close-scroll-strategy.zone.spec.ts
+++ b/src/cdk/overlay/scroll/close-scroll-strategy.zone.spec.ts
@@ -36,8 +36,6 @@ describe('CloseScrollStrategy Zone.js integration', () => {
         },
       ],
     });
-
-    TestBed.compileComponents();
   }));
 
   beforeEach(inject([Overlay], (overlay: Overlay) => {

--- a/src/cdk/overlay/scroll/reposition-scroll-strategy.spec.ts
+++ b/src/cdk/overlay/scroll/reposition-scroll-strategy.spec.ts
@@ -29,8 +29,6 @@ describe('RepositionScrollStrategy', () => {
         },
       ],
     });
-
-    TestBed.compileComponents();
   }));
 
   beforeEach(inject([Overlay], (o: Overlay) => {

--- a/src/cdk/portal/portal.spec.ts
+++ b/src/cdk/portal/portal.spec.ts
@@ -33,7 +33,7 @@ describe('Portals', () => {
         PizzaMsg,
         SaveParentNodeOnInit,
       ],
-    }).compileComponents();
+    });
   });
 
   describe('CdkPortalOutlet', () => {

--- a/src/cdk/scrolling/scroll-dispatcher.spec.ts
+++ b/src/cdk/scrolling/scroll-dispatcher.spec.ts
@@ -15,8 +15,6 @@ describe('ScrollDispatcher', () => {
     TestBed.configureTestingModule({
       imports: [ScrollingModule, ScrollingComponent, NestedScrollingComponent],
     });
-
-    TestBed.compileComponents();
   }));
 
   describe('Basic usage', () => {

--- a/src/cdk/scrolling/scroll-dispatcher.zone.spec.ts
+++ b/src/cdk/scrolling/scroll-dispatcher.zone.spec.ts
@@ -11,8 +11,6 @@ describe('ScrollDispatcher Zone.js integration', () => {
       imports: [ScrollingModule, ScrollingComponent],
       providers: [provideZoneChangeDetection()],
     });
-
-    TestBed.compileComponents();
   }));
 
   describe('Basic usage', () => {

--- a/src/cdk/scrolling/scrollable.spec.ts
+++ b/src/cdk/scrolling/scrollable.spec.ts
@@ -27,7 +27,7 @@ describe('CdkScrollable', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [ScrollingModule, ScrollableViewport],
-    }).compileComponents();
+    });
   }));
 
   beforeEach(() => {

--- a/src/cdk/scrolling/virtual-scroll-viewport.spec.ts
+++ b/src/cdk/scrolling/virtual-scroll-viewport.spec.ts
@@ -37,7 +37,7 @@ describe('CdkVirtualScrollViewport', () => {
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [ScrollingModule, FixedSizeVirtualScroll],
-      }).compileComponents();
+      });
     }));
 
     beforeEach(() => {
@@ -847,7 +847,7 @@ describe('CdkVirtualScrollViewport', () => {
     beforeEach(() => {
       TestBed.configureTestingModule({
         imports: [ScrollingModule, FixedSizeVirtualScrollWithRtlDirection],
-      }).compileComponents();
+      });
 
       fixture = TestBed.createComponent(FixedSizeVirtualScrollWithRtlDirection);
       testComponent = fixture.componentInstance;
@@ -947,7 +947,7 @@ describe('CdkVirtualScrollViewport', () => {
     beforeEach(() => {
       TestBed.configureTestingModule({
         imports: [ScrollingModule, VirtualScrollWithNoStrategy],
-      }).compileComponents();
+      });
     });
 
     it('should fail on construction', fakeAsync(() => {
@@ -969,7 +969,7 @@ describe('CdkVirtualScrollViewport', () => {
           VirtualScrollWithItemInjectingViewContainer,
           InjectsViewContainer,
         ],
-      }).compileComponents();
+      });
     }));
 
     beforeEach(() => {
@@ -1003,7 +1003,7 @@ describe('CdkVirtualScrollViewport', () => {
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [ScrollingModule, CommonModule, DelayedInitializationVirtualScroll],
-      }).compileComponents();
+      });
       fixture = TestBed.createComponent(DelayedInitializationVirtualScroll);
       testComponent = fixture.componentInstance;
       viewport = testComponent.viewport;
@@ -1033,7 +1033,7 @@ describe('CdkVirtualScrollViewport', () => {
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [ScrollingModule, CommonModule, VirtualScrollWithAppendOnly],
-      }).compileComponents();
+      });
       fixture = TestBed.createComponent(VirtualScrollWithAppendOnly);
       testComponent = fixture.componentInstance;
       viewport = testComponent.viewport;
@@ -1111,7 +1111,7 @@ describe('CdkVirtualScrollViewport', () => {
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [ScrollingModule, VirtualScrollWithCustomScrollingElement],
-      }).compileComponents();
+      });
     }));
 
     beforeEach(() => {
@@ -1148,7 +1148,7 @@ describe('CdkVirtualScrollViewport', () => {
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [ScrollingModule, VirtualScrollWithScrollableWindow],
-      }).compileComponents();
+      });
     }));
 
     beforeEach(() => {
@@ -1174,7 +1174,7 @@ describe('CdkVirtualScrollViewport', () => {
   it('should be able to query for a virtual scroll viewport as a CdkScrollable', () => {
     TestBed.configureTestingModule({
       imports: [ScrollingModule, VirtualScrollableQuery],
-    }).compileComponents();
+    });
 
     const fixture = TestBed.createComponent(VirtualScrollableQuery);
     fixture.detectChanges();

--- a/src/cdk/scrolling/virtual-scroll-viewport.zone.spec.ts
+++ b/src/cdk/scrolling/virtual-scroll-viewport.zone.spec.ts
@@ -31,7 +31,7 @@ describe('CdkVirtualScrollViewport Zone.js intergation', () => {
       TestBed.configureTestingModule({
         providers: [provideZoneChangeDetection()],
         imports: [ScrollingModule, FixedSizeVirtualScroll],
-      }).compileComponents();
+      });
     }));
 
     beforeEach(() => {

--- a/src/cdk/table/table.spec.ts
+++ b/src/cdk/table/table.spec.ts
@@ -47,7 +47,7 @@ describe('CdkTable', () => {
     TestBed.configureTestingModule({
       imports: [CdkTableModule, BidiModule],
       declarations: [componentType, ...declarations],
-    }).compileComponents();
+    });
 
     return TestBed.createComponent<T>(componentType);
   }

--- a/src/cdk/table/text-column.spec.ts
+++ b/src/cdk/table/text-column.spec.ts
@@ -17,7 +17,7 @@ describe('CdkTextColumn', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [CdkTableModule, BasicTextColumnApp, MissingTableApp, TextColumnWithoutNameApp],
-    }).compileComponents();
+    });
   }));
 
   beforeEach(() => {

--- a/src/cdk/text-field/autofill.spec.ts
+++ b/src/cdk/text-field/autofill.spec.ts
@@ -23,7 +23,7 @@ describe('AutofillMonitor', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [TextFieldModule, Inputs],
-    }).compileComponents();
+    });
   });
 
   beforeEach(inject([AutofillMonitor], (afm: AutofillMonitor) => {
@@ -175,7 +175,7 @@ describe('cdkAutofill', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [TextFieldModule, InputWithCdkAutofilled],
-    }).compileComponents();
+    });
   });
 
   beforeEach(inject([AutofillMonitor], (afm: AutofillMonitor) => {

--- a/src/cdk/text-field/autofill.zone.spec.ts
+++ b/src/cdk/text-field/autofill.zone.spec.ts
@@ -12,7 +12,7 @@ describe('AutofillMonitor Zone.js integration', () => {
     TestBed.configureTestingModule({
       providers: [provideZoneChangeDetection()],
       imports: [TextFieldModule, Inputs],
-    }).compileComponents();
+    });
   });
 
   beforeEach(inject([AutofillMonitor], (afm: AutofillMonitor) => {

--- a/src/cdk/text-field/autosize.spec.ts
+++ b/src/cdk/text-field/autosize.spec.ts
@@ -31,8 +31,6 @@ describe('CdkTextareaAutosize', () => {
         AutosizeTextareaWithoutAutosize,
       ],
     });
-
-    TestBed.compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/cdk/tree/tree-using-legacy-key-manager.spec.ts
+++ b/src/cdk/tree/tree-using-legacy-key-manager.spec.ts
@@ -12,7 +12,7 @@ describe('CdkTree when provided LegacyTreeKeyManager', () => {
       imports: [CdkTreeModule],
       declarations: [SimpleCdkTreeApp],
       providers: [NOOP_TREE_KEY_MANAGER_FACTORY_PROVIDER],
-    }).compileComponents();
+    });
 
     fixture = TestBed.createComponent(SimpleCdkTreeApp);
     fixture.detectChanges();

--- a/src/cdk/tree/tree-with-tree-control.spec.ts
+++ b/src/cdk/tree/tree-with-tree-control.spec.ts
@@ -59,7 +59,7 @@ describe('CdkTree with TreeControl', () => {
         },
       ],
       declarations: declarations,
-    }).compileComponents();
+    });
   }
 
   it('should clear out the `mostRecentTreeNode` on destroy', () => {

--- a/src/cdk/tree/tree.spec.ts
+++ b/src/cdk/tree/tree.spec.ts
@@ -63,7 +63,7 @@ describe('CdkTree', () => {
         },
       ],
       declarations: declarations,
-    }).compileComponents();
+    });
   }
 
   describe('onDestroy', () => {

--- a/src/components-examples/material/autocomplete/autocomplete-harness/autocomplete-harness-example.spec.ts
+++ b/src/components-examples/material/autocomplete/autocomplete-harness/autocomplete-harness-example.spec.ts
@@ -13,7 +13,7 @@ describe('AutocompleteHarnessExample', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [MatAutocompleteModule, NoopAnimationsModule],
-    }).compileComponents();
+    });
     fixture = TestBed.createComponent(AutocompleteHarnessExample);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.loader(fixture);

--- a/src/components-examples/material/bottom-sheet/bottom-sheet-harness/bottom-sheet-harness-example.spec.ts
+++ b/src/components-examples/material/bottom-sheet/bottom-sheet-harness/bottom-sheet-harness-example.spec.ts
@@ -13,7 +13,7 @@ describe('BottomSheetHarnessExample', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [MatBottomSheetModule, NoopAnimationsModule],
-    }).compileComponents();
+    });
     fixture = TestBed.createComponent(BottomSheetHarnessExample);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.documentRootLoader(fixture);

--- a/src/components-examples/material/datepicker/datepicker-harness/datepicker-harness-example.spec.ts
+++ b/src/components-examples/material/datepicker/datepicker-harness/datepicker-harness-example.spec.ts
@@ -14,7 +14,7 @@ describe('DatepickerHarnessExample', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [MatDatepickerModule, NoopAnimationsModule, MatNativeDateModule],
-    }).compileComponents();
+    });
     fixture = TestBed.createComponent(DatepickerHarnessExample);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.loader(fixture);

--- a/src/components-examples/material/dialog/dialog-harness/dialog-harness-example.spec.ts
+++ b/src/components-examples/material/dialog/dialog-harness/dialog-harness-example.spec.ts
@@ -12,7 +12,7 @@ describe('DialogHarnessExample', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [NoopAnimationsModule],
-    }).compileComponents();
+    });
     fixture = TestBed.createComponent(DialogHarnessExample);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.documentRootLoader(fixture);

--- a/src/components-examples/material/expansion/expansion-harness/expansion-harness-example.spec.ts
+++ b/src/components-examples/material/expansion/expansion-harness/expansion-harness-example.spec.ts
@@ -12,7 +12,7 @@ describe('ExpansionHarnessExample', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [NoopAnimationsModule],
-    }).compileComponents();
+    });
     fixture = TestBed.createComponent(ExpansionHarnessExample);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.loader(fixture);

--- a/src/components-examples/material/form-field/form-field-harness/form-field-harness-example.spec.ts
+++ b/src/components-examples/material/form-field/form-field-harness/form-field-harness-example.spec.ts
@@ -13,7 +13,7 @@ describe('FormFieldHarnessExample', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [NoopAnimationsModule],
-    }).compileComponents();
+    });
     fixture = TestBed.createComponent(FormFieldHarnessExample);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.loader(fixture);

--- a/src/components-examples/material/grid-list/grid-list-harness/grid-list-harness-example.spec.ts
+++ b/src/components-examples/material/grid-list/grid-list-harness/grid-list-harness-example.spec.ts
@@ -12,7 +12,7 @@ describe('GridListHarnessExample', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [MatGridListModule, GridListHarnessExample],
-    }).compileComponents();
+    });
     fixture = TestBed.createComponent(GridListHarnessExample);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.loader(fixture);

--- a/src/components-examples/material/icon/icon-harness/icon-harness-example.spec.ts
+++ b/src/components-examples/material/icon/icon-harness/icon-harness-example.spec.ts
@@ -13,7 +13,7 @@ describe('IconHarnessExample', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [MatIconModule],
-    }).compileComponents();
+    });
     const registry = TestBed.inject(MatIconRegistry);
     const sanitizer = TestBed.inject(DomSanitizer);
 

--- a/src/components-examples/material/input/input-harness/input-harness-example.spec.ts
+++ b/src/components-examples/material/input/input-harness/input-harness-example.spec.ts
@@ -12,7 +12,7 @@ describe('InputHarnessExample', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [NoopAnimationsModule],
-    }).compileComponents();
+    });
     fixture = TestBed.createComponent(InputHarnessExample);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.loader(fixture);

--- a/src/components-examples/material/menu/menu-harness/menu-harness-example.spec.ts
+++ b/src/components-examples/material/menu/menu-harness/menu-harness-example.spec.ts
@@ -13,7 +13,7 @@ describe('MenuHarnessExample', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [MatMenuModule, NoopAnimationsModule, MenuHarnessExample],
-    }).compileComponents();
+    });
     fixture = TestBed.createComponent(MenuHarnessExample);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.loader(fixture);

--- a/src/components-examples/material/paginator/paginator-harness/paginator-harness-example.spec.ts
+++ b/src/components-examples/material/paginator/paginator-harness/paginator-harness-example.spec.ts
@@ -14,7 +14,7 @@ describe('PaginatorHarnessExample', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [MatPaginatorModule, NoopAnimationsModule],
-    }).compileComponents();
+    });
     fixture = TestBed.createComponent(PaginatorHarnessExample);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.loader(fixture);

--- a/src/components-examples/material/select/select-harness/select-harness-example.spec.ts
+++ b/src/components-examples/material/select/select-harness/select-harness-example.spec.ts
@@ -13,7 +13,7 @@ describe('SelectHarnessExample', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [MatSelectModule, NoopAnimationsModule],
-    }).compileComponents();
+    });
     fixture = TestBed.createComponent(SelectHarnessExample);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.loader(fixture);

--- a/src/components-examples/material/sidenav/sidenav-harness/sidenav-harness-example.spec.ts
+++ b/src/components-examples/material/sidenav/sidenav-harness/sidenav-harness-example.spec.ts
@@ -16,7 +16,7 @@ describe('SidenavHarnessExample', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [NoopAnimationsModule],
-    }).compileComponents();
+    });
 
     fixture = TestBed.createComponent(SidenavHarnessExample);
     fixture.detectChanges();

--- a/src/components-examples/material/slider/slider-harness/slider-harness-example.spec.ts
+++ b/src/components-examples/material/slider/slider-harness/slider-harness-example.spec.ts
@@ -12,7 +12,7 @@ describe('SliderHarnessExample', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [MatSliderModule, SliderHarnessExample],
-    }).compileComponents();
+    });
     fixture = TestBed.createComponent(SliderHarnessExample);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.loader(fixture);

--- a/src/components-examples/material/snack-bar/snack-bar-harness/snack-bar-harness-example.spec.ts
+++ b/src/components-examples/material/snack-bar/snack-bar-harness/snack-bar-harness-example.spec.ts
@@ -12,7 +12,7 @@ describe('SnackBarHarnessExample', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [NoopAnimationsModule],
-    }).compileComponents();
+    });
     fixture = TestBed.createComponent(SnackBarHarnessExample);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.documentRootLoader(fixture);

--- a/src/components-examples/material/sort/sort-harness/sort-harness-example.spec.ts
+++ b/src/components-examples/material/sort/sort-harness/sort-harness-example.spec.ts
@@ -12,7 +12,7 @@ describe('SortHarnessExample', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [NoopAnimationsModule],
-    }).compileComponents();
+    });
     fixture = TestBed.createComponent(SortHarnessExample);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.loader(fixture);

--- a/src/components-examples/material/stepper/stepper-harness/stepper-harness-example.spec.ts
+++ b/src/components-examples/material/stepper/stepper-harness/stepper-harness-example.spec.ts
@@ -12,7 +12,7 @@ describe('StepperHarnessExample', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [NoopAnimationsModule],
-    }).compileComponents();
+    });
     fixture = TestBed.createComponent(StepperHarnessExample);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.loader(fixture);

--- a/src/components-examples/material/tabs/tab-group-harness/tab-group-harness-example.spec.ts
+++ b/src/components-examples/material/tabs/tab-group-harness/tab-group-harness-example.spec.ts
@@ -12,7 +12,7 @@ describe('TabGroupHarnessExample', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [NoopAnimationsModule],
-    }).compileComponents();
+    });
     fixture = TestBed.createComponent(TabGroupHarnessExample);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.loader(fixture);

--- a/src/components-examples/material/tooltip/tooltip-harness/tooltip-harness-example.spec.ts
+++ b/src/components-examples/material/tooltip/tooltip-harness/tooltip-harness-example.spec.ts
@@ -13,7 +13,7 @@ describe('TooltipHarnessExample', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [MatTooltipModule, NoopAnimationsModule],
-    }).compileComponents();
+    });
     fixture = TestBed.createComponent(TooltipHarnessExample);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.loader(fixture);

--- a/src/material-date-fns-adapter/adapter/date-fns-adapter.spec.ts
+++ b/src/material-date-fns-adapter/adapter/date-fns-adapter.spec.ts
@@ -23,7 +23,7 @@ describe('DateFnsAdapter', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [DateFnsModule],
-    }).compileComponents();
+    });
 
     adapter = TestBed.inject(DateAdapter);
     adapter.setLocale(enUS);
@@ -461,7 +461,7 @@ describe('DateFnsAdapter with MAT_DATE_LOCALE override', () => {
     TestBed.configureTestingModule({
       imports: [DateFnsModule],
       providers: [{provide: MAT_DATE_LOCALE, useValue: da}],
-    }).compileComponents();
+    });
 
     adapter = TestBed.inject(DateAdapter);
   }));

--- a/src/material-experimental/column-resize/column-resize.spec.ts
+++ b/src/material-experimental/column-resize/column-resize.spec.ts
@@ -375,7 +375,7 @@ describe('Material Popover Edit', () => {
         TestBed.configureTestingModule({
           imports: [BidiModule, MatTableModule, resizeModule],
           declarations: [componentClass],
-        }).compileComponents();
+        });
         fixture = TestBed.createComponent(componentClass);
         component = fixture.componentInstance;
         fixture.detectChanges();

--- a/src/material-experimental/menubar/menubar-item.spec.ts
+++ b/src/material-experimental/menubar/menubar-item.spec.ts
@@ -11,7 +11,7 @@ describe('MatMenuBarItem', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [MatMenuBarModule, CdkMenuModule, SimpleMenuBarItem],
-    }).compileComponents();
+    });
   }));
 
   beforeEach(() => {

--- a/src/material-experimental/menubar/menubar.spec.ts
+++ b/src/material-experimental/menubar/menubar.spec.ts
@@ -13,7 +13,7 @@ describe('MatMenuBar', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [MatMenuBarModule, SimpleMatMenuBar],
-    }).compileComponents();
+    });
   }));
 
   beforeEach(() => {

--- a/src/material-experimental/popover-edit/popover-edit.spec.ts
+++ b/src/material-experimental/popover-edit/popover-edit.spec.ts
@@ -302,7 +302,7 @@ describe('Material Popover Edit', () => {
         TestBed.configureTestingModule({
           imports: [MatTableModule, MatPopoverEditModule, CommonModule, FormsModule],
           declarations: [componentClass],
-        }).compileComponents();
+        });
         fixture = TestBed.createComponent(componentClass);
         component = fixture.componentInstance;
         fixture.detectChanges();

--- a/src/material-luxon-adapter/adapter/luxon-date-adapter.spec.ts
+++ b/src/material-luxon-adapter/adapter/luxon-date-adapter.spec.ts
@@ -24,7 +24,7 @@ describe('LuxonDateAdapter', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [LuxonDateModule],
-    }).compileComponents();
+    });
 
     adapter = TestBed.inject(DateAdapter);
     adapter.setLocale('en-US');
@@ -559,7 +559,7 @@ describe('LuxonDateAdapter with MAT_DATE_LOCALE override', () => {
     TestBed.configureTestingModule({
       imports: [LuxonDateModule],
       providers: [{provide: MAT_DATE_LOCALE, useValue: 'da-DK'}],
-    }).compileComponents();
+    });
 
     adapter = TestBed.inject(DateAdapter);
   }));
@@ -577,7 +577,7 @@ describe('LuxonDateAdapter with LOCALE_ID override', () => {
     TestBed.configureTestingModule({
       imports: [LuxonDateModule],
       providers: [{provide: LOCALE_ID, useValue: 'fr-FR'}],
-    }).compileComponents();
+    });
 
     adapter = TestBed.inject(DateAdapter);
   }));
@@ -600,7 +600,7 @@ describe('LuxonDateAdapter with MAT_LUXON_DATE_ADAPTER_OPTIONS override', () => 
           useValue: {useUtc: true, firstDayOfWeek: 1},
         },
       ],
-    }).compileComponents();
+    });
 
     adapter = TestBed.inject(DateAdapter);
   }));
@@ -646,7 +646,7 @@ describe('LuxonDateAdapter with MAT_LUXON_DATE_ADAPTER_OPTIONS override for defa
           useValue: {defaultOutputCalendar: calendarExample},
         },
       ],
-    }).compileComponents();
+    });
 
     adapter = TestBed.inject(DateAdapter);
   }));

--- a/src/material-moment-adapter/adapter/moment-date-adapter.spec.ts
+++ b/src/material-moment-adapter/adapter/moment-date-adapter.spec.ts
@@ -25,7 +25,7 @@ describe('MomentDateAdapter', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [MomentDateModule],
-    }).compileComponents();
+    });
   }));
 
   beforeEach(inject([DateAdapter], (dateAdapter: MomentDateAdapter) => {
@@ -543,7 +543,7 @@ describe('MomentDateAdapter with MAT_DATE_LOCALE override', () => {
     TestBed.configureTestingModule({
       imports: [MomentDateModule],
       providers: [{provide: MAT_DATE_LOCALE, useValue: 'ja-JP'}],
-    }).compileComponents();
+    });
   }));
 
   beforeEach(inject([DateAdapter], (d: MomentDateAdapter) => {
@@ -562,7 +562,7 @@ describe('MomentDateAdapter with LOCALE_ID override', () => {
     TestBed.configureTestingModule({
       imports: [MomentDateModule],
       providers: [{provide: LOCALE_ID, useValue: 'fr'}],
-    }).compileComponents();
+    });
   }));
 
   beforeEach(inject([DateAdapter], (d: MomentDateAdapter) => {
@@ -586,7 +586,7 @@ describe('MomentDateAdapter with MAT_MOMENT_DATE_ADAPTER_OPTIONS override', () =
           useValue: {useUtc: true},
         },
       ],
-    }).compileComponents();
+    });
   }));
 
   beforeEach(inject([DateAdapter], (d: MomentDateAdapter) => {
@@ -624,7 +624,7 @@ describe('MomentDateAdapter with MAT_MOMENT_DATE_ADAPTER_OPTIONS override', () =
             },
           },
         ],
-      }).compileComponents();
+      });
     }));
 
     beforeEach(inject([DateAdapter], (d: MomentDateAdapter) => {

--- a/src/material/autocomplete/autocomplete.spec.ts
+++ b/src/material/autocomplete/autocomplete.spec.ts
@@ -73,8 +73,6 @@ describe('MDC-based MatAutocomplete', () => {
       declarations: [component],
     });
 
-    TestBed.compileComponents();
-
     inject([OverlayContainer], (oc: OverlayContainer) => {
       overlayContainerElement = oc.getContainerElement();
     })();

--- a/src/material/autocomplete/autocomplete.zone.spec.ts
+++ b/src/material/autocomplete/autocomplete.zone.spec.ts
@@ -39,8 +39,6 @@ describe('MDC-based MatAutocomplete Zone.js integration', () => {
       declarations: [component],
     });
 
-    TestBed.compileComponents();
-
     return TestBed.createComponent<T>(component);
   }
 

--- a/src/material/autocomplete/testing/autocomplete-harness.spec.ts
+++ b/src/material/autocomplete/testing/autocomplete-harness.spec.ts
@@ -10,10 +10,10 @@ describe('MatAutocompleteHarness', () => {
   let fixture: ComponentFixture<AutocompleteHarnessTest>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [NoopAnimationsModule, MatAutocompleteModule, AutocompleteHarnessTest],
-    }).compileComponents();
+    });
 
     fixture = TestBed.createComponent(AutocompleteHarnessTest);
     fixture.detectChanges();

--- a/src/material/badge/badge.spec.ts
+++ b/src/material/badge/badge.spec.ts
@@ -12,8 +12,8 @@ describe('MatBadge', () => {
   describe('on an interative host', () => {
     let testComponent: BadgeOnInteractiveElement;
 
-    beforeEach(async () => {
-      await TestBed.configureTestingModule({
+    beforeEach(() => {
+      TestBed.configureTestingModule({
         imports: [
           MatBadgeModule,
           BadgeOnInteractiveElement,
@@ -21,7 +21,7 @@ describe('MatBadge', () => {
           NestedBadge,
           BadgeOnTemplate,
         ],
-      }).compileComponents();
+      });
 
       fixture = TestBed.createComponent(BadgeOnInteractiveElement);
       testComponent = fixture.debugElement.componentInstance;
@@ -230,10 +230,10 @@ describe('MatBadge', () => {
   describe('on an non-interactive host', () => {
     let testComponent: BadgeOnNonInteractiveElement;
 
-    beforeEach(async () => {
-      await TestBed.configureTestingModule({
+    beforeEach(() => {
+      TestBed.configureTestingModule({
         imports: [MatBadgeModule, BadgeOnNonInteractiveElement],
-      }).compileComponents();
+      });
 
       fixture = TestBed.createComponent(BadgeOnNonInteractiveElement);
       testComponent = fixture.debugElement.componentInstance;

--- a/src/material/badge/testing/badge-harness.spec.ts
+++ b/src/material/badge/testing/badge-harness.spec.ts
@@ -9,10 +9,10 @@ describe('MatBadgeHarness', () => {
   let fixture: ComponentFixture<BadgeHarnessTest>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatBadgeModule, BadgeHarnessTest],
-    }).compileComponents();
+    });
 
     fixture = TestBed.createComponent(BadgeHarnessTest);
     fixture.detectChanges();

--- a/src/material/bottom-sheet/bottom-sheet.spec.ts
+++ b/src/material/bottom-sheet/bottom-sheet.spec.ts
@@ -62,7 +62,7 @@ describe('MatBottomSheet', () => {
         ShadowDomComponent,
       ],
       providers: [{provide: Location, useClass: SpyLocation}],
-    }).compileComponents();
+    });
   }));
 
   beforeEach(inject(
@@ -871,7 +871,7 @@ describe('MatBottomSheet with parent MatBottomSheet', () => {
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
       imports: [MatBottomSheetModule, NoopAnimationsModule, ComponentThatProvidesMatBottomSheet],
-    }).compileComponents();
+    });
   }));
 
   beforeEach(inject(
@@ -963,8 +963,6 @@ describe('MatBottomSheet with default options', () => {
       ],
       providers: [{provide: MAT_BOTTOM_SHEET_DEFAULT_OPTIONS, useValue: defaultConfig}],
     });
-
-    TestBed.compileComponents();
   }));
 
   beforeEach(inject(

--- a/src/material/bottom-sheet/testing/bottom-sheet-harness.spec.ts
+++ b/src/material/bottom-sheet/testing/bottom-sheet-harness.spec.ts
@@ -14,10 +14,10 @@ describe('MatBottomSheetHarness', () => {
   let fixture: ComponentFixture<BottomSheetHarnessTest>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatBottomSheetModule, NoopAnimationsModule, BottomSheetHarnessTest],
-    }).compileComponents();
+    });
 
     fixture = TestBed.createComponent(BottomSheetHarnessTest);
     fixture.detectChanges();

--- a/src/material/button-toggle/button-toggle.spec.ts
+++ b/src/material/button-toggle/button-toggle.spec.ts
@@ -26,8 +26,6 @@ describe('MatButtonToggle with forms', () => {
         ButtonToggleGroupWithFormControlAndDynamicButtons,
       ],
     });
-
-    TestBed.compileComponents();
   }));
 
   describe('using FormControl', () => {
@@ -334,8 +332,6 @@ describe('MatButtonToggle without forms', () => {
         ButtonToggleWithStaticAriaAttributes,
       ],
     });
-
-    TestBed.compileComponents();
   }));
 
   describe('inside of an exclusive selection group', () => {
@@ -942,8 +938,6 @@ describe('MatButtonToggle without forms', () => {
           },
         ],
       });
-
-      TestBed.compileComponents();
     });
 
     it('should hide checkmark indicator for single selection', () => {

--- a/src/material/button-toggle/testing/button-toggle-group.spec.ts
+++ b/src/material/button-toggle/testing/button-toggle-group.spec.ts
@@ -9,10 +9,10 @@ describe('MatButtonToggleGroupHarness', () => {
   let fixture: ComponentFixture<ButtonToggleGroupHarnessTest>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatButtonToggleModule, ButtonToggleGroupHarnessTest],
-    }).compileComponents();
+    });
 
     fixture = TestBed.createComponent(ButtonToggleGroupHarnessTest);
     fixture.detectChanges();

--- a/src/material/button-toggle/testing/button-toggle-harness.spec.ts
+++ b/src/material/button-toggle/testing/button-toggle-harness.spec.ts
@@ -9,10 +9,10 @@ describe('MatButtonToggleHarness', () => {
   let fixture: ComponentFixture<ButtonToggleHarnessTest>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatButtonToggleModule, ButtonToggleHarnessTest],
-    }).compileComponents();
+    });
 
     fixture = TestBed.createComponent(ButtonToggleHarnessTest);
     fixture.detectChanges();

--- a/src/material/button/button.spec.ts
+++ b/src/material/button/button.spec.ts
@@ -16,8 +16,6 @@ describe('MDC-based MatButton', () => {
     TestBed.configureTestingModule({
       imports: [MatButtonModule, TestApp],
     });
-
-    TestBed.compileComponents();
   }));
 
   // General button tests
@@ -454,8 +452,6 @@ describe('MatFabDefaultOptions', () => {
       imports: [MatButtonModule, TestApp],
       providers: [{provide: MAT_FAB_DEFAULT_OPTIONS, useValue: defaults}],
     });
-
-    TestBed.compileComponents();
   }
 
   it('should override default color in component', () => {

--- a/src/material/button/testing/button-harness.spec.ts
+++ b/src/material/button/testing/button-harness.spec.ts
@@ -13,10 +13,10 @@ describe('MatButtonHarness', () => {
   let loader: HarnessLoader;
   let platform: Platform;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatButtonModule, MatIconModule, PlatformModule, ButtonHarnessTest],
-    }).compileComponents();
+    });
 
     fixture = TestBed.createComponent(ButtonHarnessTest);
     fixture.detectChanges();

--- a/src/material/card/card.spec.ts
+++ b/src/material/card/card.spec.ts
@@ -8,7 +8,7 @@ describe('MDC-based MatCard', () => {
     TestBed.configureTestingModule({
       imports: [MatCardModule, component],
       providers,
-    }).compileComponents();
+    });
 
     return TestBed.createComponent<T>(component);
   }

--- a/src/material/card/testing/card-harness.spec.ts
+++ b/src/material/card/testing/card-harness.spec.ts
@@ -9,10 +9,10 @@ describe('MatCardHarness', () => {
   let fixture: ComponentFixture<CardHarnessTest>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatCardModule, CardHarnessTest],
-    }).compileComponents();
+    });
 
     fixture = TestBed.createComponent(CardHarnessTest);
     fixture.detectChanges();

--- a/src/material/checkbox/checkbox.spec.ts
+++ b/src/material/checkbox/checkbox.spec.ts
@@ -18,7 +18,7 @@ describe('MDC-based MatCheckbox', () => {
   function createComponent<T>(componentType: Type<T>) {
     TestBed.configureTestingModule({
       imports: [MatCheckboxModule, FormsModule, ReactiveFormsModule, componentType],
-    }).compileComponents();
+    });
 
     return TestBed.createComponent<T>(componentType);
   }
@@ -1096,8 +1096,6 @@ describe('MatCheckboxDefaultOptions', () => {
         imports: [MatCheckboxModule, FormsModule, SingleCheckbox, SingleCheckbox],
         providers: [{provide: MAT_CHECKBOX_DEFAULT_OPTIONS, useValue: defaults}],
       });
-
-      TestBed.compileComponents();
     }
 
     it('should override default color in component', () => {

--- a/src/material/checkbox/testing/checkbox-harness.spec.ts
+++ b/src/material/checkbox/testing/checkbox-harness.spec.ts
@@ -10,10 +10,10 @@ describe('MatCheckboxHarness', () => {
   let fixture: ComponentFixture<CheckboxHarnessTest>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatCheckboxModule, ReactiveFormsModule, CheckboxHarnessTest],
-    }).compileComponents();
+    });
 
     fixture = TestBed.createComponent(CheckboxHarnessTest);
     fixture.detectChanges();

--- a/src/material/chips/chip-edit-input.spec.ts
+++ b/src/material/chips/chip-edit-input.spec.ts
@@ -15,8 +15,6 @@ describe('MDC-based MatChipEditInput', () => {
       imports: [MatChipsModule, ChipEditInputContainer],
     });
 
-    TestBed.compileComponents();
-
     fixture = TestBed.createComponent(ChipEditInputContainer);
     inputDebugElement = fixture.debugElement.query(By.directive(MatChipEditInput))!;
     inputInstance = inputDebugElement.injector.get<MatChipEditInput>(MatChipEditInput);

--- a/src/material/chips/chip-grid.spec.ts
+++ b/src/material/chips/chip-grid.spec.ts
@@ -1056,7 +1056,7 @@ describe('MDC-based MatChipGrid', () => {
       ],
       providers: [{provide: Directionality, useValue: directionality}],
       declarations: [component],
-    }).compileComponents();
+    });
 
     const fixture = TestBed.createComponent<T>(component);
     fixture.detectChanges();

--- a/src/material/chips/chip-input.spec.ts
+++ b/src/material/chips/chip-input.spec.ts
@@ -41,8 +41,6 @@ describe('MDC-based MatChipInput', () => {
       ],
       declarations: [TestChipInput],
     });
-
-    TestBed.compileComponents();
   }));
 
   beforeEach(waitForAsync(() => {
@@ -195,18 +193,16 @@ describe('MDC-based MatChipInput', () => {
     it('emits (chipEnd) when the separator keys are configured globally', () => {
       fixture.destroy();
 
-      TestBed.resetTestingModule()
-        .configureTestingModule({
-          imports: [MatChipsModule, MatFormFieldModule, PlatformModule, NoopAnimationsModule],
-          declarations: [TestChipInput],
-          providers: [
-            {
-              provide: MAT_CHIPS_DEFAULT_OPTIONS,
-              useValue: {separatorKeyCodes: [COMMA]} as MatChipsDefaultOptions,
-            },
-          ],
-        })
-        .compileComponents();
+      TestBed.resetTestingModule().configureTestingModule({
+        imports: [MatChipsModule, MatFormFieldModule, PlatformModule, NoopAnimationsModule],
+        declarations: [TestChipInput],
+        providers: [
+          {
+            provide: MAT_CHIPS_DEFAULT_OPTIONS,
+            useValue: {separatorKeyCodes: [COMMA]} as MatChipsDefaultOptions,
+          },
+        ],
+      });
 
       fixture = TestBed.createComponent(TestChipInput);
       testChipInput = fixture.debugElement.componentInstance;

--- a/src/material/chips/chip-listbox.spec.ts
+++ b/src/material/chips/chip-listbox.spec.ts
@@ -870,7 +870,7 @@ describe('MDC-based MatChipListbox', () => {
       imports: [FormsModule, ReactiveFormsModule, MatChipsModule],
       providers: [{provide: Directionality, useValue: directionality}],
       declarations: [component],
-    }).compileComponents();
+    });
 
     fixture = TestBed.createComponent<T>(component);
     beforeInitialChangeDetection?.(fixture);

--- a/src/material/chips/chip-option.spec.ts
+++ b/src/material/chips/chip-option.spec.ts
@@ -49,8 +49,6 @@ describe('MDC-based Option Chips', () => {
       ],
       declarations: [SingleChip],
     });
-
-    TestBed.compileComponents();
   }));
 
   describe('MatChipOption', () => {

--- a/src/material/chips/chip-remove.spec.ts
+++ b/src/material/chips/chip-remove.spec.ts
@@ -14,8 +14,6 @@ describe('MDC-based Chip Remove', () => {
     TestBed.configureTestingModule({
       imports: [MatChipsModule, TestChip],
     });
-
-    TestBed.compileComponents();
   }));
 
   beforeEach(waitForAsync(() => {

--- a/src/material/chips/chip-row.spec.ts
+++ b/src/material/chips/chip-row.spec.ts
@@ -40,8 +40,6 @@ describe('MDC-based Row Chips', () => {
         },
       ],
     });
-
-    TestBed.compileComponents();
   }));
 
   describe('MatChipRow', () => {

--- a/src/material/chips/chip-set.spec.ts
+++ b/src/material/chips/chip-set.spec.ts
@@ -9,8 +9,6 @@ describe('MDC-based MatChipSet', () => {
     TestBed.configureTestingModule({
       imports: [MatChipsModule, CommonModule, BasicChipSet, IndirectDescendantsChipSet],
     });
-
-    TestBed.compileComponents();
   }));
 
   describe('BasicChipSet', () => {

--- a/src/material/chips/chip.spec.ts
+++ b/src/material/chips/chip.spec.ts
@@ -32,8 +32,6 @@ describe('MDC-based MatChip', () => {
         },
       ],
     });
-
-    TestBed.compileComponents();
   }));
 
   describe('MatBasicChip', () => {

--- a/src/material/chips/testing/chip-grid-harness.spec.ts
+++ b/src/material/chips/testing/chip-grid-harness.spec.ts
@@ -10,10 +10,10 @@ describe('MatChipGridHarness', () => {
   let fixture: ComponentFixture<ChipGridHarnessTest>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatChipsModule, ReactiveFormsModule, ChipGridHarnessTest],
-    }).compileComponents();
+    });
 
     fixture = TestBed.createComponent(ChipGridHarnessTest);
     fixture.detectChanges();

--- a/src/material/chips/testing/chip-harness.spec.ts
+++ b/src/material/chips/testing/chip-harness.spec.ts
@@ -11,10 +11,10 @@ describe('MatChipHarness', () => {
   let fixture: ComponentFixture<ChipHarnessTest>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatChipsModule, MatIconModule, ChipHarnessTest],
-    }).compileComponents();
+    });
 
     fixture = TestBed.createComponent(ChipHarnessTest);
     fixture.detectChanges();

--- a/src/material/chips/testing/chip-input-harness.spec.ts
+++ b/src/material/chips/testing/chip-input-harness.spec.ts
@@ -10,10 +10,10 @@ describe('MatChipInputHarness', () => {
   let fixture: ComponentFixture<ChipInputHarnessTest>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatChipsModule, ChipInputHarnessTest],
-    }).compileComponents();
+    });
 
     fixture = TestBed.createComponent(ChipInputHarnessTest);
     fixture.detectChanges();

--- a/src/material/chips/testing/chip-listbox-harness.spec.ts
+++ b/src/material/chips/testing/chip-listbox-harness.spec.ts
@@ -9,10 +9,10 @@ describe('MatChipListboxHarness', () => {
   let fixture: ComponentFixture<ChipListboxHarnessTest>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatChipsModule, ChipListboxHarnessTest],
-    }).compileComponents();
+    });
 
     fixture = TestBed.createComponent(ChipListboxHarnessTest);
     fixture.detectChanges();

--- a/src/material/chips/testing/chip-option-harness.spec.ts
+++ b/src/material/chips/testing/chip-option-harness.spec.ts
@@ -9,10 +9,10 @@ describe('MatChipOptionHarness', () => {
   let fixture: ComponentFixture<ChipOptionHarnessTest>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatChipsModule, ChipOptionHarnessTest],
-    }).compileComponents();
+    });
 
     fixture = TestBed.createComponent(ChipOptionHarnessTest);
     fixture.detectChanges();

--- a/src/material/chips/testing/chip-row-harness.spec.ts
+++ b/src/material/chips/testing/chip-row-harness.spec.ts
@@ -9,10 +9,10 @@ describe('MatChipRowHarness', () => {
   let fixture: ComponentFixture<ChipRowHarnessTest>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatChipsModule, ChipRowHarnessTest],
-    }).compileComponents();
+    });
 
     fixture = TestBed.createComponent(ChipRowHarnessTest);
     fixture.detectChanges();

--- a/src/material/chips/testing/chip-set-harness.spec.ts
+++ b/src/material/chips/testing/chip-set-harness.spec.ts
@@ -9,10 +9,10 @@ describe('MatChipSetHarness', () => {
   let fixture: ComponentFixture<ChipSetHarnessTest>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatChipsModule, ChipSetHarnessTest],
-    }).compileComponents();
+    });
 
     fixture = TestBed.createComponent(ChipSetHarnessTest);
     fixture.detectChanges();

--- a/src/material/core/datetime/native-date-adapter.spec.ts
+++ b/src/material/core/datetime/native-date-adapter.spec.ts
@@ -10,7 +10,7 @@ describe('NativeDateAdapter', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [NativeDateModule],
-    }).compileComponents();
+    });
   }));
 
   beforeEach(inject([DateAdapter], (dateAdapter: NativeDateAdapter) => {
@@ -473,7 +473,7 @@ describe('NativeDateAdapter with MAT_DATE_LOCALE override', () => {
     TestBed.configureTestingModule({
       imports: [NativeDateModule],
       providers: [{provide: MAT_DATE_LOCALE, useValue: 'da-DK'}],
-    }).compileComponents();
+    });
   }));
 
   beforeEach(inject([DateAdapter], (d: NativeDateAdapter) => {
@@ -493,7 +493,7 @@ describe('NativeDateAdapter with LOCALE_ID override', () => {
     TestBed.configureTestingModule({
       imports: [NativeDateModule],
       providers: [{provide: LOCALE_ID, useValue: 'da-DK'}],
-    }).compileComponents();
+    });
   }));
 
   beforeEach(inject([DateAdapter], (d: NativeDateAdapter) => {

--- a/src/material/core/option/option.spec.ts
+++ b/src/material/core/option/option.spec.ts
@@ -14,7 +14,7 @@ describe('MatOption component', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [MatOptionModule, BasicOption],
-    }).compileComponents();
+    });
   }));
 
   it('should complete the `stateChanges` stream on destroy', () => {
@@ -221,7 +221,7 @@ describe('MatOption component', () => {
             useValue: {inertGroups: true},
           },
         ],
-      }).compileComponents();
+      });
 
       fixture = TestBed.createComponent(InsideGroup);
       fixture.detectChanges();

--- a/src/material/core/testing/optgroup-harness.spec.ts
+++ b/src/material/core/testing/optgroup-harness.spec.ts
@@ -9,10 +9,10 @@ describe('MatOptgroupHarness', () => {
   let fixture: ComponentFixture<OptgroupHarnessTest>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatOptionModule, OptgroupHarnessTest],
-    }).compileComponents();
+    });
 
     fixture = TestBed.createComponent(OptgroupHarnessTest);
     fixture.detectChanges();

--- a/src/material/core/testing/option-harness.spec.ts
+++ b/src/material/core/testing/option-harness.spec.ts
@@ -14,10 +14,10 @@ describe('MatOptionHarness', () => {
   let fixture: ComponentFixture<OptionHarnessTest>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatOptionModule, OptionHarnessTest],
-    }).compileComponents();
+    });
 
     fixture = TestBed.createComponent(OptionHarnessTest);
     fixture.detectChanges();

--- a/src/material/datepicker/calendar-body.spec.ts
+++ b/src/material/datepicker/calendar-body.spec.ts
@@ -13,8 +13,6 @@ describe('MatCalendarBody', () => {
     TestBed.configureTestingModule({
       imports: [MatCalendarBody, StandardCalendarBody, RangeCalendarBody],
     });
-
-    TestBed.compileComponents();
   }));
 
   describe('standard calendar body', () => {

--- a/src/material/datepicker/calendar-header.spec.ts
+++ b/src/material/datepicker/calendar-header.spec.ts
@@ -21,8 +21,6 @@ describe('MatCalendarHeader', () => {
       ],
       providers: [MatDatepickerIntl, {provide: Directionality, useFactory: () => ({value: 'ltr'})}],
     });
-
-    TestBed.compileComponents();
   }));
 
   describe('standard calendar', () => {

--- a/src/material/datepicker/calendar.spec.ts
+++ b/src/material/datepicker/calendar.spec.ts
@@ -27,8 +27,6 @@ describe('MatCalendar', () => {
         CalendarWithSelectableMinDate,
       ],
     });
-
-    TestBed.compileComponents();
   }));
 
   describe('standard calendar', () => {

--- a/src/material/datepicker/month-view.spec.ts
+++ b/src/material/datepicker/month-view.spec.ts
@@ -52,8 +52,6 @@ describe('MatMonthView', () => {
           {provide: MAT_DATE_RANGE_SELECTION_STRATEGY, useClass: DefaultMatCalendarRangeStrategy},
         ],
       });
-
-      TestBed.compileComponents();
     }));
 
     describe('standard month view', () => {
@@ -834,8 +832,6 @@ describe('MatMonthView', () => {
           },
         ],
       });
-
-      TestBed.compileComponents();
 
       fixture = TestBed.createComponent(StandardMonthView);
       fixture.detectChanges();

--- a/src/material/datepicker/multi-year-view.spec.ts
+++ b/src/material/datepicker/multi-year-view.spec.ts
@@ -35,8 +35,6 @@ describe('MatMultiYearView', () => {
       ],
       providers: [{provide: Directionality, useFactory: () => (dir = {value: 'ltr'})}],
     });
-
-    TestBed.compileComponents();
   }));
 
   describe('standard multi-year view', () => {

--- a/src/material/datepicker/testing/calendar-harness.spec.ts
+++ b/src/material/datepicker/testing/calendar-harness.spec.ts
@@ -18,8 +18,8 @@ describe('MatCalendarHarness', () => {
   let fixture: ComponentFixture<CalendarHarnessTest>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatNativeDateModule, MatDatepickerModule, CalendarHarnessTest],
       providers: [
         {
@@ -29,7 +29,7 @@ describe('MatCalendarHarness', () => {
           useClass: DefaultMatCalendarRangeStrategy,
         },
       ],
-    }).compileComponents();
+    });
 
     fixture = TestBed.createComponent(CalendarHarnessTest);
     fixture.detectChanges();

--- a/src/material/datepicker/testing/date-range-input-harness.spec.ts
+++ b/src/material/datepicker/testing/date-range-input-harness.spec.ts
@@ -23,8 +23,8 @@ describe('matDateRangeInputHarness', () => {
   let fixture: ComponentFixture<DateRangeInputHarnessTest>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [
         NoopAnimationsModule,
         MatNativeDateModule,
@@ -32,7 +32,7 @@ describe('matDateRangeInputHarness', () => {
         FormsModule,
         DateRangeInputHarnessTest,
       ],
-    }).compileComponents();
+    });
 
     fixture = TestBed.createComponent(DateRangeInputHarnessTest);
     fixture.detectChanges();

--- a/src/material/datepicker/testing/datepicker-input-harness.spec.ts
+++ b/src/material/datepicker/testing/datepicker-input-harness.spec.ts
@@ -13,8 +13,8 @@ describe('MatDatepickerInputHarness', () => {
   let fixture: ComponentFixture<DatepickerInputHarnessTest>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [
         NoopAnimationsModule,
         MatNativeDateModule,
@@ -22,7 +22,7 @@ describe('MatDatepickerInputHarness', () => {
         FormsModule,
         DatepickerInputHarnessTest,
       ],
-    }).compileComponents();
+    });
 
     fixture = TestBed.createComponent(DatepickerInputHarnessTest);
     fixture.detectChanges();

--- a/src/material/datepicker/testing/datepicker-toggle-harness.spec.ts
+++ b/src/material/datepicker/testing/datepicker-toggle-harness.spec.ts
@@ -12,15 +12,15 @@ describe('MatDatepickerToggleHarness', () => {
   let fixture: ComponentFixture<DatepickerToggleHarnessTest>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [
         NoopAnimationsModule,
         MatNativeDateModule,
         MatDatepickerModule,
         DatepickerToggleHarnessTest,
       ],
-    }).compileComponents();
+    });
 
     fixture = TestBed.createComponent(DatepickerToggleHarnessTest);
     fixture.detectChanges();

--- a/src/material/datepicker/year-view.spec.ts
+++ b/src/material/datepicker/year-view.spec.ts
@@ -34,8 +34,6 @@ describe('MatYearView', () => {
       ],
       providers: [{provide: Directionality, useFactory: () => (dir = {value: 'ltr'})}],
     });
-
-    TestBed.compileComponents();
   }));
 
   describe('standard year view', () => {

--- a/src/material/dialog/dialog.spec.ts
+++ b/src/material/dialog/dialog.spec.ts
@@ -93,8 +93,6 @@ describe('MDC-based MatDialog', () => {
         },
       ],
     });
-
-    TestBed.compileComponents();
   }));
 
   beforeEach(inject(
@@ -1912,8 +1910,6 @@ describe('MDC-based MatDialog with a parent MatDialog', () => {
         {provide: Location, useClass: SpyLocation},
       ],
     });
-
-    TestBed.compileComponents();
   }));
 
   beforeEach(inject([MatDialog], (d: MatDialog) => {
@@ -2021,8 +2017,6 @@ describe('MDC-based MatDialog with default options', () => {
       ],
       providers: [{provide: MAT_DIALOG_DEFAULT_OPTIONS, useValue: defaultConfig}],
     });
-
-    TestBed.compileComponents();
   }));
 
   beforeEach(inject([MatDialog, OverlayContainer], (d: MatDialog, oc: OverlayContainer) => {
@@ -2092,8 +2086,6 @@ describe('MDC-based MatDialog with animations enabled', () => {
         DirectiveWithViewContainer,
       ],
     });
-
-    TestBed.compileComponents();
   }));
 
   beforeEach(inject([MatDialog], (d: MatDialog) => {
@@ -2151,8 +2143,6 @@ describe('MatDialog with explicit injector provided', () => {
     TestBed.configureTestingModule({
       imports: [MatDialogModule, BrowserAnimationsModule, ModuleBoundDialogParentComponent],
     });
-
-    TestBed.compileComponents();
   }));
 
   beforeEach(inject([OverlayContainer], (oc: OverlayContainer) => {

--- a/src/material/dialog/dialog.zone.spec.ts
+++ b/src/material/dialog/dialog.zone.spec.ts
@@ -44,8 +44,6 @@ describe('MDC-based MatDialog', () => {
         },
       ],
     });
-
-    TestBed.compileComponents();
   }));
 
   beforeEach(inject([MatDialog], (d: MatDialog) => {

--- a/src/material/dialog/testing/dialog-harness.spec.ts
+++ b/src/material/dialog/testing/dialog-harness.spec.ts
@@ -16,10 +16,10 @@ describe('MatDialogHarness', () => {
   let fixture: ComponentFixture<DialogHarnessTest>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [NoopAnimationsModule],
-    }).compileComponents();
+    });
 
     fixture = TestBed.createComponent(DialogHarnessTest);
     fixture.detectChanges();

--- a/src/material/dialog/testing/dialog-opener.spec.ts
+++ b/src/material/dialog/testing/dialog-opener.spec.ts
@@ -9,8 +9,6 @@ describe('MDC-based MatTestDialogOpener', () => {
     TestBed.configureTestingModule({
       imports: [MatTestDialogOpenerModule, NoopAnimationsModule, ExampleComponent],
     });
-
-    TestBed.compileComponents();
   }));
 
   it('should open a dialog when created', fakeAsync(() => {

--- a/src/material/divider/divider.spec.ts
+++ b/src/material/divider/divider.spec.ts
@@ -11,7 +11,6 @@ describe('MatDivider', () => {
       imports: [MatDividerModule, MatDividerTestComponent],
     });
 
-    TestBed.compileComponents();
     fixture = TestBed.createComponent(MatDividerTestComponent);
   }));
 

--- a/src/material/divider/testing/divider-harness.spec.ts
+++ b/src/material/divider/testing/divider-harness.spec.ts
@@ -9,10 +9,10 @@ describe('MatLegacyButtonHarness', () => {
   let fixture: ComponentFixture<DividerHarnessTest>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatDividerModule, DividerHarnessTest],
-    }).compileComponents();
+    });
 
     fixture = TestBed.createComponent(DividerHarnessTest);
     fixture.detectChanges();

--- a/src/material/expansion/accordion.spec.ts
+++ b/src/material/expansion/accordion.spec.ts
@@ -31,7 +31,6 @@ describe('MatAccordion', () => {
         NestedAccordions,
       ],
     });
-    TestBed.compileComponents();
 
     inject([FocusMonitor], (fm: FocusMonitor) => {
       focusMonitor = fm;

--- a/src/material/expansion/expansion.spec.ts
+++ b/src/material/expansion/expansion.spec.ts
@@ -38,7 +38,6 @@ describe('MatExpansionPanel', () => {
         NestedLazyPanelWithContent,
       ],
     });
-    TestBed.compileComponents();
   }));
 
   it('should expand and collapse the panel', fakeAsync(() => {
@@ -419,21 +418,19 @@ describe('MatExpansionPanel', () => {
   }));
 
   it('should be able to set the default options through the injection token', () => {
-    TestBed.resetTestingModule()
-      .configureTestingModule({
-        imports: [MatExpansionModule, NoopAnimationsModule],
-        providers: [
-          {
-            provide: MAT_EXPANSION_PANEL_DEFAULT_OPTIONS,
-            useValue: {
-              hideToggle: true,
-              expandedHeight: '10px',
-              collapsedHeight: '16px',
-            },
+    TestBed.resetTestingModule().configureTestingModule({
+      imports: [MatExpansionModule, NoopAnimationsModule],
+      providers: [
+        {
+          provide: MAT_EXPANSION_PANEL_DEFAULT_OPTIONS,
+          useValue: {
+            hideToggle: true,
+            expandedHeight: '10px',
+            collapsedHeight: '16px',
           },
-        ],
-      })
-      .compileComponents();
+        },
+      ],
+    });
 
     const fixture = TestBed.createComponent(PanelWithTwoWayBinding);
     fixture.detectChanges();

--- a/src/material/expansion/testing/expansion-harness.spec.ts
+++ b/src/material/expansion/testing/expansion-harness.spec.ts
@@ -11,10 +11,10 @@ describe('MatExpansionHarness', () => {
   let fixture: ComponentFixture<ExpansionHarnessTestComponent>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatExpansionModule, NoopAnimationsModule, ExpansionHarnessTestComponent],
-    }).compileComponents();
+    });
 
     fixture = TestBed.createComponent(ExpansionHarnessTestComponent);
     fixture.detectChanges();

--- a/src/material/form-field/testing/form-field-harness.spec.ts
+++ b/src/material/form-field/testing/form-field-harness.spec.ts
@@ -39,15 +39,15 @@ describe('MatFormFieldHarness', () => {
   let fixture: ComponentFixture<FormFieldHarnessTest>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [
         NoopAnimationsModule,
         MatNativeDateModule,
         FormFieldHarnessTest,
         MatDatepickerModule,
       ],
-    }).compileComponents();
+    });
 
     fixture = TestBed.createComponent(FormFieldHarnessTest);
     fixture.detectChanges();

--- a/src/material/grid-list/grid-list.spec.ts
+++ b/src/material/grid-list/grid-list.spec.ts
@@ -10,7 +10,7 @@ describe('MatGridList', () => {
     TestBed.configureTestingModule({
       imports: [MatGridListModule],
       declarations: [componentType],
-    }).compileComponents();
+    });
 
     return TestBed.createComponent<T>(componentType);
   }

--- a/src/material/grid-list/testing/grid-list-harness.spec.ts
+++ b/src/material/grid-list/testing/grid-list-harness.spec.ts
@@ -11,10 +11,10 @@ describe('MatGridListHarness', () => {
   let fixture: ComponentFixture<GridListHarnessTest>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatGridListModule, NoopAnimationsModule, GridListHarnessTest],
-    }).compileComponents();
+    });
 
     fixture = TestBed.createComponent(GridListHarnessTest);
     fixture.detectChanges();

--- a/src/material/icon/icon.spec.ts
+++ b/src/material/icon/icon.spec.ts
@@ -48,8 +48,6 @@ function createComponent<T>(component: Type<T>, providers: Provider[] = []) {
     providers: [...providers],
   });
 
-  TestBed.compileComponents();
-
   return TestBed.createComponent<T>(component);
 }
 
@@ -88,8 +86,6 @@ describe('MatIcon', () => {
         },
       ],
     });
-
-    TestBed.compileComponents();
 
     iconRegistry = TestBed.inject(MatIconRegistry);
     http = TestBed.inject(HttpTestingController);
@@ -1378,8 +1374,6 @@ describe('MatIcon without HttpClientModule', () => {
       imports: [MatIconModule],
       declarations: [IconFromSvgName],
     });
-
-    TestBed.compileComponents();
   }));
 
   beforeEach(inject([MatIconRegistry, DomSanitizer], (mir: MatIconRegistry, ds: DomSanitizer) => {

--- a/src/material/icon/testing/icon-harness.spec.ts
+++ b/src/material/icon/testing/icon-harness.spec.ts
@@ -11,10 +11,10 @@ describe('MatIconHarness', () => {
   let fixture: ComponentFixture<IconHarnessTest>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatIconModule, IconHarnessTest],
-    }).compileComponents();
+    });
 
     const registry = TestBed.inject(MatIconRegistry);
     const sanitizer = TestBed.inject(DomSanitizer);

--- a/src/material/input/input.spec.ts
+++ b/src/material/input/input.spec.ts
@@ -1625,7 +1625,7 @@ function configureTestingModule(
       },
       ...providers,
     ],
-  }).compileComponents();
+  });
 }
 
 function createComponent<T>(

--- a/src/material/input/testing/input-harness.spec.ts
+++ b/src/material/input/testing/input-harness.spec.ts
@@ -12,10 +12,10 @@ describe('MatInputHarness', () => {
   let fixture: ComponentFixture<InputHarnessTest>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [NoopAnimationsModule, MatInputModule, FormsModule, InputHarnessTest],
-    }).compileComponents();
+    });
 
     fixture = TestBed.createComponent(InputHarnessTest);
     fixture.detectChanges();

--- a/src/material/input/testing/native-select-harness.spec.ts
+++ b/src/material/input/testing/native-select-harness.spec.ts
@@ -11,10 +11,10 @@ describe('MatNativeSelectHarness', () => {
   let fixture: ComponentFixture<SelectHarnessTest>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [NoopAnimationsModule, MatInputModule, FormsModule, SelectHarnessTest],
-    }).compileComponents();
+    });
 
     fixture = TestBed.createComponent(SelectHarnessTest);
     fixture.detectChanges();

--- a/src/material/list/list.spec.ts
+++ b/src/material/list/list.spec.ts
@@ -27,8 +27,6 @@ describe('MDC-based MatList', () => {
         StandaloneListItem,
       ],
     });
-
-    TestBed.compileComponents();
   }));
 
   it('should apply an additional class to lists without lines', () => {

--- a/src/material/list/selection-list.spec.ts
+++ b/src/material/list/selection-list.spec.ts
@@ -54,8 +54,6 @@ describe('MDC-based MatSelectionList without forms', () => {
           SelectionListWithSelectedOptionAndValue,
         ],
       });
-
-      TestBed.compileComponents();
     }));
 
     beforeEach(waitForAsync(() => {
@@ -688,8 +686,6 @@ describe('MDC-based MatSelectionList without forms', () => {
       TestBed.configureTestingModule({
         imports: [MatListModule, SelectionListWithSelectedOption],
       });
-
-      TestBed.compileComponents();
     }));
 
     beforeEach(waitForAsync(() => {
@@ -726,8 +722,6 @@ describe('MDC-based MatSelectionList without forms', () => {
       TestBed.configureTestingModule({
         imports: [MatListModule, SingleSelectionListWithSelectedOption],
       });
-
-      TestBed.compileComponents();
     }));
 
     beforeEach(waitForAsync(() => {
@@ -764,8 +758,6 @@ describe('MDC-based MatSelectionList without forms', () => {
         imports: [MatListModule, SingleSelectionListWithSelectedOption],
         providers: [{provide: MAT_LIST_CONFIG, useValue: matListConfig}],
       });
-
-      TestBed.compileComponents();
     }));
 
     beforeEach(waitForAsync(() => {
@@ -798,8 +790,6 @@ describe('MDC-based MatSelectionList without forms', () => {
       TestBed.configureTestingModule({
         imports: [MatListModule, SelectionListWithDisabledOption],
       });
-
-      TestBed.compileComponents();
     }));
 
     beforeEach(waitForAsync(() => {
@@ -853,8 +843,6 @@ describe('MDC-based MatSelectionList without forms', () => {
           SelectionListWithOnlyOneOption,
         ],
       });
-
-      TestBed.compileComponents();
     }));
 
     beforeEach(waitForAsync(() => {
@@ -954,8 +942,6 @@ describe('MDC-based MatSelectionList without forms', () => {
           SelectionListWithOnlyOneOption,
         ],
       });
-
-      TestBed.compileComponents();
     }));
 
     beforeEach(waitForAsync(() => {
@@ -977,7 +963,7 @@ describe('MDC-based MatSelectionList without forms', () => {
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [MatListModule, SelectionListWithAvatar, SelectionListWithIcon],
-      }).compileComponents();
+      });
     }));
 
     function expectCheckboxAtPosition(
@@ -1109,7 +1095,7 @@ describe('MDC-based MatSelectionList without forms', () => {
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [MatListModule, SelectionListWithListOptions],
-      }).compileComponents();
+      });
 
       fixture = TestBed.createComponent(SelectionListWithListOptions);
       fixture.componentInstance.multiple = false;
@@ -1235,7 +1221,7 @@ describe('MDC-based MatSelectionList without forms', () => {
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [MatListModule, ListOptionWithTwoWayBinding],
-      }).compileComponents();
+      });
 
       fixture = TestBed.createComponent(ListOptionWithTwoWayBinding);
       fixture.detectChanges();
@@ -1280,8 +1266,6 @@ describe('MDC-based MatSelectionList with forms', () => {
         SelectionListWithCustomComparator,
       ],
     });
-
-    TestBed.compileComponents();
   }));
 
   describe('and ngModel', () => {

--- a/src/material/list/testing/list-harness.spec.ts
+++ b/src/material/list/testing/list-harness.spec.ts
@@ -45,9 +45,9 @@ function runBaseListFunctionalityTests<
 
     beforeEach(async () => {
       const testComponent = testComponentFn();
-      await TestBed.configureTestingModule({
+      TestBed.configureTestingModule({
         imports: [MatListModule, testComponent],
-      }).compileComponents();
+      });
 
       fixture = TestBed.createComponent(testComponent);
       fixture.detectChanges();
@@ -319,9 +319,9 @@ describe('MatActionListHarness', () => {
     let fixture: ComponentFixture<ActionListHarnessTest>;
 
     beforeEach(async () => {
-      await TestBed.configureTestingModule({
+      TestBed.configureTestingModule({
         imports: [MatListModule, ActionListHarnessTest],
-      }).compileComponents();
+      });
 
       fixture = TestBed.createComponent(ActionListHarnessTest);
       fixture.detectChanges();
@@ -352,9 +352,9 @@ describe('MatNavListHarness', () => {
     let fixture: ComponentFixture<NavListHarnessTest>;
 
     beforeEach(async () => {
-      await TestBed.configureTestingModule({
+      TestBed.configureTestingModule({
         imports: [MatListModule, NavListHarnessTest],
-      }).compileComponents();
+      });
 
       fixture = TestBed.createComponent(NavListHarnessTest);
       fixture.detectChanges();
@@ -421,9 +421,9 @@ describe('MatSelectionListHarness', () => {
     let fixture: ComponentFixture<SelectionListHarnessTest>;
 
     beforeEach(async () => {
-      await TestBed.configureTestingModule({
+      TestBed.configureTestingModule({
         imports: [MatListModule, SelectionListHarnessTest],
-      }).compileComponents();
+      });
 
       fixture = TestBed.createComponent(SelectionListHarnessTest);
       fixture.detectChanges();

--- a/src/material/menu/menu.spec.ts
+++ b/src/material/menu/menu.spec.ts
@@ -66,7 +66,7 @@ describe('MDC-based MatMenu', () => {
       providers,
       imports: [MatMenuModule, NoopAnimationsModule],
       declarations: [component, ...declarations],
-    }).compileComponents();
+    });
 
     overlayContainerElement = TestBed.inject(OverlayContainer).getContainerElement();
     focusMonitor = TestBed.inject(FocusMonitor);
@@ -2725,7 +2725,7 @@ describe('MatMenu default overrides', () => {
         },
       ],
       declarations: [SimpleMenu, FakeIcon],
-    }).compileComponents();
+    });
   }));
 
   it('should allow for the default menu options to be overridden', fakeAsync(() => {

--- a/src/material/menu/testing/menu-harness.spec.ts
+++ b/src/material/menu/testing/menu-harness.spec.ts
@@ -11,10 +11,10 @@ describe('MatMenuHarness', () => {
     let fixture: ComponentFixture<MenuHarnessTest>;
     let loader: HarnessLoader;
 
-    beforeEach(async () => {
-      await TestBed.configureTestingModule({
+    beforeEach(() => {
+      TestBed.configureTestingModule({
         imports: [MatMenuModule, NoopAnimationsModule, MenuHarnessTest],
-      }).compileComponents();
+      });
 
       fixture = TestBed.createComponent(MenuHarnessTest);
       fixture.detectChanges();
@@ -91,10 +91,10 @@ describe('MatMenuHarness', () => {
     let fixture: ComponentFixture<NestedMenuHarnessTest>;
     let loader: HarnessLoader;
 
-    beforeEach(async () => {
-      await TestBed.configureTestingModule({
+    beforeEach(() => {
+      TestBed.configureTestingModule({
         imports: [MatMenuModule, NoopAnimationsModule, NestedMenuHarnessTest],
-      }).compileComponents();
+      });
 
       fixture = TestBed.createComponent(NestedMenuHarnessTest);
       fixture.detectChanges();

--- a/src/material/paginator/paginator.spec.ts
+++ b/src/material/paginator/paginator.spec.ts
@@ -19,7 +19,7 @@ describe('MDC-based MatPaginator', () => {
       imports: [MatPaginatorModule, NoopAnimationsModule],
       providers: [MatPaginatorIntl, ...providers],
       declarations: [type],
-    }).compileComponents();
+    });
 
     const fixture = TestBed.createComponent(type);
     fixture.detectChanges();

--- a/src/material/paginator/testing/paginator-harness.spec.ts
+++ b/src/material/paginator/testing/paginator-harness.spec.ts
@@ -11,10 +11,10 @@ describe('MatPaginatorHarness', () => {
   let loader: HarnessLoader;
   let instance: PaginatorHarnessTest;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatPaginatorModule, NoopAnimationsModule, PaginatorHarnessTest],
-    }).compileComponents();
+    });
 
     fixture = TestBed.createComponent(PaginatorHarnessTest);
     fixture.detectChanges();

--- a/src/material/progress-bar/progress-bar.spec.ts
+++ b/src/material/progress-bar/progress-bar.spec.ts
@@ -20,7 +20,7 @@ describe('MDC-based MatProgressBar', () => {
     TestBed.configureTestingModule({
       imports: [MatProgressBarModule, componentType],
       providers,
-    }).compileComponents();
+    });
 
     return TestBed.createComponent<T>(componentType);
   }

--- a/src/material/progress-bar/testing/progress-bar-harness.spec.ts
+++ b/src/material/progress-bar/testing/progress-bar-harness.spec.ts
@@ -9,10 +9,10 @@ describe('MatProgressBarHarness', () => {
   let fixture: ComponentFixture<ProgressBarHarnessTest>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatProgressBarModule, ProgressBarHarnessTest],
-    }).compileComponents();
+    });
 
     fixture = TestBed.createComponent(ProgressBarHarnessTest);
     fixture.detectChanges();

--- a/src/material/progress-spinner/progress-spinner.spec.ts
+++ b/src/material/progress-spinner/progress-spinner.spec.ts
@@ -23,7 +23,7 @@ describe('MDC-based MatProgressSpinner', () => {
         IndeterminateSpinnerInShadowDomWithNgIf,
         SpinnerWithMode,
       ],
-    }).compileComponents();
+    });
   }));
 
   it('should apply a mode of "determinate" if no mode is provided.', () => {
@@ -296,17 +296,15 @@ describe('MDC-based MatProgressSpinner', () => {
   });
 
   it('should be able to set a default diameter', () => {
-    TestBed.resetTestingModule()
-      .configureTestingModule({
-        imports: [MatProgressSpinnerModule, BasicProgressSpinner],
-        providers: [
-          {
-            provide: MAT_PROGRESS_SPINNER_DEFAULT_OPTIONS,
-            useValue: {diameter: 23},
-          },
-        ],
-      })
-      .compileComponents();
+    TestBed.resetTestingModule().configureTestingModule({
+      imports: [MatProgressSpinnerModule, BasicProgressSpinner],
+      providers: [
+        {
+          provide: MAT_PROGRESS_SPINNER_DEFAULT_OPTIONS,
+          useValue: {diameter: 23},
+        },
+      ],
+    });
 
     const fixture = TestBed.createComponent(BasicProgressSpinner);
     fixture.detectChanges();
@@ -316,17 +314,15 @@ describe('MDC-based MatProgressSpinner', () => {
   });
 
   it('should be able to set a default stroke width', () => {
-    TestBed.resetTestingModule()
-      .configureTestingModule({
-        imports: [MatProgressSpinnerModule, BasicProgressSpinner],
-        providers: [
-          {
-            provide: MAT_PROGRESS_SPINNER_DEFAULT_OPTIONS,
-            useValue: {strokeWidth: 7},
-          },
-        ],
-      })
-      .compileComponents();
+    TestBed.resetTestingModule().configureTestingModule({
+      imports: [MatProgressSpinnerModule, BasicProgressSpinner],
+      providers: [
+        {
+          provide: MAT_PROGRESS_SPINNER_DEFAULT_OPTIONS,
+          useValue: {strokeWidth: 7},
+        },
+      ],
+    });
 
     const fixture = TestBed.createComponent(BasicProgressSpinner);
     fixture.detectChanges();
@@ -336,17 +332,15 @@ describe('MDC-based MatProgressSpinner', () => {
   });
 
   it('should be able to set a default color', () => {
-    TestBed.resetTestingModule()
-      .configureTestingModule({
-        imports: [MatProgressSpinnerModule, BasicProgressSpinner],
-        providers: [
-          {
-            provide: MAT_PROGRESS_SPINNER_DEFAULT_OPTIONS,
-            useValue: {color: 'warn'},
-          },
-        ],
-      })
-      .compileComponents();
+    TestBed.resetTestingModule().configureTestingModule({
+      imports: [MatProgressSpinnerModule, BasicProgressSpinner],
+      providers: [
+        {
+          provide: MAT_PROGRESS_SPINNER_DEFAULT_OPTIONS,
+          useValue: {color: 'warn'},
+        },
+      ],
+    });
 
     const fixture = TestBed.createComponent(BasicProgressSpinner);
     fixture.detectChanges();

--- a/src/material/progress-spinner/testing/progress-spinner-harness.spec.ts
+++ b/src/material/progress-spinner/testing/progress-spinner-harness.spec.ts
@@ -9,10 +9,10 @@ describe('MatProgressSpinnerHarness', () => {
   let fixture: ComponentFixture<ProgressSpinnerHarnessTest>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatProgressSpinnerModule, ProgressSpinnerHarnessTest],
-    }).compileComponents();
+    });
 
     fixture = TestBed.createComponent(ProgressSpinnerHarnessTest);
     fixture.detectChanges();

--- a/src/material/radio/radio.spec.ts
+++ b/src/material/radio/radio.spec.ts
@@ -34,8 +34,6 @@ describe('MDC-based MatRadio', () => {
         PreselectedRadioWithStaticValueAndNgIf,
       ],
     });
-
-    TestBed.compileComponents();
   }));
 
   describe('inside of a group', () => {
@@ -1046,8 +1044,6 @@ describe('MatRadioDefaultOverrides', () => {
           },
         ],
       });
-
-      TestBed.compileComponents();
     }));
     it('should override default color in Component', () => {
       const fixture: ComponentFixture<DefaultRadioButton> =

--- a/src/material/radio/testing/radio-harness.spec.ts
+++ b/src/material/radio/testing/radio-harness.spec.ts
@@ -10,10 +10,10 @@ describe('radio harness', () => {
   let fixture: ComponentFixture<MultipleRadioButtonsHarnessTest>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatRadioModule, ReactiveFormsModule, MultipleRadioButtonsHarnessTest],
-    }).compileComponents();
+    });
 
     fixture = TestBed.createComponent(MultipleRadioButtonsHarnessTest);
     fixture.detectChanges();

--- a/src/material/select/select.spec.ts
+++ b/src/material/select/select.spec.ts
@@ -111,7 +111,7 @@ describe('MDC-based MatSelect', () => {
         ...providers,
       ],
       declarations: declarations,
-    }).compileComponents();
+    });
 
     overlayContainerElement = TestBed.inject(OverlayContainer).getContainerElement();
   }

--- a/src/material/select/testing/select-harness.spec.ts
+++ b/src/material/select/testing/select-harness.spec.ts
@@ -14,8 +14,8 @@ describe('MatSelectHarness', () => {
   let loader: HarnessLoader;
   let overlayContainer: OverlayContainer;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [
         MatSelectModule,
         MatFormFieldModule,
@@ -23,7 +23,7 @@ describe('MatSelectHarness', () => {
         ReactiveFormsModule,
         SelectHarnessTest,
       ],
-    }).compileComponents();
+    });
 
     fixture = TestBed.createComponent(SelectHarnessTest);
     fixture.detectChanges();

--- a/src/material/sidenav/drawer.spec.ts
+++ b/src/material/sidenav/drawer.spec.ts
@@ -42,8 +42,6 @@ describe('MatDrawer', () => {
         NestedDrawerContainers,
       ],
     });
-
-    TestBed.compileComponents();
   }));
 
   describe('methods', () => {
@@ -476,7 +474,7 @@ describe('MatDrawer', () => {
             useValue: errorHandler,
           },
         ],
-      }).compileComponents();
+      });
 
       const fixture = TestBed.createComponent(DrawerDynamicPosition);
       fixture.detectChanges();
@@ -520,11 +518,9 @@ describe('MatDrawer', () => {
     }));
 
     it('should not throw when a two-way binding is toggled quickly while animating', fakeAsync(() => {
-      TestBed.resetTestingModule()
-        .configureTestingModule({
-          imports: [MatSidenavModule, BrowserAnimationsModule, DrawerOpenBinding],
-        })
-        .compileComponents();
+      TestBed.resetTestingModule().configureTestingModule({
+        imports: [MatSidenavModule, BrowserAnimationsModule, DrawerOpenBinding],
+      });
 
       const fixture = TestBed.createComponent(DrawerOpenBinding);
       fixture.detectChanges();
@@ -889,8 +885,6 @@ describe('MatDrawerContainer', () => {
         DrawerContainerWithContent,
       ],
     });
-
-    TestBed.compileComponents();
   }));
 
   it('should be able to open and close all drawers', fakeAsync(() => {
@@ -1003,11 +997,9 @@ describe('MatDrawerContainer', () => {
   }));
 
   it('should not animate when the sidenav is open on load', fakeAsync(() => {
-    TestBed.resetTestingModule()
-      .configureTestingModule({
-        imports: [MatSidenavModule, BrowserAnimationsModule, DrawerSetToOpenedTrue],
-      })
-      .compileComponents();
+    TestBed.resetTestingModule().configureTestingModule({
+      imports: [MatSidenavModule, BrowserAnimationsModule, DrawerSetToOpenedTrue],
+    });
 
     const fixture = TestBed.createComponent(DrawerSetToOpenedTrue);
 

--- a/src/material/sidenav/sidenav.spec.ts
+++ b/src/material/sidenav/sidenav.spec.ts
@@ -17,8 +17,6 @@ describe('MatSidenav', () => {
         NestedSidenavContainers,
       ],
     });
-
-    TestBed.compileComponents();
   }));
 
   it('should be fixed position when in fixed mode', () => {

--- a/src/material/sidenav/testing/sidenav-harness.spec.ts
+++ b/src/material/sidenav/testing/sidenav-harness.spec.ts
@@ -16,10 +16,10 @@ describe('MatSidenavHarness', () => {
     let fixture: ComponentFixture<DrawerHarnessTest>;
     let loader: HarnessLoader;
 
-    beforeEach(async () => {
-      await TestBed.configureTestingModule({
+    beforeEach(() => {
+      TestBed.configureTestingModule({
         imports: [MatSidenavModule, NoopAnimationsModule, DrawerHarnessTest],
-      }).compileComponents();
+      });
 
       fixture = TestBed.createComponent(DrawerHarnessTest);
       fixture.detectChanges();
@@ -108,10 +108,10 @@ describe('MatSidenavHarness', () => {
     let fixture: ComponentFixture<SidenavHarnessTest>;
     let loader: HarnessLoader;
 
-    beforeEach(async () => {
-      await TestBed.configureTestingModule({
+    beforeEach(() => {
+      TestBed.configureTestingModule({
         imports: [MatSidenavModule, NoopAnimationsModule, SidenavHarnessTest],
-      }).compileComponents();
+      });
 
       fixture = TestBed.createComponent(SidenavHarnessTest);
       fixture.detectChanges();

--- a/src/material/slide-toggle/slide-toggle.spec.ts
+++ b/src/material/slide-toggle/slide-toggle.spec.ts
@@ -31,8 +31,6 @@ describe('MDC-based MatSlideToggle without forms', () => {
         SlideToggleWithStaticAriaAttributes,
       ],
     });
-
-    TestBed.compileComponents();
   }));
 
   describe('basic behavior', () => {
@@ -555,8 +553,6 @@ describe('MDC-based MatSlideToggle with forms', () => {
         SlideToggleWithModelAndChangeEvent,
       ],
     });
-
-    TestBed.compileComponents();
   }));
 
   describe('using ngModel', () => {

--- a/src/material/slide-toggle/testing/slide-toggle-harness.spec.ts
+++ b/src/material/slide-toggle/testing/slide-toggle-harness.spec.ts
@@ -10,10 +10,10 @@ describe('MatSlideToggleHarness', () => {
   let fixture: ComponentFixture<SlideToggleHarnessTest>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatSlideToggleModule, ReactiveFormsModule, SlideToggleHarnessTest],
-    }).compileComponents();
+    });
 
     fixture = TestBed.createComponent(SlideToggleHarnessTest);
     fixture.detectChanges();

--- a/src/material/slider/slider.spec.ts
+++ b/src/material/slider/slider.spec.ts
@@ -40,7 +40,7 @@ describe('MDC-based MatSlider', () => {
       imports: [FormsModule, MatSliderModule, ReactiveFormsModule, BidiModule],
       providers: [...providers],
       declarations: [component],
-    }).compileComponents();
+    });
     platform = TestBed.inject(Platform);
     return TestBed.createComponent<T>(component);
   }

--- a/src/material/slider/testing/slider-harness.spec.ts
+++ b/src/material/slider/testing/slider-harness.spec.ts
@@ -19,10 +19,10 @@ describe('MDC-based MatSliderHarness', () => {
   let fixture: ComponentFixture<SliderHarnessTest>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatSliderModule, SliderHarnessTest],
-    }).compileComponents();
+    });
 
     fixture = TestBed.createComponent(SliderHarnessTest);
     fixture.detectChanges();

--- a/src/material/snack-bar/snack-bar.spec.ts
+++ b/src/material/snack-bar/snack-bar.spec.ts
@@ -47,7 +47,7 @@ describe('MatSnackBar', () => {
         BurritosNotification,
         DirectiveWithViewContainer,
       ],
-    }).compileComponents();
+    });
   }));
 
   beforeEach(inject(
@@ -591,8 +591,7 @@ describe('MatSnackBar', () => {
         deps: [],
         useFactory: () => ({panelClass: 'custom-class'}),
       })
-      .configureTestingModule({imports: [MatSnackBarModule, NoopAnimationsModule]})
-      .compileComponents();
+      .configureTestingModule({imports: [MatSnackBarModule, NoopAnimationsModule]});
 
     inject([MatSnackBar, OverlayContainer], (sb: MatSnackBar, oc: OverlayContainer) => {
       snackBar = sb;
@@ -754,7 +753,7 @@ describe('MatSnackBar with parent MatSnackBar', () => {
         ComponentThatProvidesMatSnackBar,
         DirectiveWithViewContainer,
       ],
-    }).compileComponents();
+    });
   }));
 
   beforeEach(inject([MatSnackBar, OverlayContainer], (sb: MatSnackBar, oc: OverlayContainer) => {
@@ -832,7 +831,7 @@ describe('MatSnackBar Positioning', () => {
         ComponentWithChildViewContainer,
         DirectiveWithViewContainer,
       ],
-    }).compileComponents();
+    });
   }));
 
   beforeEach(inject([MatSnackBar, OverlayContainer], (sb: MatSnackBar, oc: OverlayContainer) => {

--- a/src/material/snack-bar/snack-bar.zone.spec.ts
+++ b/src/material/snack-bar/snack-bar.zone.spec.ts
@@ -27,7 +27,7 @@ describe('MatSnackBar Zone.js integration', () => {
         DirectiveWithViewContainer,
       ],
       providers: [provideZoneChangeDetection()],
-    }).compileComponents();
+    });
   }));
 
   beforeEach(inject([MatSnackBar], (sb: MatSnackBar) => {

--- a/src/material/snack-bar/testing/snack-bar-harness.spec.ts
+++ b/src/material/snack-bar/testing/snack-bar-harness.spec.ts
@@ -16,10 +16,10 @@ describe('MatSnackBarHarness', () => {
   let fixture: ComponentFixture<SnackbarHarnessTest>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [NoopAnimationsModule],
-    }).compileComponents();
+    });
 
     fixture = TestBed.createComponent(SnackbarHarnessTest);
     fixture.detectChanges();

--- a/src/material/sort/sort.spec.ts
+++ b/src/material/sort/sort.spec.ts
@@ -50,7 +50,7 @@ describe('MatSort', () => {
           MatSortableInvalidDirection,
           MatSortWithArrowPosition,
         ],
-      }).compileComponents();
+      });
     }));
 
     beforeEach(() => {
@@ -537,7 +537,7 @@ describe('MatSort', () => {
             },
           },
         ],
-      }).compileComponents();
+      });
     }));
 
     beforeEach(() => {
@@ -577,7 +577,7 @@ describe('MatSort', () => {
             },
           },
         ],
-      }).compileComponents();
+      });
     }));
 
     beforeEach(() => {

--- a/src/material/sort/testing/sort-harness.spec.ts
+++ b/src/material/sort/testing/sort-harness.spec.ts
@@ -10,10 +10,10 @@ describe('MatSortHarness', () => {
   let fixture: ComponentFixture<SortHarnessTest>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatSortModule, NoopAnimationsModule, SortHarnessTest],
-    }).compileComponents();
+    });
 
     fixture = TestBed.createComponent(SortHarnessTest);
     fixture.detectChanges();

--- a/src/material/stepper/stepper.spec.ts
+++ b/src/material/stepper/stepper.spec.ts
@@ -1799,7 +1799,6 @@ function createComponent<T>(
     });
   }
 
-  TestBed.compileComponents();
   return TestBed.createComponent<T>(component);
 }
 

--- a/src/material/stepper/testing/stepper-harness.spec.ts
+++ b/src/material/stepper/testing/stepper-harness.spec.ts
@@ -14,8 +14,8 @@ describe('MatStepperHarness', () => {
   let fixture: ComponentFixture<StepperHarnessTest>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatStepperModule, NoopAnimationsModule, ReactiveFormsModule, StepperHarnessTest],
       providers: [
         {
@@ -23,7 +23,7 @@ describe('MatStepperHarness', () => {
           useValue: {showError: true}, // Required so the error state shows up in tests.
         },
       ],
-    }).compileComponents();
+    });
 
     fixture = TestBed.createComponent(StepperHarnessTest);
     fixture.detectChanges();

--- a/src/material/table/table.spec.ts
+++ b/src/material/table/table.spec.ts
@@ -33,7 +33,7 @@ describe('MDC-based MatTable', () => {
         NestedTableApp,
         MatFlexTableApp,
       ],
-    }).compileComponents();
+    });
   }));
 
   describe('with basic data source', () => {

--- a/src/material/table/testing/table-harness.spec.ts
+++ b/src/material/table/testing/table-harness.spec.ts
@@ -9,10 +9,10 @@ describe('MatTableHarness', () => {
   let fixture: ComponentFixture<TableHarnessTest>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatTableModule, TableHarnessTest],
-    }).compileComponents();
+    });
 
     fixture = TestBed.createComponent(TableHarnessTest);
     fixture.detectChanges();

--- a/src/material/tabs/tab-body.spec.ts
+++ b/src/material/tabs/tab-body.spec.ts
@@ -36,8 +36,6 @@ describe('MDC-based MatTabBody', () => {
       ],
       providers: [{provide: Directionality, useFactory: () => ({value: dir, change: dirChange})}],
     });
-
-    TestBed.compileComponents();
   }));
 
   describe('when initialized as center', () => {
@@ -195,18 +193,16 @@ describe('MDC-based MatTabBody', () => {
   });
 
   it('should mark the tab body content as a scrollable container', () => {
-    TestBed.resetTestingModule()
-      .configureTestingModule({
-        imports: [
-          CommonModule,
-          PortalModule,
-          MatRippleModule,
-          NoopAnimationsModule,
-          ScrollingModule,
-          SimpleTabBodyApp,
-        ],
-      })
-      .compileComponents();
+    TestBed.resetTestingModule().configureTestingModule({
+      imports: [
+        CommonModule,
+        PortalModule,
+        MatRippleModule,
+        NoopAnimationsModule,
+        ScrollingModule,
+        SimpleTabBodyApp,
+      ],
+    });
 
     const fixture = TestBed.createComponent(SimpleTabBodyApp);
     const tabBodyContent = fixture.nativeElement.querySelector('.mat-mdc-tab-body-content');

--- a/src/material/tabs/tab-group.spec.ts
+++ b/src/material/tabs/tab-group.spec.ts
@@ -45,8 +45,6 @@ describe('MDC-based MatTabGroup', () => {
         TabsWithClassesTestApp,
       ],
     });
-
-    TestBed.compileComponents();
   }));
 
   describe('basic behavior', () => {
@@ -1043,8 +1041,6 @@ describe('nested MatTabGroup with enabled animations', () => {
         TabsWithCustomAnimationDuration,
       ],
     });
-
-    TestBed.compileComponents();
   }));
 
   it('should not throw when creating a component with nested tab groups', fakeAsync(() => {
@@ -1080,8 +1076,6 @@ describe('MatTabGroup with ink bar fit to content', () => {
     TestBed.configureTestingModule({
       imports: [MatTabsModule, BrowserAnimationsModule, TabGroupWithInkBarFitToContent],
     });
-
-    TestBed.compileComponents();
   }));
 
   beforeEach(() => {
@@ -1130,8 +1124,6 @@ describe('MatTabNavBar with a default config', () => {
         },
       ],
     });
-
-    TestBed.compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/material/tabs/tab-header.spec.ts
+++ b/src/material/tabs/tab-header.spec.ts
@@ -48,8 +48,6 @@ describe('MDC-based MatTabHeader', () => {
       providers: [ViewportRuler],
     });
 
-    TestBed.compileComponents();
-
     resizeEvents = new Subject();
     spyOn(TestBed.inject(SharedResizeObserver), 'observe').and.returnValue(resizeEvents);
   }));

--- a/src/material/tabs/tab-nav-bar/tab-nav-bar.spec.ts
+++ b/src/material/tabs/tab-nav-bar/tab-nav-bar.spec.ts
@@ -38,8 +38,6 @@ describe('MDC-based MatTabNavBar', () => {
       ],
     });
 
-    TestBed.compileComponents();
-
     resizeEvents = new Subject();
     spyOn(TestBed.inject(SharedResizeObserver), 'observe').and.returnValue(resizeEvents);
   }));
@@ -497,8 +495,6 @@ describe('MatTabNavBar with a default config', () => {
       imports: [MatTabsModule, BrowserAnimationsModule, TabLinkWithNgIf],
       providers: [{provide: MAT_TABS_CONFIG, useValue: {fitInkBarToContent: true}}],
     });
-
-    TestBed.compileComponents();
   }));
 
   beforeEach(() => {
@@ -520,8 +516,6 @@ describe('MatTabNavBar with enabled animations', () => {
     TestBed.configureTestingModule({
       imports: [MatTabsModule, BrowserAnimationsModule, TabsWithCustomAnimationDuration],
     });
-
-    TestBed.compileComponents();
   }));
 
   it('should not throw when setting an animationDuration without units', fakeAsync(() => {

--- a/src/material/tabs/testing/tab-group-harness.spec.ts
+++ b/src/material/tabs/testing/tab-group-harness.spec.ts
@@ -11,10 +11,10 @@ describe('MatTabGroupHarness', () => {
   let fixture: ComponentFixture<TabGroupHarnessTest>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatTabsModule, NoopAnimationsModule, TabGroupHarnessTest],
-    }).compileComponents();
+    });
 
     fixture = TestBed.createComponent(TabGroupHarnessTest);
     fixture.detectChanges();

--- a/src/material/tabs/testing/tab-nav-bar-harness.spec.ts
+++ b/src/material/tabs/testing/tab-nav-bar-harness.spec.ts
@@ -10,10 +10,10 @@ describe('MatTabNavBarHarness', () => {
   let fixture: ComponentFixture<TabNavBarHarnessTest>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatTabsModule, NoopAnimationsModule, TabNavBarHarnessTest],
-    }).compileComponents();
+    });
 
     fixture = TestBed.createComponent(TabNavBarHarnessTest);
     fixture.detectChanges();

--- a/src/material/toolbar/testing/toolbar-harness.spec.ts
+++ b/src/material/toolbar/testing/toolbar-harness.spec.ts
@@ -9,10 +9,10 @@ describe('MatToolbarHarness', () => {
   let fixture: ComponentFixture<ToolbarHarnessTest>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatToolbarModule, ToolbarHarnessTest],
-    }).compileComponents();
+    });
 
     fixture = TestBed.createComponent(ToolbarHarnessTest);
     fixture.detectChanges();

--- a/src/material/toolbar/toolbar.spec.ts
+++ b/src/material/toolbar/toolbar.spec.ts
@@ -16,8 +16,6 @@ describe('MatToolbar', () => {
         ToolbarMultipleIndirectRows,
       ],
     });
-
-    TestBed.compileComponents();
   }));
 
   describe('with single row', () => {

--- a/src/material/tooltip/testing/tooltip-harness.spec.ts
+++ b/src/material/tooltip/testing/tooltip-harness.spec.ts
@@ -15,10 +15,10 @@ describe('MatTooltipHarness', () => {
     });
   });
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatTooltipModule, NoopAnimationsModule, TooltipHarnessTest],
-    }).compileComponents();
+    });
 
     fixture = TestBed.createComponent(TooltipHarnessTest);
     fixture.detectChanges();

--- a/src/material/tooltip/tooltip.spec.ts
+++ b/src/material/tooltip/tooltip.spec.ts
@@ -72,8 +72,6 @@ describe('MDC-based MatTooltip', () => {
       ],
     });
 
-    TestBed.compileComponents();
-
     inject(
       [OverlayContainer, FocusMonitor, Platform],
       (oc: OverlayContainer, fm: FocusMonitor, pl: Platform) => {
@@ -170,17 +168,15 @@ describe('MDC-based MatTooltip', () => {
     }));
 
     it('should be able to override the default show and hide delays', fakeAsync(() => {
-      TestBed.resetTestingModule()
-        .configureTestingModule({
-          imports: [MatTooltipModule, OverlayModule, BasicTooltipDemo],
-          providers: [
-            {
-              provide: MAT_TOOLTIP_DEFAULT_OPTIONS,
-              useValue: {showDelay: 1337, hideDelay: 7331},
-            },
-          ],
-        })
-        .compileComponents();
+      TestBed.resetTestingModule().configureTestingModule({
+        imports: [MatTooltipModule, OverlayModule, BasicTooltipDemo],
+        providers: [
+          {
+            provide: MAT_TOOLTIP_DEFAULT_OPTIONS,
+            useValue: {showDelay: 1337, hideDelay: 7331},
+          },
+        ],
+      });
 
       fixture = TestBed.createComponent(BasicTooltipDemo);
       fixture.detectChanges();
@@ -206,18 +202,16 @@ describe('MDC-based MatTooltip', () => {
     }));
 
     it('should be able to override the default position', fakeAsync(() => {
-      TestBed.resetTestingModule()
-        .configureTestingModule({
-          imports: [MatTooltipModule, OverlayModule],
-          declarations: [TooltipDemoWithoutPositionBinding],
-          providers: [
-            {
-              provide: MAT_TOOLTIP_DEFAULT_OPTIONS,
-              useValue: {position: 'right'},
-            },
-          ],
-        })
-        .compileComponents();
+      TestBed.resetTestingModule().configureTestingModule({
+        imports: [MatTooltipModule, OverlayModule],
+        declarations: [TooltipDemoWithoutPositionBinding],
+        providers: [
+          {
+            provide: MAT_TOOLTIP_DEFAULT_OPTIONS,
+            useValue: {position: 'right'},
+          },
+        ],
+      });
 
       const newFixture = TestBed.createComponent(TooltipDemoWithoutPositionBinding);
       newFixture.detectChanges();
@@ -235,18 +229,16 @@ describe('MDC-based MatTooltip', () => {
     }));
 
     it('should be able to define a default (global) tooltip class', fakeAsync(() => {
-      TestBed.resetTestingModule()
-        .configureTestingModule({
-          declarations: [TooltipDemoWithoutTooltipClassBinding],
-          imports: [MatTooltipModule, OverlayModule],
-          providers: [
-            {
-              provide: MAT_TOOLTIP_DEFAULT_OPTIONS,
-              useValue: {tooltipClass: 'my-default-tooltip-class'},
-            },
-          ],
-        })
-        .compileComponents();
+      TestBed.resetTestingModule().configureTestingModule({
+        declarations: [TooltipDemoWithoutTooltipClassBinding],
+        imports: [MatTooltipModule, OverlayModule],
+        providers: [
+          {
+            provide: MAT_TOOLTIP_DEFAULT_OPTIONS,
+            useValue: {tooltipClass: 'my-default-tooltip-class'},
+          },
+        ],
+      });
 
       const fixture = TestBed.createComponent(TooltipDemoWithoutTooltipClassBinding);
       fixture.detectChanges();
@@ -264,18 +256,16 @@ describe('MDC-based MatTooltip', () => {
     }));
 
     it('should be able to provide tooltip class over the custom default one', fakeAsync(() => {
-      TestBed.resetTestingModule()
-        .configureTestingModule({
-          declarations: [TooltipDemoWithTooltipClassBinding],
-          imports: [MatTooltipModule, OverlayModule],
-          providers: [
-            {
-              provide: MAT_TOOLTIP_DEFAULT_OPTIONS,
-              useValue: {tooltipClass: 'my-default-tooltip-class'},
-            },
-          ],
-        })
-        .compileComponents();
+      TestBed.resetTestingModule().configureTestingModule({
+        declarations: [TooltipDemoWithTooltipClassBinding],
+        imports: [MatTooltipModule, OverlayModule],
+        providers: [
+          {
+            provide: MAT_TOOLTIP_DEFAULT_OPTIONS,
+            useValue: {tooltipClass: 'my-default-tooltip-class'},
+          },
+        ],
+      });
 
       const fixture = TestBed.createComponent(TooltipDemoWithTooltipClassBinding);
       fixture.detectChanges();
@@ -299,12 +289,10 @@ describe('MDC-based MatTooltip', () => {
         return;
       }
 
-      TestBed.resetTestingModule()
-        .configureTestingModule({
-          imports: [MatTooltipModule, OverlayModule],
-          declarations: [WideTooltipDemo],
-        })
-        .compileComponents();
+      TestBed.resetTestingModule().configureTestingModule({
+        imports: [MatTooltipModule, OverlayModule],
+        declarations: [WideTooltipDemo],
+      });
 
       const wideFixture = TestBed.createComponent(WideTooltipDemo);
       wideFixture.detectChanges();
@@ -333,18 +321,16 @@ describe('MDC-based MatTooltip', () => {
         return;
       }
 
-      await TestBed.resetTestingModule()
-        .configureTestingModule({
-          imports: [MatTooltipModule, OverlayModule],
-          declarations: [WideTooltipDemo],
-          providers: [
-            {
-              provide: MAT_TOOLTIP_DEFAULT_OPTIONS,
-              useValue: {positionAtOrigin: true},
-            },
-          ],
-        })
-        .compileComponents();
+      TestBed.resetTestingModule().configureTestingModule({
+        imports: [MatTooltipModule, OverlayModule],
+        declarations: [WideTooltipDemo],
+        providers: [
+          {
+            provide: MAT_TOOLTIP_DEFAULT_OPTIONS,
+            useValue: {positionAtOrigin: true},
+          },
+        ],
+      });
 
       const wideFixture = TestBed.createComponent(WideTooltipDemo);
       wideFixture.detectChanges();
@@ -367,18 +353,16 @@ describe('MDC-based MatTooltip', () => {
     });
 
     it('should be able to disable tooltip interactivity', fakeAsync(() => {
-      TestBed.resetTestingModule()
-        .configureTestingModule({
-          imports: [MatTooltipModule, OverlayModule, NoopAnimationsModule],
-          declarations: [TooltipDemoWithoutPositionBinding],
-          providers: [
-            {
-              provide: MAT_TOOLTIP_DEFAULT_OPTIONS,
-              useValue: {disableTooltipInteractivity: true},
-            },
-          ],
-        })
-        .compileComponents();
+      TestBed.resetTestingModule().configureTestingModule({
+        imports: [MatTooltipModule, OverlayModule, NoopAnimationsModule],
+        declarations: [TooltipDemoWithoutPositionBinding],
+        providers: [
+          {
+            provide: MAT_TOOLTIP_DEFAULT_OPTIONS,
+            useValue: {disableTooltipInteractivity: true},
+          },
+        ],
+      });
 
       const newFixture = TestBed.createComponent(TooltipDemoWithoutPositionBinding);
       newFixture.detectChanges();

--- a/src/material/tooltip/tooltip.zone.spec.ts
+++ b/src/material/tooltip/tooltip.zone.spec.ts
@@ -28,8 +28,6 @@ describe('MDC-based MatTooltip Zone.js integration', () => {
         },
       ],
     });
-
-    TestBed.compileComponents();
   }));
 
   describe('scrollable usage', () => {

--- a/src/material/tree/testing/tree-harness.spec.ts
+++ b/src/material/tree/testing/tree-harness.spec.ts
@@ -15,10 +15,10 @@ describe('MatTreeHarness', () => {
   let fixture: ComponentFixture<TreeHarnessTest>;
   let loader: HarnessLoader;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [MatTreeModule, TreeHarnessTest],
-    }).compileComponents();
+    });
 
     fixture = TestBed.createComponent(TreeHarnessTest);
     fixture.detectChanges();

--- a/src/material/tree/tree-using-legacy-key-manager.spec.ts
+++ b/src/material/tree/tree-using-legacy-key-manager.spec.ts
@@ -14,7 +14,7 @@ describe('MatTree when provided LegacyTreeKeyManager', () => {
       imports: [MatTreeModule],
       declarations: [SimpleMatTreeApp],
       providers: [NOOP_TREE_KEY_MANAGER_FACTORY_PROVIDER],
-    }).compileComponents();
+    });
 
     fixture = TestBed.createComponent(SimpleMatTreeApp);
     fixture.detectChanges();

--- a/src/material/tree/tree-using-tree-control.spec.ts
+++ b/src/material/tree/tree-using-tree-control.spec.ts
@@ -29,7 +29,7 @@ describe('MatTree', () => {
     TestBed.configureTestingModule({
       imports: [MatTreeModule],
       declarations: declarations,
-    }).compileComponents();
+    });
   }
 
   describe('flat tree', () => {

--- a/src/material/tree/tree.spec.ts
+++ b/src/material/tree/tree.spec.ts
@@ -22,7 +22,7 @@ describe('MatTree', () => {
     TestBed.configureTestingModule({
       imports: [MatTreeModule],
       declarations: declarations,
-    }).compileComponents();
+    });
   }
 
   describe('flat tree', () => {


### PR DESCRIPTION
Calls to `compileComponent` aren't necessary in the vast majority of cases. These changes clean them up from our codebase.