### PR TITLE
fix(cdk/drag-drop): error if ngDevMode is undefined

### DIFF
--- a/src/cdk/drag-drop/drag-ref.ts
+++ b/src/cdk/drag-drop/drag-ref.ts
@@ -829,7 +829,10 @@ export class DragRef<T = any> {
       const parent = element.parentNode as HTMLElement;
       const placeholder = (this._placeholder = this._createPlaceholderElement());
       const anchor = (this._anchor =
-        this._anchor || this._document.createComment(ngDevMode ? 'cdk-drag-anchor' : ''));
+        this._anchor ||
+        this._document.createComment(
+          typeof ngDevMode === 'undefined' || ngDevMode ? 'cdk-drag-anchor' : '',
+        ));
 
       // Insert an anchor node so that we can restore the element's position in the DOM.
       parent.insertBefore(anchor, element);


### PR DESCRIPTION
Fixes that the drag&drop module wasn't checking for `ngDevMode` correctly.

Fixes #29633.