### PR TITLE
fix(material/select): avoid error if panel is closed too quickly

### DIFF
--- a/src/material/select/select.spec.ts
+++ b/src/material/select/select.spec.ts
@@ -1457,6 +1457,26 @@ describe('MatSelect', () => {
         expect(() => fixture.componentInstance.select.open()).not.toThrow();
       });
 
+      it('should not throw when closing too quickly after opening', () => {
+        // Need to recreate the testing module, because the issue we're
+        // testing for only happens when animations are enabled.
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+          imports: [MatFormFieldModule, MatSelectModule],
+          declarations: [BasicSelect],
+        });
+
+        fixture = TestBed.createComponent(BasicSelect);
+        fixture.detectChanges();
+        const select = fixture.componentInstance.select;
+
+        expect(() => {
+          select.open();
+          select.close();
+        }).not.toThrow();
+        expect(select.panelOpen).toBe(false);
+      });
+
       it('should open the panel when trigger is clicked', fakeAsync(() => {
         trigger.click();
         fixture.detectChanges();

--- a/src/material/select/select.ts
+++ b/src/material/select/select.ts
@@ -844,7 +844,7 @@ export class MatSelect
 
   /** Triggers the exit animation and detaches the overlay at the end. */
   private _exitAndDetach() {
-    if (this._animationsDisabled) {
+    if (this._animationsDisabled || !this.panel) {
       this._overlayDir.detachOverlay();
       return;
     }


### PR DESCRIPTION
Fixes a regression after #30363 where the select panel throws an error if `open` and `close` are called before Angular has had a chance to resolve the `panel`.