### PR TITLE
refactor(multiple): fix initializers using constructor members

### DIFF
--- a/src/cdk-experimental/column-resize/column-resize-notifier.ts
+++ b/src/cdk-experimental/column-resize/column-resize-notifier.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Injectable} from '@angular/core';
+import {inject, Injectable} from '@angular/core';
 import {Observable, Subject} from 'rxjs';
 
 /** Indicates the width of a column. */
@@ -55,10 +55,10 @@ export class ColumnResizeNotifierSource {
 /** Service for triggering column resizes imperatively or being notified of them. */
 @Injectable()
 export class ColumnResizeNotifier {
+  private readonly _source = inject(ColumnResizeNotifierSource);
+
   /** Emits whenever a column is resized. */
   readonly resizeCompleted: Observable<ColumnSize> = this._source.resizeCompleted;
-
-  constructor(private readonly _source: ColumnResizeNotifierSource) {}
 
   /** Instantly resizes the specified column. */
   resize(columnId: string, size: number): void {

--- a/src/cdk/a11y/interactivity-checker/interactivity-checker.spec.ts
+++ b/src/cdk/a11y/interactivity-checker/interactivity-checker.spec.ts
@@ -1,6 +1,5 @@
 import {Platform} from '@angular/cdk/platform';
-import {PLATFORM_ID} from '@angular/core';
-import {inject} from '@angular/core/testing';
+import {TestBed} from '@angular/core/testing';
 import {InteractivityChecker, IsFocusableConfig} from './interactivity-checker';
 
 describe('InteractivityChecker', () => {
@@ -8,12 +7,12 @@ describe('InteractivityChecker', () => {
   let testContainerElement: HTMLElement;
   let checker: InteractivityChecker;
 
-  beforeEach(inject([PLATFORM_ID], (platformId: Object) => {
+  beforeEach(() => {
     testContainerElement = document.createElement('div');
     document.body.appendChild(testContainerElement);
-    platform = new Platform(platformId);
-    checker = new InteractivityChecker(platform);
-  }));
+    platform = TestBed.inject(Platform);
+    checker = TestBed.inject(InteractivityChecker);
+  });
 
   afterEach(() => {
     testContainerElement.remove();

--- a/src/cdk/platform/platform.ts
+++ b/src/cdk/platform/platform.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Inject, Injectable, PLATFORM_ID} from '@angular/core';
+import {inject, Injectable, PLATFORM_ID} from '@angular/core';
 import {isPlatformBrowser} from '@angular/common';
 
 // Whether the current platform supports the V8 Break Iterator. The V8 check
@@ -30,6 +30,8 @@ try {
  */
 @Injectable({providedIn: 'root'})
 export class Platform {
+  private _platformId = inject(PLATFORM_ID);
+
   // We want to use the Angular platform check because if the Document is shimmed
   // without the navigator, the following checks will fail. This is preferred because
   // sometimes the Document may be shimmed without the user's knowledge or intention
@@ -84,5 +86,8 @@ export class Platform {
   /** Whether the current browser is Safari. */
   SAFARI: boolean = this.isBrowser && /safari/i.test(navigator.userAgent) && this.WEBKIT;
 
-  constructor(@Inject(PLATFORM_ID) private _platformId: Object) {}
+  /** Backwards-compatible constructor. */
+  constructor(..._args: unknown[]);
+
+  constructor() {}
 }

--- a/src/cdk/testing/testbed/task-state-zone-interceptor.ts
+++ b/src/cdk/testing/testbed/task-state-zone-interceptor.ts
@@ -30,6 +30,8 @@ type PatchedProxyZone = ProxyZone & {
  * This serves as a workaround for https://github.com/angular/angular/issues/32896.
  */
 export class TaskStateZoneInterceptor {
+  private _lastState: HasTaskState | null = null;
+
   /** Subject that can be used to emit a new state change. */
   private readonly _stateSubject = new BehaviorSubject<TaskState>(
     this._lastState ? this._getTaskStateFromInternalZoneState(this._lastState) : {stable: true},
@@ -38,7 +40,9 @@ export class TaskStateZoneInterceptor {
   /** Public observable that emits whenever the task state changes. */
   readonly state: Observable<TaskState> = this._stateSubject;
 
-  constructor(private _lastState: HasTaskState | null) {}
+  constructor(lastState: HasTaskState | null) {
+    this._lastState = lastState;
+  }
 
   /** This will be called whenever the task state changes in the intercepted zone. */
   onHasTask(delegate: ZoneDelegate, current: Zone, target: Zone, hasTaskState: HasTaskState) {

--- a/src/material-experimental/selection/row-selection.ts
+++ b/src/material-experimental/selection/row-selection.ts
@@ -28,5 +28,5 @@ import {Input, Directive} from '@angular/core';
 })
 export class MatRowSelection<T> extends CdkRowSelection<T> {
   /** The value that is associated with the row */
-  @Input('matRowSelectionValue') override value: T;
+  @Input('matRowSelectionValue') override value: T = undefined!;
 }

--- a/src/material/dialog/dialog-container.ts
+++ b/src/material/dialog/dialog-container.ts
@@ -21,6 +21,7 @@ import {
   Optional,
   ViewEncapsulation,
   ANIMATION_MODULE_TYPE,
+  inject,
 } from '@angular/core';
 import {MatDialogConfig} from './dialog-config';
 import {CdkDialogContainer} from '@angular/cdk/dialog';
@@ -72,6 +73,8 @@ export const CLOSE_ANIMATION_DURATION = 75;
   },
 })
 export class MatDialogContainer extends CdkDialogContainer<MatDialogConfig> implements OnDestroy {
+  private _animationMode = inject(ANIMATION_MODULE_TYPE, {optional: true});
+
   /** Emits when an animation state changes. */
   _animationStateChanged = new EventEmitter<LegacyDialogAnimationEvent>();
 
@@ -102,7 +105,7 @@ export class MatDialogContainer extends CdkDialogContainer<MatDialogConfig> impl
     interactivityChecker: InteractivityChecker,
     ngZone: NgZone,
     overlayRef: OverlayRef,
-    @Optional() @Inject(ANIMATION_MODULE_TYPE) private _animationMode?: string,
+    @Optional() @Inject(ANIMATION_MODULE_TYPE) _unusedAnimationMode?: string,
     focusMonitor?: FocusMonitor,
   ) {
     super(

--- a/src/material/select/select.ts
+++ b/src/material/select/select.ts
@@ -217,6 +217,8 @@ export class MatSelect
     ControlValueAccessor,
     MatFormFieldControl<any>
 {
+  protected _defaultOptions = inject(MAT_SELECT_CONFIG, {optional: true});
+
   /** All of the defined select options. */
   @ContentChildren(MatOption, {descendants: true}) options: QueryList<MatOption>;
 
@@ -607,7 +609,7 @@ export class MatSelect
     @Attribute('tabindex') tabIndex: string,
     @Inject(MAT_SELECT_SCROLL_STRATEGY) scrollStrategyFactory: any,
     private _liveAnnouncer: LiveAnnouncer,
-    @Optional() @Inject(MAT_SELECT_CONFIG) protected _defaultOptions?: MatSelectConfig,
+    @Optional() @Inject(MAT_SELECT_CONFIG) _unusedDefaultOptions?: unknown,
   ) {
     if (this.ngControl) {
       // Note: we provide the value accessor through here, instead of
@@ -617,8 +619,8 @@ export class MatSelect
 
     // Note that we only want to set this when the defaults pass it in, otherwise it should
     // stay as `undefined` so that it falls back to the default in the key manager.
-    if (_defaultOptions?.typeaheadDebounceInterval != null) {
-      this.typeaheadDebounceInterval = _defaultOptions.typeaheadDebounceInterval;
+    if (this._defaultOptions?.typeaheadDebounceInterval != null) {
+      this.typeaheadDebounceInterval = this._defaultOptions.typeaheadDebounceInterval;
     }
 
     this._errorStateTracker = new _ErrorStateTracker(

--- a/tools/public_api_guard/cdk/platform.md
+++ b/tools/public_api_guard/cdk/platform.md
@@ -29,7 +29,7 @@ export function normalizePassiveListenerOptions(options: AddEventListenerOptions
 
 // @public
 export class Platform {
-    constructor(_platformId: Object);
+    constructor(..._args: unknown[]);
     ANDROID: boolean;
     BLINK: boolean;
     EDGE: boolean;

--- a/tools/public_api_guard/material/dialog.md
+++ b/tools/public_api_guard/material/dialog.md
@@ -188,7 +188,7 @@ export class MatDialogConfig<D = any> {
 
 // @public (undocumented)
 export class MatDialogContainer extends CdkDialogContainer<MatDialogConfig> implements OnDestroy {
-    constructor(elementRef: ElementRef, focusTrapFactory: FocusTrapFactory, _document: any, dialogConfig: MatDialogConfig, interactivityChecker: InteractivityChecker, ngZone: NgZone, overlayRef: OverlayRef, _animationMode?: string | undefined, focusMonitor?: FocusMonitor);
+    constructor(elementRef: ElementRef, focusTrapFactory: FocusTrapFactory, _document: any, dialogConfig: MatDialogConfig, interactivityChecker: InteractivityChecker, ngZone: NgZone, overlayRef: OverlayRef, _unusedAnimationMode?: string, focusMonitor?: FocusMonitor);
     protected _actionSectionCount: number;
     _animationsEnabled: boolean;
     _animationStateChanged: EventEmitter<LegacyDialogAnimationEvent>;

--- a/tools/public_api_guard/material/select.md
+++ b/tools/public_api_guard/material/select.md
@@ -87,7 +87,7 @@ export { MatPrefix }
 // @public (undocumented)
 export class MatSelect implements AfterContentInit, OnChanges, OnDestroy, OnInit, DoCheck, ControlValueAccessor, MatFormFieldControl<any> {
     constructor(_viewportRuler: ViewportRuler, _changeDetectorRef: ChangeDetectorRef,
-    _unusedNgZone: NgZone, defaultErrorStateMatcher: ErrorStateMatcher, _elementRef: ElementRef, _dir: Directionality, parentForm: NgForm, parentFormGroup: FormGroupDirective, _parentFormField: MatFormField, ngControl: NgControl, tabIndex: string, scrollStrategyFactory: any, _liveAnnouncer: LiveAnnouncer, _defaultOptions?: MatSelectConfig | undefined);
+    _unusedNgZone: NgZone, defaultErrorStateMatcher: ErrorStateMatcher, _elementRef: ElementRef, _dir: Directionality, parentForm: NgForm, parentFormGroup: FormGroupDirective, _parentFormField: MatFormField, ngControl: NgControl, tabIndex: string, scrollStrategyFactory: any, _liveAnnouncer: LiveAnnouncer, _unusedDefaultOptions?: unknown);
     ariaLabel: string;
     ariaLabelledby: string;
     protected _canOpen(): boolean;
@@ -100,7 +100,7 @@ export class MatSelect implements AfterContentInit, OnChanges, OnDestroy, OnInit
     controlType: string;
     customTrigger: MatSelectTrigger;
     // (undocumented)
-    protected _defaultOptions?: MatSelectConfig | undefined;
+    protected _defaultOptions: MatSelectConfig | null;
     protected readonly _destroy: Subject<void>;
     readonly disableAutomaticLabeling = true;
     disabled: boolean;


### PR DESCRIPTION
Fixes the cases where the initializers of properties were referencing members initialized in the constructor. This was preventing compatibility with `useDefineForClassFields`.