### PR TITLE
Optional typing of MatSelectChange

### DIFF
--- a/src/material/select/select.ts
+++ b/src/material/select/select.ts
@@ -155,12 +155,12 @@ export const MAT_SELECT_SCROLL_STRATEGY_PROVIDER = {
 export const MAT_SELECT_TRIGGER = new InjectionToken<MatSelectTrigger>('MatSelectTrigger');
 
 /** Change event object that is emitted when the select value has changed. */
-export class MatSelectChange {
+export class MatSelectChange<T = any> {
   constructor(
     /** Reference to the select that emitted the change event. */
     public source: MatSelect,
     /** Current value of the select that emitted the event. */
-    public value: any,
+    public value: T,
   ) {}
 }
 

--- a/tools/public_api_guard/material/select.md
+++ b/tools/public_api_guard/material/select.md
@@ -188,7 +188,7 @@ export class MatSelect implements AfterContentInit, OnChanges, OnDestroy, OnInit
     _scrollOptionIntoView(index: number): void;
     _scrollStrategy: ScrollStrategy;
     get selected(): MatOption | MatOption[];
-    readonly selectionChange: EventEmitter<MatSelectChange>;
+    readonly selectionChange: EventEmitter<MatSelectChange<any>>;
     _selectionModel: SelectionModel<MatOption>;
     setDescribedByIds(ids: string[]): void;
     setDisabledState(isDisabled: boolean): void;
@@ -223,12 +223,12 @@ export const matSelectAnimations: {
 };
 
 // @public
-export class MatSelectChange {
+export class MatSelectChange<T = any> {
     constructor(
     source: MatSelect,
-    value: any);
+    value: T);
     source: MatSelect;
-    value: any;
+    value: T;
 }
 
 // @public


### PR DESCRIPTION
This event should be typed. Added type and fallback to any to make this optional and backwards compatible.