### PR TITLE
fix(material/datepicker): update documentation

### DIFF
--- a/src/material/datepicker/datepicker.md
+++ b/src/material/datepicker/datepicker.md
@@ -566,6 +566,10 @@ datepicker pop-up. However, ChromeOS intercepts this key combination at the OS l
 browser only receives a `PageDown` key event. Because of this behavior, you should always include an
 additional means of opening the pop-up, such as `MatDatepickerToggle`.
 
+`MatDatepickerToggle` must be included along with `MatDatepicker` for optimal mobile a11y 
+compatibility. Mobile screen reader users currently do not have a way to trigger the datepicker
+dialog without the icon button present.
+
 #### Keyboard interaction
 
 The datepicker supports the following keyboard shortcuts:


### PR DESCRIPTION
update Datepicker documentation for mobile a11y screen reader compatibility for datepickers with no icon buttons. will also be removing the two examples in the XAP gallery that have no Datepicker toggles in order to pass GAR testing. See cl/681589416

fixes b/292120265