### PR TITLE
refactor(multiple): replace fromEvent usages

### DIFF
--- a/src/cdk/menu/menu-base.ts
+++ b/src/cdk/menu/menu-base.ts
@@ -17,6 +17,7 @@ import {
   NgZone,
   OnDestroy,
   QueryList,
+  Renderer2,
   computed,
   inject,
   signal,
@@ -51,11 +52,11 @@ export abstract class CdkMenuBase
   extends CdkMenuGroup
   implements Menu, AfterContentInit, OnDestroy
 {
+  protected ngZone = inject(NgZone);
+  private _renderer = inject(Renderer2);
+
   /** The menu's native DOM host element. */
   readonly nativeElement: HTMLElement = inject(ElementRef).nativeElement;
-
-  /** The Angular zone. */
-  protected ngZone = inject(NgZone);
 
   /** The stack of menus this menu belongs to. */
   readonly menuStack: MenuStack = inject(MENU_STACK);
@@ -225,7 +226,7 @@ export abstract class CdkMenuBase
   private _setUpPointerTracker() {
     if (this.menuAim) {
       this.ngZone.runOutsideAngular(() => {
-        this.pointerTracker = new PointerFocusTracker(this.items);
+        this.pointerTracker = new PointerFocusTracker(this._renderer, this.items);
       });
       this.menuAim.initialize(this, this.pointerTracker!);
     }

--- a/src/cdk/menu/menu-item-checkbox.spec.ts
+++ b/src/cdk/menu/menu-item-checkbox.spec.ts
@@ -1,30 +1,16 @@
-import {Component, ElementRef} from '@angular/core';
-import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
+import {Component} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {CdkMenuModule} from './menu-module';
 import {CdkMenuItemCheckbox} from './menu-item-checkbox';
-import {CDK_MENU} from './menu-interface';
-import {CdkMenu} from './menu';
-import {MENU_STACK, MenuStack} from './menu-stack';
 
 describe('MenuItemCheckbox', () => {
   let fixture: ComponentFixture<SingleCheckboxButton>;
   let checkbox: CdkMenuItemCheckbox;
   let checkboxElement: HTMLButtonElement;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [CdkMenuModule, SingleCheckboxButton],
-      providers: [
-        {provide: CDK_MENU, useClass: CdkMenu},
-        {provide: MENU_STACK, useClass: MenuStack},
-        // View engine can't figure out the ElementRef to inject so we need to provide a fake
-        {provide: ElementRef, useValue: new ElementRef<null>(null)},
-      ],
-    });
-  }));
-
   beforeEach(() => {
+    TestBed.configureTestingModule({imports: [CdkMenuModule, SingleCheckboxButton]});
     fixture = TestBed.createComponent(SingleCheckboxButton);
     fixture.detectChanges();
 
@@ -99,7 +85,11 @@ describe('MenuItemCheckbox', () => {
 });
 
 @Component({
-  template: `<button cdkMenuItemCheckbox>Click me!</button>`,
+  template: `
+    <div cdkMenu>
+      <button cdkMenuItemCheckbox>Click me!</button>
+    </div>
+  `,
   imports: [CdkMenuModule],
 })
 class SingleCheckboxButton {}

--- a/src/cdk/menu/menu-item-radio.spec.ts
+++ b/src/cdk/menu/menu-item-radio.spec.ts
@@ -1,34 +1,16 @@
-import {Component, ElementRef} from '@angular/core';
-import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
+import {Component} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
-import {UniqueSelectionDispatcher} from '@angular/cdk/collections';
 import {CdkMenuModule} from './menu-module';
 import {CdkMenuItemRadio} from './menu-item-radio';
-import {CDK_MENU} from './menu-interface';
-import {CdkMenu} from './menu';
-import {MENU_STACK, MenuStack} from './menu-stack';
 
 describe('MenuItemRadio', () => {
   let fixture: ComponentFixture<SimpleRadioButton>;
   let radioButton: CdkMenuItemRadio;
   let radioElement: HTMLButtonElement;
-  let selectionDispatcher: UniqueSelectionDispatcher;
-
-  beforeEach(waitForAsync(() => {
-    selectionDispatcher = new UniqueSelectionDispatcher();
-    TestBed.configureTestingModule({
-      imports: [CdkMenuModule, SimpleRadioButton],
-      providers: [
-        {provide: UniqueSelectionDispatcher, useValue: selectionDispatcher},
-        {provide: CDK_MENU, useClass: CdkMenu},
-        {provide: MENU_STACK, useClass: MenuStack},
-        // View engine can't figure out the ElementRef to inject so we need to provide a fake
-        {provide: ElementRef, useValue: new ElementRef<null>(null)},
-      ],
-    });
-  }));
 
   beforeEach(() => {
+    TestBed.configureTestingModule({imports: [CdkMenuModule, SimpleRadioButton]});
     fixture = TestBed.createComponent(SimpleRadioButton);
     fixture.detectChanges();
 
@@ -93,7 +75,11 @@ describe('MenuItemRadio', () => {
 });
 
 @Component({
-  template: `<button cdkMenuItemRadio>Click me!</button>`,
+  template: `
+    <div cdkMenu>
+      <button cdkMenuItemRadio>Click me!</button>
+    </div>
+  `,
   imports: [CdkMenuModule],
 })
 class SimpleRadioButton {}

--- a/src/cdk/menu/menu-item.spec.ts
+++ b/src/cdk/menu/menu-item.spec.ts
@@ -1,32 +1,16 @@
-import {Component, Type, ElementRef} from '@angular/core';
-import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
+import {Component, Type} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {dispatchKeyboardEvent} from '@angular/cdk/testing/private';
 import {By} from '@angular/platform-browser';
 import {ENTER} from '@angular/cdk/keycodes';
 import {CdkMenuModule} from './menu-module';
 import {CdkMenuItem} from './menu-item';
-import {CDK_MENU} from './menu-interface';
-import {CdkMenu} from './menu';
-import {MENU_STACK, MenuStack} from './menu-stack';
 
 describe('MenuItem', () => {
   describe('with no complex inner elements', () => {
     let fixture: ComponentFixture<SingleMenuItem>;
     let menuItem: CdkMenuItem;
     let nativeButton: HTMLButtonElement;
-
-    beforeEach(waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [CdkMenuModule],
-        declarations: [SingleMenuItem],
-        providers: [
-          {provide: CDK_MENU, useClass: CdkMenu},
-          {provide: MENU_STACK, useClass: MenuStack},
-          // View engine can't figure out the ElementRef to inject so we need to provide a fake
-          {provide: ElementRef, useValue: new ElementRef<null>(null)},
-        ],
-      });
-    }));
 
     beforeEach(() => {
       fixture = TestBed.createComponent(SingleMenuItem);
@@ -79,20 +63,7 @@ describe('MenuItem', () => {
      * @param componentClass the component to create
      */
     function createComponent<T>(componentClass: Type<T>) {
-      let fixture: ComponentFixture<T>;
-
-      TestBed.configureTestingModule({
-        imports: [CdkMenuModule, MatIcon],
-        providers: [
-          {provide: CDK_MENU, useClass: CdkMenu},
-          {provide: MENU_STACK, useClass: MenuStack},
-          // View engine can't figure out the ElementRef to inject so we need to provide a fake
-          {provide: ElementRef, useValue: new ElementRef<null>(null)},
-        ],
-        declarations: [componentClass],
-      });
-
-      fixture = TestBed.createComponent(componentClass);
+      const fixture = TestBed.createComponent(componentClass);
       fixture.detectChanges();
 
       menuItem = fixture.debugElement.query(By.directive(CdkMenuItem)).injector.get(CdkMenuItem);
@@ -113,53 +84,57 @@ describe('MenuItem', () => {
       expect(menuItem.getLabel()).toEqual('Click me!');
     });
 
-    it(
-      'should get the text for menu item with single nested component with the material ' +
-        'icon class',
-      () => {
-        const fixture = createComponent(MenuItemWithIconClass);
-        expect(menuItem.getLabel()).toEqual('unicorn Click me!');
-        fixture.componentInstance.typeahead = 'Click me!';
-        fixture.changeDetectorRef.markForCheck();
-        fixture.detectChanges();
-        expect(menuItem.getLabel()).toEqual('Click me!');
-      },
-    );
+    it('should get the text for menu item with single nested component with the material icon class', () => {
+      const fixture = createComponent(MenuItemWithIconClass);
+      expect(menuItem.getLabel()).toEqual('unicorn Click me!');
+      fixture.componentInstance.typeahead = 'Click me!';
+      fixture.changeDetectorRef.markForCheck();
+      fixture.detectChanges();
+      expect(menuItem.getLabel()).toEqual('Click me!');
+    });
 
     it('should get the text for a menu item with bold marked text', () => {
       createComponent(MenuItemWithBoldElement);
       expect(menuItem.getLabel()).toEqual('Click me!');
     });
 
-    it(
-      'should get the text for a menu item with nested icon, nested icon class and nested ' +
-        'wrapping elements',
-      () => {
-        const fixture = createComponent(MenuItemWithMultipleNestings);
-        expect(menuItem.getLabel()).toEqual('unicorn Click menume!');
-        fixture.componentInstance.typeahead = 'Click me!';
-        fixture.changeDetectorRef.markForCheck();
-        fixture.detectChanges();
-        expect(menuItem.getLabel()).toEqual('Click me!');
-      },
-    );
+    it('should get the text for a menu item with nested icon, nested icon class and nested wrapping elements', () => {
+      const fixture = createComponent(MenuItemWithMultipleNestings);
+      expect(menuItem.getLabel()).toEqual('unicorn Click menume!');
+      fixture.componentInstance.typeahead = 'Click me!';
+      fixture.changeDetectorRef.markForCheck();
+      fixture.detectChanges();
+      expect(menuItem.getLabel()).toEqual('Click me!');
+    });
   });
 });
 
 @Component({
-  template: `<button cdkMenuItem>Click me!</button>`,
-  standalone: false,
+  selector: 'mat-icon',
+  template: '<ng-content></ng-content>',
+})
+class FakeMatIcon {}
+
+@Component({
+  template: `
+    <div cdkMenu>
+      <button cdkMenuItem>Click me!</button>
+    </div>
+  `,
+  imports: [CdkMenuModule],
 })
 class SingleMenuItem {}
 
 @Component({
   template: `
-    <button cdkMenuItem [cdkMenuitemTypeaheadLabel]="typeahead">
-      <mat-icon>unicorn</mat-icon>
-      Click me!
-    </button>
+    <div cdkMenu>
+      <button cdkMenuItem [cdkMenuitemTypeaheadLabel]="typeahead">
+        <mat-icon>unicorn</mat-icon>
+        Click me!
+      </button>
+    </div>
   `,
-  standalone: false,
+  imports: [CdkMenuModule, FakeMatIcon],
 })
 class MenuItemWithIcon {
   typeahead: string;
@@ -167,45 +142,46 @@ class MenuItemWithIcon {
 
 @Component({
   template: `
-    <button cdkMenuItem [cdkMenuitemTypeaheadLabel]="typeahead">
-      <div class="material-icons">unicorn</div>
-      Click me!
-    </button>
+    <div cdkMenu>
+      <button cdkMenuItem [cdkMenuitemTypeaheadLabel]="typeahead">
+        <div class="material-icons">unicorn</div>
+        Click me!
+      </button>
+    </div>
   `,
-  standalone: false,
+  imports: [CdkMenuModule],
 })
 class MenuItemWithIconClass {
   typeahead: string;
 }
 
 @Component({
-  template: ` <button cdkMenuItem><strong>Click</strong> me!</button> `,
-  standalone: false,
+  template: `
+    <div cdkMenu>
+      <button cdkMenuItem><strong>Click</strong> me!</button>
+    </div>
+  `,
+  imports: [CdkMenuModule],
 })
 class MenuItemWithBoldElement {}
 
 @Component({
   template: `
-    <button cdkMenuItem [cdkMenuitemTypeaheadLabel]="typeahead">
-      <div>
-        <div class="material-icons">unicorn</div>
+    <div cdkMenu>
+      <button cdkMenuItem [cdkMenuitemTypeaheadLabel]="typeahead">
         <div>
-          Click
+          <div class="material-icons">unicorn</div>
+          <div>
+            Click
+          </div>
+          <mat-icon>menu</mat-icon>
+          <div>me<strong>!</strong></div>
         </div>
-        <mat-icon>menu</mat-icon>
-        <div>me<strong>!</strong></div>
-      </div>
-    </button>
+      </button>
+    </div>
   `,
-  standalone: false,
+  imports: [CdkMenuModule, FakeMatIcon],
 })
 class MenuItemWithMultipleNestings {
   typeahead: string;
 }
-
-@Component({
-  selector: 'mat-icon',
-  template: '<ng-content></ng-content>',
-  imports: [CdkMenuModule],
-})
-class MatIcon {}

--- a/src/cdk/menu/pointer-focus-tracker.spec.ts
+++ b/src/cdk/menu/pointer-focus-tracker.spec.ts
@@ -1,4 +1,12 @@
-import {Component, QueryList, ElementRef, ViewChildren, AfterViewInit, inject} from '@angular/core';
+import {
+  Component,
+  QueryList,
+  ElementRef,
+  ViewChildren,
+  AfterViewInit,
+  inject,
+  Renderer2,
+} from '@angular/core';
 import {waitForAsync, ComponentFixture, TestBed} from '@angular/core/testing';
 import {createMouseEvent, dispatchEvent} from '../../cdk/testing/private';
 import {Observable} from 'rxjs';
@@ -117,6 +125,8 @@ class MockWrapper implements FocusableElement {
   imports: [MockWrapper],
 })
 class MultiElementWithConditionalComponent implements AfterViewInit {
+  private _renderer = inject(Renderer2);
+
   /** Whether the third element should be displayed. */
   showThird = false;
 
@@ -127,6 +137,6 @@ class MultiElementWithConditionalComponent implements AfterViewInit {
   focusTracker: PointerFocusTracker<MockWrapper>;
 
   ngAfterViewInit() {
-    this.focusTracker = new PointerFocusTracker(this._allItems);
+    this.focusTracker = new PointerFocusTracker(this._renderer, this._allItems);
   }
 }

--- a/src/cdk/overlay/position/flexible-connected-position-strategy.spec.ts
+++ b/src/cdk/overlay/position/flexible-connected-position-strategy.spec.ts
@@ -6,6 +6,8 @@ import {
   Component,
   ElementRef,
   Injector,
+  Renderer2,
+  RendererFactory2,
   runInInjectionContext,
 } from '@angular/core';
 import {fakeAsync, TestBed, tick} from '@angular/core/testing';
@@ -2500,6 +2502,10 @@ describe('FlexibleConnectedPositionStrategy', () => {
           {
             provide: ElementRef,
             useValue: new ElementRef<HTMLElement>(scrollable),
+          },
+          {
+            provide: Renderer2,
+            useValue: TestBed.inject(RendererFactory2).createRenderer(null, null),
           },
         ],
       });

--- a/src/cdk/scrolling/scroll-dispatcher.spec.ts
+++ b/src/cdk/scrolling/scroll-dispatcher.spec.ts
@@ -195,73 +195,73 @@ describe('ScrollDispatcher', () => {
   describe('lazy subscription', () => {
     let scroll: ScrollDispatcher;
 
-    beforeEach(inject([ScrollDispatcher], (s: ScrollDispatcher) => {
-      scroll = s;
-    }));
+    function hasGlobalListener(): boolean {
+      return !!(scroll as any)._cleanupGlobalListener;
+    }
+
+    beforeEach(() => {
+      scroll = TestBed.inject(ScrollDispatcher);
+    });
 
     it('should lazily add global listeners as service subscriptions are added and removed', () => {
-      expect(scroll._globalSubscription)
-        .withContext('Expected no global listeners on init.')
-        .toBeNull();
+      expect(hasGlobalListener()).withContext('Expected no global listeners on init.').toBe(false);
 
       const subscription = scroll.scrolled(0).subscribe(() => {});
 
-      expect(scroll._globalSubscription).toBeTruthy(
-        'Expected global listeners after a subscription has been added.',
-      );
+      expect(hasGlobalListener())
+        .withContext('Expected global listeners after a subscription has been added.')
+        .toBe(true);
 
       subscription.unsubscribe();
 
-      expect(scroll._globalSubscription).toBeNull(
-        'Expected global listeners to have been removed after the subscription has stopped.',
-      );
+      expect(hasGlobalListener())
+        .withContext(
+          'Expected global listeners to have been removed after the subscription has stopped.',
+        )
+        .toBe(false);
     });
 
     it('should remove global listeners on unsubscribe, despite any other live scrollables', () => {
       const fixture = TestBed.createComponent(NestedScrollingComponent);
       fixture.detectChanges();
 
-      expect(scroll._globalSubscription)
-        .withContext('Expected no global listeners on init.')
-        .toBeNull();
+      expect(hasGlobalListener()).withContext('Expected no global listeners on init.').toBe(false);
       expect(scroll.scrollContainers.size).withContext('Expected multiple scrollables').toBe(4);
 
       const subscription = scroll.scrolled(0).subscribe(() => {});
 
-      expect(scroll._globalSubscription)
+      expect(hasGlobalListener())
         .withContext('Expected global listeners after a subscription has been added.')
-        .toBeTruthy();
+        .toBe(true);
 
       subscription.unsubscribe();
 
-      expect(scroll._globalSubscription)
+      expect(hasGlobalListener())
         .withContext(
           'Expected global listeners to have been removed after ' + 'the subscription has stopped.',
         )
-        .toBeNull();
+        .toBe(false);
       expect(scroll.scrollContainers.size)
         .withContext('Expected scrollable count to stay the same')
         .toBe(4);
     });
 
     it('should remove the global subscription on destroy', () => {
-      expect(scroll._globalSubscription)
-        .withContext('Expected no global listeners on init.')
-        .toBeNull();
+      expect(hasGlobalListener()).withContext('Expected no global listeners on init.').toBe(false);
 
       const subscription = scroll.scrolled(0).subscribe(() => {});
 
-      expect(scroll._globalSubscription)
+      expect(hasGlobalListener())
         .withContext('Expected global listeners after a subscription has been added.')
-        .toBeTruthy();
+        .toBe(true);
 
       scroll.ngOnDestroy();
 
-      expect(scroll._globalSubscription)
+      expect(hasGlobalListener())
         .withContext(
-          'Expected global listeners to have been removed after ' + 'the subscription has stopped.',
+          'Expected global listeners to have been removed after the subscription has stopped.',
         )
-        .toBeNull();
+        .toBe(false);
 
       subscription.unsubscribe();
     });

--- a/src/cdk/scrolling/scroll-dispatcher.ts
+++ b/src/cdk/scrolling/scroll-dispatcher.ts
@@ -8,11 +8,10 @@
 
 import {coerceElement} from '@angular/cdk/coercion';
 import {Platform} from '@angular/cdk/platform';
-import {ElementRef, Injectable, NgZone, OnDestroy, inject} from '@angular/core';
-import {fromEvent, of as observableOf, Subject, Subscription, Observable, Observer} from 'rxjs';
+import {ElementRef, Injectable, NgZone, OnDestroy, RendererFactory2, inject} from '@angular/core';
+import {of as observableOf, Subject, Subscription, Observable, Observer} from 'rxjs';
 import {auditTime, filter} from 'rxjs/operators';
 import type {CdkScrollable} from './scrollable';
-import {DOCUMENT} from '@angular/common';
 
 /** Time in ms to throttle the scrolling events by default. */
 export const DEFAULT_SCROLL_TIME = 20;
@@ -25,18 +24,14 @@ export const DEFAULT_SCROLL_TIME = 20;
 export class ScrollDispatcher implements OnDestroy {
   private _ngZone = inject(NgZone);
   private _platform = inject(Platform);
-
-  /** Used to reference correct document/window */
-  protected _document = inject(DOCUMENT, {optional: true})!;
+  private _renderer = inject(RendererFactory2).createRenderer(null, null);
+  private _cleanupGlobalListener: (() => void) | undefined;
 
   constructor(...args: unknown[]);
   constructor() {}
 
   /** Subject for notifying that a registered scrollable reference element has been scrolled. */
   private readonly _scrolled = new Subject<CdkScrollable | void>();
-
-  /** Keeps track of the global `scroll` and `resize` subscriptions. */
-  _globalSubscription: Subscription | null = null;
 
   /** Keeps track of the amount of subscriptions to `scrolled`. Used for cleaning up afterwards. */
   private _scrolledCount = 0;
@@ -90,8 +85,10 @@ export class ScrollDispatcher implements OnDestroy {
     }
 
     return new Observable((observer: Observer<CdkScrollable | void>) => {
-      if (!this._globalSubscription) {
-        this._addGlobalListener();
+      if (!this._cleanupGlobalListener) {
+        this._cleanupGlobalListener = this._ngZone.runOutsideAngular(() =>
+          this._renderer.listen('document', 'scroll', () => this._scrolled.next()),
+        );
       }
 
       // In the case of a 0ms delay, use an observable without auditTime
@@ -108,14 +105,16 @@ export class ScrollDispatcher implements OnDestroy {
         this._scrolledCount--;
 
         if (!this._scrolledCount) {
-          this._removeGlobalListener();
+          this._cleanupGlobalListener?.();
+          this._cleanupGlobalListener = undefined;
         }
       };
     });
   }
 
   ngOnDestroy() {
-    this._removeGlobalListener();
+    this._cleanupGlobalListener?.();
+    this._cleanupGlobalListener = undefined;
     this.scrollContainers.forEach((_, container) => this.deregister(container));
     this._scrolled.complete();
   }
@@ -133,9 +132,7 @@ export class ScrollDispatcher implements OnDestroy {
     const ancestors = this.getAncestorScrollContainers(elementOrElementRef);
 
     return this.scrolled(auditTimeInMs).pipe(
-      filter(target => {
-        return !target || ancestors.indexOf(target) > -1;
-      }),
+      filter(target => !target || ancestors.indexOf(target) > -1),
     );
   }
 
@@ -150,11 +147,6 @@ export class ScrollDispatcher implements OnDestroy {
     });
 
     return scrollingContainers;
-  }
-
-  /** Use defaultView of injected document if available or fallback to global window reference */
-  private _getWindow(): Window {
-    return this._document.defaultView || window;
   }
 
   /** Returns true if the element is contained within the provided Scrollable. */
@@ -174,21 +166,5 @@ export class ScrollDispatcher implements OnDestroy {
     } while ((element = element!.parentElement));
 
     return false;
-  }
-
-  /** Sets up the global scroll listeners. */
-  private _addGlobalListener() {
-    this._globalSubscription = this._ngZone.runOutsideAngular(() => {
-      const window = this._getWindow();
-      return fromEvent(window.document, 'scroll').subscribe(() => this._scrolled.next());
-    });
-  }
-
-  /** Cleans up the global scroll listener. */
-  private _removeGlobalListener() {
-    if (this._globalSubscription) {
-      this._globalSubscription.unsubscribe();
-      this._globalSubscription = null;
-    }
   }
 }

--- a/src/cdk/scrolling/virtual-scrollable-window.ts
+++ b/src/cdk/scrolling/virtual-scrollable-window.ts
@@ -7,8 +7,6 @@
  */
 
 import {Directive, ElementRef} from '@angular/core';
-import {fromEvent, Observable, Observer} from 'rxjs';
-import {takeUntil} from 'rxjs/operators';
 import {CdkVirtualScrollable, VIRTUAL_SCROLLABLE} from './virtual-scrollable';
 
 /**
@@ -19,18 +17,12 @@ import {CdkVirtualScrollable, VIRTUAL_SCROLLABLE} from './virtual-scrollable';
   providers: [{provide: VIRTUAL_SCROLLABLE, useExisting: CdkVirtualScrollableWindow}],
 })
 export class CdkVirtualScrollableWindow extends CdkVirtualScrollable {
-  protected override _elementScrolled: Observable<Event> = new Observable(
-    (observer: Observer<Event>) =>
-      this.ngZone.runOutsideAngular(() =>
-        fromEvent(document, 'scroll').pipe(takeUntil(this._destroyed)).subscribe(observer),
-      ),
-  );
-
   constructor(...args: unknown[]);
 
   constructor() {
     super();
     this.elementRef = new ElementRef(document.documentElement);
+    this._scrollElement = document;
   }
 
   override measureBoundingClientRectWithScrollOffset(

--- a/src/cdk/text-field/autosize.ts
+++ b/src/cdk/text-field/autosize.ts
@@ -22,8 +22,8 @@ import {
 import {DOCUMENT} from '@angular/common';
 import {Platform} from '@angular/cdk/platform';
 import {_CdkPrivateStyleLoader} from '@angular/cdk/private';
-import {auditTime, takeUntil} from 'rxjs/operators';
-import {fromEvent, Subject} from 'rxjs';
+import {auditTime} from 'rxjs/operators';
+import {Subject} from 'rxjs';
 import {_CdkTextFieldStyleLoader} from './text-field-style-loader';
 
 /** Directive to automatically resize a textarea to fit its content. */
@@ -43,6 +43,7 @@ export class CdkTextareaAutosize implements AfterViewInit, DoCheck, OnDestroy {
   private _platform = inject(Platform);
   private _ngZone = inject(NgZone);
   private _renderer = inject(Renderer2);
+  private _resizeEvents = new Subject<void>();
 
   /** Keep track of the previous textarea value to avoid resizing when the value hasn't changed. */
   private _previousValue?: string;
@@ -159,16 +160,12 @@ export class CdkTextareaAutosize implements AfterViewInit, DoCheck, OnDestroy {
       this.resizeToFitContent();
 
       this._ngZone.runOutsideAngular(() => {
-        const window = this._getWindow();
-
-        fromEvent(window, 'resize')
-          .pipe(auditTime(16), takeUntil(this._destroyed))
-          .subscribe(() => this.resizeToFitContent(true));
-
         this._listenerCleanups = [
+          this._renderer.listen('window', 'resize', () => this._resizeEvents.next()),
           this._renderer.listen(this._textareaElement, 'focus', this._handleFocusEvent),
           this._renderer.listen(this._textareaElement, 'blur', this._handleFocusEvent),
         ];
+        this._resizeEvents.pipe(auditTime(16)).subscribe(() => this.resizeToFitContent(true));
       });
 
       this._isViewInited = true;
@@ -178,6 +175,7 @@ export class CdkTextareaAutosize implements AfterViewInit, DoCheck, OnDestroy {
 
   ngOnDestroy() {
     this._listenerCleanups?.forEach(cleanup => cleanup());
+    this._resizeEvents.complete();
     this._destroyed.next();
     this._destroyed.complete();
   }
@@ -342,17 +340,6 @@ export class CdkTextareaAutosize implements AfterViewInit, DoCheck, OnDestroy {
 
   _noopInputHandler() {
     // no-op handler that ensures we're running change detection on input events.
-  }
-
-  /** Access injected document if available or fallback to global document reference */
-  private _getDocument(): Document {
-    return this._document || document;
-  }
-
-  /** Use defaultView of injected document if available or fallback to global window reference */
-  private _getWindow(): Window {
-    const doc = this._getDocument();
-    return doc.defaultView || window;
   }
 
   /**

--- a/tools/public_api_guard/cdk/menu.md
+++ b/tools/public_api_guard/cdk/menu.md
@@ -22,6 +22,7 @@ import { OnDestroy } from '@angular/core';
 import { Optional } from '@angular/core';
 import { OverlayRef } from '@angular/cdk/overlay';
 import { QueryList } from '@angular/core';
+import { Renderer2 } from '@angular/core';
 import { ScrollStrategy } from '@angular/cdk/overlay';
 import { Subject } from 'rxjs';
 import { TemplatePortal } from '@angular/cdk/portal';
@@ -97,6 +98,7 @@ export abstract class CdkMenuBase extends CdkMenuGroup implements Menu, AfterCon
     ngAfterContentInit(): void;
     // (undocumented)
     ngOnDestroy(): void;
+    // (undocumented)
     protected ngZone: NgZone;
     orientation: 'horizontal' | 'vertical';
     protected pointerTracker?: PointerFocusTracker<CdkMenuItem>;
@@ -205,6 +207,8 @@ export class CdkMenuTrigger extends CdkMenuTriggerBase implements OnDestroy {
     close(): void;
     getMenu(): Menu | undefined;
     _handleClick(): void;
+    // (undocumented)
+    ngOnDestroy(): void;
     open(): void;
     _setHasFocus(hasFocus: boolean): void;
     toggle(): void;
@@ -363,8 +367,7 @@ export const PARENT_OR_NEW_MENU_STACK_PROVIDER: {
 
 // @public
 export class PointerFocusTracker<T extends FocusableElement> {
-    constructor(
-    _items: QueryList<T>);
+    constructor(_renderer: Renderer2, _items: QueryList<T>);
     activeElement?: T;
     destroy(): void;
     readonly entered: Observable<T>;

--- a/tools/public_api_guard/cdk/scrolling.md
+++ b/tools/public_api_guard/cdk/scrolling.md
@@ -63,8 +63,6 @@ export class CdkScrollable implements OnInit, OnDestroy {
     // (undocumented)
     protected elementRef: ElementRef<HTMLElement>;
     elementScrolled(): Observable<Event>;
-    // (undocumented)
-    protected _elementScrolled: Observable<Event>;
     getElementRef(): ElementRef<HTMLElement>;
     measureScrollOffset(from: 'top' | 'left' | 'right' | 'bottom' | 'start' | 'end'): number;
     // (undocumented)
@@ -75,6 +73,8 @@ export class CdkScrollable implements OnInit, OnDestroy {
     protected ngZone: NgZone;
     // (undocumented)
     protected scrollDispatcher: ScrollDispatcher;
+    // (undocumented)
+    protected _scrollElement: EventTarget;
     scrollTo(options: ExtendedScrollToOptions): void;
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<CdkScrollable, "[cdk-scrollable], [cdkScrollable]", never, {}, {}, never, never, true, never>;
@@ -156,8 +156,6 @@ export class CdkVirtualScrollableElement extends CdkVirtualScrollable {
 // @public
 export class CdkVirtualScrollableWindow extends CdkVirtualScrollable {
     constructor(...args: unknown[]);
-    // (undocumented)
-    protected _elementScrolled: Observable<Event>;
     // (undocumented)
     measureBoundingClientRectWithScrollOffset(from: 'left' | 'top' | 'right' | 'bottom'): number;
     // (undocumented)
@@ -265,9 +263,7 @@ export class ScrollDispatcher implements OnDestroy {
     constructor(...args: unknown[]);
     ancestorScrolled(elementOrElementRef: ElementRef | HTMLElement, auditTimeInMs?: number): Observable<CdkScrollable | void>;
     deregister(scrollable: CdkScrollable): void;
-    protected _document: Document;
     getAncestorScrollContainers(elementOrElementRef: ElementRef | HTMLElement): CdkScrollable[];
-    _globalSubscription: Subscription | null;
     // (undocumented)
     ngOnDestroy(): void;
     register(scrollable: CdkScrollable): void;


### PR DESCRIPTION
Replaces all of our usages of the rxjs `fromEvent` with direct event listeners going through the renderer. This has a few benefits:
* In most cases it made our code simpler and easier to follow.
* By going through the renderer, other tooling can hook into it (e.g. the tracing service).
* It reduces our reliance on rxjs.

I also ended up cleaning up the fragile testing setup in `cdk/menu` which would've broken any time we introduce a new `inject` call.