### PR TITLE
refactor(multiple): use renderer for manual event bindings

### DIFF
--- a/src/cdk/dialog/dialog-container.ts
+++ b/src/cdk/dialog/dialog-container.ts
@@ -33,6 +33,7 @@ import {
   Injector,
   NgZone,
   OnDestroy,
+  Renderer2,
   ViewChild,
   ViewEncapsulation,
   afterNextRender,
@@ -79,6 +80,7 @@ export class CdkDialogContainer<C extends DialogConfig = DialogConfig>
   protected _ngZone = inject(NgZone);
   private _overlayRef = inject(OverlayRef);
   private _focusMonitor = inject(FocusMonitor);
+  private _renderer = inject(Renderer2);
 
   private _platform = inject(Platform);
   protected _document = inject(DOCUMENT, {optional: true})!;
@@ -223,13 +225,13 @@ export class CdkDialogContainer<C extends DialogConfig = DialogConfig>
       // The tabindex attribute should be removed to avoid navigating to that element again
       this._ngZone.runOutsideAngular(() => {
         const callback = () => {
-          element.removeEventListener('blur', callback);
-          element.removeEventListener('mousedown', callback);
+          deregisterBlur();
+          deregisterMousedown();
           element.removeAttribute('tabindex');
         };
 
-        element.addEventListener('blur', callback);
-        element.addEventListener('mousedown', callback);
+        const deregisterBlur = this._renderer.listen(element, 'blur', callback);
+        const deregisterMousedown = this._renderer.listen(element, 'mousedown', callback);
       });
     }
     element.focus(options);

--- a/src/cdk/drag-drop/drag-drop.ts
+++ b/src/cdk/drag-drop/drag-drop.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Injectable, NgZone, ElementRef, inject} from '@angular/core';
+import {Injectable, NgZone, ElementRef, inject, RendererFactory2} from '@angular/core';
 import {DOCUMENT} from '@angular/common';
 import {ViewportRuler} from '@angular/cdk/scrolling';
 import {DragRef, DragRefConfig} from './drag-ref';
@@ -28,6 +28,7 @@ export class DragDrop {
   private _ngZone = inject(NgZone);
   private _viewportRuler = inject(ViewportRuler);
   private _dragDropRegistry = inject(DragDropRegistry);
+  private _renderer = inject(RendererFactory2).createRenderer(null, null);
 
   constructor(...args: unknown[]);
   constructor() {}
@@ -48,6 +49,7 @@ export class DragDrop {
       this._ngZone,
       this._viewportRuler,
       this._dragDropRegistry,
+      this._renderer,
     );
   }
 

--- a/src/cdk/drag-drop/preview-ref.ts
+++ b/src/cdk/drag-drop/preview-ref.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {EmbeddedViewRef, TemplateRef, ViewContainerRef} from '@angular/core';
+import {EmbeddedViewRef, Renderer2, TemplateRef, ViewContainerRef} from '@angular/core';
 import {Direction} from '@angular/cdk/bidi';
 import {
   extendStyles,
@@ -56,6 +56,7 @@ export class PreviewRef {
     },
     private _initialTransform: string | null,
     private _zIndex: number,
+    private _renderer: Renderer2,
   ) {}
 
   attach(parent: HTMLElement): void {
@@ -91,12 +92,8 @@ export class PreviewRef {
     return getTransformTransitionDurationInMs(this._preview);
   }
 
-  addEventListener(name: string, handler: EventListenerOrEventListenerObject) {
-    this._preview.addEventListener(name, handler);
-  }
-
-  removeEventListener(name: string, handler: EventListenerOrEventListenerObject) {
-    this._preview.removeEventListener(name, handler);
+  addEventListener(name: string, handler: (event: any) => void): () => void {
+    return this._renderer.listen(this._preview, name, handler);
   }
 
   private _createPreview(): HTMLElement {

--- a/src/cdk/overlay/dispatchers/overlay-keyboard-dispatcher.spec.ts
+++ b/src/cdk/overlay/dispatchers/overlay-keyboard-dispatcher.spec.ts
@@ -138,15 +138,17 @@ describe('OverlayKeyboardDispatcher', () => {
   it('should dispose of the global keyboard event handler correctly', () => {
     const overlayRef = overlay.create();
     const body = document.body;
-
     spyOn(body, 'addEventListener');
     spyOn(body, 'removeEventListener');
 
     keyboardDispatcher.add(overlayRef);
-    expect(body.addEventListener).toHaveBeenCalledWith('keydown', jasmine.any(Function));
+    expect(body.addEventListener).toHaveBeenCalledWith('keydown', jasmine.any(Function), false);
 
     overlayRef.dispose();
-    expect(body.removeEventListener).toHaveBeenCalledWith('keydown', jasmine.any(Function));
+    expect(document.body.removeEventListener).toHaveBeenCalledWith(
+      'keydown',
+      jasmine.any(Function),
+    );
   });
 
   it('should skip overlays that do not have keydown event subscriptions', () => {

--- a/src/cdk/overlay/overlay.ts
+++ b/src/cdk/overlay/overlay.ts
@@ -17,6 +17,7 @@ import {
   ANIMATION_MODULE_TYPE,
   EnvironmentInjector,
   inject,
+  RendererFactory2,
 } from '@angular/core';
 import {_IdGenerator} from '@angular/cdk/a11y';
 import {_CdkPrivateStyleLoader} from '@angular/cdk/private';
@@ -50,6 +51,7 @@ export class Overlay {
   private _outsideClickDispatcher = inject(OverlayOutsideClickDispatcher);
   private _animationsModuleType = inject(ANIMATION_MODULE_TYPE, {optional: true});
   private _idGenerator = inject(_IdGenerator);
+  private _renderer = inject(RendererFactory2).createRenderer(null, null);
 
   private _appRef: ApplicationRef;
   private _styleLoader = inject(_CdkPrivateStyleLoader);
@@ -86,6 +88,7 @@ export class Overlay {
       this._outsideClickDispatcher,
       this._animationsModuleType === 'NoopAnimations',
       this._injector.get(EnvironmentInjector),
+      this._renderer,
     );
   }
 

--- a/src/material/button/button-base.ts
+++ b/src/material/button/button-base.ts
@@ -21,6 +21,7 @@ import {
   numberAttribute,
   OnDestroy,
   OnInit,
+  Renderer2,
 } from '@angular/core';
 import {_StructuralStylesLoader, MatRippleLoader, ThemePalette} from '@angular/material/core';
 import {_CdkPrivateStyleLoader} from '@angular/cdk/private';
@@ -242,6 +243,9 @@ export const MAT_ANCHOR_HOST = {
  */
 @Directive()
 export class MatAnchorBase extends MatButtonBase implements OnInit, OnDestroy {
+  private _renderer = inject(Renderer2);
+  private _cleanupClick: () => void;
+
   @Input({
     transform: (value: unknown) => {
       return value == null ? undefined : numberAttribute(value);
@@ -251,13 +255,17 @@ export class MatAnchorBase extends MatButtonBase implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this._ngZone.runOutsideAngular(() => {
-      this._elementRef.nativeElement.addEventListener('click', this._haltDisabledEvents);
+      this._cleanupClick = this._renderer.listen(
+        this._elementRef.nativeElement,
+        'click',
+        this._haltDisabledEvents,
+      );
     });
   }
 
   override ngOnDestroy(): void {
     super.ngOnDestroy();
-    this._elementRef.nativeElement.removeEventListener('click', this._haltDisabledEvents);
+    this._cleanupClick?.();
   }
 
   _haltDisabledEvents = (event: Event): void => {

--- a/src/material/form-field/directives/line-ripple.ts
+++ b/src/material/form-field/directives/line-ripple.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Directive, ElementRef, NgZone, OnDestroy, inject} from '@angular/core';
+import {Directive, ElementRef, NgZone, OnDestroy, Renderer2, inject} from '@angular/core';
 
 /** Class added when the line ripple is active. */
 const ACTIVATE_CLASS = 'mdc-line-ripple--active';
@@ -30,14 +30,20 @@ const DEACTIVATING_CLASS = 'mdc-line-ripple--deactivating';
 })
 export class MatFormFieldLineRipple implements OnDestroy {
   private _elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
+  private _cleanupTransitionEnd: () => void;
 
   constructor(...args: unknown[]);
 
   constructor() {
     const ngZone = inject(NgZone);
+    const renderer = inject(Renderer2);
 
     ngZone.runOutsideAngular(() => {
-      this._elementRef.nativeElement.addEventListener('transitionend', this._handleTransitionEnd);
+      this._cleanupTransitionEnd = renderer.listen(
+        this._elementRef.nativeElement,
+        'transitionend',
+        this._handleTransitionEnd,
+      );
     });
   }
 
@@ -61,6 +67,6 @@ export class MatFormFieldLineRipple implements OnDestroy {
   };
 
   ngOnDestroy() {
-    this._elementRef.nativeElement.removeEventListener('transitionend', this._handleTransitionEnd);
+    this._cleanupTransitionEnd();
   }
 }

--- a/src/material/list/selection-list.ts
+++ b/src/material/list/selection-list.ts
@@ -25,6 +25,7 @@ import {
   OnDestroy,
   Output,
   QueryList,
+  Renderer2,
   SimpleChanges,
   ViewEncapsulation,
   forwardRef,
@@ -78,9 +79,11 @@ export class MatSelectionList
 {
   _element = inject<ElementRef<HTMLElement>>(ElementRef);
   private _ngZone = inject(NgZone);
+  private _renderer = inject(Renderer2);
 
   private _initialized = false;
   private _keyManager: FocusKeyManager<MatListOption>;
+  private _listenerCleanups: (() => void)[] | undefined;
 
   /** Emits when the list has been destroyed. */
   private _destroyed = new Subject<void>();
@@ -173,8 +176,10 @@ export class MatSelectionList
     // These events are bound outside the zone, because they don't change
     // any change-detected properties and they can trigger timeouts.
     this._ngZone.runOutsideAngular(() => {
-      this._element.nativeElement.addEventListener('focusin', this._handleFocusin);
-      this._element.nativeElement.addEventListener('focusout', this._handleFocusout);
+      this._listenerCleanups = [
+        this._renderer.listen(this._element.nativeElement, 'focusin', this._handleFocusin),
+        this._renderer.listen(this._element.nativeElement, 'focusout', this._handleFocusout),
+      ];
     });
 
     if (this._value) {
@@ -200,8 +205,7 @@ export class MatSelectionList
 
   ngOnDestroy() {
     this._keyManager?.destroy();
-    this._element.nativeElement.removeEventListener('focusin', this._handleFocusin);
-    this._element.nativeElement.removeEventListener('focusout', this._handleFocusout);
+    this._listenerCleanups?.forEach(current => current());
     this._destroyed.next();
     this._destroyed.complete();
     this._isDestroyed = true;

--- a/src/material/sidenav/drawer.ts
+++ b/src/material/sidenav/drawer.ts
@@ -42,6 +42,7 @@ import {
   OnDestroy,
   Output,
   QueryList,
+  Renderer2,
   ViewChild,
   ViewEncapsulation,
 } from '@angular/core';
@@ -176,6 +177,7 @@ export class MatDrawer implements AfterViewInit, AfterContentChecked, OnDestroy 
   private _focusMonitor = inject(FocusMonitor);
   private _platform = inject(Platform);
   private _ngZone = inject(NgZone);
+  private _renderer = inject(Renderer2);
   private readonly _interactivityChecker = inject(InteractivityChecker);
   private _doc = inject(DOCUMENT, {optional: true})!;
   _container? = inject<MatDrawerContainer>(MAT_DRAWER_CONTAINER, {optional: true});
@@ -401,13 +403,13 @@ export class MatDrawer implements AfterViewInit, AfterContentChecked, OnDestroy 
       // The tabindex attribute should be removed to avoid navigating to that element again
       this._ngZone.runOutsideAngular(() => {
         const callback = () => {
-          element.removeEventListener('blur', callback);
-          element.removeEventListener('mousedown', callback);
+          cleanupBlur();
+          cleanupMousedown();
           element.removeAttribute('tabindex');
         };
 
-        element.addEventListener('blur', callback);
-        element.addEventListener('mousedown', callback);
+        const cleanupBlur = this._renderer.listen(element, 'blur', callback);
+        const cleanupMousedown = this._renderer.listen(element, 'mousedown', callback);
       });
     }
     element.focus(options);

--- a/tools/public_api_guard/cdk/drag-drop.md
+++ b/tools/public_api_guard/cdk/drag-drop.md
@@ -16,6 +16,7 @@ import { NumberInput } from '@angular/cdk/coercion';
 import { Observable } from 'rxjs';
 import { OnChanges } from '@angular/core';
 import { OnDestroy } from '@angular/core';
+import { Renderer2 } from '@angular/core';
 import { SimpleChanges } from '@angular/core';
 import { Subject } from 'rxjs';
 import { TemplateRef } from '@angular/core';
@@ -378,7 +379,7 @@ export class DragDropRegistry<_ = unknown, __ = unknown> implements OnDestroy {
 
 // @public
 export class DragRef<T = any> {
-    constructor(element: ElementRef<HTMLElement> | HTMLElement, _config: DragRefConfig, _document: Document, _ngZone: NgZone, _viewportRuler: ViewportRuler, _dragDropRegistry: DragDropRegistry);
+    constructor(element: ElementRef<HTMLElement> | HTMLElement, _config: DragRefConfig, _document: Document, _ngZone: NgZone, _viewportRuler: ViewportRuler, _dragDropRegistry: DragDropRegistry, _renderer: Renderer2);
     readonly beforeStarted: Subject<void>;
     constrainPosition?: (userPointerPosition: Point, dragRef: DragRef, dimensions: DOMRect, pickupPositionInElement: Point) => Point;
     data: T;

--- a/tools/public_api_guard/cdk/overlay.md
+++ b/tools/public_api_guard/cdk/overlay.md
@@ -27,6 +27,7 @@ import { OnChanges } from '@angular/core';
 import { OnDestroy } from '@angular/core';
 import { Platform } from '@angular/cdk/platform';
 import { PortalOutlet } from '@angular/cdk/portal';
+import { Renderer2 } from '@angular/core';
 import { ScrollDispatcher } from '@angular/cdk/scrolling';
 import { SimpleChanges } from '@angular/core';
 import { Subject } from 'rxjs';
@@ -356,7 +357,7 @@ export class OverlayPositionBuilder {
 
 // @public
 export class OverlayRef implements PortalOutlet {
-    constructor(_portalOutlet: PortalOutlet, _host: HTMLElement, _pane: HTMLElement, _config: ImmutableObject<OverlayConfig>, _ngZone: NgZone, _keyboardDispatcher: OverlayKeyboardDispatcher, _document: Document, _location: Location_2, _outsideClickDispatcher: OverlayOutsideClickDispatcher, _animationsDisabled: boolean | undefined, _injector: EnvironmentInjector);
+    constructor(_portalOutlet: PortalOutlet, _host: HTMLElement, _pane: HTMLElement, _config: ImmutableObject<OverlayConfig>, _ngZone: NgZone, _keyboardDispatcher: OverlayKeyboardDispatcher, _document: Document, _location: Location_2, _outsideClickDispatcher: OverlayOutsideClickDispatcher, _animationsDisabled: boolean | undefined, _injector: EnvironmentInjector, _renderer: Renderer2);
     addPanelClass(classes: string | string[]): void;
     // (undocumented)
     attach<T>(portal: ComponentPortal<T>): ComponentRef<T>;


### PR DESCRIPTION
Switches our manual calls into `addEventListener` to use the renderer instead so that tooling (e.g. the tracing service) gets notified about them.

Note that these changes only include the events that don't pass event options. The remaining events will be changed in a follow-up, because they require us to update to the latest `next` version of Angular.