### PR TITLE
fix(material/tabs): switch away from animations module

### DIFF
--- a/src/material/tabs/tab-body.html
+++ b/src/material/tabs/tab-body.html
@@ -1,10 +1,9 @@
-<div class="mat-mdc-tab-body-content" #content
-     [@translateTab]="{
-        value: _position,
-        params: {animationDuration: animationDuration}
-     }"
-     (@translateTab.start)="_onTranslateTabStarted($event)"
-     (@translateTab.done)="_translateTabComplete.next($event)"
-     cdkScrollable>
+<div
+   class="mat-mdc-tab-body-content"
+   #content
+   cdkScrollable
+   [class.mat-tab-body-content-left]="_position === 'left'"
+   [class.mat-tab-body-content-right]="_position === 'right'"
+   [class.mat-tab-body-content-can-animate]="_position === 'center' || _previousPosition === 'center'">
   <ng-template matTabBodyHost></ng-template>
 </div>

--- a/src/material/tabs/tab-body.scss
+++ b/src/material/tabs/tab-body.scss
@@ -27,19 +27,33 @@
 .mat-mdc-tab-body-content {
   height: 100%;
   overflow: auto;
+  transform: none;
+  visibility: hidden;
+
+  .mat-tab-body-animating > &,
+  .mat-mdc-tab-body-active > & {
+    visibility: visible;
+  }
 
   .mat-mdc-tab-group-dynamic-height & {
     overflow: hidden;
   }
+}
 
-  // Usually the `visibility: hidden` added by the animation is enough to prevent focus from
-  // entering the collapsed content, but children with their own `visibility` can override it.
-  // This is a fallback that completely hides the content when the element becomes hidden.
-  // Note that we can't do this in the animation definition, because the style gets recomputed too
-  // late, breaking the animation because Angular didn't have time to figure out the target height.
-  // This can also be achieved with JS, but it has issues when starting an animation before
-  // the previous one has finished.
-  &[style*='visibility: hidden'] {
-    display: none;
+.mat-tab-body-content-can-animate {
+  // Note: there's a 1ms delay so that transition events
+  // still fire even if the duration is set to zero.
+  transition: transform var(--mat-tab-animation-duration) 1ms cubic-bezier(0.35, 0, 0.25, 1);
+
+  .mat-mdc-tab-body-wrapper._mat-animation-noopable & {
+    transition: none;
   }
+}
+
+.mat-tab-body-content-left {
+  transform: translate3d(-100%, 0, 0);
+}
+
+.mat-tab-body-content-right {
+  transform: translate3d(100%, 0, 0);
 }

--- a/src/material/tabs/tab-body.spec.ts
+++ b/src/material/tabs/tab-body.spec.ts
@@ -36,74 +36,12 @@ describe('MatTabBody', () => {
     });
   }));
 
-  describe('when initialized as center', () => {
-    let fixture: ComponentFixture<SimpleTabBodyApp>;
+  it('should be center position if origin is unchanged', () => {
+    const fixture = TestBed.createComponent(SimpleTabBodyApp);
+    fixture.componentInstance.position = 0;
+    fixture.detectChanges();
 
-    it('should be center position if origin is unchanged', () => {
-      fixture = TestBed.createComponent(SimpleTabBodyApp);
-      fixture.componentInstance.position = 0;
-      fixture.detectChanges();
-
-      expect(fixture.componentInstance.tabBody._position).toBe('center');
-    });
-
-    it('should be center position if origin is explicitly set to null', () => {
-      fixture = TestBed.createComponent(SimpleTabBodyApp);
-      fixture.componentInstance.position = 0;
-
-      // It can happen that the `origin` is explicitly set to null through the Angular input
-      // binding. This test should ensure that the body does properly such origin value.
-      // The `MatTab` class sets the origin by default to null. See related issue: #12455
-      fixture.componentInstance.origin = null;
-      fixture.detectChanges();
-
-      expect(fixture.componentInstance.tabBody._position).toBe('center');
-    });
-
-    describe('in LTR direction', () => {
-      beforeEach(() => {
-        dir = 'ltr';
-        fixture = TestBed.createComponent(SimpleTabBodyApp);
-      });
-      it('should be left-origin-center position with negative or zero origin', () => {
-        fixture.componentInstance.position = 0;
-        fixture.componentInstance.origin = 0;
-        fixture.detectChanges();
-
-        expect(fixture.componentInstance.tabBody._position).toBe('left-origin-center');
-      });
-
-      it('should be right-origin-center position with positive nonzero origin', () => {
-        fixture.componentInstance.position = 0;
-        fixture.componentInstance.origin = 1;
-        fixture.detectChanges();
-
-        expect(fixture.componentInstance.tabBody._position).toBe('right-origin-center');
-      });
-    });
-
-    describe('in RTL direction', () => {
-      beforeEach(() => {
-        dir = 'rtl';
-        fixture = TestBed.createComponent(SimpleTabBodyApp);
-      });
-
-      it('should be right-origin-center position with negative or zero origin', () => {
-        fixture.componentInstance.position = 0;
-        fixture.componentInstance.origin = 0;
-        fixture.detectChanges();
-
-        expect(fixture.componentInstance.tabBody._position).toBe('right-origin-center');
-      });
-
-      it('should be left-origin-center position with positive nonzero origin', () => {
-        fixture.componentInstance.position = 0;
-        fixture.componentInstance.origin = 1;
-        fixture.detectChanges();
-
-        expect(fixture.componentInstance.tabBody._position).toBe('left-origin-center');
-      });
-    });
+    expect(fixture.componentInstance.tabBody._position).toBe('center');
   });
 
   describe('should properly set the position in LTR', () => {
@@ -213,14 +151,13 @@ describe('MatTabBody', () => {
 @Component({
   template: `
     <ng-template>Tab Body Content</ng-template>
-    <mat-tab-body [content]="content()" [position]="position" [origin]="origin"></mat-tab-body>
+    <mat-tab-body [content]="content()" [position]="position"></mat-tab-body>
   `,
   imports: [PortalModule, MatRippleModule, MatTabBody],
 })
 class SimpleTabBodyApp implements AfterViewInit {
   content = signal<TemplatePortal | undefined>(undefined);
   position: number;
-  origin: number | null;
 
   @ViewChild(MatTabBody) tabBody: MatTabBody;
   @ViewChild(TemplateRef) template: TemplateRef<any>;

--- a/src/material/tabs/tab-group.html
+++ b/src/material/tabs/tab-group.html
@@ -67,21 +67,19 @@
   class="mat-mdc-tab-body-wrapper"
   [class._mat-animation-noopable]="_animationMode === 'NoopAnimations'"
   #tabBodyWrapper>
-  @for (tab of _tabs; track tab; let i = $index) {
+  @for (tab of _tabs; track tab;) {
     <mat-tab-body role="tabpanel"
-                 [id]="_getTabContentId(i)"
-                 [attr.tabindex]="(contentTabIndex != null && selectedIndex === i) ? contentTabIndex : null"
-                 [attr.aria-labelledby]="_getTabLabelId(i)"
-                 [attr.aria-hidden]="selectedIndex !== i"
-                 [class.mat-mdc-tab-body-active]="selectedIndex === i"
+                 [id]="_getTabContentId($index)"
+                 [attr.tabindex]="(contentTabIndex != null && selectedIndex === $index) ? contentTabIndex : null"
+                 [attr.aria-labelledby]="_getTabLabelId($index)"
+                 [attr.aria-hidden]="selectedIndex !== $index"
                  [class]="tab.bodyClass"
                  [content]="tab.content!"
                  [position]="tab.position!"
-                 [origin]="tab.origin"
                  [animationDuration]="animationDuration"
                  [preserveContent]="preserveContent"
                  (_onCentered)="_removeTabBodyWrapperHeight()"
-                 (_onCentering)="_setTabBodyWrapperHeight($event)">
-    </mat-tab-body>
+                 (_onCentering)="_setTabBodyWrapperHeight($event)"
+                 (_beforeCentering)="_bodyCentered($event)"/>
   }
 </div>

--- a/src/material/tabs/tab-group.spec.ts
+++ b/src/material/tabs/tab-group.spec.ts
@@ -557,41 +557,6 @@ describe('MatTabGroup', () => {
       fixture.detectChanges();
     }));
 
-    it('should be able to add a new tab, select it, and have correct origin position', fakeAsync(() => {
-      const component: MatTabGroup = fixture.debugElement.query(
-        By.css('mat-tab-group'),
-      ).componentInstance;
-
-      let tabs: MatTab[] = component._tabs.toArray();
-      expect(tabs[0].origin).toBe(null);
-      expect(tabs[1].origin).toBe(0);
-      expect(tabs[2].origin).toBe(null);
-
-      // Add a new tab on the right and select it, expect an origin >= than 0 (animate right)
-      fixture.componentInstance.tabs.push({label: 'New tab', content: 'to right of index'});
-      fixture.componentInstance.selectedIndex = 4;
-      fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
-      tick();
-
-      tabs = component._tabs.toArray();
-      expect(tabs[3].origin).toBeGreaterThanOrEqual(0);
-
-      // Add a new tab in the beginning and select it, expect an origin < than 0 (animate left)
-      fixture.componentInstance.selectedIndex = 0;
-      fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
-      tick();
-
-      fixture.componentInstance.tabs.push({label: 'New tab', content: 'to left of index'});
-      fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
-      tick();
-
-      tabs = component._tabs.toArray();
-      expect(tabs[0].origin).toBeLessThan(0);
-    }));
-
     it('should update selected index if the last tab removed while selected', fakeAsync(() => {
       const component: MatTabGroup = fixture.debugElement.query(
         By.css('mat-tab-group'),
@@ -828,37 +793,22 @@ describe('MatTabGroup', () => {
       const contentElements: HTMLElement[] = Array.from(
         fixture.nativeElement.querySelectorAll('.mat-mdc-tab-body-content'),
       );
+      const getVisibilities = () =>
+        contentElements.map(element => getComputedStyle(element).visibility);
 
-      expect(contentElements.map(element => element.style.visibility)).toEqual([
-        'visible',
-        'hidden',
-        'hidden',
-        'hidden',
-      ]);
+      expect(getVisibilities()).toEqual(['visible', 'hidden', 'hidden', 'hidden']);
 
       tabGroup.selectedIndex = 2;
       fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       tick();
-
-      expect(contentElements.map(element => element.style.visibility)).toEqual([
-        'hidden',
-        'hidden',
-        'visible',
-        'hidden',
-      ]);
+      expect(getVisibilities()).toEqual(['hidden', 'hidden', 'visible', 'hidden']);
 
       tabGroup.selectedIndex = 1;
       fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       tick();
-
-      expect(contentElements.map(element => element.style.visibility)).toEqual([
-        'hidden',
-        'visible',
-        'hidden',
-        'hidden',
-      ]);
+      expect(getVisibilities()).toEqual(['hidden', 'visible', 'hidden', 'hidden']);
     }));
   });
 

--- a/src/material/tabs/tab.ts
+++ b/src/material/tabs/tab.ts
@@ -116,6 +116,7 @@ export class MatTab implements OnInit, OnChanges, OnDestroy {
    */
   position: number | null = null;
 
+  // TODO(crisbeto): we no longer use this, but some internal apps appear to rely on it.
   /**
    * The initial relatively index origin of the tab if it was created and selected after there
    * was already a selected tab. Provides context of what position the tab should originate from.

--- a/src/material/tabs/tabs-animations.ts
+++ b/src/material/tabs/tabs-animations.ts
@@ -17,6 +17,8 @@ import {
 /**
  * Animations used by the Material tabs.
  * @docs-private
+ * @deprecated No longer used, will be removed.
+ * @breaking-change 21.0.0.
  */
 export const matTabsAnimations: {
   readonly translateTab: AnimationTriggerMetadata;

--- a/tools/public_api_guard/material/tabs.md
+++ b/tools/public_api_guard/material/tabs.md
@@ -7,7 +7,6 @@
 import { AfterContentChecked } from '@angular/core';
 import { AfterContentInit } from '@angular/core';
 import { AfterViewInit } from '@angular/core';
-import { AnimationEvent as AnimationEvent_2 } from '@angular/animations';
 import { AnimationTriggerMetadata } from '@angular/animations';
 import { BehaviorSubject } from 'rxjs';
 import { CdkPortal } from '@angular/cdk/portal';
@@ -188,28 +187,28 @@ export class MatTabBody implements OnInit, OnDestroy {
     animationDuration: string;
     readonly _beforeCentering: EventEmitter<boolean>;
     _content: TemplatePortal;
+    _contentElement: ElementRef<HTMLElement> | undefined;
     _getLayoutDirection(): Direction;
-    _isCenterPosition(position: MatTabBodyPositionState | string): boolean;
+    _isCenterPosition(): boolean;
     // (undocumented)
     ngOnDestroy(): void;
+    // (undocumented)
     ngOnInit(): void;
     readonly _onCentered: EventEmitter<void>;
     readonly _onCentering: EventEmitter<number>;
-    // (undocumented)
-    _onTranslateTabStarted(event: AnimationEvent_2): void;
-    origin: number | null;
-    _portalHost: CdkPortalOutlet;
+    _portalHost: MatTabBodyPortal;
     set position(position: number);
     _position: MatTabBodyPositionState;
     preserveContent: boolean;
-    readonly _translateTabComplete: Subject<AnimationEvent_2>;
+    protected _previousPosition: MatTabBodyPositionState | undefined;
+    _setActiveClass(isActive: boolean): void;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<MatTabBody, "mat-tab-body", never, { "_content": { "alias": "content"; "required": false; }; "origin": { "alias": "origin"; "required": false; }; "animationDuration": { "alias": "animationDuration"; "required": false; }; "preserveContent": { "alias": "preserveContent"; "required": false; }; "position": { "alias": "position"; "required": false; }; }, { "_onCentering": "_onCentering"; "_beforeCentering": "_beforeCentering"; "_afterLeavingCenter": "_afterLeavingCenter"; "_onCentered": "_onCentered"; }, never, never, true, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MatTabBody, "mat-tab-body", never, { "_content": { "alias": "content"; "required": false; }; "animationDuration": { "alias": "animationDuration"; "required": false; }; "preserveContent": { "alias": "preserveContent"; "required": false; }; "position": { "alias": "position"; "required": false; }; }, { "_onCentering": "_onCentering"; "_beforeCentering": "_beforeCentering"; "_onCentered": "_onCentered"; }, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatTabBody, never>;
 }
 
-// @public
+// @public @deprecated
 export type MatTabBodyOriginState = 'left' | 'right';
 
 // @public
@@ -223,8 +222,8 @@ export class MatTabBodyPortal extends CdkPortalOutlet implements OnInit, OnDestr
     static ɵfac: i0.ɵɵFactoryDeclaration<MatTabBodyPortal, never>;
 }
 
-// @public
-export type MatTabBodyPositionState = 'left' | 'center' | 'right' | 'left-origin-center' | 'right-origin-center';
+// @public @deprecated
+export type MatTabBodyPositionState = 'left' | 'center' | 'right';
 
 // @public
 export class MatTabChangeEvent {
@@ -244,7 +243,7 @@ export class MatTabContent {
 }
 
 // @public
-export class MatTabGroup implements AfterContentInit, AfterContentChecked, OnDestroy {
+export class MatTabGroup implements AfterViewInit, AfterContentInit, AfterContentChecked, OnDestroy {
     constructor(...args: unknown[]);
     alignTabs: string | null;
     _allTabs: QueryList<MatTab>;
@@ -258,6 +257,7 @@ export class MatTabGroup implements AfterContentInit, AfterContentChecked, OnDes
     // @deprecated
     get backgroundColor(): ThemePalette;
     set backgroundColor(value: ThemePalette);
+    protected _bodyCentered(isCenter: boolean): void;
     color: ThemePalette;
     get contentTabIndex(): number | null;
     set contentTabIndex(value: number);
@@ -298,6 +298,8 @@ export class MatTabGroup implements AfterContentInit, AfterContentChecked, OnDes
     // (undocumented)
     ngAfterContentInit(): void;
     // (undocumented)
+    ngAfterViewInit(): void;
+    // (undocumented)
     ngOnDestroy(): void;
     preserveContent: boolean;
     realignInkBar(): void;
@@ -308,6 +310,8 @@ export class MatTabGroup implements AfterContentInit, AfterContentChecked, OnDes
     readonly selectedTabChange: EventEmitter<MatTabChangeEvent>;
     _setTabBodyWrapperHeight(tabHeight: number): void;
     stretchTabs: boolean;
+    // (undocumented)
+    _tabBodies: QueryList<MatTabBody> | undefined;
     // (undocumented)
     _tabBodyWrapper: ElementRef;
     _tabFocusChanged(focusOrigin: FocusOrigin, index: number): void;
@@ -501,7 +505,7 @@ export class MatTabNavPanel {
     static ɵfac: i0.ɵɵFactoryDeclaration<MatTabNavPanel, never>;
 }
 
-// @public
+// @public @deprecated
 export const matTabsAnimations: {
     readonly translateTab: AnimationTriggerMetadata;
 };


### PR DESCRIPTION
Reworks the tabs so they don't depend on the animations module anymore. This is both simpler and avoids some of the pitfalls of the animations module.