### PR TITLE
feat(material-experimental/column-resize): Add support for "lazy" rat…

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -24,11 +24,7 @@
       "matchPackageNames": ["*"]
     },
     {
-      "matchPackageNames": [
-        "@angular/ng-dev",
-        "@angular/build-tooling",
-        "angular/dev-infra"
-      ],
+      "matchPackageNames": ["@angular/ng-dev", "@angular/build-tooling", "angular/dev-infra"],
       "groupName": "angular shared dev-infra code",
       "enabled": true
     },

--- a/src/cdk-experimental/column-resize/column-resize.ts
+++ b/src/cdk-experimental/column-resize/column-resize.ts
@@ -6,7 +6,16 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {AfterViewInit, Directive, ElementRef, inject, NgZone, OnDestroy} from '@angular/core';
+import {
+  AfterViewInit,
+  Directive,
+  ElementRef,
+  inject,
+  InjectionToken,
+  Input,
+  NgZone,
+  OnDestroy,
+} from '@angular/core';
 import {_IdGenerator} from '@angular/cdk/a11y';
 import {fromEvent, merge, Subject} from 'rxjs';
 import {filter, map, mapTo, pairwise, startWith, take, takeUntil} from 'rxjs/operators';
@@ -19,6 +28,15 @@ import {HeaderRowEventDispatcher} from './event-dispatcher';
 
 const HOVER_OR_ACTIVE_CLASS = 'cdk-column-resize-hover-or-active';
 const WITH_RESIZED_COLUMN_CLASS = 'cdk-column-resize-with-resized-column';
+
+/** Configurable options for column resize. */
+export interface ColumnResizeOptions {
+  liveResizeUpdates?: boolean; // Defaults to true.
+}
+
+export const COLUMN_RESIZE_OPTIONS = new InjectionToken<ColumnResizeOptions>(
+  'CdkColumnResizeOptions',
+);
 
 /**
  * Base class for ColumnResize directives which attach to mat-table elements to
@@ -44,6 +62,13 @@ export abstract class ColumnResize implements AfterViewInit, OnDestroy {
 
   /** The id attribute of the table, if specified. */
   id?: string;
+
+  /**
+   * Whether to update the column's width continuously as the mouse position
+   * changes, or to wait until mouseup to apply the new size.
+   */
+  @Input() liveResizeUpdates =
+    inject(COLUMN_RESIZE_OPTIONS, {optional: true})?.liveResizeUpdates ?? true;
 
   ngAfterViewInit() {
     this.elementRef.nativeElement!.classList.add(this.getUniqueCssClass());

--- a/src/cdk-experimental/column-resize/resizable.ts
+++ b/src/cdk-experimental/column-resize/resizable.ts
@@ -230,6 +230,7 @@ export abstract class Resizable<HandleComponent extends ResizeOverlayHandle>
             this.overlayRef!,
             this.minWidthPx,
             this.maxWidthPx,
+            this.columnResize.liveResizeUpdates,
           ),
         },
       ],

--- a/src/cdk-experimental/column-resize/resize-ref.ts
+++ b/src/cdk-experimental/column-resize/resize-ref.ts
@@ -16,5 +16,6 @@ export class ResizeRef {
     readonly overlayRef: OverlayRef,
     readonly minWidthPx: number,
     readonly maxWidthPx: number,
+    readonly liveUpdates = true,
   ) {}
 }

--- a/src/material-experimental/column-resize/column-resize.spec.ts
+++ b/src/material-experimental/column-resize/column-resize.spec.ts
@@ -436,7 +436,7 @@ describe('Material Popover Edit', () => {
         expect(component.getOverlayThumbElement(0)).toBeUndefined();
       }));
 
-      it('resizes the target column via mouse input', fakeAsync(() => {
+      it('resizes the target column via mouse input (live updates)', fakeAsync(() => {
         const initialTableWidth = component.getTableWidth();
         const initialColumnWidth = component.getColumnWidth(1);
         const initialColumnPosition = component.getColumnOriginPosition(1);
@@ -479,6 +479,44 @@ describe('Material Popover Edit', () => {
         component.completeResizeWithMouseInProgress(1);
         flush();
 
+        (expect(component.getColumnWidth(1)) as any).isApproximately(initialColumnWidth + 1);
+
+        component.endHoverState();
+        fixture.detectChanges();
+      }));
+
+      it('resizes the target column via mouse input (no live update)', fakeAsync(() => {
+        const initialTableWidth = component.getTableWidth();
+        const initialColumnWidth = component.getColumnWidth(1);
+
+        component.columnResize.liveResizeUpdates = false;
+
+        component.triggerHoverState();
+        fixture.detectChanges();
+        component.beginColumnResizeWithMouse(1);
+
+        const initialThumbPosition = component.getOverlayThumbPosition(1);
+        component.updateResizeWithMouseInProgress(5);
+        fixture.detectChanges();
+        flush();
+
+        let thumbPositionDelta = component.getOverlayThumbPosition(1) - initialThumbPosition;
+        (expect(thumbPositionDelta) as any).isApproximately(5);
+        (expect(component.getColumnWidth(1)) as any).toBe(initialColumnWidth);
+
+        component.updateResizeWithMouseInProgress(1);
+        fixture.detectChanges();
+        flush();
+
+        thumbPositionDelta = component.getOverlayThumbPosition(1) - initialThumbPosition;
+
+        (expect(component.getTableWidth()) as any).toBe(initialTableWidth);
+        (expect(component.getColumnWidth(1)) as any).toBe(initialColumnWidth);
+
+        component.completeResizeWithMouseInProgress(1);
+        flush();
+
+        (expect(component.getTableWidth()) as any).isApproximately(initialTableWidth + 1);
         (expect(component.getColumnWidth(1)) as any).isApproximately(initialColumnWidth + 1);
 
         component.endHoverState();

--- a/src/material-experimental/column-resize/public-api.ts
+++ b/src/material-experimental/column-resize/public-api.ts
@@ -15,3 +15,5 @@ export * from './resizable-directives/default-enabled-resizable';
 export * from './resizable-directives/resizable';
 export * from './resize-strategy';
 export * from './overlay-handle';
+export type {ColumnResizeOptions} from '@angular/cdk-experimental/column-resize';
+export {COLUMN_RESIZE_OPTIONS} from '@angular/cdk-experimental/column-resize';


### PR DESCRIPTION
…her than live updating during resizing.

For complex tables, live resizing is laggy and difficult to use. Keeping the current behavior as default, but we may want to revisit that going forward.