### PR TITLE
build: move commit message check to be last in pipeline

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -42,10 +42,12 @@ jobs:
         run: yarn tslint
       - name: Check for circular dependencies
         run: yarn -s ts-circular-deps:check
-      - name: Check commit message
-        run: yarn ng-dev commit-message validate-range ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }}
       - name: Check code format
         run: yarn ng-dev format changed --check ${{ github.event.pull_request.base.sha }}
+      # Commit message check is last intentionally, because the caretaker can fix it
+      # during merge, while other lint failures have to be resolved by the PR author.
+      - name: Check commit message
+        run: yarn ng-dev commit-message validate-range ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }}
 
   api_golden_checks:
     runs-on: ubuntu-latest


### PR DESCRIPTION
It occasionally happens that we get a PR that has both the incorrect commit message and a lint failure. The process of fixing it can take multiple runs, because the author has to fix the commit, re-run and then fix the lint failures.

These changes move the commit message check to be last since if everything else passes, the caretaker can fix the commit message while merging the PR.