### PR TITLE
Account for disabledInteractive in test harnesses

### DIFF
--- a/src/material/checkbox/testing/checkbox-harness.spec.ts
+++ b/src/material/checkbox/testing/checkbox-harness.spec.ts
@@ -167,6 +167,17 @@ describe('MatCheckboxHarness', () => {
     await disabledCheckbox.toggle();
     expect(await disabledCheckbox.isChecked()).toBe(false);
   });
+
+  it('should get disabled state for checkbox with disabledInteractive', async () => {
+    fixture.componentInstance.disabled.set(false);
+    fixture.componentInstance.disabledInteractive.set(true);
+
+    const checkbox = await loader.getHarness(MatCheckboxHarness.with({label: 'Second'}));
+    expect(await checkbox.isDisabled()).toBe(false);
+
+    fixture.componentInstance.disabled.set(true);
+    expect(await checkbox.isDisabled()).toBe(true);
+  });
 });
 
 @Component({
@@ -179,7 +190,11 @@ describe('MatCheckboxHarness', () => {
         aria-label="First checkbox">
       First
     </mat-checkbox>
-    <mat-checkbox indeterminate="true" [disabled]="disabled()" aria-labelledby="second-label">
+    <mat-checkbox
+      indeterminate="true"
+      [disabled]="disabled()"
+      aria-labelledby="second-label"
+      [disabledInteractive]="disabledInteractive()">
       Second
     </mat-checkbox>
     <span id="second-label">Second checkbox</span>
@@ -190,4 +205,5 @@ describe('MatCheckboxHarness', () => {
 class CheckboxHarnessTest {
   ctrl = new FormControl(true);
   disabled = signal(true);
+  disabledInteractive = signal(false);
 }

--- a/src/material/checkbox/testing/checkbox-harness.ts
+++ b/src/material/checkbox/testing/checkbox-harness.ts
@@ -72,8 +72,14 @@ export class MatCheckboxHarness extends ComponentHarness {
 
   /** Whether the checkbox is disabled. */
   async isDisabled(): Promise<boolean> {
-    const disabled = (await this._input()).getAttribute('disabled');
-    return coerceBooleanProperty(await disabled);
+    const input = await this._input();
+    const disabled = await input.getAttribute('disabled');
+
+    if (disabled !== null) {
+      return coerceBooleanProperty(disabled);
+    }
+
+    return (await input.getAttribute('aria-disabled')) === 'true';
   }
 
   /** Whether the checkbox is required. */

--- a/src/material/radio/testing/radio-harness.spec.ts
+++ b/src/material/radio/testing/radio-harness.spec.ts
@@ -45,21 +45,17 @@ describe('radio harness', () => {
       expect(await groups[0].getId()).toBe('my-group-1');
     });
 
-    it(
-      'should throw when finding radio-group with specific name that has mismatched ' +
-        'radio-button names',
-      async () => {
-        fixture.componentInstance.thirdGroupButtonName = 'other-name';
-        fixture.changeDetectorRef.markForCheck();
-        fixture.detectChanges();
+    it('should throw when finding radio-group with specific name that has mismatched radio-button names', async () => {
+      fixture.componentInstance.thirdGroupButtonName = 'other-name';
+      fixture.changeDetectorRef.markForCheck();
+      fixture.detectChanges();
 
-        await expectAsync(
-          loader.getAllHarnesses(MatRadioGroupHarness.with({name: 'third-group-name'})),
-        ).toBeRejectedWithError(
-          /locator found a radio-group with name "third-group-name".*have mismatching names/,
-        );
-      },
-    );
+      await expectAsync(
+        loader.getAllHarnesses(MatRadioGroupHarness.with({name: 'third-group-name'})),
+      ).toBeRejectedWithError(
+        /locator found a radio-group with name "third-group-name".*have mismatching names/,
+      );
+    });
 
     it('should get name of radio-group', async () => {
       const groups = await loader.getAllHarnesses(MatRadioGroupHarness);
@@ -214,6 +210,20 @@ describe('radio harness', () => {
       expect(await firstRadio.isDisabled()).toBe(true);
     });
 
+    it('should get the disabled state with disabledInteractive is enabled', async () => {
+      fixture.componentInstance.disabledInteractive = true;
+      fixture.changeDetectorRef.markForCheck();
+
+      const [firstRadio] = await loader.getAllHarnesses(MatRadioButtonHarness);
+      expect(await firstRadio.isDisabled()).toBe(false);
+
+      fixture.componentInstance.disableAll = true;
+      fixture.changeDetectorRef.markForCheck();
+      fixture.detectChanges();
+
+      expect(await firstRadio.isDisabled()).toBe(true);
+    });
+
     it('should focus radio-button', async () => {
       const radioButton = await loader.getHarness(MatRadioButtonHarness.with({selector: '#opt2'}));
       expect(await radioButton.isFocused()).toBe(false);
@@ -272,6 +282,7 @@ describe('radio harness', () => {
       <mat-radio-button
         [name]="value === 'opt3' ? 'group2' : 'group1'"
         [disabled]="disableAll"
+        [disabledInteractive]="disabledInteractive"
         [checked]="value === 'opt2'"
         [id]="value"
         [required]="value === 'opt2'"
@@ -307,6 +318,7 @@ describe('radio harness', () => {
 class MultipleRadioButtonsHarnessTest {
   values = ['opt1', 'opt2', 'opt3'];
   disableAll = false;
+  disabledInteractive = false;
   secondGroupId = 'my-group-2';
   thirdGroupName: string = 'third-group-name';
   thirdGroupButtonName: string | undefined = undefined;

--- a/src/material/radio/testing/radio-harness.ts
+++ b/src/material/radio/testing/radio-harness.ts
@@ -205,8 +205,14 @@ export class MatRadioButtonHarness extends ComponentHarness {
 
   /** Whether the radio-button is disabled. */
   async isDisabled(): Promise<boolean> {
-    const disabled = (await this._input()).getAttribute('disabled');
-    return coerceBooleanProperty(await disabled);
+    const input = await this._input();
+    const disabled = await input.getAttribute('disabled');
+
+    if (disabled !== null) {
+      return coerceBooleanProperty(disabled);
+    }
+
+    return (await input.getAttribute('aria-disabled')) === 'true';
   }
 
   /** Whether the radio-button is required. */

--- a/src/material/slide-toggle/slide-toggle.html
+++ b/src/material/slide-toggle/slide-toggle.html
@@ -17,7 +17,7 @@
     [attr.aria-describedby]="ariaDescribedby"
     [attr.aria-required]="required || null"
     [attr.aria-checked]="checked"
-    [attr.aria-disabled]="disabledInteractive && disabledInteractive ? 'true' : null"
+    [attr.aria-disabled]="disabled && disabledInteractive ? 'true' : null"
     (click)="_handleClick()"
     #switch>
     <span class="mdc-switch__track"></span>

--- a/src/material/slide-toggle/testing/slide-toggle-harness.spec.ts
+++ b/src/material/slide-toggle/testing/slide-toggle-harness.spec.ts
@@ -160,6 +160,17 @@ describe('MatSlideToggleHarness', () => {
     await disabledToggle.toggle();
     expect(await disabledToggle.isChecked()).toBe(false);
   });
+
+  it('should get disabled state when disabledInteractive is enabled', async () => {
+    fixture.componentInstance.disabled.set(false);
+    fixture.componentInstance.disabledInteractive.set(true);
+
+    const toggle = await loader.getHarness(MatSlideToggleHarness.with({label: 'Second'}));
+    expect(await toggle.isDisabled()).toBe(false);
+
+    fixture.componentInstance.disabled.set(true);
+    expect(await toggle.isDisabled()).toBe(true);
+  });
 });
 
 @Component({
@@ -171,7 +182,10 @@ describe('MatSlideToggleHarness', () => {
           aria-label="First slide-toggle">
         First
       </mat-slide-toggle>
-      <mat-slide-toggle [disabled]="disabled()" aria-labelledby="second-label">
+      <mat-slide-toggle
+        [disabled]="disabled()"
+        [disabledInteractive]="disabledInteractive()"
+        aria-labelledby="second-label">
         Second
       </mat-slide-toggle>
       <span id="second-label">Second slide-toggle</span>
@@ -182,4 +196,5 @@ describe('MatSlideToggleHarness', () => {
 class SlideToggleHarnessTest {
   ctrl = new FormControl(true);
   disabled = signal(true);
+  disabledInteractive = signal(false);
 }

--- a/src/material/slide-toggle/testing/slide-toggle-harness.ts
+++ b/src/material/slide-toggle/testing/slide-toggle-harness.ts
@@ -70,8 +70,14 @@ export class MatSlideToggleHarness extends ComponentHarness {
 
   /** Whether the slide-toggle is disabled. */
   async isDisabled(): Promise<boolean> {
-    const disabled = (await this._nativeElement()).getAttribute('disabled');
-    return coerceBooleanProperty(await disabled);
+    const nativeElement = await this._nativeElement();
+    const disabled = await nativeElement.getAttribute('disabled');
+
+    if (disabled !== null) {
+      return coerceBooleanProperty(disabled);
+    }
+
+    return (await nativeElement.getAttribute('aria-disabled')) === 'true';
   }
 
   /** Whether the slide-toggle is required. */


### PR DESCRIPTION
Fixes that a few test harnesses weren't accounting for the new `disabledInteractive` inputs.