### PR TITLE
build: run unit tests against newer version of iOS

### DIFF
--- a/test/browser-providers.js
+++ b/test/browser-providers.js
@@ -5,7 +5,7 @@
  *   - `saucelabs`: Launches the browser within Saucelabs
  */
 const browserConfig = {
-  'iOS15': {unitTest: {target: 'saucelabs'}},
+  'iOS18': {unitTest: {target: 'saucelabs'}},
   'Safari16': {unitTest: {target: 'browserstack'}},
 };
 

--- a/test/karma-browsers.json
+++ b/test/karma-browsers.json
@@ -1,12 +1,12 @@
 {
-  "SAUCELABS_IOS15": {
+  "SAUCELABS_IOS18": {
     "base": "SauceLabs",
-    "appiumVersion": "1.22.0",
+    "appiumVersion": "2.4.1",
     "deviceOrientation": "portrait",
     "browserName": "Safari",
-    "platformVersion": "15.0",
+    "platformVersion": "18.0",
     "platformName": "iOS",
-    "deviceName": "iPhone 13 Pro Max Simulator"
+    "deviceName": "iPhone 15 Pro Max Simulator"
   },
   "BROWSERSTACK_SAFARI16": {
     "base": "BrowserStack",


### PR DESCRIPTION
Updates the unit tests to run against iOS 18 in an attempt to make them more stable.