### PR TITLE
Corrected typo in documentation: change "form" to "from"

### DIFF
--- a/src/cdk/schematics/update-tool/index.ts
+++ b/src/cdk/schematics/update-tool/index.ts
@@ -194,7 +194,7 @@ export class UpdateProject<Context> {
   }
 
   /**
-   * Creates a program form the specified tsconfig and patches the host
+   * Creates a program from the specified tsconfig and patches the host
    * to read files and directories through the given file system.
    *
    * @throws {TsconfigParseError} If the tsconfig could not be parsed.


### PR DESCRIPTION
This commit addresses a typographical error in the documentation by replacing "form" with "from" for accuracy and clarity.