### PR TITLE
fix(google-maps): resolve CLI errors in ng update schematic

### DIFF
--- a/src/google-maps/schematics/ng-update/index.ts
+++ b/src/google-maps/schematics/ng-update/index.ts
@@ -26,10 +26,14 @@ const DEPRECATED_CLASS_NAME = 'DeprecatedMapMarkerClusterer';
 export function updateToV19(): Rule {
   return tree => {
     tree.visit(path => {
-      if (path.endsWith('.html')) {
-        const content = tree.readText(path);
+      if (path.includes('node_modules')) {
+        return;
+      }
 
-        if (content.includes('<' + TAG_NAME)) {
+      if (path.endsWith('.html')) {
+        const content = tree.read(path)?.toString();
+
+        if (content && content.includes('<' + TAG_NAME)) {
           tree.overwrite(path, migrateHtml(content));
         }
       } else if (path.endsWith('.ts') && !path.endsWith('.d.ts')) {
@@ -48,13 +52,14 @@ function migrateHtml(content: string): string {
 
 /** Migrates a TypeScript file from the old tag and class names to the new ones. */
 function migrateTypeScript(path: Path, tree: Tree) {
-  const content = tree.readText(path);
+  const content = tree.read(path)?.toString();
 
   // Exit early if none of the symbols we're looking for are mentioned.
   if (
-    !content.includes('<' + TAG_NAME) &&
-    !content.includes(MODULE_NAME) &&
-    !content.includes(CLASS_NAME)
+    !content ||
+    (!content.includes('<' + TAG_NAME) &&
+      !content.includes(MODULE_NAME) &&
+      !content.includes(CLASS_NAME))
   ) {
     return;
   }


### PR DESCRIPTION
* Fixes that the schematic was throwing an error for non-UTF8 files, because we were using `Tree.readText` instead of `Tree.read.toString`.
* Fixes that we appear to be traversing the `node_modules`.

Fixes #29917.