### PR TITLE
refactor(multiple): switch the CDK to the inject function

### DIFF
--- a/src/cdk/a11y/a11y-module.ts
+++ b/src/cdk/a11y/a11y-module.ts
@@ -7,7 +7,7 @@
  */
 
 import {ObserversModule} from '@angular/cdk/observers';
-import {NgModule} from '@angular/core';
+import {NgModule, inject} from '@angular/core';
 import {CdkMonitorFocus} from './focus-monitor/focus-monitor';
 import {CdkTrapFocus} from './focus-trap/focus-trap';
 import {HighContrastModeDetector} from './high-contrast-mode/high-contrast-mode-detector';
@@ -18,7 +18,7 @@ import {CdkAriaLive} from './live-announcer/live-announcer';
   exports: [CdkAriaLive, CdkTrapFocus, CdkMonitorFocus],
 })
 export class A11yModule {
-  constructor(highContrastModeDetector: HighContrastModeDetector) {
-    highContrastModeDetector._applyBodyHighContrastModeCssClasses();
+  constructor() {
+    inject(HighContrastModeDetector)._applyBodyHighContrastModeCssClasses();
   }
 }

--- a/src/cdk/a11y/aria-describer/aria-describer.spec.ts
+++ b/src/cdk/a11y/aria-describer/aria-describer.spec.ts
@@ -1,7 +1,7 @@
 import {A11yModule, CDK_DESCRIBEDBY_HOST_ATTRIBUTE} from '../index';
 import {AriaDescriber} from './aria-describer';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
-import {Component, ElementRef, ViewChild, Provider} from '@angular/core';
+import {Component, ElementRef, ViewChild, Provider, inject} from '@angular/core';
 
 describe('AriaDescriber', () => {
   let ariaDescriber: AriaDescriber;
@@ -404,6 +404,8 @@ function expectMessage(el: Element, message: string) {
   imports: [A11yModule],
 })
 class TestApp {
+  ariaDescriber = inject(AriaDescriber);
+
   @ViewChild('element1') _element1: ElementRef<HTMLElement>;
   get element1(): Element {
     return this._element1.nativeElement;
@@ -423,6 +425,4 @@ class TestApp {
   get element4(): Element {
     return this._element4.nativeElement;
   }
-
-  constructor(public ariaDescriber: AriaDescriber) {}
 }

--- a/src/cdk/a11y/aria-describer/aria-describer.ts
+++ b/src/cdk/a11y/aria-describer/aria-describer.ts
@@ -7,7 +7,7 @@
  */
 
 import {DOCUMENT} from '@angular/common';
-import {Inject, Injectable, OnDestroy, APP_ID, inject} from '@angular/core';
+import {Injectable, OnDestroy, APP_ID, inject} from '@angular/core';
 import {Platform} from '@angular/cdk/platform';
 import {addAriaReferencedId, getAriaReferenceIds, removeAriaReferencedId} from './aria-reference';
 
@@ -54,7 +54,8 @@ let nextId = 0;
  */
 @Injectable({providedIn: 'root'})
 export class AriaDescriber implements OnDestroy {
-  private _document: Document;
+  private _platform = inject(Platform);
+  private _document = inject(DOCUMENT);
 
   /** Map of all registered message elements that have been placed into the document. */
   private _messageRegistry = new Map<string | Element, RegisteredMessage>();
@@ -65,15 +66,9 @@ export class AriaDescriber implements OnDestroy {
   /** Unique ID for the service. */
   private readonly _id = `${nextId++}`;
 
-  constructor(
-    @Inject(DOCUMENT) _document: any,
-    /**
-     * @deprecated To be turned into a required parameter.
-     * @breaking-change 14.0.0
-     */
-    private _platform?: Platform,
-  ) {
-    this._document = _document;
+  constructor(...args: unknown[]);
+
+  constructor() {
     this._id = inject(APP_ID) + '-' + nextId++;
   }
 

--- a/src/cdk/a11y/focus-trap/configurable-focus-trap-factory.ts
+++ b/src/cdk/a11y/focus-trap/configurable-focus-trap-factory.ts
@@ -7,7 +7,7 @@
  */
 
 import {DOCUMENT} from '@angular/common';
-import {Inject, Injectable, Injector, NgZone, Optional, inject} from '@angular/core';
+import {Injectable, Injector, NgZone, inject} from '@angular/core';
 import {InteractivityChecker} from '../interactivity-checker/interactivity-checker';
 import {ConfigurableFocusTrap} from './configurable-focus-trap';
 import {ConfigurableFocusTrapConfig} from './configurable-focus-trap-config';
@@ -18,21 +18,22 @@ import {FocusTrapManager} from './focus-trap-manager';
 /** Factory that allows easy instantiation of configurable focus traps. */
 @Injectable({providedIn: 'root'})
 export class ConfigurableFocusTrapFactory {
-  private _document: Document;
+  private _checker = inject(InteractivityChecker);
+  private _ngZone = inject(NgZone);
+  private _focusTrapManager = inject(FocusTrapManager);
+
+  private _document = inject(DOCUMENT);
   private _inertStrategy: FocusTrapInertStrategy;
 
   private readonly _injector = inject(Injector);
 
-  constructor(
-    private _checker: InteractivityChecker,
-    private _ngZone: NgZone,
-    private _focusTrapManager: FocusTrapManager,
-    @Inject(DOCUMENT) _document: any,
-    @Optional() @Inject(FOCUS_TRAP_INERT_STRATEGY) _inertStrategy?: FocusTrapInertStrategy,
-  ) {
-    this._document = _document;
+  constructor(...args: unknown[]);
+
+  constructor() {
+    const inertStrategy = inject(FOCUS_TRAP_INERT_STRATEGY, {optional: true});
+
     // TODO split up the strategies into different modules, similar to DateAdapter.
-    this._inertStrategy = _inertStrategy || new EventListenerFocusTrapInertStrategy();
+    this._inertStrategy = inertStrategy || new EventListenerFocusTrapInertStrategy();
   }
 
   /**

--- a/src/cdk/a11y/focus-trap/configurable-focus-trap.spec.ts
+++ b/src/cdk/a11y/focus-trap/configurable-focus-trap.spec.ts
@@ -1,4 +1,12 @@
-import {AfterViewInit, Component, ElementRef, Type, ViewChild, Provider} from '@angular/core';
+import {
+  AfterViewInit,
+  Component,
+  ElementRef,
+  Type,
+  ViewChild,
+  Provider,
+  inject,
+} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {
   A11yModule,
@@ -110,11 +118,11 @@ function createComponent<T>(
   standalone: true,
 })
 class SimpleFocusTrap implements AfterViewInit {
+  private _focusTrapFactory = inject(ConfigurableFocusTrapFactory);
+
   @ViewChild('focusTrapElement') focusTrapElement!: ElementRef;
 
   focusTrap: ConfigurableFocusTrap;
-
-  constructor(private _focusTrapFactory: ConfigurableFocusTrapFactory) {}
 
   ngAfterViewInit() {
     this.focusTrap = this._focusTrapFactory.create(this.focusTrapElement.nativeElement);

--- a/src/cdk/a11y/focus-trap/event-listener-inert-strategy.spec.ts
+++ b/src/cdk/a11y/focus-trap/event-listener-inert-strategy.spec.ts
@@ -1,4 +1,12 @@
-import {AfterViewInit, Component, ElementRef, Provider, Type, ViewChild} from '@angular/core';
+import {
+  AfterViewInit,
+  Component,
+  ElementRef,
+  Provider,
+  Type,
+  ViewChild,
+  inject,
+} from '@angular/core';
 import {ComponentFixture, TestBed, fakeAsync, flush} from '@angular/core/testing';
 import {patchElementFocus} from '../../testing/private';
 import {
@@ -80,6 +88,8 @@ function createComponent<T>(
   standalone: true,
 })
 class SimpleFocusTrap implements AfterViewInit {
+  private _focusTrapFactory = inject(ConfigurableFocusTrapFactory);
+
   @ViewChild('focusTrapElement') focusTrapElement!: ElementRef<HTMLElement>;
   @ViewChild('outsideFocusable') outsideFocusableElement!: ElementRef<HTMLElement>;
   @ViewChild('firstFocusable') firstFocusableElement!: ElementRef<HTMLElement>;
@@ -90,8 +100,6 @@ class SimpleFocusTrap implements AfterViewInit {
   // Since our custom stubbing in `patchElementFocus` won't update
   // the `document.activeElement`, we need to keep track of it here.
   activeElement: Element | null;
-
-  constructor(private _focusTrapFactory: ConfigurableFocusTrapFactory) {}
 
   ngAfterViewInit() {
     // Ensure consistent focus timing across browsers.

--- a/src/cdk/a11y/focus-trap/focus-trap.spec.ts
+++ b/src/cdk/a11y/focus-trap/focus-trap.spec.ts
@@ -6,6 +6,7 @@ import {
   ViewChild,
   ViewContainerRef,
   ViewEncapsulation,
+  inject as inject_1,
 } from '@angular/core';
 import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
@@ -481,8 +482,8 @@ class FocusTrapWithoutFocusableElements {
   imports: [A11yModule, PortalModule],
 })
 class FocusTrapInsidePortal {
+  viewContainerRef = inject_1(ViewContainerRef);
+
   @ViewChild('template') template: TemplateRef<any>;
   @ViewChild(CdkPortalOutlet) portalOutlet: CdkPortalOutlet;
-
-  constructor(public viewContainerRef: ViewContainerRef) {}
 }

--- a/src/cdk/a11y/focus-trap/focus-trap.ts
+++ b/src/cdk/a11y/focus-trap/focus-trap.ts
@@ -13,7 +13,6 @@ import {
   Directive,
   DoCheck,
   ElementRef,
-  Inject,
   Injectable,
   Injector,
   Input,
@@ -372,16 +371,14 @@ export class FocusTrap {
  */
 @Injectable({providedIn: 'root'})
 export class FocusTrapFactory {
-  private _document: Document;
+  private _checker = inject(InteractivityChecker);
+  private _ngZone = inject(NgZone);
+
+  private _document = inject(DOCUMENT);
   private _injector = inject(Injector);
 
-  constructor(
-    private _checker: InteractivityChecker,
-    private _ngZone: NgZone,
-    @Inject(DOCUMENT) _document: any,
-  ) {
-    this._document = _document;
-  }
+  constructor(...args: unknown[]);
+  constructor() {}
 
   /**
    * Creates a focus-trapped region around the given element.
@@ -409,6 +406,9 @@ export class FocusTrapFactory {
   standalone: true,
 })
 export class CdkTrapFocus implements OnDestroy, AfterContentInit, OnChanges, DoCheck {
+  private _elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
+  private _focusTrapFactory = inject(FocusTrapFactory);
+
   /** Underlying FocusTrap instance. */
   focusTrap: FocusTrap;
 
@@ -432,15 +432,9 @@ export class CdkTrapFocus implements OnDestroy, AfterContentInit, OnChanges, DoC
    */
   @Input({alias: 'cdkTrapFocusAutoCapture', transform: booleanAttribute}) autoCapture: boolean;
 
-  constructor(
-    private _elementRef: ElementRef<HTMLElement>,
-    private _focusTrapFactory: FocusTrapFactory,
-    /**
-     * @deprecated No longer being used. To be removed.
-     * @breaking-change 13.0.0
-     */
-    @Inject(DOCUMENT) _document: any,
-  ) {
+  constructor(...args: unknown[]);
+
+  constructor() {
     const platform = inject(Platform);
 
     if (platform.isBrowser) {

--- a/src/cdk/a11y/high-contrast-mode/high-contrast-mode-detector.ts
+++ b/src/cdk/a11y/high-contrast-mode/high-contrast-mode-detector.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {inject, Inject, Injectable, OnDestroy} from '@angular/core';
+import {inject, Injectable, OnDestroy} from '@angular/core';
 import {BreakpointObserver} from '@angular/cdk/layout';
 import {Platform} from '@angular/cdk/platform';
 import {DOCUMENT} from '@angular/common';
@@ -41,20 +41,19 @@ export const HIGH_CONTRAST_MODE_ACTIVE_CSS_CLASS = 'cdk-high-contrast-active';
  */
 @Injectable({providedIn: 'root'})
 export class HighContrastModeDetector implements OnDestroy {
+  private _platform = inject(Platform);
+
   /**
    * Figuring out the high contrast mode and adding the body classes can cause
    * some expensive layouts. This flag is used to ensure that we only do it once.
    */
   private _hasCheckedHighContrastMode: boolean;
-  private _document: Document;
+  private _document = inject(DOCUMENT);
   private _breakpointSubscription: Subscription;
 
-  constructor(
-    private _platform: Platform,
-    @Inject(DOCUMENT) document: any,
-  ) {
-    this._document = document;
+  constructor(...args: unknown[]);
 
+  constructor() {
     this._breakpointSubscription = inject(BreakpointObserver)
       .observe('(forced-colors: active)')
       .subscribe(() => {

--- a/src/cdk/a11y/input-modality/input-modality-detector.ts
+++ b/src/cdk/a11y/input-modality/input-modality-detector.ts
@@ -7,7 +7,7 @@
  */
 
 import {ALT, CONTROL, MAC_META, META, SHIFT} from '@angular/cdk/keycodes';
-import {Inject, Injectable, InjectionToken, OnDestroy, Optional, NgZone} from '@angular/core';
+import {Injectable, InjectionToken, OnDestroy, NgZone, inject} from '@angular/core';
 import {normalizePassiveListenerOptions, Platform, _getEventTarget} from '@angular/cdk/platform';
 import {DOCUMENT} from '@angular/common';
 import {BehaviorSubject, Observable} from 'rxjs';
@@ -90,6 +90,8 @@ const modalityEventListenerOptions = normalizePassiveListenerOptions({
  */
 @Injectable({providedIn: 'root'})
 export class InputModalityDetector implements OnDestroy {
+  private readonly _platform = inject(Platform);
+
   /** Emits whenever an input modality is detected. */
   readonly modalityDetected: Observable<InputModality>;
 
@@ -172,14 +174,13 @@ export class InputModalityDetector implements OnDestroy {
     this._mostRecentTarget = _getEventTarget(event);
   };
 
-  constructor(
-    private readonly _platform: Platform,
-    ngZone: NgZone,
-    @Inject(DOCUMENT) document: Document,
-    @Optional()
-    @Inject(INPUT_MODALITY_DETECTOR_OPTIONS)
-    options?: InputModalityDetectorOptions,
-  ) {
+  constructor(...args: unknown[]);
+
+  constructor() {
+    const ngZone = inject(NgZone);
+    const document = inject<Document>(DOCUMENT);
+    const options = inject(INPUT_MODALITY_DETECTOR_OPTIONS, {optional: true});
+
     this._options = {
       ...INPUT_MODALITY_DETECTOR_DEFAULT_OPTIONS,
       ...options,
@@ -191,7 +192,7 @@ export class InputModalityDetector implements OnDestroy {
 
     // If we're not in a browser, this service should do nothing, as there's no relevant input
     // modality to detect.
-    if (_platform.isBrowser) {
+    if (this._platform.isBrowser) {
       ngZone.runOutsideAngular(() => {
         document.addEventListener('keydown', this._onKeydown, modalityEventListenerOptions);
         document.addEventListener('mousedown', this._onMousedown, modalityEventListenerOptions);

--- a/src/cdk/a11y/interactivity-checker/interactivity-checker.ts
+++ b/src/cdk/a11y/interactivity-checker/interactivity-checker.ts
@@ -7,7 +7,7 @@
  */
 
 import {Platform} from '@angular/cdk/platform';
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 
 /**
  * Configuration for the isFocusable method.
@@ -29,7 +29,10 @@ export class IsFocusableConfig {
  */
 @Injectable({providedIn: 'root'})
 export class InteractivityChecker {
-  constructor(private _platform: Platform) {}
+  private _platform = inject(Platform);
+
+  constructor(...args: unknown[]);
+  constructor() {}
 
   /**
    * Gets whether an element is disabled.

--- a/src/cdk/a11y/live-announcer/live-announcer.spec.ts
+++ b/src/cdk/a11y/live-announcer/live-announcer.spec.ts
@@ -1,8 +1,8 @@
 import {MutationObserverFactory} from '@angular/cdk/observers';
 import {Overlay} from '@angular/cdk/overlay';
 import {ComponentPortal} from '@angular/cdk/portal';
-import {Component} from '@angular/core';
-import {ComponentFixture, TestBed, fakeAsync, flush, inject, tick} from '@angular/core/testing';
+import {Component, inject} from '@angular/core';
+import {ComponentFixture, TestBed, fakeAsync, flush, tick} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {A11yModule} from '../index';
 import {LiveAnnouncer} from './live-announcer';
@@ -133,12 +133,9 @@ describe('LiveAnnouncer', () => {
       const extraElement = document.createElement('div');
       extraElement.classList.add('cdk-live-announcer-element');
       document.body.appendChild(extraElement);
-
-      inject([LiveAnnouncer], (la: LiveAnnouncer) => {
-        announcer = la;
-        ariaLiveElement = getLiveElement();
-        fixture = TestBed.createComponent(TestApp);
-      })();
+      announcer = TestBed.inject(LiveAnnouncer);
+      ariaLiveElement = getLiveElement();
+      fixture = TestBed.createComponent(TestApp);
 
       announcer.announce('Hey Google');
       tick(100);
@@ -229,10 +226,10 @@ describe('LiveAnnouncer', () => {
       });
     });
 
-    beforeEach(inject([LiveAnnouncer], (la: LiveAnnouncer) => {
-      announcer = la;
+    beforeEach(() => {
+      announcer = TestBed.inject(LiveAnnouncer);
       ariaLiveElement = getLiveElement();
-    }));
+    });
 
     it('should allow to use a custom live element', fakeAsync(() => {
       announcer.announce('Custom Element');
@@ -260,10 +257,10 @@ describe('LiveAnnouncer', () => {
       });
     });
 
-    beforeEach(inject([LiveAnnouncer], (la: LiveAnnouncer) => {
-      announcer = la;
+    beforeEach(() => {
+      announcer = TestBed.inject(LiveAnnouncer);
       ariaLiveElement = getLiveElement();
-    }));
+    });
 
     it('should pick up the default politeness from the injection token', fakeAsync(() => {
       announcer.announce('Hello');
@@ -313,15 +310,13 @@ describe('CdkAriaLive', () => {
     });
   }));
 
-  beforeEach(fakeAsync(
-    inject([LiveAnnouncer], (la: LiveAnnouncer) => {
-      announcer = la;
-      announcerSpy = spyOn(la, 'announce').and.callThrough();
-      fixture = TestBed.createComponent(DivWithCdkAriaLive);
-      fixture.detectChanges();
-      flush();
-    }),
-  ));
+  beforeEach(fakeAsync(() => {
+    announcer = TestBed.inject(LiveAnnouncer);
+    announcerSpy = spyOn(announcer, 'announce').and.callThrough();
+    fixture = TestBed.createComponent(DivWithCdkAriaLive);
+    fixture.detectChanges();
+    flush();
+  }));
 
   it('should default politeness to polite', fakeAsync(() => {
     fixture.componentInstance.content = 'New content';
@@ -401,7 +396,7 @@ function getLiveElement(): Element {
   imports: [A11yModule],
 })
 class TestApp {
-  constructor(public live: LiveAnnouncer) {}
+  live = inject(LiveAnnouncer);
 
   announceText(message: string) {
     this.live.announce(message);

--- a/src/cdk/a11y/live-announcer/live-announcer.ts
+++ b/src/cdk/a11y/live-announcer/live-announcer.ts
@@ -8,16 +8,7 @@
 
 import {ContentObserver} from '@angular/cdk/observers';
 import {DOCUMENT} from '@angular/common';
-import {
-  Directive,
-  ElementRef,
-  Inject,
-  Injectable,
-  Input,
-  NgZone,
-  OnDestroy,
-  Optional,
-} from '@angular/core';
+import {Directive, ElementRef, Injectable, Input, NgZone, OnDestroy, inject} from '@angular/core';
 import {Subscription} from 'rxjs';
 import {
   AriaLivePoliteness,
@@ -30,24 +21,21 @@ let uniqueIds = 0;
 
 @Injectable({providedIn: 'root'})
 export class LiveAnnouncer implements OnDestroy {
+  private _ngZone = inject(NgZone);
+  private _defaultOptions = inject<LiveAnnouncerDefaultOptions>(LIVE_ANNOUNCER_DEFAULT_OPTIONS, {
+    optional: true,
+  });
+
   private _liveElement: HTMLElement;
-  private _document: Document;
+  private _document = inject(DOCUMENT);
   private _previousTimeout: number;
   private _currentPromise: Promise<void> | undefined;
   private _currentResolve: (() => void) | undefined;
 
-  constructor(
-    @Optional() @Inject(LIVE_ANNOUNCER_ELEMENT_TOKEN) elementToken: any,
-    private _ngZone: NgZone,
-    @Inject(DOCUMENT) _document: any,
-    @Optional()
-    @Inject(LIVE_ANNOUNCER_DEFAULT_OPTIONS)
-    private _defaultOptions?: LiveAnnouncerDefaultOptions,
-  ) {
-    // We inject the live element and document as `any` because the constructor signature cannot
-    // reference browser globals (HTMLElement, Document) on non-browser environments, since having
-    // a class decorator causes TypeScript to preserve the constructor signature types.
-    this._document = _document;
+  constructor(...args: unknown[]);
+
+  constructor() {
+    const elementToken = inject(LIVE_ANNOUNCER_ELEMENT_TOKEN, {optional: true});
     this._liveElement = elementToken || this._createLiveElement();
   }
 
@@ -225,6 +213,11 @@ export class LiveAnnouncer implements OnDestroy {
   standalone: true,
 })
 export class CdkAriaLive implements OnDestroy {
+  private _elementRef = inject(ElementRef);
+  private _liveAnnouncer = inject(LiveAnnouncer);
+  private _contentObserver = inject(ContentObserver);
+  private _ngZone = inject(NgZone);
+
   /** The aria-live politeness level to use when announcing messages. */
   @Input('cdkAriaLive')
   get politeness(): AriaLivePoliteness {
@@ -261,12 +254,9 @@ export class CdkAriaLive implements OnDestroy {
   private _previousAnnouncedText?: string;
   private _subscription: Subscription | null;
 
-  constructor(
-    private _elementRef: ElementRef,
-    private _liveAnnouncer: LiveAnnouncer,
-    private _contentObserver: ContentObserver,
-    private _ngZone: NgZone,
-  ) {}
+  constructor(...args: unknown[]);
+
+  constructor() {}
 
   ngOnDestroy() {
     if (this._subscription) {

--- a/src/cdk/accordion/accordion-item.ts
+++ b/src/cdk/accordion/accordion-item.ts
@@ -12,11 +12,10 @@ import {
   EventEmitter,
   Input,
   OnDestroy,
-  Optional,
   ChangeDetectorRef,
-  SkipSelf,
-  Inject,
   booleanAttribute,
+  inject,
+  OnInit,
 } from '@angular/core';
 import {UniqueSelectionDispatcher} from '@angular/cdk/collections';
 import {CDK_ACCORDION, CdkAccordion} from './accordion';
@@ -39,7 +38,11 @@ let nextId = 0;
   ],
   standalone: true,
 })
-export class CdkAccordionItem implements OnDestroy {
+export class CdkAccordionItem implements OnInit, OnDestroy {
+  accordion = inject<CdkAccordion>(CDK_ACCORDION, {optional: true, skipSelf: true})!;
+  private _changeDetectorRef = inject(ChangeDetectorRef);
+  protected _expansionDispatcher = inject(UniqueSelectionDispatcher);
+
   /** Subscription to openAll/closeAll events. */
   private _openCloseAllSubscription = Subscription.EMPTY;
   /** Event emitted every time the AccordionItem is closed. */
@@ -95,12 +98,11 @@ export class CdkAccordionItem implements OnDestroy {
   /** Unregister function for _expansionDispatcher. */
   private _removeUniqueSelectionListener: () => void = () => {};
 
-  constructor(
-    @Optional() @Inject(CDK_ACCORDION) @SkipSelf() public accordion: CdkAccordion,
-    private _changeDetectorRef: ChangeDetectorRef,
-    protected _expansionDispatcher: UniqueSelectionDispatcher,
-  ) {
-    this._removeUniqueSelectionListener = _expansionDispatcher.listen(
+  constructor(...args: unknown[]);
+  constructor() {}
+
+  ngOnInit() {
+    this._removeUniqueSelectionListener = this._expansionDispatcher.listen(
       (id: string, accordionId: string) => {
         if (
           this.accordion &&

--- a/src/cdk/bidi/directionality.spec.ts
+++ b/src/cdk/bidi/directionality.spec.ts
@@ -1,5 +1,5 @@
 import {waitForAsync, fakeAsync, TestBed, flush} from '@angular/core/testing';
-import {Component, ViewChild, signal} from '@angular/core';
+import {Component, ViewChild, signal, inject} from '@angular/core';
 import {By} from '@angular/platform-browser';
 import {BidiModule, Directionality, Dir, Direction, DIR_DOCUMENT} from './index';
 
@@ -166,7 +166,7 @@ describe('Directionality', () => {
   imports: [BidiModule],
 })
 class InjectsDirectionality {
-  constructor(public dir: Directionality) {}
+  dir = inject(Directionality);
 }
 
 @Component({

--- a/src/cdk/bidi/directionality.ts
+++ b/src/cdk/bidi/directionality.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {EventEmitter, Inject, Injectable, Optional, OnDestroy} from '@angular/core';
+import {EventEmitter, Injectable, OnDestroy, inject} from '@angular/core';
 import {DIR_DOCUMENT} from './dir-document-token';
 
 export type Direction = 'ltr' | 'rtl';
@@ -38,7 +38,11 @@ export class Directionality implements OnDestroy {
   /** Stream that emits whenever the 'ltr' / 'rtl' state changes. */
   readonly change = new EventEmitter<Direction>();
 
-  constructor(@Optional() @Inject(DIR_DOCUMENT) _document?: any) {
+  constructor(...args: unknown[]);
+
+  constructor() {
+    const _document = inject(DIR_DOCUMENT, {optional: true});
+
     if (_document) {
       const bodyDir = _document.body ? _document.body.dir : null;
       const htmlDir = _document.documentElement ? _document.documentElement.dir : null;

--- a/src/cdk/clipboard/clipboard.ts
+++ b/src/cdk/clipboard/clipboard.ts
@@ -7,7 +7,7 @@
  */
 
 import {DOCUMENT} from '@angular/common';
-import {Inject, Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 import {PendingCopy} from './pending-copy';
 
 /**
@@ -15,11 +15,10 @@ import {PendingCopy} from './pending-copy';
  */
 @Injectable({providedIn: 'root'})
 export class Clipboard {
-  private readonly _document: Document;
+  private readonly _document = inject(DOCUMENT);
 
-  constructor(@Inject(DOCUMENT) document: any) {
-    this._document = document;
-  }
+  constructor(...args: unknown[]);
+  constructor() {}
 
   /**
    * Copies the provided text into the user's clipboard.

--- a/src/cdk/clipboard/copy-to-clipboard.ts
+++ b/src/cdk/clipboard/copy-to-clipboard.ts
@@ -13,9 +13,8 @@ import {
   Output,
   NgZone,
   InjectionToken,
-  Inject,
-  Optional,
   OnDestroy,
+  inject,
 } from '@angular/core';
 import {Clipboard} from './clipboard';
 import {PendingCopy} from './pending-copy';
@@ -43,6 +42,9 @@ export const CDK_COPY_TO_CLIPBOARD_CONFIG = new InjectionToken<CdkCopyToClipboar
   standalone: true,
 })
 export class CdkCopyToClipboard implements OnDestroy {
+  private _clipboard = inject(Clipboard);
+  private _ngZone = inject(NgZone);
+
   /** Content to be copied. */
   @Input('cdkCopyToClipboard') text: string = '';
 
@@ -67,11 +69,11 @@ export class CdkCopyToClipboard implements OnDestroy {
   /** Timeout for the current copy attempt. */
   private _currentTimeout: any;
 
-  constructor(
-    private _clipboard: Clipboard,
-    private _ngZone: NgZone,
-    @Optional() @Inject(CDK_COPY_TO_CLIPBOARD_CONFIG) config?: CdkCopyToClipboardConfig,
-  ) {
+  constructor(...args: unknown[]);
+
+  constructor() {
+    const config = inject(CDK_COPY_TO_CLIPBOARD_CONFIG, {optional: true});
+
     if (config && config.attempts != null) {
       this.attempts = config.attempts;
     }

--- a/src/cdk/dialog/dialog.spec.ts
+++ b/src/cdk/dialog/dialog.spec.ts
@@ -14,7 +14,6 @@ import {
   Component,
   ComponentRef,
   Directive,
-  Inject,
   InjectionToken,
   Injector,
   TemplateRef,
@@ -1209,7 +1208,7 @@ describe('Dialog with a parent Dialog', () => {
   standalone: true,
 })
 class DirectiveWithViewContainer {
-  constructor(public viewContainerRef: ViewContainerRef) {}
+  viewContainerRef = inject(ViewContainerRef);
 }
 
 @Component({
@@ -1217,7 +1216,7 @@ class DirectiveWithViewContainer {
   template: 'hello',
 })
 class ComponentWithOnPushViewContainer {
-  constructor(public viewContainerRef: ViewContainerRef) {}
+  viewContainerRef = inject(ViewContainerRef);
 }
 
 @Component({
@@ -1260,11 +1259,9 @@ class ComponentWithTemplateRef {
   imports: [DialogModule],
 })
 class PizzaMsg {
-  constructor(
-    public dialogRef: DialogRef<PizzaMsg>,
-    public dialogInjector: Injector,
-    public directionality: Directionality,
-  ) {}
+  dialogRef = inject<DialogRef<PizzaMsg>>(DialogRef);
+  dialogInjector = inject(Injector);
+  directionality = inject(Directionality);
 }
 
 @Component({
@@ -1285,7 +1282,7 @@ class ContentElementDialog {
   imports: [DialogModule],
 })
 class ComponentThatProvidesMatDialog {
-  constructor(public dialog: Dialog) {}
+  dialog = inject(Dialog);
 }
 
 /** Simple component for testing ComponentPortal. */
@@ -1295,7 +1292,7 @@ class ComponentThatProvidesMatDialog {
   imports: [DialogModule],
 })
 class DialogWithInjectedData {
-  constructor(@Inject(DIALOG_DATA) public data: any) {}
+  data = inject(DIALOG_DATA);
 }
 
 @Component({

--- a/src/cdk/drag-drop/directives/drag-handle.ts
+++ b/src/cdk/drag-drop/directives/drag-handle.ts
@@ -9,13 +9,11 @@
 import {
   Directive,
   ElementRef,
-  Inject,
   InjectionToken,
   Input,
   OnDestroy,
-  Optional,
-  SkipSelf,
   booleanAttribute,
+  inject,
 } from '@angular/core';
 import {Subject} from 'rxjs';
 import type {CdkDrag} from './drag';
@@ -39,6 +37,10 @@ export const CDK_DRAG_HANDLE = new InjectionToken<CdkDragHandle>('CdkDragHandle'
   providers: [{provide: CDK_DRAG_HANDLE, useExisting: CdkDragHandle}],
 })
 export class CdkDragHandle implements OnDestroy {
+  element = inject<ElementRef<HTMLElement>>(ElementRef);
+
+  private _parentDrag = inject<CdkDrag>(CDK_DRAG_PARENT, {optional: true, skipSelf: true});
+
   /** Emits when the state of the handle has changed. */
   readonly _stateChanges = new Subject<CdkDragHandle>();
 
@@ -53,15 +55,14 @@ export class CdkDragHandle implements OnDestroy {
   }
   private _disabled = false;
 
-  constructor(
-    public element: ElementRef<HTMLElement>,
-    @Inject(CDK_DRAG_PARENT) @Optional() @SkipSelf() private _parentDrag?: CdkDrag,
-  ) {
+  constructor(...args: unknown[]);
+
+  constructor() {
     if (typeof ngDevMode === 'undefined' || ngDevMode) {
-      assertElementNode(element.nativeElement, 'cdkDragHandle');
+      assertElementNode(this.element.nativeElement, 'cdkDragHandle');
     }
 
-    _parentDrag?._addHandle(this);
+    this._parentDrag?._addHandle(this);
   }
 
   ngOnDestroy() {

--- a/src/cdk/drag-drop/directives/drag-placeholder.ts
+++ b/src/cdk/drag-drop/directives/drag-placeholder.ts
@@ -26,12 +26,16 @@ export const CDK_DRAG_PLACEHOLDER = new InjectionToken<CdkDragPlaceholder>('CdkD
   providers: [{provide: CDK_DRAG_PLACEHOLDER, useExisting: CdkDragPlaceholder}],
 })
 export class CdkDragPlaceholder<T = any> implements OnDestroy {
+  templateRef = inject<TemplateRef<T>>(TemplateRef);
+
   private _drag = inject(CDK_DRAG_PARENT, {optional: true});
 
   /** Context data to be added to the placeholder template instance. */
   @Input() data: T;
 
-  constructor(public templateRef: TemplateRef<T>) {
+  constructor(...args: unknown[]);
+
+  constructor() {
     this._drag?._setPlaceholderTemplate(this);
   }
 

--- a/src/cdk/drag-drop/directives/drag-preview.ts
+++ b/src/cdk/drag-drop/directives/drag-preview.ts
@@ -34,6 +34,8 @@ export const CDK_DRAG_PREVIEW = new InjectionToken<CdkDragPreview>('CdkDragPrevi
   providers: [{provide: CDK_DRAG_PREVIEW, useExisting: CdkDragPreview}],
 })
 export class CdkDragPreview<T = any> implements OnDestroy {
+  templateRef = inject<TemplateRef<T>>(TemplateRef);
+
   private _drag = inject(CDK_DRAG_PARENT, {optional: true});
 
   /** Context data to be added to the preview template instance. */
@@ -42,7 +44,9 @@ export class CdkDragPreview<T = any> implements OnDestroy {
   /** Whether the preview should preserve the same size as the item that is being dragged. */
   @Input({transform: booleanAttribute}) matchSize: boolean = false;
 
-  constructor(public templateRef: TemplateRef<T>) {
+  constructor(...args: unknown[]);
+
+  constructor() {
     this._drag?._setPreviewTemplate(this);
   }
 

--- a/src/cdk/drag-drop/directives/drop-list-shared.spec.ts
+++ b/src/cdk/drag-drop/directives/drop-list-shared.spec.ts
@@ -4890,6 +4890,8 @@ export function getHorizontalFixtures(listOrientation: Exclude<DropListOrientati
     imports: [CdkDropList, CdkDrag],
   })
   class DraggableInHorizontalDropZone implements AfterViewInit {
+    readonly _elementRef = inject(ElementRef);
+
     @ViewChildren(CdkDrag) dragItems: QueryList<CdkDrag>;
     @ViewChild(CdkDropList) dropInstance: CdkDropList;
     items = [
@@ -4903,7 +4905,9 @@ export function getHorizontalFixtures(listOrientation: Exclude<DropListOrientati
       moveItemInArray(this.items, event.previousIndex, event.currentIndex);
     });
 
-    constructor(readonly _elementRef: ElementRef) {}
+    constructor(...args: unknown[]);
+
+    constructor() {}
 
     ngAfterViewInit() {
       // Firefox preserves the `scrollLeft` value from previous similar containers. This
@@ -4933,8 +4937,8 @@ export function getHorizontalFixtures(listOrientation: Exclude<DropListOrientati
     ],
   })
   class DraggableInScrollableHorizontalDropZone extends DraggableInHorizontalDropZone {
-    constructor(elementRef: ElementRef) {
-      super(elementRef);
+    constructor() {
+      super();
 
       for (let i = 0; i < 60; i++) {
         this.items.push({value: `Extra item ${i}`, width: ITEM_WIDTH, margin: 0});
@@ -5019,6 +5023,8 @@ const DROP_ZONE_FIXTURE_TEMPLATE = `
   imports: [CdkDropList, CdkDrag, NgFor],
 })
 export class DraggableInDropZone implements AfterViewInit {
+  protected _elementRef = inject(ElementRef);
+
   @ViewChildren(CdkDrag) dragItems: QueryList<CdkDrag>;
   @ViewChild(CdkDropList) dropInstance: CdkDropList;
   @ViewChild('alternatePreviewContainer') alternatePreviewContainer: ElementRef<HTMLElement>;
@@ -5040,8 +5046,6 @@ export class DraggableInDropZone implements AfterViewInit {
   dropDisabled = signal(false);
   dropLockAxis = signal<DragAxis | undefined>(undefined);
   scale = 1;
-
-  constructor(protected _elementRef: ElementRef) {}
 
   ngAfterViewInit() {
     // Firefox preserves the `scrollTop` value from previous similar containers. This
@@ -5088,8 +5092,8 @@ class ConnectedDropListsInOnPush {}
   imports: [CdkDropList, CdkDrag, NgFor],
 })
 export class DraggableInScrollableVerticalDropZone extends DraggableInDropZone {
-  constructor(elementRef: ElementRef) {
-    super(elementRef);
+  constructor() {
+    super();
 
     for (let i = 0; i < 60; i++) {
       this.items.push({value: `Extra item ${i}`, height: ITEM_HEIGHT, margin: 0});
@@ -5119,8 +5123,8 @@ export class DraggableInScrollableVerticalDropZone extends DraggableInDropZone {
 class DraggableInScrollableParentContainer extends DraggableInDropZone implements AfterViewInit {
   @ViewChild('scrollContainer') scrollContainer: ElementRef<HTMLElement>;
 
-  constructor(elementRef: ElementRef) {
-    super(elementRef);
+  constructor() {
+    super();
 
     for (let i = 0; i < 60; i++) {
       this.items.push({value: `Extra item ${i}`, height: ITEM_HEIGHT, margin: 0});
@@ -5660,10 +5664,6 @@ class ConnectedWrappedDropZones {
   imports: [CdkDropList, CdkDrag],
 })
 class DraggableWithCanvasInDropZone extends DraggableInDropZone implements AfterViewInit {
-  constructor(elementRef: ElementRef<HTMLElement>) {
-    super(elementRef);
-  }
-
   override ngAfterViewInit() {
     super.ngAfterViewInit();
     const canvases = this._elementRef.nativeElement.querySelectorAll('canvas');

--- a/src/cdk/drag-drop/drag-drop-registry.ts
+++ b/src/cdk/drag-drop/drag-drop-registry.ts
@@ -9,7 +9,6 @@
 import {
   ChangeDetectionStrategy,
   Component,
-  Inject,
   Injectable,
   NgZone,
   OnDestroy,
@@ -53,7 +52,8 @@ export class _ResetsLoader {}
  */
 @Injectable({providedIn: 'root'})
 export class DragDropRegistry<_ = unknown, __ = unknown> implements OnDestroy {
-  private _document: Document;
+  private _ngZone = inject(NgZone);
+  private _document = inject(DOCUMENT);
   private _styleLoader = inject(_CdkPrivateStyleLoader);
 
   /** Registered drop container instances. */
@@ -99,12 +99,8 @@ export class DragDropRegistry<_ = unknown, __ = unknown> implements OnDestroy {
    */
   readonly scroll: Subject<Event> = new Subject<Event>();
 
-  constructor(
-    private _ngZone: NgZone,
-    @Inject(DOCUMENT) _document: any,
-  ) {
-    this._document = _document;
-  }
+  constructor(...args: unknown[]);
+  constructor() {}
 
   /** Adds a drop container to the registry. */
   registerDropContainer(drop: DropListRef) {

--- a/src/cdk/drag-drop/drag-drop.spec.ts
+++ b/src/cdk/drag-drop/drag-drop.spec.ts
@@ -1,4 +1,4 @@
-import {Component, ElementRef} from '@angular/core';
+import {Component, ElementRef, inject} from '@angular/core';
 import {TestBed, fakeAsync} from '@angular/core/testing';
 import {DragDrop} from './drag-drop';
 import {DragDropModule} from './drag-drop-module';
@@ -38,5 +38,5 @@ describe('DragDrop', () => {
   standalone: true,
 })
 class TestComponent {
-  constructor(public elementRef: ElementRef<HTMLElement>) {}
+  elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
 }

--- a/src/cdk/drag-drop/drag-drop.ts
+++ b/src/cdk/drag-drop/drag-drop.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Injectable, Inject, NgZone, ElementRef} from '@angular/core';
+import {Injectable, NgZone, ElementRef, inject} from '@angular/core';
 import {DOCUMENT} from '@angular/common';
 import {ViewportRuler} from '@angular/cdk/scrolling';
 import {DragRef, DragRefConfig} from './drag-ref';
@@ -24,12 +24,13 @@ const DEFAULT_CONFIG = {
  */
 @Injectable({providedIn: 'root'})
 export class DragDrop {
-  constructor(
-    @Inject(DOCUMENT) private _document: any,
-    private _ngZone: NgZone,
-    private _viewportRuler: ViewportRuler,
-    private _dragDropRegistry: DragDropRegistry,
-  ) {}
+  private _document = inject(DOCUMENT);
+  private _ngZone = inject(NgZone);
+  private _viewportRuler = inject(ViewportRuler);
+  private _dragDropRegistry = inject(DragDropRegistry);
+
+  constructor(...args: unknown[]);
+  constructor() {}
 
   /**
    * Turns an element into a draggable item.

--- a/src/cdk/layout/breakpoints-observer.ts
+++ b/src/cdk/layout/breakpoints-observer.ts
@@ -7,7 +7,7 @@
  */
 
 import {coerceArray} from '@angular/cdk/coercion';
-import {Injectable, NgZone, OnDestroy} from '@angular/core';
+import {Injectable, NgZone, OnDestroy, inject} from '@angular/core';
 import {combineLatest, concat, Observable, Observer, Subject} from 'rxjs';
 import {debounceTime, map, skip, startWith, take, takeUntil} from 'rxjs/operators';
 import {MediaMatcher} from './media-matcher';
@@ -38,18 +38,19 @@ interface Query {
   mql: MediaQueryList;
 }
 
-/** Utility for checking the matching state of @media queries. */
+/** Utility for checking the matching state of `@media` queries. */
 @Injectable({providedIn: 'root'})
 export class BreakpointObserver implements OnDestroy {
+  private _mediaMatcher = inject(MediaMatcher);
+  private _zone = inject(NgZone);
+
   /**  A map of all media queries currently being listened for. */
   private _queries = new Map<string, Query>();
   /** A subject for all other observables to takeUntil based on. */
   private readonly _destroySubject = new Subject<void>();
 
-  constructor(
-    private _mediaMatcher: MediaMatcher,
-    private _zone: NgZone,
-  ) {}
+  constructor(...args: unknown[]);
+  constructor() {}
 
   /** Completes the active subject, signalling to all other observables to complete. */
   ngOnDestroy() {

--- a/src/cdk/layout/media-matcher.ts
+++ b/src/cdk/layout/media-matcher.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {Injectable, CSP_NONCE, Optional, Inject} from '@angular/core';
+import {Injectable, CSP_NONCE, inject} from '@angular/core';
 import {Platform} from '@angular/cdk/platform';
 
 /** Global registry for all dynamically-created, injected media queries. */
@@ -17,13 +17,15 @@ let mediaQueryStyleNode: HTMLStyleElement | undefined;
 /** A utility for calling matchMedia queries. */
 @Injectable({providedIn: 'root'})
 export class MediaMatcher {
+  private _platform = inject(Platform);
+  private _nonce = inject(CSP_NONCE, {optional: true});
+
   /** The internal matchMedia method to return back a MediaQueryList like object. */
   private _matchMedia: (query: string) => MediaQueryList;
 
-  constructor(
-    private _platform: Platform,
-    @Optional() @Inject(CSP_NONCE) private _nonce?: string | null,
-  ) {
+  constructor(...args: unknown[]);
+
+  constructor() {
     this._matchMedia =
       this._platform.isBrowser && window.matchMedia
         ? // matchMedia is bound to the window scope intentionally as it is an illegal invocation to

--- a/src/cdk/menu/pointer-focus-tracker.spec.ts
+++ b/src/cdk/menu/pointer-focus-tracker.spec.ts
@@ -1,4 +1,4 @@
-import {Component, QueryList, ElementRef, ViewChildren, AfterViewInit} from '@angular/core';
+import {Component, QueryList, ElementRef, ViewChildren, AfterViewInit, inject} from '@angular/core';
 import {waitForAsync, ComponentFixture, TestBed} from '@angular/core/testing';
 import {createMouseEvent, dispatchEvent} from '../../cdk/testing/private';
 import {Observable} from 'rxjs';
@@ -102,7 +102,7 @@ describe('FocusMouseManger', () => {
   standalone: true,
 })
 class MockWrapper implements FocusableElement {
-  constructor(readonly _elementRef: ElementRef<HTMLElement>) {}
+  readonly _elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
 }
 
 @Component({

--- a/src/cdk/observers/observe-content.ts
+++ b/src/cdk/observers/observe-content.ts
@@ -65,6 +65,8 @@ export class MutationObserverFactory {
 /** An injectable service that allows watching elements for changes to their content. */
 @Injectable({providedIn: 'root'})
 export class ContentObserver implements OnDestroy {
+  private _mutationObserverFactory = inject(MutationObserverFactory);
+
   /** Keeps track of the existing MutationObservers so they can be reused. */
   private _observedElements = new Map<
     Element,
@@ -77,7 +79,8 @@ export class ContentObserver implements OnDestroy {
 
   private _ngZone = inject(NgZone);
 
-  constructor(private _mutationObserverFactory: MutationObserverFactory) {}
+  constructor(...args: unknown[]);
+  constructor() {}
 
   ngOnDestroy() {
     this._observedElements.forEach((_, element) => this._cleanupObserver(element));
@@ -178,6 +181,9 @@ export class ContentObserver implements OnDestroy {
   standalone: true,
 })
 export class CdkObserveContent implements AfterContentInit, OnDestroy {
+  private _contentObserver = inject(ContentObserver);
+  private _elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
+
   /** Event emitted for each change in the element's content. */
   @Output('cdkObserveContent') readonly event = new EventEmitter<MutationRecord[]>();
 
@@ -208,10 +214,8 @@ export class CdkObserveContent implements AfterContentInit, OnDestroy {
 
   private _currentSubscription: Subscription | null = null;
 
-  constructor(
-    private _contentObserver: ContentObserver,
-    private _elementRef: ElementRef<HTMLElement>,
-  ) {}
+  constructor(...args: unknown[]);
+  constructor() {}
 
   ngAfterContentInit() {
     if (!this._currentSubscription && !this.disabled) {

--- a/src/cdk/overlay/dispatchers/base-overlay-dispatcher.ts
+++ b/src/cdk/overlay/dispatchers/base-overlay-dispatcher.ts
@@ -7,7 +7,7 @@
  */
 
 import {DOCUMENT} from '@angular/common';
-import {Inject, Injectable, OnDestroy} from '@angular/core';
+import {Injectable, OnDestroy, inject} from '@angular/core';
 import type {OverlayRef} from '../overlay-ref';
 
 /**
@@ -20,12 +20,12 @@ export abstract class BaseOverlayDispatcher implements OnDestroy {
   /** Currently attached overlays in the order they were attached. */
   _attachedOverlays: OverlayRef[] = [];
 
-  protected _document: Document;
+  protected _document = inject(DOCUMENT);
   protected _isAttached: boolean;
 
-  constructor(@Inject(DOCUMENT) document: any) {
-    this._document = document;
-  }
+  constructor(...args: unknown[]);
+
+  constructor() {}
 
   ngOnDestroy(): void {
     this.detach();

--- a/src/cdk/overlay/dispatchers/overlay-keyboard-dispatcher.ts
+++ b/src/cdk/overlay/dispatchers/overlay-keyboard-dispatcher.ts
@@ -6,8 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {DOCUMENT} from '@angular/common';
-import {Inject, Injectable, NgZone, Optional} from '@angular/core';
+import {Injectable, NgZone, inject} from '@angular/core';
 import {BaseOverlayDispatcher} from './base-overlay-dispatcher';
 import type {OverlayRef} from '../overlay-ref';
 
@@ -18,13 +17,7 @@ import type {OverlayRef} from '../overlay-ref';
  */
 @Injectable({providedIn: 'root'})
 export class OverlayKeyboardDispatcher extends BaseOverlayDispatcher {
-  constructor(
-    @Inject(DOCUMENT) document: any,
-    /** @breaking-change 14.0.0 _ngZone will be required. */
-    @Optional() private _ngZone?: NgZone,
-  ) {
-    super(document);
-  }
+  private _ngZone = inject(NgZone, {optional: true});
 
   /** Add a new overlay to the list of attached overlay refs. */
   override add(overlayRef: OverlayRef): void {

--- a/src/cdk/overlay/dispatchers/overlay-outside-click-dispatcher.ts
+++ b/src/cdk/overlay/dispatchers/overlay-outside-click-dispatcher.ts
@@ -6,8 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {DOCUMENT} from '@angular/common';
-import {Inject, Injectable, NgZone, Optional} from '@angular/core';
+import {Injectable, NgZone, inject} from '@angular/core';
 import {Platform, _getEventTarget} from '@angular/cdk/platform';
 import {BaseOverlayDispatcher} from './base-overlay-dispatcher';
 import type {OverlayRef} from '../overlay-ref';
@@ -19,18 +18,12 @@ import type {OverlayRef} from '../overlay-ref';
  */
 @Injectable({providedIn: 'root'})
 export class OverlayOutsideClickDispatcher extends BaseOverlayDispatcher {
+  private _platform = inject(Platform);
+  private _ngZone = inject(NgZone, {optional: true});
+
   private _cursorOriginalValue: string;
   private _cursorStyleIsSet = false;
   private _pointerDownEventTarget: HTMLElement | null;
-
-  constructor(
-    @Inject(DOCUMENT) document: any,
-    private _platform: Platform,
-    /** @breaking-change 14.0.0 _ngZone will be required. */
-    @Optional() private _ngZone?: NgZone,
-  ) {
-    super(document);
-  }
 
   /** Add a new overlay to the list of attached overlay refs. */
   override add(overlayRef: OverlayRef): void {

--- a/src/cdk/overlay/fullscreen-overlay-container.spec.ts
+++ b/src/cdk/overlay/fullscreen-overlay-container.spec.ts
@@ -1,6 +1,6 @@
 import {DOCUMENT} from '@angular/common';
 import {waitForAsync, inject, TestBed} from '@angular/core/testing';
-import {Component, NgModule, ViewChild, ViewContainerRef} from '@angular/core';
+import {Component, NgModule, ViewChild, ViewContainerRef, inject as inject_1} from '@angular/core';
 import {PortalModule, CdkPortal} from '@angular/cdk/portal';
 import {Overlay, OverlayContainer, OverlayModule, FullscreenOverlayContainer} from './index';
 import {TemplatePortalDirective} from '../portal/portal-directives';
@@ -117,9 +117,9 @@ describe('FullscreenOverlayContainer', () => {
   imports: [TemplatePortalDirective],
 })
 class TestComponentWithTemplatePortals {
-  @ViewChild(CdkPortal) templatePortal: CdkPortal;
+  viewContainerRef = inject_1(ViewContainerRef);
 
-  constructor(public viewContainerRef: ViewContainerRef) {}
+  @ViewChild(CdkPortal) templatePortal: CdkPortal;
 }
 
 @NgModule({

--- a/src/cdk/overlay/fullscreen-overlay-container.ts
+++ b/src/cdk/overlay/fullscreen-overlay-container.ts
@@ -6,10 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Injectable, Inject, OnDestroy} from '@angular/core';
+import {Injectable, OnDestroy} from '@angular/core';
 import {OverlayContainer} from './overlay-container';
-import {DOCUMENT} from '@angular/common';
-import {Platform} from '@angular/cdk/platform';
 
 /**
  * Alternative to OverlayContainer that supports correct displaying of overlay elements in
@@ -23,8 +21,10 @@ export class FullscreenOverlayContainer extends OverlayContainer implements OnDe
   private _fullScreenEventName: string | undefined;
   private _fullScreenListener: () => void;
 
-  constructor(@Inject(DOCUMENT) _document: any, platform: Platform) {
-    super(_document, platform);
+  constructor(...args: unknown[]);
+
+  constructor() {
+    super();
   }
 
   override ngOnDestroy() {

--- a/src/cdk/overlay/overlay-container.spec.ts
+++ b/src/cdk/overlay/overlay-container.spec.ts
@@ -1,5 +1,5 @@
-import {waitForAsync, inject, TestBed} from '@angular/core/testing';
-import {Component, NgModule, ViewChild, ViewContainerRef} from '@angular/core';
+import {waitForAsync, TestBed} from '@angular/core/testing';
+import {Component, NgModule, ViewChild, ViewContainerRef, inject} from '@angular/core';
 import {PortalModule, CdkPortal} from '@angular/cdk/portal';
 import {Overlay, OverlayContainer, OverlayModule} from './index';
 
@@ -11,11 +11,9 @@ describe('OverlayContainer', () => {
     TestBed.configureTestingModule({
       imports: [OverlayTestModule],
     });
-  }));
 
-  beforeEach(inject([Overlay, OverlayContainer], (o: Overlay, oc: OverlayContainer) => {
-    overlay = o;
-    overlayContainer = oc;
+    overlay = TestBed.inject(Overlay);
+    overlayContainer = TestBed.inject(OverlayContainer);
   }));
 
   it('should remove the overlay container element from the DOM on destruction', () => {
@@ -95,9 +93,9 @@ describe('OverlayContainer', () => {
   imports: [CdkPortal],
 })
 class TestComponentWithTemplatePortals {
-  @ViewChild(CdkPortal) templatePortal: CdkPortal;
+  viewContainerRef = inject(ViewContainerRef);
 
-  constructor(public viewContainerRef: ViewContainerRef) {}
+  @ViewChild(CdkPortal) templatePortal: CdkPortal;
 }
 
 @NgModule({

--- a/src/cdk/overlay/overlay-container.ts
+++ b/src/cdk/overlay/overlay-container.ts
@@ -8,7 +8,6 @@
 
 import {DOCUMENT} from '@angular/common';
 import {
-  Inject,
   Injectable,
   OnDestroy,
   Component,
@@ -32,16 +31,14 @@ export class _CdkOverlayStyleLoader {}
 /** Container inside which all overlays will render. */
 @Injectable({providedIn: 'root'})
 export class OverlayContainer implements OnDestroy {
+  protected _platform = inject(Platform);
+
   protected _containerElement: HTMLElement;
-  protected _document: Document;
+  protected _document = inject(DOCUMENT);
   protected _styleLoader = inject(_CdkPrivateStyleLoader);
 
-  constructor(
-    @Inject(DOCUMENT) document: any,
-    protected _platform: Platform,
-  ) {
-    this._document = document;
-  }
+  constructor(...args: unknown[]);
+  constructor() {}
 
   ngOnDestroy() {
     this._containerElement?.remove();

--- a/src/cdk/overlay/overlay.spec.ts
+++ b/src/cdk/overlay/overlay.spec.ts
@@ -10,6 +10,7 @@ import {
   Type,
   ViewChild,
   ViewContainerRef,
+  inject,
 } from '@angular/core';
 import {
   ComponentFixture,
@@ -352,9 +353,7 @@ describe('Overlay', () => {
     /** Dummy provider that depends on `Overlay`. */
     @Injectable()
     class CustomErrorHandler extends ErrorHandler {
-      constructor(private _overlay: Overlay) {
-        super();
-      }
+      private _overlay = inject(Overlay);
 
       override handleError(error: any) {
         const overlayRef = this._overlay.create({hasBackdrop: !!error});
@@ -1113,9 +1112,9 @@ class PizzaMsg {}
   imports: [CdkPortal],
 })
 class TestComponentWithTemplatePortals {
-  @ViewChild(CdkPortal) templatePortal: CdkPortal;
+  viewContainerRef = inject(ViewContainerRef);
 
-  constructor(public viewContainerRef: ViewContainerRef) {}
+  @ViewChild(CdkPortal) templatePortal: CdkPortal;
 }
 
 class FakePositionStrategy implements PositionStrategy {

--- a/src/cdk/overlay/overlay.ts
+++ b/src/cdk/overlay/overlay.ts
@@ -12,12 +12,10 @@ import {DOCUMENT, Location} from '@angular/common';
 import {
   ApplicationRef,
   ComponentFactoryResolver,
-  Inject,
   Injectable,
   Injector,
   NgZone,
   ANIMATION_MODULE_TYPE,
-  Optional,
   EnvironmentInjector,
   inject,
 } from '@angular/core';
@@ -46,24 +44,24 @@ let nextUniqueId = 0;
  */
 @Injectable({providedIn: 'root'})
 export class Overlay {
+  scrollStrategies = inject(ScrollStrategyOptions);
+  private _overlayContainer = inject(OverlayContainer);
+  private _componentFactoryResolver = inject(ComponentFactoryResolver);
+  private _positionBuilder = inject(OverlayPositionBuilder);
+  private _keyboardDispatcher = inject(OverlayKeyboardDispatcher);
+  private _injector = inject(Injector);
+  private _ngZone = inject(NgZone);
+  private _document = inject(DOCUMENT);
+  private _directionality = inject(Directionality);
+  private _location = inject(Location);
+  private _outsideClickDispatcher = inject(OverlayOutsideClickDispatcher);
+  private _animationsModuleType = inject(ANIMATION_MODULE_TYPE, {optional: true});
+
   private _appRef: ApplicationRef;
   private _styleLoader = inject(_CdkPrivateStyleLoader);
 
-  constructor(
-    /** Scrolling strategies that can be used when creating an overlay. */
-    public scrollStrategies: ScrollStrategyOptions,
-    private _overlayContainer: OverlayContainer,
-    private _componentFactoryResolver: ComponentFactoryResolver,
-    private _positionBuilder: OverlayPositionBuilder,
-    private _keyboardDispatcher: OverlayKeyboardDispatcher,
-    private _injector: Injector,
-    private _ngZone: NgZone,
-    @Inject(DOCUMENT) private _document: any,
-    private _directionality: Directionality,
-    private _location: Location,
-    private _outsideClickDispatcher: OverlayOutsideClickDispatcher,
-    @Inject(ANIMATION_MODULE_TYPE) @Optional() private _animationsModuleType?: string,
-  ) {}
+  constructor(...args: unknown[]);
+  constructor() {}
 
   /**
    * Creates an overlay.

--- a/src/cdk/overlay/position/flexible-connected-position-strategy.spec.ts
+++ b/src/cdk/overlay/position/flexible-connected-position-strategy.spec.ts
@@ -1,7 +1,13 @@
 import {ComponentPortal, PortalModule} from '@angular/cdk/portal';
 import {CdkScrollable, ScrollingModule, ViewportRuler} from '@angular/cdk/scrolling';
 import {dispatchFakeEvent} from '../../testing/private';
-import {ApplicationRef, Component, ElementRef} from '@angular/core';
+import {
+  ApplicationRef,
+  Component,
+  ElementRef,
+  Injector,
+  runInInjectionContext,
+} from '@angular/core';
 import {fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {Subscription} from 'rxjs';
 import {map} from 'rxjs/operators';
@@ -2488,9 +2494,19 @@ describe('FlexibleConnectedPositionStrategy', () => {
           },
         ]);
 
-      strategy.withScrollableContainers([
-        new CdkScrollable(new ElementRef<HTMLElement>(scrollable), null!, null!),
-      ]);
+      const injector = Injector.create({
+        parent: TestBed.inject(Injector),
+        providers: [
+          {
+            provide: ElementRef,
+            useValue: new ElementRef<HTMLElement>(scrollable),
+          },
+        ],
+      });
+
+      runInInjectionContext(injector, () => {
+        strategy.withScrollableContainers([new CdkScrollable()]);
+      });
 
       positionChangeHandler = jasmine.createSpy('positionChange handler');
       onPositionChangeSubscription = strategy.positionChanges

--- a/src/cdk/overlay/position/overlay-position-builder.ts
+++ b/src/cdk/overlay/position/overlay-position-builder.ts
@@ -9,7 +9,7 @@
 import {Platform} from '@angular/cdk/platform';
 import {ViewportRuler} from '@angular/cdk/scrolling';
 import {DOCUMENT} from '@angular/common';
-import {Inject, Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 import {OverlayContainer} from '../overlay-container';
 import {
   FlexibleConnectedPositionStrategy,
@@ -20,12 +20,13 @@ import {GlobalPositionStrategy} from './global-position-strategy';
 /** Builder for overlay position strategy. */
 @Injectable({providedIn: 'root'})
 export class OverlayPositionBuilder {
-  constructor(
-    private _viewportRuler: ViewportRuler,
-    @Inject(DOCUMENT) private _document: any,
-    private _platform: Platform,
-    private _overlayContainer: OverlayContainer,
-  ) {}
+  private _viewportRuler = inject(ViewportRuler);
+  private _document = inject(DOCUMENT);
+  private _platform = inject(Platform);
+  private _overlayContainer = inject(OverlayContainer);
+
+  constructor(...args: unknown[]);
+  constructor() {}
 
   /**
    * Creates a global position strategy.

--- a/src/cdk/overlay/scroll/scroll-strategy-options.ts
+++ b/src/cdk/overlay/scroll/scroll-strategy-options.ts
@@ -8,7 +8,7 @@
 
 import {ScrollDispatcher, ViewportRuler} from '@angular/cdk/scrolling';
 import {DOCUMENT} from '@angular/common';
-import {Inject, Injectable, NgZone} from '@angular/core';
+import {Injectable, NgZone, inject} from '@angular/core';
 import {BlockScrollStrategy} from './block-scroll-strategy';
 import {CloseScrollStrategy, CloseScrollStrategyConfig} from './close-scroll-strategy';
 import {NoopScrollStrategy} from './noop-scroll-strategy';
@@ -25,16 +25,14 @@ import {
  */
 @Injectable({providedIn: 'root'})
 export class ScrollStrategyOptions {
-  private _document: Document;
+  private _scrollDispatcher = inject(ScrollDispatcher);
+  private _viewportRuler = inject(ViewportRuler);
+  private _ngZone = inject(NgZone);
 
-  constructor(
-    private _scrollDispatcher: ScrollDispatcher,
-    private _viewportRuler: ViewportRuler,
-    private _ngZone: NgZone,
-    @Inject(DOCUMENT) document: any,
-  ) {
-    this._document = document;
-  }
+  private _document = inject(DOCUMENT);
+
+  constructor(...args: unknown[]);
+  constructor() {}
 
   /** Do nothing on scroll. */
   noop = () => new NoopScrollStrategy();

--- a/src/cdk/portal/portal-directives.ts
+++ b/src/cdk/portal/portal-directives.ts
@@ -18,8 +18,8 @@ import {
   Output,
   TemplateRef,
   ViewContainerRef,
-  Inject,
   Input,
+  inject,
 } from '@angular/core';
 import {DOCUMENT} from '@angular/common';
 import {BasePortalOutlet, ComponentPortal, Portal, TemplatePortal, DomPortal} from './portal';
@@ -34,7 +34,12 @@ import {BasePortalOutlet, ComponentPortal, Portal, TemplatePortal, DomPortal} fr
   standalone: true,
 })
 export class CdkPortal extends TemplatePortal {
-  constructor(templateRef: TemplateRef<any>, viewContainerRef: ViewContainerRef) {
+  constructor(...args: unknown[]);
+
+  constructor() {
+    const templateRef = inject<TemplateRef<any>>(TemplateRef);
+    const viewContainerRef = inject(ViewContainerRef);
+
     super(templateRef, viewContainerRef);
   }
 }
@@ -74,7 +79,9 @@ export type CdkPortalOutletAttachedRef = ComponentRef<any> | EmbeddedViewRef<any
   standalone: true,
 })
 export class CdkPortalOutlet extends BasePortalOutlet implements OnInit, OnDestroy {
-  private _document: Document;
+  private _componentFactoryResolver = inject(ComponentFactoryResolver);
+  private _viewContainerRef = inject(ViewContainerRef);
+  private _document = inject(DOCUMENT);
 
   /** Whether the portal component is initialized. */
   private _isInitialized = false;
@@ -82,18 +89,10 @@ export class CdkPortalOutlet extends BasePortalOutlet implements OnInit, OnDestr
   /** Reference to the currently-attached component/view ref. */
   private _attachedRef: CdkPortalOutletAttachedRef;
 
-  constructor(
-    private _componentFactoryResolver: ComponentFactoryResolver,
-    private _viewContainerRef: ViewContainerRef,
+  constructor(...args: unknown[]);
 
-    /**
-     * @deprecated `_document` parameter to be made required.
-     * @breaking-change 9.0.0
-     */
-    @Inject(DOCUMENT) _document?: any,
-  ) {
+  constructor() {
     super();
-    this._document = _document;
   }
 
   /** Portal associated with the Portal outlet. */

--- a/src/cdk/scrolling/scroll-dispatcher.ts
+++ b/src/cdk/scrolling/scroll-dispatcher.ts
@@ -8,7 +8,7 @@
 
 import {coerceElement} from '@angular/cdk/coercion';
 import {Platform} from '@angular/cdk/platform';
-import {ElementRef, Injectable, NgZone, OnDestroy, Optional, Inject} from '@angular/core';
+import {ElementRef, Injectable, NgZone, OnDestroy, inject} from '@angular/core';
 import {fromEvent, of as observableOf, Subject, Subscription, Observable, Observer} from 'rxjs';
 import {auditTime, filter} from 'rxjs/operators';
 import type {CdkScrollable} from './scrollable';
@@ -23,16 +23,14 @@ export const DEFAULT_SCROLL_TIME = 20;
  */
 @Injectable({providedIn: 'root'})
 export class ScrollDispatcher implements OnDestroy {
-  /** Used to reference correct document/window */
-  protected _document: Document;
+  private _ngZone = inject(NgZone);
+  private _platform = inject(Platform);
 
-  constructor(
-    private _ngZone: NgZone,
-    private _platform: Platform,
-    @Optional() @Inject(DOCUMENT) document: any,
-  ) {
-    this._document = document;
-  }
+  /** Used to reference correct document/window */
+  protected _document = inject(DOCUMENT, {optional: true})!;
+
+  constructor(...args: unknown[]);
+  constructor() {}
 
   /** Subject for notifying that a registered scrollable reference element has been scrolled. */
   private readonly _scrolled = new Subject<CdkScrollable | void>();

--- a/src/cdk/scrolling/scrollable.ts
+++ b/src/cdk/scrolling/scrollable.ts
@@ -12,7 +12,7 @@ import {
   RtlScrollAxisType,
   supportsScrollBehavior,
 } from '@angular/cdk/platform';
-import {Directive, ElementRef, NgZone, OnDestroy, OnInit, Optional} from '@angular/core';
+import {Directive, ElementRef, NgZone, OnDestroy, OnInit, inject} from '@angular/core';
 import {fromEvent, Observable, Subject, Observer} from 'rxjs';
 import {takeUntil} from 'rxjs/operators';
 import {ScrollDispatcher} from './scroll-dispatcher';
@@ -46,6 +46,11 @@ export type ExtendedScrollToOptions = _XAxis & _YAxis & ScrollOptions;
   standalone: true,
 })
 export class CdkScrollable implements OnInit, OnDestroy {
+  protected elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
+  protected scrollDispatcher = inject(ScrollDispatcher);
+  protected ngZone = inject(NgZone);
+  protected dir? = inject(Directionality, {optional: true});
+
   protected readonly _destroyed = new Subject<void>();
 
   protected _elementScrolled: Observable<Event> = new Observable((observer: Observer<Event>) =>
@@ -56,12 +61,8 @@ export class CdkScrollable implements OnInit, OnDestroy {
     ),
   );
 
-  constructor(
-    protected elementRef: ElementRef<HTMLElement>,
-    protected scrollDispatcher: ScrollDispatcher,
-    protected ngZone: NgZone,
-    @Optional() protected dir?: Directionality,
-  ) {}
+  constructor(...args: unknown[]);
+  constructor() {}
 
   ngOnInit() {
     this.scrollDispatcher.register(this);

--- a/src/cdk/scrolling/viewport-ruler.ts
+++ b/src/cdk/scrolling/viewport-ruler.ts
@@ -7,7 +7,7 @@
  */
 
 import {Platform} from '@angular/cdk/platform';
-import {Injectable, NgZone, OnDestroy, Optional, Inject} from '@angular/core';
+import {Injectable, NgZone, OnDestroy, inject} from '@angular/core';
 import {Observable, Subject} from 'rxjs';
 import {auditTime} from 'rxjs/operators';
 import {DOCUMENT} from '@angular/common';
@@ -27,6 +27,8 @@ export interface ViewportScrollPosition {
  */
 @Injectable({providedIn: 'root'})
 export class ViewportRuler implements OnDestroy {
+  private _platform = inject(Platform);
+
   /** Cached viewport dimensions. */
   private _viewportSize: {width: number; height: number} | null;
 
@@ -39,17 +41,15 @@ export class ViewportRuler implements OnDestroy {
   };
 
   /** Used to reference correct document/window */
-  protected _document: Document;
+  protected _document = inject(DOCUMENT, {optional: true})!;
 
-  constructor(
-    private _platform: Platform,
-    ngZone: NgZone,
-    @Optional() @Inject(DOCUMENT) document: any,
-  ) {
-    this._document = document;
+  constructor(...args: unknown[]);
+
+  constructor() {
+    const ngZone = inject(NgZone);
 
     ngZone.runOutsideAngular(() => {
-      if (_platform.isBrowser) {
+      if (this._platform.isBrowser) {
         const window = this._getWindow();
 
         // Note that bind the events ourselves, rather than going through something like RxJS's

--- a/src/cdk/scrolling/virtual-for-of.ts
+++ b/src/cdk/scrolling/virtual-for-of.ts
@@ -20,7 +20,6 @@ import {
   Directive,
   DoCheck,
   EmbeddedViewRef,
-  Inject,
   Input,
   IterableChangeRecord,
   IterableChanges,
@@ -29,10 +28,10 @@ import {
   NgIterable,
   NgZone,
   OnDestroy,
-  SkipSelf,
   TemplateRef,
   TrackByFunction,
   ViewContainerRef,
+  inject,
 } from '@angular/core';
 import {NumberInput, coerceNumberProperty} from '@angular/cdk/coercion';
 import {Observable, Subject, of as observableOf, isObservable} from 'rxjs';
@@ -87,6 +86,13 @@ function getOffset(orientation: 'horizontal' | 'vertical', direction: 'start' | 
 export class CdkVirtualForOf<T>
   implements CdkVirtualScrollRepeater<T>, CollectionViewer, DoCheck, OnDestroy
 {
+  private _viewContainerRef = inject(ViewContainerRef);
+  private _template = inject<TemplateRef<CdkVirtualForOfContext<T>>>(TemplateRef);
+  private _differs = inject(IterableDiffers);
+  private _viewRepeater =
+    inject<_RecycleViewRepeaterStrategy<T, T, CdkVirtualForOfContext<T>>>(_VIEW_REPEATER_STRATEGY);
+  private _viewport = inject(CdkVirtualScrollViewport, {skipSelf: true});
+
   /** Emits when the rendered view of the data changes. */
   readonly viewChange = new Subject<ListRange>();
 
@@ -180,20 +186,11 @@ export class CdkVirtualForOf<T>
 
   private readonly _destroyed = new Subject<void>();
 
-  constructor(
-    /** The view container to add items to. */
-    private _viewContainerRef: ViewContainerRef,
-    /** The template to use when stamping out new items. */
-    private _template: TemplateRef<CdkVirtualForOfContext<T>>,
-    /** The set of available differs. */
-    private _differs: IterableDiffers,
-    /** The strategy used to render items in the virtual scroll viewport. */
-    @Inject(_VIEW_REPEATER_STRATEGY)
-    private _viewRepeater: _RecycleViewRepeaterStrategy<T, T, CdkVirtualForOfContext<T>>,
-    /** The virtual scrolling viewport that these items are being rendered in. */
-    @SkipSelf() private _viewport: CdkVirtualScrollViewport,
-    ngZone: NgZone,
-  ) {
+  constructor(...args: unknown[]);
+
+  constructor() {
+    const ngZone = inject(NgZone);
+
     this.dataStream.subscribe(data => {
       this._data = data;
       this._onRenderedDataChange();

--- a/src/cdk/scrolling/virtual-scroll-viewport.spec.ts
+++ b/src/cdk/scrolling/virtual-scroll-viewport.spec.ts
@@ -15,13 +15,13 @@ import {
   ViewChild,
   ViewContainerRef,
   ViewEncapsulation,
+  inject,
 } from '@angular/core';
 import {
   ComponentFixture,
   TestBed,
   fakeAsync,
   flush,
-  inject,
   tick,
   waitForAsync,
 } from '@angular/core/testing';
@@ -787,16 +787,15 @@ describe('CdkVirtualScrollViewport', () => {
       );
     }));
 
-    it('should register and degregister with ScrollDispatcher', fakeAsync(
-      inject([ScrollDispatcher], (dispatcher: ScrollDispatcher) => {
-        spyOn(dispatcher, 'register').and.callThrough();
-        spyOn(dispatcher, 'deregister').and.callThrough();
-        finishInit(fixture);
-        expect(dispatcher.register).toHaveBeenCalledWith(testComponent.viewport.scrollable);
-        fixture.destroy();
-        expect(dispatcher.deregister).toHaveBeenCalledWith(testComponent.viewport.scrollable);
-      }),
-    ));
+    it('should register and degregister with ScrollDispatcher', fakeAsync(() => {
+      const dispatcher = TestBed.inject(ScrollDispatcher);
+      spyOn(dispatcher, 'register').and.callThrough();
+      spyOn(dispatcher, 'deregister').and.callThrough();
+      finishInit(fixture);
+      expect(dispatcher.register).toHaveBeenCalledWith(testComponent.viewport.scrollable!);
+      fixture.destroy();
+      expect(dispatcher.deregister).toHaveBeenCalledWith(testComponent.viewport.scrollable!);
+    }));
 
     it('should not throw when disposing of a view that will not fit in the cache', fakeAsync(() => {
       finishInit(fixture);
@@ -819,9 +818,9 @@ describe('CdkVirtualScrollViewport', () => {
     describe('viewChange change detection behavior', () => {
       let appRef: ApplicationRef;
 
-      beforeEach(inject([ApplicationRef], (ar: ApplicationRef) => {
-        appRef = ar;
-      }));
+      beforeEach(() => {
+        appRef = TestBed.inject(ApplicationRef);
+      });
 
       it('should not run change detection if there are no viewChange listeners', fakeAsync(() => {
         finishInit(fixture);
@@ -1207,7 +1206,7 @@ function triggerScroll(viewport: CdkVirtualScrollViewport, offset?: number) {
   if (offset !== undefined) {
     viewport.scrollToOffset(offset);
   }
-  dispatchFakeEvent(viewport.scrollable.getElementRef().nativeElement, 'scroll');
+  dispatchFakeEvent(viewport.scrollable!.getElementRef().nativeElement, 'scroll');
   tick(16); // flush animation frame
 }
 
@@ -1373,7 +1372,7 @@ class VirtualScrollWithNoStrategy {
   standalone: true,
 })
 class InjectsViewContainer {
-  constructor(public viewContainerRef: ViewContainerRef) {}
+  viewContainerRef = inject(ViewContainerRef);
 }
 
 @Component({

--- a/src/cdk/scrolling/virtual-scroll-viewport.ts
+++ b/src/cdk/scrolling/virtual-scroll-viewport.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directionality} from '@angular/cdk/bidi';
 import {ListRange} from '@angular/cdk/collections';
 import {Platform} from '@angular/cdk/platform';
 import {
@@ -20,7 +19,6 @@ import {
   Inject,
   Injector,
   Input,
-  NgZone,
   OnDestroy,
   OnInit,
   Optional,
@@ -37,7 +35,6 @@ import {
   Subscription,
 } from 'rxjs';
 import {auditTime, startWith, takeUntil} from 'rxjs/operators';
-import {ScrollDispatcher} from './scroll-dispatcher';
 import {CdkScrollable, ExtendedScrollToOptions} from './scrollable';
 import {ViewportRuler} from './viewport-ruler';
 import {CdkVirtualScrollRepeater} from './virtual-scroll-repeater';
@@ -82,6 +79,13 @@ const SCROLL_SCHEDULER =
   ],
 })
 export class CdkVirtualScrollViewport extends CdkVirtualScrollable implements OnInit, OnDestroy {
+  override elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
+  private _changeDetectorRef = inject(ChangeDetectorRef);
+  private _scrollStrategy = inject<VirtualScrollStrategy>(VIRTUAL_SCROLL_STRATEGY, {
+    optional: true,
+  })!;
+  scrollable = inject<CdkVirtualScrollable>(VIRTUAL_SCROLLABLE, {optional: true})!;
+
   private _platform = inject(Platform);
 
   /** Emits when the viewport is detached from a CdkVirtualForOf. */
@@ -179,21 +183,13 @@ export class CdkVirtualScrollViewport extends CdkVirtualScrollable implements On
 
   private _isDestroyed = false;
 
-  constructor(
-    public override elementRef: ElementRef<HTMLElement>,
-    private _changeDetectorRef: ChangeDetectorRef,
-    ngZone: NgZone,
-    @Optional()
-    @Inject(VIRTUAL_SCROLL_STRATEGY)
-    private _scrollStrategy: VirtualScrollStrategy,
-    @Optional() dir: Directionality,
-    scrollDispatcher: ScrollDispatcher,
-    viewportRuler: ViewportRuler,
-    @Optional() @Inject(VIRTUAL_SCROLLABLE) public scrollable: CdkVirtualScrollable,
-  ) {
-    super(elementRef, scrollDispatcher, ngZone, dir);
+  constructor(...args: unknown[]);
 
-    if (!_scrollStrategy && (typeof ngDevMode === 'undefined' || ngDevMode)) {
+  constructor() {
+    super();
+    const viewportRuler = inject(ViewportRuler);
+
+    if (!this._scrollStrategy && (typeof ngDevMode === 'undefined' || ngDevMode)) {
       throw Error('Error: cdk-virtual-scroll-viewport requires the "itemSize" property to be set.');
     }
 

--- a/src/cdk/scrolling/virtual-scrollable-element.ts
+++ b/src/cdk/scrolling/virtual-scrollable-element.ts
@@ -6,9 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directionality} from '@angular/cdk/bidi';
-import {Directive, ElementRef, NgZone, Optional} from '@angular/core';
-import {ScrollDispatcher} from './scroll-dispatcher';
+import {Directive} from '@angular/core';
 import {CdkVirtualScrollable, VIRTUAL_SCROLLABLE} from './virtual-scrollable';
 
 /**
@@ -23,13 +21,10 @@ import {CdkVirtualScrollable, VIRTUAL_SCROLLABLE} from './virtual-scrollable';
   },
 })
 export class CdkVirtualScrollableElement extends CdkVirtualScrollable {
-  constructor(
-    elementRef: ElementRef,
-    scrollDispatcher: ScrollDispatcher,
-    ngZone: NgZone,
-    @Optional() dir: Directionality,
-  ) {
-    super(elementRef, scrollDispatcher, ngZone, dir);
+  constructor(...args: unknown[]);
+
+  constructor() {
+    super();
   }
 
   override measureBoundingClientRectWithScrollOffset(

--- a/src/cdk/scrolling/virtual-scrollable-window.ts
+++ b/src/cdk/scrolling/virtual-scrollable-window.ts
@@ -6,11 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directionality} from '@angular/cdk/bidi';
-import {Directive, ElementRef, NgZone, Optional} from '@angular/core';
+import {Directive, ElementRef} from '@angular/core';
 import {fromEvent, Observable, Observer} from 'rxjs';
 import {takeUntil} from 'rxjs/operators';
-import {ScrollDispatcher} from './scroll-dispatcher';
 import {CdkVirtualScrollable, VIRTUAL_SCROLLABLE} from './virtual-scrollable';
 
 /**
@@ -29,8 +27,11 @@ export class CdkVirtualScrollableWindow extends CdkVirtualScrollable {
       ),
   );
 
-  constructor(scrollDispatcher: ScrollDispatcher, ngZone: NgZone, @Optional() dir: Directionality) {
-    super(new ElementRef(document.documentElement), scrollDispatcher, ngZone, dir);
+  constructor(...args: unknown[]);
+
+  constructor() {
+    super();
+    this.elementRef = new ElementRef(document.documentElement);
   }
 
   override measureBoundingClientRectWithScrollOffset(

--- a/src/cdk/scrolling/virtual-scrollable.ts
+++ b/src/cdk/scrolling/virtual-scrollable.ts
@@ -6,9 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directionality} from '@angular/cdk/bidi';
-import {Directive, ElementRef, InjectionToken, NgZone, Optional} from '@angular/core';
-import {ScrollDispatcher} from './scroll-dispatcher';
+import {Directive, InjectionToken} from '@angular/core';
 import {CdkScrollable} from './scrollable';
 
 export const VIRTUAL_SCROLLABLE = new InjectionToken<CdkVirtualScrollable>('VIRTUAL_SCROLLABLE');
@@ -18,13 +16,9 @@ export const VIRTUAL_SCROLLABLE = new InjectionToken<CdkVirtualScrollable>('VIRT
  */
 @Directive()
 export abstract class CdkVirtualScrollable extends CdkScrollable {
-  constructor(
-    elementRef: ElementRef<HTMLElement>,
-    scrollDispatcher: ScrollDispatcher,
-    ngZone: NgZone,
-    @Optional() dir?: Directionality,
-  ) {
-    super(elementRef, scrollDispatcher, ngZone, dir);
+  constructor(...args: unknown[]);
+  constructor() {
+    super();
   }
 
   /**

--- a/src/cdk/stepper/step-header.ts
+++ b/src/cdk/stepper/step-header.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, ElementRef} from '@angular/core';
+import {Directive, ElementRef, inject} from '@angular/core';
 import {FocusableOption} from '@angular/cdk/a11y';
 
 @Directive({
@@ -17,7 +17,10 @@ import {FocusableOption} from '@angular/cdk/a11y';
   standalone: true,
 })
 export class CdkStepHeader implements FocusableOption {
-  constructor(public _elementRef: ElementRef<HTMLElement>) {}
+  _elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
+
+  constructor(...args: unknown[]);
+  constructor() {}
 
   /** Focuses the step header. */
   focus() {

--- a/src/cdk/stepper/step-label.ts
+++ b/src/cdk/stepper/step-label.ts
@@ -6,12 +6,15 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, TemplateRef} from '@angular/core';
+import {Directive, TemplateRef, inject} from '@angular/core';
 
 @Directive({
   selector: '[cdkStepLabel]',
   standalone: true,
 })
 export class CdkStepLabel {
-  constructor(/** @docs-private */ public template: TemplateRef<any>) {}
+  template = inject<TemplateRef<any>>(TemplateRef);
+
+  constructor(...args: unknown[]);
+  constructor() {}
 }

--- a/src/cdk/stepper/stepper-button.ts
+++ b/src/cdk/stepper/stepper-button.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, Input} from '@angular/core';
+import {Directive, Input, inject} from '@angular/core';
 
 import {CdkStepper} from './stepper';
 
@@ -20,10 +20,13 @@ import {CdkStepper} from './stepper';
   standalone: true,
 })
 export class CdkStepperNext {
+  _stepper = inject(CdkStepper);
+
   /** Type of the next button. Defaults to "submit" if not specified. */
   @Input() type: string = 'submit';
 
-  constructor(public _stepper: CdkStepper) {}
+  constructor(...args: unknown[]);
+  constructor() {}
 }
 
 /** Button that moves to the previous step in a stepper workflow. */
@@ -36,8 +39,11 @@ export class CdkStepperNext {
   standalone: true,
 })
 export class CdkStepperPrevious {
+  _stepper = inject(CdkStepper);
+
   /** Type of the previous button. Defaults to "button" if not specified. */
   @Input() type: string = 'button';
 
-  constructor(public _stepper: CdkStepper) {}
+  constructor(...args: unknown[]);
+  constructor() {}
 }

--- a/src/cdk/stepper/stepper.ts
+++ b/src/cdk/stepper/stepper.ts
@@ -19,13 +19,10 @@ import {
   Directive,
   ElementRef,
   EventEmitter,
-  forwardRef,
-  Inject,
   InjectionToken,
   Input,
   OnChanges,
   OnDestroy,
-  Optional,
   Output,
   QueryList,
   TemplateRef,
@@ -34,6 +31,7 @@ import {
   AfterContentInit,
   booleanAttribute,
   numberAttribute,
+  inject,
 } from '@angular/core';
 import {_getFocusedElementPierceShadowDom} from '@angular/cdk/platform';
 import {Observable, of as observableOf, Subject} from 'rxjs';
@@ -109,6 +107,7 @@ export interface StepperOptions {
 })
 export class CdkStep implements OnChanges {
   private _stepperOptions: StepperOptions;
+  _stepper = inject(CdkStepper);
   _displayDefaultIndicatorType: boolean;
 
   /** Template for step label if it exists. */
@@ -179,10 +178,10 @@ export class CdkStep implements OnChanges {
     return this.stepControl && this.stepControl.invalid && this.interacted;
   }
 
-  constructor(
-    @Inject(forwardRef(() => CdkStepper)) public _stepper: CdkStepper,
-    @Optional() @Inject(STEPPER_GLOBAL_OPTIONS) stepperOptions?: StepperOptions,
-  ) {
+  constructor(...args: unknown[]);
+
+  constructor() {
+    const stepperOptions = inject<StepperOptions>(STEPPER_GLOBAL_OPTIONS, {optional: true});
     this._stepperOptions = stepperOptions ? stepperOptions : {};
     this._displayDefaultIndicatorType = this._stepperOptions.displayDefaultIndicatorType !== false;
   }
@@ -236,6 +235,10 @@ export class CdkStep implements OnChanges {
   standalone: true,
 })
 export class CdkStepper implements AfterContentInit, AfterViewInit, OnDestroy {
+  private _dir = inject(Directionality, {optional: true});
+  private _changeDetectorRef = inject(ChangeDetectorRef);
+  private _elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
+
   /** Emits when the component is destroyed. */
   protected readonly _destroyed = new Subject<void>();
 
@@ -300,7 +303,7 @@ export class CdkStepper implements AfterContentInit, AfterViewInit, OnDestroy {
   @Output() readonly selectedIndexChange: EventEmitter<number> = new EventEmitter<number>();
 
   /** Used to track unique ID for each stepper component. */
-  _groupId: number;
+  _groupId = nextId++;
 
   /** Orientation of the stepper. */
   @Input()
@@ -317,13 +320,8 @@ export class CdkStepper implements AfterContentInit, AfterViewInit, OnDestroy {
   }
   private _orientation: StepperOrientation = 'horizontal';
 
-  constructor(
-    @Optional() private _dir: Directionality,
-    private _changeDetectorRef: ChangeDetectorRef,
-    private _elementRef: ElementRef<HTMLElement>,
-  ) {
-    this._groupId = nextId++;
-  }
+  constructor(...args: unknown[]);
+  constructor() {}
 
   ngAfterContentInit() {
     this._steps.changes

--- a/src/cdk/table/cell.ts
+++ b/src/cdk/table/cell.ts
@@ -10,11 +10,10 @@ import {
   ContentChild,
   Directive,
   ElementRef,
-  Inject,
   Input,
-  Optional,
   TemplateRef,
   booleanAttribute,
+  inject,
 } from '@angular/core';
 import {CanStick} from './can-stick';
 import {CDK_TABLE} from './tokens';
@@ -33,7 +32,11 @@ export interface CellDef {
   standalone: true,
 })
 export class CdkCellDef implements CellDef {
-  constructor(/** @docs-private */ public template: TemplateRef<any>) {}
+  /** @docs-private */
+  template = inject<TemplateRef<any>>(TemplateRef);
+
+  constructor(...args: unknown[]);
+  constructor() {}
 }
 
 /**
@@ -45,7 +48,11 @@ export class CdkCellDef implements CellDef {
   standalone: true,
 })
 export class CdkHeaderCellDef implements CellDef {
-  constructor(/** @docs-private */ public template: TemplateRef<any>) {}
+  /** @docs-private */
+  template = inject<TemplateRef<any>>(TemplateRef);
+
+  constructor(...args: unknown[]);
+  constructor() {}
 }
 
 /**
@@ -57,7 +64,11 @@ export class CdkHeaderCellDef implements CellDef {
   standalone: true,
 })
 export class CdkFooterCellDef implements CellDef {
-  constructor(/** @docs-private */ public template: TemplateRef<any>) {}
+  /** @docs-private */
+  template = inject<TemplateRef<any>>(TemplateRef);
+
+  constructor(...args: unknown[]);
+  constructor() {}
 }
 
 /**
@@ -70,6 +81,8 @@ export class CdkFooterCellDef implements CellDef {
   standalone: true,
 })
 export class CdkColumnDef implements CanStick {
+  _table? = inject(CDK_TABLE, {optional: true});
+
   private _hasStickyChanged = false;
 
   /** Unique name for this column. */
@@ -134,7 +147,8 @@ export class CdkColumnDef implements CanStick {
    */
   _columnCssClassName: string[];
 
-  constructor(@Inject(CDK_TABLE) @Optional() public _table?: any) {}
+  constructor(...args: unknown[]);
+  constructor() {}
 
   /** Whether the sticky state has changed. */
   hasStickyChanged(): boolean {
@@ -193,8 +207,10 @@ export class BaseCdkCell {
   standalone: true,
 })
 export class CdkHeaderCell extends BaseCdkCell {
-  constructor(columnDef: CdkColumnDef, elementRef: ElementRef) {
-    super(columnDef, elementRef);
+  constructor(...args: unknown[]);
+
+  constructor() {
+    super(inject(CdkColumnDef), inject(ElementRef));
   }
 }
 
@@ -207,8 +223,14 @@ export class CdkHeaderCell extends BaseCdkCell {
   standalone: true,
 })
 export class CdkFooterCell extends BaseCdkCell {
-  constructor(columnDef: CdkColumnDef, elementRef: ElementRef) {
+  constructor(...args: unknown[]);
+
+  constructor() {
+    const columnDef = inject(CdkColumnDef);
+    const elementRef = inject(ElementRef);
+
     super(columnDef, elementRef);
+
     const role = columnDef._table?._getCellRole();
     if (role) {
       elementRef.nativeElement.setAttribute('role', role);
@@ -225,8 +247,14 @@ export class CdkFooterCell extends BaseCdkCell {
   standalone: true,
 })
 export class CdkCell extends BaseCdkCell {
-  constructor(columnDef: CdkColumnDef, elementRef: ElementRef) {
+  constructor(...args: unknown[]);
+
+  constructor() {
+    const columnDef = inject(CdkColumnDef);
+    const elementRef = inject(ElementRef);
+
     super(columnDef, elementRef);
+
     const role = columnDef._table?._getCellRole();
     if (role) {
       elementRef.nativeElement.setAttribute('role', role);

--- a/src/cdk/table/coalesced-style-scheduler.ts
+++ b/src/cdk/table/coalesced-style-scheduler.ts
@@ -33,7 +33,8 @@ export class _CoalescedStyleScheduler {
   private _currentSchedule: _Schedule | null = null;
   private _ngZone = inject(NgZone);
 
-  constructor(_unusedNgZone?: NgZone) {}
+  constructor(...args: unknown[]);
+  constructor() {}
 
   /**
    * Schedules the specified task to run at the end of the current VM turn.

--- a/src/cdk/table/row.ts
+++ b/src/cdk/table/row.ts
@@ -19,10 +19,9 @@ import {
   TemplateRef,
   ViewContainerRef,
   ViewEncapsulation,
-  Inject,
-  Optional,
   Input,
   booleanAttribute,
+  inject,
 } from '@angular/core';
 import {CanStick} from './can-stick';
 import {CdkCellDef, CdkColumnDef} from './cell';
@@ -40,16 +39,17 @@ export const CDK_ROW_TEMPLATE = `<ng-container cdkCellOutlet></ng-container>`;
  */
 @Directive()
 export abstract class BaseRowDef implements OnChanges {
+  template = inject<TemplateRef<any>>(TemplateRef);
+  protected _differs = inject(IterableDiffers);
+
   /** The columns to be displayed on this row. */
   columns: Iterable<string>;
 
   /** Differ used to check if any changes were made to the columns. */
   protected _columnsDiffer: IterableDiffer<any>;
 
-  constructor(
-    /** @docs-private */ public template: TemplateRef<any>,
-    protected _differs: IterableDiffers,
-  ) {}
+  constructor(...args: unknown[]);
+  constructor() {}
 
   ngOnChanges(changes: SimpleChanges): void {
     // Create a new columns differ if one does not yet exist. Initialize it based on initial value
@@ -92,6 +92,8 @@ export abstract class BaseRowDef implements OnChanges {
   standalone: true,
 })
 export class CdkHeaderRowDef extends BaseRowDef implements CanStick, OnChanges {
+  _table? = inject(CDK_TABLE, {optional: true});
+
   private _hasStickyChanged = false;
 
   /** Whether the row is sticky. */
@@ -107,12 +109,10 @@ export class CdkHeaderRowDef extends BaseRowDef implements CanStick, OnChanges {
   }
   private _sticky = false;
 
-  constructor(
-    template: TemplateRef<any>,
-    _differs: IterableDiffers,
-    @Inject(CDK_TABLE) @Optional() public _table?: any,
-  ) {
-    super(template, _differs);
+  constructor(...args: unknown[]);
+
+  constructor() {
+    super(inject<TemplateRef<any>>(TemplateRef), inject(IterableDiffers));
   }
 
   // Prerender fails to recognize that ngOnChanges in a part of this class through inheritance.
@@ -144,6 +144,8 @@ export class CdkHeaderRowDef extends BaseRowDef implements CanStick, OnChanges {
   standalone: true,
 })
 export class CdkFooterRowDef extends BaseRowDef implements CanStick, OnChanges {
+  _table? = inject(CDK_TABLE, {optional: true});
+
   private _hasStickyChanged = false;
 
   /** Whether the row is sticky. */
@@ -159,12 +161,10 @@ export class CdkFooterRowDef extends BaseRowDef implements CanStick, OnChanges {
   }
   private _sticky = false;
 
-  constructor(
-    template: TemplateRef<any>,
-    _differs: IterableDiffers,
-    @Inject(CDK_TABLE) @Optional() public _table?: any,
-  ) {
-    super(template, _differs);
+  constructor(...args: unknown[]);
+
+  constructor() {
+    super(inject<TemplateRef<any>>(TemplateRef), inject(IterableDiffers));
   }
 
   // Prerender fails to recognize that ngOnChanges in a part of this class through inheritance.
@@ -200,6 +200,8 @@ export class CdkFooterRowDef extends BaseRowDef implements CanStick, OnChanges {
   standalone: true,
 })
 export class CdkRowDef<T> extends BaseRowDef {
+  _table? = inject(CDK_TABLE, {optional: true});
+
   /**
    * Function that should return true if this row template should be used for the provided index
    * and row data. If left undefined, this row will be considered the default row template to use
@@ -208,14 +210,12 @@ export class CdkRowDef<T> extends BaseRowDef {
    */
   when: (index: number, rowData: T) => boolean;
 
-  // TODO(andrewseguin): Add an input for providing a switch function to determine
-  //   if this template should be used.
-  constructor(
-    template: TemplateRef<any>,
-    _differs: IterableDiffers,
-    @Inject(CDK_TABLE) @Optional() public _table?: any,
-  ) {
-    super(template, _differs);
+  constructor(...args: unknown[]);
+
+  constructor() {
+    // TODO(andrewseguin): Add an input for providing a switch function to determine
+    //   if this template should be used.
+    super(inject<TemplateRef<any>>(TemplateRef), inject(IterableDiffers));
   }
 }
 
@@ -283,6 +283,8 @@ export interface CdkCellOutletMultiRowContext<T> {
   standalone: true,
 })
 export class CdkCellOutlet implements OnDestroy {
+  _viewContainer = inject(ViewContainerRef);
+
   /** The ordered list of cells to render within this outlet's view container */
   cells: CdkCellDef[];
 
@@ -298,7 +300,9 @@ export class CdkCellOutlet implements OnDestroy {
    */
   static mostRecentCellOutlet: CdkCellOutlet | null = null;
 
-  constructor(public _viewContainer: ViewContainerRef) {
+  constructor(...args: unknown[]);
+
+  constructor() {
     CdkCellOutlet.mostRecentCellOutlet = this;
   }
 
@@ -368,6 +372,10 @@ export class CdkRow {}
   standalone: true,
 })
 export class CdkNoDataRow {
+  templateRef = inject<TemplateRef<any>>(TemplateRef);
+
   _contentClassName = 'cdk-no-data-row';
-  constructor(public templateRef: TemplateRef<any>) {}
+
+  constructor(...args: unknown[]);
+  constructor() {}
 }

--- a/src/cdk/table/text-column.ts
+++ b/src/cdk/table/text-column.ts
@@ -9,13 +9,12 @@
 import {
   ChangeDetectionStrategy,
   Component,
-  Inject,
   Input,
   OnDestroy,
   OnInit,
-  Optional,
   ViewChild,
   ViewEncapsulation,
+  inject,
 } from '@angular/core';
 import {CdkCellDef, CdkColumnDef, CdkHeaderCellDef, CdkHeaderCell, CdkCell} from './cell';
 import {CdkTable} from './table';
@@ -58,6 +57,9 @@ import {TEXT_COLUMN_OPTIONS, TextColumnOptions} from './tokens';
   imports: [CdkColumnDef, CdkHeaderCellDef, CdkHeaderCell, CdkCellDef, CdkCell],
 })
 export class CdkTextColumn<T> implements OnDestroy, OnInit {
+  private _table = inject<CdkTable<T>>(CdkTable, {optional: true});
+  private _options = inject<TextColumnOptions<T>>(TEXT_COLUMN_OPTIONS, {optional: true})!;
+
   /** Column name that should be used to reference this column. */
   @Input()
   get name(): string {
@@ -110,14 +112,10 @@ export class CdkTextColumn<T> implements OnDestroy, OnInit {
    */
   @ViewChild(CdkHeaderCellDef, {static: true}) headerCell: CdkHeaderCellDef;
 
-  constructor(
-    // `CdkTextColumn` is always requiring a table, but we just assert it manually
-    // for better error reporting.
-    // tslint:disable-next-line: lightweight-tokens
-    @Optional() private _table: CdkTable<T>,
-    @Optional() @Inject(TEXT_COLUMN_OPTIONS) private _options: TextColumnOptions<T>,
-  ) {
-    this._options = _options || {};
+  constructor(...args: unknown[]);
+
+  constructor() {
+    this._options = this._options || {};
   }
 
   ngOnInit() {

--- a/src/cdk/testing/tests/test-main-component.ts
+++ b/src/cdk/testing/tests/test-main-component.ts
@@ -18,6 +18,7 @@ import {
   OnDestroy,
   ViewChild,
   ViewEncapsulation,
+  inject,
 } from '@angular/core';
 import {TestShadowBoundary} from './test-shadow-boundary';
 import {TestSubComponent} from './test-sub-component';
@@ -31,6 +32,9 @@ import {TestSubComponent} from './test-sub-component';
   imports: [TestShadowBoundary, TestSubComponent, FormsModule, ReactiveFormsModule],
 })
 export class TestMainComponent implements OnDestroy {
+  private _cdr = inject(ChangeDetectorRef);
+  private _zone = inject(NgZone);
+
   username: string;
   counter: number;
   asyncCounter: number;
@@ -58,10 +62,7 @@ export class TestMainComponent implements OnDestroy {
 
   private _fakeOverlayElement: HTMLElement;
 
-  constructor(
-    private _cdr: ChangeDetectorRef,
-    private _zone: NgZone,
-  ) {
+  constructor() {
     this.username = 'Yi';
     this.counter = 0;
     this.asyncCounter = 0;

--- a/src/cdk/text-field/autofill.ts
+++ b/src/cdk/text-field/autofill.ts
@@ -47,13 +47,14 @@ const listenerOptions = normalizePassiveListenerOptions({passive: true});
  */
 @Injectable({providedIn: 'root'})
 export class AutofillMonitor implements OnDestroy {
+  private _platform = inject(Platform);
+  private _ngZone = inject(NgZone);
+
   private _styleLoader = inject(_CdkPrivateStyleLoader);
   private _monitoredElements = new Map<Element, MonitoredElementInfo>();
 
-  constructor(
-    private _platform: Platform,
-    private _ngZone: NgZone,
-  ) {}
+  constructor(...args: unknown[]);
+  constructor() {}
 
   /**
    * Monitor for changes in the autofill state of the given input element.
@@ -155,13 +156,14 @@ export class AutofillMonitor implements OnDestroy {
   standalone: true,
 })
 export class CdkAutofill implements OnDestroy, OnInit {
+  private _elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
+  private _autofillMonitor = inject(AutofillMonitor);
+
   /** Emits when the autofill state of the element changes. */
   @Output() readonly cdkAutofill = new EventEmitter<AutofillEvent>();
 
-  constructor(
-    private _elementRef: ElementRef<HTMLElement>,
-    private _autofillMonitor: AutofillMonitor,
-  ) {}
+  constructor(...args: unknown[]);
+  constructor() {}
 
   ngOnInit() {
     this._autofillMonitor

--- a/src/cdk/text-field/autosize.ts
+++ b/src/cdk/text-field/autosize.ts
@@ -15,8 +15,6 @@ import {
   DoCheck,
   OnDestroy,
   NgZone,
-  Optional,
-  Inject,
   booleanAttribute,
   inject,
 } from '@angular/core';
@@ -41,6 +39,10 @@ import {_CdkTextFieldStyleLoader} from './text-field-style-loader';
   standalone: true,
 })
 export class CdkTextareaAutosize implements AfterViewInit, DoCheck, OnDestroy {
+  private _elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
+  private _platform = inject(Platform);
+  private _ngZone = inject(NgZone);
+
   /** Keep track of the previous textarea value to avoid resizing when the value hasn't changed. */
   private _previousValue?: string;
   private _initialHeight: string | undefined;
@@ -114,22 +116,17 @@ export class CdkTextareaAutosize implements AfterViewInit, DoCheck, OnDestroy {
   private _cachedPlaceholderHeight?: number;
 
   /** Used to reference correct document/window */
-  protected _document?: Document;
+  protected _document? = inject(DOCUMENT, {optional: true});
 
   private _hasFocus: boolean;
 
   private _isViewInited = false;
 
-  constructor(
-    private _elementRef: ElementRef<HTMLElement>,
-    private _platform: Platform,
-    private _ngZone: NgZone,
-    /** @breaking-change 11.0.0 make document required */
-    @Optional() @Inject(DOCUMENT) document?: any,
-  ) {
+  constructor(...args: unknown[]);
+
+  constructor() {
     const styleLoader = inject(_CdkPrivateStyleLoader);
     styleLoader.load(_CdkTextFieldStyleLoader);
-    this._document = document;
     this._textareaElement = this._elementRef.nativeElement as HTMLTextAreaElement;
   }
 

--- a/src/cdk/tree/nested-node.ts
+++ b/src/cdk/tree/nested-node.ts
@@ -9,17 +9,17 @@ import {
   AfterContentInit,
   ContentChildren,
   Directive,
-  ElementRef,
   IterableDiffer,
   IterableDiffers,
   OnDestroy,
   OnInit,
   QueryList,
+  inject,
 } from '@angular/core';
 import {takeUntil} from 'rxjs/operators';
 
 import {CDK_TREE_NODE_OUTLET_NODE, CdkTreeNodeOutlet} from './outlet';
-import {CdkTree, CdkTreeNode} from './tree';
+import {CdkTreeNode} from './tree';
 
 /**
  * Nested node is a child of `<cdk-tree>`. It works with nested tree.
@@ -43,6 +43,8 @@ export class CdkNestedTreeNode<T, K = T>
   extends CdkTreeNode<T, K>
   implements AfterContentInit, OnDestroy, OnInit
 {
+  protected _differs = inject(IterableDiffers);
+
   /** Differ used to find the changes in the data provided by the data source. */
   private _dataDiffer: IterableDiffer<T>;
 
@@ -57,12 +59,10 @@ export class CdkNestedTreeNode<T, K = T>
   })
   nodeOutlet: QueryList<CdkTreeNodeOutlet>;
 
-  constructor(
-    elementRef: ElementRef<HTMLElement>,
-    tree: CdkTree<T, K>,
-    protected _differs: IterableDiffers,
-  ) {
-    super(elementRef, tree);
+  constructor(...args: unknown[]);
+
+  constructor() {
+    super();
   }
 
   ngAfterContentInit() {

--- a/src/cdk/tree/node.ts
+++ b/src/cdk/tree/node.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, TemplateRef} from '@angular/core';
+import {Directive, TemplateRef, inject} from '@angular/core';
 
 /** Context provided to the tree node component. */
 export class CdkTreeNodeOutletContext<T> {
@@ -37,6 +37,9 @@ export class CdkTreeNodeOutletContext<T> {
   standalone: true,
 })
 export class CdkTreeNodeDef<T> {
+  /** @docs-private */
+  template = inject<TemplateRef<any>>(TemplateRef);
+
   /**
    * Function that should return true if this node template should be used for the provided node
    * data and index. If left undefined, this node will be considered the default node template to
@@ -46,6 +49,6 @@ export class CdkTreeNodeDef<T> {
    */
   when: (index: number, nodeData: T) => boolean;
 
-  /** @docs-private */
-  constructor(public template: TemplateRef<any>) {}
+  constructor(...args: unknown[]);
+  constructor() {}
 }

--- a/src/cdk/tree/outlet.ts
+++ b/src/cdk/tree/outlet.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {Directive, Inject, InjectionToken, Optional, ViewContainerRef} from '@angular/core';
+import {Directive, InjectionToken, ViewContainerRef, inject} from '@angular/core';
 
 /**
  * Injection token used to provide a `CdkTreeNode` to its outlet.
@@ -23,8 +23,9 @@ export const CDK_TREE_NODE_OUTLET_NODE = new InjectionToken<{}>('CDK_TREE_NODE_O
   standalone: true,
 })
 export class CdkTreeNodeOutlet {
-  constructor(
-    public viewContainer: ViewContainerRef,
-    @Inject(CDK_TREE_NODE_OUTLET_NODE) @Optional() public _node?: any,
-  ) {}
+  viewContainer = inject(ViewContainerRef);
+  _node? = inject(CDK_TREE_NODE_OUTLET_NODE, {optional: true});
+
+  constructor(...args: unknown[]);
+  constructor() {}
 }

--- a/src/cdk/tree/toggle.ts
+++ b/src/cdk/tree/toggle.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, Input, booleanAttribute} from '@angular/core';
+import {Directive, Input, booleanAttribute, inject} from '@angular/core';
 
 import {CdkTree, CdkTreeNode} from './tree';
 
@@ -24,14 +24,15 @@ import {CdkTree, CdkTreeNode} from './tree';
   standalone: true,
 })
 export class CdkTreeNodeToggle<T, K = T> {
+  protected _tree = inject<CdkTree<T, K>>(CdkTree);
+  protected _treeNode = inject<CdkTreeNode<T, K>>(CdkTreeNode);
+
   /** Whether expand/collapse the node recursively. */
   @Input({alias: 'cdkTreeNodeToggleRecursive', transform: booleanAttribute})
   recursive: boolean = false;
 
-  constructor(
-    protected _tree: CdkTree<T, K>,
-    protected _treeNode: CdkTreeNode<T, K>,
-  ) {}
+  constructor(...args: unknown[]);
+  constructor() {}
 
   // Toggle the expanded or collapsed state of this node.
   //

--- a/src/cdk/tree/tree.ts
+++ b/src/cdk/tree/tree.ts
@@ -125,6 +125,9 @@ export class CdkTree<T, K = T>
     OnDestroy,
     OnInit
 {
+  private _differs = inject(IterableDiffers);
+  private _changeDetectorRef = inject(ChangeDetectorRef);
+
   private _dir = inject(Directionality);
 
   /** Subject that emits when the component has been destroyed. */
@@ -264,10 +267,8 @@ export class CdkTree<T, K = T>
   _keyManager: TreeKeyManagerStrategy<CdkTreeNode<T, K>>;
   private _viewInit = false;
 
-  constructor(
-    private _differs: IterableDiffers,
-    private _changeDetectorRef: ChangeDetectorRef,
-  ) {}
+  constructor(...args: unknown[]);
+  constructor() {}
 
   ngAfterContentInit() {
     this._initializeKeyManager();
@@ -1148,6 +1149,8 @@ export class CdkTree<T, K = T>
   standalone: true,
 })
 export class CdkTreeNode<T, K = T> implements OnDestroy, OnInit, TreeKeyManagerItem {
+  protected _elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
+  protected _tree = inject<CdkTree<T, K>>(CdkTree);
   protected _tabindex: number | null = -1;
 
   /**
@@ -1334,10 +1337,9 @@ export class CdkTreeNode<T, K = T> implements OnDestroy, OnInit, TreeKeyManagerI
 
   private _changeDetectorRef = inject(ChangeDetectorRef);
 
-  constructor(
-    protected _elementRef: ElementRef<HTMLElement>,
-    protected _tree: CdkTree<T, K>,
-  ) {
+  constructor(...args: unknown[]);
+
+  constructor() {
     CdkTreeNode.mostRecentTreeNode = this as CdkTreeNode<T, K>;
   }
 

--- a/src/material/expansion/expansion-panel.ts
+++ b/src/material/expansion/expansion-panel.ts
@@ -160,6 +160,7 @@ export class MatExpansionPanel
     defaultOptions?: MatExpansionPanelDefaultOptions,
   ) {
     super(accordion, _changeDetectorRef, _uniqueSelectionDispatcher);
+    this._expansionDispatcher = _uniqueSelectionDispatcher;
     this.accordion = accordion;
     this._document = _document;
     this._animationsDisabled = _animationMode === 'NoopAnimations';

--- a/tools/public_api_guard/cdk/a11y.md
+++ b/tools/public_api_guard/cdk/a11y.md
@@ -6,7 +6,6 @@
 
 import { AfterContentInit } from '@angular/core';
 import { AfterViewInit } from '@angular/core';
-import { ContentObserver } from '@angular/cdk/observers';
 import { DoCheck } from '@angular/core';
 import { ElementRef } from '@angular/core';
 import { EventEmitter } from '@angular/core';
@@ -18,7 +17,6 @@ import { NgZone } from '@angular/core';
 import { Observable } from 'rxjs';
 import { OnChanges } from '@angular/core';
 import { OnDestroy } from '@angular/core';
-import { Platform } from '@angular/cdk/platform';
 import { QueryList } from '@angular/core';
 import { Signal } from '@angular/core';
 import { SimpleChanges } from '@angular/core';
@@ -26,7 +24,7 @@ import { Subject } from 'rxjs';
 
 // @public (undocumented)
 export class A11yModule {
-    constructor(highContrastModeDetector: HighContrastModeDetector);
+    constructor();
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<A11yModule, never>;
     // (undocumented)
@@ -46,8 +44,7 @@ export function addAriaReferencedId(el: Element, attr: `aria-${string}`, id: str
 
 // @public
 export class AriaDescriber implements OnDestroy {
-    constructor(_document: any,
-    _platform?: Platform | undefined);
+    constructor(...args: unknown[]);
     describe(hostElement: Element, message: string, role?: string): void;
     describe(hostElement: Element, message: HTMLElement): void;
     ngOnDestroy(): void;
@@ -70,7 +67,7 @@ export const CDK_DESCRIBEDBY_ID_PREFIX = "cdk-describedby-message";
 
 // @public
 export class CdkAriaLive implements OnDestroy {
-    constructor(_elementRef: ElementRef, _liveAnnouncer: LiveAnnouncer, _contentObserver: ContentObserver, _ngZone: NgZone);
+    constructor(...args: unknown[]);
     duration: number;
     // (undocumented)
     ngOnDestroy(): void;
@@ -84,7 +81,7 @@ export class CdkAriaLive implements OnDestroy {
 
 // @public
 export class CdkMonitorFocus implements AfterViewInit, OnDestroy {
-    constructor(_elementRef: ElementRef<HTMLElement>, _focusMonitor: FocusMonitor);
+    constructor(...args: unknown[]);
     // (undocumented)
     readonly cdkFocusChange: EventEmitter<FocusOrigin>;
     // (undocumented)
@@ -101,8 +98,7 @@ export class CdkMonitorFocus implements AfterViewInit, OnDestroy {
 
 // @public
 export class CdkTrapFocus implements OnDestroy, AfterContentInit, OnChanges, DoCheck {
-    constructor(_elementRef: ElementRef<HTMLElement>, _focusTrapFactory: FocusTrapFactory,
-    _document: any);
+    constructor(...args: unknown[]);
     autoCapture: boolean;
     get enabled(): boolean;
     set enabled(value: boolean);
@@ -142,12 +138,12 @@ export interface ConfigurableFocusTrapConfig {
 
 // @public
 export class ConfigurableFocusTrapFactory {
-    constructor(_checker: InteractivityChecker, _ngZone: NgZone, _focusTrapManager: FocusTrapManager, _document: any, _inertStrategy?: FocusTrapInertStrategy);
+    constructor(...args: unknown[]);
     create(element: HTMLElement, config?: ConfigurableFocusTrapConfig): ConfigurableFocusTrap;
     // @deprecated (undocumented)
     create(element: HTMLElement, deferCaptureElements: boolean): ConfigurableFocusTrap;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<ConfigurableFocusTrapFactory, [null, null, null, null, { optional: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<ConfigurableFocusTrapFactory, never>;
     // (undocumented)
     static ɵprov: i0.ɵɵInjectableDeclaration<ConfigurableFocusTrapFactory>;
 }
@@ -178,9 +174,8 @@ export class FocusKeyManager<T> extends ListKeyManager<FocusableOption & T> {
 
 // @public
 export class FocusMonitor implements OnDestroy {
-    constructor(_ngZone: NgZone, _platform: Platform, _inputModalityDetector: InputModalityDetector,
-    document: any | null, options: FocusMonitorOptions | null);
-    protected _document?: Document;
+    constructor(...args: unknown[]);
+    protected _document?: Document | null | undefined;
     focusVia(element: HTMLElement, origin: FocusOrigin, options?: FocusOptions_2): void;
     focusVia(element: ElementRef<HTMLElement>, origin: FocusOrigin, options?: FocusOptions_2): void;
     monitor(element: HTMLElement, checkChildren?: boolean): Observable<FocusOrigin>;
@@ -191,7 +186,7 @@ export class FocusMonitor implements OnDestroy {
     stopMonitoring(element: HTMLElement): void;
     stopMonitoring(element: ElementRef<HTMLElement>): void;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<FocusMonitor, [null, null, null, { optional: true; }, { optional: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<FocusMonitor, never>;
     // (undocumented)
     static ɵprov: i0.ɵɵInjectableDeclaration<FocusMonitor>;
 }
@@ -250,7 +245,7 @@ export class FocusTrap {
 
 // @public
 export class FocusTrapFactory {
-    constructor(_checker: InteractivityChecker, _ngZone: NgZone, _document: any);
+    constructor(...args: unknown[]);
     create(element: HTMLElement, deferCaptureElements?: boolean): FocusTrap;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<FocusTrapFactory, never>;
@@ -279,7 +274,7 @@ export enum HighContrastMode {
 
 // @public
 export class HighContrastModeDetector implements OnDestroy {
-    constructor(_platform: Platform, document: any);
+    constructor(...args: unknown[]);
     _applyBodyHighContrastModeCssClasses(): void;
     getHighContrastMode(): HighContrastMode;
     // (undocumented)
@@ -307,7 +302,7 @@ export type InputModality = 'keyboard' | 'mouse' | 'touch' | null;
 
 // @public
 export class InputModalityDetector implements OnDestroy {
-    constructor(_platform: Platform, ngZone: NgZone, document: Document, options?: InputModalityDetectorOptions);
+    constructor(...args: unknown[]);
     readonly modalityChanged: Observable<InputModality>;
     readonly modalityDetected: Observable<InputModality>;
     get mostRecentModality(): InputModality;
@@ -315,7 +310,7 @@ export class InputModalityDetector implements OnDestroy {
     // (undocumented)
     ngOnDestroy(): void;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<InputModalityDetector, [null, null, null, { optional: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<InputModalityDetector, never>;
     // (undocumented)
     static ɵprov: i0.ɵɵInjectableDeclaration<InputModalityDetector>;
 }
@@ -327,7 +322,7 @@ export interface InputModalityDetectorOptions {
 
 // @public
 export class InteractivityChecker {
-    constructor(_platform: Platform);
+    constructor(...args: unknown[]);
     isDisabled(element: HTMLElement): boolean;
     isFocusable(element: HTMLElement, config?: IsFocusableConfig): boolean;
     isTabbable(element: HTMLElement): boolean;
@@ -399,7 +394,7 @@ export function LIVE_ANNOUNCER_ELEMENT_TOKEN_FACTORY(): null;
 
 // @public (undocumented)
 export class LiveAnnouncer implements OnDestroy {
-    constructor(elementToken: any, _ngZone: NgZone, _document: any, _defaultOptions?: LiveAnnouncerDefaultOptions | undefined);
+    constructor(...args: unknown[]);
     announce(message: string): Promise<void>;
     announce(message: string, politeness?: AriaLivePoliteness): Promise<void>;
     announce(message: string, duration?: number): Promise<void>;
@@ -408,7 +403,7 @@ export class LiveAnnouncer implements OnDestroy {
     // (undocumented)
     ngOnDestroy(): void;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<LiveAnnouncer, [{ optional: true; }, null, null, { optional: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<LiveAnnouncer, never>;
     // (undocumented)
     static ɵprov: i0.ɵɵInjectableDeclaration<LiveAnnouncer>;
 }

--- a/tools/public_api_guard/cdk/accordion.md
+++ b/tools/public_api_guard/cdk/accordion.md
@@ -4,12 +4,12 @@
 
 ```ts
 
-import { ChangeDetectorRef } from '@angular/core';
 import { EventEmitter } from '@angular/core';
 import * as i0 from '@angular/core';
 import { InjectionToken } from '@angular/core';
 import { OnChanges } from '@angular/core';
 import { OnDestroy } from '@angular/core';
+import { OnInit } from '@angular/core';
 import { SimpleChanges } from '@angular/core';
 import { Subject } from 'rxjs';
 import { UniqueSelectionDispatcher } from '@angular/cdk/collections';
@@ -38,8 +38,8 @@ export class CdkAccordion implements OnDestroy, OnChanges {
 }
 
 // @public
-export class CdkAccordionItem implements OnDestroy {
-    constructor(accordion: CdkAccordion, _changeDetectorRef: ChangeDetectorRef, _expansionDispatcher: UniqueSelectionDispatcher);
+export class CdkAccordionItem implements OnInit, OnDestroy {
+    constructor(...args: unknown[]);
     // (undocumented)
     accordion: CdkAccordion;
     close(): void;
@@ -57,13 +57,15 @@ export class CdkAccordionItem implements OnDestroy {
     // (undocumented)
     static ngAcceptInputType_expanded: unknown;
     ngOnDestroy(): void;
+    // (undocumented)
+    ngOnInit(): void;
     open(): void;
     readonly opened: EventEmitter<void>;
     toggle(): void;
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<CdkAccordionItem, "cdk-accordion-item, [cdkAccordionItem]", ["cdkAccordionItem"], { "expanded": { "alias": "expanded"; "required": false; }; "disabled": { "alias": "disabled"; "required": false; }; }, { "closed": "closed"; "opened": "opened"; "destroyed": "destroyed"; "expandedChange": "expandedChange"; }, never, never, true, never>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<CdkAccordionItem, [{ optional: true; skipSelf: true; }, null, null]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<CdkAccordionItem, never>;
 }
 
 // @public (undocumented)

--- a/tools/public_api_guard/cdk/bidi.md
+++ b/tools/public_api_guard/cdk/bidi.md
@@ -44,13 +44,13 @@ export type Direction = 'ltr' | 'rtl';
 
 // @public
 export class Directionality implements OnDestroy {
-    constructor(_document?: any);
+    constructor(...args: unknown[]);
     readonly change: EventEmitter<Direction>;
     // (undocumented)
     ngOnDestroy(): void;
     readonly value: Direction;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<Directionality, [{ optional: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<Directionality, never>;
     // (undocumented)
     static ɵprov: i0.ɵɵInjectableDeclaration<Directionality>;
 }

--- a/tools/public_api_guard/cdk/clipboard.md
+++ b/tools/public_api_guard/cdk/clipboard.md
@@ -7,7 +7,6 @@
 import { EventEmitter } from '@angular/core';
 import * as i0 from '@angular/core';
 import { InjectionToken } from '@angular/core';
-import { NgZone } from '@angular/core';
 import { OnDestroy } from '@angular/core';
 
 // @public
@@ -15,7 +14,7 @@ export const CDK_COPY_TO_CLIPBOARD_CONFIG: InjectionToken<CdkCopyToClipboardConf
 
 // @public
 export class CdkCopyToClipboard implements OnDestroy {
-    constructor(_clipboard: Clipboard_2, _ngZone: NgZone, config?: CdkCopyToClipboardConfig);
+    constructor(...args: unknown[]);
     attempts: number;
     readonly copied: EventEmitter<boolean>;
     copy(attempts?: number): void;
@@ -25,7 +24,7 @@ export class CdkCopyToClipboard implements OnDestroy {
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<CdkCopyToClipboard, "[cdkCopyToClipboard]", never, { "text": { "alias": "cdkCopyToClipboard"; "required": false; }; "attempts": { "alias": "cdkCopyToClipboardAttempts"; "required": false; }; }, { "copied": "cdkCopyToClipboardCopied"; }, never, never, true, never>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<CdkCopyToClipboard, [null, null, { optional: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<CdkCopyToClipboard, never>;
 }
 
 // @public
@@ -35,7 +34,7 @@ export interface CdkCopyToClipboardConfig {
 
 // @public
 class Clipboard_2 {
-    constructor(document: any);
+    constructor(...args: unknown[]);
     beginCopy(text: string): PendingCopy;
     copy(text: string): boolean;
     // (undocumented)

--- a/tools/public_api_guard/cdk/dialog.md
+++ b/tools/public_api_guard/cdk/dialog.md
@@ -15,7 +15,6 @@ import { Direction } from '@angular/cdk/bidi';
 import { DomPortal } from '@angular/cdk/portal';
 import { ElementRef } from '@angular/core';
 import { EmbeddedViewRef } from '@angular/core';
-import { FocusMonitor } from '@angular/cdk/a11y';
 import { FocusOrigin } from '@angular/cdk/a11y';
 import { FocusTrapFactory } from '@angular/cdk/a11y';
 import * as i0 from '@angular/core';
@@ -24,12 +23,10 @@ import * as i2 from '@angular/cdk/portal';
 import * as i3 from '@angular/cdk/a11y';
 import { InjectionToken } from '@angular/core';
 import { Injector } from '@angular/core';
-import { InteractivityChecker } from '@angular/cdk/a11y';
 import { NgZone } from '@angular/core';
 import { Observable } from 'rxjs';
 import { OnDestroy } from '@angular/core';
 import { Overlay } from '@angular/cdk/overlay';
-import { OverlayContainer } from '@angular/cdk/overlay';
 import { OverlayRef } from '@angular/cdk/overlay';
 import { PositionStrategy } from '@angular/cdk/overlay';
 import { ScrollStrategy } from '@angular/cdk/overlay';
@@ -45,7 +42,7 @@ export type AutoFocusTarget = 'dialog' | 'first-tabbable' | 'first-heading';
 
 // @public
 export class CdkDialogContainer<C extends DialogConfig = DialogConfig> extends BasePortalOutlet implements OnDestroy {
-    constructor(_elementRef: ElementRef, _focusTrapFactory: FocusTrapFactory, _document: any, _config: C, _interactivityChecker: InteractivityChecker, _ngZone: NgZone, _overlayRef: OverlayRef, _focusMonitor?: FocusMonitor | undefined);
+    constructor(...args: unknown[]);
     // (undocumented)
     _addAriaLabelledBy(id: string): void;
     _ariaLabelledByQueue: string[];
@@ -64,7 +61,7 @@ export class CdkDialogContainer<C extends DialogConfig = DialogConfig> extends B
     // (undocumented)
     protected _document: Document;
     // (undocumented)
-    protected _elementRef: ElementRef;
+    protected _elementRef: ElementRef<any>;
     // (undocumented)
     protected _focusTrapFactory: FocusTrapFactory;
     // (undocumented)
@@ -79,7 +76,7 @@ export class CdkDialogContainer<C extends DialogConfig = DialogConfig> extends B
     // (undocumented)
     static ɵcmp: i0.ɵɵComponentDeclaration<CdkDialogContainer<any>, "cdk-dialog-container", never, {}, {}, never, never, true, never>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<CdkDialogContainer<any>, [null, null, { optional: true; }, null, null, null, null, null]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<CdkDialogContainer<any>, never>;
 }
 
 // @public
@@ -87,7 +84,7 @@ export const DEFAULT_DIALOG_CONFIG: InjectionToken<DialogConfig<unknown, unknown
 
 // @public (undocumented)
 export class Dialog implements OnDestroy {
-    constructor(_overlay: Overlay, _injector: Injector, _defaultOptions: DialogConfig, _parentDialog: Dialog, _overlayContainer: OverlayContainer, scrollStrategy: any);
+    constructor(...args: unknown[]);
     readonly afterAllClosed: Observable<void>;
     get afterOpened(): Subject<DialogRef<any, any>>;
     closeAll(): void;
@@ -100,7 +97,7 @@ export class Dialog implements OnDestroy {
     open<R = unknown, D = unknown, C = unknown>(componentOrTemplateRef: ComponentType<C> | TemplateRef<C>, config?: DialogConfig<D, DialogRef<R, C>>): DialogRef<R, C>;
     get openDialogs(): readonly DialogRef<any, any>[];
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<Dialog, [null, null, { optional: true; }, { optional: true; skipSelf: true; }, null, null]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<Dialog, never>;
     // (undocumented)
     static ɵprov: i0.ɵɵInjectableDeclaration<Dialog>;
 }

--- a/tools/public_api_guard/cdk/drag-drop.md
+++ b/tools/public_api_guard/cdk/drag-drop.md
@@ -5,9 +5,7 @@
 ```ts
 
 import { AfterViewInit } from '@angular/core';
-import { ChangeDetectorRef } from '@angular/core';
 import { Direction } from '@angular/cdk/bidi';
-import { Directionality } from '@angular/cdk/bidi';
 import { ElementRef } from '@angular/core';
 import { EventEmitter } from '@angular/core';
 import * as i0 from '@angular/core';
@@ -18,7 +16,6 @@ import { NumberInput } from '@angular/cdk/coercion';
 import { Observable } from 'rxjs';
 import { OnChanges } from '@angular/core';
 import { OnDestroy } from '@angular/core';
-import { ScrollDispatcher } from '@angular/cdk/scrolling';
 import { SimpleChanges } from '@angular/core';
 import { Subject } from 'rxjs';
 import { TemplateRef } from '@angular/core';
@@ -48,10 +45,7 @@ export const CDK_DROP_LIST_GROUP: InjectionToken<CdkDropListGroup<unknown>>;
 
 // @public
 export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
-    constructor(
-    element: ElementRef<HTMLElement>,
-    dropContainer: CdkDropList,
-    _document: any, _ngZone: NgZone, _viewContainerRef: ViewContainerRef, config: DragDropConfig, _dir: Directionality, dragDrop: DragDrop, _changeDetectorRef: ChangeDetectorRef, _selfHandle?: CdkDragHandle | undefined, _parentDrag?: CdkDrag | undefined);
+    constructor(...args: unknown[]);
     // (undocumented)
     _addHandle(handle: CdkDragHandle): void;
     boundaryElement: string | ElementRef<HTMLElement> | HTMLElement;
@@ -61,8 +55,10 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
     set disabled(value: boolean);
     _dragRef: DragRef<CdkDrag<T>>;
     dragStartDelay: DragStartDelay;
-    dropContainer: CdkDropList;
+    // (undocumented)
+    dropContainer: CdkDropList<any>;
     readonly dropped: EventEmitter<CdkDragDrop<any>>;
+    // (undocumented)
     element: ElementRef<HTMLElement>;
     readonly ended: EventEmitter<CdkDragEnd>;
     readonly entered: EventEmitter<CdkDragEnter<any>>;
@@ -104,7 +100,7 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<CdkDrag<any>, "[cdkDrag]", ["cdkDrag"], { "data": { "alias": "cdkDragData"; "required": false; }; "lockAxis": { "alias": "cdkDragLockAxis"; "required": false; }; "rootElementSelector": { "alias": "cdkDragRootElement"; "required": false; }; "boundaryElement": { "alias": "cdkDragBoundary"; "required": false; }; "dragStartDelay": { "alias": "cdkDragStartDelay"; "required": false; }; "freeDragPosition": { "alias": "cdkDragFreeDragPosition"; "required": false; }; "disabled": { "alias": "cdkDragDisabled"; "required": false; }; "constrainPosition": { "alias": "cdkDragConstrainPosition"; "required": false; }; "previewClass": { "alias": "cdkDragPreviewClass"; "required": false; }; "previewContainer": { "alias": "cdkDragPreviewContainer"; "required": false; }; "scale": { "alias": "cdkDragScale"; "required": false; }; }, { "started": "cdkDragStarted"; "released": "cdkDragReleased"; "ended": "cdkDragEnded"; "entered": "cdkDragEntered"; "exited": "cdkDragExited"; "dropped": "cdkDragDropped"; "moved": "cdkDragMoved"; }, never, never, true, never>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<CdkDrag<any>, [null, { optional: true; skipSelf: true; }, null, null, null, { optional: true; }, { optional: true; }, null, null, { optional: true; self: true; }, { optional: true; skipSelf: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<CdkDrag<any>, never>;
 }
 
 // @public
@@ -155,7 +151,7 @@ export interface CdkDragExit<T = any, I = T> {
 
 // @public
 export class CdkDragHandle implements OnDestroy {
-    constructor(element: ElementRef<HTMLElement>, _parentDrag?: CdkDrag | undefined);
+    constructor(...args: unknown[]);
     get disabled(): boolean;
     set disabled(value: boolean);
     // (undocumented)
@@ -168,7 +164,7 @@ export class CdkDragHandle implements OnDestroy {
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<CdkDragHandle, "[cdkDragHandle]", never, { "disabled": { "alias": "cdkDragHandleDisabled"; "required": false; }; }, {}, never, never, true, never>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<CdkDragHandle, [null, { optional: true; skipSelf: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<CdkDragHandle, never>;
 }
 
 // @public
@@ -191,7 +187,7 @@ export interface CdkDragMove<T = any> {
 
 // @public
 export class CdkDragPlaceholder<T = any> implements OnDestroy {
-    constructor(templateRef: TemplateRef<T>);
+    constructor(...args: unknown[]);
     data: T;
     // (undocumented)
     ngOnDestroy(): void;
@@ -205,7 +201,7 @@ export class CdkDragPlaceholder<T = any> implements OnDestroy {
 
 // @public
 export class CdkDragPreview<T = any> implements OnDestroy {
-    constructor(templateRef: TemplateRef<T>);
+    constructor(...args: unknown[]);
     data: T;
     matchSize: boolean;
     // (undocumented)
@@ -242,8 +238,7 @@ export interface CdkDragStart<T = any> {
 
 // @public
 export class CdkDropList<T = any> implements OnDestroy {
-    constructor(
-    element: ElementRef<HTMLElement>, dragDrop: DragDrop, _changeDetectorRef: ChangeDetectorRef, _scrollDispatcher: ScrollDispatcher, _dir?: Directionality | undefined, _group?: CdkDropListGroup<CdkDropList> | undefined, config?: DragDropConfig);
+    constructor(...args: unknown[]);
     addItem(item: CdkDrag): void;
     autoScrollDisabled: boolean;
     autoScrollStep: NumberInput;
@@ -253,6 +248,7 @@ export class CdkDropList<T = any> implements OnDestroy {
     set disabled(value: boolean);
     _dropListRef: DropListRef<CdkDropList<T>>;
     readonly dropped: EventEmitter<CdkDragDrop<T, any>>;
+    // (undocumented)
     element: ElementRef<HTMLElement>;
     elementContainerSelector: string | null;
     readonly entered: EventEmitter<CdkDragEnter<T>>;
@@ -277,7 +273,7 @@ export class CdkDropList<T = any> implements OnDestroy {
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<CdkDropList<any>, "[cdkDropList], cdk-drop-list", ["cdkDropList"], { "connectedTo": { "alias": "cdkDropListConnectedTo"; "required": false; }; "data": { "alias": "cdkDropListData"; "required": false; }; "orientation": { "alias": "cdkDropListOrientation"; "required": false; }; "id": { "alias": "id"; "required": false; }; "lockAxis": { "alias": "cdkDropListLockAxis"; "required": false; }; "disabled": { "alias": "cdkDropListDisabled"; "required": false; }; "sortingDisabled": { "alias": "cdkDropListSortingDisabled"; "required": false; }; "enterPredicate": { "alias": "cdkDropListEnterPredicate"; "required": false; }; "sortPredicate": { "alias": "cdkDropListSortPredicate"; "required": false; }; "autoScrollDisabled": { "alias": "cdkDropListAutoScrollDisabled"; "required": false; }; "autoScrollStep": { "alias": "cdkDropListAutoScrollStep"; "required": false; }; "elementContainerSelector": { "alias": "cdkDropListElementContainer"; "required": false; }; }, { "dropped": "cdkDropListDropped"; "entered": "cdkDropListEntered"; "exited": "cdkDropListExited"; "sorted": "cdkDropListSorted"; }, never, never, true, never>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<CdkDropList<any>, [null, null, null, null, { optional: true; }, { optional: true; skipSelf: true; }, { optional: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<CdkDropList<any>, never>;
 }
 
 // @public
@@ -305,7 +301,7 @@ export type DragConstrainPosition = (point: Point, dragRef: DragRef) => Point;
 
 // @public
 export class DragDrop {
-    constructor(_document: any, _ngZone: NgZone, _viewportRuler: ViewportRuler, _dragDropRegistry: DragDropRegistry);
+    constructor(...args: unknown[]);
     createDrag<T = any>(element: ElementRef<HTMLElement> | HTMLElement, config?: DragRefConfig): DragRef<T>;
     createDropList<T = any>(element: ElementRef<HTMLElement> | HTMLElement): DropListRef<T>;
     // (undocumented)
@@ -354,7 +350,7 @@ export class DragDropModule {
 
 // @public
 export class DragDropRegistry<_ = unknown, __ = unknown> implements OnDestroy {
-    constructor(_ngZone: NgZone, _document: any);
+    constructor(...args: unknown[]);
     isDragging(drag: DragRef): boolean;
     // (undocumented)
     ngOnDestroy(): void;

--- a/tools/public_api_guard/cdk/layout.md
+++ b/tools/public_api_guard/cdk/layout.md
@@ -5,14 +5,12 @@
 ```ts
 
 import * as i0 from '@angular/core';
-import { NgZone } from '@angular/core';
 import { Observable } from 'rxjs';
 import { OnDestroy } from '@angular/core';
-import { Platform } from '@angular/cdk/platform';
 
 // @public
 export class BreakpointObserver implements OnDestroy {
-    constructor(_mediaMatcher: MediaMatcher, _zone: NgZone);
+    constructor(...args: unknown[]);
     isMatched(value: string | readonly string[]): boolean;
     ngOnDestroy(): void;
     observe(value: string | readonly string[]): Observable<BreakpointState>;
@@ -60,10 +58,10 @@ export class LayoutModule {
 
 // @public
 export class MediaMatcher {
-    constructor(_platform: Platform, _nonce?: (string | null) | undefined);
+    constructor(...args: unknown[]);
     matchMedia(query: string): MediaQueryList;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<MediaMatcher, [null, { optional: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MediaMatcher, never>;
     // (undocumented)
     static ɵprov: i0.ɵɵInjectableDeclaration<MediaMatcher>;
 }

--- a/tools/public_api_guard/cdk/observers.md
+++ b/tools/public_api_guard/cdk/observers.md
@@ -14,7 +14,7 @@ import { OnDestroy } from '@angular/core';
 
 // @public
 export class CdkObserveContent implements AfterContentInit, OnDestroy {
-    constructor(_contentObserver: ContentObserver, _elementRef: ElementRef<HTMLElement>);
+    constructor(...args: unknown[]);
     get debounce(): number;
     set debounce(value: NumberInput);
     get disabled(): boolean;
@@ -34,7 +34,7 @@ export class CdkObserveContent implements AfterContentInit, OnDestroy {
 
 // @public
 export class ContentObserver implements OnDestroy {
-    constructor(_mutationObserverFactory: MutationObserverFactory);
+    constructor(...args: unknown[]);
     // (undocumented)
     ngOnDestroy(): void;
     observe(element: Element): Observable<MutationRecord[]>;

--- a/tools/public_api_guard/cdk/overlay.md
+++ b/tools/public_api_guard/cdk/overlay.md
@@ -6,7 +6,6 @@
 
 import { _CdkPrivateStyleLoader } from '@angular/cdk/private';
 import { CdkScrollable } from '@angular/cdk/scrolling';
-import { ComponentFactoryResolver } from '@angular/core';
 import { ComponentPortal } from '@angular/cdk/portal';
 import { ComponentRef } from '@angular/core';
 import { ComponentType } from '@angular/cdk/portal';
@@ -21,7 +20,6 @@ import * as i1 from '@angular/cdk/bidi';
 import * as i2 from '@angular/cdk/portal';
 import * as i3 from '@angular/cdk/scrolling';
 import { InjectionToken } from '@angular/core';
-import { Injector } from '@angular/core';
 import { Location as Location_2 } from '@angular/common';
 import { NgZone } from '@angular/core';
 import { Observable } from 'rxjs';
@@ -33,8 +31,6 @@ import { ScrollDispatcher } from '@angular/cdk/scrolling';
 import { SimpleChanges } from '@angular/core';
 import { Subject } from 'rxjs';
 import { TemplatePortal } from '@angular/cdk/portal';
-import { TemplateRef } from '@angular/core';
-import { ViewContainerRef } from '@angular/core';
 import { ViewportRuler } from '@angular/cdk/scrolling';
 
 // @public
@@ -47,7 +43,7 @@ export class BlockScrollStrategy implements ScrollStrategy {
 
 // @public
 export class CdkConnectedOverlay implements OnDestroy, OnChanges {
-    constructor(_overlay: Overlay, templateRef: TemplateRef<any>, viewContainerRef: ViewContainerRef, scrollStrategyFactory: any, _dir: Directionality);
+    constructor(...args: unknown[]);
     readonly attach: EventEmitter<void>;
     backdropClass: string | string[];
     readonly backdropClick: EventEmitter<MouseEvent>;
@@ -100,14 +96,14 @@ export class CdkConnectedOverlay implements OnDestroy, OnChanges {
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<CdkConnectedOverlay, "[cdk-connected-overlay], [connected-overlay], [cdkConnectedOverlay]", ["cdkConnectedOverlay"], { "origin": { "alias": "cdkConnectedOverlayOrigin"; "required": false; }; "positions": { "alias": "cdkConnectedOverlayPositions"; "required": false; }; "positionStrategy": { "alias": "cdkConnectedOverlayPositionStrategy"; "required": false; }; "offsetX": { "alias": "cdkConnectedOverlayOffsetX"; "required": false; }; "offsetY": { "alias": "cdkConnectedOverlayOffsetY"; "required": false; }; "width": { "alias": "cdkConnectedOverlayWidth"; "required": false; }; "height": { "alias": "cdkConnectedOverlayHeight"; "required": false; }; "minWidth": { "alias": "cdkConnectedOverlayMinWidth"; "required": false; }; "minHeight": { "alias": "cdkConnectedOverlayMinHeight"; "required": false; }; "backdropClass": { "alias": "cdkConnectedOverlayBackdropClass"; "required": false; }; "panelClass": { "alias": "cdkConnectedOverlayPanelClass"; "required": false; }; "viewportMargin": { "alias": "cdkConnectedOverlayViewportMargin"; "required": false; }; "scrollStrategy": { "alias": "cdkConnectedOverlayScrollStrategy"; "required": false; }; "open": { "alias": "cdkConnectedOverlayOpen"; "required": false; }; "disableClose": { "alias": "cdkConnectedOverlayDisableClose"; "required": false; }; "transformOriginSelector": { "alias": "cdkConnectedOverlayTransformOriginOn"; "required": false; }; "hasBackdrop": { "alias": "cdkConnectedOverlayHasBackdrop"; "required": false; }; "lockPosition": { "alias": "cdkConnectedOverlayLockPosition"; "required": false; }; "flexibleDimensions": { "alias": "cdkConnectedOverlayFlexibleDimensions"; "required": false; }; "growAfterOpen": { "alias": "cdkConnectedOverlayGrowAfterOpen"; "required": false; }; "push": { "alias": "cdkConnectedOverlayPush"; "required": false; }; "disposeOnNavigation": { "alias": "cdkConnectedOverlayDisposeOnNavigation"; "required": false; }; }, { "backdropClick": "backdropClick"; "positionChange": "positionChange"; "attach": "attach"; "detach": "detach"; "overlayKeydown": "overlayKeydown"; "overlayOutsideClick": "overlayOutsideClick"; }, never, never, true, never>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<CdkConnectedOverlay, [null, null, null, null, { optional: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<CdkConnectedOverlay, never>;
 }
 
 // @public
 export class CdkOverlayOrigin {
-    constructor(
-    elementRef: ElementRef);
-    elementRef: ElementRef;
+    constructor(...args: unknown[]);
+    // (undocumented)
+    elementRef: ElementRef<any>;
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<CdkOverlayOrigin, "[cdk-overlay-origin], [overlay-origin], [cdkOverlayOrigin]", ["cdkOverlayOrigin"], {}, {}, never, never, true, never>;
     // (undocumented)
@@ -206,7 +202,7 @@ export type FlexibleConnectedPositionStrategyOrigin = ElementRef | Element | (Po
 
 // @public
 export class FullscreenOverlayContainer extends OverlayContainer implements OnDestroy {
-    constructor(_document: any, platform: Platform);
+    constructor(...args: unknown[]);
     // (undocumented)
     protected _createContainer(): void;
     getFullscreenElement(): Element;
@@ -258,13 +254,13 @@ export interface OriginConnectionPosition {
 
 // @public
 export class Overlay {
-    constructor(
-    scrollStrategies: ScrollStrategyOptions, _overlayContainer: OverlayContainer, _componentFactoryResolver: ComponentFactoryResolver, _positionBuilder: OverlayPositionBuilder, _keyboardDispatcher: OverlayKeyboardDispatcher, _injector: Injector, _ngZone: NgZone, _document: any, _directionality: Directionality, _location: Location_2, _outsideClickDispatcher: OverlayOutsideClickDispatcher, _animationsModuleType?: string | undefined);
+    constructor(...args: unknown[]);
     create(config?: OverlayConfig): OverlayRef;
     position(): OverlayPositionBuilder;
+    // (undocumented)
     scrollStrategies: ScrollStrategyOptions;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<Overlay, [null, null, null, null, null, null, null, null, null, null, null, { optional: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<Overlay, never>;
     // (undocumented)
     static ɵprov: i0.ɵɵInjectableDeclaration<Overlay>;
 }
@@ -297,7 +293,7 @@ export interface OverlayConnectionPosition {
 
 // @public
 export class OverlayContainer implements OnDestroy {
-    constructor(document: any, _platform: Platform);
+    constructor(...args: unknown[]);
     // (undocumented)
     protected _containerElement: HTMLElement;
     protected _createContainer(): void;
@@ -319,12 +315,10 @@ export class OverlayContainer implements OnDestroy {
 
 // @public
 export class OverlayKeyboardDispatcher extends BaseOverlayDispatcher {
-    constructor(document: any,
-    _ngZone?: NgZone | undefined);
     add(overlayRef: OverlayRef): void;
     protected detach(): void;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<OverlayKeyboardDispatcher, [null, { optional: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<OverlayKeyboardDispatcher, never>;
     // (undocumented)
     static ɵprov: i0.ɵɵInjectableDeclaration<OverlayKeyboardDispatcher>;
 }
@@ -341,19 +335,17 @@ export class OverlayModule {
 
 // @public
 export class OverlayOutsideClickDispatcher extends BaseOverlayDispatcher {
-    constructor(document: any, _platform: Platform,
-    _ngZone?: NgZone | undefined);
     add(overlayRef: OverlayRef): void;
     protected detach(): void;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<OverlayOutsideClickDispatcher, [null, null, { optional: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<OverlayOutsideClickDispatcher, never>;
     // (undocumented)
     static ɵprov: i0.ɵɵInjectableDeclaration<OverlayOutsideClickDispatcher>;
 }
 
 // @public
 export class OverlayPositionBuilder {
-    constructor(_viewportRuler: ViewportRuler, _document: any, _platform: Platform, _overlayContainer: OverlayContainer);
+    constructor(...args: unknown[]);
     flexibleConnectedTo(origin: FlexibleConnectedPositionStrategyOrigin): FlexibleConnectedPositionStrategy;
     global(): GlobalPositionStrategy;
     // (undocumented)
@@ -460,7 +452,7 @@ export interface ScrollStrategy {
 
 // @public
 export class ScrollStrategyOptions {
-    constructor(_scrollDispatcher: ScrollDispatcher, _viewportRuler: ViewportRuler, _ngZone: NgZone, document: any);
+    constructor(...args: unknown[]);
     block: () => BlockScrollStrategy;
     close: (config?: CloseScrollStrategyConfig) => CloseScrollStrategy;
     noop: () => NoopScrollStrategy;

--- a/tools/public_api_guard/cdk/portal.md
+++ b/tools/public_api_guard/cdk/portal.md
@@ -44,7 +44,7 @@ export abstract class BasePortalOutlet implements PortalOutlet {
 
 // @public
 export class CdkPortal extends TemplatePortal {
-    constructor(templateRef: TemplateRef<any>, viewContainerRef: ViewContainerRef);
+    constructor(...args: unknown[]);
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<CdkPortal, "[cdkPortal]", ["cdkPortal"], {}, {}, never, never, true, never>;
     // (undocumented)
@@ -53,8 +53,7 @@ export class CdkPortal extends TemplatePortal {
 
 // @public
 export class CdkPortalOutlet extends BasePortalOutlet implements OnInit, OnDestroy {
-    constructor(_componentFactoryResolver: ComponentFactoryResolver, _viewContainerRef: ViewContainerRef,
-    _document?: any);
+    constructor(...args: unknown[]);
     attachComponentPortal<T>(portal: ComponentPortal<T>): ComponentRef<T>;
     // @deprecated
     attachDomPortal: (portal: DomPortal) => void;

--- a/tools/public_api_guard/cdk/scrolling.md
+++ b/tools/public_api_guard/cdk/scrolling.md
@@ -4,7 +4,6 @@
 
 ```ts
 
-import { ChangeDetectorRef } from '@angular/core';
 import { CollectionViewer } from '@angular/cdk/collections';
 import { DataSource } from '@angular/cdk/collections';
 import { Directionality } from '@angular/cdk/bidi';
@@ -13,7 +12,6 @@ import { ElementRef } from '@angular/core';
 import * as i0 from '@angular/core';
 import * as i2 from '@angular/cdk/bidi';
 import { InjectionToken } from '@angular/core';
-import { IterableDiffers } from '@angular/core';
 import { ListRange } from '@angular/cdk/collections';
 import { NgIterable } from '@angular/core';
 import { NgZone } from '@angular/core';
@@ -22,13 +20,10 @@ import { Observable } from 'rxjs';
 import { OnChanges } from '@angular/core';
 import { OnDestroy } from '@angular/core';
 import { OnInit } from '@angular/core';
-import { Platform } from '@angular/cdk/platform';
-import { _RecycleViewRepeaterStrategy } from '@angular/cdk/collections';
 import { Subject } from 'rxjs';
 import { Subscription } from 'rxjs';
 import { TemplateRef } from '@angular/core';
 import { TrackByFunction } from '@angular/core';
-import { ViewContainerRef } from '@angular/core';
 
 // @public (undocumented)
 export type _Bottom = {
@@ -60,11 +55,11 @@ export class CdkFixedSizeVirtualScroll implements OnChanges {
 
 // @public
 export class CdkScrollable implements OnInit, OnDestroy {
-    constructor(elementRef: ElementRef<HTMLElement>, scrollDispatcher: ScrollDispatcher, ngZone: NgZone, dir?: Directionality | undefined);
+    constructor(...args: unknown[]);
     // (undocumented)
     protected readonly _destroyed: Subject<void>;
     // (undocumented)
-    protected dir?: Directionality | undefined;
+    protected dir?: Directionality | null | undefined;
     // (undocumented)
     protected elementRef: ElementRef<HTMLElement>;
     elementScrolled(): Observable<Event>;
@@ -84,7 +79,7 @@ export class CdkScrollable implements OnInit, OnDestroy {
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<CdkScrollable, "[cdk-scrollable], [cdkScrollable]", never, {}, {}, never, never, true, never>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<CdkScrollable, [null, null, null, { optional: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<CdkScrollable, never>;
 }
 
 // @public (undocumented)
@@ -99,12 +94,7 @@ export class CdkScrollableModule {
 
 // @public
 export class CdkVirtualForOf<T> implements CdkVirtualScrollRepeater<T>, CollectionViewer, DoCheck, OnDestroy {
-    constructor(
-    _viewContainerRef: ViewContainerRef,
-    _template: TemplateRef<CdkVirtualForOfContext<T>>,
-    _differs: IterableDiffers,
-    _viewRepeater: _RecycleViewRepeaterStrategy<T, T, CdkVirtualForOfContext<T>>,
-    _viewport: CdkVirtualScrollViewport, ngZone: NgZone);
+    constructor(...args: unknown[]);
     get cdkVirtualForOf(): DataSource<T> | Observable<T[]> | NgIterable<T> | null | undefined;
     set cdkVirtualForOf(value: DataSource<T> | Observable<T[]> | NgIterable<T> | null | undefined);
     // (undocumented)
@@ -126,7 +116,7 @@ export class CdkVirtualForOf<T> implements CdkVirtualScrollRepeater<T>, Collecti
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<CdkVirtualForOf<any>, "[cdkVirtualFor][cdkVirtualForOf]", never, { "cdkVirtualForOf": { "alias": "cdkVirtualForOf"; "required": false; }; "cdkVirtualForTrackBy": { "alias": "cdkVirtualForTrackBy"; "required": false; }; "cdkVirtualForTemplate": { "alias": "cdkVirtualForTemplate"; "required": false; }; "cdkVirtualForTemplateCacheSize": { "alias": "cdkVirtualForTemplateCacheSize"; "required": false; }; }, {}, never, never, true, never>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<CdkVirtualForOf<any>, [null, null, null, null, { skipSelf: true; }, null]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<CdkVirtualForOf<any>, never>;
 }
 
 // @public
@@ -143,29 +133,29 @@ export type CdkVirtualForOfContext<T> = {
 
 // @public
 export abstract class CdkVirtualScrollable extends CdkScrollable {
-    constructor(elementRef: ElementRef<HTMLElement>, scrollDispatcher: ScrollDispatcher, ngZone: NgZone, dir?: Directionality);
+    constructor(...args: unknown[]);
     abstract measureBoundingClientRectWithScrollOffset(from: 'left' | 'top' | 'right' | 'bottom'): number;
     measureViewportSize(orientation: 'horizontal' | 'vertical'): number;
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<CdkVirtualScrollable, never, never, {}, {}, never, never, false, never>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<CdkVirtualScrollable, [null, null, null, { optional: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<CdkVirtualScrollable, never>;
 }
 
 // @public
 export class CdkVirtualScrollableElement extends CdkVirtualScrollable {
-    constructor(elementRef: ElementRef, scrollDispatcher: ScrollDispatcher, ngZone: NgZone, dir: Directionality);
+    constructor(...args: unknown[]);
     // (undocumented)
     measureBoundingClientRectWithScrollOffset(from: 'left' | 'top' | 'right' | 'bottom'): number;
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<CdkVirtualScrollableElement, "[cdkVirtualScrollingElement]", never, {}, {}, never, never, true, never>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<CdkVirtualScrollableElement, [null, null, null, { optional: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<CdkVirtualScrollableElement, never>;
 }
 
 // @public
 export class CdkVirtualScrollableWindow extends CdkVirtualScrollable {
-    constructor(scrollDispatcher: ScrollDispatcher, ngZone: NgZone, dir: Directionality);
+    constructor(...args: unknown[]);
     // (undocumented)
     protected _elementScrolled: Observable<Event>;
     // (undocumented)
@@ -173,7 +163,7 @@ export class CdkVirtualScrollableWindow extends CdkVirtualScrollable {
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<CdkVirtualScrollableWindow, "cdk-virtual-scroll-viewport[scrollWindow]", never, {}, {}, never, never, true, never>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<CdkVirtualScrollableWindow, [null, null, { optional: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<CdkVirtualScrollableWindow, never>;
 }
 
 // @public
@@ -186,7 +176,7 @@ export interface CdkVirtualScrollRepeater<T> {
 
 // @public
 export class CdkVirtualScrollViewport extends CdkVirtualScrollable implements OnInit, OnDestroy {
-    constructor(elementRef: ElementRef<HTMLElement>, _changeDetectorRef: ChangeDetectorRef, ngZone: NgZone, _scrollStrategy: VirtualScrollStrategy, dir: Directionality, scrollDispatcher: ScrollDispatcher, viewportRuler: ViewportRuler, scrollable: CdkVirtualScrollable);
+    constructor(...args: unknown[]);
     appendOnly: boolean;
     attach(forOf: CdkVirtualScrollRepeater<any>): void;
     checkViewportSize(): void;
@@ -226,7 +216,7 @@ export class CdkVirtualScrollViewport extends CdkVirtualScrollable implements On
     // (undocumented)
     static ɵcmp: i0.ɵɵComponentDeclaration<CdkVirtualScrollViewport, "cdk-virtual-scroll-viewport", never, { "orientation": { "alias": "orientation"; "required": false; }; "appendOnly": { "alias": "appendOnly"; "required": false; }; }, { "scrolledIndexChange": "scrolledIndexChange"; }, never, ["*"], true, never>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<CdkVirtualScrollViewport, [null, null, null, { optional: true; }, { optional: true; }, null, null, { optional: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<CdkVirtualScrollViewport, never>;
 }
 
 // @public
@@ -272,7 +262,7 @@ export type _Right = {
 
 // @public
 export class ScrollDispatcher implements OnDestroy {
-    constructor(_ngZone: NgZone, _platform: Platform, document: any);
+    constructor(...args: unknown[]);
     ancestorScrolled(elementOrElementRef: ElementRef | HTMLElement, auditTimeInMs?: number): Observable<CdkScrollable | void>;
     deregister(scrollable: CdkScrollable): void;
     protected _document: Document;
@@ -284,7 +274,7 @@ export class ScrollDispatcher implements OnDestroy {
     scrollContainers: Map<CdkScrollable, Subscription>;
     scrolled(auditTimeInMs?: number): Observable<CdkScrollable | void>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<ScrollDispatcher, [null, null, { optional: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<ScrollDispatcher, never>;
     // (undocumented)
     static ɵprov: i0.ɵɵInjectableDeclaration<ScrollDispatcher>;
 }
@@ -311,7 +301,7 @@ export type _Top = {
 
 // @public
 export class ViewportRuler implements OnDestroy {
-    constructor(_platform: Platform, ngZone: NgZone, document: any);
+    constructor(...args: unknown[]);
     change(throttleTime?: number): Observable<Event>;
     protected _document: Document;
     getViewportRect(): {
@@ -330,7 +320,7 @@ export class ViewportRuler implements OnDestroy {
     // (undocumented)
     ngOnDestroy(): void;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<ViewportRuler, [null, null, { optional: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<ViewportRuler, never>;
     // (undocumented)
     static ɵprov: i0.ɵɵInjectableDeclaration<ViewportRuler>;
 }

--- a/tools/public_api_guard/cdk/stepper.md
+++ b/tools/public_api_guard/cdk/stepper.md
@@ -6,8 +6,6 @@
 
 import { AfterContentInit } from '@angular/core';
 import { AfterViewInit } from '@angular/core';
-import { ChangeDetectorRef } from '@angular/core';
-import { Directionality } from '@angular/cdk/bidi';
 import { ElementRef } from '@angular/core';
 import { EventEmitter } from '@angular/core';
 import { FocusableOption } from '@angular/cdk/a11y';
@@ -23,7 +21,7 @@ import { TemplateRef } from '@angular/core';
 
 // @public (undocumented)
 export class CdkStep implements OnChanges {
-    constructor(_stepper: CdkStepper, stepperOptions?: StepperOptions);
+    constructor(...args: unknown[]);
     ariaLabel: string;
     ariaLabelledby: string;
     get completed(): boolean;
@@ -64,12 +62,12 @@ export class CdkStep implements OnChanges {
     // (undocumented)
     static ɵcmp: i0.ɵɵComponentDeclaration<CdkStep, "cdk-step", ["cdkStep"], { "stepControl": { "alias": "stepControl"; "required": false; }; "label": { "alias": "label"; "required": false; }; "errorMessage": { "alias": "errorMessage"; "required": false; }; "ariaLabel": { "alias": "aria-label"; "required": false; }; "ariaLabelledby": { "alias": "aria-labelledby"; "required": false; }; "state": { "alias": "state"; "required": false; }; "editable": { "alias": "editable"; "required": false; }; "optional": { "alias": "optional"; "required": false; }; "completed": { "alias": "completed"; "required": false; }; "hasError": { "alias": "hasError"; "required": false; }; }, { "interactedStream": "interacted"; }, ["stepLabel"], ["*"], true, never>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<CdkStep, [null, { optional: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<CdkStep, never>;
 }
 
 // @public (undocumented)
 export class CdkStepHeader implements FocusableOption {
-    constructor(_elementRef: ElementRef<HTMLElement>);
+    constructor(...args: unknown[]);
     // (undocumented)
     _elementRef: ElementRef<HTMLElement>;
     focus(): void;
@@ -81,7 +79,7 @@ export class CdkStepHeader implements FocusableOption {
 
 // @public (undocumented)
 export class CdkStepLabel {
-    constructor(template: TemplateRef<any>);
+    constructor(...args: unknown[]);
     // (undocumented)
     template: TemplateRef<any>;
     // (undocumented)
@@ -92,7 +90,7 @@ export class CdkStepLabel {
 
 // @public (undocumented)
 export class CdkStepper implements AfterContentInit, AfterViewInit, OnDestroy {
-    constructor(_dir: Directionality, _changeDetectorRef: ChangeDetectorRef, _elementRef: ElementRef<HTMLElement>);
+    constructor(...args: unknown[]);
     protected readonly _destroyed: Subject<void>;
     _getAnimationDirection(index: number): StepContentPositionState;
     _getFocusIndex(): number | null;
@@ -131,7 +129,7 @@ export class CdkStepper implements AfterContentInit, AfterViewInit, OnDestroy {
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<CdkStepper, "[cdkStepper]", ["cdkStepper"], { "linear": { "alias": "linear"; "required": false; }; "selectedIndex": { "alias": "selectedIndex"; "required": false; }; "selected": { "alias": "selected"; "required": false; }; "orientation": { "alias": "orientation"; "required": false; }; }, { "selectionChange": "selectionChange"; "selectedIndexChange": "selectedIndexChange"; }, ["_steps", "_stepHeader"], never, true, never>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<CdkStepper, [{ optional: true; }, null, null]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<CdkStepper, never>;
 }
 
 // @public (undocumented)
@@ -146,7 +144,7 @@ export class CdkStepperModule {
 
 // @public
 export class CdkStepperNext {
-    constructor(_stepper: CdkStepper);
+    constructor(...args: unknown[]);
     // (undocumented)
     _stepper: CdkStepper;
     type: string;
@@ -158,7 +156,7 @@ export class CdkStepperNext {
 
 // @public
 export class CdkStepperPrevious {
-    constructor(_stepper: CdkStepper);
+    constructor(...args: unknown[]);
     // (undocumented)
     _stepper: CdkStepper;
     type: string;

--- a/tools/public_api_guard/cdk/table.md
+++ b/tools/public_api_guard/cdk/table.md
@@ -20,18 +20,15 @@ import { InjectionToken } from '@angular/core';
 import { IterableChanges } from '@angular/core';
 import { IterableDiffer } from '@angular/core';
 import { IterableDiffers } from '@angular/core';
-import { NgZone } from '@angular/core';
 import { Observable } from 'rxjs';
 import { OnChanges } from '@angular/core';
 import { OnDestroy } from '@angular/core';
 import { OnInit } from '@angular/core';
-import { Platform } from '@angular/cdk/platform';
 import { QueryList } from '@angular/core';
 import { SimpleChanges } from '@angular/core';
 import { TemplateRef } from '@angular/core';
 import { TrackByFunction } from '@angular/core';
 import { ViewContainerRef } from '@angular/core';
-import { ViewportRuler } from '@angular/cdk/scrolling';
 import { _ViewRepeater } from '@angular/cdk/collections';
 
 // @public
@@ -41,8 +38,7 @@ export class BaseCdkCell {
 
 // @public
 export abstract class BaseRowDef implements OnChanges {
-    constructor(
-    template: TemplateRef<any>, _differs: IterableDiffers);
+    constructor(...args: unknown[]);
     columns: Iterable<string>;
     protected _columnsDiffer: IterableDiffer<any>;
     // (undocumented)
@@ -51,6 +47,7 @@ export abstract class BaseRowDef implements OnChanges {
     getColumnsDiff(): IterableChanges<any> | null;
     // (undocumented)
     ngOnChanges(changes: SimpleChanges): void;
+    // (undocumented)
     template: TemplateRef<any>;
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<BaseRowDef, never, never, {}, {}, never, never, false, never>;
@@ -79,7 +76,7 @@ export const CDK_TABLE_TEMPLATE = "\n  <ng-content select=\"caption\"/>\n  <ng-c
 
 // @public
 export class CdkCell extends BaseCdkCell {
-    constructor(columnDef: CdkColumnDef, elementRef: ElementRef);
+    constructor(...args: unknown[]);
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<CdkCell, "cdk-cell, td[cdk-cell]", never, {}, {}, never, never, true, never>;
     // (undocumented)
@@ -88,8 +85,7 @@ export class CdkCell extends BaseCdkCell {
 
 // @public
 export class CdkCellDef implements CellDef {
-    constructor(template: TemplateRef<any>);
-    // (undocumented)
+    constructor(...args: unknown[]);
     template: TemplateRef<any>;
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<CdkCellDef, "[cdkCellDef]", never, {}, {}, never, never, true, never>;
@@ -99,7 +95,7 @@ export class CdkCellDef implements CellDef {
 
 // @public
 export class CdkCellOutlet implements OnDestroy {
-    constructor(_viewContainer: ViewContainerRef);
+    constructor(...args: unknown[]);
     cells: CdkCellDef[];
     context: any;
     static mostRecentCellOutlet: CdkCellOutlet | null;
@@ -138,7 +134,7 @@ export interface CdkCellOutletRowContext<T> {
 
 // @public
 export class CdkColumnDef implements CanStick {
-    constructor(_table?: any);
+    constructor(...args: unknown[]);
     cell: CdkCellDef;
     _columnCssClassName: string[];
     cssClassFriendlyName: string;
@@ -167,12 +163,12 @@ export class CdkColumnDef implements CanStick {
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<CdkColumnDef, "[cdkColumnDef]", never, { "name": { "alias": "cdkColumnDef"; "required": false; }; "sticky": { "alias": "sticky"; "required": false; }; "stickyEnd": { "alias": "stickyEnd"; "required": false; }; }, {}, ["cell", "headerCell", "footerCell"], never, true, never>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<CdkColumnDef, [{ optional: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<CdkColumnDef, never>;
 }
 
 // @public
 export class CdkFooterCell extends BaseCdkCell {
-    constructor(columnDef: CdkColumnDef, elementRef: ElementRef);
+    constructor(...args: unknown[]);
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<CdkFooterCell, "cdk-footer-cell, td[cdk-footer-cell]", never, {}, {}, never, never, true, never>;
     // (undocumented)
@@ -181,8 +177,7 @@ export class CdkFooterCell extends BaseCdkCell {
 
 // @public
 export class CdkFooterCellDef implements CellDef {
-    constructor(template: TemplateRef<any>);
-    // (undocumented)
+    constructor(...args: unknown[]);
     template: TemplateRef<any>;
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<CdkFooterCellDef, "[cdkFooterCellDef]", never, {}, {}, never, never, true, never>;
@@ -200,7 +195,7 @@ export class CdkFooterRow {
 
 // @public
 export class CdkFooterRowDef extends BaseRowDef implements CanStick, OnChanges {
-    constructor(template: TemplateRef<any>, _differs: IterableDiffers, _table?: any);
+    constructor(...args: unknown[]);
     hasStickyChanged(): boolean;
     // (undocumented)
     static ngAcceptInputType_sticky: unknown;
@@ -214,12 +209,12 @@ export class CdkFooterRowDef extends BaseRowDef implements CanStick, OnChanges {
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<CdkFooterRowDef, "[cdkFooterRowDef]", never, { "columns": { "alias": "cdkFooterRowDef"; "required": false; }; "sticky": { "alias": "cdkFooterRowDefSticky"; "required": false; }; }, {}, never, never, true, never>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<CdkFooterRowDef, [null, null, { optional: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<CdkFooterRowDef, never>;
 }
 
 // @public
 export class CdkHeaderCell extends BaseCdkCell {
-    constructor(columnDef: CdkColumnDef, elementRef: ElementRef);
+    constructor(...args: unknown[]);
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<CdkHeaderCell, "cdk-header-cell, th[cdk-header-cell]", never, {}, {}, never, never, true, never>;
     // (undocumented)
@@ -228,8 +223,7 @@ export class CdkHeaderCell extends BaseCdkCell {
 
 // @public
 export class CdkHeaderCellDef implements CellDef {
-    constructor(template: TemplateRef<any>);
-    // (undocumented)
+    constructor(...args: unknown[]);
     template: TemplateRef<any>;
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<CdkHeaderCellDef, "[cdkHeaderCellDef]", never, {}, {}, never, never, true, never>;
@@ -247,7 +241,7 @@ export class CdkHeaderRow {
 
 // @public
 export class CdkHeaderRowDef extends BaseRowDef implements CanStick, OnChanges {
-    constructor(template: TemplateRef<any>, _differs: IterableDiffers, _table?: any);
+    constructor(...args: unknown[]);
     hasStickyChanged(): boolean;
     // (undocumented)
     static ngAcceptInputType_sticky: unknown;
@@ -261,12 +255,12 @@ export class CdkHeaderRowDef extends BaseRowDef implements CanStick, OnChanges {
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<CdkHeaderRowDef, "[cdkHeaderRowDef]", never, { "columns": { "alias": "cdkHeaderRowDef"; "required": false; }; "sticky": { "alias": "cdkHeaderRowDefSticky"; "required": false; }; }, {}, never, never, true, never>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<CdkHeaderRowDef, [null, null, { optional: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<CdkHeaderRowDef, never>;
 }
 
 // @public
 export class CdkNoDataRow {
-    constructor(templateRef: TemplateRef<any>);
+    constructor(...args: unknown[]);
     // (undocumented)
     _contentClassName: string;
     // (undocumented)
@@ -295,21 +289,19 @@ export class CdkRow {
 
 // @public
 export class CdkRowDef<T> extends BaseRowDef {
-    constructor(template: TemplateRef<any>, _differs: IterableDiffers, _table?: any);
+    constructor(...args: unknown[]);
     // (undocumented)
     _table?: any;
     when: (index: number, rowData: T) => boolean;
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<CdkRowDef<any>, "[cdkRowDef]", never, { "columns": { "alias": "cdkRowDefColumns"; "required": false; }; "when": { "alias": "cdkRowDefWhen"; "required": false; }; }, {}, never, never, true, never>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<CdkRowDef<any>, [null, null, { optional: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<CdkRowDef<any>, never>;
 }
 
 // @public
 export class CdkTable<T> implements AfterContentInit, AfterContentChecked, CollectionViewer, OnDestroy, OnInit {
-    constructor(_differs: IterableDiffers, _changeDetectorRef: ChangeDetectorRef, _elementRef: ElementRef, role: string, _dir: Directionality, _document: any, _platform: Platform, _viewRepeater: _ViewRepeater<T, RenderRow<T>, RowContext<T>>, _coalescedStyleScheduler: _CoalescedStyleScheduler, _viewportRuler: ViewportRuler,
-    _stickyPositioningListener: StickyPositioningListener,
-    _unusedNgZone?: NgZone);
+    constructor(...args: unknown[]);
     addColumnDef(columnDef: CdkColumnDef): void;
     addFooterRowDef(footerRowDef: CdkFooterRowDef): void;
     addHeaderRowDef(headerRowDef: CdkHeaderRowDef): void;
@@ -329,9 +321,9 @@ export class CdkTable<T> implements AfterContentInit, AfterContentChecked, Colle
     // (undocumented)
     protected readonly _differs: IterableDiffers;
     // (undocumented)
-    protected readonly _dir: Directionality;
+    protected readonly _dir: Directionality | null;
     // (undocumented)
-    protected readonly _elementRef: ElementRef;
+    protected readonly _elementRef: ElementRef<any>;
     get fixedLayout(): boolean;
     set fixedLayout(value: boolean);
     // (undocumented)
@@ -373,7 +365,7 @@ export class CdkTable<T> implements AfterContentInit, AfterContentChecked, Colle
     _rowOutlet: DataRowOutlet;
     setNoDataRow(noDataRow: CdkNoDataRow | null): void;
     protected stickyCssClass: string;
-    // @deprecated (undocumented)
+    // (undocumented)
     protected readonly _stickyPositioningListener: StickyPositioningListener;
     get trackBy(): TrackByFunction<T>;
     set trackBy(fn: TrackByFunction<T>);
@@ -389,7 +381,7 @@ export class CdkTable<T> implements AfterContentInit, AfterContentChecked, Colle
     // (undocumented)
     static ɵcmp: i0.ɵɵComponentDeclaration<CdkTable<any>, "cdk-table, table[cdk-table]", ["cdkTable"], { "trackBy": { "alias": "trackBy"; "required": false; }; "dataSource": { "alias": "dataSource"; "required": false; }; "multiTemplateDataRows": { "alias": "multiTemplateDataRows"; "required": false; }; "fixedLayout": { "alias": "fixedLayout"; "required": false; }; }, { "contentChanged": "contentChanged"; }, ["_noDataRow", "_contentColumnDefs", "_contentRowDefs", "_contentHeaderRowDefs", "_contentFooterRowDefs"], ["caption", "colgroup, col", "*"], true, never>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<CdkTable<any>, [null, null, null, { attribute: "role"; }, { optional: true; }, null, null, null, null, null, { optional: true; skipSelf: true; }, { optional: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<CdkTable<any>, never>;
 }
 
 // @public
@@ -407,7 +399,7 @@ export class CdkTableModule {
 
 // @public
 export class CdkTextColumn<T> implements OnDestroy, OnInit {
-    constructor(_table: CdkTable<T>, _options: TextColumnOptions<T>);
+    constructor(...args: unknown[]);
     cell: CdkCellDef;
     columnDef: CdkColumnDef;
     _createDefaultHeaderText(): string;
@@ -426,7 +418,7 @@ export class CdkTextColumn<T> implements OnDestroy, OnInit {
     // (undocumented)
     static ɵcmp: i0.ɵɵComponentDeclaration<CdkTextColumn<any>, "cdk-text-column", never, { "name": { "alias": "name"; "required": false; }; "headerText": { "alias": "headerText"; "required": false; }; "dataAccessor": { "alias": "dataAccessor"; "required": false; }; "justify": { "alias": "justify"; "required": false; }; }, {}, never, never, true, never>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<CdkTextColumn<any>, [{ optional: true; }, { optional: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<CdkTextColumn<any>, never>;
 }
 
 // @public
@@ -440,7 +432,7 @@ export const _COALESCED_STYLE_SCHEDULER: InjectionToken<_CoalescedStyleScheduler
 
 // @public
 export class _CoalescedStyleScheduler {
-    constructor(_unusedNgZone?: NgZone);
+    constructor(...args: unknown[]);
     schedule(task: () => unknown): void;
     scheduleEnd(task: () => unknown): void;
     // (undocumented)
@@ -454,9 +446,9 @@ export type Constructor<T> = new (...args: any[]) => T;
 
 // @public
 export class DataRowOutlet implements RowOutlet {
-    constructor(viewContainer: ViewContainerRef, elementRef: ElementRef);
+    constructor(...args: unknown[]);
     // (undocumented)
-    elementRef: ElementRef;
+    elementRef: ElementRef<any>;
     // (undocumented)
     viewContainer: ViewContainerRef;
     // (undocumented)
@@ -469,9 +461,9 @@ export { DataSource }
 
 // @public
 export class FooterRowOutlet implements RowOutlet {
-    constructor(viewContainer: ViewContainerRef, elementRef: ElementRef);
+    constructor(...args: unknown[]);
     // (undocumented)
-    elementRef: ElementRef;
+    elementRef: ElementRef<any>;
     // (undocumented)
     viewContainer: ViewContainerRef;
     // (undocumented)
@@ -482,9 +474,9 @@ export class FooterRowOutlet implements RowOutlet {
 
 // @public
 export class HeaderRowOutlet implements RowOutlet {
-    constructor(viewContainer: ViewContainerRef, elementRef: ElementRef);
+    constructor(...args: unknown[]);
     // (undocumented)
-    elementRef: ElementRef;
+    elementRef: ElementRef<any>;
     // (undocumented)
     viewContainer: ViewContainerRef;
     // (undocumented)
@@ -498,9 +490,9 @@ export function mixinHasStickyInput<T extends Constructor<{}>>(base: T): CanStic
 
 // @public
 export class NoDataRowOutlet implements RowOutlet {
-    constructor(viewContainer: ViewContainerRef, elementRef: ElementRef);
+    constructor(...args: unknown[]);
     // (undocumented)
-    elementRef: ElementRef;
+    elementRef: ElementRef<any>;
     // (undocumented)
     viewContainer: ViewContainerRef;
     // (undocumented)

--- a/tools/public_api_guard/cdk/text-field.md
+++ b/tools/public_api_guard/cdk/text-field.md
@@ -9,12 +9,10 @@ import { DoCheck } from '@angular/core';
 import { ElementRef } from '@angular/core';
 import { EventEmitter } from '@angular/core';
 import * as i0 from '@angular/core';
-import { NgZone } from '@angular/core';
 import { NumberInput } from '@angular/cdk/coercion';
 import { Observable } from 'rxjs';
 import { OnDestroy } from '@angular/core';
 import { OnInit } from '@angular/core';
-import { Platform } from '@angular/cdk/platform';
 
 // @public
 export type AutofillEvent = {
@@ -24,7 +22,7 @@ export type AutofillEvent = {
 
 // @public
 export class AutofillMonitor implements OnDestroy {
-    constructor(_platform: Platform, _ngZone: NgZone);
+    constructor(...args: unknown[]);
     monitor(element: Element): Observable<AutofillEvent>;
     monitor(element: ElementRef<Element>): Observable<AutofillEvent>;
     // (undocumented)
@@ -39,7 +37,7 @@ export class AutofillMonitor implements OnDestroy {
 
 // @public
 export class CdkAutofill implements OnDestroy, OnInit {
-    constructor(_elementRef: ElementRef<HTMLElement>, _autofillMonitor: AutofillMonitor);
+    constructor(...args: unknown[]);
     readonly cdkAutofill: EventEmitter<AutofillEvent>;
     // (undocumented)
     ngOnDestroy(): void;
@@ -53,9 +51,8 @@ export class CdkAutofill implements OnDestroy, OnInit {
 
 // @public
 export class CdkTextareaAutosize implements AfterViewInit, DoCheck, OnDestroy {
-    constructor(_elementRef: ElementRef<HTMLElement>, _platform: Platform, _ngZone: NgZone,
-    document?: any);
-    protected _document?: Document;
+    constructor(...args: unknown[]);
+    protected _document?: Document | null | undefined;
     get enabled(): boolean;
     set enabled(value: boolean);
     get maxRows(): number;
@@ -82,7 +79,7 @@ export class CdkTextareaAutosize implements AfterViewInit, DoCheck, OnDestroy {
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<CdkTextareaAutosize, "textarea[cdkTextareaAutosize]", ["cdkTextareaAutosize"], { "minRows": { "alias": "cdkAutosizeMinRows"; "required": false; }; "maxRows": { "alias": "cdkAutosizeMaxRows"; "required": false; }; "enabled": { "alias": "cdkTextareaAutosize"; "required": false; }; "placeholder": { "alias": "placeholder"; "required": false; }; }, {}, never, never, true, never>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<CdkTextareaAutosize, [null, null, null, { optional: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<CdkTextareaAutosize, never>;
 }
 
 // @public (undocumented)

--- a/tools/public_api_guard/cdk/tree.md
+++ b/tools/public_api_guard/cdk/tree.md
@@ -8,10 +8,8 @@ import { AfterContentChecked } from '@angular/core';
 import { AfterContentInit } from '@angular/core';
 import { AfterViewInit } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
-import { ChangeDetectorRef } from '@angular/core';
 import { CollectionViewer } from '@angular/cdk/collections';
 import { DataSource } from '@angular/cdk/collections';
-import { Directionality } from '@angular/cdk/bidi';
 import { ElementRef } from '@angular/core';
 import { EventEmitter } from '@angular/core';
 import * as i0 from '@angular/core';
@@ -57,7 +55,7 @@ export const CDK_TREE_NODE_OUTLET_NODE: InjectionToken<{}>;
 
 // @public
 export class CdkNestedTreeNode<T, K = T> extends CdkTreeNode<T, K> implements AfterContentInit, OnDestroy, OnInit {
-    constructor(elementRef: ElementRef<HTMLElement>, tree: CdkTree<T, K>, _differs: IterableDiffers);
+    constructor(...args: unknown[]);
     protected _children: T[];
     protected _clear(): void;
     // (undocumented)
@@ -78,7 +76,7 @@ export class CdkNestedTreeNode<T, K = T> extends CdkTreeNode<T, K> implements Af
 
 // @public
 export class CdkTree<T, K = T> implements AfterContentChecked, AfterContentInit, AfterViewInit, CollectionViewer, OnDestroy, OnInit {
-    constructor(_differs: IterableDiffers, _changeDetectorRef: ChangeDetectorRef);
+    constructor(...args: unknown[]);
     childrenAccessor?: (dataNode: T) => T[] | Observable<T[]>;
     collapse(dataNode: T): void;
     collapseAll(): void;
@@ -149,7 +147,7 @@ export class CdkTreeModule {
 
 // @public
 export class CdkTreeNode<T, K = T> implements OnDestroy, OnInit, TreeKeyManagerItem {
-    constructor(_elementRef: ElementRef<HTMLElement>, _tree: CdkTree<T, K>);
+    constructor(...args: unknown[]);
     activate(): void;
     readonly activation: EventEmitter<T>;
     collapse(): void;
@@ -217,8 +215,7 @@ export class CdkTreeNode<T, K = T> implements OnDestroy, OnInit, TreeKeyManagerI
 
 // @public
 export class CdkTreeNodeDef<T> {
-    constructor(template: TemplateRef<any>);
-    // (undocumented)
+    constructor(...args: unknown[]);
     template: TemplateRef<any>;
     when: (index: number, nodeData: T) => boolean;
     // (undocumented)
@@ -229,15 +226,15 @@ export class CdkTreeNodeDef<T> {
 
 // @public
 export class CdkTreeNodeOutlet {
-    constructor(viewContainer: ViewContainerRef, _node?: any);
+    constructor(...args: unknown[]);
     // (undocumented)
-    _node?: any;
+    _node?: {} | null | undefined;
     // (undocumented)
     viewContainer: ViewContainerRef;
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<CdkTreeNodeOutlet, "[cdkTreeNodeOutlet]", never, {}, {}, never, never, true, never>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<CdkTreeNodeOutlet, [null, { optional: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<CdkTreeNodeOutlet, never>;
 }
 
 // @public
@@ -251,7 +248,7 @@ export class CdkTreeNodeOutletContext<T> {
 
 // @public
 export class CdkTreeNodePadding<T, K = T> implements OnDestroy {
-    constructor(_treeNode: CdkTreeNode<T, K>, _tree: CdkTree<T, K>, _element: ElementRef<HTMLElement>, _dir: Directionality);
+    constructor(...args: unknown[]);
     get indent(): number | string;
     set indent(indent: number | string);
     // (undocumented)
@@ -273,12 +270,12 @@ export class CdkTreeNodePadding<T, K = T> implements OnDestroy {
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<CdkTreeNodePadding<any, any>, "[cdkTreeNodePadding]", never, { "level": { "alias": "cdkTreeNodePadding"; "required": false; }; "indent": { "alias": "cdkTreeNodePaddingIndent"; "required": false; }; }, {}, never, never, true, never>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<CdkTreeNodePadding<any, any>, [null, null, null, { optional: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<CdkTreeNodePadding<any, any>, never>;
 }
 
 // @public
 export class CdkTreeNodeToggle<T, K = T> {
-    constructor(_tree: CdkTree<T, K>, _treeNode: CdkTreeNode<T, K>);
+    constructor(...args: unknown[]);
     // (undocumented)
     static ngAcceptInputType_recursive: unknown;
     recursive: boolean;


### PR DESCRIPTION
Reworks all of the CDK directives and injectables to use the `inject` function instead of constructor-based injection. All the constructors have a backwards-compatible signature for the apps that may be extending them.