### PR TITLE
feat(cdk/scrolling): resize viewport on content size changes

### DIFF
--- a/src/dev-app/virtual-scroll/BUILD.bazel
+++ b/src/dev-app/virtual-scroll/BUILD.bazel
@@ -14,6 +14,7 @@ ng_module(
         "//src/cdk/scrolling",
         "//src/components-examples/cdk/scrolling",
         "//src/material/button",
+        "//src/material/expansion",
         "//src/material/form-field",
         "//src/material/input",
         "//src/material/select",

--- a/src/dev-app/virtual-scroll/virtual-scroll-demo.html
+++ b/src/dev-app/virtual-scroll/virtual-scroll-demo.html
@@ -1,5 +1,20 @@
 <h2>Autosize</h2>
 
+<h3>Dynamic size + window scroll</h3>
+<div class="demo-wrapper">
+  <mat-accordion multi="true">
+    <!-- append only is a workaround for https://github.com/angular/components/issues/13697 -->
+    <cdk-virtual-scroll-viewport autosize scrollWindow appendOnly>
+      <div class="demo-item-dynamic" *cdkVirtualFor="let item of shortData">
+        <mat-expansion-panel>
+          <mat-expansion-panel-header>{{ item }}</mat-expansion-panel-header>
+          <p *ngFor="let text of placeholderText">{{ text }}</p>
+        </mat-expansion-panel>
+      </div>
+    </cdk-virtual-scroll-viewport>
+  </mat-accordion>
+</div>
+
 <h3>Uniform size</h3>
 <cdk-virtual-scroll-viewport class="demo-viewport" autosize>
   <div *cdkVirtualFor="let size of fixedSizeData; let i = index" class="demo-item"

--- a/src/dev-app/virtual-scroll/virtual-scroll-demo.scss
+++ b/src/dev-app/virtual-scroll/virtual-scroll-demo.scss
@@ -64,3 +64,15 @@ cdk-virtual-scroll-window-scrolling-example {
   display: block;
   width: 500px;
 }
+
+.demo-wrapper {
+  padding: 1rem;
+  background: gainsboro;
+  border: 1px solid lightgrey;
+  width: 500px;
+}
+
+.demo-item-dynamic {
+  min-height: 60px;
+  padding: 5px;
+}

--- a/src/dev-app/virtual-scroll/virtual-scroll-demo.ts
+++ b/src/dev-app/virtual-scroll/virtual-scroll-demo.ts
@@ -6,20 +6,21 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ChangeDetectionStrategy, Component, OnDestroy, ViewEncapsulation} from '@angular/core';
-import {CdkVirtualScrollViewport, ScrollingModule} from '@angular/cdk/scrolling';
 import {ScrollingModule as ExperimentalScrollingModule} from '@angular/cdk-experimental/scrolling';
+import {CdkVirtualScrollViewport, ScrollingModule} from '@angular/cdk/scrolling';
 import {CommonModule} from '@angular/common';
-import {FormsModule} from '@angular/forms';
-import {MatButtonModule} from '@angular/material/button';
-import {MatFormFieldModule} from '@angular/material/form-field';
-import {MatInputModule} from '@angular/material/input';
-import {MatSelectModule} from '@angular/material/select';
-import {BehaviorSubject} from 'rxjs';
 import {
   CdkVirtualScrollParentScrollingExample,
   CdkVirtualScrollWindowScrollingExample,
 } from '@angular/components-examples/cdk/scrolling';
+import {ChangeDetectionStrategy, Component, OnDestroy, ViewEncapsulation} from '@angular/core';
+import {FormsModule} from '@angular/forms';
+import {MatButtonModule} from '@angular/material/button';
+import {MatExpansionModule} from '@angular/material/expansion';
+import {MatFormFieldModule} from '@angular/material/form-field';
+import {MatInputModule} from '@angular/material/input';
+import {MatSelectModule} from '@angular/material/select';
+import {BehaviorSubject} from 'rxjs';
 
 type State = {
   name: string;
@@ -41,6 +42,7 @@ type State = {
     MatFormFieldModule,
     MatInputModule,
     MatSelectModule,
+    MatExpansionModule,
     ScrollingModule,
     CdkVirtualScrollParentScrollingExample,
     CdkVirtualScrollWindowScrollingExample,
@@ -62,6 +64,12 @@ export class VirtualScrollDemo implements OnDestroy {
     .fill(0)
     .map(() => Math.round(Math.random() * 100));
   readonly observableData = new BehaviorSubject<number[]>([]);
+  shortData = Array.from({length: 20}).map((_, i) => `Item #${i}`);
+  placeholderText = [
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit,',
+    'sed do eiusmod tempor incididunt',
+    'ut labore et dolore magna aliqua.',
+  ];
   states = [
     {name: 'Alabama', capital: 'Montgomery'},
     {name: 'Alaska', capital: 'Juneau'},


### PR DESCRIPTION
Implements resizing of the viewport of `AutoSizeVirtualScrollStrategy` when the content changes size. Currently, the viewport only resizes on scroll/data change events.

- Do you agree with my strategy of watching `viewport._contentWrapper` for size changes?
- Not sure if the attach method is the best place for this. Thoughts?
- Would it make more sense to add a method to `VirtualScrollStrategy` and implement a handler in `FixedSizeVirtualScrollStrategy/AutoSizeVirtualScrollStrategy`?
- Any mistakes you see so far or general changes that need to be made?

See https://github.com/angular/components/issues/10117