### PR TITLE
fix(material/select): adds cdkFocusTrap to attempt to make options focusable

### DIFF
--- a/src/material/select/select.html
+++ b/src/material/select/select.html
@@ -47,6 +47,7 @@
     role="listbox"
     cdkListbox
     cdkListboxUseActiveDescendant
+    useActiveDescendant="true"
     tabindex="-1"
     class="mat-mdc-select-panel mdc-menu-surface mdc-menu-surface--open {{ _getPanelTheme() }}"
     [attr.id]="id + '-panel'"

--- a/src/material/select/select.html
+++ b/src/material/select/select.html
@@ -45,6 +45,8 @@
   <div
     #panel
     role="listbox"
+    cdkFocusTrap
+    cdkTrapFocusAutoCapture
     tabindex="-1"
     class="mat-mdc-select-panel mdc-menu-surface mdc-menu-surface--open {{ _getPanelTheme() }}"
     [attr.id]="id + '-panel'"

--- a/src/material/select/select.html
+++ b/src/material/select/select.html
@@ -45,8 +45,8 @@
   <div
     #panel
     role="listbox"
-    cdkFocusTrap
-    cdkTrapFocusAutoCapture
+    cdkListbox
+    cdkListboxUseActiveDescendant
     tabindex="-1"
     class="mat-mdc-select-panel mdc-menu-surface mdc-menu-surface--open {{ _getPanelTheme() }}"
     [attr.id]="id + '-panel'"


### PR DESCRIPTION
Attempts to fix bug in Angular Components Select Component where the options in the listbox are not accessible/focusable on mobile. When swiping right to access the listbox the focus moves to the next focusable item rather than into the listbox of options. This fix adds cdkFocusTrap and cdkFocusAutoCapture to attempt to remedy that.

Fixes b/285945157