### PR TITLE
feat(material/input): add the ability to interact with disabled inputs

### DIFF
--- a/src/dev-app/input/input-demo.html
+++ b/src/dev-app/input/input-demo.html
@@ -712,6 +712,53 @@
 </mat-card>
 
 <mat-card class="demo-card demo-basic">
+  <mat-toolbar color="primary">Disabled interactive inputs</mat-toolbar>
+  <mat-card-content>
+    @for (appearance of appearances; track $index) {
+      <div>
+        <mat-form-field [appearance]="appearance">
+          <mat-label>Label</mat-label>
+          <input
+            matNativeControl
+            disabled
+            disabledInteractive
+            value="Value"
+            matTooltip="I can trigger a tooltip!">
+        </mat-form-field>
+
+        <mat-form-field [appearance]="appearance">
+          <mat-label>Label</mat-label>
+          <input
+            matNativeControl
+            disabled
+            disabledInteractive
+            matTooltip="I can trigger a tooltip!">
+        </mat-form-field>
+
+        <mat-form-field [appearance]="appearance">
+          <mat-label>Label</mat-label>
+          <input
+            matNativeControl
+            disabled
+            disabledInteractive
+            placeholder="Placeholder"
+            matTooltip="I can trigger a tooltip!">
+        </mat-form-field>
+
+        <mat-form-field [appearance]="appearance">
+          <input
+            matNativeControl
+            disabled
+            disabledInteractive
+            matTooltip="I can trigger a tooltip!"
+            placeholder="Placeholder">
+        </mat-form-field>
+      </div>
+    }
+  </mat-card-content>
+</mat-card>
+
+<mat-card class="demo-card demo-basic">
   <mat-toolbar color="primary">Textarea form-fields</mat-toolbar>
   <mat-card-content>
     <mat-form-field appearance="fill" class="demo-horizontal-spacing">

--- a/src/dev-app/input/input-demo.ts
+++ b/src/dev-app/input/input-demo.ts
@@ -100,6 +100,7 @@ export class InputDemo {
   standardAppearance: string;
   fillAppearance: string;
   outlineAppearance: string;
+  appearances: MatFormFieldAppearance[] = ['fill', 'outline'];
 
   hasLabel$ = new BehaviorSubject(true);
 

--- a/src/material/form-field/_mdc-text-field-structure.scss
+++ b/src/material/form-field/_mdc-text-field-structure.scss
@@ -72,6 +72,12 @@
       }
     }
 
+    .mdc-text-field--disabled:not(.mdc-text-field--no-label) &.mat-mdc-input-disabled-interactive {
+      @include vendor-prefixes.input-placeholder {
+        opacity: 0;
+      }
+    }
+
     .mdc-text-field--outlined &,
     .mdc-text-field--filled.mdc-text-field--no-label & {
       height: 100%;

--- a/src/material/input/input.spec.ts
+++ b/src/material/input/input.spec.ts
@@ -403,6 +403,65 @@ describe('MatMdcInput without forms', () => {
     expect(inputEl.disabled).toBe(true);
   }));
 
+  it('should be able to set an input as being disabled and interactive', fakeAsync(() => {
+    const fixture = createComponent(MatInputWithDisabled);
+    fixture.componentInstance.disabled = true;
+    fixture.detectChanges();
+
+    const input = fixture.nativeElement.querySelector('input') as HTMLInputElement;
+    expect(input.disabled).toBe(true);
+    expect(input.readOnly).toBe(false);
+    expect(input.hasAttribute('aria-disabled')).toBe(false);
+    expect(input.classList).not.toContain('mat-mdc-input-disabled-interactive');
+
+    fixture.componentInstance.disabledInteractive = true;
+    fixture.changeDetectorRef.markForCheck();
+    fixture.detectChanges();
+
+    expect(input.disabled).toBe(false);
+    expect(input.readOnly).toBe(true);
+    expect(input.getAttribute('aria-disabled')).toBe('true');
+    expect(input.classList).toContain('mat-mdc-input-disabled-interactive');
+  }));
+
+  it('should not float the label when disabled and disabledInteractive are set', fakeAsync(() => {
+    const fixture = createComponent(MatInputTextTestController);
+    fixture.componentInstance.disabled = fixture.componentInstance.disabledInteractive = true;
+    fixture.detectChanges();
+
+    const label = fixture.nativeElement.querySelector('label');
+    const input = fixture.debugElement
+      .query(By.directive(MatInput))!
+      .injector.get<MatInput>(MatInput);
+
+    expect(label.classList).not.toContain('mdc-floating-label--float-above');
+
+    // Call the focus handler directly to avoid flakyness where
+    // browsers don't focus elements if the window is minimized.
+    input._focusChanged(true);
+    fixture.detectChanges();
+
+    expect(label.classList).not.toContain('mdc-floating-label--float-above');
+  }));
+
+  it('should float the label when disabledInteractive is set and the input has a value', fakeAsync(() => {
+    const fixture = createComponent(MatInputWithDynamicLabel);
+    fixture.componentInstance.shouldFloat = 'auto';
+    fixture.componentInstance.disabled = fixture.componentInstance.disabledInteractive = true;
+    fixture.detectChanges();
+
+    const input = fixture.nativeElement.querySelector('input');
+    const label = fixture.nativeElement.querySelector('label');
+
+    expect(label.classList).not.toContain('mdc-floating-label--float-above');
+
+    input.value = 'Text';
+    dispatchFakeEvent(input, 'input');
+    fixture.detectChanges();
+
+    expect(label.classList).toContain('mdc-floating-label--float-above');
+  }));
+
   it('supports the disabled attribute as binding for select', fakeAsync(() => {
     const fixture = createComponent(MatInputSelect);
     fixture.detectChanges();
@@ -719,16 +778,13 @@ describe('MatMdcInput without forms', () => {
     expect(labelEl.classList).not.toContain('mdc-floating-label--float-above');
   }));
 
-  it(
-    'should not float labels when select has no value, no option label, ' + 'no option innerHtml',
-    fakeAsync(() => {
-      const fixture = createComponent(MatInputSelectWithNoLabelNoValue);
-      fixture.detectChanges();
+  it('should not float labels when select has no value, no option label, no option innerHtml', fakeAsync(() => {
+    const fixture = createComponent(MatInputSelectWithNoLabelNoValue);
+    fixture.detectChanges();
 
-      const labelEl = fixture.debugElement.query(By.css('label'))!.nativeElement;
-      expect(labelEl.classList).not.toContain('mdc-floating-label--float-above');
-    }),
-  );
+    const labelEl = fixture.debugElement.query(By.css('label'))!.nativeElement;
+    expect(labelEl.classList).not.toContain('mdc-floating-label--float-above');
+  }));
 
   it('should floating labels when select has no value but has option label', fakeAsync(() => {
     const fixture = createComponent(MatInputSelectWithLabel);
@@ -1532,6 +1588,7 @@ describe('MatFormField default options', () => {
     ).toBe(true);
   });
 });
+
 describe('MatFormField without label', () => {
   it('should not float the label when no label is defined.', () => {
     let fixture = createComponent(MatInputWithoutDefinedLabel);
@@ -1650,10 +1707,15 @@ class MatInputWithId {
 }
 
 @Component({
-  template: `<mat-form-field><input matInput [disabled]="disabled"></mat-form-field>`,
+  template: `
+    <mat-form-field>
+      <input matInput [disabled]="disabled" [disabledInteractive]="disabledInteractive">
+    </mat-form-field>
+  `,
 })
 class MatInputWithDisabled {
-  disabled: boolean;
+  disabled = false;
+  disabledInteractive = false;
 }
 
 @Component({
@@ -1783,10 +1845,18 @@ class MatInputDateTestController {}
   template: `
     <mat-form-field>
       <mat-label>Label</mat-label>
-      <input matInput type="text" placeholder="Placeholder">
+      <input
+        matInput
+        type="text"
+        placeholder="Placeholder"
+        [disabled]="disabled"
+        [disabledInteractive]="disabledInteractive">
     </mat-form-field>`,
 })
-class MatInputTextTestController {}
+class MatInputTextTestController {
+  disabled = false;
+  disabledInteractive = false;
+}
 
 @Component({
   template: `
@@ -1837,11 +1907,17 @@ class MatInputWithStaticLabel {}
   template: `
     <mat-form-field [floatLabel]="shouldFloat">
       <mat-label>Label</mat-label>
-      <input matInput placeholder="Placeholder">
+      <input
+        matInput
+        placeholder="Placeholder"
+        [disabled]="disabled"
+        [disabledInteractive]="disabledInteractive">
     </mat-form-field>`,
 })
 class MatInputWithDynamicLabel {
   shouldFloat: 'always' | 'auto' = 'always';
+  disabled = false;
+  disabledInteractive = false;
 }
 
 @Component({

--- a/src/material/input/public-api.ts
+++ b/src/material/input/public-api.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-export {MatInput} from './input';
+export {MatInput, MatInputConfig, MAT_INPUT_CONFIG} from './input';
 export {MatInputModule} from './module';
 export * from './input-value-accessor';
 export * from './input-errors';

--- a/src/material/input/testing/input-harness.spec.ts
+++ b/src/material/input/testing/input-harness.spec.ts
@@ -220,6 +220,17 @@ describe('MatInputHarness', () => {
     await input.setValue('#00ff00');
     expect((await input.getValue()).toLowerCase()).toBe('#00ff00');
   });
+
+  it('should be able to get disabled state when disabledInteractive is enabled', async () => {
+    const input = (await loader.getAllHarnesses(MatInputHarness))[1];
+
+    fixture.componentInstance.disabled.set(false);
+    fixture.componentInstance.disabledInteractive.set(true);
+    expect(await input.isDisabled()).toBe(false);
+
+    fixture.componentInstance.disabled.set(true);
+    expect(await input.isDisabled()).toBe(true);
+  });
 });
 
 @Component({
@@ -229,10 +240,13 @@ describe('MatInputHarness', () => {
     </mat-form-field>
 
     <mat-form-field>
-      <input matInput [type]="inputType()"
-                      [readonly]="readonly()"
-                      [disabled]="disabled()"
-                      [required]="required()">
+      <input
+        matInput
+        [type]="inputType()"
+        [readonly]="readonly()"
+        [disabled]="disabled()"
+        [disabledInteractive]="disabledInteractive()"
+        [required]="required()">
     </mat-form-field>
 
     <mat-form-field>
@@ -272,6 +286,7 @@ class InputHarnessTest {
   inputType = signal('number');
   readonly = signal(false);
   disabled = signal(false);
+  disabledInteractive = signal(false);
   required = signal(false);
   ngModelValue = '';
   ngModelName = 'has-ng-model';

--- a/src/material/input/testing/input-harness.ts
+++ b/src/material/input/testing/input-harness.ts
@@ -8,6 +8,7 @@
 
 import {HarnessPredicate, parallel} from '@angular/cdk/testing';
 import {MatFormFieldControlHarness} from '@angular/material/form-field/testing/control';
+import {coerceBooleanProperty} from '@angular/cdk/coercion';
 import {InputHarnessFilters} from './input-harness-filters';
 
 /** Harness for interacting with a standard Material inputs in tests. */
@@ -35,7 +36,14 @@ export class MatInputHarness extends MatFormFieldControlHarness {
 
   /** Whether the input is disabled. */
   async isDisabled(): Promise<boolean> {
-    return (await this.host()).getProperty<boolean>('disabled');
+    const host = await this.host();
+    const disabled = await host.getAttribute('disabled');
+
+    if (disabled !== null) {
+      return coerceBooleanProperty(disabled);
+    }
+
+    return (await host.getAttribute('aria-disabled')) === 'true';
   }
 
   /** Whether the input is required. */

--- a/tools/public_api_guard/material/input.md
+++ b/tools/public_api_guard/material/input.md
@@ -35,6 +35,9 @@ import { Subject } from 'rxjs';
 export function getMatInputUnsupportedTypeError(type: string): Error;
 
 // @public
+export const MAT_INPUT_CONFIG: InjectionToken<MatInputConfig>;
+
+// @public
 export const MAT_INPUT_VALUE_ACCESSOR: InjectionToken<{
     value: any;
 }>;
@@ -55,6 +58,7 @@ export class MatInput implements MatFormFieldControl<any>, OnChanges, OnDestroy,
     set disabled(value: BooleanInput);
     // (undocumented)
     protected _disabled: boolean;
+    disabledInteractive: boolean;
     // (undocumented)
     protected _elementRef: ElementRef<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>;
     get empty(): boolean;
@@ -68,6 +72,7 @@ export class MatInput implements MatFormFieldControl<any>, OnChanges, OnDestroy,
     // (undocumented)
     protected _formField?: MatFormField | undefined;
     protected _getPlaceholder(): string | null;
+    protected _getReadonlyAttribute(): string | null;
     get id(): string;
     set id(value: string);
     // (undocumented)
@@ -82,6 +87,8 @@ export class MatInput implements MatFormFieldControl<any>, OnChanges, OnDestroy,
     name: string;
     // (undocumented)
     protected _neverEmptyInputTypes: string[];
+    // (undocumented)
+    static ngAcceptInputType_disabledInteractive: unknown;
     // (undocumented)
     ngAfterViewInit(): void;
     // (undocumented)
@@ -121,9 +128,14 @@ export class MatInput implements MatFormFieldControl<any>, OnChanges, OnDestroy,
     get value(): string;
     set value(value: any);
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<MatInput, "input[matInput], textarea[matInput], select[matNativeControl],      input[matNativeControl], textarea[matNativeControl]", ["matInput"], { "disabled": { "alias": "disabled"; "required": false; }; "id": { "alias": "id"; "required": false; }; "placeholder": { "alias": "placeholder"; "required": false; }; "name": { "alias": "name"; "required": false; }; "required": { "alias": "required"; "required": false; }; "type": { "alias": "type"; "required": false; }; "errorStateMatcher": { "alias": "errorStateMatcher"; "required": false; }; "userAriaDescribedBy": { "alias": "aria-describedby"; "required": false; }; "value": { "alias": "value"; "required": false; }; "readonly": { "alias": "readonly"; "required": false; }; }, {}, never, never, true, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<MatInput, "input[matInput], textarea[matInput], select[matNativeControl],      input[matNativeControl], textarea[matNativeControl]", ["matInput"], { "disabled": { "alias": "disabled"; "required": false; }; "id": { "alias": "id"; "required": false; }; "placeholder": { "alias": "placeholder"; "required": false; }; "name": { "alias": "name"; "required": false; }; "required": { "alias": "required"; "required": false; }; "type": { "alias": "type"; "required": false; }; "errorStateMatcher": { "alias": "errorStateMatcher"; "required": false; }; "userAriaDescribedBy": { "alias": "aria-describedby"; "required": false; }; "value": { "alias": "value"; "required": false; }; "readonly": { "alias": "readonly"; "required": false; }; "disabledInteractive": { "alias": "disabledInteractive"; "required": false; }; }, {}, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatInput, [null, null, { optional: true; self: true; }, { optional: true; }, { optional: true; }, null, { optional: true; self: true; }, null, null, { optional: true; }]>;
+}
+
+// @public
+export interface MatInputConfig {
+    disabledInteractive?: boolean;
 }
 
 // @public (undocumented)


### PR DESCRIPTION
Adds the `disabledInteractive` input to `MatInput` which allows users to opt into having disabled input receive focus and dispatch events. Changing the value is prevented through the `readonly` attribute while disabled state is conveyed via `aria-disabled`.