### PR TITLE
fix(cdk/tree): capturing focus on load

### DIFF
--- a/src/cdk/a11y/key-manager/tree-key-manager-strategy.ts
+++ b/src/cdk/a11y/key-manager/tree-key-manager-strategy.ts
@@ -44,6 +44,11 @@ export interface TreeKeyManagerItem {
    * Unfocus the item. This should remove the focus state.
    */
   unfocus(): void;
+
+  /**
+   * Sets the item to be focusable without actually focusing it.
+   */
+  makeFocusable?(): void;
 }
 
 /**

--- a/src/cdk/tree/tree.ts
+++ b/src/cdk/tree/tree.ts
@@ -1414,6 +1414,12 @@ export class CdkTreeNode<T, K = T> implements OnDestroy, OnInit, TreeKeyManagerI
     }
   }
 
+  /** Makes the node focusable. Implemented for TreeKeyManagerItem. */
+  makeFocusable(): void {
+    this._tabindex = 0;
+    this._changeDetectorRef.markForCheck();
+  }
+
   _focusItem() {
     if (this.isDisabled) {
       return;

--- a/tools/public_api_guard/cdk/a11y.md
+++ b/tools/public_api_guard/cdk/a11y.md
@@ -505,6 +505,7 @@ export interface TreeKeyManagerItem {
     getParent(): TreeKeyManagerItem | null;
     isDisabled?: (() => boolean) | boolean;
     isExpanded: (() => boolean) | boolean;
+    makeFocusable?(): void;
     unfocus(): void;
 }
 

--- a/tools/public_api_guard/cdk/tree.md
+++ b/tools/public_api_guard/cdk/tree.md
@@ -188,6 +188,7 @@ export class CdkTreeNode<T, K = T> implements OnDestroy, OnInit, TreeKeyManagerI
     get isLeafNode(): boolean;
     // (undocumented)
     get level(): number;
+    makeFocusable(): void;
     static mostRecentTreeNode: CdkTreeNode<any> | null;
     // (undocumented)
     static ngAcceptInputType_isDisabled: unknown;


### PR DESCRIPTION
The tree implements a roving tabindex which needs to have an initial item with `tabindex = 0` to work correctly. This happens by waiting for the data to be initialized in the `TreeKeyManager` and focusing the active/first item. The problem is that this ends up stealing focus on load. We didn't notice this issue in the demo app, because all the tree are `visibility: hidden` since they're inside closed `mat-expansion-panel`, but the issue is visible in the docs site.

These changes resolve the issue by setting the `tabindex` without actually moving focus.

Fixes #29628.