### PR TITLE
feat(cdk/menu): not to close on outside click, add output event for outside click of menu, add output event for contextmenu,

### DIFF
--- a/src/cdk/menu/context-menu-trigger.spec.ts
+++ b/src/cdk/menu/context-menu-trigger.spec.ts
@@ -153,6 +153,18 @@ describe('CdkContextMenuTrigger', () => {
       fixture.detectChanges();
       expect(getContextMenu()).toBeDefined();
     });
+
+    it('should emit that menu had click outside of it', () => {
+      openContextMenu();
+      expect(getContextMenu()).toBeDefined();
+      spyOn(fixture.componentInstance.trigger.outsideClicked, 'emit');
+
+      fixture.nativeElement.querySelector('#other').click();
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.trigger.outsideClicked.emit).toHaveBeenCalled();
+      expect(getContextMenu()).not.toBeDefined();
+    });
   });
 
   describe('nested context menu triggers', () => {

--- a/src/cdk/menu/context-menu-trigger.spec.ts
+++ b/src/cdk/menu/context-menu-trigger.spec.ts
@@ -143,6 +143,16 @@ describe('CdkContextMenuTrigger', () => {
       fixture.detectChanges();
       expect(getContextMenu()).toBeDefined();
     });
+
+    it('should stay open with disable close on outside click', () => {
+      fixture.componentInstance.shoudCloseOnOutsideClicks = true;
+      openContextMenu();
+      expect(getContextMenu()).toBeDefined();
+
+      fixture.nativeElement.querySelector('#other').click();
+      fixture.detectChanges();
+      expect(getContextMenu()).toBeDefined();
+    });
   });
 
   describe('nested context menu triggers', () => {
@@ -442,7 +452,8 @@ describe('CdkContextMenuTrigger', () => {
 
 @Component({
   template: `
-    <div [cdkContextMenuTriggerFor]="context"></div>
+    <div [cdkContextMenuTriggerFor]="context"
+    [cdkContextMenuDisableCloseOnOutsideClick]="shoudCloseOnOutsideClicks"></div>
     <div id="other"></div>
 
     <ng-template #context>
@@ -459,6 +470,8 @@ class SimpleContextMenu {
   @ViewChild(CdkMenu, {read: ElementRef}) nativeMenu?: ElementRef<HTMLElement>;
 
   @ViewChildren(CdkMenu) menus: QueryList<CdkMenu>;
+
+  shoudCloseOnOutsideClicks = false;
 }
 
 @Component({

--- a/src/cdk/menu/context-menu-trigger.spec.ts
+++ b/src/cdk/menu/context-menu-trigger.spec.ts
@@ -165,6 +165,15 @@ describe('CdkContextMenuTrigger', () => {
       expect(fixture.componentInstance.trigger.outsideClicked.emit).toHaveBeenCalled();
       expect(getContextMenu()).not.toBeDefined();
     });
+
+    it('should emit that menu was triggered', () => {
+      fixture.detectChanges();
+      spyOn(fixture.componentInstance.trigger.triggered, 'emit');
+
+      openContextMenu();
+
+      expect(fixture.componentInstance.trigger.triggered.emit).toHaveBeenCalled();
+    });
   });
 
   describe('nested context menu triggers', () => {

--- a/src/cdk/menu/context-menu-trigger.ts
+++ b/src/cdk/menu/context-menu-trigger.ts
@@ -96,6 +96,10 @@ export class CdkContextMenuTrigger extends CdkMenuTriggerBase implements OnDestr
   /** Whether the context menu is disabled. */
   @Input({alias: 'cdkContextMenuDisabled', transform: booleanAttribute}) disabled: boolean = false;
 
+  /** Whether on clicking outside of menu should close it */
+  @Input({alias: 'cdkContextMenuDisableCloseOnOutsideClick', transform: booleanAttribute})
+  disableCloseOnOutsideClick: boolean = false;
+
   constructor() {
     super();
     this._setMenuStackCloseListener();
@@ -210,7 +214,10 @@ export class CdkContextMenuTrigger extends CdkMenuTriggerBase implements OnDestr
 
       outsideClicks.pipe(takeUntil(this.stopOutsideClicksListener)).subscribe(event => {
         if (!this.isElementInsideMenuStack(_getEventTarget(event)!)) {
-          this.menuStack.closeAll();
+          // We do not want to close menu if user does not want to on outside clicks.
+          if (!this.disableCloseOnOutsideClick) {
+            this.menuStack.closeAll();
+          }
         }
       });
     }

--- a/src/cdk/menu/context-menu-trigger.ts
+++ b/src/cdk/menu/context-menu-trigger.ts
@@ -75,7 +75,11 @@ export type ContextMenuCoordinates = {x: number; y: number};
     {name: 'menuPosition', alias: 'cdkContextMenuPosition'},
     {name: 'menuData', alias: 'cdkContextMenuTriggerData'},
   ],
-  outputs: ['opened: cdkContextMenuOpened', 'closed: cdkContextMenuClosed'],
+  outputs: [
+    'opened: cdkContextMenuOpened',
+    'closed: cdkContextMenuClosed',
+    'outsideClicked: cdkContextMenuOutsideClicked',
+  ],
   providers: [
     {provide: MENU_TRIGGER, useExisting: CdkContextMenuTrigger},
     {provide: MENU_STACK, useClass: MenuStack},
@@ -218,6 +222,9 @@ export class CdkContextMenuTrigger extends CdkMenuTriggerBase implements OnDestr
           if (!this.disableCloseOnOutsideClick) {
             this.menuStack.closeAll();
           }
+
+          // Emit that we had a click outside the menu.
+          this.outsideClicked.emit(event);
         }
       });
     }

--- a/src/cdk/menu/context-menu-trigger.ts
+++ b/src/cdk/menu/context-menu-trigger.ts
@@ -79,6 +79,7 @@ export type ContextMenuCoordinates = {x: number; y: number};
     'opened: cdkContextMenuOpened',
     'closed: cdkContextMenuClosed',
     'outsideClicked: cdkContextMenuOutsideClicked',
+    'triggered: cdkContextMenuTriggered',
   ],
   providers: [
     {provide: MENU_TRIGGER, useExisting: CdkContextMenuTrigger},
@@ -148,6 +149,9 @@ export class CdkContextMenuTrigger extends CdkMenuTriggerBase implements OnDestr
       } else {
         this.childMenu?.focusFirstItem('program');
       }
+
+      // Emit that the user have triggered contextmenu event.
+      this.triggered.emit({x: event.clientX, y: event.clientY});
     }
   }
 

--- a/src/cdk/menu/menu-trigger-base.ts
+++ b/src/cdk/menu/menu-trigger-base.ts
@@ -73,6 +73,9 @@ export abstract class CdkMenuTriggerBase implements OnDestroy {
   /** Emits when the attached menu is requested to close */
   readonly closed: EventEmitter<void> = new EventEmitter();
 
+  /** Emits when the attached menu has click outside of it in open state */
+  readonly outsideClicked: EventEmitter<MouseEvent> = new EventEmitter();
+
   /** Template reference variable to the menu this trigger opens */
   menuTemplateRef: TemplateRef<unknown> | null;
 

--- a/src/cdk/menu/menu-trigger-base.ts
+++ b/src/cdk/menu/menu-trigger-base.ts
@@ -76,6 +76,9 @@ export abstract class CdkMenuTriggerBase implements OnDestroy {
   /** Emits when the attached menu has click outside of it in open state */
   readonly outsideClicked: EventEmitter<MouseEvent> = new EventEmitter();
 
+  /** Emits when the user triggers context menu */
+  readonly triggered: EventEmitter<{x: number; y: number}> = new EventEmitter();
+
   /** Template reference variable to the menu this trigger opens */
   menuTemplateRef: TemplateRef<unknown> | null;
 

--- a/tools/public_api_guard/cdk/menu.md
+++ b/tools/public_api_guard/cdk/menu.md
@@ -44,7 +44,7 @@ export class CdkContextMenuTrigger extends CdkMenuTriggerBase implements OnDestr
     open(coordinates: ContextMenuCoordinates): void;
     _openOnContextMenu(event: MouseEvent): void;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkContextMenuTrigger, "[cdkContextMenuTriggerFor]", ["cdkContextMenuTriggerFor"], { "menuTemplateRef": { "alias": "cdkContextMenuTriggerFor"; "required": false; }; "menuPosition": { "alias": "cdkContextMenuPosition"; "required": false; }; "menuData": { "alias": "cdkContextMenuTriggerData"; "required": false; }; "disabled": { "alias": "cdkContextMenuDisabled"; "required": false; }; "disableCloseOnOutsideClick": { "alias": "cdkContextMenuDisableCloseOnOutsideClick"; "required": false; }; }, { "opened": "cdkContextMenuOpened"; "closed": "cdkContextMenuClosed"; "outsideClicked": "cdkContextMenuOutsideClicked"; }, never, never, true, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkContextMenuTrigger, "[cdkContextMenuTriggerFor]", ["cdkContextMenuTriggerFor"], { "menuTemplateRef": { "alias": "cdkContextMenuTriggerFor"; "required": false; }; "menuPosition": { "alias": "cdkContextMenuPosition"; "required": false; }; "menuData": { "alias": "cdkContextMenuTriggerData"; "required": false; }; "disabled": { "alias": "cdkContextMenuDisabled"; "required": false; }; "disableCloseOnOutsideClick": { "alias": "cdkContextMenuDisableCloseOnOutsideClick"; "required": false; }; }, { "opened": "cdkContextMenuOpened"; "closed": "cdkContextMenuClosed"; "outsideClicked": "cdkContextMenuOutsideClicked"; "triggered": "cdkContextMenuTriggered"; }, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<CdkContextMenuTrigger, never>;
 }
@@ -239,6 +239,10 @@ export abstract class CdkMenuTriggerBase implements OnDestroy {
     protected overlayRef: OverlayRef | null;
     registerChildMenu(child: Menu): void;
     protected readonly stopOutsideClicksListener: Observable<void>;
+    readonly triggered: EventEmitter<{
+        x: number;
+        y: number;
+    }>;
     protected readonly viewContainerRef: ViewContainerRef;
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<CdkMenuTriggerBase, never, never, {}, {}, never, never, true, never>;

--- a/tools/public_api_guard/cdk/menu.md
+++ b/tools/public_api_guard/cdk/menu.md
@@ -35,13 +35,16 @@ export const CDK_MENU: InjectionToken<Menu>;
 export class CdkContextMenuTrigger extends CdkMenuTriggerBase implements OnDestroy {
     constructor();
     close(): void;
+    disableCloseOnOutsideClick: boolean;
     disabled: boolean;
+    // (undocumented)
+    static ngAcceptInputType_disableCloseOnOutsideClick: unknown;
     // (undocumented)
     static ngAcceptInputType_disabled: unknown;
     open(coordinates: ContextMenuCoordinates): void;
     _openOnContextMenu(event: MouseEvent): void;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkContextMenuTrigger, "[cdkContextMenuTriggerFor]", ["cdkContextMenuTriggerFor"], { "menuTemplateRef": { "alias": "cdkContextMenuTriggerFor"; "required": false; }; "menuPosition": { "alias": "cdkContextMenuPosition"; "required": false; }; "menuData": { "alias": "cdkContextMenuTriggerData"; "required": false; }; "disabled": { "alias": "cdkContextMenuDisabled"; "required": false; }; }, { "opened": "cdkContextMenuOpened"; "closed": "cdkContextMenuClosed"; }, never, never, true, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkContextMenuTrigger, "[cdkContextMenuTriggerFor]", ["cdkContextMenuTriggerFor"], { "menuTemplateRef": { "alias": "cdkContextMenuTriggerFor"; "required": false; }; "menuPosition": { "alias": "cdkContextMenuPosition"; "required": false; }; "menuData": { "alias": "cdkContextMenuTriggerData"; "required": false; }; "disabled": { "alias": "cdkContextMenuDisabled"; "required": false; }; "disableCloseOnOutsideClick": { "alias": "cdkContextMenuDisableCloseOnOutsideClick"; "required": false; }; }, { "opened": "cdkContextMenuOpened"; "closed": "cdkContextMenuClosed"; "outsideClicked": "cdkContextMenuOutsideClicked"; }, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<CdkContextMenuTrigger, never>;
 }

--- a/tools/public_api_guard/cdk/menu.md
+++ b/tools/public_api_guard/cdk/menu.md
@@ -235,6 +235,7 @@ export abstract class CdkMenuTriggerBase implements OnDestroy {
     // (undocumented)
     ngOnDestroy(): void;
     readonly opened: EventEmitter<void>;
+    readonly outsideClicked: EventEmitter<MouseEvent>;
     protected overlayRef: OverlayRef | null;
     registerChildMenu(child: Menu): void;
     protected readonly stopOutsideClicksListener: Observable<void>;


### PR DESCRIPTION
feat(cdk/menu): not to close on outside click

this commit adds new input in menu trigger which allows users to disable closing menu on outside clicks

---

feat(cdk/menu): add output event for outside click of menu

this commit exposes an output which emits whenever the user clicks outside open menu

---

feat(cdk/menu): add output event for contextmenu

this commit exposes an output that emits whenever user triggers `contextmenu` event which contains `clientX` and `clientY` position respectively
