### PR TITLE
fix(material/timepicker): switch away from animations module

### DIFF
--- a/src/material/timepicker/timepicker.html
+++ b/src/material/timepicker/timepicker.html
@@ -2,14 +2,16 @@
   <div
     role="listbox"
     class="mat-timepicker-panel"
+    [class.mat-timepicker-panel-animations-enabled]="!_animationsDisabled"
+    [class.mat-timepicker-panel-exit]="!isOpen()"
     [attr.aria-label]="ariaLabel() || null"
     [attr.aria-labelledby]="_getAriaLabelledby()"
     [id]="panelId"
-    @panel>
+    (animationend)="_handleAnimationEnd($event)">
     @for (option of _timeOptions; track option.value) {
       <mat-option
         [value]="option.value"
-        (onSelectionChange)="_selectValue(option.value)">{{option.label}}</mat-option>
+        (onSelectionChange)="_selectValue($event.source)">{{option.label}}</mat-option>
     }
   </div>
 </ng-template>

--- a/src/material/timepicker/timepicker.scss
+++ b/src/material/timepicker/timepicker.scss
@@ -2,6 +2,28 @@
 @use '../core/tokens/token-utils';
 @use '../core/tokens/m2/mat/timepicker' as tokens-mat-timepicker;
 
+@keyframes _mat-timepicker-enter {
+  from {
+    opacity: 0;
+    transform: scaleY(0.8);
+  }
+
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@keyframes _mat-timepicker-exit {
+  from {
+    opacity: 1;
+  }
+
+  to {
+    opacity: 0;
+  }
+}
+
 mat-timepicker {
   display: none;
 }
@@ -35,6 +57,14 @@ mat-timepicker {
       @include token-utils.create-token-slot(border-top-left-radius, container-shape);
       @include token-utils.create-token-slot(border-top-right-radius, container-shape);
     }
+  }
+}
+
+.mat-timepicker-panel-animations-enabled {
+  animation: _mat-timepicker-enter 120ms cubic-bezier(0, 0, 0.2, 1);
+
+  &.mat-timepicker-panel-exit {
+    animation: _mat-timepicker-exit 100ms linear;
   }
 }
 

--- a/tools/public_api_guard/material/timepicker.md
+++ b/tools/public_api_guard/material/timepicker.md
@@ -29,6 +29,8 @@ export const MAT_TIMEPICKER_CONFIG: InjectionToken<MatTimepickerConfig>;
 export class MatTimepicker<D> implements OnDestroy, MatOptionParentComponent {
     constructor();
     readonly activeDescendant: Signal<string | null>;
+    // (undocumented)
+    protected _animationsDisabled: boolean;
     readonly ariaLabel: InputSignal<string | null>;
     readonly ariaLabelledby: InputSignal<string | null>;
     close(): void;
@@ -36,6 +38,7 @@ export class MatTimepicker<D> implements OnDestroy, MatOptionParentComponent {
     readonly disabled: Signal<boolean>;
     readonly disableRipple: InputSignalWithTransform<boolean, unknown>;
     protected _getAriaLabelledby(): string | null;
+    protected _handleAnimationEnd(event: AnimationEvent): void;
     readonly interval: InputSignalWithTransform<number | null, number | string | null>;
     readonly isOpen: Signal<boolean>;
     // (undocumented)
@@ -50,7 +53,7 @@ export class MatTimepicker<D> implements OnDestroy, MatOptionParentComponent {
     protected _panelTemplate: Signal<TemplateRef<unknown>>;
     registerInput(input: MatTimepickerInput<D>): void;
     readonly selected: OutputEmitterRef<MatTimepickerSelected<D>>;
-    protected _selectValue(value: D): void;
+    protected _selectValue(option: MatOption<D>): void;
     // (undocumented)
     protected _timeOptions: readonly MatTimepickerOption<D>[];
     // (undocumented)


### PR DESCRIPTION
Reworks the timepicker to move it away from the animations module for the dropdown animation.