### PR TITLE
fix(material/core): stop manually instantiating MatRipple directive

### DIFF
--- a/tools/public_api_guard/material/core.md
+++ b/tools/public_api_guard/material/core.md
@@ -402,8 +402,6 @@ export class MatRipple implements OnInit, OnDestroy, RippleTarget {
 // @public
 export class MatRippleLoader implements OnDestroy {
     constructor();
-    // (undocumented)
-    attachRipple(host: HTMLElement, ripple: MatRipple): void;
     configureRipple(host: HTMLElement, config: {
         className?: string;
         centered?: boolean;


### PR DESCRIPTION
Previously we had to manually instantiate `MatRipple` in order to maintain backwards compatibility, but it was problematic because it would break whenever we tried to use DI in `MatRipple` and it prevented us from switching to the `inject` function.

Instantiating `MatRipple` is no longer necessary after #29622 so these changes switch to creating an internal `RippleRenderer` instead.