### PR TITLE
mat.core migration fixes

### DIFF
--- a/src/material/schematics/ng-update/migrations/mat-core-removal.ts
+++ b/src/material/schematics/ng-update/migrations/mat-core-removal.ts
@@ -25,16 +25,23 @@ export class MatCoreMigration extends Migration<UpgradeData, DevkitContext> {
   }
 
   override visitStylesheet(stylesheet: ResolvedResource): void {
-    const processor = new postcss.Processor([
-      {
-        postcssPlugin: 'mat-core-removal-v19-plugin',
-        AtRule: {
-          use: node => this._getNamespace(node),
-          include: node => this._handleAtInclude(node, stylesheet.filePath),
+    try {
+      const processor = new postcss.Processor([
+        {
+          postcssPlugin: 'mat-core-removal-v19-plugin',
+          AtRule: {
+            use: node => this._getNamespace(node),
+            include: node => this._handleAtInclude(node, stylesheet.filePath),
+          },
         },
-      },
-    ]);
-    processor.process(stylesheet.content, {syntax: scss}).sync();
+      ]);
+      processor.process(stylesheet.content, {syntax: scss}).sync();
+    } catch (e) {
+      this.logger.warn(
+        `Failed to migrate usages of mat.core in ${stylesheet.filePath} due to error:`,
+      );
+      this.logger.warn(e + '');
+    }
   }
 
   /** Handles updating the at-include rules of uses of the core mixin. */

--- a/src/material/schematics/ng-update/migrations/mat-core-removal.ts
+++ b/src/material/schematics/ng-update/migrations/mat-core-removal.ts
@@ -16,6 +16,8 @@ import {
   WorkspacePath,
 } from '@angular/cdk/schematics';
 
+const MATERIAL_IMPORT_PATH = '@angular/material';
+
 export class MatCoreMigration extends Migration<UpgradeData, DevkitContext> {
   override enabled = true;
   private _namespace: string | undefined;
@@ -25,6 +27,11 @@ export class MatCoreMigration extends Migration<UpgradeData, DevkitContext> {
   }
 
   override visitStylesheet(stylesheet: ResolvedResource): void {
+    // Avoid parsing the template Material isn't used.
+    if (!stylesheet.content.includes(MATERIAL_IMPORT_PATH)) {
+      return;
+    }
+
     try {
       const processor = new postcss.Processor([
         {
@@ -77,7 +84,7 @@ export class MatCoreMigration extends Migration<UpgradeData, DevkitContext> {
 
   /** Sets the namespace if the given at-rule if it is importing from @angular/material. */
   private _getNamespace(node: postcss.AtRule): void {
-    if (!this._namespace && node.params.startsWith('@angular/material', 1)) {
+    if (!this._namespace && node.params.startsWith(MATERIAL_IMPORT_PATH, 1)) {
       this._namespace = node.params.split(/\s+/)[2] || 'material';
     }
   }

--- a/src/material/schematics/ng-update/test-cases/v19-mat-core-removal.spec.ts
+++ b/src/material/schematics/ng-update/test-cases/v19-mat-core-removal.spec.ts
@@ -6,7 +6,7 @@ import {MIGRATION_PATH} from '../../paths';
 const PROJECT_ROOT_DIR = '/projects/cdk-testing';
 const THEME_FILE_PATH = join(PROJECT_ROOT_DIR, 'src/theme.scss');
 
-describe('v15 legacy components migration', () => {
+describe('v19 mat.core migration', () => {
   let tree: UnitTestTree;
 
   /** Writes multiple lines to a file. */
@@ -71,6 +71,13 @@ describe('v15 legacy components migration', () => {
           `	 	@include material.elevation-classes();`,
           `	 	@include material.app-background();	 	  `,
         ],
+      });
+    });
+
+    it('should not break if there is an invalid syntax', async () => {
+      await runSassMigrationTest('', {
+        old: [`@use '@angular/material' as mat;`, `.foo { content: '; }`],
+        new: [`@use '@angular/material' as mat;`, `.foo { content: '; }`],
       });
     });
   });


### PR DESCRIPTION
Includes the following fixes for the `mat.core` migration:

### fix(material/schematics): error if stylesheet contains syntax errors 
Fixes that the `mat.core` migration was breaking the whole update process if a stylesheet has syntax errors.

### fix(material/schematics): avoid parsing stylesheets that don't include Material

Adds a check in the `mat.core` migration so that it avoids parsing stylesheets that don't contain `@angular/material` altogether. This both makes the schematic faster and avoids potential issues for stylesheets we don't care about.

Fixes #30115.