### PR TITLE
fix(cdk/table): adds scope=col to role=columnheader for cell

### DIFF
--- a/src/cdk/table/cell.ts
+++ b/src/cdk/table/cell.ts
@@ -189,6 +189,7 @@ export class BaseCdkCell {
   host: {
     'class': 'cdk-header-cell',
     'role': 'columnheader',
+    'scope': 'col',
   },
   standalone: true,
 })


### PR DESCRIPTION
Updates Angular Components Table component so that whenever aria role=columnheader the related scope=col is also applied to the cell to provide more accessibility context for the screenreader.

[Before screenshot](https://screenshot.googleplex.com/AB3L3orqUQwaMN4)
[After screenshot](https://screenshot.googleplex.com/5pERnhEBeKMd6AL)

Fixes b/286285430