### PR TITLE
fix(cdk/platform): preserve compatibility with angular versions less than 19.1

### DIFF
--- a/src/cdk/platform/features/backwards-compatibility.ts
+++ b/src/cdk/platform/features/backwards-compatibility.ts
@@ -6,7 +6,15 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Renderer2, VERSION, ListenerOptions} from '@angular/core';
+import {Renderer2, VERSION} from '@angular/core';
+
+// TODO(crisbeto): replace interface with the one from core when making breaking changes for v20.
+/** Options when binding events manually. */
+export interface _ListenerOptions {
+  capture?: boolean;
+  once?: boolean;
+  passive?: boolean;
+}
 
 // TODO(crisbeto): remove this function when making breaking changes for v20.
 /**
@@ -20,7 +28,7 @@ export function _bindEventWithOptions(
   target: EventTarget,
   eventName: string,
   callback: (event: any) => boolean | void,
-  options: ListenerOptions,
+  options: _ListenerOptions,
 ): () => void {
   const major = parseInt(VERSION.major);
   const minor = parseInt(VERSION.minor);

--- a/tools/public_api_guard/cdk/platform.md
+++ b/tools/public_api_guard/cdk/platform.md
@@ -5,11 +5,10 @@
 ```ts
 
 import * as i0 from '@angular/core';
-import { ListenerOptions } from '@angular/core';
 import { Renderer2 } from '@angular/core';
 
 // @public
-export function _bindEventWithOptions(renderer: Renderer2, target: EventTarget, eventName: string, callback: (event: any) => boolean | void, options: ListenerOptions): () => void;
+export function _bindEventWithOptions(renderer: Renderer2, target: EventTarget, eventName: string, callback: (event: any) => boolean | void, options: _ListenerOptions): () => void;
 
 // @public
 export function _getEventTarget<T extends EventTarget>(event: Event): T | null;
@@ -28,6 +27,16 @@ export function getSupportedInputTypes(): Set<string>;
 
 // @public
 export function _isTestEnvironment(): boolean;
+
+// @public
+export interface _ListenerOptions {
+    // (undocumented)
+    capture?: boolean;
+    // (undocumented)
+    once?: boolean;
+    // (undocumented)
+    passive?: boolean;
+}
 
 // @public
 export function normalizePassiveListenerOptions(options: AddEventListenerOptions): AddEventListenerOptions | boolean;


### PR DESCRIPTION
**Note:** this is a cherry pick of #30401.

Fixes that we were importing a symbol only available in Angular 19.1, even though our peer dependencies allow 19.0.x.

Fixes #30388.