### PR TITLE
fix(cdk/scrolling): avoid SSR error in CdkVirtualScrollableWindow

### DIFF
--- a/src/cdk/scrolling/virtual-scrollable-window.ts
+++ b/src/cdk/scrolling/virtual-scrollable-window.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Directive, ElementRef} from '@angular/core';
+import {Directive, ElementRef, inject} from '@angular/core';
+import {DOCUMENT} from '@angular/common';
 import {CdkVirtualScrollable, VIRTUAL_SCROLLABLE} from './virtual-scrollable';
 
 /**
@@ -21,6 +22,7 @@ export class CdkVirtualScrollableWindow extends CdkVirtualScrollable {
 
   constructor() {
     super();
+    const document = inject(DOCUMENT);
     this.elementRef = new ElementRef(document.documentElement);
     this._scrollElement = document;
   }


### PR DESCRIPTION
The `CdkVirtualScrollableWindow` was referring to the `document` directly which can break in SSR. These changes use the DI token instead.