### PR TITLE
fix(material/core): correctly identify color input

### DIFF
--- a/src/material/core/theming/_config-validation.scss
+++ b/src/material/core/theming/_config-validation.scss
@@ -29,7 +29,7 @@
 /// Validates that the given object is an M3 palette.
 /// @param {*} $palette The object to test
 /// @return {Boolean|null} null if it is a valid M3 palette, else true.
-@function _validate-palette($palette) {
+@function validate-palette($palette) {
   @if not meta.type-of($palette) == 'map' {
     @return true;
   }
@@ -108,7 +108,7 @@
   }
   @each $palette in (primary, secondary, tertiary) {
     @if $config and map.has-key($config, $palette) {
-      $err: _validate-palette(map.get($config, $palette));
+      $err: validate-palette(map.get($config, $palette));
       @if $err {
         @return (
           #{'Expected $config.#{$palette} to be a valid M3 palette. Got:'}

--- a/src/material/core/tokens/_m3-system.scss
+++ b/src/material/core/tokens/_m3-system.scss
@@ -1,5 +1,6 @@
 @use '../style/elevation';
 @use '../style/sass-utils';
+@use '../theming/config-validation';
 @use '../theming/definition';
 @use './m3/definitions';
 @use 'sass:map';
@@ -44,14 +45,17 @@ $_system-level-prefix: sys;
   $color: map.get($config, color);
   $color-config: null;
   @if ($color) {
+    // validate-palette returns null if it is a valid M3 palette
+    $is-palette: config-validation.validate-palette($color) == null;
+
     // Default to "color-scheme" theme type if the config's color does not provide one.
-    @if (meta.type-of($color) == 'map' and not map.has-key($color, theme-type)) {
+    @if (not $is-palette and not map.has-key($color, theme-type)) {
       $color: map.set($color, theme-type, color-scheme);
     }
 
-    $color-config: if(meta.type-of($color) == 'map',
-      definition.define-colors($color),
-      definition.define-colors((primary: $color, theme-type: color-scheme)));
+    $color-config: if($is-palette,
+            definition.define-colors((primary: $color, theme-type: color-scheme)),
+            definition.define-colors($color));
     @include system-level-colors($color-config, $overrides, $_system-fallback-prefix);
     @include system-level-elevation($color-config, $overrides, $_system-fallback-prefix);
   }


### PR DESCRIPTION
Color input was checking if a map was provided (primary, tertiary, theme type) but the alternative is a palette, which is also a map. This adds the right nuance.

TODO: Send a PR that adds types to Sass so this can be more  intuitive