### PR TITLE
fix(multiple): remove final references to ComponentFactoryResolver

### DIFF
--- a/src/cdk/dialog/dialog-config.ts
+++ b/src/cdk/dialog/dialog-config.ts
@@ -6,13 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {
-  ViewContainerRef,
-  ComponentFactoryResolver,
-  Injector,
-  StaticProvider,
-  Type,
-} from '@angular/core';
+import {ViewContainerRef, Injector, StaticProvider, Type} from '@angular/core';
 import {Direction} from '@angular/cdk/bidi';
 import {PositionStrategy, ScrollStrategy} from '@angular/cdk/overlay';
 import {BasePortalOutlet} from '@angular/cdk/portal';
@@ -140,8 +134,12 @@ export class DialogConfig<D = unknown, R = unknown, C extends BasePortalOutlet =
    */
   closeOnOverlayDetachments?: boolean = true;
 
-  /** Alternate `ComponentFactoryResolver` to use when resolving the associated component. */
-  componentFactoryResolver?: ComponentFactoryResolver;
+  /**
+   * Alternate `ComponentFactoryResolver` to use when resolving the associated component.
+   * @deprecated No longer used. Will be removed.
+   * @breaking-change 20.0.0
+   */
+  componentFactoryResolver?: unknown;
 
   /**
    * Providers that will be exposed to the contents of the dialog. Can also

--- a/src/cdk/dialog/dialog.ts
+++ b/src/cdk/dialog/dialog.ts
@@ -240,7 +240,6 @@ export class Dialog implements OnDestroy {
       containerType,
       config.viewContainerRef,
       Injector.create({parent: userInjector || this._injector, providers}),
-      config.componentFactoryResolver,
     );
     const containerRef = overlay.attach(containerPortal);
 
@@ -280,12 +279,7 @@ export class Dialog implements OnDestroy {
     } else {
       const injector = this._createInjector(config, dialogRef, dialogContainer, this._injector);
       const contentRef = dialogContainer.attachComponentPortal<C>(
-        new ComponentPortal(
-          componentOrTemplateRef,
-          config.viewContainerRef,
-          injector,
-          config.componentFactoryResolver,
-        ),
+        new ComponentPortal(componentOrTemplateRef, config.viewContainerRef, injector),
       );
       (dialogRef as {componentRef: ComponentRef<C>}).componentRef = contentRef;
       (dialogRef as {componentInstance: C}).componentInstance = contentRef.instance;

--- a/src/cdk/overlay/overlay.ts
+++ b/src/cdk/overlay/overlay.ts
@@ -11,7 +11,6 @@ import {DomPortalOutlet} from '@angular/cdk/portal';
 import {DOCUMENT, Location} from '@angular/common';
 import {
   ApplicationRef,
-  ComponentFactoryResolver,
   Injectable,
   Injector,
   NgZone,
@@ -31,9 +30,6 @@ import {ScrollStrategyOptions} from './scroll/index';
 /** Next overlay unique ID. */
 let nextUniqueId = 0;
 
-// Note that Overlay is *not* scoped to the app root because of the ComponentFactoryResolver
-// which needs to be different depending on where OverlayModule is imported.
-
 /**
  * Service to create Overlays. Overlays are dynamically added pieces of floating UI, meant to be
  * used as a low-level building block for other components. Dialogs, tooltips, menus,
@@ -46,7 +42,6 @@ let nextUniqueId = 0;
 export class Overlay {
   scrollStrategies = inject(ScrollStrategyOptions);
   private _overlayContainer = inject(OverlayContainer);
-  private _componentFactoryResolver = inject(ComponentFactoryResolver);
   private _positionBuilder = inject(OverlayPositionBuilder);
   private _keyboardDispatcher = inject(OverlayKeyboardDispatcher);
   private _injector = inject(Injector);
@@ -141,12 +136,6 @@ export class Overlay {
       this._appRef = this._injector.get<ApplicationRef>(ApplicationRef);
     }
 
-    return new DomPortalOutlet(
-      pane,
-      this._componentFactoryResolver,
-      this._appRef,
-      this._injector,
-      this._document,
-    );
+    return new DomPortalOutlet(pane, null, this._appRef, this._injector, this._document);
   }
 }

--- a/src/cdk/portal/dom-portal-outlet.ts
+++ b/src/cdk/portal/dom-portal-outlet.ts
@@ -25,7 +25,7 @@ export class DomPortalOutlet extends BasePortalOutlet {
 
   /**
    * @param outletElement Element into which the content is projected.
-   * @param _componentFactoryResolver Used to resolve the component factory.
+   * @param _unusedComponentFactoryResolver Used to resolve the component factory.
    *   Only required when attaching component portals.
    * @param _appRef Reference to the application. Only used in component portals when there
    *   is no `ViewContainerRef` available.
@@ -41,7 +41,7 @@ export class DomPortalOutlet extends BasePortalOutlet {
      * @deprecated No longer in use. To be removed.
      * @breaking-change 18.0.0
      */
-    _componentFactoryResolver?: any,
+    _unusedComponentFactoryResolver?: any,
     private _appRef?: ApplicationRef,
     private _defaultInjector?: Injector,
 

--- a/src/material/dialog/dialog-config.ts
+++ b/src/material/dialog/dialog-config.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ViewContainerRef, ComponentFactoryResolver, Injector} from '@angular/core';
+import {ViewContainerRef, Injector} from '@angular/core';
 import {Direction} from '@angular/cdk/bidi';
 import {ScrollStrategy} from '@angular/cdk/overlay';
 import {_defaultParams} from './dialog-animations';
@@ -133,8 +133,12 @@ export class MatDialogConfig<D = any> {
    */
   closeOnNavigation?: boolean = true;
 
-  /** Alternate `ComponentFactoryResolver` to use when resolving the associated component. */
-  componentFactoryResolver?: ComponentFactoryResolver;
+  /**
+   * Alternate `ComponentFactoryResolver` to use when resolving the associated component.
+   * @deprecated No longer used. Will be removed.
+   * @breaking-change 20.0.0
+   */
+  componentFactoryResolver?: unknown;
 
   /**
    * Duration of the enter animation in ms.

--- a/src/material/menu/menu-content.ts
+++ b/src/material/menu/menu-content.ts
@@ -11,7 +11,6 @@ import {DOCUMENT} from '@angular/common';
 import {
   ApplicationRef,
   ChangeDetectorRef,
-  ComponentFactoryResolver,
   Directive,
   InjectionToken,
   Injector,
@@ -37,7 +36,6 @@ export const MAT_MENU_CONTENT = new InjectionToken<MatMenuContent>('MatMenuConte
 })
 export class MatMenuContent implements OnDestroy {
   private _template = inject<TemplateRef<any>>(TemplateRef);
-  private _componentFactoryResolver = inject(ComponentFactoryResolver);
   private _appRef = inject(ApplicationRef);
   private _injector = inject(Injector);
   private _viewContainerRef = inject(ViewContainerRef);
@@ -68,7 +66,7 @@ export class MatMenuContent implements OnDestroy {
     if (!this._outlet) {
       this._outlet = new DomPortalOutlet(
         this._document.createElement('div'),
-        this._componentFactoryResolver,
+        null,
         this._appRef,
         this._injector,
       );

--- a/src/material/tabs/tab-body.ts
+++ b/src/material/tabs/tab-body.ts
@@ -10,12 +10,10 @@ import {AnimationEvent} from '@angular/animations';
 import {Direction, Directionality} from '@angular/cdk/bidi';
 import {CdkPortalOutlet, TemplatePortal} from '@angular/cdk/portal';
 import {CdkScrollable} from '@angular/cdk/scrolling';
-import {DOCUMENT} from '@angular/common';
 import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
-  ComponentFactoryResolver,
   Directive,
   ElementRef,
   EventEmitter,
@@ -24,7 +22,6 @@ import {
   OnInit,
   Output,
   ViewChild,
-  ViewContainerRef,
   ViewEncapsulation,
   inject,
 } from '@angular/core';
@@ -51,11 +48,7 @@ export class MatTabBodyPortal extends CdkPortalOutlet implements OnInit, OnDestr
   constructor(...args: unknown[]);
 
   constructor() {
-    const componentFactoryResolver = inject(ComponentFactoryResolver);
-    const viewContainerRef = inject(ViewContainerRef);
-    const _document = inject(DOCUMENT);
-
-    super(componentFactoryResolver, viewContainerRef, _document);
+    super();
   }
 
   /** Set initial visibility or set up subscription for changing visibility. */

--- a/tools/public_api_guard/cdk/dialog.md
+++ b/tools/public_api_guard/cdk/dialog.md
@@ -7,7 +7,6 @@
 import { BasePortalOutlet } from '@angular/cdk/portal';
 import { CdkPortalOutlet } from '@angular/cdk/portal';
 import { ChangeDetectorRef } from '@angular/core';
-import { ComponentFactoryResolver } from '@angular/core';
 import { ComponentPortal } from '@angular/cdk/portal';
 import { ComponentRef } from '@angular/core';
 import { ComponentType } from '@angular/cdk/overlay';
@@ -134,7 +133,8 @@ export class DialogConfig<D = unknown, R = unknown, C extends BasePortalOutlet =
     closeOnDestroy?: boolean;
     closeOnNavigation?: boolean;
     closeOnOverlayDetachments?: boolean;
-    componentFactoryResolver?: ComponentFactoryResolver;
+    // @deprecated
+    componentFactoryResolver?: unknown;
     container?: Type<C> | {
         type: Type<C>;
         providers: (config: DialogConfig<D, R, C>) => StaticProvider[];

--- a/tools/public_api_guard/cdk/portal.md
+++ b/tools/public_api_guard/cdk/portal.md
@@ -106,7 +106,7 @@ export class DomPortalHost extends DomPortalOutlet {
 export class DomPortalOutlet extends BasePortalOutlet {
     constructor(
     outletElement: Element,
-    _componentFactoryResolver?: any, _appRef?: ApplicationRef | undefined, _defaultInjector?: Injector | undefined,
+    _unusedComponentFactoryResolver?: any, _appRef?: ApplicationRef | undefined, _defaultInjector?: Injector | undefined,
     _document?: any);
     attachComponentPortal<T>(portal: ComponentPortal<T>): ComponentRef<T>;
     // @deprecated

--- a/tools/public_api_guard/material/dialog.md
+++ b/tools/public_api_guard/material/dialog.md
@@ -6,7 +6,6 @@
 
 import { AnimationTriggerMetadata } from '@angular/animations';
 import { CdkDialogContainer } from '@angular/cdk/dialog';
-import { ComponentFactoryResolver } from '@angular/core';
 import { ComponentPortal } from '@angular/cdk/portal';
 import { ComponentRef } from '@angular/core';
 import { ComponentType } from '@angular/cdk/overlay';
@@ -151,7 +150,8 @@ export class MatDialogConfig<D = any> {
     autoFocus?: AutoFocusTarget | string | boolean;
     backdropClass?: string | string[];
     closeOnNavigation?: boolean;
-    componentFactoryResolver?: ComponentFactoryResolver;
+    // @deprecated
+    componentFactoryResolver?: unknown;
     data?: D | null;
     delayFocusTrap?: boolean;
     direction?: Direction;


### PR DESCRIPTION
Removes the final places where we were referring to `ComponentFactoryResolver` in our code.