### PR TITLE
fix(material/timepicker): disable toggle if timepicker is disabled

### DIFF
--- a/src/material/timepicker/timepicker-input.ts
+++ b/src/material/timepicker/timepicker-input.ts
@@ -244,7 +244,9 @@ export class MatTimepickerInput<D> implements ControlValueAccessor, Validator, O
 
   /** Handles clicks on the input or the containing form field. */
   private _handleClick = (): void => {
-    this.timepicker().open();
+    if (!this.disabled()) {
+      this.timepicker().open();
+    }
   };
 
   /** Handles the `input` event. */
@@ -278,7 +280,7 @@ export class MatTimepickerInput<D> implements ControlValueAccessor, Validator, O
   /** Handles the `keydown` event. */
   protected _handleKeydown(event: KeyboardEvent) {
     // All keyboard events while open are handled through the timepicker.
-    if (this.timepicker().isOpen()) {
+    if (this.timepicker().isOpen() || this.disabled()) {
       return;
     }
 
@@ -286,7 +288,7 @@ export class MatTimepickerInput<D> implements ControlValueAccessor, Validator, O
       event.preventDefault();
       this.value.set(null);
       this._formatValue(null);
-    } else if ((event.keyCode === DOWN_ARROW || event.keyCode === UP_ARROW) && !this.disabled()) {
+    } else if (event.keyCode === DOWN_ARROW || event.keyCode === UP_ARROW) {
       event.preventDefault();
       this.timepicker().open();
     }

--- a/src/material/timepicker/timepicker-toggle.html
+++ b/src/material/timepicker/timepicker-toggle.html
@@ -4,8 +4,8 @@
   aria-haspopup="listbox"
   [attr.aria-label]="ariaLabel()"
   [attr.aria-expanded]="timepicker().isOpen()"
-  [attr.tabindex]="disabled() ? -1 : tabIndex()"
-  [disabled]="disabled()"
+  [attr.tabindex]="_isDisabled() ? -1 : tabIndex()"
+  [disabled]="_isDisabled()"
   [disableRipple]="disableRipple()">
 
   <ng-content select="[matTimepickerToggleIcon]">

--- a/src/material/timepicker/timepicker-toggle.ts
+++ b/src/material/timepicker/timepicker-toggle.ts
@@ -10,6 +10,7 @@ import {
   booleanAttribute,
   ChangeDetectionStrategy,
   Component,
+  computed,
   HostAttributeToken,
   inject,
   input,
@@ -46,6 +47,11 @@ export class MatTimepickerToggle<D> {
     return isNaN(parsed) ? null : parsed;
   })();
 
+  protected _isDisabled = computed(() => {
+    const timepicker = this.timepicker();
+    return this.disabled() || timepicker.disabled();
+  });
+
   /** Timepicker instance that the button will toggle. */
   readonly timepicker: InputSignal<MatTimepicker<D>> = input.required<MatTimepicker<D>>({
     alias: 'for',
@@ -73,7 +79,7 @@ export class MatTimepickerToggle<D> {
 
   /** Opens the connected timepicker. */
   protected _open(event: Event): void {
-    if (this.timepicker() && !this.disabled()) {
+    if (this.timepicker() && !this._isDisabled()) {
       this.timepicker().open();
       event.stopPropagation();
     }

--- a/src/material/timepicker/timepicker.scss
+++ b/src/material/timepicker/timepicker.scss
@@ -38,11 +38,9 @@ mat-timepicker {
   }
 }
 
-// stylelint-disable material/no-prefixes
-.mat-timepicker-input:read-only {
+.mat-timepicker-input[readonly] {
   cursor: pointer;
 }
-// stylelint-enable material/no-prefixes
 
 @include cdk.high-contrast {
   .mat-timepicker-toggle-default-icon {

--- a/src/material/timepicker/timepicker.spec.ts
+++ b/src/material/timepicker/timepicker.spec.ts
@@ -1164,6 +1164,19 @@ describe('MatTimepicker', () => {
       fixture.detectChanges();
       expect(getPanel()).toBeFalsy();
     });
+
+    it('should disable the toggle when the timepicker is disabled', () => {
+      const fixture = TestBed.createComponent(StandaloneTimepicker);
+      const toggle = getToggle(fixture);
+      fixture.detectChanges();
+      expect(toggle.disabled).toBe(false);
+      expect(toggle.getAttribute('tabindex')).toBe('0');
+
+      fixture.componentInstance.disabled.set(true);
+      fixture.detectChanges();
+      expect(toggle.disabled).toBe(true);
+      expect(toggle.getAttribute('tabindex')).toBe('-1');
+    });
   });
 
   describe('global defaults', () => {

--- a/tools/public_api_guard/material/timepicker.md
+++ b/tools/public_api_guard/material/timepicker.md
@@ -33,6 +33,7 @@ export class MatTimepicker<D> implements OnDestroy, MatOptionParentComponent {
     readonly ariaLabelledby: InputSignal<string | null>;
     close(): void;
     readonly closed: OutputEmitterRef<void>;
+    readonly disabled: Signal<boolean>;
     readonly disableRipple: InputSignalWithTransform<boolean, unknown>;
     protected _getAriaLabelledby(): string | null;
     readonly interval: InputSignalWithTransform<number | null, number | string | null>;
@@ -125,6 +126,8 @@ export class MatTimepickerToggle<D> {
     readonly ariaLabel: InputSignal<string | undefined>;
     readonly disabled: InputSignalWithTransform<boolean, unknown>;
     readonly disableRipple: InputSignalWithTransform<boolean, unknown>;
+    // (undocumented)
+    protected _isDisabled: Signal<boolean>;
     protected _open(event: Event): void;
     readonly tabIndex: InputSignal<number | null>;
     readonly timepicker: InputSignal<MatTimepicker<D>>;


### PR DESCRIPTION
Fixes that the timepicker toggle wasn't considered as disabled automatically when the timepicker is disabled.

Fixes #30134.