### PR TITLE
docs: add commit input validation in vscode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,5 +24,8 @@
   "editor.rulers": [100],
   "bazel.buildifierExecutable": "node_modules/.bin/buildifier",
   "bazel.buildifierFixOnFormat": true,
-  "bazel.executable": "node_modules/.bin/bazel"
+  "bazel.executable": "node_modules/.bin/bazel",
+  "git.inputValidation": true,
+  "git.inputValidationSubjectLength": 100,
+  "git.inputValidationLength": 100
 }


### PR DESCRIPTION
previously vscode used to warn about commit lines when they exceed certain characters but this was changed to be off by default, lets explicitly add this to vscode settings so it aligns with our contributing docment that no line should 100 characters