### PR TITLE
build: bump up machine size

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,7 +180,7 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.ANGULAR_ROBOT_SLACK_TOKEN }}
 
   build:
-    runs-on: ubuntu-latest-4core
+    runs-on: ubuntu-latest-16core
     steps:
       - name: Initialize environment
         uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@89624a6442b75b5cda33c5e9b5c8c4f87ca4f13d

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -149,7 +149,7 @@ jobs:
         run: bazel test --build_tag_filters=-e2e --test_tag_filters=-e2e --build_tests_only -- src/...
 
   build:
-    runs-on: ubuntu-latest-4core
+    runs-on: ubuntu-latest-16core
     steps:
       - name: Initialize environment
         uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@89624a6442b75b5cda33c5e9b5c8c4f87ca4f13d


### PR DESCRIPTION
Some of the `build` jobs have been OOMing recently. These changes bump them up to a bigger machine which is identical to the `test` job.