### PR TITLE
fix(material/bottom-sheet): switch away from animations module

### DIFF
--- a/src/material/bottom-sheet/bottom-sheet-animations.ts
+++ b/src/material/bottom-sheet/bottom-sheet-animations.ts
@@ -16,9 +16,12 @@ import {
   query,
   animateChild,
 } from '@angular/animations';
-import {AnimationCurves, AnimationDurations} from '@angular/material/core';
 
-/** Animations used by the Material bottom sheet. */
+/**
+ * Animations used by the Material bottom sheet.
+ * @deprecated No longer used. Will be removed.
+ * @breaking-change 21.0.0
+ */
 export const matBottomSheetAnimations: {
   readonly bottomSheetState: AnimationTriggerMetadata;
 } = {
@@ -29,14 +32,14 @@ export const matBottomSheetAnimations: {
     transition(
       'visible => void, visible => hidden',
       group([
-        animate(`${AnimationDurations.COMPLEX} ${AnimationCurves.ACCELERATION_CURVE}`),
+        animate('375ms cubic-bezier(0.4, 0, 1, 1)'),
         query('@*', animateChild(), {optional: true}),
       ]),
     ),
     transition(
       'void => visible',
       group([
-        animate(`${AnimationDurations.EXITING} ${AnimationCurves.DECELERATION_CURVE}`),
+        animate('195ms cubic-bezier(0, 0, 0.2, 1)'),
         query('@*', animateChild(), {optional: true}),
       ]),
     ),

--- a/src/material/bottom-sheet/bottom-sheet-container.scss
+++ b/src/material/bottom-sheet/bottom-sheet-container.scss
@@ -10,6 +10,26 @@ $_width-increment: 64px;
 $container-vertical-padding: 8px !default;
 $container-horizontal-padding: 16px !default;
 
+@keyframes _mat-bottom-sheet-enter {
+  from {
+    transform: translateY(100%);
+  }
+
+  to {
+    transform: none;
+  }
+}
+
+@keyframes _mat-bottom-sheet-exit {
+  from {
+    transform: none;
+  }
+
+  to {
+    transform: translateY(100%);
+  }
+}
+
 .mat-bottom-sheet-container {
   @include elevation.elevation(16);
   padding: $container-vertical-padding
@@ -20,6 +40,10 @@ $container-horizontal-padding: 16px !default;
   outline: 0;
   max-height: 80vh;
   overflow: auto;
+
+  // We don't use this, but it's useful for consumers to position
+  // elements (e.g. close buttons) inside the bottom sheet.
+  position: relative;
 
   @include token-utils.use-tokens(
     tokens-mat-bottom-sheet.$prefix, tokens-mat-bottom-sheet.get-token-slots()) {
@@ -34,6 +58,18 @@ $container-horizontal-padding: 16px !default;
 
   @include cdk.high-contrast {
     outline: 1px solid;
+  }
+}
+
+.mat-bottom-sheet-container-animations-enabled {
+  transform: translateY(100%);
+
+  &.mat-bottom-sheet-container-enter {
+    animation: _mat-bottom-sheet-enter 195ms cubic-bezier(0, 0, 0.2, 1) forwards;
+  }
+
+  &.mat-bottom-sheet-container-exit {
+    animation: _mat-bottom-sheet-exit 375ms cubic-bezier(0.4, 0, 1, 1) backwards;
   }
 }
 

--- a/src/material/bottom-sheet/bottom-sheet-ref.ts
+++ b/src/material/bottom-sheet/bottom-sheet-ref.ts
@@ -60,7 +60,7 @@ export class MatBottomSheetRef<T = any, R = any> {
     // Emit when opening animation completes
     containerInstance._animationStateChanged
       .pipe(
-        filter(event => event.phaseName === 'done' && event.toState === 'visible'),
+        filter(event => event.phase === 'done' && event.toState === 'visible'),
         take(1),
       )
       .subscribe(() => {
@@ -71,7 +71,7 @@ export class MatBottomSheetRef<T = any, R = any> {
     // Dispose overlay when closing animation is complete
     containerInstance._animationStateChanged
       .pipe(
-        filter(event => event.phaseName === 'done' && event.toState === 'hidden'),
+        filter(event => event.phase === 'done' && event.toState === 'hidden'),
         take(1),
       )
       .subscribe(() => {
@@ -109,19 +109,16 @@ export class MatBottomSheetRef<T = any, R = any> {
     // Transition the backdrop in parallel to the bottom sheet.
     this.containerInstance._animationStateChanged
       .pipe(
-        filter(event => event.phaseName === 'start'),
+        filter(event => event.phase === 'start'),
         take(1),
       )
-      .subscribe(event => {
+      .subscribe(() => {
         // The logic that disposes of the overlay depends on the exit animation completing, however
         // it isn't guaranteed if the parent view is destroyed while it's running. Add a fallback
         // timeout which will clean everything up if the animation hasn't fired within the specified
         // amount of time plus 100ms. We don't need to run this outside the NgZone, because for the
         // vast majority of cases the timeout will have been cleared before it has fired.
-        this._closeFallbackTimeout = setTimeout(() => {
-          this._ref.close(this._result);
-        }, event.totalTime + 100);
-
+        this._closeFallbackTimeout = setTimeout(() => this._ref.close(this._result), 500);
         this._ref.overlayRef.detachBackdrop();
       });
 

--- a/src/material/bottom-sheet/testing/bottom-sheet-harness.ts
+++ b/src/material/bottom-sheet/testing/bottom-sheet-harness.ts
@@ -13,7 +13,7 @@ import {BottomSheetHarnessFilters} from './bottom-sheet-harness-filters';
 export class MatBottomSheetHarness extends ContentContainerComponentHarness<string> {
   // Developers can provide a custom component or template for the
   // bottom sheet. The canonical parent is the ".mat-bottom-sheet-container".
-  static hostSelector = '.mat-bottom-sheet-container';
+  static hostSelector = '.mat-bottom-sheet-container:not([mat-exit])';
 
   /**
    * Gets a `HarnessPredicate` that can be used to search for a bottom sheet with

--- a/tools/public_api_guard/material/bottom-sheet.md
+++ b/tools/public_api_guard/material/bottom-sheet.md
@@ -4,7 +4,6 @@
 
 ```ts
 
-import { AnimationEvent as AnimationEvent_2 } from '@angular/animations';
 import { AnimationTriggerMetadata } from '@angular/animations';
 import { CdkDialogContainer } from '@angular/cdk/dialog';
 import { ComponentRef } from '@angular/core';
@@ -48,7 +47,7 @@ export class MatBottomSheet implements OnDestroy {
     static ɵprov: i0.ɵɵInjectableDeclaration<MatBottomSheet>;
 }
 
-// @public
+// @public @deprecated
 export const matBottomSheetAnimations: {
     readonly bottomSheetState: AnimationTriggerMetadata;
 };
@@ -76,18 +75,21 @@ export class MatBottomSheetConfig<D = any> {
 // @public
 export class MatBottomSheetContainer extends CdkDialogContainer implements OnDestroy {
     constructor(...args: unknown[]);
+    // (undocumented)
+    protected _animationsDisabled: boolean;
     _animationState: 'void' | 'visible' | 'hidden';
-    _animationStateChanged: EventEmitter<AnimationEvent_2>;
+    _animationStateChanged: EventEmitter<{
+        toState: "visible" | "hidden";
+        phase: "start" | "done";
+    }>;
     // (undocumented)
     protected _captureInitialFocus(): void;
     enter(): void;
     exit(): void;
     // (undocumented)
+    protected _handleAnimationEvent(isStart: boolean, animationName: string): void;
+    // (undocumented)
     ngOnDestroy(): void;
-    // (undocumented)
-    _onAnimationDone(event: AnimationEvent_2): void;
-    // (undocumented)
-    _onAnimationStart(event: AnimationEvent_2): void;
     // (undocumented)
     static ɵcmp: i0.ɵɵComponentDeclaration<MatBottomSheetContainer, "mat-bottom-sheet-container", never, {}, {}, never, never, true, never>;
     // (undocumented)


### PR DESCRIPTION
Reworks the bottom sheet so it doesn't use the animations module to animate itself.