### PR TITLE
fix(material/select): Update checkbox color to match the selected label text color

### DIFF
--- a/src/material/core/option/option.scss
+++ b/src/material/core/option/option.scss
@@ -52,6 +52,11 @@ $_side-padding: 16px;
         @include token-utils.create-token-slot(background-color, selected-state-layer-color);
       }
     }
+
+    .mat-pseudo-checkbox {
+      --mat-minimal-pseudo-checkbox-selected-checkmark-color: #{
+          token-utils.get-token-variable(selected-state-label-text-color)};
+    }
   }
 
   &.mdc-list-item {


### PR DESCRIPTION
Fixes #29553

Before
![image](https://github.com/user-attachments/assets/57108ce0-3a05-443b-a86f-d4c6840532c0)
![image](https://github.com/user-attachments/assets/c7429972-467c-46d3-ab18-0aee1fa72d57)

After
![image](https://github.com/user-attachments/assets/b4eeba6f-5c53-4800-9ac0-208ccd572e7e)
![image](https://github.com/user-attachments/assets/d12b622c-06ea-43c4-bfe3-4306ed8fa215)
