### PR TITLE
fix(material/sidenav): end positioned sidenav not opening in RTL

### DIFF
--- a/src/material/sidenav/drawer.scss
+++ b/src/material/sidenav/drawer.scss
@@ -230,7 +230,8 @@ $drawer-over-drawer-z-index: 4;
     }
   }
 
-  &.mat-drawer-opened {
+  // Needs additional specificity to override the RTL styles.
+  &.mat-drawer-opened.mat-drawer-opened {
     transform: none;
   }
 }


### PR DESCRIPTION
Fixes a regression that happened when we switched the sidenav away from the animations module. The specificity of the selector that shows the sidenav was decreased which meant that the RTL styles were overriding it.

Fixes #30422.