### PR TITLE
fix(material/option): add fix for autocomplete mobile screen readers

### DIFF
--- a/src/material/core/option/option.ts
+++ b/src/material/core/option/option.ts
@@ -55,6 +55,7 @@ export class MatOptionSelectionChange<T = any> {
   exportAs: 'matOption',
   host: {
     'role': 'option',
+    'tabindex': '-1',
     '[class.mdc-list-item--selected]': 'selected',
     '[class.mat-mdc-option-multiple]': 'multiple',
     '[class.mat-mdc-option-active]': 'active',

--- a/src/material/select/select.spec.ts
+++ b/src/material/select/select.spec.ts
@@ -1297,10 +1297,10 @@ describe('MatSelect', () => {
             .toBe(true);
         }));
 
-        it('should omit the tabindex attribute on each option', fakeAsync(() => {
-          expect(options[0].hasAttribute('tabindex')).toBeFalse();
-          expect(options[1].hasAttribute('tabindex')).toBeFalse();
-          expect(options[2].hasAttribute('tabindex')).toBeFalse();
+        it('should not omit the tabindex attribute on each option', fakeAsync(() => {
+          expect(options[0].hasAttribute('tabindex')).toBeTrue();
+          expect(options[1].hasAttribute('tabindex')).toBeTrue();
+          expect(options[2].hasAttribute('tabindex')).toBeTrue();
         }));
 
         it('should set aria-disabled for disabled options', fakeAsync(() => {


### PR DESCRIPTION
added tabindex=-1 to add programmatic focus to mat-options

fixes b/272216403