### PR TITLE
fix(multiple): ripples not showing up in some cases

### DIFF
--- a/src/material/checkbox/checkbox.scss
+++ b/src/material/checkbox/checkbox.scss
@@ -68,7 +68,7 @@
   }
 }
 
-.mat-mdc-checkbox-ripple,
+.mat-mdc-checkbox .mat-mdc-checkbox-ripple,
 .mdc-checkbox__ripple {
   @include layout-common.fill();
 

--- a/src/material/core/private/ripple-loader.ts
+++ b/src/material/core/private/ripple-loader.ts
@@ -7,7 +7,14 @@
  */
 
 import {DOCUMENT} from '@angular/common';
-import {ANIMATION_MODULE_TYPE, Injectable, NgZone, OnDestroy, inject} from '@angular/core';
+import {
+  ANIMATION_MODULE_TYPE,
+  Injectable,
+  Injector,
+  NgZone,
+  OnDestroy,
+  inject,
+} from '@angular/core';
 import {
   MAT_RIPPLE_GLOBAL_OPTIONS,
   RippleRenderer,
@@ -54,6 +61,7 @@ export class MatRippleLoader implements OnDestroy {
   private _globalRippleOptions = inject(MAT_RIPPLE_GLOBAL_OPTIONS, {optional: true});
   private _platform = inject(Platform);
   private _ngZone = inject(NgZone);
+  private _injector = inject(Injector);
   private _hosts = new Map<
     HTMLElement,
     {renderer: RippleRenderer; target: RippleTarget; hasSetUpEvents: boolean}
@@ -184,7 +192,13 @@ export class MatRippleLoader implements OnDestroy {
       },
     };
 
-    const renderer = new RippleRenderer(target, this._ngZone, rippleEl, this._platform);
+    const renderer = new RippleRenderer(
+      target,
+      this._ngZone,
+      rippleEl,
+      this._platform,
+      this._injector,
+    );
     const hasSetUpEvents = !target.rippleDisabled;
 
     if (hasSetUpEvents) {

--- a/src/material/tabs/_tabs-common.scss
+++ b/src/material/tabs/_tabs-common.scss
@@ -83,7 +83,7 @@ $mat-tab-animation-duration: 500ms !default;
     }
   }
 
-  .mat-mdc-tab-ripple {
+  .mat-mdc-tab-ripple.mat-mdc-tab-ripple {
     position: absolute;
     top: 0;
     left: 0;


### PR DESCRIPTION
Fixes the following issues that prevented the ripples from showing up:
* We weren't passing an injector into the `RippleRenderer` created by the `RippleLoader` which meant that it was never injecting the structural styles.
* The checkbox and tabs ripple selectors weren't specific enough which meant that they would be overridden in some cases. We were handling this in other components, but for some reason these two were skipped.

Fixes #29670.