### PR TITLE
fix(cdk/drag-drop): positioning thrown off with align-self

### DIFF
--- a/src/cdk/drag-drop/resets.scss
+++ b/src/cdk/drag-drop/resets.scss
@@ -4,6 +4,10 @@
     border: none;
     padding: 0;
     color: inherit;
+
+    // Chrome sets a user agent style of `inset: 0` which combined
+    // with `align-self` can break the positioning (see #29809).
+    inset: auto;
   }
 }
 


### PR DESCRIPTION
Fixes that the combination of setting `align-self: center` and the user agent styling of `inset: 0` on popovers was breaking the positioning of the preview.

Fixes #29809.