### PR TITLE
test(multiple): remove CommonModule imports

### DIFF
--- a/src/cdk-experimental/popover-edit/popover-edit.spec.ts
+++ b/src/cdk-experimental/popover-edit/popover-edit.spec.ts
@@ -3,7 +3,6 @@ import {DataSource} from '@angular/cdk/collections';
 import {DOWN_ARROW, LEFT_ARROW, RIGHT_ARROW, TAB, UP_ARROW} from '@angular/cdk/keycodes';
 import {CdkTableModule} from '@angular/cdk/table';
 import {dispatchKeyboardEvent} from '@angular/cdk/testing/private';
-import {CommonModule} from '@angular/common';
 import {
   ChangeDetectorRef,
   Component,
@@ -399,7 +398,7 @@ describe('CDK Popover Edit', () => {
 
       beforeEach(fakeAsync(() => {
         TestBed.configureTestingModule({
-          imports: [CdkTableModule, CdkPopoverEditModule, CommonModule, FormsModule, BidiModule],
+          imports: [CdkTableModule, CdkPopoverEditModule, FormsModule, BidiModule],
           declarations: [componentClass],
         });
         fixture = TestBed.createComponent<BaseTestComponent>(componentClass);

--- a/src/cdk/listbox/listbox.spec.ts
+++ b/src/cdk/listbox/listbox.spec.ts
@@ -9,7 +9,6 @@ import {
   SPACE,
   UP_ARROW,
 } from '@angular/cdk/keycodes';
-import {CommonModule} from '@angular/common';
 import {Component, Type, signal} from '@angular/core';
 import {TestBed, fakeAsync, tick} from '@angular/core/testing';
 import {FormControl, ReactiveFormsModule} from '@angular/forms';
@@ -532,7 +531,6 @@ describe('CdkOption and CdkListbox', () => {
     it('should allow custom function to compare option values', () => {
       const {fixture, listbox, options} = setupComponent<ListboxWithObjectValues, {name: string}>(
         ListboxWithObjectValues,
-        [CommonModule],
       );
       listbox.value = [{name: 'Banana'}];
       fixture.detectChanges();

--- a/src/cdk/portal/portal.spec.ts
+++ b/src/cdk/portal/portal.spec.ts
@@ -1,4 +1,3 @@
-import {CommonModule} from '@angular/common';
 import {
   AfterViewInit,
   ApplicationRef,
@@ -24,7 +23,6 @@ describe('Portals', () => {
     TestBed.configureTestingModule({
       imports: [
         PortalModule,
-        CommonModule,
         PortalTestApp,
         UnboundPortalTestApp,
         ArbitraryViewContainerRefComponent,
@@ -728,7 +726,7 @@ class ChocolateInjector {
   selector: 'pizza-msg',
   template: '<p>Pizza</p><p>{{snack}}</p><ng-content></ng-content>',
   standalone: true,
-  imports: [PortalModule, CommonModule],
+  imports: [PortalModule],
 })
 class PizzaMsg {
   snack = inject(Chocolate, {optional: true});

--- a/src/cdk/scrolling/virtual-scroll-viewport.spec.ts
+++ b/src/cdk/scrolling/virtual-scroll-viewport.spec.ts
@@ -6,7 +6,6 @@ import {
   ScrollDispatcher,
   ScrollingModule,
 } from '@angular/cdk/scrolling';
-import {CommonModule} from '@angular/common';
 import {
   ApplicationRef,
   Component,
@@ -1004,7 +1003,7 @@ describe('CdkVirtualScrollViewport', () => {
 
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
-        imports: [ScrollingModule, CommonModule, DelayedInitializationVirtualScroll],
+        imports: [ScrollingModule, DelayedInitializationVirtualScroll],
       });
       fixture = TestBed.createComponent(DelayedInitializationVirtualScroll);
       testComponent = fixture.componentInstance;
@@ -1034,7 +1033,7 @@ describe('CdkVirtualScrollViewport', () => {
 
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
-        imports: [ScrollingModule, CommonModule, VirtualScrollWithAppendOnly],
+        imports: [ScrollingModule, VirtualScrollWithAppendOnly],
       });
       fixture = TestBed.createComponent(VirtualScrollWithAppendOnly);
       testComponent = fixture.componentInstance;
@@ -1441,7 +1440,7 @@ class VirtualScrollWithItemInjectingViewContainer {
   `,
   encapsulation: ViewEncapsulation.None,
   standalone: true,
-  imports: [ScrollingModule, CommonModule],
+  imports: [ScrollingModule],
 })
 class DelayedInitializationVirtualScroll {
   @ViewChild(CdkVirtualScrollViewport, {static: true}) viewport: CdkVirtualScrollViewport;
@@ -1480,7 +1479,7 @@ class DelayedInitializationVirtualScroll {
   `,
   encapsulation: ViewEncapsulation.None,
   standalone: true,
-  imports: [ScrollingModule, CommonModule],
+  imports: [ScrollingModule],
 })
 class VirtualScrollWithAppendOnly {
   @ViewChild(CdkVirtualScrollViewport, {static: true}) viewport: CdkVirtualScrollViewport;

--- a/src/material-experimental/popover-edit/popover-edit.spec.ts
+++ b/src/material-experimental/popover-edit/popover-edit.spec.ts
@@ -1,6 +1,5 @@
 import {DataSource} from '@angular/cdk/collections';
 import {DOWN_ARROW, LEFT_ARROW, RIGHT_ARROW, TAB, UP_ARROW} from '@angular/cdk/keycodes';
-import {CommonModule} from '@angular/common';
 import {Component, Directive, ElementRef, ViewChild} from '@angular/core';
 import {ComponentFixture, TestBed, fakeAsync, flush, tick} from '@angular/core/testing';
 import {FormsModule, NgForm} from '@angular/forms';
@@ -302,7 +301,7 @@ describe('Material Popover Edit', () => {
 
       beforeEach(fakeAsync(() => {
         TestBed.configureTestingModule({
-          imports: [MatTableModule, MatPopoverEditModule, CommonModule, FormsModule],
+          imports: [MatTableModule, MatPopoverEditModule, FormsModule],
           declarations: [componentClass],
         });
         fixture = TestBed.createComponent(componentClass);

--- a/src/material/button-toggle/button-toggle.spec.ts
+++ b/src/material/button-toggle/button-toggle.spec.ts
@@ -1,5 +1,4 @@
 import {dispatchMouseEvent} from '@angular/cdk/testing/private';
-import {CommonModule} from '@angular/common';
 import {Component, DebugElement, QueryList, ViewChild, ViewChildren} from '@angular/core';
 import {ComponentFixture, TestBed, fakeAsync, flush, tick} from '@angular/core/testing';
 import {FormControl, FormsModule, NgModel, ReactiveFormsModule} from '@angular/forms';
@@ -19,7 +18,6 @@ describe('MatButtonToggle with forms', () => {
         MatButtonToggleModule,
         FormsModule,
         ReactiveFormsModule,
-        CommonModule,
         ButtonToggleGroupWithNgModel,
         ButtonToggleGroupWithFormControl,
         ButtonToggleGroupWithIndirectDescendantToggles,
@@ -1112,7 +1110,7 @@ class ButtonTogglesInsideButtonToggleGroup {
   </mat-button-toggle-group>
   `,
   standalone: true,
-  imports: [MatButtonToggleModule, FormsModule, ReactiveFormsModule, CommonModule],
+  imports: [MatButtonToggleModule, FormsModule, ReactiveFormsModule],
 })
 class ButtonToggleGroupWithNgModel {
   groupName = 'group-name';
@@ -1191,7 +1189,7 @@ class ButtonToggleGroupWithInitialValue {
   </mat-button-toggle-group>
   `,
   standalone: true,
-  imports: [MatButtonToggleModule, FormsModule, ReactiveFormsModule, CommonModule],
+  imports: [MatButtonToggleModule, FormsModule, ReactiveFormsModule],
 })
 class ButtonToggleGroupWithFormControl {
   control = new FormControl('');
@@ -1209,7 +1207,7 @@ class ButtonToggleGroupWithFormControl {
     </mat-button-toggle-group>
   `,
   standalone: true,
-  imports: [MatButtonToggleModule, FormsModule, ReactiveFormsModule, CommonModule],
+  imports: [MatButtonToggleModule, FormsModule, ReactiveFormsModule],
 })
 class ButtonToggleGroupWithIndirectDescendantToggles {
   control = new FormControl('');
@@ -1297,7 +1295,7 @@ class ButtonToggleWithStaticAriaAttributes {}
   </mat-button-toggle-group>
   `,
   standalone: true,
-  imports: [MatButtonToggleModule, FormsModule, ReactiveFormsModule, CommonModule],
+  imports: [MatButtonToggleModule, FormsModule, ReactiveFormsModule],
 })
 class ButtonToggleGroupWithFormControlAndDynamicButtons {
   @ViewChildren(MatButtonToggle) toggles: QueryList<MatButtonToggle>;

--- a/src/material/chips/chip-set.spec.ts
+++ b/src/material/chips/chip-set.spec.ts
@@ -1,4 +1,3 @@
-import {CommonModule} from '@angular/common';
 import {Component, DebugElement, QueryList} from '@angular/core';
 import {ComponentFixture, TestBed, fakeAsync, tick, waitForAsync} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
@@ -7,7 +6,7 @@ import {MatChip, MatChipSet, MatChipsModule} from './index';
 describe('MatChipSet', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [MatChipsModule, CommonModule, BasicChipSet, IndirectDescendantsChipSet],
+      imports: [MatChipsModule, BasicChipSet, IndirectDescendantsChipSet],
     });
   }));
 
@@ -117,7 +116,7 @@ describe('MatChipSet', () => {
       </mat-chip-set>
   `,
   standalone: true,
-  imports: [MatChipsModule, CommonModule],
+  imports: [MatChipsModule],
 })
 class BasicChipSet {
   name: string = 'Test';
@@ -135,6 +134,6 @@ class BasicChipSet {
     </mat-chip-set>
   `,
   standalone: true,
-  imports: [MatChipsModule, CommonModule],
+  imports: [MatChipsModule],
 })
 class IndirectDescendantsChipSet extends BasicChipSet {}

--- a/src/material/datepicker/datepicker-actions.spec.ts
+++ b/src/material/datepicker/datepicker-actions.spec.ts
@@ -1,4 +1,3 @@
-import {CommonModule} from '@angular/common';
 import {Component, ElementRef, Type, ViewChild} from '@angular/core';
 import {ComponentFixture, TestBed, fakeAsync, flush, tick} from '@angular/core/testing';
 import {FormControl, FormsModule, ReactiveFormsModule} from '@angular/forms';
@@ -14,7 +13,6 @@ describe('MatDatepickerActions', () => {
     TestBed.configureTestingModule({
       declarations: [component],
       imports: [
-        CommonModule,
         FormsModule,
         MatDatepickerModule,
         MatFormFieldModule,

--- a/src/material/progress-spinner/progress-spinner.spec.ts
+++ b/src/material/progress-spinner/progress-spinner.spec.ts
@@ -1,5 +1,4 @@
 import {waitForAsync, TestBed} from '@angular/core/testing';
-import {CommonModule} from '@angular/common';
 import {By} from '@angular/platform-browser';
 import {Component, ElementRef, ViewChild, ViewEncapsulation, signal} from '@angular/core';
 import {MatProgressSpinnerModule} from './module';
@@ -10,7 +9,6 @@ describe('MatProgressSpinner', () => {
     TestBed.configureTestingModule({
       imports: [
         MatProgressSpinnerModule,
-        CommonModule,
         BasicProgressSpinner,
         IndeterminateProgressSpinner,
         ProgressSpinnerWithValueAndBoundMode,
@@ -398,14 +396,14 @@ describe('MatProgressSpinner', () => {
 @Component({
   template: '<mat-progress-spinner></mat-progress-spinner>',
   standalone: true,
-  imports: [MatProgressSpinnerModule, CommonModule],
+  imports: [MatProgressSpinnerModule],
 })
 class BasicProgressSpinner {}
 
 @Component({
   template: '<mat-progress-spinner [strokeWidth]="strokeWidth"></mat-progress-spinner>',
   standalone: true,
-  imports: [MatProgressSpinnerModule, CommonModule],
+  imports: [MatProgressSpinnerModule],
 })
 class ProgressSpinnerCustomStrokeWidth {
   strokeWidth: number;
@@ -414,7 +412,7 @@ class ProgressSpinnerCustomStrokeWidth {
 @Component({
   template: '<mat-progress-spinner [diameter]="diameter"></mat-progress-spinner>',
   standalone: true,
-  imports: [MatProgressSpinnerModule, CommonModule],
+  imports: [MatProgressSpinnerModule],
 })
 class ProgressSpinnerCustomDiameter {
   diameter: number;
@@ -423,14 +421,14 @@ class ProgressSpinnerCustomDiameter {
 @Component({
   template: '<mat-progress-spinner mode="indeterminate"></mat-progress-spinner>',
   standalone: true,
-  imports: [MatProgressSpinnerModule, CommonModule],
+  imports: [MatProgressSpinnerModule],
 })
 class IndeterminateProgressSpinner {}
 
 @Component({
   template: '<mat-progress-spinner [value]="value()" [mode]="mode()"></mat-progress-spinner>',
   standalone: true,
-  imports: [MatProgressSpinnerModule, CommonModule],
+  imports: [MatProgressSpinnerModule],
 })
 class ProgressSpinnerWithValueAndBoundMode {
   mode = signal('indeterminate');
@@ -441,7 +439,7 @@ class ProgressSpinnerWithValueAndBoundMode {
   template: `
     <mat-spinner [color]="color()"></mat-spinner>`,
   standalone: true,
-  imports: [MatProgressSpinnerModule, CommonModule],
+  imports: [MatProgressSpinnerModule],
 })
 class SpinnerWithColor {
   color = signal('primary');
@@ -451,7 +449,7 @@ class SpinnerWithColor {
   template: `
     <mat-progress-spinner value="50" [color]="color()"></mat-progress-spinner>`,
   standalone: true,
-  imports: [MatProgressSpinnerModule, CommonModule],
+  imports: [MatProgressSpinnerModule],
 })
 class ProgressSpinnerWithColor {
   color = signal('primary');
@@ -462,7 +460,7 @@ class ProgressSpinnerWithColor {
     <mat-progress-spinner value="25" diameter="37" strokeWidth="11"></mat-progress-spinner>
   `,
   standalone: true,
-  imports: [MatProgressSpinnerModule, CommonModule],
+  imports: [MatProgressSpinnerModule],
 })
 class ProgressSpinnerWithStringValues {}
 
@@ -472,7 +470,7 @@ class ProgressSpinnerWithStringValues {}
   `,
   encapsulation: ViewEncapsulation.ShadowDom,
   standalone: true,
-  imports: [MatProgressSpinnerModule, CommonModule],
+  imports: [MatProgressSpinnerModule],
 })
 class IndeterminateSpinnerInShadowDom {
   diameter: number;
@@ -488,7 +486,7 @@ class IndeterminateSpinnerInShadowDom {
   `,
   encapsulation: ViewEncapsulation.ShadowDom,
   standalone: true,
-  imports: [MatProgressSpinnerModule, CommonModule],
+  imports: [MatProgressSpinnerModule],
 })
 class IndeterminateSpinnerInShadowDomWithNgIf {
   @ViewChild(MatProgressSpinner, {read: ElementRef})
@@ -500,6 +498,6 @@ class IndeterminateSpinnerInShadowDomWithNgIf {
 @Component({
   template: '<mat-spinner mode="determinate"></mat-spinner>',
   standalone: true,
-  imports: [MatProgressSpinnerModule, CommonModule],
+  imports: [MatProgressSpinnerModule],
 })
 class SpinnerWithMode {}

--- a/src/material/radio/radio.spec.ts
+++ b/src/material/radio/radio.spec.ts
@@ -1,5 +1,4 @@
 import {dispatchFakeEvent} from '@angular/cdk/testing/private';
-import {CommonModule} from '@angular/common';
 import {Component, DebugElement, ViewChild} from '@angular/core';
 import {ComponentFixture, TestBed, fakeAsync, tick, waitForAsync} from '@angular/core/testing';
 import {FormControl, FormsModule, NgModel, ReactiveFormsModule} from '@angular/forms';
@@ -19,7 +18,6 @@ describe('MatRadio', () => {
         MatRadioModule,
         FormsModule,
         ReactiveFormsModule,
-        CommonModule,
         DisableableRadioButton,
         FocusableRadioButton,
         RadiosInsideRadioGroup,
@@ -1092,7 +1090,7 @@ describe('MatRadioDefaultOverrides', () => {
   </mat-radio-group>
   `,
   standalone: true,
-  imports: [MatRadioModule, FormsModule, ReactiveFormsModule, CommonModule],
+  imports: [MatRadioModule, FormsModule, ReactiveFormsModule],
 })
 class RadiosInsideRadioGroup {
   labelPos: 'before' | 'after';
@@ -1115,7 +1113,7 @@ class RadiosInsideRadioGroup {
   </mat-radio-group>
   `,
   standalone: true,
-  imports: [MatRadioModule, FormsModule, ReactiveFormsModule, CommonModule],
+  imports: [MatRadioModule, FormsModule, ReactiveFormsModule],
 })
 class RadiosInsidePreCheckedRadioGroup {}
 
@@ -1141,7 +1139,7 @@ class RadiosInsidePreCheckedRadioGroup {}
     <mat-radio-button id="nameless" value="no-name">No name</mat-radio-button>
   `,
   standalone: true,
-  imports: [MatRadioModule, FormsModule, ReactiveFormsModule, CommonModule],
+  imports: [MatRadioModule, FormsModule, ReactiveFormsModule],
 })
 class StandaloneRadioButtons {
   ariaLabel: string = 'Banana';
@@ -1158,7 +1156,7 @@ class StandaloneRadioButtons {
   </mat-radio-group>
   `,
   standalone: true,
-  imports: [MatRadioModule, FormsModule, ReactiveFormsModule, CommonModule],
+  imports: [MatRadioModule, FormsModule, ReactiveFormsModule],
 })
 class RadioGroupWithNgModel {
   modelValue: string;
@@ -1177,7 +1175,7 @@ class RadioGroupWithNgModel {
       [disabled]="disabled"
       [disabledInteractive]="disabledInteractive">One</mat-radio-button>`,
   standalone: true,
-  imports: [MatRadioModule, FormsModule, ReactiveFormsModule, CommonModule],
+  imports: [MatRadioModule, FormsModule, ReactiveFormsModule],
 })
 class DisableableRadioButton {
   disabled = false;
@@ -1194,7 +1192,7 @@ class DisableableRadioButton {
     </mat-radio-group>
   `,
   standalone: true,
-  imports: [MatRadioModule, FormsModule, ReactiveFormsModule, CommonModule],
+  imports: [MatRadioModule, FormsModule, ReactiveFormsModule],
 })
 class RadioGroupWithFormControl {
   @ViewChild(MatRadioGroup) group: MatRadioGroup;
@@ -1204,7 +1202,7 @@ class RadioGroupWithFormControl {
 @Component({
   template: `<mat-radio-button [disabled]="disabled" [tabIndex]="tabIndex"></mat-radio-button>`,
   standalone: true,
-  imports: [MatRadioModule, FormsModule, ReactiveFormsModule, CommonModule],
+  imports: [MatRadioModule, FormsModule, ReactiveFormsModule],
 })
 class FocusableRadioButton {
   tabIndex: number;
@@ -1217,7 +1215,7 @@ class FocusableRadioButton {
     <div><ng-content></ng-content></div>
   `,
   standalone: true,
-  imports: [MatRadioModule, FormsModule, ReactiveFormsModule, CommonModule],
+  imports: [MatRadioModule, FormsModule, ReactiveFormsModule],
 })
 class TranscludingWrapper {}
 
@@ -1232,7 +1230,7 @@ class TranscludingWrapper {}
   </mat-radio-group>
   `,
   standalone: true,
-  imports: [MatRadioModule, FormsModule, ReactiveFormsModule, CommonModule, TranscludingWrapper],
+  imports: [MatRadioModule, FormsModule, ReactiveFormsModule, TranscludingWrapper],
 })
 class InterleavedRadioGroup {
   modelValue = 'strawberry';
@@ -1246,7 +1244,7 @@ class InterleavedRadioGroup {
 @Component({
   template: `<mat-radio-button tabindex="5"></mat-radio-button>`,
   standalone: true,
-  imports: [MatRadioModule, FormsModule, ReactiveFormsModule, CommonModule],
+  imports: [MatRadioModule, FormsModule, ReactiveFormsModule],
 })
 class RadioButtonWithPredefinedTabindex {}
 
@@ -1271,7 +1269,7 @@ class RadioButtonWithColorBinding {}
       aria-describedby="something"
       aria-labelledby="something-else"></mat-radio-button>`,
   standalone: true,
-  imports: [MatRadioModule, FormsModule, ReactiveFormsModule, CommonModule],
+  imports: [MatRadioModule, FormsModule, ReactiveFormsModule],
 })
 class RadioButtonWithPredefinedAriaAttributes {}
 
@@ -1292,7 +1290,7 @@ class RadioButtonWithPredefinedAriaAttributes {}
     </mat-radio-group>
   `,
   standalone: true,
-  imports: [MatRadioModule, FormsModule, ReactiveFormsModule, CommonModule],
+  imports: [MatRadioModule, FormsModule, ReactiveFormsModule],
 })
 class PreselectedRadioWithStaticValueAndNgIf {
   @ViewChild('preselectedGroup', {read: MatRadioGroup}) preselectedGroup: MatRadioGroup;

--- a/src/material/sidenav/drawer.spec.ts
+++ b/src/material/sidenav/drawer.spec.ts
@@ -7,7 +7,6 @@ import {
   dispatchEvent,
   dispatchKeyboardEvent,
 } from '@angular/cdk/testing/private';
-import {CommonModule} from '@angular/common';
 import {Component, ElementRef, ErrorHandler, ViewChild} from '@angular/core';
 import {
   ComponentFixture,
@@ -29,7 +28,6 @@ describe('MatDrawer', () => {
         MatSidenavModule,
         A11yModule,
         NoopAnimationsModule,
-        CommonModule,
         BasicTestApp,
         DrawerContainerNoDrawerTestApp,
         DrawerSetToOpenedFalse,
@@ -1210,7 +1208,7 @@ describe('MatDrawerContainer', () => {
 @Component({
   template: `<mat-drawer-container></mat-drawer-container>`,
   standalone: true,
-  imports: [MatSidenavModule, A11yModule, CommonModule],
+  imports: [MatSidenavModule, A11yModule],
 })
 class DrawerContainerNoDrawerTestApp {}
 
@@ -1251,7 +1249,7 @@ class DrawerContainerTwoDrawerTestApp {
       </svg>
     </mat-drawer-container>`,
   standalone: true,
-  imports: [MatSidenavModule, A11yModule, CommonModule],
+  imports: [MatSidenavModule, A11yModule],
 })
 class BasicTestApp {
   openCount = 0;
@@ -1297,7 +1295,7 @@ class BasicTestApp {
       </mat-drawer>
     </mat-drawer-container>`,
   standalone: true,
-  imports: [MatSidenavModule, A11yModule, CommonModule],
+  imports: [MatSidenavModule, A11yModule],
 })
 class DrawerSetToOpenedFalse {}
 
@@ -1309,7 +1307,7 @@ class DrawerSetToOpenedFalse {}
       </mat-drawer>
     </mat-drawer-container>`,
   standalone: true,
-  imports: [MatSidenavModule, A11yModule, CommonModule],
+  imports: [MatSidenavModule, A11yModule],
 })
 class DrawerSetToOpenedTrue {
   openCallback = jasmine.createSpy('open callback');
@@ -1323,7 +1321,7 @@ class DrawerSetToOpenedTrue {
       </mat-drawer>
     </mat-drawer-container>`,
   standalone: true,
-  imports: [MatSidenavModule, A11yModule, CommonModule],
+  imports: [MatSidenavModule, A11yModule],
 })
 class DrawerOpenBinding {
   isOpen = false;
@@ -1336,7 +1334,7 @@ class DrawerOpenBinding {
       <mat-drawer #drawer2 [position]="drawer2Position"></mat-drawer>
     </mat-drawer-container>`,
   standalone: true,
-  imports: [MatSidenavModule, A11yModule, CommonModule],
+  imports: [MatSidenavModule, A11yModule],
 })
 class DrawerDynamicPosition {
   drawer1Position = 'start';
@@ -1354,7 +1352,7 @@ class DrawerDynamicPosition {
       <input type="text" class="input2"/>
     </mat-drawer-container>`,
   standalone: true,
-  imports: [MatSidenavModule, A11yModule, CommonModule],
+  imports: [MatSidenavModule, A11yModule],
 })
 class DrawerWithFocusableElements {
   mode: string = 'over';
@@ -1369,7 +1367,7 @@ class DrawerWithFocusableElements {
       </mat-drawer>
     </mat-drawer-container>`,
   standalone: true,
-  imports: [MatSidenavModule, A11yModule, CommonModule],
+  imports: [MatSidenavModule, A11yModule],
 })
 class DrawerWithoutFocusableElements {}
 
@@ -1449,7 +1447,7 @@ class DrawerContainerWithContent {
       }
     </mat-drawer-container>`,
   standalone: true,
-  imports: [MatSidenavModule, A11yModule, CommonModule],
+  imports: [MatSidenavModule, A11yModule],
 })
 class IndirectDescendantDrawer {
   @ViewChild('container') container: MatDrawerContainer;
@@ -1468,7 +1466,7 @@ class IndirectDescendantDrawer {
     </mat-drawer-container>
   `,
   standalone: true,
-  imports: [MatSidenavModule, A11yModule, CommonModule],
+  imports: [MatSidenavModule, A11yModule],
 })
 class NestedDrawerContainers {
   @ViewChild('outerContainer') outerContainer: MatDrawerContainer;

--- a/src/material/sidenav/sidenav.spec.ts
+++ b/src/material/sidenav/sidenav.spec.ts
@@ -1,4 +1,3 @@
-import {CommonModule} from '@angular/common';
 import {Component, ViewChild} from '@angular/core';
 import {TestBed, fakeAsync, tick, waitForAsync} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
@@ -11,7 +10,6 @@ describe('MatSidenav', () => {
       imports: [
         MatSidenavModule,
         NoopAnimationsModule,
-        CommonModule,
         SidenavWithFixedPosition,
         IndirectDescendantSidenav,
         NestedSidenavContainers,
@@ -104,7 +102,7 @@ describe('MatSidenav', () => {
       </mat-sidenav-content>
     </mat-sidenav-container>`,
   standalone: true,
-  imports: [MatSidenavModule, CommonModule],
+  imports: [MatSidenavModule],
 })
 class SidenavWithFixedPosition {
   fixed = true;
@@ -123,7 +121,7 @@ class SidenavWithFixedPosition {
       <mat-sidenav-content>Some content.</mat-sidenav-content>
     </mat-sidenav-container>`,
   standalone: true,
-  imports: [MatSidenavModule, CommonModule],
+  imports: [MatSidenavModule],
 })
 class IndirectDescendantSidenav {
   @ViewChild('container') container: MatSidenavContainer;
@@ -142,7 +140,7 @@ class IndirectDescendantSidenav {
     </mat-sidenav-container>
   `,
   standalone: true,
-  imports: [MatSidenavModule, CommonModule],
+  imports: [MatSidenavModule],
 })
 class NestedSidenavContainers {
   @ViewChild('outerContainer') outerContainer: MatSidenavContainer;

--- a/src/material/tabs/tab-body.spec.ts
+++ b/src/material/tabs/tab-body.spec.ts
@@ -1,7 +1,6 @@
 import {Direction, Directionality} from '@angular/cdk/bidi';
 import {PortalModule, TemplatePortal} from '@angular/cdk/portal';
 import {CdkScrollable, ScrollingModule} from '@angular/cdk/scrolling';
-import {CommonModule} from '@angular/common';
 import {
   AfterViewInit,
   Component,
@@ -26,7 +25,6 @@ describe('MatTabBody', () => {
     dir = 'ltr';
     TestBed.configureTestingModule({
       imports: [
-        CommonModule,
         PortalModule,
         MatRippleModule,
         NoopAnimationsModule,
@@ -195,7 +193,6 @@ describe('MatTabBody', () => {
   it('should mark the tab body content as a scrollable container', () => {
     TestBed.resetTestingModule().configureTestingModule({
       imports: [
-        CommonModule,
         PortalModule,
         MatRippleModule,
         NoopAnimationsModule,
@@ -219,7 +216,7 @@ describe('MatTabBody', () => {
     <mat-tab-body [content]="content()" [position]="position" [origin]="origin"></mat-tab-body>
   `,
   standalone: true,
-  imports: [CommonModule, PortalModule, MatRippleModule, MatTabBody],
+  imports: [PortalModule, MatRippleModule, MatTabBody],
 })
 class SimpleTabBodyApp implements AfterViewInit {
   content = signal<TemplatePortal | undefined>(undefined);

--- a/src/material/tabs/tab-group.spec.ts
+++ b/src/material/tabs/tab-group.spec.ts
@@ -1,6 +1,6 @@
 import {LEFT_ARROW, RIGHT_ARROW} from '@angular/cdk/keycodes';
 import {dispatchFakeEvent, dispatchKeyboardEvent} from '@angular/cdk/testing/private';
-import {CommonModule} from '@angular/common';
+import {AsyncPipe} from '@angular/common';
 import {Component, DebugElement, OnInit, QueryList, ViewChild, ViewChildren} from '@angular/core';
 import {
   ComponentFixture,
@@ -27,7 +27,6 @@ describe('MatTabGroup', () => {
     TestBed.configureTestingModule({
       imports: [
         MatTabsModule,
-        CommonModule,
         NoopAnimationsModule,
         SimpleTabsTestApp,
         SimpleDynamicTabsTestApp,
@@ -1303,7 +1302,7 @@ describe('MatTabGroup labels aligned with a config', () => {
     </mat-tab-group>
   `,
   standalone: true,
-  imports: [MatTabsModule, CommonModule],
+  imports: [MatTabsModule],
 })
 class SimpleTabsTestApp {
   @ViewChild(MatTabGroup) tabGroup: MatTabGroup;
@@ -1341,7 +1340,7 @@ class SimpleTabsTestApp {
     </mat-tab-group>
   `,
   standalone: true,
-  imports: [MatTabsModule, CommonModule],
+  imports: [MatTabsModule],
 })
 class SimpleDynamicTabsTestApp {
   tabs = [
@@ -1370,7 +1369,7 @@ class SimpleDynamicTabsTestApp {
     </mat-tab-group>
   `,
   standalone: true,
-  imports: [MatTabsModule, CommonModule],
+  imports: [MatTabsModule],
 })
 class BindedTabsTestApp {
   tabs = [
@@ -1406,7 +1405,7 @@ class BindedTabsTestApp {
     </mat-tab-group>
   `,
   standalone: true,
-  imports: [MatTabsModule, CommonModule],
+  imports: [MatTabsModule],
 })
 class DisabledTabsTestApp {
   @ViewChildren(MatTab) tabs: QueryList<MatTab>;
@@ -1425,7 +1424,7 @@ class DisabledTabsTestApp {
    </mat-tab-group>
   `,
   standalone: true,
-  imports: [MatTabsModule, CommonModule],
+  imports: [MatTabsModule, AsyncPipe],
 })
 class AsyncTabsTestApp implements OnInit {
   private _tabs = [
@@ -1453,7 +1452,7 @@ class AsyncTabsTestApp implements OnInit {
   </mat-tab-group>
   `,
   standalone: true,
-  imports: [MatTabsModule, CommonModule],
+  imports: [MatTabsModule],
 })
 class TabGroupWithSimpleApi {
   preserveContent = false;
@@ -1476,7 +1475,7 @@ class TabGroupWithSimpleApi {
     </mat-tab-group>
   `,
   standalone: true,
-  imports: [MatTabsModule, CommonModule],
+  imports: [MatTabsModule],
 })
 class NestedTabs {
   @ViewChildren(MatTabGroup) groups: QueryList<MatTabGroup>;
@@ -1496,7 +1495,7 @@ class NestedTabs {
     </mat-tab-group>
   `,
   standalone: true,
-  imports: [MatTabsModule, CommonModule],
+  imports: [MatTabsModule],
 })
 class TemplateTabs {}
 
@@ -1507,7 +1506,7 @@ class TemplateTabs {}
   </mat-tab-group>
   `,
   standalone: true,
-  imports: [MatTabsModule, CommonModule],
+  imports: [MatTabsModule],
 })
 class TabGroupWithAriaInputs {
   ariaLabel: string;
@@ -1526,7 +1525,7 @@ class TabGroupWithAriaInputs {
     }
   `,
   standalone: true,
-  imports: [MatTabsModule, CommonModule],
+  imports: [MatTabsModule],
 })
 class TabGroupWithIsActiveBinding {}
 
@@ -1552,7 +1551,7 @@ class TabsWithCustomAnimationDuration {}
     </mat-tab-group>
   `,
   standalone: true,
-  imports: [MatTabsModule, CommonModule],
+  imports: [MatTabsModule],
 })
 class TabGroupWithIndirectDescendantTabs {
   @ViewChild(MatTabGroup) tabGroup: MatTabGroup;
@@ -1589,7 +1588,7 @@ class TabGroupWithInkBarFitToContent {
     </mat-tab-group>
   `,
   standalone: true,
-  imports: [MatTabsModule, CommonModule],
+  imports: [MatTabsModule],
 })
 class TabGroupWithSpaceAbove {
   @ViewChild(MatTabGroup) tabGroup: MatTabGroup;
@@ -1613,7 +1612,7 @@ class TabGroupWithSpaceAbove {
     </mat-tab-group>
   `,
   standalone: true,
-  imports: [MatTabsModule, CommonModule],
+  imports: [MatTabsModule],
 })
 class NestedTabGroupWithLabel {}
 
@@ -1630,7 +1629,7 @@ class NestedTabGroupWithLabel {}
     </mat-tab-group>
   `,
   standalone: true,
-  imports: [MatTabsModule, CommonModule],
+  imports: [MatTabsModule],
 })
 class TabsWithClassesTestApp {
   labelClassList?: string | string[];

--- a/src/material/tabs/tab-header.spec.ts
+++ b/src/material/tabs/tab-header.spec.ts
@@ -11,7 +11,6 @@ import {
   dispatchFakeEvent,
   dispatchKeyboardEvent,
 } from '@angular/cdk/testing/private';
-import {CommonModule} from '@angular/common';
 import {ChangeDetectorRef, Component, ViewChild, inject} from '@angular/core';
 import {
   ComponentFixture,
@@ -37,7 +36,6 @@ describe('MatTabHeader', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [
-        CommonModule,
         PortalModule,
         MatRippleModule,
         ScrollingModule,

--- a/src/material/toolbar/toolbar.spec.ts
+++ b/src/material/toolbar/toolbar.spec.ts
@@ -1,4 +1,3 @@
-import {CommonModule} from '@angular/common';
 import {Component, signal} from '@angular/core';
 import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
@@ -9,7 +8,6 @@ describe('MatToolbar', () => {
     TestBed.configureTestingModule({
       imports: [
         MatToolbarModule,
-        CommonModule,
         ToolbarSingleRow,
         ToolbarMultipleRows,
         ToolbarMixedRowModes,
@@ -107,7 +105,7 @@ describe('MatToolbar', () => {
     </mat-toolbar>
   `,
   standalone: true,
-  imports: [MatToolbarModule, CommonModule],
+  imports: [MatToolbarModule],
 })
 class ToolbarSingleRow {
   toolbarColor = signal('');
@@ -121,7 +119,7 @@ class ToolbarSingleRow {
     </mat-toolbar>
   `,
   standalone: true,
-  imports: [MatToolbarModule, CommonModule],
+  imports: [MatToolbarModule],
 })
 class ToolbarMultipleRows {}
 
@@ -135,7 +133,7 @@ class ToolbarMultipleRows {}
     </mat-toolbar>
   `,
   standalone: true,
-  imports: [MatToolbarModule, CommonModule],
+  imports: [MatToolbarModule],
 })
 class ToolbarMixedRowModes {
   showToolbarRow = signal(true);
@@ -152,6 +150,6 @@ class ToolbarMixedRowModes {
     </mat-toolbar>
   `,
   standalone: true,
-  imports: [MatToolbarModule, CommonModule],
+  imports: [MatToolbarModule],
 })
 class ToolbarMultipleIndirectRows {}


### PR DESCRIPTION
Removes all our imports of `CommonModule` in tests since it wasn't being used for anything.