### PR TITLE
fix(material/core): Allow system variables to be formatted for opacity

### DIFF
--- a/src/material/core/style/_sass-utils.scss
+++ b/src/material/core/style/_sass-utils.scss
@@ -77,6 +77,10 @@ $use-system-typography-variables: false;
       $opacity: ($opacity * 100) + '%';
     }
 
+    @if (is-css-var-name($opacity)) {
+      $opacity: calc(var($opacity) * 100%);
+    }
+
     @if (is-css-var-name($color)) {
       $color: var($color);
     }


### PR DESCRIPTION
Hover styles for some components (like menu and select) weren't being shown properly since the opacity was not formatted like a number.

Before: https://screencast.googleplex.com/cast/NTA2NDE5ODgzNTkyOTA4OHwzZjVjNDlmZi1lMw
After: https://screencast.googleplex.com/cast/NjcwMTk4MDg2Mzk1NDk0NHxhMzU3YzYyZC1mMA