### PR TITLE
fix(material/chips): emit state changes when chip grid is disabled

### DIFF
--- a/src/material/chips/chip-grid.ts
+++ b/src/material/chips/chip-grid.ts
@@ -129,6 +129,7 @@ export class MatChipGrid
   override set disabled(value: boolean) {
     this._disabled = value;
     this._syncChipsState();
+    this.stateChanges.next();
   }
 
   /**


### PR DESCRIPTION
Fixes that the chip grid wasn't emitting to its `stateChanges` when it becomes disabled which meant that the parent form field might not update correctly.

Fixes #30017.