### PR TITLE
refactor(cdk/drag-drop): remove unnecessary generics

### DIFF
--- a/src/cdk/drag-drop/drag-drop-registry.spec.ts
+++ b/src/cdk/drag-drop/drag-drop-registry.spec.ts
@@ -9,10 +9,11 @@ import {
 } from '../testing/private';
 import {DragDropRegistry} from './drag-drop-registry';
 import {DragDropModule} from './drag-drop-module';
+import {DragRef} from './drag-ref';
 
 describe('DragDropRegistry', () => {
   let fixture: ComponentFixture<BlankComponent>;
-  let registry: DragDropRegistry<DragItem, DragList>;
+  let registry: DragDropRegistry;
 
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
@@ -22,13 +23,13 @@ describe('DragDropRegistry', () => {
     fixture = TestBed.createComponent(BlankComponent);
     fixture.detectChanges();
 
-    inject([DragDropRegistry], (c: DragDropRegistry<DragItem, DragList>) => {
+    inject([DragDropRegistry], (c: DragDropRegistry) => {
       registry = c;
     })();
   }));
 
   it('should be able to start dragging an item', () => {
-    const item = new DragItem();
+    const item = new DragItem() as unknown as DragRef;
 
     expect(registry.isDragging(item)).toBe(false);
     registry.startDragging(item, createMouseEvent('mousedown'));
@@ -36,7 +37,7 @@ describe('DragDropRegistry', () => {
   });
 
   it('should be able to stop dragging an item', () => {
-    const item = new DragItem();
+    const item = new DragItem() as unknown as DragRef;
 
     registry.startDragging(item, createMouseEvent('mousedown'));
     expect(registry.isDragging(item)).toBe(true);
@@ -46,7 +47,7 @@ describe('DragDropRegistry', () => {
   });
 
   it('should stop dragging an item if it is removed', () => {
-    const item = new DragItem();
+    const item = new DragItem() as unknown as DragRef;
 
     registry.startDragging(item, createMouseEvent('mousedown'));
     expect(registry.isDragging(item)).toBe(true);
@@ -58,7 +59,7 @@ describe('DragDropRegistry', () => {
   it('should dispatch `mousemove` events after starting to drag via the mouse', () => {
     const spy = jasmine.createSpy('pointerMove spy');
     const subscription = registry.pointerMove.subscribe(spy);
-    const item = new DragItem(true);
+    const item = new DragItem(true) as unknown as DragRef;
     registry.startDragging(item, createMouseEvent('mousedown'));
     dispatchMouseEvent(document, 'mousemove');
 
@@ -70,7 +71,7 @@ describe('DragDropRegistry', () => {
   it('should dispatch `touchmove` events after starting to drag via touch', () => {
     const spy = jasmine.createSpy('pointerMove spy');
     const subscription = registry.pointerMove.subscribe(spy);
-    const item = new DragItem(true);
+    const item = new DragItem(true) as unknown as DragRef;
     registry.startDragging(item, createTouchEvent('touchstart') as TouchEvent);
     dispatchTouchEvent(document, 'touchmove');
 
@@ -82,7 +83,7 @@ describe('DragDropRegistry', () => {
   it('should dispatch pointer move events if event propagation is stopped', () => {
     const spy = jasmine.createSpy('pointerMove spy');
     const subscription = registry.pointerMove.subscribe(spy);
-    const item = new DragItem(true);
+    const item = new DragItem(true) as unknown as DragRef;
     fixture.nativeElement.addEventListener('mousemove', (e: MouseEvent) => e.stopPropagation());
     registry.startDragging(item, createMouseEvent('mousedown'));
     dispatchMouseEvent(fixture.nativeElement, 'mousemove');
@@ -95,7 +96,7 @@ describe('DragDropRegistry', () => {
   it('should dispatch `mouseup` events after ending the drag via the mouse', () => {
     const spy = jasmine.createSpy('pointerUp spy');
     const subscription = registry.pointerUp.subscribe(spy);
-    const item = new DragItem();
+    const item = new DragItem() as unknown as DragRef;
 
     registry.startDragging(item, createMouseEvent('mousedown'));
     dispatchMouseEvent(document, 'mouseup');
@@ -108,7 +109,7 @@ describe('DragDropRegistry', () => {
   it('should dispatch `touchend` events after ending the drag via touch', () => {
     const spy = jasmine.createSpy('pointerUp spy');
     const subscription = registry.pointerUp.subscribe(spy);
-    const item = new DragItem();
+    const item = new DragItem() as unknown as DragRef;
 
     registry.startDragging(item, createTouchEvent('touchstart') as TouchEvent);
     dispatchTouchEvent(document, 'touchend');
@@ -121,7 +122,7 @@ describe('DragDropRegistry', () => {
   it('should dispatch pointer up events if event propagation is stopped', () => {
     const spy = jasmine.createSpy('pointerUp spy');
     const subscription = registry.pointerUp.subscribe(spy);
-    const item = new DragItem();
+    const item = new DragItem() as unknown as DragRef;
 
     fixture.nativeElement.addEventListener('mouseup', (e: MouseEvent) => e.stopPropagation());
     registry.startDragging(item, createMouseEvent('mousedown'));
@@ -148,7 +149,7 @@ describe('DragDropRegistry', () => {
   });
 
   it('should not emit pointer events when dragging is over (multi touch)', () => {
-    const item = new DragItem();
+    const item = new DragItem() as unknown as DragRef;
 
     // First finger down
     registry.startDragging(item, createTouchEvent('touchstart') as TouchEvent);
@@ -183,7 +184,7 @@ describe('DragDropRegistry', () => {
   });
 
   it('should prevent the default `touchmove` action when an item is being dragged', () => {
-    const item = new DragItem(true);
+    const item = new DragItem(true) as unknown as DragRef;
     registry.startDragging(item, createTouchEvent('touchstart') as TouchEvent);
     expect(dispatchTouchEvent(document, 'touchmove').defaultPrevented).toBe(true);
   });
@@ -192,7 +193,7 @@ describe('DragDropRegistry', () => {
     'should prevent the default `touchmove` if the item does not consider itself as being ' +
       'dragged yet',
     () => {
-      const item = new DragItem(false);
+      const item = new DragItem(false) as unknown as DragRef & DragItem;
       registry.startDragging(item, createTouchEvent('touchstart') as TouchEvent);
       expect(dispatchTouchEvent(document, 'touchmove').defaultPrevented).toBe(false);
 
@@ -202,7 +203,7 @@ describe('DragDropRegistry', () => {
   );
 
   it('should prevent the default `touchmove` if event propagation is stopped', () => {
-    const item = new DragItem(true);
+    const item = new DragItem(true) as unknown as DragRef;
     registry.startDragging(item, createTouchEvent('touchstart') as TouchEvent);
     fixture.nativeElement.addEventListener('touchmove', (e: TouchEvent) => e.stopPropagation());
 
@@ -215,7 +216,7 @@ describe('DragDropRegistry', () => {
   });
 
   it('should prevent the default `selectstart` action when an item is being dragged', () => {
-    const item = new DragItem(true);
+    const item = new DragItem(true) as unknown as DragRef;
     registry.startDragging(item, createMouseEvent('mousedown'));
     expect(dispatchFakeEvent(document, 'selectstart').defaultPrevented).toBe(true);
   });
@@ -223,7 +224,7 @@ describe('DragDropRegistry', () => {
   it('should dispatch `scroll` events if the viewport is scrolled while dragging', () => {
     const spy = jasmine.createSpy('scroll spy');
     const subscription = registry.scrolled().subscribe(spy);
-    const item = new DragItem();
+    const item = new DragItem() as unknown as DragRef;
 
     registry.startDragging(item, createMouseEvent('mousedown'));
     dispatchFakeEvent(document, 'scroll');
@@ -247,13 +248,7 @@ describe('DragDropRegistry', () => {
       return this.shouldBeDragging;
     }
     constructor(public shouldBeDragging = false) {
-      registry.registerDragItem(this);
-    }
-  }
-
-  class DragList {
-    constructor() {
-      registry.registerDropContainer(this);
+      registry.registerDragItem(this as unknown as DragRef);
     }
   }
 

--- a/src/cdk/drag-drop/drag-drop.ts
+++ b/src/cdk/drag-drop/drag-drop.ts
@@ -28,7 +28,7 @@ export class DragDrop {
     @Inject(DOCUMENT) private _document: any,
     private _ngZone: NgZone,
     private _viewportRuler: ViewportRuler,
-    private _dragDropRegistry: DragDropRegistry<DragRef, DropListRef>,
+    private _dragDropRegistry: DragDropRegistry,
   ) {}
 
   /**

--- a/src/cdk/drag-drop/drag-ref.ts
+++ b/src/cdk/drag-drop/drag-ref.ts
@@ -377,7 +377,7 @@ export class DragRef<T = any> {
     private _document: Document,
     private _ngZone: NgZone,
     private _viewportRuler: ViewportRuler,
-    private _dragDropRegistry: DragDropRegistry<DragRef, DropListRef>,
+    private _dragDropRegistry: DragDropRegistry,
   ) {
     this.withRootElement(element).withParent(_config.parentDragRef || null);
     this._parentPositions = new ParentPositionTracker(_document);

--- a/src/cdk/drag-drop/drop-list-ref.ts
+++ b/src/cdk/drag-drop/drop-list-ref.ts
@@ -197,7 +197,7 @@ export class DropListRef<T = any> {
 
   constructor(
     element: ElementRef<HTMLElement> | HTMLElement,
-    private _dragDropRegistry: DragDropRegistry<DragRef, DropListRef>,
+    private _dragDropRegistry: DragDropRegistry,
     _document: any,
     private _ngZone: NgZone,
     private _viewportRuler: ViewportRuler,

--- a/src/cdk/drag-drop/sorting/mixed-sort-strategy.ts
+++ b/src/cdk/drag-drop/sorting/mixed-sort-strategy.ts
@@ -54,7 +54,7 @@ export class MixedSortStrategy implements DropListSortStrategy {
 
   constructor(
     private _document: Document,
-    private _dragDropRegistry: DragDropRegistry<DragRef, unknown>,
+    private _dragDropRegistry: DragDropRegistry,
   ) {}
 
   /**

--- a/src/cdk/drag-drop/sorting/single-axis-sort-strategy.ts
+++ b/src/cdk/drag-drop/sorting/single-axis-sort-strategy.ts
@@ -57,7 +57,7 @@ export class SingleAxisSortStrategy implements DropListSortStrategy {
   /** Layout direction of the drop list. */
   direction: Direction;
 
-  constructor(private _dragDropRegistry: DragDropRegistry<DragRef, unknown>) {}
+  constructor(private _dragDropRegistry: DragDropRegistry) {}
 
   /**
    * Keeps track of the item that was last swapped with the dragged item, as well as what direction

--- a/tools/public_api_guard/cdk/drag-drop.md
+++ b/tools/public_api_guard/cdk/drag-drop.md
@@ -305,7 +305,7 @@ export type DragConstrainPosition = (point: Point, dragRef: DragRef) => Point;
 
 // @public
 export class DragDrop {
-    constructor(_document: any, _ngZone: NgZone, _viewportRuler: ViewportRuler, _dragDropRegistry: DragDropRegistry<DragRef, DropListRef>);
+    constructor(_document: any, _ngZone: NgZone, _viewportRuler: ViewportRuler, _dragDropRegistry: DragDropRegistry);
     createDrag<T = any>(element: ElementRef<HTMLElement> | HTMLElement, config?: DragRefConfig): DragRef<T>;
     createDropList<T = any>(element: ElementRef<HTMLElement> | HTMLElement): DropListRef<T>;
     // (undocumented)
@@ -353,24 +353,22 @@ export class DragDropModule {
 }
 
 // @public
-export class DragDropRegistry<I extends {
-    isDragging(): boolean;
-}, C> implements OnDestroy {
+export class DragDropRegistry<_ = unknown, __ = unknown> implements OnDestroy {
     constructor(_ngZone: NgZone, _document: any);
-    isDragging(drag: I): boolean;
+    isDragging(drag: DragRef): boolean;
     // (undocumented)
     ngOnDestroy(): void;
     readonly pointerMove: Subject<TouchEvent | MouseEvent>;
     readonly pointerUp: Subject<TouchEvent | MouseEvent>;
-    registerDragItem(drag: I): void;
-    registerDropContainer(drop: C): void;
-    removeDragItem(drag: I): void;
-    removeDropContainer(drop: C): void;
+    registerDragItem(drag: DragRef): void;
+    registerDropContainer(drop: DropListRef): void;
+    removeDragItem(drag: DragRef): void;
+    removeDropContainer(drop: DropListRef): void;
     // @deprecated
     readonly scroll: Subject<Event>;
     scrolled(shadowRoot?: DocumentOrShadowRoot | null): Observable<Event>;
-    startDragging(drag: I, event: TouchEvent | MouseEvent): void;
-    stopDragging(drag: I): void;
+    startDragging(drag: DragRef, event: TouchEvent | MouseEvent): void;
+    stopDragging(drag: DragRef): void;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<DragDropRegistry<any, any>, never>;
     // (undocumented)
@@ -379,7 +377,7 @@ export class DragDropRegistry<I extends {
 
 // @public
 export class DragRef<T = any> {
-    constructor(element: ElementRef<HTMLElement> | HTMLElement, _config: DragRefConfig, _document: Document, _ngZone: NgZone, _viewportRuler: ViewportRuler, _dragDropRegistry: DragDropRegistry<DragRef, DropListRef>);
+    constructor(element: ElementRef<HTMLElement> | HTMLElement, _config: DragRefConfig, _document: Document, _ngZone: NgZone, _viewportRuler: ViewportRuler, _dragDropRegistry: DragDropRegistry);
     readonly beforeStarted: Subject<void>;
     constrainPosition?: (userPointerPosition: Point, dragRef: DragRef, dimensions: DOMRect, pickupPositionInElement: Point) => Point;
     data: T;
@@ -480,7 +478,7 @@ export type DropListOrientation = 'horizontal' | 'vertical' | 'mixed';
 
 // @public
 export class DropListRef<T = any> {
-    constructor(element: ElementRef<HTMLElement> | HTMLElement, _dragDropRegistry: DragDropRegistry<DragRef, DropListRef>, _document: any, _ngZone: NgZone, _viewportRuler: ViewportRuler);
+    constructor(element: ElementRef<HTMLElement> | HTMLElement, _dragDropRegistry: DragDropRegistry, _document: any, _ngZone: NgZone, _viewportRuler: ViewportRuler);
     autoScrollDisabled: boolean;
     autoScrollStep: number;
     readonly beforeStarted: Subject<void>;


### PR DESCRIPTION
Previously we used generics in the `DragDropRegistry` to avoid circular dependencies. Now that we can use type-only imports, we don't need the generics anymore.