### PR TITLE
[feat] drag start predicate

### DIFF
--- a/src/cdk/drag-drop/directives/config.ts
+++ b/src/cdk/drag-drop/directives/config.ts
@@ -12,6 +12,9 @@ import {DragRefConfig, Point, DragRef} from '../drag-ref';
 /** Possible values that can be used to configure the drag start delay. */
 export type DragStartDelay = number | {touch: number; mouse: number};
 
+/** Function that is used to determine whether a drag operation is allowed to start. */
+export type DragStartPredicate = (event: MouseEvent | TouchEvent) => boolean;
+
 /** Possible axis along which dragging can be locked. */
 export type DragAxis = 'x' | 'y';
 

--- a/src/cdk/drag-drop/directives/drag.ts
+++ b/src/cdk/drag-drop/directives/drag.ts
@@ -46,7 +46,13 @@ import {CDK_DRAG_PARENT} from '../drag-parent';
 import {DragRef, Point, PreviewContainer} from '../drag-ref';
 import type {CdkDropList} from './drop-list';
 import {DragDrop} from '../drag-drop';
-import {CDK_DRAG_CONFIG, DragDropConfig, DragStartDelay, DragAxis} from './config';
+import {
+  CDK_DRAG_CONFIG,
+  DragDropConfig,
+  DragStartDelay,
+  DragAxis,
+  DragStartPredicate,
+} from './config';
 import {assertElementNode} from './assertions';
 import {DragDropRegistry} from '../drag-drop-registry';
 
@@ -113,6 +119,9 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
    * pointer down before starting to drag the element.
    */
   @Input('cdkDragStartDelay') dragStartDelay: DragStartDelay;
+
+  /** Function that is used to determine whether a drag operation is allowed to start. */
+  @Input('cdkDragStartPredicate') dragStartPredicate?: DragStartPredicate;
 
   /**
    * Sets the position of a `CdkDrag` that is outside of a drop container.
@@ -430,6 +439,7 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
       if (!ref.isDragging()) {
         const dir = this._dir;
         const dragStartDelay = this.dragStartDelay;
+        const dragStartPredicate = this.dragStartPredicate;
         const placeholder = this._placeholderTemplate
           ? {
               template: this._placeholderTemplate.templateRef,
@@ -453,6 +463,7 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
           typeof dragStartDelay === 'object' && dragStartDelay
             ? dragStartDelay
             : coerceNumberProperty(dragStartDelay);
+        ref.dragStartPredicate = dragStartPredicate;
         ref.constrainPosition = this.constrainPosition;
         ref.previewClass = this.previewClass;
         ref

--- a/src/cdk/drag-drop/drag-ref.ts
+++ b/src/cdk/drag-drop/drag-ref.ts
@@ -39,6 +39,7 @@ import {
 import {DragDropRegistry} from './drag-drop-registry';
 import type {DropListRef} from './drop-list-ref';
 import {DragPreviewTemplate, PreviewRef} from './preview-ref';
+import {DragStartPredicate} from './directives/config';
 
 /** Object that can be used to configure the behavior of DragRef. */
 export interface DragRefConfig {
@@ -285,6 +286,9 @@ export class DragRef<T = any> {
    * pointer down before starting to drag the element.
    */
   dragStartDelay: number | {touch: number; mouse: number} = 0;
+
+  /** Function that is used to determine whether a drag operation is allowed to start. */
+  dragStartPredicate: DragStartPredicate | undefined;
 
   /** Class to be added to the preview element. */
   previewClass: string | string[] | undefined;
@@ -903,6 +907,11 @@ export class DragRef<T = any> {
     const isFakeEvent = isTouchSequence
       ? isFakeTouchstartFromScreenReader(event as TouchEvent)
       : isFakeMousedownFromScreenReader(event as MouseEvent);
+
+    // Check the drag start predicate if one is provided
+    if (this.dragStartPredicate && !this.dragStartPredicate(event)) {
+      return;
+    }
 
     // If the event started from an element with the native HTML drag&drop, it'll interfere
     // with our own dragging (e.g. `img` tags do it by default). Prevent the default action


### PR DESCRIPTION
## Feature
### Problem Statement
Currently, the CdkDrag directive doesn't provide a way to conditionally prevent drag operations from starting based on the initial mouse/touch event. This makes it impossible to implement complex drag start conditions, such as only allowing drags from specific elements or under certain event conditions.
Add a new input [cdkDragStartPredicate] to the CdkDrag directive that accepts a predicate function to determine whether a drag operation should start.
### Proposed API
```typescript
@Input('cdkDragStartPredicate')
dragStartPredicate: ((event: TouchEvent | MouseEvent) => boolean) | undefined;
```
### Example Usage
_HTML:_
```html
<div cdkDrag [cdkDragStartPredicate]="myDragStartPredicate">
  Draggable content
  <input #input>
</div>
```
_component:_
```typescript
myDragStartPredicate(event: TouchEvent | MouseEvent): boolean {
  const element = event.target as HTMLElement;
  // Check if the target or any of its parents is an input element
  return !element.closest('input, textarea, [contenteditable="true"]');
}
```
See: https://stackblitz.com/edit/wc3rt4?file=src%2Fexample%2Fcdk-drag-drop-sorting-example.css

# Details
### Benefits
- More granular control over drag initialization
- Better integration with custom UI patterns
- Improved accessibility by allowing precise control over drag triggers
- Reduced need for workarounds using multiple directives
- 
### Implementation Notes
- The predicate should be called before the drag sequence begins
- Return true to allow the drag to start, false to prevent it
- Should work with both mouse and touch events
- Should integrate well with existing cdkDragHandle functionality
- 
### Related Issues
closes: https://github.com/angular/components/issues/30101
also resolve this issue: https://github.com/angular/components/issues/14117

### Use Case

- Prevent drags from starting on specific child elements
- Implement custom handle logic without using cdkDragHandle
- Add conditional drag start behavior based on application state
- Implement complex touch gesture requirements

