### PR TITLE
Fix sidenav container-background color according to M3

### DIFF
--- a/src/material/core/tokens/m3/mat/_sidenav.scss
+++ b/src/material/core/tokens/m3/mat/_sidenav.scss
@@ -16,7 +16,7 @@ $prefix: (mat, sidenav);
     container-divider-color: token-definition.hardcode(transparent, $exclude-hardcoded),
     container-width: token-definition.hardcode(360px, $exclude-hardcoded),
     container-shape: map.get($systems, md-sys-shape, corner-large),
-    container-background-color: map.get($systems, md-sys-color, surface),
+    container-background-color: map.get($systems, md-sys-color, surface-container-low),
     container-text-color: map.get($systems, md-sys-color, on-surface-variant),
     content-background-color: map.get($systems, md-sys-color, background),
     content-text-color: map.get($systems, md-sys-color, on-background),


### PR DESCRIPTION
According to https://m3.material.io/components/navigation-drawer/specs it should use "Surface container low".
Otherwise, when used in fixed opened, there won't be any separation from the content.

![image](https://github.com/user-attachments/assets/a55b72da-d2a1-4ebf-a6f5-2973a8e84773)
