### PR TITLE
Update next branch to reflect new release-train "v18.3.0-next.0".

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+<a name="18.2.0-rc.0"></a>
+# 18.2.0-rc.0 "wicker-whirlwind" (2024-08-07)
+### material
+| Commit | Type | Description |
+| -- | -- | -- |
+| [ddc307e284](https://github.com/angular/components/commit/ddc307e28449045c484510ff26798fc1a6efa7c1) | feat | **button-toggle:** allow disabled buttons to be interactive ([#29550](https://github.com/angular/components/pull/29550)) |
+| [7370eb92fc](https://github.com/angular/components/commit/7370eb92fc0a4364670914add9b12393c0f84dfe) | fix | **chips:** missing tokens in M3 ([#29531](https://github.com/angular/components/pull/29531)) |
+| [d22a24d667](https://github.com/angular/components/commit/d22a24d667a16c39d4a4ec5f59b248f990fa029e) | fix | **list:** checkmark not visible in high contrast mode ([#29546](https://github.com/angular/components/pull/29546)) |
+| [626164ba5f](https://github.com/angular/components/commit/626164ba5ff1b729d1d3baeef6e9dfd89566f3f4) | fix | **sidenav:** disable focus trap while closed ([#29548](https://github.com/angular/components/pull/29548)) |
+| [fd416a30e8](https://github.com/angular/components/commit/fd416a30e8de0e741ac45f3fb45e695abecf5ded) | fix | **tooltip:** remove aria-describedby when disabled ([#29520](https://github.com/angular/components/pull/29520)) |
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="18.1.4"></a>
 # 18.1.4 "pewter-polka" (2024-08-07)
 ### material

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "ci-notify-slack-failure": "node --no-warnings=ExperimentalWarning --loader ts-node/esm/transpile-only scripts/circleci/notify-slack-job-failure.mts",
     "prepare": "husky"
   },
-  "version": "18.2.0-next.3",
+  "version": "18.3.0-next.0",
   "dependencies": {
     "@angular/animations": "^18.2.0-next.2",
     "@angular/common": "^18.2.0-next.2",


### PR DESCRIPTION
The previous "next" release-train has moved into the release-candidate phase. This PR updates the next branch to the subsequent release-train.

Also this PR cherry-picks the changelog for v18.2.0-rc.0 into the main branch so that the changelog is up to date.