### PR TITLE
fix(material/chips): forced colors disabled chip fix

### DIFF
--- a/src/material/chips/chip.scss
+++ b/src/material/chips/chip.scss
@@ -62,6 +62,9 @@ $_avatar-trailing-padding: 8px;
 .mdc-evolution-chip--disabled,
 .mdc-evolution-chip__action:disabled {
   pointer-events: none;
+  @include cdk.high-contrast {
+    forced-color-adjust: none;
+  }
 }
 
 .mdc-evolution-chip__action--primary {


### PR DESCRIPTION
doesn't apply forced color to disabled chips to distingiush from active chips

BEFORE: https://screenshot.googleplex.com/3hAWxwjoxEntW5V
AFTER: https://screenshot.googleplex.com/6wkdMVSXsEmYpPY

fixes b/383354169