### PR TITLE
feat(google-maps/map-advanced-marker): Add support for some mouse events #29741

### DIFF
--- a/src/google-maps/map-advanced-marker/map-advanced-marker.spec.ts
+++ b/src/google-maps/map-advanced-marker/map-advanced-marker.spec.ts
@@ -127,6 +127,11 @@ describe('MapAdvancedMarker', () => {
     flush();
 
     expect(addSpy).toHaveBeenCalledWith('click', jasmine.any(Function));
+    expect(addSpy).toHaveBeenCalledWith('dblclick', jasmine.any(Function));
+    expect(addSpy).toHaveBeenCalledWith('mouseout', jasmine.any(Function));
+    expect(addSpy).toHaveBeenCalledWith('mouseover', jasmine.any(Function));
+    expect(addSpy).toHaveBeenCalledWith('mouseup', jasmine.any(Function));
+    expect(addSpy).toHaveBeenCalledWith('rightclick', jasmine.any(Function));
     expect(addSpy).not.toHaveBeenCalledWith('drag', jasmine.any(Function));
     expect(addSpy).not.toHaveBeenCalledWith('dragend', jasmine.any(Function));
     expect(addSpy).not.toHaveBeenCalledWith('dragstart', jasmine.any(Function));
@@ -163,6 +168,11 @@ describe('MapAdvancedMarker', () => {
         [gmpDraggable]="gmpDraggable"
         [zIndex]="zIndex"
         (mapClick)="handleClick()"
+        (mapDblclick)="handleDblclick()"
+        (mapMouseout)="handleMouseout()"
+        (mapMouseover)="handleMouseover()"
+        (mapMouseup)="handleMouseup()"
+        (mapRightclick)="handleRightclick()"
         [options]="options" />
     </google-map>
   `,
@@ -179,4 +189,9 @@ class TestApp {
   options: google.maps.marker.AdvancedMarkerElementOptions;
 
   handleClick() {}
+  handleDblclick() {}
+  handleMouseout() {}
+  handleMouseover() {}
+  handleMouseup() {}
+  handleRightclick() {}
 }

--- a/src/google-maps/map-advanced-marker/map-advanced-marker.ts
+++ b/src/google-maps/map-advanced-marker/map-advanced-marker.ts
@@ -125,6 +125,36 @@ export class MapAdvancedMarker implements OnInit, OnChanges, OnDestroy, MapAncho
     this._eventManager.getLazyEmitter<google.maps.MapMouseEvent>('click');
 
   /**
+   * This event is fired when the AdvancedMarkerElement is double-clicked.
+   */
+  @Output() readonly mapDblclick: Observable<google.maps.MapMouseEvent> =
+    this._eventManager.getLazyEmitter<google.maps.MapMouseEvent>('dblclick');
+
+  /**
+   * This event is fired when the mouse moves out of the AdvancedMarkerElement.
+   */
+  @Output() readonly mapMouseout: Observable<google.maps.MapMouseEvent> =
+    this._eventManager.getLazyEmitter<google.maps.MapMouseEvent>('mouseout');
+
+  /**
+   * This event is fired when the mouse moves over the AdvancedMarkerElement.
+   */
+  @Output() readonly mapMouseover: Observable<google.maps.MapMouseEvent> =
+    this._eventManager.getLazyEmitter<google.maps.MapMouseEvent>('mouseover');
+
+  /**
+   * This event is fired when the mouse button is released over the AdvancedMarkerElement.
+   */
+  @Output() readonly mapMouseup: Observable<google.maps.MapMouseEvent> =
+    this._eventManager.getLazyEmitter<google.maps.MapMouseEvent>('mouseup');
+
+  /**
+   * This event is fired when the AdvancedMarkerElement is right-clicked.
+   */
+  @Output() readonly mapRightclick: Observable<google.maps.MapMouseEvent> =
+    this._eventManager.getLazyEmitter<google.maps.MapMouseEvent>('rightclick');
+
+  /**
    * This event is repeatedly fired while the user drags the AdvancedMarkerElement.
    * https://developers.google.com/maps/documentation/javascript/reference/advanced-markers#AdvancedMarkerElement.drag
    */

--- a/tools/public_api_guard/google-maps/google-maps.md
+++ b/tools/public_api_guard/google-maps/google-maps.md
@@ -143,9 +143,14 @@ export class MapAdvancedMarker implements OnInit, OnChanges, OnDestroy, MapAncho
     getAnchor(): google.maps.marker.AdvancedMarkerElement;
     set gmpDraggable(draggable: boolean);
     readonly mapClick: Observable<google.maps.MapMouseEvent>;
+    readonly mapDblclick: Observable<google.maps.MapMouseEvent>;
     readonly mapDrag: Observable<google.maps.MapMouseEvent>;
     readonly mapDragend: Observable<google.maps.MapMouseEvent>;
     readonly mapDragstart: Observable<google.maps.MapMouseEvent>;
+    readonly mapMouseout: Observable<google.maps.MapMouseEvent>;
+    readonly mapMouseover: Observable<google.maps.MapMouseEvent>;
+    readonly mapMouseup: Observable<google.maps.MapMouseEvent>;
+    readonly mapRightclick: Observable<google.maps.MapMouseEvent>;
     readonly markerInitialized: EventEmitter<google.maps.marker.AdvancedMarkerElement>;
     // (undocumented)
     ngOnChanges(changes: SimpleChanges): void;
@@ -158,7 +163,7 @@ export class MapAdvancedMarker implements OnInit, OnChanges, OnDestroy, MapAncho
     set title(title: string);
     set zIndex(zIndex: number);
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<MapAdvancedMarker, "map-advanced-marker", ["mapAdvancedMarker"], { "title": { "alias": "title"; "required": false; }; "position": { "alias": "position"; "required": false; }; "content": { "alias": "content"; "required": false; }; "gmpDraggable": { "alias": "gmpDraggable"; "required": false; }; "options": { "alias": "options"; "required": false; }; "zIndex": { "alias": "zIndex"; "required": false; }; }, { "mapClick": "mapClick"; "mapDrag": "mapDrag"; "mapDragend": "mapDragend"; "mapDragstart": "mapDragstart"; "markerInitialized": "markerInitialized"; }, never, never, true, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<MapAdvancedMarker, "map-advanced-marker", ["mapAdvancedMarker"], { "title": { "alias": "title"; "required": false; }; "position": { "alias": "position"; "required": false; }; "content": { "alias": "content"; "required": false; }; "gmpDraggable": { "alias": "gmpDraggable"; "required": false; }; "options": { "alias": "options"; "required": false; }; "zIndex": { "alias": "zIndex"; "required": false; }; }, { "mapClick": "mapClick"; "mapDblclick": "mapDblclick"; "mapMouseout": "mapMouseout"; "mapMouseover": "mapMouseover"; "mapMouseup": "mapMouseup"; "mapRightclick": "mapRightclick"; "mapDrag": "mapDrag"; "mapDragend": "mapDragend"; "mapDragstart": "mapDragstart"; "markerInitialized": "markerInitialized"; }, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MapAdvancedMarker, never>;
 }


### PR DESCRIPTION
This PR adds support for the following mouse events to the map-advanced-marker component:

- Double click (dblclick)
- Mouse out (mouseout)
- Mouse over (mouseover)
- Mouse up (mouseup)
- Right click (right-click)

These events were available in the deprecated map-marker and are now implemented to enable similar functionality in map-advanced-marker.

**Testing:**
- Unit tests added for each event.