### PR TITLE
Simplify structural style setup

### DIFF
--- a/src/cdk/overlay/BUILD.bazel
+++ b/src/cdk/overlay/BUILD.bazel
@@ -18,6 +18,9 @@ ng_module(
         ["**/*.ts"],
         exclude = ["**/*.spec.ts"],
     ),
+    assets = [
+        ":overlay-prebuilt.css",
+    ],
     deps = [
         "//src:dev_mode_types",
         "//src/cdk/bidi",
@@ -25,6 +28,7 @@ ng_module(
         "//src/cdk/keycodes",
         "//src/cdk/platform",
         "//src/cdk/portal",
+        "//src/cdk/private",
         "//src/cdk/scrolling",
         "@npm//@angular/common",
         "@npm//@angular/core",

--- a/src/cdk/overlay/_index.scss
+++ b/src/cdk/overlay/_index.scss
@@ -76,23 +76,24 @@ $backdrop-animation-timing-function: cubic-bezier(0.25, 0.8, 0.25, 1) !default;
     -webkit-tap-highlight-color: transparent;
     transition: opacity $backdrop-animation-duration $backdrop-animation-timing-function;
     opacity: 0;
+  }
 
-    &.cdk-overlay-backdrop-showing {
-      opacity: 1;
+  .cdk-overlay-backdrop-showing {
+    opacity: 1;
 
-      // Note that we can't import and use the `high-contrast` mixin from `_a11y.scss`, because
-      // this file will be copied to the top-level `cdk` package when putting together the files
-      // for npm. Any relative import paths we use here will become invalid once the file is copied.
-      .cdk-high-contrast-active & {
-        // In high contrast mode the rgba background will become solid
-        // so we need to fall back to making it opaque using `opacity`.
-        opacity: 0.6;
-      }
+    // Note that we can't import and use the `high-contrast` mixin from `_a11y.scss`, because
+    // this file will be copied to the top-level `cdk` package when putting together the files
+    // for npm. Any relative import paths we use here will become invalid once the file is copied.
+    .cdk-high-contrast-active & {
+      // In high contrast mode the rgba background will become solid
+      // so we need to fall back to making it opaque using `opacity`.
+      opacity: 0.6;
     }
   }
 
   .cdk-overlay-dark-backdrop {
-    background: $overlay-backdrop-color;
+    // Add a CSS variable to make this easier to override.
+    background: var(--cdk-overlay-backdrop-dark-color, $overlay-backdrop-color);
   }
 
   .cdk-overlay-transparent-backdrop {
@@ -105,7 +106,8 @@ $backdrop-animation-timing-function: cubic-bezier(0.25, 0.8, 0.25, 1) !default;
     // capturing the user's mouse scroll events. Since we also can't use something like
     // `rgba(0, 0, 0, 0)`, we work around the inconsistency by not setting the background at
     // all and using `opacity` to make the element transparent.
-    &.cdk-overlay-backdrop-showing {
+    &.cdk-overlay-backdrop-showing,
+    .cdk-high-contrast-active & {
       opacity: 0;
       visibility: visible;
     }

--- a/src/cdk/overlay/fullscreen-overlay-container.spec.ts
+++ b/src/cdk/overlay/fullscreen-overlay-container.spec.ts
@@ -26,6 +26,7 @@ describe('FullscreenOverlayContainer', () => {
             // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy
             fakeDocument = {
               body: document.body,
+              head: document.head,
               fullscreenElement: document.createElement('div'),
               fullscreenEnabled: true,
               addEventListener: (eventName: string, listener: EventListener) => {

--- a/src/cdk/overlay/overlay-container.ts
+++ b/src/cdk/overlay/overlay-container.ts
@@ -7,14 +7,34 @@
  */
 
 import {DOCUMENT} from '@angular/common';
-import {Inject, Injectable, OnDestroy} from '@angular/core';
+import {
+  Inject,
+  Injectable,
+  OnDestroy,
+  Component,
+  ChangeDetectionStrategy,
+  ViewEncapsulation,
+  inject,
+} from '@angular/core';
+import {_CdkPrivateStyleLoader} from '@angular/cdk/private';
 import {Platform, _isTestEnvironment} from '@angular/cdk/platform';
+
+@Component({
+  template: '',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  standalone: true,
+  styleUrl: 'overlay-prebuilt.css',
+  host: {'cdk-overlay-style-loader': ''},
+})
+export class _CdkOverlayStyleLoader {}
 
 /** Container inside which all overlays will render. */
 @Injectable({providedIn: 'root'})
 export class OverlayContainer implements OnDestroy {
   protected _containerElement: HTMLElement;
   protected _document: Document;
+  protected _styleLoader = inject(_CdkPrivateStyleLoader);
 
   constructor(
     @Inject(DOCUMENT) document: any,
@@ -34,6 +54,8 @@ export class OverlayContainer implements OnDestroy {
    * @returns the container element
    */
   getContainerElement(): HTMLElement {
+    this._loadStyles();
+
     if (!this._containerElement) {
       this._createContainer();
     }
@@ -83,5 +105,10 @@ export class OverlayContainer implements OnDestroy {
 
     this._document.body.appendChild(container);
     this._containerElement = container;
+  }
+
+  /** Loads the structural styles necessary for the overlay to work. */
+  protected _loadStyles(): void {
+    this._styleLoader.load(_CdkOverlayStyleLoader);
   }
 }

--- a/src/cdk/overlay/overlay.ts
+++ b/src/cdk/overlay/overlay.ts
@@ -19,11 +19,13 @@ import {
   ANIMATION_MODULE_TYPE,
   Optional,
   EnvironmentInjector,
+  inject,
 } from '@angular/core';
+import {_CdkPrivateStyleLoader} from '@angular/cdk/private';
 import {OverlayKeyboardDispatcher} from './dispatchers/overlay-keyboard-dispatcher';
 import {OverlayOutsideClickDispatcher} from './dispatchers/overlay-outside-click-dispatcher';
 import {OverlayConfig} from './overlay-config';
-import {OverlayContainer} from './overlay-container';
+import {_CdkOverlayStyleLoader, OverlayContainer} from './overlay-container';
 import {OverlayRef} from './overlay-ref';
 import {OverlayPositionBuilder} from './position/overlay-position-builder';
 import {ScrollStrategyOptions} from './scroll/index';
@@ -45,6 +47,7 @@ let nextUniqueId = 0;
 @Injectable({providedIn: 'root'})
 export class Overlay {
   private _appRef: ApplicationRef;
+  private _styleLoader = inject(_CdkPrivateStyleLoader);
 
   constructor(
     /** Scrolling strategies that can be used when creating an overlay. */
@@ -68,6 +71,10 @@ export class Overlay {
    * @returns Reference to the created overlay.
    */
   create(config?: OverlayConfig): OverlayRef {
+    // This is done in the overlay container as well, but we have it here
+    // since it's common to mock out the overlay container in tests.
+    this._styleLoader.load(_CdkOverlayStyleLoader);
+
     const host = this._createHostElement();
     const pane = this._createPaneElement(host);
     const portalOutlet = this._createPortalOutlet(pane);

--- a/src/cdk/private/style-loader.ts
+++ b/src/cdk/private/style-loader.ts
@@ -13,6 +13,7 @@ import {
   EnvironmentInjector,
   inject,
   Injectable,
+  Injector,
   Type,
 } from '@angular/core';
 
@@ -34,7 +35,8 @@ const appsWithLoaders = new WeakMap<
  */
 @Injectable({providedIn: 'root'})
 export class _CdkPrivateStyleLoader {
-  private _appRef = inject(ApplicationRef);
+  private _appRef: ApplicationRef | undefined;
+  private _injector = inject(Injector);
   private _environmentInjector = inject(EnvironmentInjector);
 
   /**
@@ -42,17 +44,19 @@ export class _CdkPrivateStyleLoader {
    * @param loader Component which will be instantiated to load the styles.
    */
   load(loader: Type<unknown>): void {
-    let data = appsWithLoaders.get(this._appRef);
+    // Resolve the app ref lazily to avoid circular dependency errors if this is called too early.
+    const appRef = (this._appRef = this._appRef || this._injector.get(ApplicationRef));
+    let data = appsWithLoaders.get(appRef);
 
     // If we haven't loaded for this app before, we have to initialize it.
     if (!data) {
       data = {loaders: new Set(), refs: []};
-      appsWithLoaders.set(this._appRef, data);
+      appsWithLoaders.set(appRef, data);
 
       // When the app is destroyed, we need to clean up all the related loaders.
-      this._appRef.onDestroy(() => {
-        appsWithLoaders.get(this._appRef)?.refs.forEach(ref => ref.destroy());
-        appsWithLoaders.delete(this._appRef);
+      appRef.onDestroy(() => {
+        appsWithLoaders.get(appRef)?.refs.forEach(ref => ref.destroy());
+        appsWithLoaders.delete(appRef);
       });
     }
 

--- a/src/cdk/text-field/BUILD.bazel
+++ b/src/cdk/text-field/BUILD.bazel
@@ -16,9 +16,13 @@ ng_module(
         ["**/*.ts"],
         exclude = ["**/*.spec.ts"],
     ),
+    assets = [
+        ":text-field-prebuilt.css",
+    ],
     deps = [
         "//src/cdk/coercion",
         "//src/cdk/platform",
+        "//src/cdk/private",
         "@npm//@angular/core",
         "@npm//rxjs",
     ],

--- a/src/cdk/text-field/autofill.ts
+++ b/src/cdk/text-field/autofill.ts
@@ -11,14 +11,17 @@ import {
   Directive,
   ElementRef,
   EventEmitter,
+  inject,
   Injectable,
   NgZone,
   OnDestroy,
   OnInit,
   Output,
 } from '@angular/core';
+import {_CdkPrivateStyleLoader} from '@angular/cdk/private';
 import {coerceElement} from '@angular/cdk/coercion';
 import {EMPTY, Observable, Subject} from 'rxjs';
+import {_CdkTextFieldStyleLoader} from './text-field-style-loader';
 
 /** An event that is emitted when the autofill state of an input changes. */
 export type AutofillEvent = {
@@ -44,6 +47,7 @@ const listenerOptions = normalizePassiveListenerOptions({passive: true});
  */
 @Injectable({providedIn: 'root'})
 export class AutofillMonitor implements OnDestroy {
+  private _styleLoader = inject(_CdkPrivateStyleLoader);
   private _monitoredElements = new Map<Element, MonitoredElementInfo>();
 
   constructor(
@@ -69,6 +73,8 @@ export class AutofillMonitor implements OnDestroy {
     if (!this._platform.isBrowser) {
       return EMPTY;
     }
+
+    this._styleLoader.load(_CdkTextFieldStyleLoader);
 
     const element = coerceElement(elementOrRef);
     const info = this._monitoredElements.get(element);

--- a/src/cdk/text-field/autosize.ts
+++ b/src/cdk/text-field/autosize.ts
@@ -18,11 +18,14 @@ import {
   Optional,
   Inject,
   booleanAttribute,
+  inject,
 } from '@angular/core';
+import {DOCUMENT} from '@angular/common';
 import {Platform} from '@angular/cdk/platform';
+import {_CdkPrivateStyleLoader} from '@angular/cdk/private';
 import {auditTime, takeUntil} from 'rxjs/operators';
 import {fromEvent, Subject} from 'rxjs';
-import {DOCUMENT} from '@angular/common';
+import {_CdkTextFieldStyleLoader} from './text-field-style-loader';
 
 /** Directive to automatically resize a textarea to fit its content. */
 @Directive({
@@ -124,8 +127,9 @@ export class CdkTextareaAutosize implements AfterViewInit, DoCheck, OnDestroy {
     /** @breaking-change 11.0.0 make document required */
     @Optional() @Inject(DOCUMENT) document?: any,
   ) {
+    const styleLoader = inject(_CdkPrivateStyleLoader);
+    styleLoader.load(_CdkTextFieldStyleLoader);
     this._document = document;
-
     this._textareaElement = this._elementRef.nativeElement as HTMLTextAreaElement;
   }
 

--- a/src/cdk/text-field/text-field-style-loader.ts
+++ b/src/cdk/text-field/text-field-style-loader.ts
@@ -1,0 +1,20 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ChangeDetectionStrategy, Component, ViewEncapsulation} from '@angular/core';
+
+/** Component used to load the structural styles of the text field. */
+@Component({
+  template: '',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  styleUrl: 'text-field-prebuilt.css',
+  standalone: true,
+  host: {'cdk-text-field-style-loader': ''},
+})
+export class _CdkTextFieldStyleLoader {}

--- a/src/e2e-app/components/block-scroll-strategy/block-scroll-strategy-e2e.ts
+++ b/src/e2e-app/components/block-scroll-strategy/block-scroll-strategy-e2e.ts
@@ -1,5 +1,5 @@
 import {Component, inject} from '@angular/core';
-import {Overlay} from '@angular/cdk/overlay';
+import {Overlay, OverlayContainer} from '@angular/cdk/overlay';
 import {ScrollingModule} from '@angular/cdk/scrolling';
 
 @Component({
@@ -11,4 +11,9 @@ import {ScrollingModule} from '@angular/cdk/scrolling';
 })
 export class BlockScrollStrategyE2E {
   scrollStrategy = inject(Overlay).scrollStrategies.block();
+
+  constructor() {
+    // This loads the structural styles for the test.
+    inject(OverlayContainer).getContainerElement();
+  }
 }

--- a/src/material/core/BUILD.bazel
+++ b/src/material/core/BUILD.bazel
@@ -24,6 +24,7 @@ ng_module(
         ":option/option.css",
         ":option/optgroup.css",
         ":internal-form-field/internal-form-field.css",
+        ":ripple/ripple-structure.css",
     ] + glob(["**/*.html"]),
     deps = [
         "//src:dev_mode_types",
@@ -33,6 +34,7 @@ ng_module(
         "//src/cdk/coercion",
         "//src/cdk/keycodes",
         "//src/cdk/platform",
+        "//src/cdk/private",
         "@npm//@angular/animations",
         "@npm//@angular/core",
         "@npm//@angular/forms",
@@ -91,6 +93,12 @@ sass_binary(
 sass_binary(
     name = "internal_form_field_scss",
     src = "internal-form-field/internal-form-field.scss",
+    deps = [":core_scss_lib"],
+)
+
+sass_binary(
+    name = "ripple_structure_scss",
+    src = "ripple/ripple-structure.scss",
     deps = [":core_scss_lib"],
 )
 

--- a/src/material/core/_core.scss
+++ b/src/material/core/_core.scss
@@ -1,7 +1,6 @@
 @use '@angular/cdk';
 @use './tokens/m2/mat/app' as tokens-mat-app;
 @use './tokens/token-utils';
-@use './ripple/ripple';
 @use './style/elevation';
 @use './focus-indicators/private';
 
@@ -15,7 +14,6 @@
     --mat-app-on-surface: initial;
   }
 
-  @include ripple.ripple();
   @include cdk.a11y-visually-hidden();
   @include cdk.overlay();
   @include cdk.text-field-autosize();

--- a/src/material/core/_core.scss
+++ b/src/material/core/_core.scss
@@ -15,8 +15,6 @@
   }
 
   @include cdk.a11y-visually-hidden();
-  @include cdk.text-field-autosize();
-  @include cdk.text-field-autofill();
   @include private.structural-styling('mat');
   @include private.structural-styling('mat-mdc');
 

--- a/src/material/core/_core.scss
+++ b/src/material/core/_core.scss
@@ -15,7 +15,6 @@
   }
 
   @include cdk.a11y-visually-hidden();
-  @include cdk.overlay();
   @include cdk.text-field-autosize();
   @include cdk.text-field-autofill();
   @include private.structural-styling('mat');

--- a/src/material/core/private/ripple-loader.ts
+++ b/src/material/core/private/ripple-loader.ts
@@ -15,6 +15,7 @@ import {
   defaultRippleAnimationConfig,
 } from '../ripple';
 import {Platform, _getEventTarget} from '@angular/cdk/platform';
+import {_CdkPrivateStyleLoader} from '@angular/cdk/private';
 
 /** The options for the MatRippleLoader's event listeners. */
 const eventListenerOptions = {capture: true};

--- a/src/material/core/ripple/index.ts
+++ b/src/material/core/ripple/index.ts
@@ -12,7 +12,7 @@ import {MatRipple} from './ripple';
 
 export * from './ripple';
 export * from './ripple-ref';
-export * from './ripple-renderer';
+export {RippleRenderer, RippleTarget, defaultRippleAnimationConfig} from './ripple-renderer';
 
 @NgModule({
   imports: [MatCommonModule, MatRipple],

--- a/src/material/core/ripple/ripple-renderer.ts
+++ b/src/material/core/ripple/ripple-renderer.ts
@@ -5,10 +5,18 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {ElementRef, NgZone} from '@angular/core';
+import {
+  ElementRef,
+  NgZone,
+  Component,
+  ChangeDetectionStrategy,
+  ViewEncapsulation,
+  Injector,
+} from '@angular/core';
 import {Platform, normalizePassiveListenerOptions, _getEventTarget} from '@angular/cdk/platform';
 import {isFakeMousedownFromScreenReader, isFakeTouchstartFromScreenReader} from '@angular/cdk/a11y';
 import {coerceElement} from '@angular/cdk/coercion';
+import {_CdkPrivateStyleLoader} from '@angular/cdk/private';
 import {RippleRef, RippleState, RippleConfig} from './ripple-ref';
 import {RippleEventManager} from './ripple-event-manager';
 
@@ -58,6 +66,16 @@ const pointerDownEvents = ['mousedown', 'touchstart'];
 /** Events that signal that the pointer is up. */
 const pointerUpEvents = ['mouseup', 'mouseleave', 'touchend', 'touchcancel'];
 
+@Component({
+  template: '',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  standalone: true,
+  styleUrl: 'ripple-structure.css',
+  host: {'mat-ripple-style-loader': ''},
+})
+export class _MatRippleStylesLoader {}
+
 /**
  * Helper service that performs DOM manipulations. Not intended to be used outside this module.
  * The constructor takes a reference to the ripple directive's host element and a map of DOM
@@ -105,10 +123,15 @@ export class RippleRenderer implements EventListenerObject {
     private _ngZone: NgZone,
     elementOrElementRef: HTMLElement | ElementRef<HTMLElement>,
     private _platform: Platform,
+    injector?: Injector,
   ) {
     // Only do anything if we're on the browser.
     if (_platform.isBrowser) {
       this._containerElement = coerceElement(elementOrElementRef);
+    }
+
+    if (injector) {
+      injector.get(_CdkPrivateStyleLoader).load(_MatRippleStylesLoader);
     }
   }
 

--- a/src/material/core/ripple/ripple-structure.scss
+++ b/src/material/core/ripple/ripple-structure.scss
@@ -1,0 +1,3 @@
+@use './ripple';
+
+@include ripple.ripple;

--- a/src/material/core/ripple/ripple.ts
+++ b/src/material/core/ripple/ripple.ts
@@ -18,7 +18,9 @@ import {
   OnInit,
   Optional,
   ANIMATION_MODULE_TYPE,
+  Injector,
 } from '@angular/core';
+import {_CdkPrivateStyleLoader} from '@angular/cdk/private';
 import {RippleAnimationConfig, RippleConfig, RippleRef} from './ripple-ref';
 import {RippleRenderer, RippleTarget} from './ripple-renderer';
 
@@ -136,9 +138,12 @@ export class MatRipple implements OnInit, OnDestroy, RippleTarget {
     platform: Platform,
     @Optional() @Inject(MAT_RIPPLE_GLOBAL_OPTIONS) globalOptions?: RippleGlobalOptions,
     @Optional() @Inject(ANIMATION_MODULE_TYPE) private _animationMode?: string,
+    injector?: Injector,
   ) {
+    // Note: cannot use `inject()` here, because this class
+    // gets instantiated manually in the ripple loader.
     this._globalOptions = globalOptions || {};
-    this._rippleRenderer = new RippleRenderer(this, ngZone, _elementRef, platform);
+    this._rippleRenderer = new RippleRenderer(this, ngZone, _elementRef, platform, injector);
   }
 
   ngOnInit() {

--- a/src/material/list/BUILD.bazel
+++ b/src/material/list/BUILD.bazel
@@ -27,6 +27,7 @@ ng_module(
         "//src/cdk/coercion",
         "//src/cdk/collections",
         "//src/cdk/observers",
+        "//src/cdk/private",
         "//src/material/core",
         "//src/material/divider",
         "@npm//@angular/core",

--- a/src/material/list/list-base.ts
+++ b/src/material/list/list-base.ts
@@ -21,6 +21,7 @@ import {
   Optional,
   QueryList,
   ANIMATION_MODULE_TYPE,
+  Injector,
 } from '@angular/core';
 import {
   MAT_RIPPLE_GLOBAL_OPTIONS,
@@ -29,6 +30,7 @@ import {
   RippleRenderer,
   RippleTarget,
 } from '@angular/material/core';
+import {_CdkPrivateStyleLoader} from '@angular/cdk/private';
 import {Subscription, merge} from 'rxjs';
 import {
   MatListItemLine,
@@ -223,6 +225,7 @@ export abstract class MatListItemBase implements AfterViewInit, OnDestroy, Rippl
       this._ngZone,
       this._hostElement,
       this._platform,
+      inject(Injector),
     );
     this._rippleRenderer.setupTriggerEvents(this._hostElement);
   }

--- a/tools/public_api_guard/cdk/overlay.md
+++ b/tools/public_api_guard/cdk/overlay.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import { _CdkPrivateStyleLoader } from '@angular/cdk/private';
 import { CdkScrollable } from '@angular/cdk/scrolling';
 import { ComponentFactoryResolver } from '@angular/core';
 import { ComponentPortal } from '@angular/cdk/portal';
@@ -303,10 +304,13 @@ export class OverlayContainer implements OnDestroy {
     // (undocumented)
     protected _document: Document;
     getContainerElement(): HTMLElement;
+    protected _loadStyles(): void;
     // (undocumented)
     ngOnDestroy(): void;
     // (undocumented)
     protected _platform: Platform;
+    // (undocumented)
+    protected _styleLoader: _CdkPrivateStyleLoader;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<OverlayContainer, never>;
     // (undocumented)

--- a/tools/public_api_guard/material/core.md
+++ b/tools/public_api_guard/material/core.md
@@ -16,6 +16,7 @@ import { HighContrastModeDetector } from '@angular/cdk/a11y';
 import * as i0 from '@angular/core';
 import * as i1 from '@angular/cdk/bidi';
 import { InjectionToken } from '@angular/core';
+import { Injector } from '@angular/core';
 import { NgControl } from '@angular/forms';
 import { NgForm } from '@angular/forms';
 import { NgZone } from '@angular/core';
@@ -372,7 +373,7 @@ export type MatPseudoCheckboxState = 'unchecked' | 'checked' | 'indeterminate';
 
 // @public (undocumented)
 export class MatRipple implements OnInit, OnDestroy, RippleTarget {
-    constructor(_elementRef: ElementRef<HTMLElement>, ngZone: NgZone, platform: Platform, globalOptions?: RippleGlobalOptions, _animationMode?: string | undefined);
+    constructor(_elementRef: ElementRef<HTMLElement>, ngZone: NgZone, platform: Platform, globalOptions?: RippleGlobalOptions, _animationMode?: string | undefined, injector?: Injector);
     animation: RippleAnimationConfig;
     centered: boolean;
     color: string;
@@ -396,7 +397,7 @@ export class MatRipple implements OnInit, OnDestroy, RippleTarget {
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<MatRipple, "[mat-ripple], [matRipple]", ["matRipple"], { "color": { "alias": "matRippleColor"; "required": false; }; "unbounded": { "alias": "matRippleUnbounded"; "required": false; }; "centered": { "alias": "matRippleCentered"; "required": false; }; "radius": { "alias": "matRippleRadius"; "required": false; }; "animation": { "alias": "matRippleAnimation"; "required": false; }; "disabled": { "alias": "matRippleDisabled"; "required": false; }; "trigger": { "alias": "matRippleTrigger"; "required": false; }; }, {}, never, never, true, never>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<MatRipple, [null, null, null, { optional: true; }, { optional: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MatRipple, [null, null, null, { optional: true; }, { optional: true; }, null]>;
 }
 
 // @public
@@ -557,7 +558,7 @@ export class RippleRef {
 
 // @public
 export class RippleRenderer implements EventListenerObject {
-    constructor(_target: RippleTarget, _ngZone: NgZone, elementOrElementRef: HTMLElement | ElementRef<HTMLElement>, _platform: Platform);
+    constructor(_target: RippleTarget, _ngZone: NgZone, elementOrElementRef: HTMLElement | ElementRef<HTMLElement>, _platform: Platform, injector?: Injector);
     fadeInRipple(x: number, y: number, config?: RippleConfig): RippleRef;
     fadeOutAll(): void;
     fadeOutAllNonPersistent(): void;


### PR DESCRIPTION
Reworks `cdk/overlay`, `cdk/text-field` and `material/ripple` so that they load their structural styles automatically. In the past this has been a source of a lot of bugs.

BREAKING CHANGES:
* The ripples styles are now loaded slightly later than before which can change their specificity. You may have to update any ripple style overrides.
* The overlay stays are now loaded slightly later than before which can change their specificity. You may have to update any overlay style overrides.