### PR TITLE
fix(material/sidenav): switch away from animations module

### DIFF
--- a/src/dev-app/sidenav/sidenav-demo.ts
+++ b/src/dev-app/sidenav/sidenav-demo.ts
@@ -22,7 +22,7 @@ import {MatToolbarModule} from '@angular/material/toolbar';
 })
 export class SidenavDemo {
   isLaunched = false;
-  fillerContent = Array(30);
+  fillerContent = Array.from({length: 30}, (_, index) => index);
   fixed = false;
   coverHeader = false;
   showHeader = false;

--- a/src/material/sidenav/drawer-animations.ts
+++ b/src/material/sidenav/drawer-animations.ts
@@ -17,6 +17,8 @@ import {
 /**
  * Animations used by the Material drawers.
  * @docs-private
+ * @deprecated No longer used, will be removed.
+ * @breaking-change 21.0.0
  */
 export const matDrawerAnimations: {
   readonly transformDrawer: AnimationTriggerMetadata;

--- a/src/material/sidenav/drawer.scss
+++ b/src/material/sidenav/drawer.scss
@@ -211,15 +211,27 @@ $drawer-over-drawer-z-index: 4;
     }
   }
 
-  // Usually the `visibility: hidden` added by the animation is enough to prevent focus from
-  // entering the hidden drawer content, but children with their own `visibility` can override it.
-  // This is a fallback that completely hides the content when the element becomes hidden.
-  // Note that we can't do this in the animation definition, because the style gets recomputed too
-  // late, breaking the animation because Angular didn't have time to figure out the target
-  // transform. This can also be achieved with JS, but it has issues when starting an
-  // animation before the previous one has finished.
-  &[style*='visibility: hidden'] {
-    display: none;
+  .mat-drawer-transition & {
+    transition: transform 400ms cubic-bezier(0.25, 0.8, 0.25, 1);
+  }
+
+  &:not(.mat-drawer-opened):not(.mat-drawer-animating) {
+    // Stops the sidenav from poking out (e.g. with the box shadow) while it's off-screen.
+    // We can't use `display` because it interrupts the transition and `transition-behavior`
+    // isn't available in all browsers.
+    visibility: hidden;
+    box-shadow: none;
+
+    // The `visibility` above should prevent focus from entering the sidenav, but if a child
+    // element has `visibility`, it'll override the inherited value. This guarantees that the
+    // content won't be focusable.
+    .mat-drawer-inner-container {
+      display: none;
+    }
+  }
+
+  &.mat-drawer-opened {
+    transform: none;
   }
 }
 

--- a/src/material/sidenav/sidenav.ts
+++ b/src/material/sidenav/sidenav.ts
@@ -16,7 +16,6 @@ import {
   QueryList,
 } from '@angular/core';
 import {MatDrawer, MatDrawerContainer, MatDrawerContent, MAT_DRAWER_CONTAINER} from './drawer';
-import {matDrawerAnimations} from './drawer-animations';
 import {
   BooleanInput,
   coerceBooleanProperty,
@@ -46,7 +45,6 @@ export class MatSidenavContent extends MatDrawerContent {}
   selector: 'mat-sidenav',
   exportAs: 'matSidenav',
   templateUrl: 'drawer.html',
-  animations: [matDrawerAnimations.transformDrawer],
   host: {
     'class': 'mat-drawer mat-sidenav',
     'tabIndex': '-1',
@@ -56,7 +54,6 @@ export class MatSidenavContent extends MatDrawerContent {}
     '[class.mat-drawer-over]': 'mode === "over"',
     '[class.mat-drawer-push]': 'mode === "push"',
     '[class.mat-drawer-side]': 'mode === "side"',
-    '[class.mat-drawer-opened]': 'opened',
     '[class.mat-sidenav-fixed]': 'fixedInViewport',
     '[style.top.px]': 'fixedInViewport ? fixedTopGap : null',
     '[style.bottom.px]': 'fixedInViewport ? fixedBottomGap : null',

--- a/tools/public_api_guard/material/sidenav.md
+++ b/tools/public_api_guard/material/sidenav.md
@@ -4,10 +4,8 @@
 
 ```ts
 
-import { AfterContentChecked } from '@angular/core';
 import { AfterContentInit } from '@angular/core';
 import { AfterViewInit } from '@angular/core';
-import { AnimationEvent as AnimationEvent_2 } from '@angular/animations';
 import { AnimationTriggerMetadata } from '@angular/animations';
 import { BooleanInput } from '@angular/cdk/coercion';
 import { CdkScrollable } from '@angular/cdk/scrolling';
@@ -32,11 +30,10 @@ export const MAT_DRAWER_DEFAULT_AUTOSIZE: InjectionToken<boolean>;
 export function MAT_DRAWER_DEFAULT_AUTOSIZE_FACTORY(): boolean;
 
 // @public
-export class MatDrawer implements AfterViewInit, AfterContentChecked, OnDestroy {
+export class MatDrawer implements AfterViewInit, OnDestroy {
     constructor(...args: unknown[]);
-    readonly _animationEnd: Subject<AnimationEvent_2>;
-    readonly _animationStarted: Subject<AnimationEvent_2>;
-    _animationState: 'open-instant' | 'open' | 'void';
+    readonly _animationEnd: Subject<unknown>;
+    readonly _animationStarted: Subject<unknown>;
     get autoFocus(): AutoFocusTarget | string | boolean;
     set autoFocus(value: AutoFocusTarget | string | BooleanInput);
     close(): Promise<MatDrawerToggleResult>;
@@ -53,8 +50,6 @@ export class MatDrawer implements AfterViewInit, AfterContentChecked, OnDestroy 
     get mode(): MatDrawerMode;
     set mode(value: MatDrawerMode);
     readonly _modeChanged: Subject<void>;
-    // (undocumented)
-    ngAfterContentChecked(): void;
     // (undocumented)
     ngAfterViewInit(): void;
     // (undocumented)
@@ -75,7 +70,7 @@ export class MatDrawer implements AfterViewInit, AfterContentChecked, OnDestroy 
     static ɵfac: i0.ɵɵFactoryDeclaration<MatDrawer, never>;
 }
 
-// @public
+// @public @deprecated
 export const matDrawerAnimations: {
     readonly transformDrawer: AnimationTriggerMetadata;
 };
@@ -120,6 +115,8 @@ export class MatDrawerContainer implements AfterContentInit, DoCheck, OnDestroy 
     open(): void;
     get scrollable(): CdkScrollable;
     get start(): MatDrawer | null;
+    // (undocumented)
+    _transitionsEnabled: boolean;
     updateContentMargins(): void;
     // (undocumented)
     _userContent: MatDrawerContent;


### PR DESCRIPTION
Reworks the sidenav to animate using CSS, rather than the animations module. This requires less JavaScript, is simpler to maintain and avoids some memory leaks caused by the animations module.