### PR TITLE
fix(cdk/table): run differ for all columns

### DIFF
--- a/src/cdk/table/table.ts
+++ b/src/cdk/table/table.ts
@@ -1086,6 +1086,8 @@ export class CdkTable<T>
    */
   private _renderUpdatedColumns(): boolean {
     const columnsDiffReducer = (acc: boolean, def: BaseRowDef) => {
+      // The differ should be run for every column, even if `acc` is already
+      // true (see #29922)
       const diff = !!def.getColumnsDiff();
       return acc || diff;
     };

--- a/src/cdk/table/table.ts
+++ b/src/cdk/table/table.ts
@@ -1085,7 +1085,10 @@ export class CdkTable<T>
    * re-render that section.
    */
   private _renderUpdatedColumns(): boolean {
-    const columnsDiffReducer = (acc: boolean, def: BaseRowDef) => acc || !!def.getColumnsDiff();
+    const columnsDiffReducer = (acc: boolean, def: BaseRowDef) => {
+      const diff = !!def.getColumnsDiff();
+      return acc || diff;
+    };
 
     // Force re-render data rows if the list of column definitions have changed.
     const dataColumnsChanged = this._rowDefs.reduce(columnsDiffReducer, false);


### PR DESCRIPTION
Cloned from original author's change but is failing CLA https://github.com/angular/components/issues/29922

This ensures the differ is run without short-circuiting and skipping columns, which is apparently important for change detection reasons

Fixes https://github.com/angular/components/issues/29922