### PR TITLE
perf(cdk/table): Use ResizeObservers instead of dom measurement to re…

### DIFF
--- a/tools/public_api_guard/cdk/table.md
+++ b/tools/public_api_guard/cdk/table.md
@@ -565,7 +565,7 @@ export class StickyStyler {
     _getStickyStartColumnPositions(widths: number[], stickyStates: boolean[]): number[];
     _removeStickyStyle(element: HTMLElement, stickyDirections: StickyDirection[]): void;
     stickRows(rowsToStick: HTMLElement[], stickyStates: boolean[], position: 'top' | 'bottom'): void;
-    updateStickyColumns(rows: HTMLElement[], stickyStartStates: boolean[], stickyEndStates: boolean[], recalculateCellWidths?: boolean): void;
+    updateStickyColumns(rows: HTMLElement[], stickyStartStates: boolean[], stickyEndStates: boolean[], recalculateCellWidths?: boolean, replay?: boolean): void;
     updateStickyFooterContainer(tableElement: Element, stickyStates: boolean[]): void;
 }
 


### PR DESCRIPTION
…duce layout thrashing (where possible)

There's still one set of measurements at startup. It might be possible to eliminate that along with some of the existing code  with some additional changes but as-is this is already a substantial improvement.