### PR TITLE
fix(material/badge): resolve memory leak

### DIFF
--- a/src/material/badge/badge.ts
+++ b/src/material/badge/badge.ts
@@ -173,9 +173,7 @@ export class MatBadge implements OnInit, OnDestroy {
 
       appRef.onDestroy(() => {
         badgeApps.delete(appRef);
-        if (badgeApps.size === 0) {
-          componentRef.destroy();
-        }
+        componentRef.destroy();
       });
     }
 


### PR DESCRIPTION
The badge had an extra unnecessary check which meant that it would sometimes leak memory through the style loader. This isn't a big deal on the client since there's usually only one app on the page, but it can be a problem on the server which can create and destroy an app for each request.

Note that this is no longer an issue in 19.x where we use the common style loader, but we need to backport the fix to 18.x.

Fixes https://github.com/angular/angular/issues/57529.