### PR TITLE
fix(material/snack-bar): switch away from animations module

### DIFF
--- a/src/material/snack-bar/snack-bar-animations.ts
+++ b/src/material/snack-bar/snack-bar-animations.ts
@@ -17,6 +17,8 @@ import {
 /**
  * Animations used by the Material snack bar.
  * @docs-private
+ * @deprecated No longer used, will be removed.
+ * @breaking-change 21.0.0
  */
 export const matSnackBarAnimations: {
   readonly snackBarState: AnimationTriggerMetadata;

--- a/src/material/snack-bar/snack-bar-container.scss
+++ b/src/material/snack-bar/snack-bar-container.scss
@@ -45,6 +45,11 @@ $_side-padding: 8px;
 .mat-snack-bar-container-animations-enabled {
   opacity: 0;
 
+  // Fallback in case the animation fails.
+  &.mat-snack-bar-fallback-visible {
+    opacity: 1;
+  }
+
   &.mat-snack-bar-container-enter {
     animation: _mat-snack-bar-enter 150ms cubic-bezier(0, 0, 0.2, 1) forwards;
   }

--- a/src/material/snack-bar/snack-bar-container.scss
+++ b/src/material/snack-bar/snack-bar-container.scss
@@ -42,11 +42,15 @@ $_side-padding: 8px;
   }
 }
 
-.mat-snack-bar-animations-enabled {
-  animation: _mat-snack-bar-enter 150ms cubic-bezier(0, 0, 0.2, 1);
+.mat-snack-bar-container-animations-enabled {
+  opacity: 0;
 
-  &[mat-exit] {
-    animation: _mat-snack-bar-exit 75ms cubic-bezier(0.4, 0, 1, 1);
+  &.mat-snack-bar-container-enter {
+    animation: _mat-snack-bar-enter 150ms cubic-bezier(0, 0, 0.2, 1) forwards;
+  }
+
+  &.mat-snack-bar-container-exit {
+    animation: _mat-snack-bar-exit 75ms cubic-bezier(0.4, 0, 1, 1) forwards;
   }
 }
 

--- a/src/material/snack-bar/snack-bar-container.scss
+++ b/src/material/snack-bar/snack-bar-container.scss
@@ -7,6 +7,28 @@
 
 $_side-padding: 8px;
 
+@keyframes _mat-snack-bar-enter {
+  from {
+    transform: scale(0.8);
+    opacity: 0;
+  }
+
+  to {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+@keyframes _mat-snack-bar-exit {
+  from {
+    opacity: 1;
+  }
+
+  to {
+    opacity: 0;
+  }
+}
+
 .mat-mdc-snack-bar-container {
   display: flex;
   align-items: center;
@@ -17,6 +39,14 @@ $_side-padding: 8px;
 
   .mat-mdc-snack-bar-handset & {
     width: 100vw;
+  }
+}
+
+.mat-snack-bar-animations-enabled {
+  animation: _mat-snack-bar-enter 150ms cubic-bezier(0, 0, 0.2, 1);
+
+  &[mat-exit] {
+    animation: _mat-snack-bar-exit 75ms cubic-bezier(0.4, 0, 1, 1);
   }
 }
 

--- a/src/material/snack-bar/snack-bar.spec.ts
+++ b/src/material/snack-bar/snack-bar.spec.ts
@@ -17,7 +17,6 @@ import {
   MAT_SNACK_BAR_DATA,
   MatSnackBar,
   MatSnackBarConfig,
-  MatSnackBarContainer,
   MatSnackBarModule,
   MatSnackBarRef,
   SimpleSnackBar,
@@ -360,67 +359,6 @@ describe('MatSnackBar', () => {
       .toBe(0);
   }));
 
-  it('should set the animation state to visible on entry', () => {
-    const config: MatSnackBarConfig = {viewContainerRef: testViewContainerRef};
-    const snackBarRef = snackBar.open(simpleMessage, undefined, config);
-
-    viewContainerFixture.detectChanges();
-    const container = snackBarRef.containerInstance as MatSnackBarContainer;
-    expect(container._animationState)
-      .withContext(`Expected the animation state would be 'visible'.`)
-      .toBe('visible');
-    snackBarRef.dismiss();
-
-    viewContainerFixture.detectChanges();
-    expect(container._animationState)
-      .withContext(`Expected the animation state would be 'hidden'.`)
-      .toBe('hidden');
-  });
-
-  it('should set the animation state to complete on exit', () => {
-    const config: MatSnackBarConfig = {viewContainerRef: testViewContainerRef};
-    const snackBarRef = snackBar.open(simpleMessage, undefined, config);
-    snackBarRef.dismiss();
-
-    viewContainerFixture.detectChanges();
-    const container = snackBarRef.containerInstance as MatSnackBarContainer;
-    expect(container._animationState)
-      .withContext(`Expected the animation state would be 'hidden'.`)
-      .toBe('hidden');
-  });
-
-  it(`should set the old snack bar animation state to complete and the new snack bar animation
-      state to visible on entry of new snack bar`, fakeAsync(() => {
-    const config: MatSnackBarConfig = {viewContainerRef: testViewContainerRef};
-    const snackBarRef = snackBar.open(simpleMessage, undefined, config);
-    const dismissCompleteSpy = jasmine.createSpy('dismiss complete spy');
-
-    viewContainerFixture.detectChanges();
-
-    const containerElement = document.querySelector('mat-snack-bar-container')!;
-    expect(containerElement.classList).toContain('ng-animating');
-    const container1 = snackBarRef.containerInstance as MatSnackBarContainer;
-    expect(container1._animationState)
-      .withContext(`Expected the animation state would be 'visible'.`)
-      .toBe('visible');
-
-    const config2 = {viewContainerRef: testViewContainerRef};
-    const snackBarRef2 = snackBar.open(simpleMessage, undefined, config2);
-
-    viewContainerFixture.detectChanges();
-    snackBarRef.afterDismissed().subscribe({complete: dismissCompleteSpy});
-    flush();
-
-    expect(dismissCompleteSpy).toHaveBeenCalled();
-    const container2 = snackBarRef2.containerInstance as MatSnackBarContainer;
-    expect(container1._animationState)
-      .withContext(`Expected the animation state would be 'hidden'.`)
-      .toBe('hidden');
-    expect(container2._animationState)
-      .withContext(`Expected the animation state would be 'visible'.`)
-      .toBe('visible');
-  }));
-
   it('should open a new snackbar after dismissing a previous snackbar', fakeAsync(() => {
     let config: MatSnackBarConfig = {viewContainerRef: testViewContainerRef};
     let snackBarRef = snackBar.open(simpleMessage, 'Dismiss', config);
@@ -610,9 +548,9 @@ describe('MatSnackBar', () => {
   it('should cap the timeout to the maximum accepted delay in setTimeout', fakeAsync(() => {
     const config = new MatSnackBarConfig();
     config.duration = Infinity;
+    spyOn(window, 'setTimeout').and.callThrough();
     snackBar.open('content', 'test', config);
     viewContainerFixture.detectChanges();
-    spyOn(window, 'setTimeout').and.callThrough();
     tick(100);
 
     expect(window.setTimeout).toHaveBeenCalledWith(jasmine.any(Function), Math.pow(2, 31) - 1);

--- a/src/material/snack-bar/snack-bar.spec.ts
+++ b/src/material/snack-bar/snack-bar.spec.ts
@@ -564,7 +564,7 @@ describe('MatSnackBar', () => {
       viewContainerFixture.detectChanges();
     }
 
-    flush();
+    flush(50);
     expect(overlayContainerElement.querySelectorAll('mat-snack-bar-container').length).toBe(1);
   }));
 

--- a/src/material/snack-bar/snack-bar.ts
+++ b/src/material/snack-bar/snack-bar.ts
@@ -242,6 +242,11 @@ export class MatSnackBar implements OnDestroy {
       }
     });
 
+    // If a dismiss timeout is provided, set up dismiss based on after the snackbar is opened.
+    if (config.duration && config.duration > 0) {
+      snackBarRef.afterOpened().subscribe(() => snackBarRef._dismissAfter(config.duration!));
+    }
+
     if (this._openedSnackBarRef) {
       // If a snack bar is already in view, dismiss it and enter the
       // new snack bar after exit animation is complete.
@@ -252,11 +257,6 @@ export class MatSnackBar implements OnDestroy {
     } else {
       // If no snack bar is in view, enter the new snack bar.
       snackBarRef.containerInstance.enter();
-    }
-
-    // If a dismiss timeout is provided, set up dismiss based on after the snackbar is opened.
-    if (config.duration && config.duration > 0) {
-      snackBarRef.afterOpened().subscribe(() => snackBarRef._dismissAfter(config.duration!));
     }
   }
 

--- a/src/material/snack-bar/snack-bar.ts
+++ b/src/material/snack-bar/snack-bar.ts
@@ -242,11 +242,6 @@ export class MatSnackBar implements OnDestroy {
       }
     });
 
-    // If a dismiss timeout is provided, set up dismiss based on after the snackbar is opened.
-    if (config.duration && config.duration > 0) {
-      snackBarRef.afterOpened().subscribe(() => snackBarRef._dismissAfter(config.duration!));
-    }
-
     if (this._openedSnackBarRef) {
       // If a snack bar is already in view, dismiss it and enter the
       // new snack bar after exit animation is complete.
@@ -257,6 +252,11 @@ export class MatSnackBar implements OnDestroy {
     } else {
       // If no snack bar is in view, enter the new snack bar.
       snackBarRef.containerInstance.enter();
+    }
+
+    // If a dismiss timeout is provided, set up dismiss based on after the snackbar is opened.
+    if (config.duration && config.duration > 0) {
+      snackBarRef.afterOpened().subscribe(() => snackBarRef._dismissAfter(config.duration!));
     }
   }
 

--- a/tools/public_api_guard/material/snack-bar.md
+++ b/tools/public_api_guard/material/snack-bar.md
@@ -4,7 +4,6 @@
 
 ```ts
 
-import { AnimationEvent as AnimationEvent_2 } from '@angular/animations';
 import { AnimationTriggerMetadata } from '@angular/animations';
 import { AriaLivePoliteness } from '@angular/cdk/a11y';
 import { BasePortalOutlet } from '@angular/cdk/portal';
@@ -75,7 +74,7 @@ export class MatSnackBarActions {
     static ɵfac: i0.ɵɵFactoryDeclaration<MatSnackBarActions, never>;
 }
 
-// @public
+// @public @deprecated
 export const matSnackBarAnimations: {
     readonly snackBarState: AnimationTriggerMetadata;
 };
@@ -96,7 +95,9 @@ export class MatSnackBarConfig<D = any> {
 // @public
 export class MatSnackBarContainer extends BasePortalOutlet implements OnDestroy {
     constructor(...args: unknown[]);
-    _animationState: string;
+    protected _animationDone(event: AnimationEvent): void;
+    // (undocumented)
+    protected _animationsDisabled: boolean;
     attachComponentPortal<T>(portal: ComponentPortal<T>): ComponentRef<T>;
     // @deprecated
     attachDomPortal: (portal: DomPortal) => void;
@@ -107,7 +108,6 @@ export class MatSnackBarContainer extends BasePortalOutlet implements OnDestroy 
     _live: AriaLivePoliteness;
     readonly _liveElementId: string;
     ngOnDestroy(): void;
-    onAnimationEnd(event: AnimationEvent_2): void;
     readonly _onAnnounce: Subject<void>;
     readonly _onEnter: Subject<void>;
     readonly _onExit: Subject<void>;

--- a/tools/public_api_guard/material/snack-bar.md
+++ b/tools/public_api_guard/material/snack-bar.md
@@ -94,11 +94,11 @@ export class MatSnackBarConfig<D = any> {
 }
 
 // @public
-export class MatSnackBarContainer extends BasePortalOutlet implements OnDestroy, DoCheck {
+export class MatSnackBarContainer extends BasePortalOutlet implements DoCheck, OnDestroy {
     constructor(...args: unknown[]);
-    protected _animationDone(event: AnimationEvent): void;
     // (undocumented)
     protected _animationsDisabled: boolean;
+    _animationState: string;
     attachComponentPortal<T>(portal: ComponentPortal<T>): ComponentRef<T>;
     // @deprecated
     attachDomPortal: (portal: DomPortal) => void;
@@ -110,8 +110,8 @@ export class MatSnackBarContainer extends BasePortalOutlet implements OnDestroy,
     readonly _liveElementId: string;
     // (undocumented)
     ngDoCheck(): void;
-    // (undocumented)
     ngOnDestroy(): void;
+    onAnimationEnd(event: AnimationEvent): void;
     readonly _onAnnounce: Subject<void>;
     readonly _onEnter: Subject<void>;
     readonly _onExit: Subject<void>;

--- a/tools/public_api_guard/material/snack-bar.md
+++ b/tools/public_api_guard/material/snack-bar.md
@@ -12,7 +12,6 @@ import { ComponentPortal } from '@angular/cdk/portal';
 import { ComponentRef } from '@angular/core';
 import { ComponentType } from '@angular/cdk/overlay';
 import { Direction } from '@angular/cdk/bidi';
-import { DoCheck } from '@angular/core';
 import { DomPortal } from '@angular/cdk/portal';
 import { ElementRef } from '@angular/core';
 import { EmbeddedViewRef } from '@angular/core';
@@ -94,7 +93,7 @@ export class MatSnackBarConfig<D = any> {
 }
 
 // @public
-export class MatSnackBarContainer extends BasePortalOutlet implements DoCheck, OnDestroy {
+export class MatSnackBarContainer extends BasePortalOutlet implements OnDestroy {
     constructor(...args: unknown[]);
     // (undocumented)
     protected _animationsDisabled: boolean;
@@ -108,10 +107,8 @@ export class MatSnackBarContainer extends BasePortalOutlet implements DoCheck, O
     _label: ElementRef;
     _live: AriaLivePoliteness;
     readonly _liveElementId: string;
-    // (undocumented)
-    ngDoCheck(): void;
     ngOnDestroy(): void;
-    onAnimationEnd(event: AnimationEvent): void;
+    onAnimationEnd(animationName: string): void;
     readonly _onAnnounce: Subject<void>;
     readonly _onEnter: Subject<void>;
     readonly _onExit: Subject<void>;

--- a/tools/public_api_guard/material/snack-bar.md
+++ b/tools/public_api_guard/material/snack-bar.md
@@ -12,6 +12,7 @@ import { ComponentPortal } from '@angular/cdk/portal';
 import { ComponentRef } from '@angular/core';
 import { ComponentType } from '@angular/cdk/overlay';
 import { Direction } from '@angular/cdk/bidi';
+import { DoCheck } from '@angular/core';
 import { DomPortal } from '@angular/cdk/portal';
 import { ElementRef } from '@angular/core';
 import { EmbeddedViewRef } from '@angular/core';
@@ -93,7 +94,7 @@ export class MatSnackBarConfig<D = any> {
 }
 
 // @public
-export class MatSnackBarContainer extends BasePortalOutlet implements OnDestroy {
+export class MatSnackBarContainer extends BasePortalOutlet implements OnDestroy, DoCheck {
     constructor(...args: unknown[]);
     protected _animationDone(event: AnimationEvent): void;
     // (undocumented)
@@ -107,6 +108,9 @@ export class MatSnackBarContainer extends BasePortalOutlet implements OnDestroy 
     _label: ElementRef;
     _live: AriaLivePoliteness;
     readonly _liveElementId: string;
+    // (undocumented)
+    ngDoCheck(): void;
+    // (undocumented)
     ngOnDestroy(): void;
     readonly _onAnnounce: Subject<void>;
     readonly _onEnter: Subject<void>;


### PR DESCRIPTION
Reworks the snack bar so it animates using CSS instead of the animations module.