### PR TITLE
docs(material/icon): #29838 update broken link in icon documentation

### DIFF
--- a/src/material/icon/icon.ts
+++ b/src/material/icon/icon.ts
@@ -127,7 +127,7 @@ const funcIriPattern = /^url\(['"]?#(.*?)['"]?\)$/;
  * - Specify a font glyph to be included via CSS rules by setting the fontSet input to specify the
  *   font, and the fontIcon input to specify the icon. Typically the fontIcon will specify a
  *   CSS class which causes the glyph to be displayed via a :before selector, as in
- *   https://fortawesome.github.io/Font-Awesome/examples/
+ *   https://fontawesome-v4.github.io/examples/
  *   Example:
  *     `<mat-icon fontSet="fa" fontIcon="alarm"></mat-icon>`
  */


### PR DESCRIPTION
This pull request fixes a broken link in the documentation for the Angular Material `icon` component. 

**Changes:**
- The incorrect link in `components/src/material/icon/icon.ts` has been updated to the correct one.
  
**Motivation:**
- A broken link can lead to confusion and a poor user experience when reading the documentation.

**No functionality or API was modified.**

- closes #29838 

Please review and merge if everything looks good. Let me know if any further changes are needed.
