### PR TITLE
fix(material/paginator): ignore clicks on disabled buttons

### DIFF
--- a/src/material/paginator/paginator.html
+++ b/src/material/paginator/paginator.html
@@ -44,11 +44,11 @@
       @if (showFirstLastButtons) {
         <button mat-icon-button type="button"
                 class="mat-mdc-paginator-navigation-first"
-                (click)="firstPage()"
+                (click)="_buttonClicked(0, _previousButtonsDisabled())"
                 [attr.aria-label]="_intl.firstPageLabel"
                 [matTooltip]="_intl.firstPageLabel"
                 [matTooltipDisabled]="_previousButtonsDisabled()"
-                [matTooltipPosition]="'above'"
+                matTooltipPosition="above"
                 [disabled]="_previousButtonsDisabled()"
                 disabledInteractive>
           <svg class="mat-mdc-paginator-icon"
@@ -61,11 +61,11 @@
       }
       <button mat-icon-button type="button"
               class="mat-mdc-paginator-navigation-previous"
-              (click)="previousPage()"
+              (click)="_buttonClicked(pageIndex - 1, _previousButtonsDisabled())"
               [attr.aria-label]="_intl.previousPageLabel"
               [matTooltip]="_intl.previousPageLabel"
               [matTooltipDisabled]="_previousButtonsDisabled()"
-              [matTooltipPosition]="'above'"
+              matTooltipPosition="above"
               [disabled]="_previousButtonsDisabled()"
               disabledInteractive>
         <svg class="mat-mdc-paginator-icon"
@@ -77,11 +77,11 @@
       </button>
       <button mat-icon-button type="button"
               class="mat-mdc-paginator-navigation-next"
-              (click)="nextPage()"
+              (click)="_buttonClicked(pageIndex + 1, _nextButtonsDisabled())"
               [attr.aria-label]="_intl.nextPageLabel"
               [matTooltip]="_intl.nextPageLabel"
               [matTooltipDisabled]="_nextButtonsDisabled()"
-              [matTooltipPosition]="'above'"
+              matTooltipPosition="above"
               [disabled]="_nextButtonsDisabled()"
               disabledInteractive>
         <svg class="mat-mdc-paginator-icon"
@@ -94,11 +94,11 @@
       @if (showFirstLastButtons) {
         <button mat-icon-button type="button"
                 class="mat-mdc-paginator-navigation-last"
-                (click)="lastPage()"
+                (click)="_buttonClicked(getNumberOfPages() - 1, _nextButtonsDisabled())"
                 [attr.aria-label]="_intl.lastPageLabel"
                 [matTooltip]="_intl.lastPageLabel"
                 [matTooltipDisabled]="_nextButtonsDisabled()"
-                [matTooltipPosition]="'above'"
+                matTooltipPosition="above"
                 [disabled]="_nextButtonsDisabled()"
                 disabledInteractive>
           <svg class="mat-mdc-paginator-icon"

--- a/src/material/paginator/paginator.spec.ts
+++ b/src/material/paginator/paginator.spec.ts
@@ -1,4 +1,3 @@
-import {dispatchMouseEvent} from '@angular/cdk/testing/private';
 import {ChangeDetectorRef, Component, Provider, Type, ViewChild, inject} from '@angular/core';
 import {ComponentFixture, TestBed, fakeAsync, tick} from '@angular/core/testing';
 import {ThemePalette} from '@angular/material/core';
@@ -135,7 +134,7 @@ describe('MatPaginator', () => {
       const paginator = component.paginator;
       expect(paginator.pageIndex).toBe(0);
 
-      dispatchMouseEvent(getNextButton(fixture), 'click');
+      getNextButton(fixture).click();
 
       expect(paginator.pageIndex).toBe(1);
       expect(component.pageEvent).toHaveBeenCalledWith(
@@ -154,7 +153,7 @@ describe('MatPaginator', () => {
       fixture.detectChanges();
       expect(paginator.pageIndex).toBe(1);
 
-      dispatchMouseEvent(getPreviousButton(fixture), 'click');
+      getPreviousButton(fixture).click();
 
       expect(paginator.pageIndex).toBe(0);
       expect(component.pageEvent).toHaveBeenCalledWith(
@@ -164,12 +163,37 @@ describe('MatPaginator', () => {
         }),
       );
     });
+
+    it('should not navigate to the next page when the paginator is disabled', () => {
+      const fixture = createComponent(MatPaginatorApp);
+      expect(fixture.componentInstance.paginator.pageIndex).toBe(0);
+
+      fixture.componentInstance.disabled = true;
+      fixture.changeDetectorRef.markForCheck();
+      fixture.detectChanges();
+      getNextButton(fixture).click();
+      expect(fixture.componentInstance.paginator.pageIndex).toBe(0);
+    });
+
+    it('should not navigate to the previous page when the paginator is disabled', () => {
+      const fixture = createComponent(MatPaginatorApp);
+      fixture.componentInstance.pageIndex = 1;
+      fixture.changeDetectorRef.markForCheck();
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.paginator.pageIndex).toBe(1);
+
+      fixture.componentInstance.disabled = true;
+      fixture.changeDetectorRef.markForCheck();
+      fixture.detectChanges();
+      getPreviousButton(fixture).click();
+      expect(fixture.componentInstance.paginator.pageIndex).toBe(1);
+    });
   });
 
   it('should be able to show the first/last buttons', () => {
     const fixture = createComponent(MatPaginatorApp);
     expect(getFirstButton(fixture)).withContext('Expected first button to not exist.').toBeNull();
-
     expect(getLastButton(fixture)).withContext('Expected last button to not exist.').toBeNull();
 
     fixture.componentInstance.showFirstLastButtons = true;
@@ -271,7 +295,7 @@ describe('MatPaginator', () => {
     it('should be able to go to the last page via the last page button', () => {
       expect(paginator.pageIndex).toBe(0);
 
-      dispatchMouseEvent(getLastButton(fixture), 'click');
+      getLastButton(fixture).click();
 
       expect(paginator.pageIndex).toBe(9);
       expect(component.pageEvent).toHaveBeenCalledWith(
@@ -287,7 +311,7 @@ describe('MatPaginator', () => {
       fixture.detectChanges();
       expect(paginator.pageIndex).toBe(3);
 
-      dispatchMouseEvent(getFirstButton(fixture), 'click');
+      getFirstButton(fixture).click();
 
       expect(paginator.pageIndex).toBe(0);
       expect(component.pageEvent).toHaveBeenCalledWith(
@@ -305,7 +329,7 @@ describe('MatPaginator', () => {
       expect(paginator.hasNextPage()).toBe(false);
 
       component.pageEvent.calls.reset();
-      dispatchMouseEvent(getNextButton(fixture), 'click');
+      getNextButton(fixture).click();
 
       expect(component.pageEvent).not.toHaveBeenCalled();
       expect(paginator.pageIndex).toBe(9);
@@ -316,10 +340,34 @@ describe('MatPaginator', () => {
       expect(paginator.hasPreviousPage()).toBe(false);
 
       component.pageEvent.calls.reset();
-      dispatchMouseEvent(getPreviousButton(fixture), 'click');
+      getPreviousButton(fixture).click();
 
       expect(component.pageEvent).not.toHaveBeenCalled();
       expect(paginator.pageIndex).toBe(0);
+    });
+
+    it('should not navigate to the last page when the paginator is disabled', () => {
+      expect(fixture.componentInstance.paginator.pageIndex).toBe(0);
+
+      fixture.componentInstance.disabled = true;
+      fixture.changeDetectorRef.markForCheck();
+      fixture.detectChanges();
+      getLastButton(fixture).click();
+      expect(fixture.componentInstance.paginator.pageIndex).toBe(0);
+    });
+
+    it('should not navigate to the first page when the paginator is disabled', () => {
+      fixture.componentInstance.pageIndex = 1;
+      fixture.changeDetectorRef.markForCheck();
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.paginator.pageIndex).toBe(1);
+
+      fixture.componentInstance.disabled = true;
+      fixture.changeDetectorRef.markForCheck();
+      fixture.detectChanges();
+      getFirstButton(fixture).click();
+      expect(fixture.componentInstance.paginator.pageIndex).toBe(1);
     });
   });
 
@@ -569,19 +617,19 @@ describe('MatPaginator', () => {
   });
 });
 
-function getPreviousButton(fixture: ComponentFixture<any>) {
+function getPreviousButton(fixture: ComponentFixture<any>): HTMLButtonElement {
   return fixture.nativeElement.querySelector('.mat-mdc-paginator-navigation-previous');
 }
 
-function getNextButton(fixture: ComponentFixture<any>) {
+function getNextButton(fixture: ComponentFixture<any>): HTMLButtonElement {
   return fixture.nativeElement.querySelector('.mat-mdc-paginator-navigation-next');
 }
 
-function getFirstButton(fixture: ComponentFixture<any>) {
+function getFirstButton(fixture: ComponentFixture<any>): HTMLButtonElement {
   return fixture.nativeElement.querySelector('.mat-mdc-paginator-navigation-first');
 }
 
-function getLastButton(fixture: ComponentFixture<any>) {
+function getLastButton(fixture: ComponentFixture<any>): HTMLButtonElement {
   return fixture.nativeElement.querySelector('.mat-mdc-paginator-navigation-last');
 }
 

--- a/src/material/paginator/paginator.ts
+++ b/src/material/paginator/paginator.ts
@@ -241,48 +241,32 @@ export class MatPaginator implements OnInit, OnDestroy {
 
   /** Advances to the next page if it exists. */
   nextPage(): void {
-    if (!this.hasNextPage()) {
-      return;
+    if (this.hasNextPage()) {
+      this._navigate(this.pageIndex + 1);
     }
-
-    const previousPageIndex = this.pageIndex;
-    this.pageIndex = this.pageIndex + 1;
-    this._emitPageEvent(previousPageIndex);
   }
 
   /** Move back to the previous page if it exists. */
   previousPage(): void {
-    if (!this.hasPreviousPage()) {
-      return;
+    if (this.hasPreviousPage()) {
+      this._navigate(this.pageIndex - 1);
     }
-
-    const previousPageIndex = this.pageIndex;
-    this.pageIndex = this.pageIndex - 1;
-    this._emitPageEvent(previousPageIndex);
   }
 
   /** Move to the first page if not already there. */
   firstPage(): void {
     // hasPreviousPage being false implies at the start
-    if (!this.hasPreviousPage()) {
-      return;
+    if (this.hasPreviousPage()) {
+      this._navigate(0);
     }
-
-    const previousPageIndex = this.pageIndex;
-    this.pageIndex = 0;
-    this._emitPageEvent(previousPageIndex);
   }
 
   /** Move to the last page if not already there. */
   lastPage(): void {
     // hasNextPage being false implies at the end
-    if (!this.hasNextPage()) {
-      return;
+    if (this.hasNextPage()) {
+      this._navigate(this.getNumberOfPages() - 1);
     }
-
-    const previousPageIndex = this.pageIndex;
-    this.pageIndex = this.getNumberOfPages() - 1;
-    this._emitPageEvent(previousPageIndex);
   }
 
   /** Whether there is a previous page. */
@@ -368,5 +352,29 @@ export class MatPaginator implements OnInit, OnDestroy {
       pageSize: this.pageSize,
       length: this.length,
     });
+  }
+
+  /** Navigates to a specific page index. */
+  private _navigate(index: number) {
+    const previousIndex = this.pageIndex;
+
+    if (index !== previousIndex) {
+      this.pageIndex = index;
+      this._emitPageEvent(previousIndex);
+    }
+  }
+
+  /**
+   * Callback invoked when one of the navigation buttons is called.
+   * @param targetIndex Index to which the paginator should navigate.
+   * @param isDisabled Whether the button is disabled.
+   */
+  protected _buttonClicked(targetIndex: number, isDisabled: boolean) {
+    // Note that normally disabled buttons won't dispatch the click event, but the paginator ones
+    // do, because we're using `disabledInteractive` to allow them to be focusable. We need to
+    // check here to avoid the navigation.
+    if (!isDisabled) {
+      this._navigate(targetIndex);
+    }
   }
 }

--- a/tools/public_api_guard/material/paginator.md
+++ b/tools/public_api_guard/material/paginator.md
@@ -35,6 +35,7 @@ export function MAT_PAGINATOR_INTL_PROVIDER_FACTORY(parentIntl: MatPaginatorIntl
 // @public
 export class MatPaginator implements OnInit, OnDestroy {
     constructor(_intl: MatPaginatorIntl, _changeDetectorRef: ChangeDetectorRef, defaults?: MatPaginatorDefaultOptions);
+    protected _buttonClicked(targetIndex: number, isDisabled: boolean): void;
     _changePageSize(pageSize: number): void;
     color: ThemePalette;
     disabled: boolean;


### PR DESCRIPTION
The changes in #29379 made the paginator interactive while they're disabled in order to improve accessibility, but as a result it also allows for the buttons to navigate while they're disabled.

These changes add internal checks to ensure that the buttons don't navigate while disabled. I've also cleaned up the logic a bit so we don't have four different places that deal with navigations.

Fixes #30124.