### PR TITLE
fix(material/timepicker): adds default aria-label to timepicker toggle

### DIFF
--- a/src/dev-app/timepicker/timepicker-demo.html
+++ b/src/dev-app/timepicker/timepicker-demo.html
@@ -11,7 +11,7 @@
           [matTimepickerMax]="maxControl.value"
           [formControl]="control">
         <mat-timepicker [interval]="intervalControl.value" #basicPicker/>
-        <mat-timepicker-toggle [for]="basicPicker" aria-labelledby="mat-mdc-form-field-label-0" matSuffix/>
+        <mat-timepicker-toggle [for]="basicPicker" matSuffix/>
       </mat-form-field>
 
       <p>Value: {{control.value}}</p>

--- a/src/dev-app/timepicker/timepicker-demo.html
+++ b/src/dev-app/timepicker/timepicker-demo.html
@@ -11,7 +11,7 @@
           [matTimepickerMax]="maxControl.value"
           [formControl]="control">
         <mat-timepicker [interval]="intervalControl.value" #basicPicker/>
-        <mat-timepicker-toggle [for]="basicPicker" matSuffix/>
+        <mat-timepicker-toggle [for]="basicPicker" aria-labelledby="mat-mdc-form-field-label-0" matSuffix/>
       </mat-form-field>
 
       <p>Value: {{control.value}}</p>

--- a/src/material/timepicker/timepicker-toggle.html
+++ b/src/material/timepicker/timepicker-toggle.html
@@ -3,6 +3,7 @@
   type="button"
   aria-haspopup="listbox"
   [attr.aria-label]="ariaLabel()"
+  [attr.aria-labelledby]="ariaLabelledby()"
   [attr.aria-expanded]="timepicker().isOpen()"
   [attr.tabindex]="_isDisabled() ? -1 : tabIndex()"
   [disabled]="_isDisabled()"

--- a/src/material/timepicker/timepicker-toggle.html
+++ b/src/material/timepicker/timepicker-toggle.html
@@ -2,7 +2,7 @@
   mat-icon-button
   type="button"
   aria-haspopup="listbox"
-  [attr.aria-label]="ariaLabel()"
+  [attr.aria-label]="getAriaLabel()"
   [attr.aria-labelledby]="ariaLabelledby()"
   [attr.aria-expanded]="timepicker().isOpen()"
   [attr.tabindex]="_isDisabled() ? -1 : tabIndex()"

--- a/src/material/timepicker/timepicker-toggle.ts
+++ b/src/material/timepicker/timepicker-toggle.ts
@@ -94,11 +94,10 @@ export class MatTimepickerToggle<D> {
   }
 
   /**
-   * Gets the aria-label to use for the toggle button.
-   * Returns the user-provided aria-label if one exists,
-   * otherwise returns the default aria-label using the timepicker's panelId.
+   * Checks for ariaLabelledby and if empty uses custom
+   * aria-label or defaultAriaLabel if neither is provided.
    */
-  getAriaLabel(): string {
-    return this.ariaLabel() || this._defaultAriaLabel;
+  getAriaLabel(): string | null {
+    return this.ariaLabelledby() ? null : this.ariaLabel() || this._defaultAriaLabel;
   }
 }

--- a/src/material/timepicker/timepicker-toggle.ts
+++ b/src/material/timepicker/timepicker-toggle.ts
@@ -67,6 +67,9 @@ export class MatTimepickerToggle<D> {
     alias: 'aria-labelledby',
   });
 
+  /** Default aria-label for the toggle if none is provided. */
+  private readonly defaultAriaLabel = 'Open timepicker options';
+
   /** Whether the toggle button is disabled. */
   readonly disabled: InputSignalWithTransform<boolean, unknown> = input(false, {
     transform: booleanAttribute,
@@ -88,5 +91,14 @@ export class MatTimepickerToggle<D> {
       this.timepicker().open();
       event.stopPropagation();
     }
+  }
+
+  /**
+   * Gets the aria-label to use for the toggle button.
+   * Returns the user-provided aria-label if one exists,
+   * otherwise returns the default aria-label using the timepicker's panelId.
+   */
+  getAriaLabel(): string {
+    return this.ariaLabel() || this.defaultAriaLabel;
   }
 }

--- a/src/material/timepicker/timepicker-toggle.ts
+++ b/src/material/timepicker/timepicker-toggle.ts
@@ -62,6 +62,11 @@ export class MatTimepickerToggle<D> {
     alias: 'aria-label',
   });
 
+  /** Screen-reader labelled by id for the button. */
+  readonly ariaLabelledby = input<string | undefined>(undefined, {
+    alias: 'aria-labelledby',
+  });
+
   /** Whether the toggle button is disabled. */
   readonly disabled: InputSignalWithTransform<boolean, unknown> = input(false, {
     transform: booleanAttribute,

--- a/src/material/timepicker/timepicker-toggle.ts
+++ b/src/material/timepicker/timepicker-toggle.ts
@@ -68,7 +68,7 @@ export class MatTimepickerToggle<D> {
   });
 
   /** Default aria-label for the toggle if none is provided. */
-  private readonly defaultAriaLabel = 'Open timepicker options';
+  private readonly _defaultAriaLabel = 'Open timepicker options';
 
   /** Whether the toggle button is disabled. */
   readonly disabled: InputSignalWithTransform<boolean, unknown> = input(false, {
@@ -99,6 +99,6 @@ export class MatTimepickerToggle<D> {
    * otherwise returns the default aria-label using the timepicker's panelId.
    */
   getAriaLabel(): string {
-    return this.ariaLabel() || this.defaultAriaLabel;
+    return this.ariaLabel() || this._defaultAriaLabel;
   }
 }

--- a/tools/public_api_guard/material/timepicker.md
+++ b/tools/public_api_guard/material/timepicker.md
@@ -127,7 +127,7 @@ export class MatTimepickerToggle<D> {
     readonly ariaLabelledby: InputSignal<string | undefined>;
     readonly disabled: InputSignalWithTransform<boolean, unknown>;
     readonly disableRipple: InputSignalWithTransform<boolean, unknown>;
-    getAriaLabel(): string;
+    getAriaLabel(): string | null;
     // (undocumented)
     protected _isDisabled: Signal<boolean>;
     protected _open(event: Event): void;

--- a/tools/public_api_guard/material/timepicker.md
+++ b/tools/public_api_guard/material/timepicker.md
@@ -124,15 +124,17 @@ export interface MatTimepickerSelected<D> {
 // @public
 export class MatTimepickerToggle<D> {
     readonly ariaLabel: InputSignal<string | undefined>;
+    readonly ariaLabelledby: InputSignal<string | undefined>;
     readonly disabled: InputSignalWithTransform<boolean, unknown>;
     readonly disableRipple: InputSignalWithTransform<boolean, unknown>;
+    getAriaLabel(): string;
     // (undocumented)
     protected _isDisabled: Signal<boolean>;
     protected _open(event: Event): void;
     readonly tabIndex: InputSignal<number | null>;
     readonly timepicker: InputSignal<MatTimepicker<D>>;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<MatTimepickerToggle<any>, "mat-timepicker-toggle", ["matTimepickerToggle"], { "timepicker": { "alias": "for"; "required": true; "isSignal": true; }; "ariaLabel": { "alias": "aria-label"; "required": false; "isSignal": true; }; "disabled": { "alias": "disabled"; "required": false; "isSignal": true; }; "tabIndex": { "alias": "tabIndex"; "required": false; "isSignal": true; }; "disableRipple": { "alias": "disableRipple"; "required": false; "isSignal": true; }; }, {}, never, ["[matTimepickerToggleIcon]"], true, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MatTimepickerToggle<any>, "mat-timepicker-toggle", ["matTimepickerToggle"], { "timepicker": { "alias": "for"; "required": true; "isSignal": true; }; "ariaLabel": { "alias": "aria-label"; "required": false; "isSignal": true; }; "ariaLabelledby": { "alias": "aria-labelledby"; "required": false; "isSignal": true; }; "disabled": { "alias": "disabled"; "required": false; "isSignal": true; }; "tabIndex": { "alias": "tabIndex"; "required": false; "isSignal": true; }; "disableRipple": { "alias": "disableRipple"; "required": false; "isSignal": true; }; }, {}, never, ["[matTimepickerToggleIcon]"], true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatTimepickerToggle<any>, never>;
 }


### PR DESCRIPTION
Updates Angular Component Timepicker so the timepicker toggle has a default aria-label value if no aria-label is applied for the timepicker toggle button to make it more accessible.  Also adds additional option of applying aria-labelledby to Timepicker toggle button.

[Before screencast](https://screencast.googleplex.com/cast/NjQxMDM4NjI4OTk4MzQ4OHxmYTQyYzVjNC02Zg)
[After screencast](https://screencast.googleplex.com/cast/NTI5MTA0NTgzODM4OTI0OHw3NmY4MjQ3Ny02Zg)

Fixes b/380308482