### PR TITLE
fix(material/menu): inconsistent layout of submenu icon

### DIFF
--- a/src/material/core/style/_menu-common.scss
+++ b/src/material/core/style/_menu-common.scss
@@ -74,6 +74,7 @@ $icon-margin: 16px !default;
     // Invert the arrow direction.
     polygon {
       transform: scaleX(-1);
+      transform-origin: center;
     }
   }
 


### PR DESCRIPTION
Fixes that the offset of the submenu icon wasn't identical between LTR and RTL.

Fixes #29599.