### PR TITLE
fix(material/form-field): changes show/hide mechanism of mat-error for screenreaders

### DIFF
--- a/src/material/form-field/form-field.html
+++ b/src/material/form-field/form-field.html
@@ -97,27 +97,25 @@
 
 <div
   class="mat-mdc-form-field-subscript-wrapper mat-mdc-form-field-bottom-align"
+  aria-atomic="true"
+  aria-live="assertive"
   [class.mat-mdc-form-field-subscript-dynamic-size]="subscriptSizing === 'dynamic'"
 >
-  @switch (_getDisplayedMessages()) {
-    @case ('error') {
-      <div
-        class="mat-mdc-form-field-error-wrapper"
-        [@transitionMessages]="_subscriptAnimationState"
-      >
-        <ng-content select="mat-error, [matError]"></ng-content>
-      </div>
+  <div
+    class="mat-mdc-form-field-error-wrapper"
+    [@transitionMessages]="_subscriptAnimationState"
+  >
+    <ng-content select="mat-error, [matError]"></ng-content>
+  </div>
+  <div
+    class="mat-mdc-form-field-hint-wrapper"
+    [@transitionMessages]="_subscriptAnimationState"
+  >
+    @if (hintLabel) {
+      <mat-hint [id]="_hintLabelId">{{hintLabel}}</mat-hint>
     }
-
-    @case ('hint') {
-      <div class="mat-mdc-form-field-hint-wrapper" [@transitionMessages]="_subscriptAnimationState">
-        @if (hintLabel) {
-          <mat-hint [id]="_hintLabelId">{{hintLabel}}</mat-hint>
-        }
-        <ng-content select="mat-hint:not([align='end'])"></ng-content>
-        <div class="mat-mdc-form-field-hint-spacer"></div>
-        <ng-content select="mat-hint[align='end']"></ng-content>
-      </div>
-    }
-  }
+    <ng-content select="mat-hint:not([align='end'])"></ng-content>
+    <div class="mat-mdc-form-field-hint-spacer"></div>
+    <ng-content select="mat-hint[align='end']"></ng-content>
+  </div>
 </div>


### PR DESCRIPTION
Attempts to fix a bug with Angular Components Form-field component where the mat-error and mat-hint component are just visually hidden in the DOM, but visibility is toggled depending on the form field state. Also updates the .mat-mdc-form-field-subscript-wrapper to have aria-live=assertive in order to prioritize the error/hint being read when it appears.

Fixes b/370743693