### PR TITLE
fix(material/select): match disabled placeholder color with label

### DIFF
--- a/src/material/select/select.scss
+++ b/src/material/select/select.scss
@@ -41,6 +41,13 @@ $scale: 0.75 !default;
     tokens-mat-select.$prefix, tokens-mat-select.get-token-slots()) {
     @include token-utils.create-token-slot(color, disabled-trigger-text-color);
   }
+
+  .mat-mdc-select-placeholder {
+    @include token-utils.use-tokens(
+      tokens-mat-select.$prefix, tokens-mat-select.get-token-slots()) {
+      @include token-utils.create-token-slot(color, disabled-trigger-text-color);
+    }
+  }
 }
 
 .mat-mdc-select-trigger {


### PR DESCRIPTION
this commit ensures select with disabled placeholder matches the color with label

fixes #29807