### PR TITLE
test(material/select): fix broken test

### DIFF
--- a/src/material/select/select.spec.ts
+++ b/src/material/select/select.spec.ts
@@ -143,7 +143,6 @@ describe('MatSelect', () => {
 
         it('should set the role of the select to combobox', () => {
           expect(select.getAttribute('role')).toEqual('combobox');
-          expect(select.getAttribute('aria-autocomplete')).toBe('none');
           expect(select.getAttribute('aria-haspopup')).toBe('listbox');
         });
 


### PR DESCRIPTION
After #29645, the assertion for `aria-autocomplete` isn't valid anymore.