### PR TITLE
fix(cdk/tree): avoid breaking change in constructor

### DIFF
--- a/src/cdk/tree/tree.ts
+++ b/src/cdk/tree/tree.ts
@@ -125,6 +125,8 @@ export class CdkTree<T, K = T>
     OnDestroy,
     OnInit
 {
+  private _dir = inject(Directionality);
+
   /** Subject that emits when the component has been destroyed. */
   private readonly _onDestroy = new Subject<void>();
 
@@ -265,7 +267,6 @@ export class CdkTree<T, K = T>
   constructor(
     private _differs: IterableDiffers,
     private _changeDetectorRef: ChangeDetectorRef,
-    private _dir: Directionality,
   ) {}
 
   ngAfterContentInit() {

--- a/tools/public_api_guard/cdk/tree.md
+++ b/tools/public_api_guard/cdk/tree.md
@@ -78,7 +78,7 @@ export class CdkNestedTreeNode<T, K = T> extends CdkTreeNode<T, K> implements Af
 
 // @public
 export class CdkTree<T, K = T> implements AfterContentChecked, AfterContentInit, AfterViewInit, CollectionViewer, OnDestroy, OnInit {
-    constructor(_differs: IterableDiffers, _changeDetectorRef: ChangeDetectorRef, _dir: Directionality);
+    constructor(_differs: IterableDiffers, _changeDetectorRef: ChangeDetectorRef);
     childrenAccessor?: (dataNode: T) => T[] | Observable<T[]>;
     collapse(dataNode: T): void;
     collapseAll(): void;


### PR DESCRIPTION
In #29062 a new parameter was added to the `CdkTree` constructor which is a breaking change.

These changes switch to using `inject` which allows us to avoid the breaking change.

Fixes #29595.