### PR TITLE
fix(material/sort): show arrow on focus

### DIFF
--- a/src/material/sort/sort-header.scss
+++ b/src/material/sort/sort-header.scss
@@ -79,6 +79,8 @@
     @include token-utils.create-token-slot(color, arrow-color);
   }
 
+  .mat-sort-header.cdk-keyboard-focused &,
+  .mat-sort-header.cdk-program-focused &,
   .mat-sort-header:hover & {
     opacity: 0.54;
   }


### PR DESCRIPTION
Fixes that the sort header wasn't showing the arrow when it's focused.

Fixes #30196.