### PR TITLE
docs(material/button): avoid clipping icon

### DIFF
--- a/src/components-examples/material/button/button-overview/button-overview-example.css
+++ b/src/components-examples/material/button/button-overview/button-overview-example.css
@@ -27,5 +27,5 @@ section {
 .example-button-container {
   display: flex;
   justify-content: center;
-  width: 120px;
+  width: 140px;
 }


### PR DESCRIPTION
Fixes that the container in the button example was too narrow and was clipping the button.

Fixes #30091.