### PR TITLE
fix(material/sort): simplify animations

### DIFF
--- a/src/material/sort/sort-animations.ts
+++ b/src/material/sort/sort-animations.ts
@@ -24,6 +24,8 @@ const SORT_ANIMATION_TRANSITION =
 /**
  * Animations used by MatSort.
  * @docs-private
+ * @deprecated No longer being used, to be removed.
+ * @breaking-change 21.0.0
  */
 export const matSortAnimations: {
   readonly indicator: AnimationTriggerMetadata;

--- a/src/material/sort/sort-header.html
+++ b/src/material/sort/sort-header.html
@@ -11,6 +11,11 @@
 <div class="mat-sort-header-container mat-focus-indicator"
      [class.mat-sort-header-sorted]="_isSorted()"
      [class.mat-sort-header-position-before]="arrowPosition === 'before'"
+     [class.mat-sort-header-descending]="this._sort.direction === 'desc'"
+     [class.mat-sort-header-ascending]="this._sort.direction === 'asc'"
+     [class.mat-sort-header-recently-cleared-ascending]="_recentlyCleared() === 'asc'"
+     [class.mat-sort-header-recently-cleared-descending]="_recentlyCleared() === 'desc'"
+     [class.mat-sort-header-animations-disabled]="_animationModule === 'NoopAnimations'"
      [attr.tabindex]="_isDisabled() ? null : 0"
      [attr.role]="_isDisabled() ? null : 'button'">
 
@@ -26,18 +31,10 @@
 
   <!-- Disable animations while a current animation is running -->
   @if (_renderArrow()) {
-    <div class="mat-sort-header-arrow"
-        [@arrowOpacity]="_getArrowViewState()"
-        [@arrowPosition]="_getArrowViewState()"
-        [@allowChildren]="_getArrowDirectionState()"
-        (@arrowPosition.start)="_disableViewStateAnimation = true"
-        (@arrowPosition.done)="_disableViewStateAnimation = false">
-      <div class="mat-sort-header-stem"></div>
-      <div class="mat-sort-header-indicator" [@indicator]="_getArrowDirectionState()">
-        <div class="mat-sort-header-pointer-left" [@leftPointer]="_getArrowDirectionState()"></div>
-        <div class="mat-sort-header-pointer-right" [@rightPointer]="_getArrowDirectionState()"></div>
-        <div class="mat-sort-header-pointer-middle"></div>
-      </div>
+    <div class="mat-sort-header-arrow">
+      <svg viewBox="0 -960 960 960" focusable="false" aria-hidden="true">
+        <path d="M440-240v-368L296-464l-56-56 240-240 240 240-56 56-144-144v368h-80Z"/>
+      </svg>
     </div>
   }
 </div>

--- a/src/material/sort/sort-header.scss
+++ b/src/material/sort/sort-header.scss
@@ -1,15 +1,6 @@
-@use '@angular/cdk';
-
 @use '../core/tokens/m2/mat/sort' as tokens-mat-sort;
 @use '../core/tokens/token-utils';
 @use '../core/focus-indicators/private';
-
-$header-arrow-margin: 6px;
-$header-arrow-container-size: 12px;
-$header-arrow-stem-size: 10px;
-$header-arrow-pointer-length: 6px;
-$header-arrow-thickness: 2px;
-$header-arrow-hint-opacity: 0.38;
 
 .mat-sort-header-container {
   display: flex;
@@ -51,93 +42,96 @@ $header-arrow-hint-opacity: 0.38;
   flex-direction: row-reverse;
 }
 
+@keyframes _mat-sort-header-recently-cleared-ascending {
+  from {
+    transform: translateY(0);
+    opacity: 1;
+  }
+
+  to {
+    transform: translateY(-25%);
+    opacity: 0;
+  }
+}
+
+@keyframes _mat-sort-header-recently-cleared-descending {
+  from {
+    transform: translateY(0) rotate(180deg);
+    opacity: 1;
+  }
+
+  to {
+    transform: translateY(25%) rotate(180deg);
+    opacity: 0;
+  }
+}
+
 .mat-sort-header-arrow {
-  height: $header-arrow-container-size;
-  width: $header-arrow-container-size;
-  min-width: $header-arrow-container-size;
+  $timing: 225ms cubic-bezier(0.4, 0, 0.2, 1);
+  height: 12px;
+  width: 12px;
   position: relative;
-  display: flex;
+  transition: transform $timing, opacity $timing;
+  opacity: 0;
+  overflow: visible;
 
   @include token-utils.use-tokens(tokens-mat-sort.$prefix, tokens-mat-sort.get-token-slots()) {
     @include token-utils.create-token-slot(color, arrow-color);
   }
 
-  // Start off at 0 since the arrow may become visible while parent are animating.
-  // This will be overwritten when the arrow animations kick in. See #11819.
-  opacity: 0;
+  .mat-sort-header:hover & {
+    opacity: 0.54;
+  }
+
+  .mat-sort-header .mat-sort-header-sorted & {
+    opacity: 1;
+  }
+
+  .mat-sort-header-descending & {
+    transform: rotate(180deg);
+  }
+
+  .mat-sort-header-recently-cleared-ascending & {
+    transform: translateY(-25%);
+  }
+
+  .mat-sort-header-recently-cleared-ascending & {
+    transition: none; // Without this the animation looks glitchy on Safari.
+    animation: _mat-sort-header-recently-cleared-ascending $timing forwards;
+  }
+
+  .mat-sort-header-recently-cleared-descending & {
+    transition: none; // Without this the animation looks glitchy on Safari.
+    animation: _mat-sort-header-recently-cleared-descending $timing forwards;
+  }
+
+  // Set the durations to 0, but keep the actual animation, since we still want it to play.
+  .mat-sort-header-animations-disabled & {
+    transition-duration: 0ms;
+    animation-duration: 0ms;
+  }
+
+  svg {
+    // Even though this is 24x24, the actual `path` inside ends up being 12x12.
+    width: 24px;
+    height: 24px;
+    fill: currentColor;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    margin: -12px 0 0 -12px;
+
+    // Without this transform the element twitches at the end of the transition on Safari.
+    transform: translateZ(0);
+  }
 
   &,
   [dir='rtl'] .mat-sort-header-position-before & {
-    margin: 0 0 0 $header-arrow-margin;
+    margin: 0 0 0 6px;
   }
 
   .mat-sort-header-position-before &,
   [dir='rtl'] & {
-    margin: 0 $header-arrow-margin 0 0;
+    margin: 0 6px 0 0;
   }
-}
-
-.mat-sort-header-stem {
-  background: currentColor;
-  height: $header-arrow-stem-size;
-  width: $header-arrow-thickness;
-  margin: auto;
-  display: flex;
-  align-items: center;
-
-  @include cdk.high-contrast {
-    width: 0;
-    border-left: solid $header-arrow-thickness;
-  }
-}
-
-.mat-sort-header-indicator {
-  width: 100%;
-  height: $header-arrow-thickness;
-  display: flex;
-  align-items: center;
-  position: absolute;
-  top: 0;
-  left: 0;
-}
-
-.mat-sort-header-pointer-middle {
-  margin: auto;
-  height: $header-arrow-thickness;
-  width: $header-arrow-thickness;
-  background: currentColor;
-  transform: rotate(45deg);
-
-  @include cdk.high-contrast {
-    width: 0;
-    height: 0;
-    border-top: solid $header-arrow-thickness;
-    border-left: solid $header-arrow-thickness;
-  }
-}
-
-.mat-sort-header-pointer-left,
-.mat-sort-header-pointer-right {
-  background: currentColor;
-  width: $header-arrow-pointer-length;
-  height: $header-arrow-thickness;
-  position: absolute;
-  top: 0;
-
-  @include cdk.high-contrast {
-    width: 0;
-    height: 0;
-    border-left: solid $header-arrow-pointer-length;
-    border-top: solid $header-arrow-thickness;
-  }
-}
-
-.mat-sort-header-pointer-left {
-  transform-origin: right;
-  left: 0;
-}
-
-.mat-sort-header-pointer-right {
-  transform-origin: left;
-  right: 0;
 }

--- a/src/material/sort/sort.spec.ts
+++ b/src/material/sort/sort.spec.ts
@@ -1,11 +1,6 @@
 import {CollectionViewer, DataSource} from '@angular/cdk/collections';
 import {CdkTableModule} from '@angular/cdk/table';
-import {
-  createFakeEvent,
-  createMouseEvent,
-  dispatchMouseEvent,
-  wrappedErrorMessage,
-} from '@angular/cdk/testing/private';
+import {dispatchMouseEvent, wrappedErrorMessage} from '@angular/cdk/testing/private';
 import {Component, ElementRef, ViewChild, inject} from '@angular/core';
 import {ComponentFixture, TestBed, fakeAsync, tick, waitForAsync} from '@angular/core/testing';
 import {MatTableModule} from '@angular/material/table';
@@ -101,116 +96,6 @@ describe('MatSort', () => {
       expect(sortables.has('column_a')).toBe(true);
       expect(sortables.has('column_b')).toBe(true);
       expect(sortables.has('column_c')).toBe(true);
-    });
-
-    describe('checking correct arrow direction and view state for its various states', () => {
-      let expectedStates: Map<string, {viewState: string; arrowDirection: string}>;
-
-      beforeEach(() => {
-        // Starting state for the view and directions - note that overrideStart is reversed to be
-        // desc
-        expectedStates = new Map<string, {viewState: string; arrowDirection: string}>([
-          ['defaultA', {viewState: 'asc', arrowDirection: 'asc'}],
-          ['defaultB', {viewState: 'asc', arrowDirection: 'asc'}],
-          ['overrideStart', {viewState: 'desc', arrowDirection: 'desc'}],
-          ['overrideDisableClear', {viewState: 'asc', arrowDirection: 'asc'}],
-        ]);
-        component.expectViewAndDirectionStates(expectedStates);
-      });
-
-      it('should be correct when mousing over headers and leaving on mouseleave', () => {
-        // Mousing over the first sort should set the view state to hint (asc)
-        component.dispatchMouseEvent('defaultA', 'mouseenter');
-        expectedStates.set('defaultA', {viewState: 'asc-to-hint', arrowDirection: 'asc'});
-        component.expectViewAndDirectionStates(expectedStates);
-
-        // Mousing away from the first sort should hide the arrow
-        component.dispatchMouseEvent('defaultA', 'mouseleave');
-        expectedStates.set('defaultA', {viewState: 'hint-to-asc', arrowDirection: 'asc'});
-        component.expectViewAndDirectionStates(expectedStates);
-
-        // Mousing over another sort should set the view state to hint (desc)
-        component.dispatchMouseEvent('overrideStart', 'mouseenter');
-        expectedStates.set('overrideStart', {viewState: 'desc-to-hint', arrowDirection: 'desc'});
-        component.expectViewAndDirectionStates(expectedStates);
-      });
-
-      it('should be correct when mousing over header and then sorting', () => {
-        // Mousing over the first sort should set the view state to hint
-        component.dispatchMouseEvent('defaultA', 'mouseenter');
-        expectedStates.set('defaultA', {viewState: 'asc-to-hint', arrowDirection: 'asc'});
-        component.expectViewAndDirectionStates(expectedStates);
-
-        // Clicking sort on the header should set it to be active immediately
-        // (since it was already hinted)
-        component.dispatchMouseEvent('defaultA', 'click');
-        expectedStates.set('defaultA', {viewState: 'active', arrowDirection: 'active-asc'});
-        component.expectViewAndDirectionStates(expectedStates);
-      });
-
-      it('should be correct when cycling through a default sort header', () => {
-        // Sort the header to set it to the active start state
-        component.sort('defaultA');
-        expectedStates.set('defaultA', {viewState: 'asc-to-active', arrowDirection: 'active-asc'});
-        component.expectViewAndDirectionStates(expectedStates);
-
-        // Sorting again will reverse its direction
-        component.dispatchMouseEvent('defaultA', 'click');
-        expectedStates.set('defaultA', {viewState: 'active', arrowDirection: 'active-desc'});
-        component.expectViewAndDirectionStates(expectedStates);
-
-        // Sorting again will remove the sort and animate away the view
-        component.dispatchMouseEvent('defaultA', 'click');
-        expectedStates.set('defaultA', {viewState: 'active-to-desc', arrowDirection: 'desc'});
-        component.expectViewAndDirectionStates(expectedStates);
-      });
-
-      it('should not enter sort with animations if an animations is disabled', () => {
-        // Sort the header to set it to the active start state
-        component.defaultA._disableViewStateAnimation = true;
-        component.sort('defaultA');
-        expectedStates.set('defaultA', {viewState: 'active', arrowDirection: 'active-asc'});
-        component.expectViewAndDirectionStates(expectedStates);
-
-        // Sorting again will reverse its direction
-        component.defaultA._disableViewStateAnimation = true;
-        component.dispatchMouseEvent('defaultA', 'click');
-        expectedStates.set('defaultA', {viewState: 'active', arrowDirection: 'active-desc'});
-        component.expectViewAndDirectionStates(expectedStates);
-      });
-
-      it('should be correct when sort has changed while a header is active', () => {
-        // Sort the first header to set up
-        component.sort('defaultA');
-        expectedStates.set('defaultA', {viewState: 'asc-to-active', arrowDirection: 'active-asc'});
-        component.expectViewAndDirectionStates(expectedStates);
-
-        // Sort the second header and verify that the first header animated away
-        component.dispatchMouseEvent('defaultB', 'click');
-        expectedStates.set('defaultA', {viewState: 'active-to-asc', arrowDirection: 'asc'});
-        expectedStates.set('defaultB', {viewState: 'asc-to-active', arrowDirection: 'active-asc'});
-        component.expectViewAndDirectionStates(expectedStates);
-      });
-
-      it('should be correct when sort has been disabled', () => {
-        // Mousing over the first sort should set the view state to hint
-        component.disabledColumnSort = true;
-        fixture.changeDetectorRef.markForCheck();
-        fixture.detectChanges();
-
-        component.dispatchMouseEvent('defaultA', 'mouseenter');
-        component.expectViewAndDirectionStates(expectedStates);
-      });
-
-      it('should be correct when sorting programmatically', () => {
-        component.active = 'defaultB';
-        component.direction = 'asc';
-        fixture.changeDetectorRef.markForCheck();
-        fixture.detectChanges();
-
-        expectedStates.set('defaultB', {viewState: 'asc-to-active', arrowDirection: 'active-asc'});
-        component.expectViewAndDirectionStates(expectedStates);
-      });
     });
 
     it('should be able to cycle from asc -> desc from either start point', () => {
@@ -326,54 +211,6 @@ describe('MatSort', () => {
       testSingleColumnSortDirectionSequence(fixture, ['desc', 'asc', ''], 'overrideStart');
 
       testSingleColumnSortDirectionSequence(fixture, ['asc', 'desc'], 'overrideDisableClear');
-    });
-
-    it('should toggle indicator hint on button focus/blur and hide on click', () => {
-      const header = fixture.componentInstance.defaultA;
-      const container = fixture.nativeElement.querySelector('#defaultA .mat-sort-header-container');
-      const focusEvent = createFakeEvent('focus');
-      const blurEvent = createFakeEvent('blur');
-
-      // Should start without a displayed hint
-      expect(header._showIndicatorHint).toBeFalsy();
-
-      // Focusing the button should show the hint, blurring should hide it
-      container.dispatchEvent(focusEvent);
-      expect(header._showIndicatorHint).toBeTruthy();
-
-      container.dispatchEvent(blurEvent);
-      expect(header._showIndicatorHint).toBeFalsy();
-
-      // Show the indicator hint. On click the hint should be hidden
-      container.dispatchEvent(focusEvent);
-      expect(header._showIndicatorHint).toBeTruthy();
-
-      header._handleClick();
-      expect(header._showIndicatorHint).toBeFalsy();
-    });
-
-    it('should toggle indicator hint on mouseenter/mouseleave and hide on click', () => {
-      const header = fixture.componentInstance.defaultA;
-      const headerElement = fixture.nativeElement.querySelector('#defaultA');
-      const mouseenterEvent = createMouseEvent('mouseenter');
-      const mouseleaveEvent = createMouseEvent('mouseleave');
-
-      // Should start without a displayed hint
-      expect(header._showIndicatorHint).toBeFalsy();
-
-      // Mouse enter should show the hint, blurring should hide it
-      headerElement.dispatchEvent(mouseenterEvent);
-      expect(header._showIndicatorHint).toBeTruthy();
-
-      headerElement.dispatchEvent(mouseleaveEvent);
-      expect(header._showIndicatorHint).toBeFalsy();
-
-      // Show the indicator hint. On click the hint should be hidden
-      headerElement.dispatchEvent(mouseenterEvent);
-      expect(header._showIndicatorHint).toBeTruthy();
-
-      header._handleClick();
-      expect(header._showIndicatorHint).toBeFalsy();
     });
 
     it('should apply the aria-sort label to the header when sorted', () => {
@@ -700,27 +537,6 @@ class SimpleMatSortApp {
   dispatchMouseEvent(id: SimpleMatSortAppColumnIds, event: string) {
     const sortElement = this.elementRef.nativeElement.querySelector(`#${id}`)!;
     dispatchMouseEvent(sortElement, event);
-  }
-
-  /**
-   * Checks expectations for each sort header's view state and arrow direction states. Receives a
-   * map that is keyed by each sort header's ID and contains the expectation for that header's
-   * states.
-   */
-  expectViewAndDirectionStates(
-    viewStates: Map<string, {viewState: string; arrowDirection: string}>,
-  ) {
-    const sortHeaders = new Map([
-      ['defaultA', this.defaultA],
-      ['defaultB', this.defaultB],
-      ['overrideStart', this.overrideStart],
-      ['overrideDisableClear', this.overrideDisableClear],
-    ]);
-
-    viewStates.forEach((viewState, id) => {
-      expect(sortHeaders.get(id)!._getArrowViewState()).toEqual(viewState.viewState);
-      expect(sortHeaders.get(id)!._getArrowDirectionState()).toEqual(viewState.arrowDirection);
-    });
   }
 }
 

--- a/tools/public_api_guard/material/sort.md
+++ b/tools/public_api_guard/material/sort.md
@@ -16,11 +16,12 @@ import { OnDestroy } from '@angular/core';
 import { OnInit } from '@angular/core';
 import { Optional } from '@angular/core';
 import { Subject } from 'rxjs';
+import { WritableSignal } from '@angular/core';
 
-// @public
+// @public @deprecated
 export type ArrowViewState = SortDirection | 'hint' | 'active';
 
-// @public
+// @public @deprecated
 export interface ArrowViewStateTransition {
     // (undocumented)
     fromState?: ArrowViewState;
@@ -81,7 +82,7 @@ export interface MatSortable {
     start: SortDirection;
 }
 
-// @public
+// @public @deprecated
 export const matSortAnimations: {
     readonly indicator: AnimationTriggerMetadata;
     readonly leftPointer: AnimationTriggerMetadata;
@@ -100,18 +101,14 @@ export interface MatSortDefaultOptions {
 // @public
 export class MatSortHeader implements MatSortable, OnDestroy, OnInit, AfterViewInit {
     constructor(...args: unknown[]);
-    _arrowDirection: SortDirection;
+    // (undocumented)
+    protected _animationModule: "NoopAnimations" | "BrowserAnimations" | null;
     arrowPosition: SortHeaderArrowPosition;
     // (undocumented)
     _columnDef: MatSortHeaderColumnDef | null;
     disableClear: boolean;
     disabled: boolean;
-    _disableViewStateAnimation: boolean;
     _getAriaSortAttribute(): "none" | "ascending" | "descending";
-    _getArrowDirectionState(): string;
-    _getArrowViewState(): string;
-    // (undocumented)
-    _handleClick(): void;
     // (undocumented)
     _handleKeydown(event: KeyboardEvent): void;
     id: string;
@@ -130,18 +127,14 @@ export class MatSortHeader implements MatSortable, OnDestroy, OnInit, AfterViewI
     ngOnDestroy(): void;
     // (undocumented)
     ngOnInit(): void;
+    protected _recentlyCleared: WritableSignal<SortDirection | null>;
     _renderArrow(): boolean;
-    _setAnimationTransitionState(viewState: ArrowViewStateTransition): void;
-    _setIndicatorHintVisible(visible: boolean): void;
-    _showIndicatorHint: boolean;
     // (undocumented)
     _sort: MatSort;
     get sortActionDescription(): string;
     set sortActionDescription(value: string);
     start: SortDirection;
     _toggleOnInteraction(): void;
-    _updateArrowDirection(): void;
-    _viewState: ArrowViewStateTransition;
     // (undocumented)
     static ɵcmp: i0.ɵɵComponentDeclaration<MatSortHeader, "[mat-sort-header]", ["matSortHeader"], { "id": { "alias": "mat-sort-header"; "required": false; }; "arrowPosition": { "alias": "arrowPosition"; "required": false; }; "start": { "alias": "start"; "required": false; }; "disabled": { "alias": "disabled"; "required": false; }; "sortActionDescription": { "alias": "sortActionDescription"; "required": false; }; "disableClear": { "alias": "disableClear"; "required": false; }; }, {}, never, ["*"], true, never>;
     // (undocumented)


### PR DESCRIPTION
For a long time the sort header's animation was set up by rendering out 4 `div` elements and then arranging them to look like an arrow. This is somewhat complicated to maintain, difficult to customize, in some cases it leads to weird visual bugs and ends up triggering excessive change detections. On top of that, because it depends on `@angular/animations`, it is prone to memory leaks (see https://github.com/angular/angular/issues/54149).

These changes aim to simplify the component and make it more robust by using an `svg` icon and dealing with the animations using CSS.

Fixes #9758.
Fixes #9844.
Fixes #10088.
Fixes #15451.
Fixes #19441.
Fixes #10242.