### PR TITLE
fix(material/button): increase touch target for icon buttons

### DIFF
--- a/src/material/button/icon-button.scss
+++ b/src/material/button/icon-button.scss
@@ -76,6 +76,11 @@
     border-radius: 50%;
   }
 
+  .mat-mdc-button-touch-target {
+    display: block;
+    opacity: 0;
+  }
+
   // MDC used to include this and it seems like a lot of apps depend on it.
   &[hidden] {
     display: none;
@@ -93,18 +98,4 @@
     }
   }
 
-  &::after {
-    content: '';
-    padding: 8px;
-    margin: -8px;
-    box-sizing: border-box;
-    background-clip: content-box;
-    left: 0;
-    right: 0;
-    display: block;
-    position: absolute;
-    opacity: 0;
-    top: 0;
-    bottom: 0;
-  }
 }

--- a/src/material/button/icon-button.scss
+++ b/src/material/button/icon-button.scss
@@ -92,4 +92,19 @@
       opacity: 1;
     }
   }
+
+  &::after {
+    content: '';
+    padding: 8px;
+    margin: -8px;
+    box-sizing: border-box;
+    background-clip: content-box;
+    left: 0;
+    right: 0;
+    display: block;
+    position: absolute;
+    opacity: 0;
+    top: 0;
+    bottom: 0;
+  }
 }


### PR DESCRIPTION
Updates Angular Components Button styles for icon buttons to add pseudo class styles to increase the icon buttons' target size.

[Before screenshot](https://screenshot.googleplex.com/ANaWFgBfuYWC4gA)
Updated after screenshot with refactor:
[After screenshot](https://screenshot.googleplex.com/6XTsmMHqybgePAC)

Fixes b/378903269