### PR TITLE
fix(material/badge): change legacy container size default

### DIFF
--- a/src/material/badge/badge.scss
+++ b/src/material/badge/badge.scss
@@ -26,8 +26,7 @@ $large-size: $default-size + 6;
       height: token-utils.get-token-variable($legacy-size-var-name, $fallback: unset);
       min-width: token-utils.get-token-variable($size-var-name, $fallback: unset);
       min-height: token-utils.get-token-variable($size-var-name, $fallback: unset);
-      line-height: token-utils.get-token-variable(
-          $legacy-size-var-name, $fallback: token-utils.get-token-variable($size-var-name));
+      line-height: token-utils.get-token-variable($legacy-size-var-name);
       @include token-utils.create-token-slot(padding, '#{$prefix}container-padding');
       @include token-utils.create-token-slot(font-size, '#{$prefix}text-size');
       @include token-utils.create-token-slot(margin, '#{$prefix}container-offset');

--- a/src/material/core/tokens/m3/mat/_badge.scss
+++ b/src/material/core/tokens/m3/mat/_badge.scss
@@ -25,8 +25,8 @@ $prefix: (mat, badge);
     small-size-text-size: token-definition.hardcode(0, $exclude-hardcoded),
     container-shape: map.get($systems, md-sys-shape, corner-full),
     container-size: token-definition.hardcode(16px, $exclude-hardcoded),
-    legacy-container-size: token-definition.hardcode(unset, $exclude-hardcoded),
-    legacy-small-size-container-size: token-definition.hardcode(unset, $exclude-hardcoded),
+    legacy-container-size: token-definition.hardcode(16px, $exclude-hardcoded),
+    legacy-small-size-container-size: token-definition.hardcode(16px, $exclude-hardcoded),
     small-size-container-size: token-definition.hardcode(6px, $exclude-hardcoded),
     container-padding: token-definition.hardcode(0 4px, $exclude-hardcoded),
     small-size-container-padding: token-definition.hardcode(0, $exclude-hardcoded),
@@ -41,7 +41,7 @@ $prefix: (mat, badge);
     large-size-container-overlap-offset: token-definition.hardcode(-12px, $exclude-hardcoded),
     large-size-text-size: map.get($systems, md-sys-typescale, label-small-size),
     large-size-container-padding: token-definition.hardcode(0 4px, $exclude-hardcoded),
-    legacy-large-size-container-size: token-definition.hardcode(unset, $exclude-hardcoded),
+    legacy-large-size-container-size: token-definition.hardcode(16px, $exclude-hardcoded),
   ), (
     primary: (
       background-color: map.get($systems, md-sys-color, primary),


### PR DESCRIPTION
Correct M3 value for the line height is 16px - make this explicit in the styles