### PR TITLE
fix(material/list): fix text trim

### DIFF
--- a/src/material/list/list-item-sections.ts
+++ b/src/material/list/list-item-sections.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, ElementRef, Inject, Optional} from '@angular/core';
+import {AfterViewInit, Directive, ElementRef, Inject, Optional} from '@angular/core';
 import {LIST_OPTION, ListOption} from './list-option-types';
 
 /**
@@ -35,7 +35,7 @@ export class MatListItemTitle {
   host: {'class': 'mat-mdc-list-item-line mdc-list-item__secondary-text'},
   standalone: true,
 })
-export class MatListItemLine {
+export class MatListItemLine implements AfterViewInit {
   constructor(public _elementRef: ElementRef<HTMLElement>) {}
 
   ngAfterViewInit() {

--- a/src/material/list/list-item-sections.ts
+++ b/src/material/list/list-item-sections.ts
@@ -39,12 +39,12 @@ export class MatListItemLine implements AfterViewInit {
   constructor(public _elementRef: ElementRef<HTMLElement>) {}
 
   ngAfterViewInit() {
-    this.addTitleToTruncatedText();
+    this._addTitleToTruncatedText();
   }
 
   // In case text overflow is triggered and ellipsis is applied, adds role='tooltip' and title
   // attribute to container so visual users can see the full text on hover
-  addTitleToTruncatedText() {
+  private _addTitleToTruncatedText() {
     if (this._elementRef.nativeElement.offsetWidth < this._elementRef.nativeElement.scrollWidth) {
       this._elementRef.nativeElement.setAttribute('role', 'tooltip');
       this._elementRef.nativeElement.setAttribute(

--- a/src/material/list/list-item-sections.ts
+++ b/src/material/list/list-item-sections.ts
@@ -37,6 +37,25 @@ export class MatListItemTitle {
 })
 export class MatListItemLine {
   constructor(public _elementRef: ElementRef<HTMLElement>) {}
+
+  ngAfterViewInit() {
+    this.addTitleToTruncatedText();
+  }
+
+  // In case text overflow is triggered and ellipsis is applied, adds role='tooltip' and title
+  // attribute to container so visual users can see the full text on hover
+  addTitleToTruncatedText() {
+    if (this._elementRef.nativeElement.offsetWidth < this._elementRef.nativeElement.scrollWidth) {
+      this._elementRef.nativeElement.setAttribute('role', 'tooltip');
+      this._elementRef.nativeElement.setAttribute(
+        'title',
+        this._elementRef.nativeElement.innerText,
+      );
+    } else {
+      this._elementRef.nativeElement.removeAttribute('role');
+      this._elementRef.nativeElement.removeAttribute('title');
+    }
+  }
 }
 
 /**

--- a/tools/public_api_guard/material/list.md
+++ b/tools/public_api_guard/material/list.md
@@ -123,8 +123,6 @@ export class MatListItemIcon extends _MatListItemGraphicBase {
 export class MatListItemLine implements AfterViewInit {
     constructor(_elementRef: ElementRef<HTMLElement>);
     // (undocumented)
-    addTitleToTruncatedText(): void;
-    // (undocumented)
     _elementRef: ElementRef<HTMLElement>;
     // (undocumented)
     ngAfterViewInit(): void;

--- a/tools/public_api_guard/material/list.md
+++ b/tools/public_api_guard/material/list.md
@@ -120,7 +120,7 @@ export class MatListItemIcon extends _MatListItemGraphicBase {
 }
 
 // @public
-export class MatListItemLine {
+export class MatListItemLine implements AfterViewInit {
     constructor(_elementRef: ElementRef<HTMLElement>);
     // (undocumented)
     addTitleToTruncatedText(): void;

--- a/tools/public_api_guard/material/list.md
+++ b/tools/public_api_guard/material/list.md
@@ -123,7 +123,11 @@ export class MatListItemIcon extends _MatListItemGraphicBase {
 export class MatListItemLine {
     constructor(_elementRef: ElementRef<HTMLElement>);
     // (undocumented)
+    addTitleToTruncatedText(): void;
+    // (undocumented)
     _elementRef: ElementRef<HTMLElement>;
+    // (undocumented)
+    ngAfterViewInit(): void;
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<MatListItemLine, "[matListItemLine]", never, {}, {}, never, never, true, never>;
     // (undocumented)


### PR DESCRIPTION
fix text trim issue where visual users won't be able to see full text if list item text is overflowed in container and ellipsis is shown.

fixes b/291296866

After: https://screencast.googleplex.com/cast/NDc3NDY5OTE0OTAzMzQ3Mnw3MjJlZjA2ZS05MQ
NOTE: cursor is slightly off from text container in video for some reason