### PR TITLE
fix(material/card): elevated card container color

### DIFF
--- a/src/material/core/tokens/m3/definitions/_md-comp-elevated-card.scss
+++ b/src/material/core/tokens/m3/definitions/_md-comp-elevated-card.scss
@@ -22,7 +22,7 @@ $_default: (
 
 @function values($deps: $_default, $exclude-hardcoded-values: false) {
   @return (
-    'container-color': map.get($deps, 'md-sys-color', 'surface'),
+    'container-color': map.get($deps, 'md-sys-color', 'surface-container-low'),
     'container-elevation': map.get($deps, 'md-sys-elevation', 'level1'),
     'container-shadow-color': map.get($deps, 'md-sys-color', 'shadow'),
     'container-shape': map.get($deps, 'md-sys-shape', 'corner-medium'),


### PR DESCRIPTION
update elevated card container color from `surface` to  `surface-container-low` matching the M3 specification

fixes #29163

---
before:
![image](https://github.com/user-attachments/assets/24bb0bbb-c95a-470e-8d58-7001a59e6ed8)
![image](https://github.com/user-attachments/assets/732c2062-28e1-4c70-b490-2048776b8691)

after:
![image](https://github.com/user-attachments/assets/fbd0ec5b-a097-4c4a-843d-4122d96099a8)
![image](https://github.com/user-attachments/assets/61d27cb4-226d-4fb0-8065-dc11a26a1067)


