### PR TITLE
feat(cdk/drag-drop): introduce `resetToBoundary`

### DIFF
--- a/goldens/cdk/drag-drop/index.api.md
+++ b/goldens/cdk/drag-drop/index.api.md
@@ -88,6 +88,7 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
     _resetPlaceholderTemplate(placeholder: CdkDragPlaceholder): void;
     // (undocumented)
     _resetPreviewTemplate(preview: CdkDragPreview): void;
+    resetToBoundary(): void;
     rootElementSelector: string;
     scale: number;
     setFreeDragPosition(value: Point): void;
@@ -439,6 +440,7 @@ export class DragRef<T = any> {
         event: MouseEvent | TouchEvent;
     }>;
     reset(): void;
+    resetToBoundary(): void;
     scale: number;
     setFreeDragPosition(value: Point): this;
     _sortFromLastPointerPosition(): void;

--- a/src/cdk/drag-drop/directives/drag.ts
+++ b/src/cdk/drag-drop/directives/drag.ts
@@ -279,6 +279,11 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
     this._dragRef.reset();
   }
 
+  /** Resets drag item to end of boundary element. */
+  resetToBoundary() {
+    this._dragRef.resetToBoundary();
+  }
+
   /**
    * Gets the pixel coordinates of the draggable outside of a drop container.
    */

--- a/src/cdk/drag-drop/dom/dom-rect.ts
+++ b/src/cdk/drag-drop/dom/dom-rect.ts
@@ -38,6 +38,23 @@ export function isInsideClientRect(clientRect: DOMRect, x: number, y: number) {
 }
 
 /**
+ * Checks if the child element is overflowing from its parent.
+ * @param parentRect - The bounding rect of the parent element.
+ * @param childRect - The bounding rect of the child element.
+ */
+export function isOverflowingParent(parentRect: DOMRect, childRect: DOMRect): boolean {
+  // check for horizontal overflow (left and right)
+  const isLeftOverflowing = childRect.left < parentRect.left;
+  const isRightOverflowing = childRect.left + childRect.width > parentRect.right;
+
+  // check for vertical overflow (top and bottom)
+  const isTopOverflowing = childRect.top < parentRect.top;
+  const isBottomOverflowing = childRect.top + childRect.height > parentRect.bottom;
+
+  return isLeftOverflowing || isRightOverflowing || isTopOverflowing || isBottomOverflowing;
+}
+
+/**
  * Updates the top/left positions of a `DOMRect`, as well as their bottom/right counterparts.
  * @param domRect `DOMRect` that should be updated.
  * @param top Amount to add to the `top` position.


### PR DESCRIPTION
this commit introduces `resetToBoundary` in DragRef which allows user to align DragItem to its boundary on demand if at one point it was at a place where the boundary element used to be and has shrinked causing DragItem to be outside of the boundary box

fixes #30325