### PR TITLE
docs(dialog-harness): fix typo

### DIFF
--- a/src/material/dialog/testing/dialog-harness.ts
+++ b/src/material/dialog/testing/dialog-harness.ts
@@ -83,7 +83,7 @@ export class MatDialogHarness
     await (await this.host()).sendKeys(TestKey.ESCAPE);
   }
 
-  /** Gets te dialog's text. */
+  /** Gets the dialog's text. */
   async getText() {
     return (await this.host()).text();
   }


### PR DESCRIPTION
Fixed a typo in the JSDocs of `MatDialogHarness#getText` method.