### PR TITLE
fix(material/timepicker): don't mark as touched when blurred while dropdown is open

### DIFF
--- a/src/material/timepicker/timepicker-input.ts
+++ b/src/material/timepicker/timepicker-input.ts
@@ -285,7 +285,9 @@ export class MatTimepickerInput<D> implements ControlValueAccessor, Validator, O
       this._formatValue(value);
     }
 
-    this._onTouched?.();
+    if (!this.timepicker().isOpen()) {
+      this._onTouched?.();
+    }
   }
 
   /** Handles the `keydown` event. */

--- a/src/material/timepicker/timepicker.spec.ts
+++ b/src/material/timepicker/timepicker.spec.ts
@@ -955,6 +955,18 @@ describe('MatTimepicker', () => {
       fixture.detectChanges();
       expect(fixture.componentInstance.control.touched).toBe(false);
 
+      getInput(fixture).click();
+      fixture.detectChanges();
+      dispatchFakeEvent(getInput(fixture), 'blur');
+      fixture.detectChanges();
+      expect(fixture.componentInstance.control.touched).toBe(false);
+    });
+
+    it('should mark the control as touched on blur while dropdown is open', () => {
+      const fixture = TestBed.createComponent(TimepickerWithForms);
+      fixture.detectChanges();
+      expect(fixture.componentInstance.control.touched).toBe(false);
+
       dispatchFakeEvent(getInput(fixture), 'blur');
       fixture.detectChanges();
       expect(fixture.componentInstance.control.touched).toBe(true);


### PR DESCRIPTION
Fixes that the timepicker was marking itself as touched too early when clicking on an item in the dropdown.

Fixes #30223.