### PR TITLE
docs(material/theming): fix typo in custom theme guide

### DIFF
--- a/src/material/schematics/ng-generate/theme-color/README.md
+++ b/src/material/schematics/ng-generate/theme-color/README.md
@@ -63,14 +63,14 @@ provided to the `theme` mixin within your theme file to use the custom colors.
 @use './path/to/_theme-colors' as my-theme; // location of generated file
 
 html {
-  @include mat.theme(
+  @include mat.theme((
     color: (
       primary: my-theme.$primary-palette,
       tertiary: my-theme.$tertiary-palette,
     ),
     typography: Roboto,
     density: 0,
-  )
+  ));
 }
 ```
 


### PR DESCRIPTION
#### Summary:
This PR fixes a syntax error in the usage of the `mat.theme` mixin in the SCSS files of the project. The error occurred due to incorrect wrapping of the Sass map passed as an argument to the `mat.theme` mixin. Specifically, the map was not correctly enclosed in an additional pair of parentheses, leading to a compilation error.

```
✘ [ERROR] expected ")".
   ╷
36 │         color: (
```

#### Fix:
- Wrapped the theme configuration map inside an additional set of parentheses for proper syntax in the `@include mat.theme()` function.