### PR TITLE
fix(form-field-custom-control-example) _focused signal not firing stateChanges

### DIFF
--- a/src/components-examples/material/form-field/form-field-custom-control/form-field-custom-control-example.ts
+++ b/src/components-examples/material/form-field/form-field-custom-control/form-field-custom-control-example.ts
@@ -173,6 +173,7 @@ export class MyTelInput implements ControlValueAccessor, MatFormFieldControl<MyT
       this._placeholder();
       this._required();
       this._disabled();
+      this._focused();
       // Propagate state changes.
       untracked(() => this.stateChanges.next());
     });


### PR DESCRIPTION
Fixes that form-field-custom-control-example.ts wasn't correctly handling focused events. 

This can easily be checked on the official docs page or the stackblitz, here's two sample screenshots:

![image](https://github.com/user-attachments/assets/4ea7246f-462a-46e3-8bcc-9ccf80ed3541)
In the above screenshot, the user has focused the input, but the form field outline is not becoming blue.

Another failure case is when you leave the input: in this case, it will stay forever outlined in blue:
![image](https://github.com/user-attachments/assets/1149587c-b9bb-4b51-a161-5a9a2f7e2ea3)
