### PR TITLE
docs(material/sidenav): fix sidenav not working

### DIFF
--- a/src/components-examples/material/sidenav/sidenav-responsive/sidenav-responsive-example.html
+++ b/src/components-examples/material/sidenav/sidenav-responsive/sidenav-responsive-example.html
@@ -11,7 +11,7 @@
                   [fixedInViewport]="isMobile()" fixedTopGap="56">
         <mat-nav-list>
           @for (nav of fillerNav; track nav) {
-            <a mat-list-item routerLink=".">{{nav}}</a>
+            <a mat-list-item>{{nav}}</a>
           }
         </mat-nav-list>
       </mat-sidenav>

--- a/src/components-examples/material/sidenav/sidenav-responsive/sidenav-responsive-example.ts
+++ b/src/components-examples/material/sidenav/sidenav-responsive/sidenav-responsive-example.ts
@@ -5,21 +5,13 @@ import {MatSidenavModule} from '@angular/material/sidenav';
 import {MatIconModule} from '@angular/material/icon';
 import {MatButtonModule} from '@angular/material/button';
 import {MatToolbarModule} from '@angular/material/toolbar';
-import {RouterLink} from '@angular/router';
 
 /** @title Responsive sidenav */
 @Component({
   selector: 'sidenav-responsive-example',
   templateUrl: 'sidenav-responsive-example.html',
   styleUrl: 'sidenav-responsive-example.css',
-  imports: [
-    MatToolbarModule,
-    MatButtonModule,
-    MatIconModule,
-    MatSidenavModule,
-    MatListModule,
-    RouterLink,
-  ],
+  imports: [MatToolbarModule, MatButtonModule, MatIconModule, MatSidenavModule, MatListModule],
 })
 export class SidenavResponsiveExample implements OnDestroy {
   protected readonly fillerNav = Array.from({length: 50}, (_, i) => `Nav Item ${i + 1}`);


### PR DESCRIPTION
fixes broken example for responsive sidebar which included routerLink directive but is missing router module which prevents sidebar from opening by removing directive as it serve no purpose

fixes #30307

![image](https://github.com/user-attachments/assets/c8cfc6bb-bd67-4d06-b7a4-1642778e5b70)
