### PR TITLE
feat(material-date-fns-adapter): add support for date-fns 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "browser-sync": "2.26.13",
     "chalk": "^4.1.0",
     "cross-env": "^7.0.3",
-    "date-fns": "^3.0.6",
+    "date-fns": "^4.1.0",
     "dgeni": "^0.4.14",
     "dgeni-packages": "^0.29.5",
     "esbuild": "^0.17.5",

--- a/src/material-date-fns-adapter/package.json
+++ b/src/material-date-fns-adapter/package.json
@@ -14,7 +14,7 @@
   "peerDependencies": {
     "@angular/material": "0.0.0-PLACEHOLDER",
     "@angular/core": "0.0.0-NG",
-    "date-fns": ">2.20.0 <4.0"
+    "date-fns": ">2.20.0 <5.0"
   },
   "dependencies": {
     "tslib": "0.0.0-TSLIB"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6653,10 +6653,10 @@ data-uri-to-buffer@^6.0.2:
   resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz#8a58bb67384b261a38ef18bea1810cb01badd28b"
   integrity sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==
 
-date-fns@^3.0.6:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-3.6.0.tgz#f20ca4fe94f8b754951b24240676e8618c0206bf"
-  integrity sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==
+date-fns@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-4.1.0.tgz#64b3d83fff5aa80438f5b1a633c2e83b8a1c2d14"
+  integrity sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==
 
 date-format@^4.0.14:
   version "4.0.14"


### PR DESCRIPTION
Updates the `date-fns` adapter to support version 4.

Fixes #29740.