### PR TITLE
docs(material/tabs): add dynamically aligned tabs group example

### DIFF
--- a/src/components-examples/material/tabs/tab-group-align/tab-group-align-example.css
+++ b/src/components-examples/material/tabs/tab-group-align/tab-group-align-example.css
@@ -1,3 +1,9 @@
 .mat-tab-group {
   margin-bottom: 48px;
 }
+
+.example-action-button {
+  margin-top: 8px;
+  margin-bottom: 8px;
+  margin-right: 8px;
+}

--- a/src/components-examples/material/tabs/tab-group-align/tab-group-align-example.html
+++ b/src/components-examples/material/tabs/tab-group-align/tab-group-align-example.html
@@ -1,19 +1,19 @@
+<button mat-raised-button class="example-action-button" (click)="alignment = 'start'">
+  Start
+</button>
+
+<button mat-raised-button class="example-action-button" (click)="alignment = 'center'">
+  Center
+</button>
+
+<button mat-raised-button class="example-action-button" (click)="alignment = 'end'">
+  End
+</button>
+
 <!-- #docregion align-start -->
-<mat-tab-group mat-stretch-tabs="false" mat-align-tabs="start">
-<!-- #enddocregion align-start -->
+<mat-tab-group mat-stretch-tabs="false" [mat-align-tabs]="alignment">
   <mat-tab label="First">Content 1</mat-tab>
   <mat-tab label="Second">Content 2</mat-tab>
   <mat-tab label="Third">Content 3</mat-tab>
 </mat-tab-group>
-
-<mat-tab-group mat-stretch-tabs="false" mat-align-tabs="center">
-  <mat-tab label="First">Content 1</mat-tab>
-  <mat-tab label="Second">Content 2</mat-tab>
-  <mat-tab label="Third">Content 3</mat-tab>
-</mat-tab-group>
-
-<mat-tab-group mat-stretch-tabs="false" mat-align-tabs="end">
-  <mat-tab label="First">Content 1</mat-tab>
-  <mat-tab label="Second">Content 2</mat-tab>
-  <mat-tab label="Third">Content 3</mat-tab>
-</mat-tab-group>
+<!-- #docregion align-end -->

--- a/src/components-examples/material/tabs/tab-group-align/tab-group-align-example.ts
+++ b/src/components-examples/material/tabs/tab-group-align/tab-group-align-example.ts
@@ -1,4 +1,5 @@
 import {Component} from '@angular/core';
+import {MatButtonModule} from '@angular/material/button';
 import {MatTabsModule} from '@angular/material/tabs';
 
 /**
@@ -8,6 +9,8 @@ import {MatTabsModule} from '@angular/material/tabs';
   selector: 'tab-group-align-example',
   templateUrl: 'tab-group-align-example.html',
   styleUrl: 'tab-group-align-example.css',
-  imports: [MatTabsModule],
+  imports: [MatTabsModule, MatButtonModule],
 })
-export class TabGroupAlignExample {}
+export class TabGroupAlignExample {
+  alignment: 'start' | 'center' | 'end' = 'start';
+}

--- a/src/material/tabs/tabs.md
+++ b/src/material/tabs/tabs.md
@@ -70,7 +70,7 @@ with the `matTabContent` attribute.
 
 ### Label alignment
 If you want to align the tab labels in the center or towards the end of the container, you can
-do so using the `[mat-align-tabs]` attribute.
+do so using the `mat-align-tabs` input or attribute.
 
  <!-- example({"example": "tab-group-align",
                "file": "tab-group-align-example.html",


### PR DESCRIPTION
adds an example for dynamically aligned tabs group

closes #29029

---
since I can't add preview label I shall attach screenshots.

![image](https://github.com/user-attachments/assets/c30f4a8f-052a-4060-93fb-3df1fa044519)
![image](https://github.com/user-attachments/assets/61c72c1a-4838-4ccc-bb1d-11db11674271)

