### PR TITLE
fix(cdk/drag-drop): account for scale when setting free drag position

### DIFF
--- a/src/cdk/drag-drop/directives/drag.ts
+++ b/src/cdk/drag-drop/directives/drag.ts
@@ -314,6 +314,7 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
       () => {
         this._updateRootElement();
         this._setupHandlesListener();
+        this._dragRef.scale = this.scale;
 
         if (this.freeDragPosition) {
           this._dragRef.setFreeDragPosition(this.freeDragPosition);
@@ -332,6 +333,9 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
     if (rootSelectorChange && !rootSelectorChange.firstChange) {
       this._updateRootElement();
     }
+
+    // Scale affects the free drag position so we need to sync it up here.
+    this._dragRef.scale = this.scale;
 
     // Skip the first change since it's being handled in the `afterNextRender` queued up in the
     // constructor.

--- a/src/cdk/drag-drop/directives/standalone-drag.spec.ts
+++ b/src/cdk/drag-drop/directives/standalone-drag.spec.ts
@@ -1371,6 +1371,20 @@ describe('Standalone CdkDrag', () => {
     expect(dragElement.style.transform).toBe('translate3d(150px, 300px, 0px)');
   }));
 
+  it('should account for the scale when setting the free drag position', fakeAsync(() => {
+    const fixture = createComponent(StandaloneDraggable);
+    fixture.componentInstance.scale = 0.5;
+    fixture.componentInstance.freeDragPosition = {x: 50, y: 100};
+    fixture.changeDetectorRef.markForCheck();
+    fixture.detectChanges();
+
+    const dragElement = fixture.componentInstance.dragElement.nativeElement;
+    const dragInstance = fixture.componentInstance.dragInstance;
+
+    expect(dragElement.style.transform).toBe('translate3d(100px, 200px, 0px)');
+    expect(dragInstance.getFreeDragPosition()).toEqual({x: 50, y: 100});
+  }));
+
   it('should include the dragged distance as the user is dragging', fakeAsync(() => {
     const fixture = createComponent(StandaloneDraggable);
     fixture.detectChanges();


### PR DESCRIPTION
Fixes that the scale was only being synced when the user drags, but we need it also when setting the free drag position.

Fixes #29737.