### PR TITLE
docs(material/select): prevent select from jumping in custom trigger example

### DIFF
--- a/src/components-examples/material/select/select-custom-trigger/select-custom-trigger-example.css
+++ b/src/components-examples/material/select/select-custom-trigger/select-custom-trigger-example.css
@@ -1,4 +1,5 @@
 .example-additional-selection {
   opacity: 0.75;
   font-size: 0.75em;
+  line-height: 1;
 }


### PR DESCRIPTION
The `mat-select` in the custom trigger example was jumping around, because the projected `span` didn't have a `line-height`.

Fixes #29743.