### PR TITLE
feat(cdk/private): create cdk-visually-hidden style loader

### DIFF
--- a/src/cdk/private/BUILD.bazel
+++ b/src/cdk/private/BUILD.bazel
@@ -17,7 +17,7 @@ ng_module(
 sass_binary(
     name = "visually-hidden-styles",
     src = ":visually-hidden/visually-hidden.scss",
-    deps = ["@npm//@angular/cdk"],
+    deps = ["//src/cdk/a11y:a11y_scss_lib"],
 )
 
 markdown_to_html(

--- a/src/cdk/private/BUILD.bazel
+++ b/src/cdk/private/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//tools:defaults.bzl", "markdown_to_html", "ng_module")
+load("//tools:defaults.bzl", "markdown_to_html", "ng_module", "sass_binary")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -8,9 +8,15 @@ ng_module(
         ["**/*.ts"],
         exclude = ["**/*.spec.ts"],
     ),
+    assets = [":visually-hidden-styles"],
     deps = [
         "@npm//@angular/core",
     ],
+)
+
+sass_binary(
+    name = "visually-hidden-styles",
+    src = ":visually-hidden/visually-hidden.scss",
 )
 
 markdown_to_html(

--- a/src/cdk/private/BUILD.bazel
+++ b/src/cdk/private/BUILD.bazel
@@ -17,6 +17,7 @@ ng_module(
 sass_binary(
     name = "visually-hidden-styles",
     src = ":visually-hidden/visually-hidden.scss",
+    deps = ["@npm//@angular/cdk"],
 )
 
 markdown_to_html(

--- a/src/cdk/private/public-api.ts
+++ b/src/cdk/private/public-api.ts
@@ -7,3 +7,4 @@
  */
 
 export * from './style-loader';
+export * from './visually-hidden/visually-hidden';

--- a/src/cdk/private/visually-hidden/visually-hidden.scss
+++ b/src/cdk/private/visually-hidden/visually-hidden.scss
@@ -1,34 +1,3 @@
-/// This class can be applied to an element to make that element
-/// visually hidden while remaining available to assistive technology.
-.cdk-visually-hidden {
-  border: 0;
-  clip: rect(0 0 0 0);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  width: 1px;
+@use '@angular/cdk';
 
-  // This works around a Chrome bug that can cause the tab to crash when large amounts of
-  // non-English text get wrapped: https://bugs.chromium.org/p/chromium/issues/detail?id=1201444
-  white-space: nowrap;
-
-  // Avoid browsers rendering the focus ring in some cases.
-  outline: 0;
-
-  // Avoid some cases where the browser will still render the native controls (see #9049).
-  -webkit-appearance: none;
-  -moz-appearance: none;
-
-  // We need at least one of top/bottom/left/right in order to prevent cases where the
-  // absolute-positioned element is pushed down and can affect scrolling (see #24597).
-  // `left` was chosen here, because it's the least likely to break overrides where the
-  // element might have been positioned (e.g. `mat-checkbox`).
-  left: 0;
-
-  [dir='rtl'] & {
-    left: auto;
-    right: 0;
-  }
-}
+@include cdk.a11y-visually-hidden();

--- a/src/cdk/private/visually-hidden/visually-hidden.scss
+++ b/src/cdk/private/visually-hidden/visually-hidden.scss
@@ -1,0 +1,34 @@
+/// This class can be applied to an element to make that element
+/// visually hidden while remaining available to assistive technology.
+.cdk-visually-hidden {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+
+  // This works around a Chrome bug that can cause the tab to crash when large amounts of
+  // non-English text get wrapped: https://bugs.chromium.org/p/chromium/issues/detail?id=1201444
+  white-space: nowrap;
+
+  // Avoid browsers rendering the focus ring in some cases.
+  outline: 0;
+
+  // Avoid some cases where the browser will still render the native controls (see #9049).
+  -webkit-appearance: none;
+  -moz-appearance: none;
+
+  // We need at least one of top/bottom/left/right in order to prevent cases where the
+  // absolute-positioned element is pushed down and can affect scrolling (see #24597).
+  // `left` was chosen here, because it's the least likely to break overrides where the
+  // element might have been positioned (e.g. `mat-checkbox`).
+  left: 0;
+
+  [dir='rtl'] & {
+    left: auto;
+    right: 0;
+  }
+}

--- a/src/cdk/private/visually-hidden/visually-hidden.scss
+++ b/src/cdk/private/visually-hidden/visually-hidden.scss
@@ -1,3 +1,3 @@
-@use '@angular/cdk';
+@use '../../a11y';
 
-@include cdk.a11y-visually-hidden();
+@include a11y.a11y-visually-hidden();

--- a/src/cdk/private/visually-hidden/visually-hidden.ts
+++ b/src/cdk/private/visually-hidden/visually-hidden.ts
@@ -1,0 +1,22 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ChangeDetectionStrategy, Component, ViewEncapsulation} from '@angular/core';
+
+/**
+ * Component used to load the .cdk-visually-hidden styles.
+ * @docs-private
+ */
+@Component({
+  standalone: true,
+  styleUrl: 'visually-hidden.css',
+  encapsulation: ViewEncapsulation.None,
+  template: '',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class _VisuallyHiddenLoader {}

--- a/src/cdk/private/visually-hidden/visually-hidden.ts
+++ b/src/cdk/private/visually-hidden/visually-hidden.ts
@@ -15,6 +15,7 @@ import {ChangeDetectionStrategy, Component, ViewEncapsulation} from '@angular/co
 @Component({
   standalone: true,
   styleUrl: 'visually-hidden.css',
+  exportAs: 'cdkVisuallyHidden',
   encapsulation: ViewEncapsulation.None,
   template: '',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/cdk/private/visually-hidden/visually-hidden.ts
+++ b/src/cdk/private/visually-hidden/visually-hidden.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {ChangeDetectionStrategy, Component, ViewEncapsulation} from '@angular/core';

--- a/tools/public_api_guard/cdk/private.md
+++ b/tools/public_api_guard/cdk/private.md
@@ -16,6 +16,14 @@ export class _CdkPrivateStyleLoader {
     static ɵprov: i0.ɵɵInjectableDeclaration<_CdkPrivateStyleLoader>;
 }
 
+// @public
+export class _VisuallyHiddenLoader {
+    // (undocumented)
+    static ɵcmp: i0.ɵɵComponentDeclaration<_VisuallyHiddenLoader, "ng-component", never, {}, {}, never, never, true, never>;
+    // (undocumented)
+    static ɵfac: i0.ɵɵFactoryDeclaration<_VisuallyHiddenLoader, never>;
+}
+
 // (No @packageDocumentation comment for this package)
 
 ```

--- a/tools/public_api_guard/cdk/private.md
+++ b/tools/public_api_guard/cdk/private.md
@@ -19,7 +19,7 @@ export class _CdkPrivateStyleLoader {
 // @public
 export class _VisuallyHiddenLoader {
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<_VisuallyHiddenLoader, "ng-component", never, {}, {}, never, never, true, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<_VisuallyHiddenLoader, "ng-component", ["cdkVisuallyHidden"], {}, {}, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<_VisuallyHiddenLoader, never>;
 }


### PR DESCRIPTION
This is part of a larger effort to remove the `mat.core()` mixin. The goal of this PR is to provide a way for components to load the styles for the `.cdk-visually-hidden` class without needing it to be loaded via `mat.core()`'s call to `cdk.a11y-visually-hidden()`.