### PR TITLE
fix(material/datepicker): switch away from animations module

### DIFF
--- a/src/material/datepicker/datepicker-animations.ts
+++ b/src/material/datepicker/datepicker-animations.ts
@@ -18,6 +18,8 @@ import {
 /**
  * Animations used by the Material datepicker.
  * @docs-private
+ * @deprecated No longer used, will be removed.
+ * @breaking-change 21.0.0
  */
 export const matDatepickerAnimations: {
   readonly transformPanel: AnimationTriggerMetadata;

--- a/src/material/datepicker/datepicker-content.html
+++ b/src/material/datepicker/datepicker-content.html
@@ -19,7 +19,6 @@
     [dateClass]="datepicker.dateClass"
     [comparisonStart]="comparisonStart"
     [comparisonEnd]="comparisonEnd"
-    [@fadeInCalendar]="'enter'"
     [startDateAccessibleName]="startDateAccessibleName"
     [endDateAccessibleName]="endDateAccessibleName"
     (yearSelected)="datepicker._selectYear($event)"

--- a/src/material/datepicker/datepicker-content.scss
+++ b/src/material/datepicker/datepicker-content.scss
@@ -24,6 +24,39 @@ $touch-min-height: 312px;
 $touch-max-width: 750px;
 $touch-max-height: 788px;
 
+@keyframes _mat-datepicker-content-dropdown-enter {
+  from {
+    opacity: 0;
+    transform: scaleY(0.8);
+  }
+
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@keyframes _mat-datepicker-content-dialog-enter {
+  from {
+    opacity: 0;
+    transform: scale(0.8);
+  }
+
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@keyframes _mat-datepicker-content-exit {
+  from {
+    opacity: 1;
+  }
+
+  to {
+    opacity: 0;
+  }
+}
 
 .mat-datepicker-content {
   display: block;
@@ -35,6 +68,10 @@ $touch-max-height: 788px;
     @include token-utils.create-token-slot(color, calendar-container-text-color);
     @include token-utils.create-token-slot(box-shadow, calendar-container-elevation-shadow);
     @include token-utils.create-token-slot(border-radius, calendar-container-shape);
+  }
+
+  &.mat-datepicker-content-animations-enabled {
+    animation: _mat-datepicker-content-dropdown-enter 120ms cubic-bezier(0, 0, 0.2, 1);
   }
 
   .mat-calendar {
@@ -59,7 +96,7 @@ $touch-max-height: 788px;
 
     // Hide the button while the overlay is animating, because it's rendered
     // outside of it and it seems to cause scrollbars in some cases (see #21493).
-    .ng-animating & {
+    .mat-datepicker-content-animating & {
       display: none;
     }
   }
@@ -89,6 +126,10 @@ $touch-max-height: 788px;
   // Prevents the content from jumping around on Windows while the animation is running.
   overflow: visible;
 
+  &.mat-datepicker-content-animations-enabled {
+    animation: _mat-datepicker-content-dialog-enter 150ms cubic-bezier(0, 0, 0.2, 1);
+  }
+
   .mat-datepicker-content-container {
     min-height: $touch-min-height;
     max-height: $touch-max-height;
@@ -100,6 +141,10 @@ $touch-max-height: 788px;
     width: 100%;
     height: auto;
   }
+}
+
+.mat-datepicker-content-exit.mat-datepicker-content-animations-enabled {
+  animation: _mat-datepicker-content-exit 100ms linear;
 }
 
 @media all and (orientation: landscape) {

--- a/src/material/datepicker/datepicker.spec.ts
+++ b/src/material/datepicker/datepicker.spec.ts
@@ -481,17 +481,13 @@ describe('MatDatepicker', () => {
         for (let i = 0; i < 3; i++) {
           testComponent.datepicker.open();
           fixture.detectChanges();
-          tick();
 
           testComponent.datepicker.close();
           fixture.detectChanges();
-          tick();
         }
 
         testComponent.datepicker.open();
         fixture.detectChanges();
-        tick();
-        flush();
 
         const spy = jasmine.createSpy('close event spy');
         const subscription = testComponent.datepicker.closedStream.subscribe(spy);
@@ -499,7 +495,6 @@ describe('MatDatepicker', () => {
 
         backdrop.click();
         fixture.detectChanges();
-        flush();
 
         expect(spy).toHaveBeenCalledTimes(1);
         expect(testComponent.datepicker.opened).toBe(false);

--- a/tools/public_api_guard/material/datepicker.md
+++ b/tools/public_api_guard/material/datepicker.md
@@ -8,7 +8,6 @@ import { AbstractControl } from '@angular/forms';
 import { AfterContentInit } from '@angular/core';
 import { AfterViewChecked } from '@angular/core';
 import { AfterViewInit } from '@angular/core';
-import { AnimationEvent as AnimationEvent_2 } from '@angular/animations';
 import { AnimationTriggerMetadata } from '@angular/animations';
 import { ChangeDetectorRef } from '@angular/core';
 import { ComponentType } from '@angular/cdk/portal';
@@ -338,7 +337,7 @@ export class MatDatepickerActions implements AfterViewInit, OnDestroy {
     static ɵfac: i0.ɵɵFactoryDeclaration<MatDatepickerActions, never>;
 }
 
-// @public
+// @public @deprecated
 export const matDatepickerAnimations: {
     readonly transformPanel: AnimationTriggerMetadata;
     readonly fadeInCalendar: AnimationTriggerMetadata;
@@ -367,11 +366,12 @@ export class MatDatepickerCancel {
 }
 
 // @public
-export class MatDatepickerContent<S, D = ExtractDateTypeFromSelection<S>> implements OnInit, AfterViewInit, OnDestroy {
+export class MatDatepickerContent<S, D = ExtractDateTypeFromSelection<S>> implements AfterViewInit, OnDestroy {
     constructor(...args: unknown[]);
     _actionsPortal: TemplatePortal | null;
     readonly _animationDone: Subject<void>;
-    _animationState: 'enter-dropdown' | 'enter-dialog' | 'void';
+    // (undocumented)
+    protected _animationsDisabled: boolean;
     _applyPendingSelection(): void;
     _assignActions(portal: TemplatePortal<any> | null, forceRerender: boolean): void;
     _calendar: MatCalendar<D>;
@@ -383,12 +383,10 @@ export class MatDatepickerContent<S, D = ExtractDateTypeFromSelection<S>> implem
     datepicker: MatDatepickerBase<any, S, D>;
     _dialogLabelId: string | null;
     // (undocumented)
-    protected _elementRef: ElementRef<any>;
+    protected _elementRef: ElementRef<HTMLElement>;
     endDateAccessibleName: string | null;
     // (undocumented)
     _getSelected(): D | DateRange<D> | null;
-    // (undocumented)
-    _handleAnimationEvent(event: AnimationEvent_2): void;
     // (undocumented)
     _handleUserDragDrop(event: MatCalendarUserEvent<DateRange<D>>): void;
     // (undocumented)
@@ -399,8 +397,6 @@ export class MatDatepickerContent<S, D = ExtractDateTypeFromSelection<S>> implem
     ngAfterViewInit(): void;
     // (undocumented)
     ngOnDestroy(): void;
-    // (undocumented)
-    ngOnInit(): void;
     startDateAccessibleName: string | null;
     // (undocumented)
     _startExitAnimation(): void;


### PR DESCRIPTION
Reworks the datepicker so it no longer depends on the animations module.