### PR TITLE
fix(material/tooltip): deprecate matTooltipAnimations

### DIFF
--- a/src/material/tooltip/tooltip-animations.ts
+++ b/src/material/tooltip/tooltip-animations.ts
@@ -17,6 +17,8 @@ import {
 /**
  * Animations used by MatTooltip.
  * @docs-private
+ * @deprecated No longer being used, to be removed.
+ * @breaking-change 21.0.0
  */
 export const matTooltipAnimations: {
   readonly tooltipState: AnimationTriggerMetadata;

--- a/tools/public_api_guard/material/tooltip.md
+++ b/tools/public_api_guard/material/tooltip.md
@@ -103,7 +103,7 @@ export class MatTooltip implements OnDestroy, AfterViewInit {
     static ɵfac: i0.ɵɵFactoryDeclaration<MatTooltip, never>;
 }
 
-// @public
+// @public @deprecated
 export const matTooltipAnimations: {
     readonly tooltipState: AnimationTriggerMetadata;
 };


### PR DESCRIPTION
The `matTooltipAnimations` haven't been used for a while. These changes deprecate it so we can remove it completely later.