### PR TITLE
refactor(google-maps/map-advanced-marker): remove duplicate condition for setting content

### DIFF
--- a/src/google-maps/map-advanced-marker/map-advanced-marker.ts
+++ b/src/google-maps/map-advanced-marker/map-advanced-marker.ts
@@ -231,10 +231,6 @@ export class MapAdvancedMarker implements OnInit, OnChanges, OnDestroy, MapAncho
         advancedMarker.title = _title;
       }
 
-      if (changes['content']) {
-        advancedMarker.content = _content;
-      }
-
       if (changes['gmpDraggable']) {
         advancedMarker.gmpDraggable = _draggable;
       }


### PR DESCRIPTION
refactor(google-maps/map-advanced-marker): remove duplicate condition for setting content

Seems like the condition for setting the `advancedMarker.content` is redundant here:
![image](https://github.com/user-attachments/assets/b9011f50-afda-4569-8571-06ec49a6e12b)
I think it's safe to remove the first condition.