### PR TITLE
fix(cdk/menu): disable flexible dimensions

### DIFF
--- a/src/cdk/menu/menu-trigger.ts
+++ b/src/cdk/menu/menu-trigger.ts
@@ -259,7 +259,7 @@ export class CdkMenuTrigger extends CdkMenuTriggerBase implements OnDestroy {
       .position()
       .flexibleConnectedTo(this._elementRef)
       .withLockedPosition()
-      .withGrowAfterOpen()
+      .withFlexibleDimensions(false)
       .withPositions(this._getOverlayPositions());
   }
 


### PR DESCRIPTION
Disables flexible dimensions for the CDK menu since supporting them properly requires some CSS tweaks and we don't control the CSS of the menu.

Fixes #30077.