### PR TITLE
docs: update system var prefix

### DIFF
--- a/tools/extract-tokens/extract-tokens.ts
+++ b/tools/extract-tokens/extract-tokens.ts
@@ -231,8 +231,8 @@ function getTokenExtractionCode(
     }
 
     $__all-color: ${m3Tokens}.generate-color-tokens(light, ${palettes}.$azure-palette,
-      ${palettes}.$azure-palette, ${palettes}.$azure-palette, 'sys');
-    $__all-typography: ${m3Tokens}.generate-typography-tokens(font, 100, 100, 100, 100, 'sys');
+      ${palettes}.$azure-palette, ${palettes}.$azure-palette, 'mat-sys');
+    $__all-typography: ${m3Tokens}.generate-typography-tokens(font, 100, 100, 100, 100, 'mat-sys');
     $__all-density: ${m3Tokens}.generate-density-tokens(0);
     $__all-base: ${m3Tokens}.generate-base-tokens();
     $__results: ();


### PR DESCRIPTION
System variables are prefixed with "mat-sys", not "sys" (this was the case in v18)

Currently the docs use the old prefix

![image](https://github.com/user-attachments/assets/a0eda868-eb14-4d5e-83d5-32bf3467a825)
