### PR TITLE
fix(material/sort): avoid center align for sort header

### DIFF
--- a/src/material/sort/sort-header.scss
+++ b/src/material/sort/sort-header.scss
@@ -33,7 +33,6 @@
 }
 
 .mat-sort-header-content {
-  text-align: center;
   display: flex;
   align-items: center;
 }


### PR DESCRIPTION
Copied with #27494 which has failing CLA