### PR TITLE
fix(material/snack-bar): creates default assertive aria-live if not specified

### DIFF
--- a/src/material/snack-bar/snack-bar-container.ts
+++ b/src/material/snack-bar/snack-bar-container.ts
@@ -93,8 +93,11 @@ export class MatSnackBarContainer extends BasePortalOutlet implements OnDestroy 
   /** The state of the snack bar animations. */
   _animationState = 'void';
 
-  /** aria-live value for the live region. */
-  _live: AriaLivePoliteness;
+  /**
+   * aria-live value for the live region. Set as 'assertive' by default if not specificed by
+   * developer.
+   */
+  _live?: AriaLivePoliteness | 'assertive';
 
   /**
    * Element that will have the `mdc-snackbar__label` class applied if the attached component


### PR DESCRIPTION
Updates Angular Material Snack-Bar component snack-bar-container's aria-live value from AriaLivePoliteness value to default to assertive if there is no given value. This is to fix existing bugs where the snack-bar content is not read by the screenreader when the snack-bar appears.

Fixes b/369493945