### PR TITLE
fix(material/form-field): remove dependency on animations module

### DIFF
--- a/src/material/form-field/_form-field-subscript.scss
+++ b/src/material/form-field/_form-field-subscript.scss
@@ -3,6 +3,18 @@
 @use '../core/tokens/token-utils';
 
 @mixin private-form-field-subscript() {
+  @keyframes _mat-form-field-subscript-animation {
+    from {
+      opacity: 0;
+      transform: translateY(-5px);
+    }
+
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
   // Wrapper for the hints and error messages.
   .mat-mdc-form-field-subscript-wrapper {
     box-sizing: border-box;
@@ -17,6 +29,12 @@
     left: 0;
     right: 0;
     padding: 0 16px;
+    opacity: 1;
+    transform: translateY(0);
+
+    // Note: animation-duration gets set when animations are enabled.
+    // This allows us to skip the animation on init.
+    animation: _mat-form-field-subscript-animation 0ms cubic-bezier(0.55, 0, 0.55, 0.2);
   }
 
   .mat-mdc-form-field-subscript-dynamic-size {

--- a/src/material/form-field/_mdc-text-field-structure.scss
+++ b/src/material/form-field/_mdc-text-field-structure.scss
@@ -611,8 +611,11 @@
   }
 
   .mdc-line-ripple::after {
-    transition:
-      transform 180ms $timing-curve,
-      opacity 180ms $timing-curve;
+    transition: transform 180ms $timing-curve, opacity 180ms $timing-curve;
+  }
+
+  .mat-mdc-form-field-hint-wrapper,
+  .mat-mdc-form-field-error-wrapper {
+    animation-duration: 300ms;
   }
 }

--- a/src/material/form-field/form-field-animations.ts
+++ b/src/material/form-field/form-field-animations.ts
@@ -17,6 +17,8 @@ import {
 /**
  * Animations used by the MatFormField.
  * @docs-private
+ * @deprecated No longer used, will be removed.
+ * @breaking-change 21.0.0
  */
 export const matFormFieldAnimations: {
   readonly transitionMessages: AnimationTriggerMetadata;

--- a/src/material/form-field/form-field.html
+++ b/src/material/form-field/form-field.html
@@ -101,16 +101,13 @@
 >
   @switch (_getDisplayedMessages()) {
     @case ('error') {
-      <div
-        class="mat-mdc-form-field-error-wrapper"
-        [@transitionMessages]="_subscriptAnimationState"
-      >
+      <div class="mat-mdc-form-field-error-wrapper">
         <ng-content select="mat-error, [matError]"></ng-content>
       </div>
     }
 
     @case ('hint') {
-      <div class="mat-mdc-form-field-hint-wrapper" [@transitionMessages]="_subscriptAnimationState">
+      <div class="mat-mdc-form-field-hint-wrapper">
         @if (hintLabel) {
           <mat-hint [id]="_hintLabelId">{{hintLabel}}</mat-hint>
         }

--- a/src/material/form-field/form-field.scss
+++ b/src/material/form-field/form-field.scss
@@ -212,7 +212,7 @@ $_icon-prefix-infix-padding: 4px;
 
 // In order to make it possible for developers to disable animations for form-fields,
 // we only activate the animation styles if animations are not explicitly disabled.
-.mat-mdc-form-field:not(.mat-form-field-no-animations) {
+.mat-mdc-form-field.mat-form-field-animations-enabled {
   @include mdc-text-field-structure.private-text-field-animations;
 }
 

--- a/src/material/input/input.spec.ts
+++ b/src/material/input/input.spec.ts
@@ -486,15 +486,6 @@ describe('MatMdcInput without forms', () => {
     expect(selectEl.disabled).toBe(true);
   }));
 
-  it('should add a class to the form-field if animations are disabled', () => {
-    configureTestingModule(MatInputWithId, {animations: false});
-    const fixture = TestBed.createComponent(MatInputWithId);
-    fixture.detectChanges();
-
-    const formFieldEl = fixture.nativeElement.querySelector('.mat-mdc-form-field');
-    expect(formFieldEl.classList).toContain('mat-form-field-no-animations');
-  });
-
   it('should add a class to the form field if it has a native select', fakeAsync(() => {
     const fixture = createComponent(MatInputSelect);
     fixture.detectChanges();

--- a/src/material/select/select.scss
+++ b/src/material/select/select.scss
@@ -185,7 +185,7 @@ div.mat-mdc-select-panel {
     @include token-utils.create-token-slot(color, placeholder-text-color);
   }
 
-  .mat-form-field-no-animations &,
+  .mat-mdc-form-field:not(.mat-form-field-animations-enabled) &,
   ._mat-animation-noopable & {
     transition: none;
   }

--- a/tools/public_api_guard/material/form-field.md
+++ b/tools/public_api_guard/material/form-field.md
@@ -65,7 +65,7 @@ export class MatFormField implements FloatingLabelParent, AfterContentInit, Afte
     constructor(...args: unknown[]);
     _animateAndLockLabel(): void;
     // (undocumented)
-    _animationMode: "NoopAnimations" | "BrowserAnimations" | null;
+    protected readonly _animationsDisabled: boolean;
     get appearance(): MatFormFieldAppearance;
     set appearance(value: MatFormFieldAppearance);
     color: ThemePalette;
@@ -131,7 +131,6 @@ export class MatFormField implements FloatingLabelParent, AfterContentInit, Afte
     _shouldForward(prop: keyof AbstractControlDirective): boolean;
     // (undocumented)
     _shouldLabelFloat(): boolean;
-    _subscriptAnimationState: string;
     get subscriptSizing(): SubscriptSizing;
     set subscriptSizing(value: SubscriptSizing);
     // (undocumented)
@@ -148,7 +147,7 @@ export class MatFormField implements FloatingLabelParent, AfterContentInit, Afte
     static ɵfac: i0.ɵɵFactoryDeclaration<MatFormField, never>;
 }
 
-// @public
+// @public @deprecated
 export const matFormFieldAnimations: {
     readonly transitionMessages: AnimationTriggerMetadata;
 };


### PR DESCRIPTION
Switches the form field to use CSS for the subscript animations, instead of going through the animations module.