### PR TITLE
docs(material/timepicker): fix missing icon in example

### DIFF
--- a/src/components-examples/material/timepicker/timepicker-custom-icon/timepicker-custom-icon-example.html
+++ b/src/components-examples/material/timepicker/timepicker-custom-icon/timepicker-custom-icon-example.html
@@ -2,7 +2,7 @@
   <mat-label>Pick a time</mat-label>
   <input matInput [matTimepicker]="picker">
   <mat-timepicker-toggle matIconSuffix [for]="picker">
-    <mat-icon matTimepickerToggleIcon>globe</mat-icon>
+    <mat-icon matTimepickerToggleIcon>keyboard_arrow_down</mat-icon>
   </mat-timepicker-toggle>
   <mat-timepicker #picker/>
 </mat-form-field>


### PR DESCRIPTION
Fixes that one of the timepicker examples didn't have an icon.

Fixes #30076.