### PR TITLE
fix(cdk/tree): resolve maximum call stack error

### DIFF
--- a/src/cdk/tree/tree.ts
+++ b/src/cdk/tree/tree.ts
@@ -551,9 +551,15 @@ export class CdkTree<T, K = T>
       }
     });
 
-    // TODO: change to `this._changeDetectorRef.markForCheck()`, or just switch this component to
-    // use signals.
-    this._changeDetectorRef.detectChanges();
+    // Note: we only `detectChanges` from a top-level call, otherwise we risk overflowing
+    // the call stack since this method is called recursively (see #29733.)
+    // TODO: change to `this._changeDetectorRef.markForCheck()`,
+    // or just switch this component to use signals.
+    if (parentData) {
+      this._changeDetectorRef.markForCheck();
+    } else {
+      this._changeDetectorRef.detectChanges();
+    }
   }
 
   /**


### PR DESCRIPTION
The CDK tree was calling `ChangeDetectorRef.detectChanges` recursively for each node in the tree which was overflowing the call stack with some larger trees.

These changes resolve the issue by only calling `detectChanges` on the root.

Fixes #29733.