### PR TITLE
fix(material/select): fixed text color for selected options in multiple select

### DIFF
--- a/src/material/core/option/option.scss
+++ b/src/material/core/option/option.scss
@@ -42,7 +42,7 @@ $_side-padding: 16px;
     }
 
     &.mdc-list-item--selected:not(.mdc-list-item--disabled) {
-      // We don't change the background in multiple mode since
+      // We don't change the background & text color in multiple mode since
       // it has the checkbox to show the selected state.
       &:not(.mat-mdc-option-multiple) {
         @include token-utils.create-token-slot(background-color, selected-state-layer-color);

--- a/src/material/core/option/option.scss
+++ b/src/material/core/option/option.scss
@@ -42,14 +42,13 @@ $_side-padding: 16px;
     }
 
     &.mdc-list-item--selected:not(.mdc-list-item--disabled) {
-      .mdc-list-item__primary-text {
-        @include token-utils.create-token-slot(color, selected-state-label-text-color);
-      }
-
       // We don't change the background in multiple mode since
       // it has the checkbox to show the selected state.
       &:not(.mat-mdc-option-multiple) {
         @include token-utils.create-token-slot(background-color, selected-state-layer-color);
+        .mdc-list-item__primary-text {
+          @include token-utils.create-token-slot(color, selected-state-label-text-color);
+        }
       }
     }
 


### PR DESCRIPTION
Fixes a bug in the Angular Material `select` component where the selected options in a  `select` with the multiple attribute have the wrong text color. This is because the the text color styling for the `select` without the multiple attribute is applied.

fixes #30366 