### PR TITLE
docs(cdk/overlay): keep state in sync in example

### DIFF
--- a/src/components-examples/cdk/overlay/cdk-overlay-basic/cdk-overlay-basic-example.html
+++ b/src/components-examples/cdk/overlay/cdk-overlay-basic/cdk-overlay-basic-example.html
@@ -8,6 +8,7 @@
   cdkConnectedOverlay
   [cdkConnectedOverlayOrigin]="trigger"
   [cdkConnectedOverlayOpen]="isOpen"
+  (detach)="isOpen = false"
 >
   <ul class="example-list">
     <li>Item 1</li>


### PR DESCRIPTION
Updates the overlay example to ensure that the state of the `isOpen` flag reflects the state of the overlay.

Fixes #30185.