### PR TITLE
ci: add `material-angular-io` to commit scopes

### DIFF
--- a/.ng-dev/commit-message.mts
+++ b/.ng-dev/commit-message.mts
@@ -89,5 +89,6 @@ export const commitMessage: CommitMessageConfig = {
     'material-date-fns-adapter',
     'material-luxon-adapter',
     'youtube-player',
+    'material-angular-io',
   ],
 };


### PR DESCRIPTION
since [material.angular.io](https://material.angular.io/) is now part of this repository we should probably add a scope for it unless we still want to refer changes in that folder under `docs` scope then we can close this