### PR TITLE
build: account for absolute paths in token extraction

### DIFF
--- a/tools/extract-tokens/extract-tokens.ts
+++ b/tools/extract-tokens/extract-tokens.ts
@@ -74,8 +74,9 @@ function extractTokens(themePath: string): Token[] {
 
   const startMarker = '/*! extract tokens start */';
   const endMarker = '/*! extract tokens end */';
-  const absoluteThemePath = join(process.cwd(), themePath);
-  const srcPath = join(process.cwd(), 'src');
+  const root = process.cwd();
+  const absoluteThemePath = join(root, themePath);
+  const srcPath = join(root, 'src');
   const {prepend, append} = getTokenExtractionCode(
     srcPath,
     themePath,
@@ -93,6 +94,16 @@ function extractTokens(themePath: string): Token[] {
   compileString(toCompile, {
     loadPaths: [srcPath],
     url: pathToFileURL(absoluteThemePath),
+    importers: [
+      {
+        findFileUrl: (url: string) => {
+          const angularPrefix = '@angular/';
+          return url.startsWith(angularPrefix)
+            ? pathToFileURL(join(srcPath, url.substring(angularPrefix.length)))
+            : null;
+        },
+      },
+    ],
     sourceMap: false,
     logger: {
       debug: message => {


### PR DESCRIPTION
Fixes an error that is currently breaking the patch branch, because we didn't have a resolver for imports like `@use '@angular/cdk';`.