### PR TITLE
feat(material/button-toggle): allow disabled buttons to be interactive

### DIFF
--- a/src/dev-app/button-toggle/button-toggle-demo.html
+++ b/src/dev-app/button-toggle/button-toggle-demo.html
@@ -7,6 +7,10 @@
 </p>
 
 <p>
+  <mat-checkbox (change)="disabledInteractive = $event.checked">Allow Interaction with Disabled Button Toggles</mat-checkbox>
+</p>
+
+<p>
   <mat-checkbox (change)="hideSingleSelectionIndicator = $event.checked">Hide Single Selection Indicator</mat-checkbox>
 </p>
 
@@ -17,7 +21,11 @@
 <h1>Exclusive Selection</h1>
 
 <section>
-  <mat-button-toggle-group name="alignment" [vertical]="isVertical" [hideSingleSelectionIndicator]="hideSingleSelectionIndicator">
+  <mat-button-toggle-group
+    name="alignment"
+    [vertical]="isVertical"
+    [hideSingleSelectionIndicator]="hideSingleSelectionIndicator"
+    [disabledInteractive]="disabledInteractive">
     <mat-button-toggle value="left" [disabled]="isDisabled">
       <mat-icon>format_align_left</mat-icon>
     </mat-button-toggle>
@@ -34,7 +42,12 @@
 </section>
 
 <section>
-  <mat-button-toggle-group appearance="legacy" name="alignment" [vertical]="isVertical" [hideSingleSelectionIndicator]="hideSingleSelectionIndicator">
+  <mat-button-toggle-group
+    appearance="legacy"
+    name="alignment"
+    [vertical]="isVertical"
+    [hideSingleSelectionIndicator]="hideSingleSelectionIndicator"
+    [disabledInteractive]="disabledInteractive">
     <mat-button-toggle value="left" [disabled]="isDisabled">
       <mat-icon>format_align_left</mat-icon>
     </mat-button-toggle>
@@ -53,7 +66,12 @@
 <h1>Disabled Group</h1>
 
 <section>
-  <mat-button-toggle-group name="checkbox" [vertical]="isVertical" [disabled]="isDisabled" [hideSingleSelectionIndicator]="hideSingleSelectionIndicator">
+  <mat-button-toggle-group
+    name="checkbox"
+    [vertical]="isVertical"
+    [disabled]="isDisabled"
+    [hideSingleSelectionIndicator]="hideSingleSelectionIndicator"
+    [disabledInteractive]="disabledInteractive">
     <mat-button-toggle value="bold">
       <mat-icon>format_bold</mat-icon>
     </mat-button-toggle>
@@ -61,14 +79,18 @@
       <mat-icon>format_italic</mat-icon>
     </mat-button-toggle>
     <mat-button-toggle value="underline">
-      <mat-icon>format_underline</mat-icon>
+      <mat-icon>format_underlined</mat-icon>
     </mat-button-toggle>
   </mat-button-toggle-group>
 </section>
 
 <h1>Multiple Selection</h1>
 <section>
-  <mat-button-toggle-group multiple [vertical]="isVertical" [hideMultipleSelectionIndicator]="hideMultipleSelectionIndicator">
+  <mat-button-toggle-group
+    multiple
+    [vertical]="isVertical"
+    [hideMultipleSelectionIndicator]="hideMultipleSelectionIndicator"
+    [disabledInteractive]="disabledInteractive">
     <mat-button-toggle>Flour</mat-button-toggle>
     <mat-button-toggle>Eggs</mat-button-toggle>
     <mat-button-toggle>Sugar</mat-button-toggle>
@@ -76,7 +98,12 @@
   </mat-button-toggle-group>
 </section>
 <section>
-  <mat-button-toggle-group appearance="legacy" multiple [vertical]="isVertical" [hideMultipleSelectionIndicator]="hideMultipleSelectionIndicator">
+  <mat-button-toggle-group
+    appearance="legacy"
+    multiple
+    [vertical]="isVertical"
+    [hideMultipleSelectionIndicator]="hideMultipleSelectionIndicator"
+    [disabledInteractive]="disabledInteractive">
     <mat-button-toggle>Flour</mat-button-toggle>
     <mat-button-toggle>Eggs</mat-button-toggle>
     <mat-button-toggle>Sugar</mat-button-toggle>
@@ -90,7 +117,12 @@
 
 <h1>Dynamic Exclusive Selection</h1>
 <section>
-  <mat-button-toggle-group name="pies" [(ngModel)]="favoritePie" [vertical]="isVertical" [hideSingleSelectionIndicator]="hideSingleSelectionIndicator">
+  <mat-button-toggle-group
+    name="pies"
+    [(ngModel)]="favoritePie"
+    [vertical]="isVertical"
+    [hideSingleSelectionIndicator]="hideSingleSelectionIndicator"
+    [disabledInteractive]="disabledInteractive">
     @for (pie of pieOptions; track pie) {
       <mat-button-toggle [value]="pie">{{pie}}</mat-button-toggle>
     }

--- a/src/dev-app/button-toggle/button-toggle-demo.ts
+++ b/src/dev-app/button-toggle/button-toggle-demo.ts
@@ -24,6 +24,7 @@ import {MatIconModule} from '@angular/material/icon';
 export class ButtonToggleDemo {
   isVertical = false;
   isDisabled = false;
+  disabledInteractive = false;
   hideSingleSelectionIndicator = false;
   hideMultipleSelectionIndicator = false;
   favoritePie = 'Apple';

--- a/src/material/button-toggle/button-toggle.html
+++ b/src/material/button-toggle/button-toggle.html
@@ -2,13 +2,14 @@
         type="button"
         [id]="buttonId"
         [attr.role]="isSingleSelector() ? 'radio' : 'button'"
-        [attr.tabindex]="disabled ? -1 : tabIndex"
+        [attr.tabindex]="disabled && !disabledInteractive ? -1 : tabIndex"
         [attr.aria-pressed]="!isSingleSelector() ? checked : null"
         [attr.aria-checked]="isSingleSelector() ? checked : null"
-        [disabled]="disabled || null"
+        [disabled]="(disabled && !disabledInteractive) || null"
         [attr.name]="_getButtonName()"
         [attr.aria-label]="ariaLabel"
         [attr.aria-labelledby]="ariaLabelledby"
+        [attr.aria-disabled]="disabled && disabledInteractive ? 'true' : null"
         (click)="_onButtonClick()">
   <span class="mat-button-toggle-label-content">
     <!-- Render checkmark at the beginning for single-selection. -->

--- a/src/material/button-toggle/button-toggle.scss
+++ b/src/material/button-toggle/button-toggle.scss
@@ -121,6 +121,8 @@ $_standard-tokens: (
 }
 
 .mat-button-toggle-disabled {
+  pointer-events: none;
+
   @include token-utils.use-tokens($_legacy-tokens...) {
     @include token-utils.create-token-slot(color, disabled-state-text-color);
     @include token-utils.create-token-slot(background-color, disabled-state-background-color);
@@ -132,6 +134,10 @@ $_standard-tokens: (
         disabled-selected-state-background-color);
     }
   }
+}
+
+.mat-button-toggle-disabled-interactive {
+  pointer-events: auto;
 }
 
 .mat-button-toggle-appearance-standard {
@@ -185,16 +191,15 @@ $_standard-tokens: (
       @include token-utils.create-token-slot(background-color, state-layer-color);
     }
 
-    &:not(.mat-button-toggle-disabled):hover .mat-button-toggle-focus-overlay {
+    &:hover .mat-button-toggle-focus-overlay {
       @include token-utils.create-token-slot(opacity, hover-state-layer-opacity);
     }
 
     // Similar to components like the checkbox, slide-toggle and radio, we cannot show the focus
     // overlay for `.cdk-program-focused` because mouse clicks on the <label> element would be
-    // always treated as programmatic focus. Note that it needs the extra `:not` in order to have
-    // more specificity than the `:hover` above.
+    // always treated as programmatic focus.
     // TODO(paul): support `program` as well. See https://github.com/angular/components/issues/9889
-    &.cdk-keyboard-focused:not(.mat-button-toggle-disabled) .mat-button-toggle-focus-overlay {
+    &.cdk-keyboard-focused .mat-button-toggle-focus-overlay {
       @include token-utils.create-token-slot(opacity, focus-state-layer-opacity);
     }
   }
@@ -204,7 +209,7 @@ $_standard-tokens: (
   // because we still want to preserve the keyboard focus state for hybrid devices that have
   // a keyboard and a touchscreen.
   @media (hover: none) {
-    &:not(.mat-button-toggle-disabled):hover .mat-button-toggle-focus-overlay {
+    &:hover .mat-button-toggle-focus-overlay {
       display: none;
     }
   }

--- a/src/material/button-toggle/button-toggle.spec.ts
+++ b/src/material/button-toggle/button-toggle.spec.ts
@@ -434,6 +434,25 @@ describe('MatButtonToggle without forms', () => {
       expect(buttons.every(input => input.disabled)).toBe(true);
     });
 
+    it('should be able to keep the button interactive while disabled', () => {
+      const button = buttonToggleNativeElements[0].querySelector('button')!;
+      testComponent.isGroupDisabled = true;
+      fixture.changeDetectorRef.markForCheck();
+      fixture.detectChanges();
+
+      expect(button.hasAttribute('disabled')).toBe(true);
+      expect(button.hasAttribute('aria-disabled')).toBe(false);
+      expect(button.getAttribute('tabindex')).toBe('-1');
+
+      testComponent.disabledIntearctive = true;
+      fixture.changeDetectorRef.markForCheck();
+      fixture.detectChanges();
+
+      expect(button.hasAttribute('disabled')).toBe(false);
+      expect(button.getAttribute('aria-disabled')).toBe('true');
+      expect(button.getAttribute('tabindex')).toBe('0');
+    });
+
     it('should update the group value when one of the toggles changes', () => {
       expect(groupInstance.value).toBeFalsy();
       buttonToggleLabelElements[0].click();
@@ -1052,9 +1071,11 @@ describe('MatButtonToggle without forms', () => {
 
 @Component({
   template: `
-  <mat-button-toggle-group [disabled]="isGroupDisabled"
-                           [vertical]="isVertical"
-                           [(value)]="groupValue">
+  <mat-button-toggle-group
+    [disabled]="isGroupDisabled"
+    [disabledInteractive]="disabledIntearctive"
+    [vertical]="isVertical"
+    [(value)]="groupValue">
     @if (renderFirstToggle) {
       <mat-button-toggle value="test1">Test1</mat-button-toggle>
     }
@@ -1067,6 +1088,7 @@ describe('MatButtonToggle without forms', () => {
 })
 class ButtonTogglesInsideButtonToggleGroup {
   isGroupDisabled: boolean = false;
+  disabledIntearctive = false;
   isVertical: boolean = false;
   groupValue: string;
   renderFirstToggle = true;

--- a/src/material/button-toggle/testing/button-toggle-harness.spec.ts
+++ b/src/material/button-toggle/testing/button-toggle-harness.spec.ts
@@ -59,6 +59,14 @@ describe('MatButtonToggleHarness', () => {
     expect(await disabledToggle.isDisabled()).toBe(true);
   });
 
+  it('should get the disabled state for an interactive disabled button', async () => {
+    fixture.componentInstance.disabledInteractive = true;
+    fixture.changeDetectorRef.markForCheck();
+
+    const disabledToggle = (await loader.getAllHarnesses(MatButtonToggleHarness))[1];
+    expect(await disabledToggle.isDisabled()).toBe(true);
+  });
+
   it('should get the toggle name', async () => {
     const toggle = await loader.getHarness(MatButtonToggleHarness.with({text: 'First'}));
     expect(await toggle.getName()).toBe('first-name');
@@ -141,6 +149,7 @@ describe('MatButtonToggleHarness', () => {
         checked>First</mat-button-toggle>
       <mat-button-toggle
         [disabled]="disabled"
+        [disabledInteractive]="disabledInteractive"
         aria-labelledby="second-label"
         appearance="legacy">Second</mat-button-toggle>
       <span id="second-label">Second toggle</span>
@@ -150,4 +159,5 @@ describe('MatButtonToggleHarness', () => {
 })
 class ButtonToggleHarnessTest {
   disabled = true;
+  disabledInteractive = false;
 }

--- a/src/material/button-toggle/testing/button-toggle-harness.ts
+++ b/src/material/button-toggle/testing/button-toggle-harness.ts
@@ -55,8 +55,8 @@ export class MatButtonToggleHarness extends ComponentHarness {
 
   /** Gets a boolean promise indicating if the button toggle is disabled. */
   async isDisabled(): Promise<boolean> {
-    const disabled = (await this._button()).getAttribute('disabled');
-    return coerceBooleanProperty(await disabled);
+    const host = await this.host();
+    return host.hasClass('mat-button-toggle-disabled');
   }
 
   /** Gets a promise for the button toggle's name. */

--- a/tools/public_api_guard/material/button-toggle.md
+++ b/tools/public_api_guard/material/button-toggle.md
@@ -47,6 +47,8 @@ export class MatButtonToggle implements OnInit, AfterViewInit, OnDestroy {
     set checked(value: boolean);
     get disabled(): boolean;
     set disabled(value: boolean);
+    get disabledInteractive(): boolean;
+    set disabledInteractive(value: boolean);
     disableRipple: boolean;
     focus(options?: FocusOptions): void;
     _getButtonName(): string | null;
@@ -58,6 +60,8 @@ export class MatButtonToggle implements OnInit, AfterViewInit, OnDestroy {
     static ngAcceptInputType_checked: unknown;
     // (undocumented)
     static ngAcceptInputType_disabled: unknown;
+    // (undocumented)
+    static ngAcceptInputType_disabledInteractive: unknown;
     // (undocumented)
     static ngAcceptInputType_disableRipple: unknown;
     // (undocumented)
@@ -71,7 +75,7 @@ export class MatButtonToggle implements OnInit, AfterViewInit, OnDestroy {
     set tabIndex(value: number | null);
     value: any;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<MatButtonToggle, "mat-button-toggle", ["matButtonToggle"], { "ariaLabel": { "alias": "aria-label"; "required": false; }; "ariaLabelledby": { "alias": "aria-labelledby"; "required": false; }; "id": { "alias": "id"; "required": false; }; "name": { "alias": "name"; "required": false; }; "value": { "alias": "value"; "required": false; }; "tabIndex": { "alias": "tabIndex"; "required": false; }; "disableRipple": { "alias": "disableRipple"; "required": false; }; "appearance": { "alias": "appearance"; "required": false; }; "checked": { "alias": "checked"; "required": false; }; "disabled": { "alias": "disabled"; "required": false; }; }, { "change": "change"; }, never, ["*"], true, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MatButtonToggle, "mat-button-toggle", ["matButtonToggle"], { "ariaLabel": { "alias": "aria-label"; "required": false; }; "ariaLabelledby": { "alias": "aria-labelledby"; "required": false; }; "id": { "alias": "id"; "required": false; }; "name": { "alias": "name"; "required": false; }; "value": { "alias": "value"; "required": false; }; "tabIndex": { "alias": "tabIndex"; "required": false; }; "disableRipple": { "alias": "disableRipple"; "required": false; }; "appearance": { "alias": "appearance"; "required": false; }; "checked": { "alias": "checked"; "required": false; }; "disabled": { "alias": "disabled"; "required": false; }; "disabledInteractive": { "alias": "disabledInteractive"; "required": false; }; }, { "change": "change"; }, never, ["*"], true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatButtonToggle, [{ optional: true; }, null, null, null, { attribute: "tabindex"; }, { optional: true; }]>;
 }
@@ -91,6 +95,7 @@ export class MatButtonToggleChange {
 // @public
 export interface MatButtonToggleDefaultOptions {
     appearance?: MatButtonToggleAppearance;
+    disabledInteractive?: boolean;
     hideMultipleSelectionIndicator?: boolean;
     hideSingleSelectionIndicator?: boolean;
 }
@@ -105,6 +110,8 @@ export class MatButtonToggleGroup implements ControlValueAccessor, OnInit, After
     get dir(): Direction;
     get disabled(): boolean;
     set disabled(value: boolean);
+    get disabledInteractive(): boolean;
+    set disabledInteractive(value: boolean);
     _emitChangeEvent(toggle: MatButtonToggle): void;
     get hideMultipleSelectionIndicator(): boolean;
     set hideMultipleSelectionIndicator(value: boolean);
@@ -119,6 +126,8 @@ export class MatButtonToggleGroup implements ControlValueAccessor, OnInit, After
     set name(value: string);
     // (undocumented)
     static ngAcceptInputType_disabled: unknown;
+    // (undocumented)
+    static ngAcceptInputType_disabledInteractive: unknown;
     // (undocumented)
     static ngAcceptInputType_hideMultipleSelectionIndicator: unknown;
     // (undocumented)
@@ -146,7 +155,7 @@ export class MatButtonToggleGroup implements ControlValueAccessor, OnInit, After
     vertical: boolean;
     writeValue(value: any): void;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<MatButtonToggleGroup, "mat-button-toggle-group", ["matButtonToggleGroup"], { "appearance": { "alias": "appearance"; "required": false; }; "name": { "alias": "name"; "required": false; }; "vertical": { "alias": "vertical"; "required": false; }; "value": { "alias": "value"; "required": false; }; "multiple": { "alias": "multiple"; "required": false; }; "disabled": { "alias": "disabled"; "required": false; }; "hideSingleSelectionIndicator": { "alias": "hideSingleSelectionIndicator"; "required": false; }; "hideMultipleSelectionIndicator": { "alias": "hideMultipleSelectionIndicator"; "required": false; }; }, { "valueChange": "valueChange"; "change": "change"; }, ["_buttonToggles"], never, true, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<MatButtonToggleGroup, "mat-button-toggle-group", ["matButtonToggleGroup"], { "appearance": { "alias": "appearance"; "required": false; }; "name": { "alias": "name"; "required": false; }; "vertical": { "alias": "vertical"; "required": false; }; "value": { "alias": "value"; "required": false; }; "multiple": { "alias": "multiple"; "required": false; }; "disabled": { "alias": "disabled"; "required": false; }; "disabledInteractive": { "alias": "disabledInteractive"; "required": false; }; "hideSingleSelectionIndicator": { "alias": "hideSingleSelectionIndicator"; "required": false; }; "hideMultipleSelectionIndicator": { "alias": "hideMultipleSelectionIndicator"; "required": false; }; }, { "valueChange": "valueChange"; "change": "change"; }, ["_buttonToggles"], never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatButtonToggleGroup, [null, { optional: true; }, { optional: true; }]>;
 }


### PR DESCRIPTION
Adds the `disabledInteractive` input to the button toggle that allows users to opt into supporting focus on disabled button toggles.