### PR TITLE
build: generate styling example during the build

### DIFF
--- a/tools/extract-tokens/BUILD.bazel
+++ b/tools/extract-tokens/BUILD.bazel
@@ -10,6 +10,7 @@ ts_library(
     devmode_module = "commonjs",
     tsconfig = ":tsconfig.json",
     deps = [
+        "//tools/highlight-files:sources",
         "@npm//@types/node",
         "@npm//sass",
     ],
@@ -19,6 +20,7 @@ nodejs_binary(
     name = "extract-tokens",
     data = [
         ":extract_tokens_lib",
+        "@npm//highlight.js",
         "@npm//sass",
     ],
     entry_point = ":extract-tokens.ts",


### PR DESCRIPTION
Currently the example in the styling pages on the docs site is generated at runtime which doesn't allow us to highlight it as code correctly. These changes move the generation of the example into the main repo and add syntax highlighting.