### PR TITLE
fix(material/sidenav): prevent the content from jumping when hydrated

### DIFF
--- a/src/material/sidenav/drawer.scss
+++ b/src/material/sidenav/drawer.scss
@@ -109,6 +109,10 @@ $drawer-over-drawer-z-index: 4;
   height: 100%;
   overflow: auto;
 
+  &.mat-drawer-content-hidden {
+    opacity: 0;
+  }
+
   .mat-drawer-transition & {
     transition: {
       duration: variables.$swift-ease-out-duration;

--- a/src/material/sidenav/sidenav.ts
+++ b/src/material/sidenav/sidenav.ts
@@ -30,8 +30,6 @@ import {CdkScrollable} from '@angular/cdk/scrolling';
   template: '<ng-content></ng-content>',
   host: {
     'class': 'mat-drawer-content mat-sidenav-content',
-    '[style.margin-left.px]': '_container._contentMargins.left',
-    '[style.margin-right.px]': '_container._contentMargins.right',
   },
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,

--- a/tools/public_api_guard/material/sidenav.md
+++ b/tools/public_api_guard/material/sidenav.md
@@ -136,6 +136,7 @@ export class MatDrawerContent extends CdkScrollable implements AfterContentInit 
     _container: MatDrawerContainer;
     // (undocumented)
     ngAfterContentInit(): void;
+    protected _shouldBeHidden(): boolean;
     // (undocumented)
     static ɵcmp: i0.ɵɵComponentDeclaration<MatDrawerContent, "mat-drawer-content", never, {}, {}, never, ["*"], true, never>;
     // (undocumented)


### PR DESCRIPTION
Fixes that the content of the sidenav was jumping when the page is hydrated, because we can't measure the sidenav on the server.