### PR TITLE
fix(material/core): optgroup label color not inferred correctly

### DIFF
--- a/src/material/core/option/optgroup.scss
+++ b/src/material/core/option/optgroup.scss
@@ -42,5 +42,6 @@
     text-decoration: inherit;
     text-transform: inherit;
     white-space: normal;
+    color: inherit;
   }
 }


### PR DESCRIPTION
Fixes that we weren't setting the color of the `mat-optgroup` label correctly, resulting in it being taken from `mat-list`.

Fixes #30081.