### PR TITLE
fix: override theme-picker button ripple to use the primary color

### DIFF
--- a/material.angular.io/src/app/shared/theme-picker/theme-picker.scss
+++ b/material.angular.io/src/app/shared/theme-picker/theme-picker.scss
@@ -1,5 +1,16 @@
+@use '@angular/material' as mat;
+
 button.docs-theme-picker-trigger {
   color: inherit;
+
+  &.mat-mdc-icon-button {
+    @include mat.icon-button-overrides(
+      (
+        state-layer-color: var(--mat-sys-primary),
+        ripple-color: color-mix(in srgb, var(--mat-sys-primary) 10%, transparent),
+      )
+    );
+  }
 }
 
 .docs-theme-picker-menu {


### PR DESCRIPTION
The theme-picker button was using the default surface colors for it's hover and ripple effects, however this was wrong because its located in the navbar where we want it to use the primary color for its state-layer and ripple effects.

### Before
On Hover 
![image](https://github.com/user-attachments/assets/1b0c2b91-b757-48ee-9bde-80b305d72c92)
On Click 
![image](https://github.com/user-attachments/assets/d157da7b-02a9-4161-8e9e-499cbecb5f77)

### After
On Hover
![image](https://github.com/user-attachments/assets/df53c514-9df0-483c-b6cc-615a74bbbd08)
On Click
![image](https://github.com/user-attachments/assets/c371ff21-c77b-4dcd-9d1e-e7d522280ebf)
