### PR TITLE
fix(material/timepicker): make disabled input public

### DIFF
--- a/src/material/timepicker/timepicker-input.ts
+++ b/src/material/timepicker/timepicker-input.ts
@@ -144,8 +144,11 @@ export class MatTimepickerInput<D> implements ControlValueAccessor, Validator, O
     () => this.disabledInput() || this._accessorDisabled(),
   );
 
-  /** Whether the input should be disabled through the template. */
-  protected readonly disabledInput: InputSignalWithTransform<boolean, unknown> = input(false, {
+  /**
+   * Whether the input should be disabled through the template.
+   * @docs-private
+   */
+  readonly disabledInput: InputSignalWithTransform<boolean, unknown> = input(false, {
     transform: booleanAttribute,
     alias: 'disabled',
   });

--- a/tools/public_api_guard/material/timepicker.md
+++ b/tools/public_api_guard/material/timepicker.md
@@ -71,7 +71,7 @@ export class MatTimepickerInput<D> implements ControlValueAccessor, Validator, O
     protected readonly _ariaControls: Signal<string | null>;
     protected readonly _ariaExpanded: Signal<string>;
     readonly disabled: Signal<boolean>;
-    protected readonly disabledInput: InputSignalWithTransform<boolean, unknown>;
+    readonly disabledInput: InputSignalWithTransform<boolean, unknown>;
     focus(): void;
     _getLabelId(): string | null;
     getOverlayOrigin(): ElementRef<HTMLElement>;


### PR DESCRIPTION
Initially the `disabled` input was marked as `protected`, because the actual disabled state is a `computed`. This seems to break with some compiler options so these changes switches it to be public.

Fixes #30061.