### PR TITLE
fix(material/icon): update error message for missing HttpClient

### DIFF
--- a/src/material/icon/icon-registry.ts
+++ b/src/material/icon/icon-registry.ts
@@ -39,9 +39,8 @@ export function getMatIconNameNotFoundError(iconName: string): Error {
  */
 export function getMatIconNoHttpProviderError(): Error {
   return Error(
-    'Could not find HttpClient provider for use with Angular Material icons. ' +
-      'Please include the HttpClientModule from @angular/common/http in your ' +
-      'app imports.',
+    'Could not find HttpClient for use with Angular Material icons. ' +
+      'Please add provideHttpClient() to your providers.',
   );
 }
 


### PR DESCRIPTION
Updates the message saying that `HttpClient` is missing to refer to a non-deprecated API.

Fixes #29587.