### PR TITLE
fix(material/table): set border none for header cells on last row

### DIFF
--- a/src/material/table/table.scss
+++ b/src/material/table/table.scss
@@ -102,6 +102,10 @@
     [dir='rtl'] & {
       text-align: right;
     }
+
+    .mdc-data-table__row:last-child > & {
+      border-bottom: none;
+    }
   }
 
   .mat-mdc-cell {


### PR DESCRIPTION
This affects tables that want to use a `th` element in each data row. The last row's header cell should not have a bottom border, similar to other data cells in the last row

Inspired by #27762 which cannot be merged due to missing CLA. 

Fixes https://github.com/angular/components/issues/27731
