### PR TITLE
fix(material/menu): prevent interaction with <a> in disabled menu ite…

### DIFF
--- a/src/material/menu/menu.scss
+++ b/src/material/menu/menu.scss
@@ -177,6 +177,7 @@ mat-menu {
 
   &[disabled] {
     cursor: default;
+    pointer-events: none;
     opacity: 0.38;
 
     // The browser prevents clicks on disabled buttons from propagating which prevents the menu


### PR DESCRIPTION
Fix the issue where <a> tags inside disabled mat-menu-items were still interactive, allowing users to navigate even when the menu item was disabled.

### Problem:
- The anchor links inside disabled `mat-menu-items` were still interactive.
- Users could right click on them and navigate to the associated link with the `Open link in new tab`  for example, despite the items being disabled.

### Solution:
- Added the CSS rule pointer-events: none; to disable interaction with anchor tags inside disabled mat-menu-item elements.

### Additional Information:
- A StackBlitz demo is available to showcase both the bug and the fix: https://stackblitz.com/~/github.com/IgnacioCabanellas/met-menu-item-demo

Fixes #30203
