### PR TITLE
docs(material/datepicker): Fixed typo in date-range-picker-selection-…

### DIFF
--- a/src/components-examples/material/datepicker/date-range-picker-selection-strategy/date-range-picker-selection-strategy-example.ts
+++ b/src/components-examples/material/datepicker/date-range-picker-selection-strategy/date-range-picker-selection-strategy-example.ts
@@ -31,7 +31,7 @@ export class FiveDayRangeSelectionStrategy<D> implements MatDateRangeSelectionSt
   }
 }
 
-/** @title Date range picker with custom a selection strategy */
+/** @title Date range picker with a custom selection strategy */
 @Component({
   selector: 'date-range-picker-selection-strategy-example',
   templateUrl: 'date-range-picker-selection-strategy-example.html',


### PR DESCRIPTION
…strategy-example

Current description is not gramatically correct