### PR TITLE
build: remove outdated `--non-interactive` yarn option from doc site install

### DIFF
--- a/scripts/docs-deploy/docs-deps-install.mts
+++ b/scripts/docs-deploy/docs-deps-install.mts
@@ -10,7 +10,7 @@ export async function installDepsForDocsSite(
   repoDirPath: string,
   options: InstallOptions = {frozenLockfile: true},
 ) {
-  const additionalArgs = ['--non-interactive'];
+  const additionalArgs = [];
 
   if (options.frozenLockfile) {
     additionalArgs.push('--frozen-lockfile');


### PR DESCRIPTION
The `--non-interactive` option is not supported on newer version of yarn and should not be used moving forward to ensure support with yarn version upgrades.