### PR TITLE
refactor(multiple): remove mdc-based descriptions

### DIFF
--- a/src/material/autocomplete/autocomplete.spec.ts
+++ b/src/material/autocomplete/autocomplete.spec.ts
@@ -54,7 +54,7 @@ import {
   getMatAutocompleteMissingPanelError,
 } from './index';
 
-describe('MDC-based MatAutocomplete', () => {
+describe('MatAutocomplete', () => {
   let overlayContainerElement: HTMLElement;
 
   // Creates a test component fixture.

--- a/src/material/autocomplete/autocomplete.zone.spec.ts
+++ b/src/material/autocomplete/autocomplete.zone.spec.ts
@@ -22,7 +22,7 @@ import {MatAutocomplete} from './autocomplete';
 import {MatAutocompleteTrigger} from './autocomplete-trigger';
 import {MatAutocompleteModule} from './module';
 
-describe('MDC-based MatAutocomplete Zone.js integration', () => {
+describe('MatAutocomplete Zone.js integration', () => {
   // Creates a test component fixture.
   function createComponent<T>(component: Type<T>, providers: Provider[] = []) {
     TestBed.configureTestingModule({

--- a/src/material/button/button.spec.ts
+++ b/src/material/button/button.spec.ts
@@ -11,7 +11,7 @@ import {
   MatFabDefaultOptions,
 } from './index';
 
-describe('MDC-based MatButton', () => {
+describe('MatButton', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [MatButtonModule, TestApp],

--- a/src/material/button/testing/button-harness.ts
+++ b/src/material/button/testing/button-harness.ts
@@ -14,7 +14,7 @@ import {
 } from '@angular/cdk/testing';
 import {ButtonHarnessFilters, ButtonVariant} from './button-harness-filters';
 
-/** Harness for interacting with a MDC-based mat-button in tests. */
+/** Harness for interacting with a mat-button in tests. */
 export class MatButtonHarness extends ContentContainerComponentHarness {
   // TODO(jelbourn) use a single class, like `.mat-button-base`
   static hostSelector = `[mat-button], [mat-raised-button], [mat-flat-button],

--- a/src/material/card/card.spec.ts
+++ b/src/material/card/card.spec.ts
@@ -3,7 +3,7 @@ import {Component, Provider, Type, signal} from '@angular/core';
 import {MatCardModule} from './module';
 import {MatCard, MAT_CARD_CONFIG, MatCardAppearance} from './card';
 
-describe('MDC-based MatCard', () => {
+describe('MatCard', () => {
   function createComponent<T>(component: Type<T>, providers: Provider[] = []): ComponentFixture<T> {
     TestBed.configureTestingModule({
       imports: [MatCardModule, component],

--- a/src/material/card/testing/card-harness.ts
+++ b/src/material/card/testing/card-harness.ts
@@ -21,7 +21,7 @@ export enum MatCardSection {
   FOOTER = '.mat-mdc-card-footer',
 }
 
-/** Harness for interacting with an MDC-based mat-card in tests. */
+/** Harness for interacting with a mat-card in tests. */
 export class MatCardHarness extends ContentContainerComponentHarness<MatCardSection> {
   /** The selector for the host element of a `MatCard` instance. */
   static hostSelector = '.mat-mdc-card';

--- a/src/material/checkbox/checkbox.spec.ts
+++ b/src/material/checkbox/checkbox.spec.ts
@@ -12,7 +12,7 @@ import {
   MatCheckboxModule,
 } from './index';
 
-describe('MDC-based MatCheckbox', () => {
+describe('MatCheckbox', () => {
   let fixture: ComponentFixture<any>;
 
   function createComponent<T>(componentType: Type<T>) {

--- a/src/material/chips/chip-edit-input.spec.ts
+++ b/src/material/chips/chip-edit-input.spec.ts
@@ -3,7 +3,7 @@ import {waitForAsync, TestBed, ComponentFixture} from '@angular/core/testing';
 import {MatChipEditInput, MatChipsModule} from './index';
 import {By} from '@angular/platform-browser';
 
-describe('MDC-based MatChipEditInput', () => {
+describe('MatChipEditInput', () => {
   const DEFAULT_INITIAL_VALUE = 'INITIAL_VALUE';
 
   let fixture: ComponentFixture<any>;

--- a/src/material/chips/chip-grid.spec.ts
+++ b/src/material/chips/chip-grid.spec.ts
@@ -41,7 +41,7 @@ import {By} from '@angular/platform-browser';
 import {BrowserAnimationsModule, NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {MatChipEvent, MatChipGrid, MatChipInputEvent, MatChipRow, MatChipsModule} from './index';
 
-describe('MDC-based MatChipGrid', () => {
+describe('MatChipGrid', () => {
   let chipGridDebugElement: DebugElement;
   let chipGridNativeElement: HTMLElement;
   let chipGridInstance: MatChipGrid;

--- a/src/material/chips/chip-input.spec.ts
+++ b/src/material/chips/chip-input.spec.ts
@@ -17,7 +17,7 @@ import {
   MatChipsModule,
 } from './index';
 
-describe('MDC-based MatChipInput', () => {
+describe('MatChipInput', () => {
   let fixture: ComponentFixture<any>;
   let testChipInput: TestChipInput;
   let inputDebugElement: DebugElement;

--- a/src/material/chips/chip-listbox.spec.ts
+++ b/src/material/chips/chip-listbox.spec.ts
@@ -19,7 +19,7 @@ import {FormControl, FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {By} from '@angular/platform-browser';
 import {MatChipListbox, MatChipOption, MatChipsModule} from './index';
 
-describe('MDC-based MatChipListbox', () => {
+describe('MatChipListbox', () => {
   let fixture: ComponentFixture<any>;
   let chipListboxDebugElement: DebugElement;
   let chipListboxNativeElement: HTMLElement;

--- a/src/material/chips/chip-option.spec.ts
+++ b/src/material/chips/chip-option.spec.ts
@@ -16,7 +16,7 @@ import {
   MatChipsModule,
 } from './index';
 
-describe('MDC-based Option Chips', () => {
+describe('Option Chips', () => {
   let fixture: ComponentFixture<any>;
   let chipDebugElement: DebugElement;
   let chipNativeElement: HTMLElement;

--- a/src/material/chips/chip-remove.spec.ts
+++ b/src/material/chips/chip-remove.spec.ts
@@ -5,7 +5,7 @@ import {ComponentFixture, TestBed, fakeAsync, flush, waitForAsync} from '@angula
 import {By} from '@angular/platform-browser';
 import {MatChip, MatChipsModule} from './index';
 
-describe('MDC-based Chip Remove', () => {
+describe('Chip Remove', () => {
   let fixture: ComponentFixture<TestChip>;
   let testChip: TestChip;
   let chipNativeElement: HTMLElement;

--- a/src/material/chips/chip-row.spec.ts
+++ b/src/material/chips/chip-row.spec.ts
@@ -19,7 +19,7 @@ import {
   MatChipsModule,
 } from './index';
 
-describe('MDC-based Row Chips', () => {
+describe('Row Chips', () => {
   let fixture: ComponentFixture<any>;
   let chipDebugElement: DebugElement;
   let chipNativeElement: HTMLElement;

--- a/src/material/chips/chip-set.spec.ts
+++ b/src/material/chips/chip-set.spec.ts
@@ -4,7 +4,7 @@ import {ComponentFixture, TestBed, fakeAsync, tick, waitForAsync} from '@angular
 import {By} from '@angular/platform-browser';
 import {MatChip, MatChipSet, MatChipsModule} from './index';
 
-describe('MDC-based MatChipSet', () => {
+describe('MatChipSet', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [MatChipsModule, CommonModule, BasicChipSet, IndirectDescendantsChipSet],

--- a/src/material/chips/chip.spec.ts
+++ b/src/material/chips/chip.spec.ts
@@ -5,7 +5,7 @@ import {By} from '@angular/platform-browser';
 import {Subject} from 'rxjs';
 import {MatChip, MatChipEvent, MatChipSet, MatChipsModule} from './index';
 
-describe('MDC-based MatChip', () => {
+describe('MatChip', () => {
   let fixture: ComponentFixture<any>;
   let chipDebugElement: DebugElement;
   let chipNativeElement: HTMLElement;

--- a/src/material/core/testing/optgroup-harness.ts
+++ b/src/material/core/testing/optgroup-harness.ts
@@ -15,7 +15,7 @@ import {OptgroupHarnessFilters} from './optgroup-harness-filters';
 import {MatOptionHarness} from './option-harness';
 import {OptionHarnessFilters} from './option-harness-filters';
 
-/** Harness for interacting with an MDC-based `mat-optgroup` in tests. */
+/** Harness for interacting with a `mat-optgroup` in tests. */
 export class MatOptgroupHarness extends ComponentHarness {
   /** Selector used to locate option group instances. */
   static hostSelector = '.mat-mdc-optgroup';

--- a/src/material/core/testing/option-harness.ts
+++ b/src/material/core/testing/option-harness.ts
@@ -13,7 +13,7 @@ import {
 } from '@angular/cdk/testing';
 import {OptionHarnessFilters} from './option-harness-filters';
 
-/** Harness for interacting with an MDC-based `mat-option` in tests. */
+/** Harness for interacting with a `mat-option` in tests. */
 export class MatOptionHarness extends ContentContainerComponentHarness {
   /** Selector used to locate option instances. */
   static hostSelector = '.mat-mdc-option';

--- a/src/material/dialog/dialog.spec.ts
+++ b/src/material/dialog/dialog.spec.ts
@@ -57,7 +57,7 @@ import {
   MatDialogTitle,
 } from './index';
 
-describe('MDC-based MatDialog', () => {
+describe('MatDialog', () => {
   let dialog: MatDialog;
   let overlayContainerElement: HTMLElement;
   let scrolledSubject = new Subject();
@@ -1890,7 +1890,7 @@ describe('MDC-based MatDialog', () => {
   }));
 });
 
-describe('MDC-based MatDialog with a parent MatDialog', () => {
+describe('MatDialog with a parent MatDialog', () => {
   let parentDialog: MatDialog;
   let childDialog: MatDialog;
   let overlayContainerElement: HTMLElement;
@@ -1988,7 +1988,7 @@ describe('MDC-based MatDialog with a parent MatDialog', () => {
   }));
 });
 
-describe('MDC-based MatDialog with default options', () => {
+describe('MatDialog with default options', () => {
   let dialog: MatDialog;
   let overlayContainerElement: HTMLElement;
 
@@ -2071,7 +2071,7 @@ describe('MDC-based MatDialog with default options', () => {
   }));
 });
 
-describe('MDC-based MatDialog with animations enabled', () => {
+describe('MatDialog with animations enabled', () => {
   let dialog: MatDialog;
 
   let testViewContainerRef: ViewContainerRef;

--- a/src/material/dialog/dialog.zone.spec.ts
+++ b/src/material/dialog/dialog.zone.spec.ts
@@ -15,7 +15,7 @@ import {MatDialog, MatDialogModule, MatDialogRef} from '@angular/material/dialog
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {Subject} from 'rxjs';
 
-describe('MDC-based MatDialog', () => {
+describe('MatDialog', () => {
   let dialog: MatDialog;
   let scrolledSubject = new Subject();
 

--- a/src/material/dialog/testing/dialog-opener.spec.ts
+++ b/src/material/dialog/testing/dialog-opener.spec.ts
@@ -4,7 +4,7 @@ import {MAT_DIALOG_DATA, MatDialogRef, MatDialogState} from '@angular/material/d
 import {MatTestDialogOpener, MatTestDialogOpenerModule} from '@angular/material/dialog/testing';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 
-describe('MDC-based MatTestDialogOpener', () => {
+describe('MatTestDialogOpener', () => {
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
       imports: [MatTestDialogOpenerModule, NoopAnimationsModule, ExampleComponent],

--- a/src/material/form-field/testing/error-harness.ts
+++ b/src/material/form-field/testing/error-harness.ts
@@ -19,7 +19,7 @@ export interface ErrorHarnessFilters extends BaseHarnessFilters {
   text?: string | RegExp;
 }
 
-/** Harness for interacting with an MDC-based `mat-error` in tests. */
+/** Harness for interacting with a `mat-error` in tests. */
 export class MatErrorHarness extends ComponentHarness {
   static hostSelector = '.mat-mdc-form-field-error';
 

--- a/src/material/list/list.spec.ts
+++ b/src/material/list/list.spec.ts
@@ -4,7 +4,7 @@ import {TestBed, fakeAsync, waitForAsync} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {MatListItem, MatListModule} from './index';
 
-describe('MDC-based MatList', () => {
+describe('MatList', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [

--- a/src/material/list/selection-list.spec.ts
+++ b/src/material/list/selection-list.spec.ts
@@ -34,7 +34,7 @@ import {
   MatSelectionListChange,
 } from './index';
 
-describe('MDC-based MatSelectionList without forms', () => {
+describe('MatSelectionList without forms', () => {
   const typeaheadInterval = 200;
 
   describe('with list option', () => {
@@ -1251,7 +1251,7 @@ describe('MDC-based MatSelectionList without forms', () => {
   });
 });
 
-describe('MDC-based MatSelectionList with forms', () => {
+describe('MatSelectionList with forms', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [

--- a/src/material/list/testing/action-list-harness.ts
+++ b/src/material/list/testing/action-list-harness.ts
@@ -11,7 +11,7 @@ import {MatListHarnessBase} from './list-harness-base';
 import {ActionListHarnessFilters, ActionListItemHarnessFilters} from './list-harness-filters';
 import {getListItemPredicate, MatListItemHarnessBase} from './list-item-harness-base';
 
-/** Harness for interacting with a MDC-based action-list in tests. */
+/** Harness for interacting with a action-list in tests. */
 export class MatActionListHarness extends MatListHarnessBase<
   typeof MatActionListItemHarness,
   MatActionListItemHarness,

--- a/src/material/list/testing/list-harness.ts
+++ b/src/material/list/testing/list-harness.ts
@@ -11,7 +11,7 @@ import {MatListHarnessBase} from './list-harness-base';
 import {ListHarnessFilters, ListItemHarnessFilters} from './list-harness-filters';
 import {getListItemPredicate, MatListItemHarnessBase} from './list-item-harness-base';
 
-/** Harness for interacting with a MDC-based list in tests. */
+/** Harness for interacting with a list in tests. */
 export class MatListHarness extends MatListHarnessBase<
   typeof MatListItemHarness,
   MatListItemHarness,

--- a/src/material/list/testing/list-item-harness-base.ts
+++ b/src/material/list/testing/list-item-harness-base.ts
@@ -48,7 +48,7 @@ export function getListItemPredicate<H extends MatListItemHarnessBase>(
     );
 }
 
-/** Harness for interacting with a MDC-based list subheader. */
+/** Harness for interacting with a list subheader. */
 export class MatSubheaderHarness extends ComponentHarness {
   static hostSelector = '.mat-mdc-subheader';
 

--- a/src/material/list/testing/nav-list-harness.ts
+++ b/src/material/list/testing/nav-list-harness.ts
@@ -11,7 +11,7 @@ import {MatListHarnessBase} from './list-harness-base';
 import {NavListHarnessFilters, NavListItemHarnessFilters} from './list-harness-filters';
 import {getListItemPredicate, MatListItemHarnessBase} from './list-item-harness-base';
 
-/** Harness for interacting with a MDC-based mat-nav-list in tests. */
+/** Harness for interacting with a mat-nav-list in tests. */
 export class MatNavListHarness extends MatListHarnessBase<
   typeof MatNavListItemHarness,
   MatNavListItemHarness,
@@ -36,7 +36,7 @@ export class MatNavListHarness extends MatListHarnessBase<
   override _itemHarness = MatNavListItemHarness;
 }
 
-/** Harness for interacting with a MDC-based nav-list item. */
+/** Harness for interacting with a nav-list item. */
 export class MatNavListItemHarness extends MatListItemHarnessBase {
   /** The selector for the host element of a `MatListItem` instance. */
   static hostSelector = `${MatNavListHarness.hostSelector} .mat-mdc-list-item`;

--- a/src/material/list/testing/selection-list-harness.ts
+++ b/src/material/list/testing/selection-list-harness.ts
@@ -75,7 +75,7 @@ export class MatSelectionListHarness extends MatListHarnessBase<
   }
 }
 
-/** Harness for interacting with a MDC-based list option. */
+/** Harness for interacting with a list option. */
 export class MatListOptionHarness extends MatListItemHarnessBase {
   /** The selector for the host element of a `MatListOption` instance. */
   static hostSelector = '.mat-mdc-list-option';

--- a/src/material/menu/menu.spec.ts
+++ b/src/material/menu/menu.spec.ts
@@ -52,7 +52,7 @@ import {
 
 const MENU_PANEL_TOP_PADDING = 8;
 
-describe('MDC-based MatMenu', () => {
+describe('MatMenu', () => {
   let overlayContainerElement: HTMLElement;
   let focusMonitor: FocusMonitor;
   let viewportRuler: ViewportRuler;

--- a/src/material/menu/testing/menu-harness.ts
+++ b/src/material/menu/testing/menu-harness.ts
@@ -17,7 +17,7 @@ import {
 import {coerceBooleanProperty} from '@angular/cdk/coercion';
 import {MenuHarnessFilters, MenuItemHarnessFilters} from './menu-harness-filters';
 
-/** Harness for interacting with an MDC-based mat-menu in tests. */
+/** Harness for interacting with a mat-menu in tests. */
 export class MatMenuHarness extends ContentContainerComponentHarness<string> {
   private _documentRootLocator = this.documentRootLocatorFactory();
 

--- a/src/material/paginator/paginator.spec.ts
+++ b/src/material/paginator/paginator.spec.ts
@@ -13,7 +13,7 @@ import {
 } from './index';
 import {MAT_PAGINATOR_DEFAULT_OPTIONS, MatPaginatorDefaultOptions} from './paginator';
 
-describe('MDC-based MatPaginator', () => {
+describe('MatPaginator', () => {
   function createComponent<T>(type: Type<T>, providers: Provider[] = []): ComponentFixture<T> {
     TestBed.configureTestingModule({
       imports: [MatPaginatorModule, NoopAnimationsModule],

--- a/src/material/progress-bar/progress-bar.spec.ts
+++ b/src/material/progress-bar/progress-bar.spec.ts
@@ -12,7 +12,7 @@ import {By} from '@angular/platform-browser';
 import {MAT_PROGRESS_BAR_DEFAULT_OPTIONS, MatProgressBarModule} from './index';
 import {MatProgressBar} from './progress-bar';
 
-describe('MDC-based MatProgressBar', () => {
+describe('MatProgressBar', () => {
   function createComponent<T>(
     componentType: Type<T>,
     providers: (Provider | EnvironmentProviders)[] = [],

--- a/src/material/progress-bar/testing/progress-bar-harness.ts
+++ b/src/material/progress-bar/testing/progress-bar-harness.ts
@@ -14,7 +14,7 @@ import {
 } from '@angular/cdk/testing';
 import {ProgressBarHarnessFilters} from './progress-bar-harness-filters';
 
-/** Harness for interacting with an MDC-based `mat-progress-bar` in tests. */
+/** Harness for interacting with a `mat-progress-bar` in tests. */
 export class MatProgressBarHarness extends ComponentHarness {
   static hostSelector = '.mat-mdc-progress-bar';
 

--- a/src/material/progress-spinner/progress-spinner.spec.ts
+++ b/src/material/progress-spinner/progress-spinner.spec.ts
@@ -5,7 +5,7 @@ import {Component, ElementRef, ViewChild, ViewEncapsulation, signal} from '@angu
 import {MatProgressSpinnerModule} from './module';
 import {MatProgressSpinner, MAT_PROGRESS_SPINNER_DEFAULT_OPTIONS} from './progress-spinner';
 
-describe('MDC-based MatProgressSpinner', () => {
+describe('MatProgressSpinner', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [

--- a/src/material/radio/radio.spec.ts
+++ b/src/material/radio/radio.spec.ts
@@ -12,7 +12,7 @@ import {
   MatRadioModule,
 } from './index';
 
-describe('MDC-based MatRadio', () => {
+describe('MatRadio', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [

--- a/src/material/radio/testing/radio-harness.ts
+++ b/src/material/radio/testing/radio-harness.ts
@@ -14,7 +14,7 @@ import {
 } from '@angular/cdk/testing';
 import {RadioButtonHarnessFilters, RadioGroupHarnessFilters} from './radio-harness-filters';
 
-/** Harness for interacting with an MDC-based mat-radio-group in tests. */
+/** Harness for interacting with a mat-radio-group in tests. */
 export class MatRadioGroupHarness extends ComponentHarness {
   /** The selector for the host element of a `MatRadioGroup` instance. */
   static hostSelector = '.mat-mdc-radio-group';
@@ -166,7 +166,7 @@ export class MatRadioGroupHarness extends ComponentHarness {
   }
 }
 
-/** Harness for interacting with an MDC-based mat-radio-button in tests. */
+/** Harness for interacting with a mat-radio-button in tests. */
 export class MatRadioButtonHarness extends ComponentHarness {
   /** The selector for the host element of a `MatRadioButton` instance. */
   static hostSelector = '.mat-mdc-radio-button';

--- a/src/material/select/select.spec.ts
+++ b/src/material/select/select.spec.ts
@@ -78,7 +78,7 @@ import {
 /** Default debounce interval when typing letters to select an option. */
 const DEFAULT_TYPEAHEAD_DEBOUNCE_INTERVAL = 200;
 
-describe('MDC-based MatSelect', () => {
+describe('MatSelect', () => {
   let overlayContainerElement: HTMLElement;
   let dir: {value: 'ltr' | 'rtl'; change: Observable<string>};
   let scrolledSubject = new Subject();

--- a/src/material/select/testing/select-harness.ts
+++ b/src/material/select/testing/select-harness.ts
@@ -16,7 +16,7 @@ import {
 import {MatFormFieldControlHarness} from '@angular/material/form-field/testing/control';
 import {SelectHarnessFilters} from './select-harness-filters';
 
-/** Harness for interacting with an MDC-based mat-select in tests. */
+/** Harness for interacting with a mat-select in tests. */
 export class MatSelectHarness extends MatFormFieldControlHarness {
   static hostSelector = '.mat-mdc-select';
   private _prefix = 'mat-mdc';

--- a/src/material/slide-toggle/slide-toggle.spec.ts
+++ b/src/material/slide-toggle/slide-toggle.spec.ts
@@ -16,7 +16,7 @@ import {By} from '@angular/platform-browser';
 import {MatSlideToggle, MatSlideToggleChange, MatSlideToggleModule} from './index';
 import {MAT_SLIDE_TOGGLE_DEFAULT_OPTIONS} from './slide-toggle-config';
 
-describe('MDC-based MatSlideToggle without forms', () => {
+describe('MatSlideToggle without forms', () => {
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
       imports: [
@@ -540,7 +540,7 @@ describe('MDC-based MatSlideToggle without forms', () => {
   }));
 });
 
-describe('MDC-based MatSlideToggle with forms', () => {
+describe('MatSlideToggle with forms', () => {
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
       imports: [

--- a/src/material/slider/slider.spec.ts
+++ b/src/material/slider/slider.spec.ts
@@ -32,7 +32,7 @@ interface Point {
   y: number;
 }
 
-describe('MDC-based MatSlider', () => {
+describe('MatSlider', () => {
   let platform: Platform;
 
   function createComponent<T>(component: Type<T>, providers: Provider[] = []): ComponentFixture<T> {

--- a/src/material/slider/testing/slider-harness.spec.ts
+++ b/src/material/slider/testing/slider-harness.spec.ts
@@ -15,7 +15,7 @@ import {MatSliderHarness} from './slider-harness';
 import {MatSliderThumbHarness} from './slider-thumb-harness';
 import {ThumbPosition} from './slider-harness-filters';
 
-describe('MDC-based MatSliderHarness', () => {
+describe('MatSliderHarness', () => {
   let fixture: ComponentFixture<SliderHarnessTest>;
   let loader: HarnessLoader;
 

--- a/src/material/snack-bar/testing/snack-bar-harness.ts
+++ b/src/material/snack-bar/testing/snack-bar-harness.ts
@@ -10,7 +10,7 @@ import {ContentContainerComponentHarness, HarnessPredicate, parallel} from '@ang
 import {AriaLivePoliteness} from '@angular/cdk/a11y';
 import {SnackBarHarnessFilters} from './snack-bar-harness-filters';
 
-/** Harness for interacting with an MDC-based mat-snack-bar in tests. */
+/** Harness for interacting with a mat-snack-bar in tests. */
 export class MatSnackBarHarness extends ContentContainerComponentHarness<string> {
   // Developers can provide a custom component or template for the
   // snackbar. The canonical snack-bar parent is the "MatSnackBarContainer".

--- a/src/material/table/table.spec.ts
+++ b/src/material/table/table.spec.ts
@@ -14,7 +14,7 @@ import {MatSort, MatSortHeader, MatSortModule} from '@angular/material/sort';
 import {MatPaginator, MatPaginatorModule} from '@angular/material/paginator';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 
-describe('MDC-based MatTable', () => {
+describe('MatTable', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [

--- a/src/material/tabs/tab-body.spec.ts
+++ b/src/material/tabs/tab-body.spec.ts
@@ -18,7 +18,7 @@ import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {Subject} from 'rxjs';
 import {MatTabBody, MatTabBodyPortal} from './tab-body';
 
-describe('MDC-based MatTabBody', () => {
+describe('MatTabBody', () => {
   let dir: Direction = 'ltr';
   let dirChange: Subject<Direction> = new Subject<Direction>();
 

--- a/src/material/tabs/tab-group.spec.ts
+++ b/src/material/tabs/tab-group.spec.ts
@@ -22,7 +22,7 @@ import {
   MatTabsModule,
 } from './index';
 
-describe('MDC-based MatTabGroup', () => {
+describe('MatTabGroup', () => {
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
       imports: [

--- a/src/material/tabs/tab-header.spec.ts
+++ b/src/material/tabs/tab-header.spec.ts
@@ -28,7 +28,7 @@ import {Subject} from 'rxjs';
 import {MatTabHeader} from './tab-header';
 import {MatTabLabelWrapper} from './tab-label-wrapper';
 
-describe('MDC-based MatTabHeader', () => {
+describe('MatTabHeader', () => {
   let fixture: ComponentFixture<SimpleTabHeaderApp>;
   let appComponent: SimpleTabHeaderApp;
   let resizeEvents: Subject<ResizeObserverEntry[]>;

--- a/src/material/tabs/tab-nav-bar/tab-nav-bar.spec.ts
+++ b/src/material/tabs/tab-nav-bar/tab-nav-bar.spec.ts
@@ -16,7 +16,7 @@ import {MAT_TABS_CONFIG} from '../index';
 import {MatTabsModule} from '../module';
 import {MatTabLink, MatTabNav} from './tab-nav-bar';
 
-describe('MDC-based MatTabNavBar', () => {
+describe('MatTabNavBar', () => {
   let dir: Direction = 'ltr';
   let dirChange = new Subject();
   let globalRippleOptions: RippleGlobalOptions;

--- a/src/material/tabs/testing/tab-group-harness.ts
+++ b/src/material/tabs/testing/tab-group-harness.ts
@@ -15,7 +15,7 @@ import {
 import {TabGroupHarnessFilters, TabHarnessFilters} from './tab-harness-filters';
 import {MatTabHarness} from './tab-harness';
 
-/** Harness for interacting with an MDC-based mat-tab-group in tests. */
+/** Harness for interacting with a mat-tab-group in tests. */
 export class MatTabGroupHarness extends ComponentHarness {
   /** The selector for the host element of a `MatTabGroup` instance. */
   static hostSelector = '.mat-mdc-tab-group';

--- a/src/material/tabs/testing/tab-link-harness.ts
+++ b/src/material/tabs/testing/tab-link-harness.ts
@@ -13,7 +13,7 @@ import {
 } from '@angular/cdk/testing';
 import {TabLinkHarnessFilters} from './tab-harness-filters';
 
-/** Harness for interacting with an MDC-based Angular Material tab link in tests. */
+/** Harness for interacting with a Angular Material tab link in tests. */
 export class MatTabLinkHarness extends ComponentHarness {
   /** The selector for the host element of a `MatTabLink` instance. */
   static hostSelector = '.mat-mdc-tab-link';

--- a/src/material/tabs/testing/tab-nav-bar-harness.ts
+++ b/src/material/tabs/testing/tab-nav-bar-harness.ts
@@ -20,7 +20,7 @@ import {
 import {MatTabLinkHarness} from './tab-link-harness';
 import {MatTabNavPanelHarness} from './tab-nav-panel-harness';
 
-/** Harness for interacting with an MDC-based mat-tab-nav-bar in tests. */
+/** Harness for interacting with a mat-tab-nav-bar in tests. */
 export class MatTabNavBarHarness extends ComponentHarness {
   /** The selector for the host element of a `MatTabNavBar` instance. */
   static hostSelector = '.mat-mdc-tab-nav-bar';

--- a/src/material/tooltip/tooltip.spec.ts
+++ b/src/material/tooltip/tooltip.spec.ts
@@ -43,7 +43,7 @@ import {
 
 const initialTooltipMessage = 'initial tooltip message';
 
-describe('MDC-based MatTooltip', () => {
+describe('MatTooltip', () => {
   let overlayContainerElement: HTMLElement;
   let dir: {value: Direction; change: Subject<Direction>};
   let platform: Platform;

--- a/src/material/tooltip/tooltip.zone.spec.ts
+++ b/src/material/tooltip/tooltip.zone.spec.ts
@@ -16,7 +16,7 @@ import {MatTooltip} from './tooltip';
 
 const initialTooltipMessage = 'initial tooltip message';
 
-describe('MDC-based MatTooltip Zone.js integration', () => {
+describe('MatTooltip Zone.js integration', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [MatTooltipModule, OverlayModule, ScrollableTooltipDemo],


### PR DESCRIPTION
We had a bunch of places left over where things were described as "MDC-based" from the time when we had two versions of each component.