### PR TITLE
Allow setting setContenteditableValue to `plaintext-only` for tests

### DIFF
--- a/src/cdk/testing/selenium-webdriver/selenium-web-driver-element.ts
+++ b/src/cdk/testing/selenium-webdriver/selenium-web-driver-element.ts
@@ -161,7 +161,11 @@ export class SeleniumWebDriverElement implements TestElement {
   async setContenteditableValue(value: string): Promise<void> {
     const contenteditableAttr = await this.getAttribute('contenteditable');
 
-    if (contenteditableAttr !== '' && contenteditableAttr !== 'true') {
+    if (
+      contenteditableAttr !== '' &&
+      contenteditableAttr !== 'true' &&
+      contenteditableAttr !== 'plaintext-only'
+    ) {
       throw new Error('setContenteditableValue can only be called on a `contenteditable` element.');
     }
 

--- a/src/cdk/testing/testbed/unit-test-element.ts
+++ b/src/cdk/testing/testbed/unit-test-element.ts
@@ -196,7 +196,11 @@ export class UnitTestElement implements TestElement {
   async setContenteditableValue(value: string): Promise<void> {
     const contenteditableAttr = await this.getAttribute('contenteditable');
 
-    if (contenteditableAttr !== '' && contenteditableAttr !== 'true') {
+    if (
+      contenteditableAttr !== '' &&
+      contenteditableAttr !== 'true' &&
+      contenteditableAttr !== 'plaintext-only'
+    ) {
       throw new Error('setContenteditableValue can only be called on a `contenteditable` element.');
     }
 


### PR DESCRIPTION
`plaintext-only` is a valid value for `contenteditable` that specifies that the raw text is editable but rich formatting is disabled. This is supported now for every browser except for Firefox, where it is now supported in a nightly version. See more specifications [here]([https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/contenteditable](https://www.google.com/url?sa=D&q=https%3A%2F%2Fdeveloper.mozilla.org%2Fen-US%2Fdocs%2FWeb%2FHTML%2FGlobal_attributes%2Fcontenteditable)).