### PR TITLE
refactor(multiple): use renderer for manually-bound events with options

### DIFF
--- a/src/cdk/a11y/input-modality/input-modality-detector.ts
+++ b/src/cdk/a11y/input-modality/input-modality-detector.ts
@@ -7,8 +7,15 @@
  */
 
 import {ALT, CONTROL, MAC_META, META, SHIFT} from '@angular/cdk/keycodes';
-import {Injectable, InjectionToken, OnDestroy, NgZone, inject} from '@angular/core';
-import {normalizePassiveListenerOptions, Platform, _getEventTarget} from '@angular/cdk/platform';
+import {
+  Injectable,
+  InjectionToken,
+  OnDestroy,
+  NgZone,
+  inject,
+  RendererFactory2,
+} from '@angular/core';
+import {Platform, _bindEventWithOptions, _getEventTarget} from '@angular/cdk/platform';
 import {DOCUMENT} from '@angular/common';
 import {BehaviorSubject, Observable} from 'rxjs';
 import {distinctUntilChanged, skip} from 'rxjs/operators';
@@ -69,10 +76,10 @@ export const TOUCH_BUFFER_MS = 650;
  * Event listener options that enable capturing and also mark the listener as passive if the browser
  * supports it.
  */
-const modalityEventListenerOptions = normalizePassiveListenerOptions({
+const modalityEventListenerOptions = {
   passive: true,
   capture: true,
-});
+};
 
 /**
  * Service that detects the user's input modality.
@@ -91,6 +98,7 @@ const modalityEventListenerOptions = normalizePassiveListenerOptions({
 @Injectable({providedIn: 'root'})
 export class InputModalityDetector implements OnDestroy {
   private readonly _platform = inject(Platform);
+  private readonly _listenerCleanups: (() => void)[] | undefined;
 
   /** Emits whenever an input modality is detected. */
   readonly modalityDetected: Observable<InputModality>;
@@ -193,21 +201,38 @@ export class InputModalityDetector implements OnDestroy {
     // If we're not in a browser, this service should do nothing, as there's no relevant input
     // modality to detect.
     if (this._platform.isBrowser) {
-      ngZone.runOutsideAngular(() => {
-        document.addEventListener('keydown', this._onKeydown, modalityEventListenerOptions);
-        document.addEventListener('mousedown', this._onMousedown, modalityEventListenerOptions);
-        document.addEventListener('touchstart', this._onTouchstart, modalityEventListenerOptions);
+      const renderer = inject(RendererFactory2).createRenderer(null, null);
+
+      this._listenerCleanups = ngZone.runOutsideAngular(() => {
+        return [
+          _bindEventWithOptions(
+            renderer,
+            document,
+            'keydown',
+            this._onKeydown,
+            modalityEventListenerOptions,
+          ),
+          _bindEventWithOptions(
+            renderer,
+            document,
+            'mousedown',
+            this._onMousedown,
+            modalityEventListenerOptions,
+          ),
+          _bindEventWithOptions(
+            renderer,
+            document,
+            'touchstart',
+            this._onTouchstart,
+            modalityEventListenerOptions,
+          ),
+        ];
       });
     }
   }
 
   ngOnDestroy() {
     this._modality.complete();
-
-    if (this._platform.isBrowser) {
-      document.removeEventListener('keydown', this._onKeydown, modalityEventListenerOptions);
-      document.removeEventListener('mousedown', this._onMousedown, modalityEventListenerOptions);
-      document.removeEventListener('touchstart', this._onTouchstart, modalityEventListenerOptions);
-    }
+    this._listenerCleanups?.forEach(cleanup => cleanup());
   }
 }

--- a/src/cdk/drag-drop/drag-drop-registry.ts
+++ b/src/cdk/drag-drop/drag-drop-registry.ts
@@ -10,26 +10,33 @@ import {
   ChangeDetectionStrategy,
   Component,
   Injectable,
+  ListenerOptions,
   NgZone,
   OnDestroy,
+  RendererFactory2,
   ViewEncapsulation,
   WritableSignal,
   inject,
   signal,
 } from '@angular/core';
 import {DOCUMENT} from '@angular/common';
-import {normalizePassiveListenerOptions} from '@angular/cdk/platform';
+import {_bindEventWithOptions} from '@angular/cdk/platform';
 import {_CdkPrivateStyleLoader} from '@angular/cdk/private';
 import {Observable, Observer, Subject, merge} from 'rxjs';
 import type {DropListRef} from './drop-list-ref';
 import type {DragRef} from './drag-ref';
 import type {CdkDrag} from './directives/drag';
 
+/** Event options that can be used to bind a capturing event. */
+const capturingEventOptions = {
+  capture: true,
+};
+
 /** Event options that can be used to bind an active, capturing event. */
-const activeCapturingEventOptions = normalizePassiveListenerOptions({
+const activeCapturingEventOptions = {
   passive: false,
   capture: true,
-});
+};
 
 /**
  * Component used to load the drag&drop reset styles.
@@ -55,6 +62,8 @@ export class DragDropRegistry<_ = unknown, __ = unknown> implements OnDestroy {
   private _ngZone = inject(NgZone);
   private _document = inject(DOCUMENT);
   private _styleLoader = inject(_CdkPrivateStyleLoader);
+  private _renderer = inject(RendererFactory2).createRenderer(null, null);
+  private _cleanupDocumentTouchmove: (() => void) | undefined;
 
   /** Registered drop container instances. */
   private _dropInstances = new Set<DropListRef>();
@@ -66,13 +75,7 @@ export class DragDropRegistry<_ = unknown, __ = unknown> implements OnDestroy {
   private _activeDragInstances: WritableSignal<DragRef[]> = signal([]);
 
   /** Keeps track of the event listeners that we've bound to the `document`. */
-  private _globalListeners = new Map<
-    string,
-    {
-      handler: (event: Event) => void;
-      options?: AddEventListenerOptions | boolean;
-    }
-  >();
+  private _globalListeners: (() => void)[] | undefined;
 
   /**
    * Predicate function to check if an item is being dragged.  Moved out into a property,
@@ -127,7 +130,10 @@ export class DragDropRegistry<_ = unknown, __ = unknown> implements OnDestroy {
       this._ngZone.runOutsideAngular(() => {
         // The event handler has to be explicitly active,
         // because newer browsers make it passive by default.
-        this._document.addEventListener(
+        this._cleanupDocumentTouchmove?.();
+        this._cleanupDocumentTouchmove = _bindEventWithOptions(
+          this._renderer,
+          this._document,
           'touchmove',
           this._persistentTouchmoveListener,
           activeCapturingEventOptions,
@@ -147,11 +153,7 @@ export class DragDropRegistry<_ = unknown, __ = unknown> implements OnDestroy {
     this.stopDragging(drag);
 
     if (this._dragInstances.size === 0) {
-      this._document.removeEventListener(
-        'touchmove',
-        this._persistentTouchmoveListener,
-        activeCapturingEventOptions,
-      );
+      this._cleanupDocumentTouchmove?.();
     }
   }
 
@@ -174,47 +176,43 @@ export class DragDropRegistry<_ = unknown, __ = unknown> implements OnDestroy {
       // passive ones for `mousemove` and `touchmove`. The events need to be active, because we
       // use `preventDefault` to prevent the page from scrolling while the user is dragging.
       const isTouchEvent = event.type.startsWith('touch');
-      const endEventHandler = {
-        handler: (e: Event) => this.pointerUp.next(e as TouchEvent | MouseEvent),
-        options: true,
-      };
+      const endEventHandler = (e: Event) => this.pointerUp.next(e as TouchEvent | MouseEvent);
 
-      if (isTouchEvent) {
-        this._globalListeners.set('touchend', endEventHandler);
-        this._globalListeners.set('touchcancel', endEventHandler);
-      } else {
-        this._globalListeners.set('mouseup', endEventHandler);
-      }
+      const toBind: [name: string, handler: (event: Event) => void, options: ListenerOptions][] = [
+        // Use capturing so that we pick up scroll changes in any scrollable nodes that aren't
+        // the document. See https://github.com/angular/components/issues/17144.
+        ['scroll', (e: Event) => this.scroll.next(e), capturingEventOptions],
 
-      this._globalListeners
-        .set('scroll', {
-          handler: (e: Event) => this.scroll.next(e),
-          // Use capturing so that we pick up scroll changes in any scrollable nodes that aren't
-          // the document. See https://github.com/angular/components/issues/17144.
-          options: true,
-        })
         // Preventing the default action on `mousemove` isn't enough to disable text selection
         // on Safari so we need to prevent the selection event as well. Alternatively this can
         // be done by setting `user-select: none` on the `body`, however it has causes a style
         // recalculation which can be expensive on pages with a lot of elements.
-        .set('selectstart', {
-          handler: this._preventDefaultWhileDragging,
-          options: activeCapturingEventOptions,
-        });
+        ['selectstart', this._preventDefaultWhileDragging, activeCapturingEventOptions],
+      ];
+
+      if (isTouchEvent) {
+        toBind.push(
+          ['touchend', endEventHandler, capturingEventOptions],
+          ['touchcancel', endEventHandler, capturingEventOptions],
+        );
+      } else {
+        toBind.push(['mouseup', endEventHandler, capturingEventOptions]);
+      }
 
       // We don't have to bind a move event for touch drag sequences, because
       // we already have a persistent global one bound from `registerDragItem`.
       if (!isTouchEvent) {
-        this._globalListeners.set('mousemove', {
-          handler: (e: Event) => this.pointerMove.next(e as MouseEvent),
-          options: activeCapturingEventOptions,
-        });
+        toBind.push([
+          'mousemove',
+          (e: Event) => this.pointerMove.next(e as MouseEvent),
+          activeCapturingEventOptions,
+        ]);
       }
 
       this._ngZone.runOutsideAngular(() => {
-        this._globalListeners.forEach((config, name) => {
-          this._document.addEventListener(name, config.handler, config.options);
-        });
+        this._globalListeners = toBind.map(([name, handler, options]) =>
+          _bindEventWithOptions(this._renderer, this._document, name, handler, options),
+        );
       });
     }
   }
@@ -257,17 +255,20 @@ export class DragDropRegistry<_ = unknown, __ = unknown> implements OnDestroy {
       streams.push(
         new Observable((observer: Observer<Event>) => {
           return this._ngZone.runOutsideAngular(() => {
-            const eventOptions = true;
-            const callback = (event: Event) => {
-              if (this._activeDragInstances().length) {
-                observer.next(event);
-              }
-            };
-
-            (shadowRoot as ShadowRoot).addEventListener('scroll', callback, eventOptions);
+            const cleanup = _bindEventWithOptions(
+              this._renderer,
+              shadowRoot as ShadowRoot,
+              'scroll',
+              (event: Event) => {
+                if (this._activeDragInstances().length) {
+                  observer.next(event);
+                }
+              },
+              capturingEventOptions,
+            );
 
             return () => {
-              (shadowRoot as ShadowRoot).removeEventListener('scroll', callback, eventOptions);
+              cleanup();
             };
           });
         }),
@@ -338,10 +339,7 @@ export class DragDropRegistry<_ = unknown, __ = unknown> implements OnDestroy {
 
   /** Clears out the global event listeners from the `document`. */
   private _clearGlobalListeners() {
-    this._globalListeners.forEach((config, name) => {
-      this._document.removeEventListener(name, config.handler, config.options);
-    });
-
-    this._globalListeners.clear();
+    this._globalListeners?.forEach(cleanup => cleanup());
+    this._globalListeners = undefined;
   }
 }

--- a/src/cdk/overlay/dispatchers/overlay-outside-click-dispatcher.spec.ts
+++ b/src/cdk/overlay/dispatchers/overlay-outside-click-dispatcher.spec.ts
@@ -138,10 +138,18 @@ describe('OverlayOutsideClickDispatcher', () => {
     spyOn(body, 'removeEventListener');
 
     outsideClickDispatcher.add(overlayRef);
-    expect(body.addEventListener).toHaveBeenCalledWith('click', jasmine.any(Function), true);
+    expect(body.addEventListener).toHaveBeenCalledWith(
+      'click',
+      jasmine.any(Function),
+      jasmine.objectContaining({capture: true}),
+    );
 
     overlayRef.dispose();
-    expect(body.removeEventListener).toHaveBeenCalledWith('click', jasmine.any(Function), true);
+    expect(body.removeEventListener).toHaveBeenCalledWith(
+      'click',
+      jasmine.any(Function),
+      jasmine.objectContaining({capture: true}),
+    );
   });
 
   it('should not add the same overlay to the stack multiple times', () => {

--- a/src/cdk/overlay/dispatchers/overlay-outside-click-dispatcher.ts
+++ b/src/cdk/overlay/dispatchers/overlay-outside-click-dispatcher.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Injectable, NgZone, inject} from '@angular/core';
-import {Platform, _getEventTarget} from '@angular/cdk/platform';
+import {Injectable, NgZone, RendererFactory2, inject} from '@angular/core';
+import {Platform, _bindEventWithOptions, _getEventTarget} from '@angular/cdk/platform';
 import {BaseOverlayDispatcher} from './base-overlay-dispatcher';
 import type {OverlayRef} from '../overlay-ref';
 
@@ -19,11 +19,13 @@ import type {OverlayRef} from '../overlay-ref';
 @Injectable({providedIn: 'root'})
 export class OverlayOutsideClickDispatcher extends BaseOverlayDispatcher {
   private _platform = inject(Platform);
-  private _ngZone = inject(NgZone, {optional: true});
+  private _ngZone = inject(NgZone);
+  private _renderer = inject(RendererFactory2).createRenderer(null, null);
 
   private _cursorOriginalValue: string;
   private _cursorStyleIsSet = false;
   private _pointerDownEventTarget: HTMLElement | null;
+  private _cleanups: (() => void)[] | undefined;
 
   /** Add a new overlay to the list of attached overlay refs. */
   override add(overlayRef: OverlayRef): void {
@@ -37,13 +39,26 @@ export class OverlayOutsideClickDispatcher extends BaseOverlayDispatcher {
     // https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariWebContent/HandlingEvents/HandlingEvents.html
     if (!this._isAttached) {
       const body = this._document.body;
+      const eventOptions = {capture: true};
 
-      /** @breaking-change 14.0.0 _ngZone will be required. */
-      if (this._ngZone) {
-        this._ngZone.runOutsideAngular(() => this._addEventListeners(body));
-      } else {
-        this._addEventListeners(body);
-      }
+      this._cleanups = this._ngZone.runOutsideAngular(() => [
+        _bindEventWithOptions(
+          this._renderer,
+          body,
+          'pointerdown',
+          this._pointerDownListener,
+          eventOptions,
+        ),
+        _bindEventWithOptions(this._renderer, body, 'click', this._clickListener, eventOptions),
+        _bindEventWithOptions(this._renderer, body, 'auxclick', this._clickListener, eventOptions),
+        _bindEventWithOptions(
+          this._renderer,
+          body,
+          'contextmenu',
+          this._clickListener,
+          eventOptions,
+        ),
+      ]);
 
       // click event is not fired on iOS. To make element "clickable" we are
       // setting the cursor to pointer
@@ -60,24 +75,14 @@ export class OverlayOutsideClickDispatcher extends BaseOverlayDispatcher {
   /** Detaches the global keyboard event listener. */
   protected detach() {
     if (this._isAttached) {
-      const body = this._document.body;
-      body.removeEventListener('pointerdown', this._pointerDownListener, true);
-      body.removeEventListener('click', this._clickListener, true);
-      body.removeEventListener('auxclick', this._clickListener, true);
-      body.removeEventListener('contextmenu', this._clickListener, true);
+      this._cleanups?.forEach(cleanup => cleanup());
+      this._cleanups = undefined;
       if (this._platform.IOS && this._cursorStyleIsSet) {
-        body.style.cursor = this._cursorOriginalValue;
+        this._document.body.style.cursor = this._cursorOriginalValue;
         this._cursorStyleIsSet = false;
       }
       this._isAttached = false;
     }
-  }
-
-  private _addEventListeners(body: HTMLElement): void {
-    body.addEventListener('pointerdown', this._pointerDownListener, true);
-    body.addEventListener('click', this._clickListener, true);
-    body.addEventListener('auxclick', this._clickListener, true);
-    body.addEventListener('contextmenu', this._clickListener, true);
   }
 
   /** Store pointerdown event target to track origin of click. */

--- a/src/material/core/private/ripple-loader.ts
+++ b/src/material/core/private/ripple-loader.ts
@@ -13,6 +13,7 @@ import {
   Injector,
   NgZone,
   OnDestroy,
+  RendererFactory2,
   inject,
 } from '@angular/core';
 import {
@@ -21,7 +22,7 @@ import {
   RippleTarget,
   defaultRippleAnimationConfig,
 } from '../ripple';
-import {Platform, _getEventTarget} from '@angular/cdk/platform';
+import {Platform, _bindEventWithOptions, _getEventTarget} from '@angular/cdk/platform';
 import {_CdkPrivateStyleLoader} from '@angular/cdk/private';
 
 /** The options for the MatRippleLoader's event listeners. */
@@ -56,22 +57,31 @@ const matRippleDisabled = 'mat-ripple-loader-disabled';
  */
 @Injectable({providedIn: 'root'})
 export class MatRippleLoader implements OnDestroy {
-  private _document = inject(DOCUMENT, {optional: true});
+  private _document = inject(DOCUMENT);
   private _animationMode = inject(ANIMATION_MODULE_TYPE, {optional: true});
   private _globalRippleOptions = inject(MAT_RIPPLE_GLOBAL_OPTIONS, {optional: true});
   private _platform = inject(Platform);
   private _ngZone = inject(NgZone);
   private _injector = inject(Injector);
+  private _eventCleanups: (() => void)[];
   private _hosts = new Map<
     HTMLElement,
     {renderer: RippleRenderer; target: RippleTarget; hasSetUpEvents: boolean}
   >();
 
   constructor() {
-    this._ngZone.runOutsideAngular(() => {
-      for (const event of rippleInteractionEvents) {
-        this._document?.addEventListener(event, this._onInteraction, eventListenerOptions);
-      }
+    const renderer = inject(RendererFactory2).createRenderer(null, null);
+
+    this._eventCleanups = this._ngZone.runOutsideAngular(() => {
+      return rippleInteractionEvents.map(name =>
+        _bindEventWithOptions(
+          renderer,
+          this._document,
+          name,
+          this._onInteraction,
+          eventListenerOptions,
+        ),
+      );
     });
   }
 
@@ -82,9 +92,7 @@ export class MatRippleLoader implements OnDestroy {
       this.destroyRipple(host);
     }
 
-    for (const event of rippleInteractionEvents) {
-      this._document?.removeEventListener(event, this._onInteraction, eventListenerOptions);
-    }
+    this._eventCleanups.forEach(cleanup => cleanup());
   }
 
   /**

--- a/src/material/datepicker/calendar-body.ts
+++ b/src/material/datepicker/calendar-body.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Platform, normalizePassiveListenerOptions} from '@angular/cdk/platform';
+import {Platform, _bindEventWithOptions} from '@angular/cdk/platform';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -23,6 +23,7 @@ import {
   inject,
   afterNextRender,
   Injector,
+  Renderer2,
 } from '@angular/core';
 import {_IdGenerator} from '@angular/cdk/a11y';
 import {NgClass} from '@angular/common';
@@ -66,19 +67,19 @@ export interface MatCalendarUserEvent<D> {
 }
 
 /** Event options that can be used to bind an active, capturing event. */
-const activeCapturingEventOptions = normalizePassiveListenerOptions({
+const activeCapturingEventOptions = {
   passive: false,
   capture: true,
-});
+};
 
 /** Event options that can be used to bind a passive, capturing event. */
-const passiveCapturingEventOptions = normalizePassiveListenerOptions({
+const passiveCapturingEventOptions = {
   passive: true,
   capture: true,
-});
+};
 
 /** Event options that can be used to bind a passive, non-capturing event. */
-const passiveEventOptions = normalizePassiveListenerOptions({passive: true});
+const passiveEventOptions = {passive: true};
 
 /**
  * An internal component used to display calendar data in a table.
@@ -101,6 +102,7 @@ export class MatCalendarBody<D = any> implements OnChanges, OnDestroy, AfterView
   private _ngZone = inject(NgZone);
   private _platform = inject(Platform);
   private _intl = inject(MatDatepickerIntl);
+  private _eventCleanups: (() => void)[];
 
   /**
    * Used to skip the next focus event when rendering the preview range.
@@ -224,6 +226,7 @@ export class MatCalendarBody<D = any> implements OnChanges, OnDestroy, AfterView
   constructor(...args: unknown[]);
 
   constructor() {
+    const renderer = inject(Renderer2);
     const idGenerator = inject(_IdGenerator);
     this._startDateLabelId = idGenerator.getId('mat-calendar-body-start-');
     this._endDateLabelId = idGenerator.getId('mat-calendar-body-end-');
@@ -234,22 +237,67 @@ export class MatCalendarBody<D = any> implements OnChanges, OnDestroy, AfterView
 
     this._ngZone.runOutsideAngular(() => {
       const element = this._elementRef.nativeElement;
-
-      // `touchmove` is active since we need to call `preventDefault`.
-      element.addEventListener('touchmove', this._touchmoveHandler, activeCapturingEventOptions);
-
-      element.addEventListener('mouseenter', this._enterHandler, passiveCapturingEventOptions);
-      element.addEventListener('focus', this._enterHandler, passiveCapturingEventOptions);
-      element.addEventListener('mouseleave', this._leaveHandler, passiveCapturingEventOptions);
-      element.addEventListener('blur', this._leaveHandler, passiveCapturingEventOptions);
-
-      element.addEventListener('mousedown', this._mousedownHandler, passiveEventOptions);
-      element.addEventListener('touchstart', this._mousedownHandler, passiveEventOptions);
+      const cleanups = [
+        // `touchmove` is active since we need to call `preventDefault`.
+        _bindEventWithOptions(
+          renderer,
+          element,
+          'touchmove',
+          this._touchmoveHandler,
+          activeCapturingEventOptions,
+        ),
+        _bindEventWithOptions(
+          renderer,
+          element,
+          'mouseenter',
+          this._enterHandler,
+          passiveCapturingEventOptions,
+        ),
+        _bindEventWithOptions(
+          renderer,
+          element,
+          'focus',
+          this._enterHandler,
+          passiveCapturingEventOptions,
+        ),
+        _bindEventWithOptions(
+          renderer,
+          element,
+          'mouseleave',
+          this._leaveHandler,
+          passiveCapturingEventOptions,
+        ),
+        _bindEventWithOptions(
+          renderer,
+          element,
+          'blur',
+          this._leaveHandler,
+          passiveCapturingEventOptions,
+        ),
+        _bindEventWithOptions(
+          renderer,
+          element,
+          'mousedown',
+          this._mousedownHandler,
+          passiveEventOptions,
+        ),
+        _bindEventWithOptions(
+          renderer,
+          element,
+          'touchstart',
+          this._mousedownHandler,
+          passiveEventOptions,
+        ),
+      ];
 
       if (this._platform.isBrowser) {
-        window.addEventListener('mouseup', this._mouseupHandler);
-        window.addEventListener('touchend', this._touchendHandler);
+        cleanups.push(
+          renderer.listen('window', 'mouseup', this._mouseupHandler),
+          renderer.listen('window', 'touchend', this._touchendHandler),
+        );
       }
+
+      this._eventCleanups = cleanups;
     });
   }
 
@@ -295,22 +343,7 @@ export class MatCalendarBody<D = any> implements OnChanges, OnDestroy, AfterView
   }
 
   ngOnDestroy() {
-    const element = this._elementRef.nativeElement;
-
-    element.removeEventListener('touchmove', this._touchmoveHandler, activeCapturingEventOptions);
-
-    element.removeEventListener('mouseenter', this._enterHandler, passiveCapturingEventOptions);
-    element.removeEventListener('focus', this._enterHandler, passiveCapturingEventOptions);
-    element.removeEventListener('mouseleave', this._leaveHandler, passiveCapturingEventOptions);
-    element.removeEventListener('blur', this._leaveHandler, passiveCapturingEventOptions);
-
-    element.removeEventListener('mousedown', this._mousedownHandler, passiveEventOptions);
-    element.removeEventListener('touchstart', this._mousedownHandler, passiveEventOptions);
-
-    if (this._platform.isBrowser) {
-      window.removeEventListener('mouseup', this._mouseupHandler);
-      window.removeEventListener('touchend', this._touchendHandler);
-    }
+    this._eventCleanups.forEach(cleanup => cleanup());
   }
 
   /** Returns whether a cell is active. */


### PR DESCRIPTION
This is a second attempt at landing the changes from #30195. I've removed some of the riskier changes.

Switches all manually-bound event handlers that were passing options to go through the renderer.