### PR TITLE
feat(material-angular-io): allow module imports to be copied from API tab

### DIFF
--- a/material.angular.io/src/app/shared/doc-viewer/doc-viewer-module.ts
+++ b/material.angular.io/src/app/shared/doc-viewer/doc-viewer-module.ts
@@ -10,6 +10,7 @@ import {NgModule} from '@angular/core';
 import {HeaderLink} from './header-link';
 import {CodeSnippet} from '../example-viewer/code-snippet';
 import {DeprecatedFieldComponent} from './deprecated-tooltip';
+import {ModuleImportCopyButton} from './module-import-copy-button';
 
 // ExampleViewer is included in the DocViewerModule because they have a circular dependency.
 @NgModule({
@@ -25,7 +26,8 @@ import {DeprecatedFieldComponent} from './deprecated-tooltip';
     HeaderLink,
     CodeSnippet,
     DeprecatedFieldComponent,
+    ModuleImportCopyButton,
   ],
-  exports: [DocViewer, ExampleViewer, HeaderLink, DeprecatedFieldComponent],
+  exports: [DocViewer, ExampleViewer, HeaderLink, DeprecatedFieldComponent, ModuleImportCopyButton],
 })
 export class DocViewerModule {}

--- a/material.angular.io/src/app/shared/doc-viewer/doc-viewer.ts
+++ b/material.angular.io/src/app/shared/doc-viewer/doc-viewer.ts
@@ -28,6 +28,7 @@ import {shareReplay, take, tap} from 'rxjs/operators';
 import {ExampleViewer} from '../example-viewer/example-viewer';
 import {HeaderLink} from './header-link';
 import {DeprecatedFieldComponent} from './deprecated-tooltip';
+import {ModuleImportCopyButton} from './module-import-copy-button';
 
 @Injectable({providedIn: 'root'})
 class DocFetcher {
@@ -150,6 +151,9 @@ export class DocViewer implements OnDestroy {
     // Create tooltips for the deprecated fields
     this._createTooltipsForDeprecated();
 
+    // Create icon buttons to copy module import
+    this._createCopyIconForModule();
+
     // Resolving and creating components dynamically in Angular happens synchronously, but since
     // we want to emit the output if the components are actually rendered completely, we wait
     // until the Angular zone becomes stable.
@@ -230,6 +234,37 @@ export class DocViewer implements OnDestroy {
 
       if (deprecationTitle) {
         tooltipOutlet.instance.message = deprecationTitle;
+      }
+
+      this._portalHosts.push(elementPortalOutlet);
+    });
+  }
+
+  _createCopyIconForModule() {
+    // every module import element will be marked with docs-api-module-import-button attribute
+    const moduleImportElements = this._elementRef.nativeElement.querySelectorAll(
+      '[data-docs-api-module-import-button]',
+    );
+
+    [...moduleImportElements].forEach((element: HTMLElement) => {
+      // get the module import path stored in the attribute
+      const moduleImport = element.getAttribute('data-docs-api-module-import-button');
+
+      const elementPortalOutlet = new DomPortalOutlet(
+        element,
+        this._componentFactoryResolver,
+        this._appRef,
+        this._injector,
+      );
+
+      const moduleImportPortal = new ComponentPortal(
+        ModuleImportCopyButton,
+        this._viewContainerRef,
+      );
+      const moduleImportOutlet = elementPortalOutlet.attach(moduleImportPortal);
+
+      if (moduleImport) {
+        moduleImportOutlet.instance.import = moduleImport;
       }
 
       this._portalHosts.push(elementPortalOutlet);

--- a/material.angular.io/src/app/shared/doc-viewer/module-import-copy-button.ts
+++ b/material.angular.io/src/app/shared/doc-viewer/module-import-copy-button.ts
@@ -1,0 +1,34 @@
+import {Component, inject} from '@angular/core';
+import {MatIconButton} from '@angular/material/button';
+import {MatIcon} from '@angular/material/icon';
+import {MatSnackBar} from '@angular/material/snack-bar';
+import {MatTooltip} from '@angular/material/tooltip';
+import {Clipboard} from '@angular/cdk/clipboard';
+
+/**
+ * Shows up an icon button which will allow users to copy the module import
+ */
+@Component({
+  selector: 'module-import-copy-button',
+  template: `<button
+  mat-icon-button
+  matTooltip="Copy import to the clipboard"
+  (click)="copy()">
+  <mat-icon>content_copy</mat-icon>
+</button>`,
+  standalone: true,
+  imports: [MatIconButton, MatIcon, MatTooltip],
+})
+export class ModuleImportCopyButton {
+  private clipboard = inject(Clipboard);
+  private snackbar = inject(MatSnackBar);
+  /** Import path for the module that will be copied */
+  import = '';
+
+  copy(): void {
+    const message = this.clipboard.copy(this.import)
+      ? 'Copied module import'
+      : 'Failed to copy module import';
+    this.snackbar.open(message, undefined, {duration: 2500});
+  }
+}

--- a/material.angular.io/src/styles/_api.scss
+++ b/material.angular.io/src/styles/_api.scss
@@ -27,6 +27,15 @@
   word-break: break-word;
 }
 
+.docs-api-module {
+  display: flex;
+  align-items: center;
+}
+
+.docs-api-module-import {
+  margin: 0px;
+}
+
 .docs-api-class-name,
 .docs-api-module-import,
 .docs-api-class-selector-name,

--- a/tools/dgeni/templates/entry-point.template.html
+++ b/tools/dgeni/templates/entry-point.template.html
@@ -37,11 +37,15 @@
   </h2>
 
   {%- if doc.primaryExportName -%}
-    <p class="docs-api-module-import">
-      <code>
-        import {{$ doc.primaryExportName $}} from '{$ doc.moduleImportPath $}';
-      </code>
-    </p>
+    <div class="docs-api-module">
+      <p class="docs-api-module-import">
+        <code>
+          import {{$ doc.primaryExportName $}} from '{$ doc.moduleImportPath $}';
+        </code>
+      </p>
+
+      <div class="docs-api-module-import-button" data-docs-api-module-import-button="import {{$ doc.primaryExportName $}} from '{$ doc.moduleImportPath $}';"></div>
+    </div>
   {% else %}
     <p>Import symbols from <code>{$ doc.moduleImportPath $}</code></p>
   {%- endif -%}


### PR DESCRIPTION
adds icon button next to module import text allowing users to copy

fixes #16127

![image](https://github.com/user-attachments/assets/71c436b0-a6eb-4645-8671-24cbb2bb8914)
