### PR TITLE
Remove animations dependency from the public API

### DIFF
--- a/src/material/bottom-sheet/BUILD.bazel
+++ b/src/material/bottom-sheet/BUILD.bazel
@@ -32,7 +32,6 @@ ng_module(
         "//src/cdk/platform",
         "//src/cdk/portal",
         "//src/material/core",
-        "@npm//@angular/animations",
         "@npm//@angular/core",
         "@npm//rxjs",
     ],

--- a/src/material/bottom-sheet/bottom-sheet-animations.ts
+++ b/src/material/bottom-sheet/bottom-sheet-animations.ts
@@ -5,17 +5,6 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.dev/license
  */
-import {
-  animate,
-  state,
-  style,
-  transition,
-  trigger,
-  AnimationTriggerMetadata,
-  group,
-  query,
-  animateChild,
-} from '@angular/animations';
 
 /**
  * Animations used by the Material bottom sheet.
@@ -23,25 +12,80 @@ import {
  * @breaking-change 21.0.0
  */
 export const matBottomSheetAnimations: {
-  readonly bottomSheetState: AnimationTriggerMetadata;
+  readonly bottomSheetState: any;
 } = {
+  // Represents the output of:
+  // trigger('state', [
+  //   state('void, hidden', style({transform: 'translateY(100%)'})),
+  //   state('visible', style({transform: 'translateY(0%)'})),
+  //   transition(
+  //     'visible => void, visible => hidden',
+  //     group([
+  //       animate('375ms cubic-bezier(0.4, 0, 1, 1)'),
+  //       query('@*', animateChild(), {optional: true}),
+  //     ]),
+  //   ),
+  //   transition(
+  //     'void => visible',
+  //     group([
+  //       animate('195ms cubic-bezier(0, 0, 0.2, 1)'),
+  //       query('@*', animateChild(), {optional: true}),
+  //     ]),
+  //   ),
+  // ])
+
   /** Animation that shows and hides a bottom sheet. */
-  bottomSheetState: trigger('state', [
-    state('void, hidden', style({transform: 'translateY(100%)'})),
-    state('visible', style({transform: 'translateY(0%)'})),
-    transition(
-      'visible => void, visible => hidden',
-      group([
-        animate('375ms cubic-bezier(0.4, 0, 1, 1)'),
-        query('@*', animateChild(), {optional: true}),
-      ]),
-    ),
-    transition(
-      'void => visible',
-      group([
-        animate('195ms cubic-bezier(0, 0, 0.2, 1)'),
-        query('@*', animateChild(), {optional: true}),
-      ]),
-    ),
-  ]),
+  bottomSheetState: {
+    type: 7,
+    name: 'state',
+    definitions: [
+      {
+        type: 0,
+        name: 'void, hidden',
+        styles: {type: 6, styles: {transform: 'translateY(100%)'}, offset: null},
+      },
+      {
+        type: 0,
+        name: 'visible',
+        styles: {type: 6, styles: {transform: 'translateY(0%)'}, offset: null},
+      },
+      {
+        type: 1,
+        expr: 'visible => void, visible => hidden',
+        animation: {
+          type: 3,
+          steps: [
+            {type: 4, styles: null, timings: '375ms cubic-bezier(0.4, 0, 1, 1)'},
+            {
+              type: 11,
+              selector: '@*',
+              animation: {type: 9, options: null},
+              options: {optional: true},
+            },
+          ],
+          options: null,
+        },
+        options: null,
+      },
+      {
+        type: 1,
+        expr: 'void => visible',
+        animation: {
+          type: 3,
+          steps: [
+            {type: 4, styles: null, timings: '195ms cubic-bezier(0, 0, 0.2, 1)'},
+            {
+              type: 11,
+              selector: '@*',
+              animation: {type: 9, options: null},
+              options: {optional: true},
+            },
+          ],
+          options: null,
+        },
+        options: null,
+      },
+    ],
+    options: {},
+  },
 };

--- a/src/material/datepicker/BUILD.bazel
+++ b/src/material/datepicker/BUILD.bazel
@@ -38,7 +38,6 @@ ng_module(
         "//src/material/core",
         "//src/material/form-field",
         "//src/material/input",
-        "@npm//@angular/animations",
         "@npm//@angular/common",
         "@npm//@angular/core",
         "@npm//@angular/forms",

--- a/src/material/datepicker/datepicker-animations.ts
+++ b/src/material/datepicker/datepicker-animations.ts
@@ -5,15 +5,6 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.dev/license
  */
-import {
-  animate,
-  state,
-  style,
-  transition,
-  trigger,
-  keyframes,
-  AnimationTriggerMetadata,
-} from '@angular/animations';
 
 /**
  * Animations used by the Material datepicker.
@@ -22,41 +13,113 @@ import {
  * @breaking-change 21.0.0
  */
 export const matDatepickerAnimations: {
-  readonly transformPanel: AnimationTriggerMetadata;
-  readonly fadeInCalendar: AnimationTriggerMetadata;
+  readonly transformPanel: any;
+  readonly fadeInCalendar: any;
 } = {
+  // Represents:
+  // trigger('transformPanel', [
+  //   transition(
+  //     'void => enter-dropdown',
+  //     animate(
+  //       '120ms cubic-bezier(0, 0, 0.2, 1)',
+  //       keyframes([
+  //         style({opacity: 0, transform: 'scale(1, 0.8)'}),
+  //         style({opacity: 1, transform: 'scale(1, 1)'}),
+  //       ]),
+  //     ),
+  //   ),
+  //   transition(
+  //     'void => enter-dialog',
+  //     animate(
+  //       '150ms cubic-bezier(0, 0, 0.2, 1)',
+  //       keyframes([
+  //         style({opacity: 0, transform: 'scale(0.7)'}),
+  //         style({transform: 'none', opacity: 1}),
+  //       ]),
+  //     ),
+  //   ),
+  //   transition('* => void', animate('100ms linear', style({opacity: 0}))),
+  // ])
+
   /** Transforms the height of the datepicker's calendar. */
-  transformPanel: trigger('transformPanel', [
-    transition(
-      'void => enter-dropdown',
-      animate(
-        '120ms cubic-bezier(0, 0, 0.2, 1)',
-        keyframes([
-          style({opacity: 0, transform: 'scale(1, 0.8)'}),
-          style({opacity: 1, transform: 'scale(1, 1)'}),
-        ]),
-      ),
-    ),
-    transition(
-      'void => enter-dialog',
-      animate(
-        '150ms cubic-bezier(0, 0, 0.2, 1)',
-        keyframes([
-          style({opacity: 0, transform: 'scale(0.7)'}),
-          style({transform: 'none', opacity: 1}),
-        ]),
-      ),
-    ),
-    transition('* => void', animate('100ms linear', style({opacity: 0}))),
-  ]),
+  transformPanel: {
+    type: 7,
+    name: 'transformPanel',
+    definitions: [
+      {
+        type: 1,
+        expr: 'void => enter-dropdown',
+        animation: {
+          type: 4,
+          styles: {
+            type: 5,
+            steps: [
+              {type: 6, styles: {opacity: 0, transform: 'scale(1, 0.8)'}, offset: null},
+              {type: 6, styles: {opacity: 1, transform: 'scale(1, 1)'}, offset: null},
+            ],
+          },
+          timings: '120ms cubic-bezier(0, 0, 0.2, 1)',
+        },
+        options: null,
+      },
+      {
+        type: 1,
+        expr: 'void => enter-dialog',
+        animation: {
+          type: 4,
+          styles: {
+            type: 5,
+            steps: [
+              {type: 6, styles: {opacity: 0, transform: 'scale(0.7)'}, offset: null},
+              {type: 6, styles: {transform: 'none', opacity: 1}, offset: null},
+            ],
+          },
+          timings: '150ms cubic-bezier(0, 0, 0.2, 1)',
+        },
+        options: null,
+      },
+      {
+        type: 1,
+        expr: '* => void',
+        animation: {
+          type: 4,
+          styles: {type: 6, styles: {opacity: 0}, offset: null},
+          timings: '100ms linear',
+        },
+        options: null,
+      },
+    ],
+    options: {},
+  },
+
+  // Represents:
+  // trigger('fadeInCalendar', [
+  //   state('void', style({opacity: 0})),
+  //   state('enter', style({opacity: 1})),
+
+  //   // TODO(crisbeto): this animation should be removed since it isn't quite on spec, but we
+  //   // need to keep it until #12440 gets in, otherwise the exit animation will look glitchy.
+  //   transition('void => *', animate('120ms 100ms cubic-bezier(0.55, 0, 0.55, 0.2)')),
+  // ])
 
   /** Fades in the content of the calendar. */
-  fadeInCalendar: trigger('fadeInCalendar', [
-    state('void', style({opacity: 0})),
-    state('enter', style({opacity: 1})),
-
-    // TODO(crisbeto): this animation should be removed since it isn't quite on spec, but we
-    // need to keep it until #12440 gets in, otherwise the exit animation will look glitchy.
-    transition('void => *', animate('120ms 100ms cubic-bezier(0.55, 0, 0.55, 0.2)')),
-  ]),
+  fadeInCalendar: {
+    type: 7,
+    name: 'fadeInCalendar',
+    definitions: [
+      {type: 0, name: 'void', styles: {type: 6, styles: {opacity: 0}, offset: null}},
+      {type: 0, name: 'enter', styles: {type: 6, styles: {opacity: 1}, offset: null}},
+      {
+        type: 1,
+        expr: 'void => *',
+        animation: {
+          type: 4,
+          styles: null,
+          timings: '120ms 100ms cubic-bezier(0.55, 0, 0.55, 0.2)',
+        },
+        options: null,
+      },
+    ],
+    options: {},
+  },
 };

--- a/src/material/dialog/dialog-animations.ts
+++ b/src/material/dialog/dialog-animations.ts
@@ -5,21 +5,12 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.dev/license
  */
-import {
-  animate,
-  state,
-  style,
-  transition,
-  trigger,
-  AnimationTriggerMetadata,
-  query,
-  animateChild,
-  group,
-} from '@angular/animations';
 
 /**
  * Default parameters for the animation for backwards compatibility.
  * @docs-private
+ * @deprecated Will stop being exported.
+ * @breaking-change 21.0.0
  */
 export const _defaultParams = {
   params: {enterAnimationDuration: '150ms', exitAnimationDuration: '75ms'},
@@ -28,35 +19,100 @@ export const _defaultParams = {
 /**
  * Animations used by MatDialog.
  * @docs-private
+ * @deprecated No longer used, will be removed.
+ * @breaking-change 21.0.0
  */
 export const matDialogAnimations: {
-  readonly dialogContainer: AnimationTriggerMetadata;
+  readonly dialogContainer: any;
 } = {
+  // Represents:
+  // trigger('dialogContainer', [
+  //   // Note: The `enter` animation transitions to `transform: none`, because for some reason
+  //   // specifying the transform explicitly, causes IE both to blur the dialog content and
+  //   // decimate the animation performance. Leaving it as `none` solves both issues.
+  //   state('void, exit', style({opacity: 0, transform: 'scale(0.7)'})),
+  //   state('enter', style({transform: 'none'})),
+  //   transition(
+  //     '* => enter',
+  //     group([
+  //       animate(
+  //         '{{enterAnimationDuration}} cubic-bezier(0, 0, 0.2, 1)',
+  //         style({transform: 'none', opacity: 1}),
+  //       ),
+  //       query('@*', animateChild(), {optional: true}),
+  //     ]),
+  //     _defaultParams,
+  //   ),
+  //   transition(
+  //     '* => void, * => exit',
+  //     group([
+  //       animate('{{exitAnimationDuration}} cubic-bezier(0.4, 0.0, 0.2, 1)', style({opacity: 0})),
+  //       query('@*', animateChild(), {optional: true}),
+  //     ]),
+  //     _defaultParams,
+  //   ),
+  // ])
+
   /** Animation that is applied on the dialog container by default. */
-  dialogContainer: trigger('dialogContainer', [
-    // Note: The `enter` animation transitions to `transform: none`, because for some reason
-    // specifying the transform explicitly, causes IE both to blur the dialog content and
-    // decimate the animation performance. Leaving it as `none` solves both issues.
-    state('void, exit', style({opacity: 0, transform: 'scale(0.7)'})),
-    state('enter', style({transform: 'none'})),
-    transition(
-      '* => enter',
-      group([
-        animate(
-          '{{enterAnimationDuration}} cubic-bezier(0, 0, 0.2, 1)',
-          style({transform: 'none', opacity: 1}),
-        ),
-        query('@*', animateChild(), {optional: true}),
-      ]),
-      _defaultParams,
-    ),
-    transition(
-      '* => void, * => exit',
-      group([
-        animate('{{exitAnimationDuration}} cubic-bezier(0.4, 0.0, 0.2, 1)', style({opacity: 0})),
-        query('@*', animateChild(), {optional: true}),
-      ]),
-      _defaultParams,
-    ),
-  ]),
+  dialogContainer: {
+    type: 7,
+    name: 'dialogContainer',
+    definitions: [
+      {
+        type: 0,
+        name: 'void, exit',
+        styles: {type: 6, styles: {opacity: 0, transform: 'scale(0.7)'}, offset: null},
+      },
+      {
+        type: 0,
+        name: 'enter',
+        styles: {type: 6, styles: {transform: 'none'}, offset: null},
+      },
+      {
+        type: 1,
+        expr: '* => enter',
+        animation: {
+          type: 3,
+          steps: [
+            {
+              type: 4,
+              styles: {type: 6, styles: {transform: 'none', opacity: 1}, offset: null},
+              timings: '{{enterAnimationDuration}} cubic-bezier(0, 0, 0.2, 1)',
+            },
+            {
+              type: 11,
+              selector: '@*',
+              animation: {type: 9, options: null},
+              options: {optional: true},
+            },
+          ],
+          options: null,
+        },
+        options: {params: {enterAnimationDuration: '150ms', exitAnimationDuration: '75ms'}},
+      },
+      {
+        type: 1,
+        expr: '* => void, * => exit',
+        animation: {
+          type: 3,
+          steps: [
+            {
+              type: 4,
+              styles: {type: 6, styles: {opacity: 0}, offset: null},
+              timings: '{{exitAnimationDuration}} cubic-bezier(0.4, 0.0, 0.2, 1)',
+            },
+            {
+              type: 11,
+              selector: '@*',
+              animation: {type: 9, options: null},
+              options: {optional: true},
+            },
+          ],
+          options: null,
+        },
+        options: {params: {enterAnimationDuration: '150ms', exitAnimationDuration: '75ms'}},
+      },
+    ],
+    options: {},
+  },
 };

--- a/src/material/expansion/BUILD.bazel
+++ b/src/material/expansion/BUILD.bazel
@@ -28,7 +28,6 @@ ng_module(
         "//src/cdk/keycodes",
         "//src/cdk/portal",
         "//src/material/core",
-        "@npm//@angular/animations",
         "@npm//@angular/core",
         "@npm//@angular/platform-browser",
         "@npm//rxjs",

--- a/src/material/expansion/expansion-animations.ts
+++ b/src/material/expansion/expansion-animations.ts
@@ -5,17 +5,12 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.dev/license
  */
-import {
-  animate,
-  AnimationTriggerMetadata,
-  state,
-  style,
-  transition,
-  trigger,
-} from '@angular/animations';
 
-/** Time and timing curve for expansion panel animations. */
-// Note: Keep this in sync with the Sass variable for the panel header animation.
+/**
+ * Time and timing curve for expansion panel animations.
+ * @deprecated No longer used. Will be removed.
+ * @breaking-change 21.0.0
+ */
 export const EXPANSION_PANEL_ANIMATION_TIMING = '225ms cubic-bezier(0.4,0.0,0.2,1)';
 
 /**
@@ -43,28 +38,79 @@ export const EXPANSION_PANEL_ANIMATION_TIMING = '225ms cubic-bezier(0.4,0.0,0.2,
  * @breaking-change 21.0.0
  */
 export const matExpansionAnimations: {
-  readonly indicatorRotate: AnimationTriggerMetadata;
-  readonly bodyExpansion: AnimationTriggerMetadata;
+  readonly indicatorRotate: any;
+  readonly bodyExpansion: any;
 } = {
+  // Represents:
+  // trigger('indicatorRotate', [
+  //   state('collapsed, void', style({transform: 'rotate(0deg)'})),
+  //   state('expanded', style({transform: 'rotate(180deg)'})),
+  //   transition(
+  //     'expanded <=> collapsed, void => collapsed',
+  //     animate(EXPANSION_PANEL_ANIMATION_TIMING),
+  //   ),
+  // ])
+
   /** Animation that rotates the indicator arrow. */
-  indicatorRotate: trigger('indicatorRotate', [
-    state('collapsed, void', style({transform: 'rotate(0deg)'})),
-    state('expanded', style({transform: 'rotate(180deg)'})),
-    transition(
-      'expanded <=> collapsed, void => collapsed',
-      animate(EXPANSION_PANEL_ANIMATION_TIMING),
-    ),
-  ]),
+  indicatorRotate: {
+    type: 7,
+    name: 'indicatorRotate',
+    definitions: [
+      {
+        type: 0,
+        name: 'collapsed, void',
+        styles: {type: 6, styles: {transform: 'rotate(0deg)'}, offset: null},
+      },
+      {
+        type: 0,
+        name: 'expanded',
+        styles: {type: 6, styles: {transform: 'rotate(180deg)'}, offset: null},
+      },
+      {
+        type: 1,
+        expr: 'expanded <=> collapsed, void => collapsed',
+        animation: {type: 4, styles: null, timings: '225ms cubic-bezier(0.4,0.0,0.2,1)'},
+        options: null,
+      },
+    ],
+    options: {},
+  },
+
+  // Represents:
+  // trigger('bodyExpansion', [
+  //   state('collapsed, void', style({height: '0px', visibility: 'hidden'})),
+  //   // Clear the `visibility` while open, otherwise the content will be visible when placed in
+  //   // a parent that's `visibility: hidden`, because `visibility` doesn't apply to descendants
+  //   // that have a `visibility` of their own (see #27436).
+  //   state('expanded', style({height: '*', visibility: ''})),
+  //   transition(
+  //     'expanded <=> collapsed, void => collapsed',
+  //     animate(EXPANSION_PANEL_ANIMATION_TIMING),
+  //   ),
+  // ])
+
   /** Animation that expands and collapses the panel content. */
-  bodyExpansion: trigger('bodyExpansion', [
-    state('collapsed, void', style({height: '0px', visibility: 'hidden'})),
-    // Clear the `visibility` while open, otherwise the content will be visible when placed in
-    // a parent that's `visibility: hidden`, because `visibility` doesn't apply to descendants
-    // that have a `visibility` of their own (see #27436).
-    state('expanded', style({height: '*', visibility: ''})),
-    transition(
-      'expanded <=> collapsed, void => collapsed',
-      animate(EXPANSION_PANEL_ANIMATION_TIMING),
-    ),
-  ]),
+  bodyExpansion: {
+    type: 7,
+    name: 'bodyExpansion',
+    definitions: [
+      {
+        type: 0,
+        name: 'collapsed, void',
+        styles: {type: 6, styles: {'height': '0px', 'visibility': 'hidden'}, offset: null},
+      },
+      {
+        type: 0,
+        name: 'expanded',
+        styles: {type: 6, styles: {'height': '*', 'visibility': ''}, offset: null},
+      },
+      {
+        type: 1,
+        expr: 'expanded <=> collapsed, void => collapsed',
+        animation: {type: 4, styles: null, timings: '225ms cubic-bezier(0.4,0.0,0.2,1)'},
+        options: null,
+      },
+    ],
+    options: {},
+  },
 };

--- a/src/material/form-field/form-field-animations.ts
+++ b/src/material/form-field/form-field-animations.ts
@@ -5,14 +5,6 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.dev/license
  */
-import {
-  animate,
-  state,
-  style,
-  transition,
-  trigger,
-  AnimationTriggerMetadata,
-} from '@angular/animations';
 
 /**
  * Animations used by the MatFormField.
@@ -21,15 +13,42 @@ import {
  * @breaking-change 21.0.0
  */
 export const matFormFieldAnimations: {
-  readonly transitionMessages: AnimationTriggerMetadata;
+  readonly transitionMessages: any;
 } = {
+  // Represents:
+  // trigger('transitionMessages', [
+  //   // TODO(mmalerba): Use angular animations for label animation as well.
+  //   state('enter', style({opacity: 1, transform: 'translateY(0%)'})),
+  //   transition('void => enter', [
+  //     style({opacity: 0, transform: 'translateY(-5px)'}),
+  //     animate('300ms cubic-bezier(0.55, 0, 0.55, 0.2)'),
+  //   ]),
+  // ])
+
   /** Animation that transitions the form field's error and hint messages. */
-  transitionMessages: trigger('transitionMessages', [
-    // TODO(mmalerba): Use angular animations for label animation as well.
-    state('enter', style({opacity: 1, transform: 'translateY(0%)'})),
-    transition('void => enter', [
-      style({opacity: 0, transform: 'translateY(-5px)'}),
-      animate('300ms cubic-bezier(0.55, 0, 0.55, 0.2)'),
-    ]),
-  ]),
+  transitionMessages: {
+    type: 7,
+    name: 'transitionMessages',
+    definitions: [
+      {
+        type: 0,
+        name: 'enter',
+        styles: {
+          type: 6,
+          styles: {opacity: 1, transform: 'translateY(0%)'},
+          offset: null,
+        },
+      },
+      {
+        type: 1,
+        expr: 'void => enter',
+        animation: [
+          {type: 6, styles: {opacity: 0, transform: 'translateY(-5px)'}, offset: null},
+          {type: 4, styles: null, timings: '300ms cubic-bezier(0.55, 0, 0.55, 0.2)'},
+        ],
+        options: null,
+      },
+    ],
+    options: {},
+  },
 };

--- a/src/material/menu/BUILD.bazel
+++ b/src/material/menu/BUILD.bazel
@@ -24,7 +24,6 @@ ng_module(
         "//src/cdk/overlay",
         "//src/cdk/scrolling",
         "//src/material/core",
-        "@npm//@angular/animations",
         "@npm//@angular/common",
         "@npm//@angular/core",
     ],

--- a/src/material/menu/menu-animations.ts
+++ b/src/material/menu/menu-animations.ts
@@ -6,15 +6,6 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {
-  trigger,
-  state,
-  style,
-  animate,
-  transition,
-  AnimationTriggerMetadata,
-} from '@angular/animations';
-
 /**
  * Animations used by the mat-menu component.
  * Animation duration and timing values are based on:
@@ -24,9 +15,31 @@ import {
  * @breaking-change 21.0.0
  */
 export const matMenuAnimations: {
-  readonly transformMenu: AnimationTriggerMetadata;
-  readonly fadeInItems: AnimationTriggerMetadata;
+  readonly transformMenu: any;
+  readonly fadeInItems: any;
 } = {
+  // Represents:
+  // trigger('transformMenu', [
+  //   state(
+  //     'void',
+  //     style({
+  //       opacity: 0,
+  //       transform: 'scale(0.8)',
+  //     }),
+  //   ),
+  //   transition(
+  //     'void => enter',
+  //     animate(
+  //       '120ms cubic-bezier(0, 0, 0.2, 1)',
+  //       style({
+  //         opacity: 1,
+  //         transform: 'scale(1)',
+  //       }),
+  //     ),
+  //   ),
+  //   transition('* => void', animate('100ms 25ms linear', style({opacity: 0}))),
+  // ])
+
   /**
    * This animation controls the menu panel's entry and exit from the page.
    *
@@ -35,40 +48,75 @@ export const matMenuAnimations: {
    * When the menu panel is removed from the DOM, it simply fades out after a brief
    * delay to display the ripple.
    */
-  transformMenu: trigger('transformMenu', [
-    state(
-      'void',
-      style({
-        opacity: 0,
-        transform: 'scale(0.8)',
-      }),
-    ),
-    transition(
-      'void => enter',
-      animate(
-        '120ms cubic-bezier(0, 0, 0.2, 1)',
-        style({
-          opacity: 1,
-          transform: 'scale(1)',
-        }),
-      ),
-    ),
-    transition('* => void', animate('100ms 25ms linear', style({opacity: 0}))),
-  ]),
+  transformMenu: {
+    type: 7,
+    name: 'transformMenu',
+    definitions: [
+      {
+        type: 0,
+        name: 'void',
+        styles: {type: 6, styles: {opacity: 0, transform: 'scale(0.8)'}, offset: null},
+      },
+      {
+        type: 1,
+        expr: 'void => enter',
+        animation: {
+          type: 4,
+          styles: {type: 6, styles: {opacity: 1, transform: 'scale(1)'}, offset: null},
+          timings: '120ms cubic-bezier(0, 0, 0.2, 1)',
+        },
+        options: null,
+      },
+      {
+        type: 1,
+        expr: '* => void',
+        animation: {
+          type: 4,
+          styles: {type: 6, styles: {opacity: 0}, offset: null},
+          timings: '100ms 25ms linear',
+        },
+        options: null,
+      },
+    ],
+    options: {},
+  },
+
+  // Represents:
+  // trigger('fadeInItems', [
+  //   // TODO(crisbeto): this is inside the `transformMenu`
+  //   // now. Remove next time we do breaking changes.
+  //   state('showing', style({opacity: 1})),
+  //   transition('void => *', [
+  //     style({opacity: 0}),
+  //     animate('400ms 100ms cubic-bezier(0.55, 0, 0.55, 0.2)'),
+  //   ]),
+  // ])
 
   /**
    * This animation fades in the background color and content of the menu panel
    * after its containing element is scaled in.
    */
-  fadeInItems: trigger('fadeInItems', [
-    // TODO(crisbeto): this is inside the `transformMenu`
-    // now. Remove next time we do breaking changes.
-    state('showing', style({opacity: 1})),
-    transition('void => *', [
-      style({opacity: 0}),
-      animate('400ms 100ms cubic-bezier(0.55, 0, 0.55, 0.2)'),
-    ]),
-  ]),
+  fadeInItems: {
+    type: 7,
+    name: 'fadeInItems',
+    definitions: [
+      {
+        type: 0,
+        name: 'showing',
+        styles: {type: 6, styles: {opacity: 1}, offset: null},
+      },
+      {
+        type: 1,
+        expr: 'void => *',
+        animation: [
+          {type: 6, styles: {opacity: 0}, offset: null},
+          {type: 4, styles: null, timings: '400ms 100ms cubic-bezier(0.55, 0, 0.55, 0.2)'},
+        ],
+        options: null,
+      },
+    ],
+    options: {},
+  },
 };
 
 /**

--- a/src/material/select/BUILD.bazel
+++ b/src/material/select/BUILD.bazel
@@ -30,7 +30,6 @@ ng_module(
         "//src/cdk/scrolling",
         "//src/material/core",
         "//src/material/form-field",
-        "@npm//@angular/animations",
         "@npm//@angular/common",
         "@npm//@angular/core",
         "@npm//@angular/forms",

--- a/src/material/select/select-animations.ts
+++ b/src/material/select/select-animations.ts
@@ -6,17 +6,6 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {
-  animate,
-  animateChild,
-  AnimationTriggerMetadata,
-  query,
-  state,
-  style,
-  transition,
-  trigger,
-} from '@angular/animations';
-
 /**
  * The following are all the animations for the mat-select component, with each
  * const containing the metadata for one animation.
@@ -31,37 +20,99 @@ export const matSelectAnimations: {
    * @deprecated No longer being used. To be removed.
    * @breaking-change 12.0.0
    */
-  readonly transformPanelWrap: AnimationTriggerMetadata;
-  readonly transformPanel: AnimationTriggerMetadata;
+  readonly transformPanelWrap: any;
+  readonly transformPanel: any;
 } = {
+  // Represents
+  // trigger('transformPanelWrap', [
+  //   transition('* => void', query('@transformPanel', [animateChild()], {optional: true})),
+  // ])
+
   /**
    * This animation ensures the select's overlay panel animation (transformPanel) is called when
    * closing the select.
    * This is needed due to https://github.com/angular/angular/issues/23302
    */
-  transformPanelWrap: trigger('transformPanelWrap', [
-    transition('* => void', query('@transformPanel', [animateChild()], {optional: true})),
-  ]),
+  transformPanelWrap: {
+    type: 7,
+    name: 'transformPanelWrap',
+    definitions: [
+      {
+        type: 1,
+        expr: '* => void',
+        animation: {
+          type: 11,
+          selector: '@transformPanel',
+          animation: [{type: 9, options: null}],
+          options: {optional: true},
+        },
+        options: null,
+      },
+    ],
+    options: {},
+  },
+
+  // Represents
+  // trigger('transformPanel', [
+  //   state(
+  //     'void',
+  //     style({
+  //       opacity: 0,
+  //       transform: 'scale(1, 0.8)',
+  //     }),
+  //   ),
+  //   transition(
+  //     'void => showing',
+  //     animate(
+  //       '120ms cubic-bezier(0, 0, 0.2, 1)',
+  //       style({
+  //         opacity: 1,
+  //         transform: 'scale(1, 1)',
+  //       }),
+  //     ),
+  //   ),
+  //   transition('* => void', animate('100ms linear', style({opacity: 0}))),
+  // ])
 
   /** This animation transforms the select's overlay panel on and off the page. */
-  transformPanel: trigger('transformPanel', [
-    state(
-      'void',
-      style({
-        opacity: 0,
-        transform: 'scale(1, 0.8)',
-      }),
-    ),
-    transition(
-      'void => showing',
-      animate(
-        '120ms cubic-bezier(0, 0, 0.2, 1)',
-        style({
-          opacity: 1,
-          transform: 'scale(1, 1)',
-        }),
-      ),
-    ),
-    transition('* => void', animate('100ms linear', style({opacity: 0}))),
-  ]),
+  transformPanel: {
+    type: 7,
+    name: 'transformPanel',
+    definitions: [
+      {
+        type: 0,
+        name: 'void',
+        styles: {
+          type: 6,
+          styles: {opacity: 0, transform: 'scale(1, 0.8)'},
+          offset: null,
+        },
+      },
+      {
+        type: 1,
+        expr: 'void => showing',
+        animation: {
+          type: 4,
+          styles: {
+            type: 6,
+            styles: {opacity: 1, transform: 'scale(1, 1)'},
+            offset: null,
+          },
+          timings: '120ms cubic-bezier(0, 0, 0.2, 1)',
+        },
+        options: null,
+      },
+      {
+        type: 1,
+        expr: '* => void',
+        animation: {
+          type: 4,
+          styles: {type: 6, styles: {opacity: 0}, offset: null},
+          timings: '100ms linear',
+        },
+        options: null,
+      },
+    ],
+    options: {},
+  },
 };

--- a/src/material/sidenav/BUILD.bazel
+++ b/src/material/sidenav/BUILD.bazel
@@ -26,7 +26,6 @@ ng_module(
         "//src/cdk/keycodes",
         "//src/cdk/scrolling",
         "//src/material/core",
-        "@npm//@angular/animations",
         "@npm//@angular/core",
         "@npm//@angular/platform-browser",
         "@npm//rxjs",

--- a/src/material/sidenav/drawer-animations.ts
+++ b/src/material/sidenav/drawer-animations.ts
@@ -5,14 +5,6 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.dev/license
  */
-import {
-  animate,
-  state,
-  style,
-  transition,
-  trigger,
-  AnimationTriggerMetadata,
-} from '@angular/animations';
 
 /**
  * Animations used by the Material drawers.
@@ -21,33 +13,76 @@ import {
  * @breaking-change 21.0.0
  */
 export const matDrawerAnimations: {
-  readonly transformDrawer: AnimationTriggerMetadata;
+  readonly transformDrawer: any;
 } = {
+  // Represents
+  // trigger('transform', [
+  //   // We remove the `transform` here completely, rather than setting it to zero, because:
+  //   // 1. Having a transform can cause elements with ripples or an animated
+  //   //    transform to shift around in Chrome with an RTL layout (see #10023).
+  //   // 2. 3d transforms causes text to appear blurry on IE and Edge.
+  //   state(
+  //     'open, open-instant',
+  //     style({
+  //       'transform': 'none',
+  //       'visibility': 'visible',
+  //     }),
+  //   ),
+  //   state(
+  //     'void',
+  //     style({
+  //       // Avoids the shadow showing up when closed in SSR.
+  //       'box-shadow': 'none',
+  //       'visibility': 'hidden',
+  //     }),
+  //   ),
+  //   transition('void => open-instant', animate('0ms')),
+  //   transition(
+  //     'void <=> open, open-instant => void',
+  //     animate('400ms cubic-bezier(0.25, 0.8, 0.25, 1)'),
+  //   ),
+  // ])
+
   /** Animation that slides a drawer in and out. */
-  transformDrawer: trigger('transform', [
-    // We remove the `transform` here completely, rather than setting it to zero, because:
-    // 1. Having a transform can cause elements with ripples or an animated
-    //    transform to shift around in Chrome with an RTL layout (see #10023).
-    // 2. 3d transforms causes text to appear blurry on IE and Edge.
-    state(
-      'open, open-instant',
-      style({
-        'transform': 'none',
-        'visibility': 'visible',
-      }),
-    ),
-    state(
-      'void',
-      style({
-        // Avoids the shadow showing up when closed in SSR.
-        'box-shadow': 'none',
-        'visibility': 'hidden',
-      }),
-    ),
-    transition('void => open-instant', animate('0ms')),
-    transition(
-      'void <=> open, open-instant => void',
-      animate('400ms cubic-bezier(0.25, 0.8, 0.25, 1)'),
-    ),
-  ]),
+  transformDrawer: {
+    type: 7,
+    name: 'transform',
+    definitions: [
+      {
+        type: 0,
+        name: 'open, open-instant',
+        styles: {
+          type: 6,
+          styles: {transform: 'none', visibility: 'visible'},
+          offset: null,
+        },
+      },
+      {
+        type: 0,
+        name: 'void',
+        styles: {
+          type: 6,
+          styles: {'box-shadow': 'none', visibility: 'hidden'},
+          offset: null,
+        },
+      },
+      {
+        type: 1,
+        expr: 'void => open-instant',
+        animation: {type: 4, styles: null, timings: '0ms'},
+        options: null,
+      },
+      {
+        type: 1,
+        expr: 'void <=> open, open-instant => void',
+        animation: {
+          type: 4,
+          styles: null,
+          timings: '400ms cubic-bezier(0.25, 0.8, 0.25, 1)',
+        },
+        options: null,
+      },
+    ],
+    options: {},
+  },
 };

--- a/src/material/snack-bar/snack-bar-animations.ts
+++ b/src/material/snack-bar/snack-bar-animations.ts
@@ -5,14 +5,6 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.dev/license
  */
-import {
-  animate,
-  state,
-  style,
-  transition,
-  trigger,
-  AnimationTriggerMetadata,
-} from '@angular/animations';
 
 /**
  * Animations used by the Material snack bar.
@@ -21,33 +13,68 @@ import {
  * @breaking-change 21.0.0
  */
 export const matSnackBarAnimations: {
-  readonly snackBarState: AnimationTriggerMetadata;
+  readonly snackBarState: any;
 } = {
+  // Represents
+  // trigger('state', [
+  //   state(
+  //     'void, hidden',
+  //     style({
+  //       transform: 'scale(0.8)',
+  //       opacity: 0,
+  //     }),
+  //   ),
+  //   state(
+  //     'visible',
+  //     style({
+  //       transform: 'scale(1)',
+  //       opacity: 1,
+  //     }),
+  //   ),
+  //   transition('* => visible', animate('150ms cubic-bezier(0, 0, 0.2, 1)')),
+  //   transition(
+  //     '* => void, * => hidden',
+  //     animate(
+  //       '75ms cubic-bezier(0.4, 0.0, 1, 1)',
+  //       style({
+  //         opacity: 0,
+  //       }),
+  //     ),
+  //   ),
+  // ])
+
   /** Animation that shows and hides a snack bar. */
-  snackBarState: trigger('state', [
-    state(
-      'void, hidden',
-      style({
-        transform: 'scale(0.8)',
-        opacity: 0,
-      }),
-    ),
-    state(
-      'visible',
-      style({
-        transform: 'scale(1)',
-        opacity: 1,
-      }),
-    ),
-    transition('* => visible', animate('150ms cubic-bezier(0, 0, 0.2, 1)')),
-    transition(
-      '* => void, * => hidden',
-      animate(
-        '75ms cubic-bezier(0.4, 0.0, 1, 1)',
-        style({
-          opacity: 0,
-        }),
-      ),
-    ),
-  ]),
+  snackBarState: {
+    type: 7,
+    name: 'state',
+    'definitions': [
+      {
+        type: 0,
+        name: 'void, hidden',
+        styles: {type: 6, styles: {transform: 'scale(0.8)', opacity: 0}, offset: null},
+      },
+      {
+        type: 0,
+        name: 'visible',
+        styles: {type: 6, styles: {transform: 'scale(1)', opacity: 1}, offset: null},
+      },
+      {
+        type: 1,
+        expr: '* => visible',
+        animation: {type: 4, styles: null, timings: '150ms cubic-bezier(0, 0, 0.2, 1)'},
+        options: null,
+      },
+      {
+        type: 1,
+        expr: '* => void, * => hidden',
+        animation: {
+          type: 4,
+          styles: {type: 6, styles: {opacity: 0}, offset: null},
+          timings: '75ms cubic-bezier(0.4, 0.0, 1, 1)',
+        },
+        options: null,
+      },
+    ],
+    options: {},
+  },
 };

--- a/src/material/sort/BUILD.bazel
+++ b/src/material/sort/BUILD.bazel
@@ -23,7 +23,6 @@ ng_module(
         "//src/cdk/a11y",
         "//src/cdk/keycodes",
         "//src/material/core",
-        "@npm//@angular/animations",
         "@npm//@angular/core",
         "@npm//rxjs",
     ],

--- a/src/material/sort/sort-animations.ts
+++ b/src/material/sort/sort-animations.ts
@@ -5,21 +5,6 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.dev/license
  */
-import {
-  animate,
-  state,
-  style,
-  transition,
-  trigger,
-  keyframes,
-  AnimationTriggerMetadata,
-  query,
-  animateChild,
-} from '@angular/animations';
-import {AnimationCurves, AnimationDurations} from '@angular/material/core';
-
-const SORT_ANIMATION_TRANSITION =
-  AnimationDurations.ENTERING + ' ' + AnimationCurves.STANDARD_CURVE;
 
 /**
  * Animations used by MatSort.
@@ -28,47 +13,200 @@ const SORT_ANIMATION_TRANSITION =
  * @breaking-change 21.0.0
  */
 export const matSortAnimations: {
-  readonly indicator: AnimationTriggerMetadata;
-  readonly leftPointer: AnimationTriggerMetadata;
-  readonly rightPointer: AnimationTriggerMetadata;
-  readonly arrowOpacity: AnimationTriggerMetadata;
-  readonly arrowPosition: AnimationTriggerMetadata;
-  readonly allowChildren: AnimationTriggerMetadata;
+  readonly indicator: any;
+  readonly leftPointer: any;
+  readonly rightPointer: any;
+  readonly arrowOpacity: any;
+  readonly arrowPosition: any;
+  readonly allowChildren: any;
 } = {
+  // Represents:
+  // trigger('indicator', [
+  //   state('active-asc, asc', style({transform: 'translateY(0px)'})),
+  //   // 10px is the height of the sort indicator, minus the width of the pointers
+  //   state('active-desc, desc', style({transform: 'translateY(10px)'})),
+  //   transition('active-asc <=> active-desc', animate(SORT_ANIMATION_TRANSITION)),
+  // ])
+
   /** Animation that moves the sort indicator. */
-  indicator: trigger('indicator', [
-    state('active-asc, asc', style({transform: 'translateY(0px)'})),
-    // 10px is the height of the sort indicator, minus the width of the pointers
-    state('active-desc, desc', style({transform: 'translateY(10px)'})),
-    transition('active-asc <=> active-desc', animate(SORT_ANIMATION_TRANSITION)),
-  ]),
+  indicator: {
+    type: 7,
+    name: 'indicator',
+    definitions: [
+      {
+        type: 0,
+        name: 'active-asc, asc',
+        styles: {type: 6, styles: {transform: 'translateY(0px)'}, offset: null},
+      },
+      {
+        type: 0,
+        name: 'active-desc, desc',
+        styles: {type: 6, styles: {transform: 'translateY(10px)'}, offset: null},
+      },
+      {
+        type: 1,
+        expr: 'active-asc <=> active-desc',
+        animation: {type: 4, styles: null, timings: '225ms cubic-bezier(0.4,0.0,0.2,1)'},
+        options: null,
+      },
+    ],
+    options: {},
+  },
+
+  // Represents:
+  // trigger('leftPointer', [
+  //   state('active-asc, asc', style({transform: 'rotate(-45deg)'})),
+  //   state('active-desc, desc', style({transform: 'rotate(45deg)'})),
+  //   transition('active-asc <=> active-desc', animate(SORT_ANIMATION_TRANSITION)),
+  // ])
 
   /** Animation that rotates the left pointer of the indicator based on the sorting direction. */
-  leftPointer: trigger('leftPointer', [
-    state('active-asc, asc', style({transform: 'rotate(-45deg)'})),
-    state('active-desc, desc', style({transform: 'rotate(45deg)'})),
-    transition('active-asc <=> active-desc', animate(SORT_ANIMATION_TRANSITION)),
-  ]),
+  leftPointer: {
+    type: 7,
+    name: 'leftPointer',
+    definitions: [
+      {
+        type: 0,
+        name: 'active-asc, asc',
+        styles: {type: 6, styles: {transform: 'rotate(-45deg)'}, offset: null},
+      },
+      {
+        type: 0,
+        name: 'active-desc, desc',
+        styles: {type: 6, styles: {transform: 'rotate(45deg)'}, offset: null},
+      },
+      {
+        type: 1,
+        expr: 'active-asc <=> active-desc',
+        animation: {type: 4, styles: null, timings: '225ms cubic-bezier(0.4,0.0,0.2,1)'},
+        options: null,
+      },
+    ],
+    options: {},
+  },
+
+  // Represents:
+  // trigger('rightPointer', [
+  //   state('active-asc, asc', style({transform: 'rotate(45deg)'})),
+  //   state('active-desc, desc', style({transform: 'rotate(-45deg)'})),
+  //   transition('active-asc <=> active-desc', animate(SORT_ANIMATION_TRANSITION)),
+  // ])
 
   /** Animation that rotates the right pointer of the indicator based on the sorting direction. */
-  rightPointer: trigger('rightPointer', [
-    state('active-asc, asc', style({transform: 'rotate(45deg)'})),
-    state('active-desc, desc', style({transform: 'rotate(-45deg)'})),
-    transition('active-asc <=> active-desc', animate(SORT_ANIMATION_TRANSITION)),
-  ]),
+  rightPointer: {
+    type: 7,
+    name: 'rightPointer',
+    definitions: [
+      {
+        type: 0,
+        name: 'active-asc, asc',
+        styles: {type: 6, styles: {transform: 'rotate(45deg)'}, offset: null},
+      },
+      {
+        type: 0,
+        name: 'active-desc, desc',
+        styles: {type: 6, styles: {transform: 'rotate(-45deg)'}, offset: null},
+      },
+      {
+        type: 1,
+        expr: 'active-asc <=> active-desc',
+        animation: {type: 4, styles: null, timings: '225ms cubic-bezier(0.4,0.0,0.2,1)'},
+        options: null,
+      },
+    ],
+    options: {},
+  },
+
+  // Represents:
+  // trigger('arrowOpacity', [
+  //   state('desc-to-active, asc-to-active, active', style({opacity: 1})),
+  //   state('desc-to-hint, asc-to-hint, hint', style({opacity: 0.54})),
+  //   state(
+  //     'hint-to-desc, active-to-desc, desc, hint-to-asc, active-to-asc, asc, void',
+  //     style({opacity: 0}),
+  //   ),
+  //   // Transition between all states except for immediate transitions
+  //   transition('* => asc, * => desc, * => active, * => hint, * => void', animate('0ms')),
+  //   transition('* <=> *', animate(SORT_ANIMATION_TRANSITION)),
+  // ])
 
   /** Animation that controls the arrow opacity. */
-  arrowOpacity: trigger('arrowOpacity', [
-    state('desc-to-active, asc-to-active, active', style({opacity: 1})),
-    state('desc-to-hint, asc-to-hint, hint', style({opacity: 0.54})),
-    state(
-      'hint-to-desc, active-to-desc, desc, hint-to-asc, active-to-asc, asc, void',
-      style({opacity: 0}),
-    ),
-    // Transition between all states except for immediate transitions
-    transition('* => asc, * => desc, * => active, * => hint, * => void', animate('0ms')),
-    transition('* <=> *', animate(SORT_ANIMATION_TRANSITION)),
-  ]),
+  arrowOpacity: {
+    type: 7,
+    name: 'arrowOpacity',
+    definitions: [
+      {
+        type: 0,
+        name: 'desc-to-active, asc-to-active, active',
+        styles: {type: 6, styles: {'opacity': 1}, offset: null},
+      },
+      {
+        type: 0,
+        name: 'desc-to-hint, asc-to-hint, hint',
+        styles: {type: 6, styles: {'opacity': 0.54}, offset: null},
+      },
+      {
+        type: 0,
+        name: 'hint-to-desc, active-to-desc, desc, hint-to-asc, active-to-asc, asc, void',
+        styles: {type: 6, styles: {'opacity': 0}, offset: null},
+      },
+      {
+        type: 1,
+        expr: '* => asc, * => desc, * => active, * => hint, * => void',
+        animation: {type: 4, styles: null, timings: '0ms'},
+        options: null,
+      },
+      {
+        type: 1,
+        expr: '* <=> *',
+        animation: {type: 4, styles: null, timings: '225ms cubic-bezier(0.4,0.0,0.2,1)'},
+        options: null,
+      },
+    ],
+    options: {},
+  },
+
+  // Represents:
+  // trigger('arrowPosition', [
+  //   // Hidden Above => Hint Center
+  //   transition(
+  //     '* => desc-to-hint, * => desc-to-active',
+  //     animate(
+  //       SORT_ANIMATION_TRANSITION,
+  //       keyframes([style({transform: 'translateY(-25%)'}), style({transform: 'translateY(0)'})]),
+  //     ),
+  //   ),
+  //   // Hint Center => Hidden Below
+  //   transition(
+  //     '* => hint-to-desc, * => active-to-desc',
+  //     animate(
+  //       SORT_ANIMATION_TRANSITION,
+  //       keyframes([style({transform: 'translateY(0)'}), style({transform: 'translateY(25%)'})]),
+  //     ),
+  //   ),
+  //   // Hidden Below => Hint Center
+  //   transition(
+  //     '* => asc-to-hint, * => asc-to-active',
+  //     animate(
+  //       SORT_ANIMATION_TRANSITION,
+  //       keyframes([style({transform: 'translateY(25%)'}), style({transform: 'translateY(0)'})]),
+  //     ),
+  //   ),
+  //   // Hint Center => Hidden Above
+  //   transition(
+  //     '* => hint-to-asc, * => active-to-asc',
+  //     animate(
+  //       SORT_ANIMATION_TRANSITION,
+  //       keyframes([style({transform: 'translateY(0)'}), style({transform: 'translateY(-25%)'})]),
+  //     ),
+  //   ),
+  //   state(
+  //     'desc-to-hint, asc-to-hint, hint, desc-to-active, asc-to-active, active',
+  //     style({transform: 'translateY(0)'}),
+  //   ),
+  //   state('hint-to-desc, active-to-desc, desc', style({transform: 'translateY(-25%)'})),
+  //   state('hint-to-asc, active-to-asc, asc', style({transform: 'translateY(25%)'})),
+  // ])
 
   /**
    * Animation for the translation of the arrow as a whole. States are separated into two
@@ -77,49 +215,117 @@ export const matSortAnimations: {
    * and are determined as a function of their prev user-perceived state and what the next state
    * should be.
    */
-  arrowPosition: trigger('arrowPosition', [
-    // Hidden Above => Hint Center
-    transition(
-      '* => desc-to-hint, * => desc-to-active',
-      animate(
-        SORT_ANIMATION_TRANSITION,
-        keyframes([style({transform: 'translateY(-25%)'}), style({transform: 'translateY(0)'})]),
-      ),
-    ),
-    // Hint Center => Hidden Below
-    transition(
-      '* => hint-to-desc, * => active-to-desc',
-      animate(
-        SORT_ANIMATION_TRANSITION,
-        keyframes([style({transform: 'translateY(0)'}), style({transform: 'translateY(25%)'})]),
-      ),
-    ),
-    // Hidden Below => Hint Center
-    transition(
-      '* => asc-to-hint, * => asc-to-active',
-      animate(
-        SORT_ANIMATION_TRANSITION,
-        keyframes([style({transform: 'translateY(25%)'}), style({transform: 'translateY(0)'})]),
-      ),
-    ),
-    // Hint Center => Hidden Above
-    transition(
-      '* => hint-to-asc, * => active-to-asc',
-      animate(
-        SORT_ANIMATION_TRANSITION,
-        keyframes([style({transform: 'translateY(0)'}), style({transform: 'translateY(-25%)'})]),
-      ),
-    ),
-    state(
-      'desc-to-hint, asc-to-hint, hint, desc-to-active, asc-to-active, active',
-      style({transform: 'translateY(0)'}),
-    ),
-    state('hint-to-desc, active-to-desc, desc', style({transform: 'translateY(-25%)'})),
-    state('hint-to-asc, active-to-asc, asc', style({transform: 'translateY(25%)'})),
-  ]),
+  arrowPosition: {
+    type: 7,
+    name: 'arrowPosition',
+    definitions: [
+      {
+        type: 1,
+        expr: '* => desc-to-hint, * => desc-to-active',
+        animation: {
+          type: 4,
+          styles: {
+            type: 5,
+            'steps': [
+              {type: 6, styles: {transform: 'translateY(-25%)'}, offset: null},
+              {type: 6, styles: {transform: 'translateY(0)'}, offset: null},
+            ],
+          },
+          timings: '225ms cubic-bezier(0.4,0.0,0.2,1)',
+        },
+        options: null,
+      },
+      {
+        type: 1,
+        expr: '* => hint-to-desc, * => active-to-desc',
+        animation: {
+          type: 4,
+          styles: {
+            type: 5,
+            'steps': [
+              {type: 6, styles: {transform: 'translateY(0)'}, offset: null},
+              {type: 6, styles: {transform: 'translateY(25%)'}, offset: null},
+            ],
+          },
+          timings: '225ms cubic-bezier(0.4,0.0,0.2,1)',
+        },
+        options: null,
+      },
+      {
+        type: 1,
+        expr: '* => asc-to-hint, * => asc-to-active',
+        animation: {
+          type: 4,
+          styles: {
+            type: 5,
+            'steps': [
+              {type: 6, styles: {transform: 'translateY(25%)'}, offset: null},
+              {type: 6, styles: {transform: 'translateY(0)'}, offset: null},
+            ],
+          },
+          timings: '225ms cubic-bezier(0.4,0.0,0.2,1)',
+        },
+        options: null,
+      },
+      {
+        type: 1,
+        expr: '* => hint-to-asc, * => active-to-asc',
+        animation: {
+          type: 4,
+          styles: {
+            type: 5,
+            'steps': [
+              {type: 6, styles: {transform: 'translateY(0)'}, offset: null},
+              {type: 6, styles: {transform: 'translateY(-25%)'}, offset: null},
+            ],
+          },
+          timings: '225ms cubic-bezier(0.4,0.0,0.2,1)',
+        },
+        options: null,
+      },
+      {
+        type: 0,
+        name: 'desc-to-hint, asc-to-hint, hint, desc-to-active, asc-to-active, active',
+        styles: {type: 6, styles: {transform: 'translateY(0)'}, offset: null},
+      },
+      {
+        type: 0,
+        name: 'hint-to-desc, active-to-desc, desc',
+        styles: {type: 6, styles: {transform: 'translateY(-25%)'}, offset: null},
+      },
+      {
+        type: 0,
+        name: 'hint-to-asc, active-to-asc, asc',
+        styles: {type: 6, styles: {transform: 'translateY(25%)'}, offset: null},
+      },
+    ],
+    options: {},
+  },
+
+  // Represents:
+  // trigger('allowChildren', [
+  //   transition('* <=> *', [query('@*', animateChild(), {optional: true})]),
+  // ])
 
   /** Necessary trigger that calls animate on children animations. */
-  allowChildren: trigger('allowChildren', [
-    transition('* <=> *', [query('@*', animateChild(), {optional: true})]),
-  ]),
+  allowChildren: {
+    type: 7,
+    name: 'allowChildren',
+    definitions: [
+      {
+        type: 1,
+        expr: '* <=> *',
+        animation: [
+          {
+            type: 11,
+            selector: '@*',
+            animation: {type: 9, options: null},
+            options: {optional: true},
+          },
+        ],
+        options: null,
+      },
+    ],
+    options: {},
+  },
 };

--- a/src/material/stepper/BUILD.bazel
+++ b/src/material/stepper/BUILD.bazel
@@ -29,7 +29,6 @@ ng_module(
         "//src/cdk/stepper",
         "//src/material/core",
         "//src/material/icon",
-        "@npm//@angular/animations",
         "@npm//@angular/common",
         "@npm//@angular/core",
         "@npm//@angular/forms",

--- a/src/material/stepper/stepper-animations.ts
+++ b/src/material/stepper/stepper-animations.ts
@@ -5,17 +5,6 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.dev/license
  */
-import {
-  animate,
-  state,
-  style,
-  transition,
-  trigger,
-  AnimationTriggerMetadata,
-  group,
-  query,
-  animateChild,
-} from '@angular/animations';
 
 /**
  * Animations used by the Material steppers.
@@ -24,46 +13,150 @@ import {
  * @breaking-change 21.0.0
  */
 export const matStepperAnimations: {
-  readonly horizontalStepTransition: AnimationTriggerMetadata;
-  readonly verticalStepTransition: AnimationTriggerMetadata;
+  readonly horizontalStepTransition: any;
+  readonly verticalStepTransition: any;
 } = {
+  // Represents:
+  // trigger('horizontalStepTransition', [
+  //   state('previous', style({transform: 'translate3d(-100%, 0, 0)', visibility: 'hidden'})),
+  //   // Transition to `inherit`, rather than `visible`,
+  //   // because visibility on a child element the one from the parent,
+  //   // making this element focusable inside of a `hidden` element.
+  //   state('current', style({transform: 'none', visibility: 'inherit'})),
+  //   state('next', style({transform: 'translate3d(100%, 0, 0)', visibility: 'hidden'})),
+  //   transition(
+  //     '* => *',
+  //     group([
+  //       animate('{{animationDuration}} cubic-bezier(0.35, 0, 0.25, 1)'),
+  //       query('@*', animateChild(), {optional: true}),
+  //     ]),
+  //     {
+  //       params: {animationDuration: '500ms'},
+  //     },
+  //   ),
+  // ])
+
   /** Animation that transitions the step along the X axis in a horizontal stepper. */
-  horizontalStepTransition: trigger('horizontalStepTransition', [
-    state('previous', style({transform: 'translate3d(-100%, 0, 0)', visibility: 'hidden'})),
-    // Transition to `inherit`, rather than `visible`,
-    // because visibility on a child element the one from the parent,
-    // making this element focusable inside of a `hidden` element.
-    state('current', style({transform: 'none', visibility: 'inherit'})),
-    state('next', style({transform: 'translate3d(100%, 0, 0)', visibility: 'hidden'})),
-    transition(
-      '* => *',
-      group([
-        animate('{{animationDuration}} cubic-bezier(0.35, 0, 0.25, 1)'),
-        query('@*', animateChild(), {optional: true}),
-      ]),
+  horizontalStepTransition: {
+    type: 7,
+    name: 'horizontalStepTransition',
+    definitions: [
       {
-        params: {'animationDuration': '500ms'},
+        type: 0,
+        name: 'previous',
+        styles: {
+          type: 6,
+          styles: {transform: 'translate3d(-100%, 0, 0)', visibility: 'hidden'},
+          offset: null,
+        },
       },
-    ),
-  ]),
+      {
+        type: 0,
+        name: 'current',
+        styles: {
+          type: 6,
+          styles: {transform: 'none', visibility: 'inherit'},
+          offset: null,
+        },
+      },
+      {
+        type: 0,
+        name: 'next',
+        styles: {
+          type: 6,
+          styles: {transform: 'translate3d(100%, 0, 0)', visibility: 'hidden'},
+          offset: null,
+        },
+      },
+      {
+        type: 1,
+        expr: '* => *',
+        animation: {
+          type: 3,
+          steps: [
+            {
+              type: 4,
+              styles: null,
+              timings: '{{animationDuration}} cubic-bezier(0.35, 0, 0.25, 1)',
+            },
+            {
+              type: 11,
+              selector: '@*',
+              animation: {type: 9, options: null},
+              options: {optional: true},
+            },
+          ],
+          options: null,
+        },
+        options: {params: {animationDuration: '500ms'}},
+      },
+    ],
+    options: {},
+  },
+
+  // Represents:
+  // trigger('verticalStepTransition', [
+  //   state('previous', style({height: '0px', visibility: 'hidden'})),
+  //   state('next', style({height: '0px', visibility: 'hidden'})),
+  //   // Transition to `inherit`, rather than `visible`,
+  //   // because visibility on a child element the one from the parent,
+  //   // making this element focusable inside of a `hidden` element.
+  //   state('current', style({height: '*', visibility: 'inherit'})),
+  //   transition(
+  //     '* <=> current',
+  //     group([
+  //       animate('{{animationDuration}} cubic-bezier(0.4, 0.0, 0.2, 1)'),
+  //       query('@*', animateChild(), {optional: true}),
+  //     ]),
+  //     {
+  //       params: {animationDuration: '225ms'},
+  //     },
+  //   ),
+  // ])
 
   /** Animation that transitions the step along the Y axis in a vertical stepper. */
-  verticalStepTransition: trigger('verticalStepTransition', [
-    state('previous', style({height: '0px', visibility: 'hidden'})),
-    state('next', style({height: '0px', visibility: 'hidden'})),
-    // Transition to `inherit`, rather than `visible`,
-    // because visibility on a child element the one from the parent,
-    // making this element focusable inside of a `hidden` element.
-    state('current', style({height: '*', visibility: 'inherit'})),
-    transition(
-      '* <=> current',
-      group([
-        animate('{{animationDuration}} cubic-bezier(0.4, 0.0, 0.2, 1)'),
-        query('@*', animateChild(), {optional: true}),
-      ]),
+  verticalStepTransition: {
+    type: 7,
+    name: 'verticalStepTransition',
+    definitions: [
       {
-        params: {'animationDuration': '225ms'},
+        type: 0,
+        name: 'previous',
+        styles: {type: 6, styles: {'height': '0px', visibility: 'hidden'}, offset: null},
       },
-    ),
-  ]),
+      {
+        type: 0,
+        name: 'next',
+        styles: {type: 6, styles: {'height': '0px', visibility: 'hidden'}, offset: null},
+      },
+      {
+        type: 0,
+        name: 'current',
+        styles: {type: 6, styles: {'height': '*', visibility: 'inherit'}, offset: null},
+      },
+      {
+        type: 1,
+        expr: '* <=> current',
+        animation: {
+          type: 3,
+          steps: [
+            {
+              type: 4,
+              styles: null,
+              timings: '{{animationDuration}} cubic-bezier(0.4, 0.0, 0.2, 1)',
+            },
+            {
+              type: 11,
+              selector: '@*',
+              animation: {type: 9, options: null},
+              options: {optional: true},
+            },
+          ],
+          options: null,
+        },
+        options: {params: {animationDuration: '225ms'}},
+      },
+    ],
+    options: {},
+  },
 };

--- a/src/material/tabs/BUILD.bazel
+++ b/src/material/tabs/BUILD.bazel
@@ -36,7 +36,6 @@ ng_module(
         "//src/cdk/portal",
         "//src/cdk/scrolling",
         "//src/material/core",
-        "@npm//@angular/animations",
         "@npm//@angular/common",
         "@npm//@angular/core",
     ],

--- a/src/material/tabs/tabs-animations.ts
+++ b/src/material/tabs/tabs-animations.ts
@@ -5,14 +5,6 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.dev/license
  */
-import {
-  AnimationTriggerMetadata,
-  animate,
-  state,
-  style,
-  transition,
-  trigger,
-} from '@angular/animations';
 
 /**
  * Animations used by the Material tabs.
@@ -21,51 +13,139 @@ import {
  * @breaking-change 21.0.0.
  */
 export const matTabsAnimations: {
-  readonly translateTab: AnimationTriggerMetadata;
+  readonly translateTab: any;
 } = {
+  // Represents:
+  // trigger('translateTab', [
+  //   // Transitions to `none` instead of 0, because some browsers might blur the content.
+  //   state(
+  //     'center, void, left-origin-center, right-origin-center',
+  //     style({transform: 'none', visibility: 'visible'}),
+  //   ),
+
+  //   // If the tab is either on the left or right, we additionally add a `min-height` of 1px
+  //   // in order to ensure that the element has a height before its state changes. This is
+  //   // necessary because Chrome does seem to skip the transition in RTL mode if the element does
+  //   // not have a static height and is not rendered. See related issue: #9465
+  //   state(
+  //     'left',
+  //     style({
+  //       transform: 'translate3d(-100%, 0, 0)',
+  //       minHeight: '1px',
+
+  //       // Normally this is redundant since we detach the content from the DOM, but if the user
+  //       // opted into keeping the content in the DOM, we have to hide it so it isn't focusable.
+  //       visibility: 'hidden',
+  //     }),
+  //   ),
+  //   state(
+  //     'right',
+  //     style({
+  //       transform: 'translate3d(100%, 0, 0)',
+  //       minHeight: '1px',
+  //       visibility: 'hidden',
+  //     }),
+  //   ),
+
+  //   transition(
+  //     '* => left, * => right, left => center, right => center',
+  //     animate('{{animationDuration}} cubic-bezier(0.35, 0, 0.25, 1)'),
+  //   ),
+  //   transition('void => left-origin-center', [
+  //     style({transform: 'translate3d(-100%, 0, 0)', visibility: 'hidden'}),
+  //     animate('{{animationDuration}} cubic-bezier(0.35, 0, 0.25, 1)'),
+  //   ]),
+  //   transition('void => right-origin-center', [
+  //     style({transform: 'translate3d(100%, 0, 0)', visibility: 'hidden'}),
+  //     animate('{{animationDuration}} cubic-bezier(0.35, 0, 0.25, 1)'),
+  //   ]),
+  // ])
+
   /** Animation translates a tab along the X axis. */
-  translateTab: trigger('translateTab', [
-    // Transitions to `none` instead of 0, because some browsers might blur the content.
-    state(
-      'center, void, left-origin-center, right-origin-center',
-      style({transform: 'none', visibility: 'visible'}),
-    ),
-
-    // If the tab is either on the left or right, we additionally add a `min-height` of 1px
-    // in order to ensure that the element has a height before its state changes. This is
-    // necessary because Chrome does seem to skip the transition in RTL mode if the element does
-    // not have a static height and is not rendered. See related issue: #9465
-    state(
-      'left',
-      style({
-        transform: 'translate3d(-100%, 0, 0)',
-        minHeight: '1px',
-
-        // Normally this is redundant since we detach the content from the DOM, but if the user
-        // opted into keeping the content in the DOM, we have to hide it so it isn't focusable.
-        visibility: 'hidden',
-      }),
-    ),
-    state(
-      'right',
-      style({
-        transform: 'translate3d(100%, 0, 0)',
-        minHeight: '1px',
-        visibility: 'hidden',
-      }),
-    ),
-
-    transition(
-      '* => left, * => right, left => center, right => center',
-      animate('{{animationDuration}} cubic-bezier(0.35, 0, 0.25, 1)'),
-    ),
-    transition('void => left-origin-center', [
-      style({transform: 'translate3d(-100%, 0, 0)', visibility: 'hidden'}),
-      animate('{{animationDuration}} cubic-bezier(0.35, 0, 0.25, 1)'),
-    ]),
-    transition('void => right-origin-center', [
-      style({transform: 'translate3d(100%, 0, 0)', visibility: 'hidden'}),
-      animate('{{animationDuration}} cubic-bezier(0.35, 0, 0.25, 1)'),
-    ]),
-  ]),
+  translateTab: {
+    type: 7,
+    name: 'translateTab',
+    definitions: [
+      {
+        type: 0,
+        name: 'center, void, left-origin-center, right-origin-center',
+        styles: {
+          type: 6,
+          styles: {transform: 'none', visibility: 'visible'},
+          offset: null,
+        },
+      },
+      {
+        type: 0,
+        name: 'left',
+        styles: {
+          type: 6,
+          styles: {
+            transform: 'translate3d(-100%, 0, 0)',
+            minHeight: '1px',
+            visibility: 'hidden',
+          },
+          offset: null,
+        },
+      },
+      {
+        type: 0,
+        name: 'right',
+        styles: {
+          type: 6,
+          styles: {
+            transform: 'translate3d(100%, 0, 0)',
+            minHeight: '1px',
+            visibility: 'hidden',
+          },
+          offset: null,
+        },
+      },
+      {
+        type: 1,
+        expr: '* => left, * => right, left => center, right => center',
+        animation: {
+          type: 4,
+          styles: null,
+          timings: '{{animationDuration}} cubic-bezier(0.35, 0, 0.25, 1)',
+        },
+        options: null,
+      },
+      {
+        type: 1,
+        expr: 'void => left-origin-center',
+        animation: [
+          {
+            type: 6,
+            styles: {transform: 'translate3d(-100%, 0, 0)', visibility: 'hidden'},
+            offset: null,
+          },
+          {
+            type: 4,
+            styles: null,
+            timings: '{{animationDuration}} cubic-bezier(0.35, 0, 0.25, 1)',
+          },
+        ],
+        options: null,
+      },
+      {
+        type: 1,
+        expr: 'void => right-origin-center',
+        animation: [
+          {
+            type: 6,
+            styles: {transform: 'translate3d(100%, 0, 0)', visibility: 'hidden'},
+            offset: null,
+          },
+          {
+            type: 4,
+            styles: null,
+            timings: '{{animationDuration}} cubic-bezier(0.35, 0, 0.25, 1)',
+          },
+        ],
+        options: null,
+      },
+    ],
+    options: {},
+  },
 };

--- a/src/material/tooltip/BUILD.bazel
+++ b/src/material/tooltip/BUILD.bazel
@@ -62,7 +62,6 @@ ng_test_library(
         "//src/cdk/overlay",
         "//src/cdk/platform",
         "//src/cdk/testing/private",
-        "@npm//@angular/animations",
         "@npm//@angular/platform-browser",
         "@npm//rxjs",
     ],

--- a/src/material/tooltip/tooltip-animations.ts
+++ b/src/material/tooltip/tooltip-animations.ts
@@ -5,14 +5,6 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.dev/license
  */
-import {
-  animate,
-  AnimationTriggerMetadata,
-  state,
-  style,
-  transition,
-  trigger,
-} from '@angular/animations';
 
 /**
  * Animations used by MatTooltip.
@@ -21,15 +13,44 @@ import {
  * @breaking-change 21.0.0
  */
 export const matTooltipAnimations: {
-  readonly tooltipState: AnimationTriggerMetadata;
+  readonly tooltipState: any;
 } = {
+  // Represents:
+  // trigger('state', [
+  //   state('initial, void, hidden', style({opacity: 0, transform: 'scale(0.8)'})),
+  //   state('visible', style({transform: 'scale(1)'})),
+  //   transition('* => visible', animate('150ms cubic-bezier(0, 0, 0.2, 1)')),
+  //   transition('* => hidden', animate('75ms cubic-bezier(0.4, 0, 1, 1)')),
+  // ])
+
   /** Animation that transitions a tooltip in and out. */
-  tooltipState: trigger('state', [
-    // TODO(crisbeto): these values are based on MDC's CSS.
-    // We should be able to use their styles directly once we land #19432.
-    state('initial, void, hidden', style({opacity: 0, transform: 'scale(0.8)'})),
-    state('visible', style({transform: 'scale(1)'})),
-    transition('* => visible', animate('150ms cubic-bezier(0, 0, 0.2, 1)')),
-    transition('* => hidden', animate('75ms cubic-bezier(0.4, 0, 1, 1)')),
-  ]),
+  tooltipState: {
+    type: 7,
+    name: 'state',
+    definitions: [
+      {
+        type: 0,
+        name: 'initial, void, hidden',
+        styles: {type: 6, styles: {opacity: 0, transform: 'scale(0.8)'}, offset: null},
+      },
+      {
+        type: 0,
+        name: 'visible',
+        styles: {type: 6, styles: {transform: 'scale(1)'}, offset: null},
+      },
+      {
+        type: 1,
+        expr: '* => visible',
+        animation: {type: 4, styles: null, timings: '150ms cubic-bezier(0, 0, 0.2, 1)'},
+        options: null,
+      },
+      {
+        type: 1,
+        expr: '* => hidden',
+        animation: {type: 4, styles: null, timings: '75ms cubic-bezier(0.4, 0, 1, 1)'},
+        options: null,
+      },
+    ],
+    options: {},
+  },
 };

--- a/tools/public_api_guard/material/bottom-sheet.md
+++ b/tools/public_api_guard/material/bottom-sheet.md
@@ -4,7 +4,6 @@
 
 ```ts
 
-import { AnimationTriggerMetadata } from '@angular/animations';
 import { CdkDialogContainer } from '@angular/cdk/dialog';
 import { ComponentRef } from '@angular/core';
 import { ComponentType } from '@angular/cdk/portal';
@@ -49,7 +48,7 @@ export class MatBottomSheet implements OnDestroy {
 
 // @public @deprecated
 export const matBottomSheetAnimations: {
-    readonly bottomSheetState: AnimationTriggerMetadata;
+    readonly bottomSheetState: any;
 };
 
 // @public

--- a/tools/public_api_guard/material/datepicker.md
+++ b/tools/public_api_guard/material/datepicker.md
@@ -8,7 +8,6 @@ import { AbstractControl } from '@angular/forms';
 import { AfterContentInit } from '@angular/core';
 import { AfterViewChecked } from '@angular/core';
 import { AfterViewInit } from '@angular/core';
-import { AnimationTriggerMetadata } from '@angular/animations';
 import { ChangeDetectorRef } from '@angular/core';
 import { ComponentType } from '@angular/cdk/portal';
 import { ControlValueAccessor } from '@angular/forms';
@@ -339,8 +338,8 @@ export class MatDatepickerActions implements AfterViewInit, OnDestroy {
 
 // @public @deprecated
 export const matDatepickerAnimations: {
-    readonly transformPanel: AnimationTriggerMetadata;
-    readonly fadeInCalendar: AnimationTriggerMetadata;
+    readonly transformPanel: any;
+    readonly fadeInCalendar: any;
 };
 
 // @public

--- a/tools/public_api_guard/material/dialog.md
+++ b/tools/public_api_guard/material/dialog.md
@@ -4,7 +4,6 @@
 
 ```ts
 
-import { AnimationTriggerMetadata } from '@angular/animations';
 import { CdkDialogContainer } from '@angular/cdk/dialog';
 import { ComponentPortal } from '@angular/cdk/portal';
 import { ComponentRef } from '@angular/core';
@@ -39,7 +38,7 @@ export type AutoFocusTarget = 'dialog' | 'first-tabbable' | 'first-heading';
 // @public
 export function _closeDialogVia<R>(ref: MatDialogRef<R>, interactionType: FocusOrigin, result?: R): void;
 
-// @public
+// @public @deprecated
 export const _defaultParams: {
     params: {
         enterAnimationDuration: string;
@@ -114,9 +113,9 @@ export class MatDialogActions extends MatDialogLayoutSection {
     static ɵfac: i0.ɵɵFactoryDeclaration<MatDialogActions, never>;
 }
 
-// @public
+// @public @deprecated
 export const matDialogAnimations: {
-    readonly dialogContainer: AnimationTriggerMetadata;
+    readonly dialogContainer: any;
 };
 
 // @public

--- a/tools/public_api_guard/material/expansion.md
+++ b/tools/public_api_guard/material/expansion.md
@@ -6,7 +6,6 @@
 
 import { AfterContentInit } from '@angular/core';
 import { AfterViewInit } from '@angular/core';
-import { AnimationTriggerMetadata } from '@angular/animations';
 import { CdkAccordion } from '@angular/cdk/accordion';
 import { CdkAccordionItem } from '@angular/cdk/accordion';
 import { ElementRef } from '@angular/core';
@@ -26,7 +25,7 @@ import { Subject } from 'rxjs';
 import { TemplatePortal } from '@angular/cdk/portal';
 import { TemplateRef } from '@angular/core';
 
-// @public
+// @public @deprecated
 export const EXPANSION_PANEL_ANIMATION_TIMING = "225ms cubic-bezier(0.4,0.0,0.2,1)";
 
 // @public
@@ -76,8 +75,8 @@ export type MatAccordionTogglePosition = 'before' | 'after';
 
 // @public @deprecated
 export const matExpansionAnimations: {
-    readonly indicatorRotate: AnimationTriggerMetadata;
-    readonly bodyExpansion: AnimationTriggerMetadata;
+    readonly indicatorRotate: any;
+    readonly bodyExpansion: any;
 };
 
 // @public (undocumented)

--- a/tools/public_api_guard/material/form-field.md
+++ b/tools/public_api_guard/material/form-field.md
@@ -8,7 +8,6 @@ import { AbstractControlDirective } from '@angular/forms';
 import { AfterContentChecked } from '@angular/core';
 import { AfterContentInit } from '@angular/core';
 import { AfterViewInit } from '@angular/core';
-import { AnimationTriggerMetadata } from '@angular/animations';
 import { BooleanInput } from '@angular/cdk/coercion';
 import { ElementRef } from '@angular/core';
 import * as i0 from '@angular/core';
@@ -149,7 +148,7 @@ export class MatFormField implements FloatingLabelParent, AfterContentInit, Afte
 
 // @public @deprecated
 export const matFormFieldAnimations: {
-    readonly transitionMessages: AnimationTriggerMetadata;
+    readonly transitionMessages: any;
 };
 
 // @public

--- a/tools/public_api_guard/material/menu.md
+++ b/tools/public_api_guard/material/menu.md
@@ -6,7 +6,6 @@
 
 import { AfterContentInit } from '@angular/core';
 import { AfterViewInit } from '@angular/core';
-import { AnimationTriggerMetadata } from '@angular/animations';
 import { Direction } from '@angular/cdk/bidi';
 import { EventEmitter } from '@angular/core';
 import { FocusableOption } from '@angular/cdk/a11y';
@@ -26,7 +25,7 @@ import { Subject } from 'rxjs';
 import { TemplateRef } from '@angular/core';
 
 // @public @deprecated (undocumented)
-export const fadeInItems: AnimationTriggerMetadata;
+export const fadeInItems: any;
 
 // @public
 export const MAT_MENU_CONTENT: InjectionToken<MatMenuContent>;
@@ -119,8 +118,8 @@ export class MatMenu implements AfterContentInit, MatMenuPanel<MatMenuItem>, OnI
 
 // @public @deprecated
 export const matMenuAnimations: {
-    readonly transformMenu: AnimationTriggerMetadata;
-    readonly fadeInItems: AnimationTriggerMetadata;
+    readonly transformMenu: any;
+    readonly fadeInItems: any;
 };
 
 // @public
@@ -287,7 +286,7 @@ export type MenuPositionX = 'before' | 'after';
 export type MenuPositionY = 'above' | 'below';
 
 // @public @deprecated (undocumented)
-export const transformMenu: AnimationTriggerMetadata;
+export const transformMenu: any;
 
 // (No @packageDocumentation comment for this package)
 

--- a/tools/public_api_guard/material/select.md
+++ b/tools/public_api_guard/material/select.md
@@ -6,7 +6,6 @@
 
 import { ActiveDescendantKeyManager } from '@angular/cdk/a11y';
 import { AfterContentInit } from '@angular/core';
-import { AnimationTriggerMetadata } from '@angular/animations';
 import { CdkConnectedOverlay } from '@angular/cdk/overlay';
 import { CdkOverlayOrigin } from '@angular/cdk/overlay';
 import { ChangeDetectorRef } from '@angular/core';
@@ -219,8 +218,8 @@ export class MatSelect implements AfterContentInit, OnChanges, OnDestroy, OnInit
 
 // @public @deprecated
 export const matSelectAnimations: {
-    readonly transformPanelWrap: AnimationTriggerMetadata;
-    readonly transformPanel: AnimationTriggerMetadata;
+    readonly transformPanelWrap: any;
+    readonly transformPanel: any;
 };
 
 // @public

--- a/tools/public_api_guard/material/sidenav.md
+++ b/tools/public_api_guard/material/sidenav.md
@@ -6,7 +6,6 @@
 
 import { AfterContentInit } from '@angular/core';
 import { AfterViewInit } from '@angular/core';
-import { AnimationTriggerMetadata } from '@angular/animations';
 import { BooleanInput } from '@angular/cdk/coercion';
 import { CdkScrollable } from '@angular/cdk/scrolling';
 import { DoCheck } from '@angular/core';
@@ -72,7 +71,7 @@ export class MatDrawer implements AfterViewInit, OnDestroy {
 
 // @public @deprecated
 export const matDrawerAnimations: {
-    readonly transformDrawer: AnimationTriggerMetadata;
+    readonly transformDrawer: any;
 };
 
 // @public

--- a/tools/public_api_guard/material/snack-bar.md
+++ b/tools/public_api_guard/material/snack-bar.md
@@ -4,7 +4,6 @@
 
 ```ts
 
-import { AnimationTriggerMetadata } from '@angular/animations';
 import { AriaLivePoliteness } from '@angular/cdk/a11y';
 import { BasePortalOutlet } from '@angular/cdk/portal';
 import { CdkPortalOutlet } from '@angular/cdk/portal';
@@ -76,7 +75,7 @@ export class MatSnackBarActions {
 
 // @public @deprecated
 export const matSnackBarAnimations: {
-    readonly snackBarState: AnimationTriggerMetadata;
+    readonly snackBarState: any;
 };
 
 // @public

--- a/tools/public_api_guard/material/sort.md
+++ b/tools/public_api_guard/material/sort.md
@@ -5,7 +5,6 @@
 ```ts
 
 import { AfterViewInit } from '@angular/core';
-import { AnimationTriggerMetadata } from '@angular/animations';
 import { EventEmitter } from '@angular/core';
 import * as i0 from '@angular/core';
 import * as i1 from '@angular/material/core';
@@ -84,12 +83,12 @@ export interface MatSortable {
 
 // @public @deprecated
 export const matSortAnimations: {
-    readonly indicator: AnimationTriggerMetadata;
-    readonly leftPointer: AnimationTriggerMetadata;
-    readonly rightPointer: AnimationTriggerMetadata;
-    readonly arrowOpacity: AnimationTriggerMetadata;
-    readonly arrowPosition: AnimationTriggerMetadata;
-    readonly allowChildren: AnimationTriggerMetadata;
+    readonly indicator: any;
+    readonly leftPointer: any;
+    readonly rightPointer: any;
+    readonly arrowOpacity: any;
+    readonly arrowPosition: any;
+    readonly allowChildren: any;
 };
 
 // @public

--- a/tools/public_api_guard/material/stepper.md
+++ b/tools/public_api_guard/material/stepper.md
@@ -7,7 +7,6 @@
 import { AbstractControl } from '@angular/forms';
 import { AfterContentInit } from '@angular/core';
 import { AfterViewInit } from '@angular/core';
-import { AnimationTriggerMetadata } from '@angular/animations';
 import { CdkStep } from '@angular/cdk/stepper';
 import { CdkStepHeader } from '@angular/cdk/stepper';
 import { CdkStepLabel } from '@angular/cdk/stepper';
@@ -153,8 +152,8 @@ export class MatStepper extends CdkStepper implements AfterViewInit, AfterConten
 
 // @public @deprecated
 export const matStepperAnimations: {
-    readonly horizontalStepTransition: AnimationTriggerMetadata;
-    readonly verticalStepTransition: AnimationTriggerMetadata;
+    readonly horizontalStepTransition: any;
+    readonly verticalStepTransition: any;
 };
 
 // @public

--- a/tools/public_api_guard/material/tabs.md
+++ b/tools/public_api_guard/material/tabs.md
@@ -7,7 +7,6 @@
 import { AfterContentChecked } from '@angular/core';
 import { AfterContentInit } from '@angular/core';
 import { AfterViewInit } from '@angular/core';
-import { AnimationTriggerMetadata } from '@angular/animations';
 import { BehaviorSubject } from 'rxjs';
 import { CdkPortal } from '@angular/cdk/portal';
 import { CdkPortalOutlet } from '@angular/cdk/portal';
@@ -507,7 +506,7 @@ export class MatTabNavPanel {
 
 // @public @deprecated
 export const matTabsAnimations: {
-    readonly translateTab: AnimationTriggerMetadata;
+    readonly translateTab: any;
 };
 
 // @public

--- a/tools/public_api_guard/material/tooltip.md
+++ b/tools/public_api_guard/material/tooltip.md
@@ -5,7 +5,6 @@
 ```ts
 
 import { AfterViewInit } from '@angular/core';
-import { AnimationTriggerMetadata } from '@angular/animations';
 import { BooleanInput } from '@angular/cdk/coercion';
 import { ConnectedPosition } from '@angular/cdk/overlay';
 import { Directionality } from '@angular/cdk/bidi';
@@ -105,7 +104,7 @@ export class MatTooltip implements OnDestroy, AfterViewInit {
 
 // @public @deprecated
 export const matTooltipAnimations: {
-    readonly tooltipState: AnimationTriggerMetadata;
+    readonly tooltipState: any;
 };
 
 // @public


### PR DESCRIPTION
We're exposing some deprecated public APIs that depend on the animations. These changes remove the dependency while keeping the APIs backwards-compatible until we can remove them in v21.