### PR TITLE
docs(material/components): fix typos in material components

### DIFF
--- a/src/material/autocomplete/autocomplete.ts
+++ b/src/material/autocomplete/autocomplete.ts
@@ -74,7 +74,7 @@ export interface MatAutocompleteDefaultOptions {
   /** Class or list of classes to be applied to the autocomplete's overlay panel. */
   overlayPanelClass?: string | string[];
 
-  /** Wheter icon indicators should be hidden for single-selection. */
+  /** Whether icon indicators should be hidden for single-selection. */
   hideSingleSelectionIndicator?: boolean;
 }
 

--- a/src/material/chips/tokens.ts
+++ b/src/material/chips/tokens.ts
@@ -14,7 +14,7 @@ export interface MatChipsDefaultOptions {
   /** The list of key codes that will trigger a chipEnd event. */
   separatorKeyCodes: readonly number[] | ReadonlySet<number>;
 
-  /** Wheter icon indicators should be hidden for single-selection. */
+  /** Whether icon indicators should be hidden for single-selection. */
   hideSingleSelectionIndicator?: boolean;
 }
 

--- a/src/material/list/tokens.ts
+++ b/src/material/list/tokens.ts
@@ -10,7 +10,7 @@ import {InjectionToken} from '@angular/core';
 
 /** Object that can be used to configure the default options for the list module. */
 export interface MatListConfig {
-  /** Wheter icon indicators should be hidden for single-selection. */
+  /** Whether icon indicators should be hidden for single-selection. */
   hideSingleSelectionIndicator?: boolean;
 }
 

--- a/src/material/select/select.ts
+++ b/src/material/select/select.ts
@@ -127,7 +127,7 @@ export interface MatSelectConfig {
   /** Class or list of classes to be applied to the menu's overlay panel. */
   overlayPanelClass?: string | string[];
 
-  /** Wheter icon indicators should be hidden for single-selection. */
+  /** Whether icon indicators should be hidden for single-selection. */
   hideSingleSelectionIndicator?: boolean;
 
   /**


### PR DESCRIPTION
This pr fixes a similar typo in below material components:

1. `autocomplete`
2. `chips`
3. `list`
4. `select`

### Issue
A typo "**Wheter**" in above mentioned components.

### Fix

Updated "**Wheter**" to "**Whether**".