### PR TITLE
fix(material/chips): Add missing padding to basic chips in M3

### DIFF
--- a/src/material/chips/chip.scss
+++ b/src/material/chips/chip.scss
@@ -88,7 +88,8 @@ $_avatar-trailing-padding: 8px;
       border-style: solid;
     }
 
-    .mat-mdc-standard-chip & {
+    .mat-mdc-standard-chip &,
+    .mat-mdc-basic-chip & {
       padding-left: $_action-padding;
       padding-right: $_action-padding;
     }


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/98d9676f-859a-4313-9233-bf3d740d04dd)

After:
![image](https://github.com/user-attachments/assets/09cd14bc-76de-4ad1-b7d3-1626d4480972)