### PR TITLE
fix(material/select): remove incompatible aria-autocomplete attribute

### DIFF
--- a/src/material/select/select.ts
+++ b/src/material/select/select.ts
@@ -178,7 +178,6 @@ export class MatSelectChange {
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     'role': 'combobox',
-    'aria-autocomplete': 'none',
     'aria-haspopup': 'listbox',
     'class': 'mat-mdc-select',
     '[attr.id]': 'id',


### PR DESCRIPTION
Fixes a bug reported in MatSelect where the usage of aria-autocomplete is not a valid attribute that can be used with aria role=listbox. Removes the aria-autocomplete attribute to fix the violation: aria-allowed-attr.

[W3 Documentation on allowed attributes for role="listbox"](https://www.w3.org/WAI/ARIA/apg/patterns/listbox/#wai-ariaroles,states,andproperties)

Fixes [b/352496530](b/352496530)