### PR TITLE
refactor: create mixins for core classes

### DIFF
--- a/src/dev-app/theme.scss
+++ b/src/dev-app/theme.scss
@@ -25,6 +25,8 @@ $candy-app-theme: mat.m2-define-light-theme((
 // have to load a single css file for Angular Material in your app.
 // **Be sure that you only ever include this mixin once!**
 @include mat.core();
+@include mat.app-background();
+@include mat.elevation-classes();
 
 // Include the default theme styles.
 @include mat.all-component-themes($candy-app-theme);

--- a/src/material/_index.scss
+++ b/src/material/_index.scss
@@ -36,7 +36,7 @@
 @forward './core/style/validation' as private-*;
 
 // Structural
-@forward './core/core' show core;
+@forward './core/core' show core, app-background, elevation-classes;
 @forward './core/ripple/ripple' show ripple;
 @forward './core/focus-indicators/private' show strong-focus-indicators,
   strong-focus-indicators-color, strong-focus-indicators-theme;

--- a/src/material/core/_core.scss
+++ b/src/material/core/_core.scss
@@ -42,3 +42,9 @@
     }
   }
 }
+
+// Mixin that provides the .mat-app-background class.
+@mixin app-background() {}
+
+// Mixin that provides the .mat-elevation-* classes.
+@mixin elevation-classes() {}

--- a/src/universal-app/styles.scss
+++ b/src/universal-app/styles.scss
@@ -1,6 +1,7 @@
 @use '@angular/material' as mat;
 
 @include mat.core();
+@include mat.app-background();
 
 $theme: mat.define-theme((
   color: (


### PR DESCRIPTION
* This is an intermediary step so we can roll out calls to these empty mixins progressively.
* Once all of the instances of mat.core have been updated to also call mat.app-background and mat.elevation-classes we can move the styles over without breaking any clients