### PR TITLE
refactor(material/schematics): drop standalone flag from schematics

### DIFF
--- a/src/cdk/schematics/ng-generate/drag-drop/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.ts.template
+++ b/src/cdk/schematics/ng-generate/drag-drop/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.ts.template
@@ -13,8 +13,8 @@ import { <% if(standalone) { %>CdkDrag, CdkDropList, <% } %>CdkDragDrop, moveIte
   styleUrl: './<%= dasherize(name) %>.component.<%= style %>'<% } %><% if(!!viewEncapsulation) { %>,
   encapsulation: ViewEncapsulation.<%= viewEncapsulation %><% } if (changeDetection !== 'Default') { %>,
   changeDetection: ChangeDetectionStrategy.<%= changeDetection %><% } %><% if(standalone) { %>,
-  standalone: true,
-  imports: [CdkDrag, CdkDropList]<% } %>
+  imports: [CdkDrag, CdkDropList]<% } else { %>,
+  standalone: false<% } %>
 })
 export class <%= classify(name) %>Component {
   todo = [

--- a/src/cdk/schematics/ng-generate/drag-drop/index.spec.ts
+++ b/src/cdk/schematics/ng-generate/drag-drop/index.spec.ts
@@ -52,8 +52,20 @@ describe('CDK drag-drop schematic', () => {
       expect(module).not.toContain('FooComponent');
 
       expect(component).not.toContain('DragDropModule');
-      expect(component).toContain('standalone: true');
       expect(component).toContain('imports: [');
+    });
+
+    it('should generate a component with no imports and standalone false', async () => {
+      const app = await createTestApp(runner, {standalone: false});
+      const tree = await runner.runSchematic('drag-drop', {...baseOptions, standalone: false}, app);
+      const module = getFileContent(tree, '/projects/material/src/app/app.module.ts');
+      const component = getFileContent(tree, '/projects/material/src/app/foo/foo.component.ts');
+
+      expect(module).toContain('DragDropModule');
+      expect(module).toContain('FooComponent');
+
+      expect(component).toContain('standalone: false');
+      expect(component).not.toContain('imports: [');
     });
 
     it('should infer the standalone option from the project structure', async () => {
@@ -64,7 +76,6 @@ describe('CDK drag-drop schematic', () => {
 
       expect(tree.exists('/projects/material/src/app/app.module.ts')).toBe(false);
 
-      expect(component).toContain('standalone: true');
       expect(component).toContain('imports: [');
 
       expect(test).not.toContain('TestBed.configureTestingModule');

--- a/src/material/schematics/ng-generate/address-form/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.ts.template
+++ b/src/material/schematics/ng-generate/address-form/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.ts.template
@@ -22,7 +22,6 @@ import { FormBuilder, Validators } from '@angular/forms';
   styleUrl: './<%= dasherize(name) %>.component.<%= style %>'<% } %><% if(!!viewEncapsulation) { %>,
   encapsulation: ViewEncapsulation.<%= viewEncapsulation %><% } if (changeDetection !== 'Default') { %>,
   changeDetection: ChangeDetectionStrategy.<%= changeDetection %><% } %><% if(standalone) { %>,
-  standalone: true,
   imports: [
     MatInputModule,
     MatButtonModule,
@@ -30,7 +29,8 @@ import { FormBuilder, Validators } from '@angular/forms';
     MatRadioModule,
     MatCardModule,
     ReactiveFormsModule
-  ]<% } %>
+  ]<% } else { %>,
+  standalone: false<% } %>
 })
 export class <%= classify(name) %>Component {
   private fb = inject(FormBuilder);

--- a/src/material/schematics/ng-generate/address-form/index.spec.ts
+++ b/src/material/schematics/ng-generate/address-form/index.spec.ts
@@ -74,8 +74,33 @@ describe('Material address-form schematic', () => {
       });
 
       expect(module).not.toContain('FooComponent');
-      expect(content).toContain('standalone: true');
       expect(content).toContain('imports: [');
+    });
+
+    it('should generate a component with no imports and standalone false', async () => {
+      const app = await createTestApp(runner, {standalone: false});
+      const tree = await runner.runSchematic(
+        'address-form',
+        {...baseOptions, standalone: false},
+        app,
+      );
+      const module = getFileContent(tree, '/projects/material/src/app/app.module.ts');
+      const content = getFileContent(tree, '/projects/material/src/app/foo/foo.component.ts');
+      const requiredModules = [
+        'MatInputModule',
+        'MatButtonModule',
+        'MatSelectModule',
+        'MatRadioModule',
+        'ReactiveFormsModule',
+      ];
+
+      requiredModules.forEach(name => {
+        expect(module).withContext('Module should import dependencies').toContain(name);
+        expect(content).withContext('Component should not import dependencies').not.toContain(name);
+      });
+
+      expect(content).toContain('standalone: false');
+      expect(content).not.toContain('imports: [');
     });
 
     it('should infer the standalone option from the project structure', async () => {
@@ -84,7 +109,6 @@ describe('Material address-form schematic', () => {
       const component = getFileContent(tree, '/projects/material/src/app/foo/foo.component.ts');
 
       expect(tree.exists('/projects/material/src/app/app.module.ts')).toBe(false);
-      expect(component).toContain('standalone: true');
       expect(component).toContain('imports: [');
     });
   });

--- a/src/material/schematics/ng-generate/dashboard/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.ts.template
+++ b/src/material/schematics/ng-generate/dashboard/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.ts.template
@@ -20,7 +20,6 @@ import { MatCardModule } from '@angular/material/card';<% } %>
   styleUrl: './<%= dasherize(name) %>.component.<%= style %>'<% } %><% if(!!viewEncapsulation) { %>,
   encapsulation: ViewEncapsulation.<%= viewEncapsulation %><% } if (changeDetection !== 'Default') { %>,
   changeDetection: ChangeDetectionStrategy.<%= changeDetection %><% } %><% if(standalone) { %>,
-  standalone: true,
   imports: [
     AsyncPipe,
     MatGridListModule,
@@ -28,7 +27,8 @@ import { MatCardModule } from '@angular/material/card';<% } %>
     MatIconModule,
     MatButtonModule,
     MatCardModule
-  ]<% } %>
+  ]<% } else { %>,
+  standalone: false<% } %>
 })
 export class <%= classify(name) %>Component {
   private breakpointObserver = inject(BreakpointObserver);

--- a/src/material/schematics/ng-generate/dashboard/index.spec.ts
+++ b/src/material/schematics/ng-generate/dashboard/index.spec.ts
@@ -78,8 +78,31 @@ describe('material-dashboard-schematic', () => {
       });
 
       expect(module).not.toContain('FooComponent');
-      expect(component).toContain('standalone: true');
       expect(component).toContain('imports: [');
+    });
+
+    it('should generate a component with no imports and standalone false', async () => {
+      const app = await createTestApp(runner, {standalone: false});
+      const tree = await runner.runSchematic('dashboard', {...baseOptions, standalone: false}, app);
+      const module = getFileContent(tree, '/projects/material/src/app/app.module.ts');
+      const component = getFileContent(tree, '/projects/material/src/app/foo/foo.component.ts');
+      const requiredModules = [
+        'MatButtonModule',
+        'MatCardModule',
+        'MatGridListModule',
+        'MatIconModule',
+        'MatMenuModule',
+      ];
+
+      requiredModules.forEach(name => {
+        expect(module).withContext('Module should import dependencies').toContain(name);
+        expect(component)
+          .withContext('Component should not import dependencies')
+          .not.toContain(name);
+      });
+
+      expect(component).toContain('standalone: false');
+      expect(component).not.toContain('imports: [');
     });
 
     it('should infer the standalone option from the project structure', async () => {
@@ -91,7 +114,6 @@ describe('material-dashboard-schematic', () => {
       );
 
       expect(tree.exists('/projects/material/src/app/app.module.ts')).toBe(false);
-      expect(componentContent).toContain('standalone: true');
       expect(componentContent).toContain('imports: [');
     });
   });

--- a/src/material/schematics/ng-generate/navigation/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.ts.template
+++ b/src/material/schematics/ng-generate/navigation/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.ts.template
@@ -21,7 +21,6 @@ import { map, shareReplay } from 'rxjs/operators';
   styleUrl: './<%= dasherize(name) %>.component.<%= style %>'<% } %><% if(!!viewEncapsulation) { %>,
   encapsulation: ViewEncapsulation.<%= viewEncapsulation %><% } if (changeDetection !== 'Default') { %>,
   changeDetection: ChangeDetectionStrategy.<%= changeDetection %><% } %><% if(standalone) { %>,
-  standalone: true,
   imports: [
     MatToolbarModule,
     MatButtonModule,
@@ -29,7 +28,8 @@ import { map, shareReplay } from 'rxjs/operators';
     MatListModule,
     MatIconModule,
     AsyncPipe,
-  ]<% } %>
+  ]<% } else { %>,
+  standalone: false<% } %>
 })
 export class <%= classify(name) %>Component {
   private breakpointObserver = inject(BreakpointObserver);

--- a/src/material/schematics/ng-generate/navigation/index.spec.ts
+++ b/src/material/schematics/ng-generate/navigation/index.spec.ts
@@ -89,8 +89,35 @@ describe('material-navigation-schematic', () => {
       });
 
       expect(module).not.toContain('FooComponent');
-      expect(component).toContain('standalone: true');
       expect(component).toContain('imports: [');
+    });
+
+    it('should generate a component with no imports and standalone false', async () => {
+      const app = await createTestApp(runner, {standalone: false});
+      const tree = await runner.runSchematic(
+        'navigation',
+        {...baseOptions, standalone: false},
+        app,
+      );
+      const module = getFileContent(tree, '/projects/material/src/app/app.module.ts');
+      const component = getFileContent(tree, '/projects/material/src/app/foo/foo.component.ts');
+      const requiredModules = [
+        'MatToolbarModule',
+        'MatButtonModule',
+        'MatSidenavModule',
+        'MatListModule',
+        'MatIconModule',
+      ];
+
+      requiredModules.forEach(name => {
+        expect(module).withContext('Module should import dependencies').toContain(name);
+        expect(component)
+          .withContext('Component should not import dependencies')
+          .not.toContain(name);
+      });
+
+      expect(component).toContain('standalone: false');
+      expect(component).not.toContain('imports: [');
     });
 
     it('should infer the standalone option from the project structure', async () => {
@@ -102,7 +129,6 @@ describe('material-navigation-schematic', () => {
       );
 
       expect(tree.exists('/projects/material/src/app/app.module.ts')).toBe(false);
-      expect(componentContent).toContain('standalone: true');
       expect(componentContent).toContain('imports: [');
     });
   });

--- a/src/material/schematics/ng-generate/table/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.ts.template
+++ b/src/material/schematics/ng-generate/table/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.ts.template
@@ -16,8 +16,8 @@ import { <%= classify(name) %>DataSource, <%= classify(name) %>Item } from './<%
   styleUrl: './<%= dasherize(name) %>.component.<%= style %>'<% } %><% if(!!viewEncapsulation) { %>,
   encapsulation: ViewEncapsulation.<%= viewEncapsulation %><% } if (changeDetection !== 'Default') { %>,
   changeDetection: ChangeDetectionStrategy.<%= changeDetection %><% } %><% if(standalone) { %>,
-  standalone: true,
-  imports: [MatTableModule, MatPaginatorModule, MatSortModule]<% } %>
+  imports: [MatTableModule, MatPaginatorModule, MatSortModule]<% } else { %>,
+  standalone: false<% } %>
 })
 export class <%= classify(name) %>Component implements AfterViewInit {
   @ViewChild(MatPaginator) paginator!: MatPaginator;

--- a/src/material/schematics/ng-generate/table/index.spec.ts
+++ b/src/material/schematics/ng-generate/table/index.spec.ts
@@ -84,8 +84,25 @@ describe('material-table-schematic', () => {
       });
 
       expect(module).not.toContain('FooComponent');
-      expect(component).toContain('standalone: true');
       expect(component).toContain('imports: [');
+    });
+
+    it('should generate a component with no imports and standalone false', async () => {
+      const app = await createTestApp(runner, {standalone: false});
+      const tree = await runner.runSchematic('table', {...baseOptions, standalone: false}, app);
+      const module = getFileContent(tree, '/projects/material/src/app/app.module.ts');
+      const component = getFileContent(tree, '/projects/material/src/app/foo/foo.component.ts');
+      const requiredModules = ['MatTableModule', 'MatPaginatorModule', 'MatSortModule'];
+
+      requiredModules.forEach(name => {
+        expect(module).withContext('Module should import dependencies').toContain(name);
+        expect(component)
+          .withContext('Component should not import dependencies')
+          .not.toContain(name);
+      });
+
+      expect(component).toContain('standalone: false');
+      expect(component).not.toContain('imports: [');
     });
 
     it('should infer the standalone option from the project structure', async () => {
@@ -97,7 +114,6 @@ describe('material-table-schematic', () => {
       );
 
       expect(tree.exists('/projects/material/src/app/app.module.ts')).toBe(false);
-      expect(componentContent).toContain('standalone: true');
       expect(componentContent).toContain('imports: [');
     });
   });

--- a/src/material/schematics/ng-generate/tree/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.ts.template
+++ b/src/material/schematics/ng-generate/tree/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.ts.template
@@ -35,8 +35,8 @@ export interface FlatTreeNode {
   styleUrl: './<%= dasherize(name) %>.component.<%= style %>'<% } %><% if(!!viewEncapsulation) { %>,
   encapsulation: ViewEncapsulation.<%= viewEncapsulation %><% } if (changeDetection !== 'Default') { %>,
   changeDetection: ChangeDetectionStrategy.<%= changeDetection %><% } %><% if(standalone) { %>,
-  standalone: true,
-  imports: [MatTreeModule, MatButtonModule, MatIconModule]<% } %>
+  imports: [MatTreeModule, MatButtonModule, MatIconModule]<% } else { %>,
+  standalone: false<% } %>
 })
 export class <%= classify(name) %>Component {
 

--- a/src/material/schematics/ng-generate/tree/index.spec.ts
+++ b/src/material/schematics/ng-generate/tree/index.spec.ts
@@ -62,8 +62,25 @@ describe('Material tree schematic', () => {
       });
 
       expect(module).not.toContain('FooComponent');
-      expect(component).toContain('standalone: true');
       expect(component).toContain('imports: [');
+    });
+
+    it('should generate a component with no imports and standalone false', async () => {
+      const app = await createTestApp(runner, {standalone: false});
+      const tree = await runner.runSchematic('tree', {...baseOptions, standalone: false}, app);
+      const module = getFileContent(tree, '/projects/material/src/app/app.module.ts');
+      const component = getFileContent(tree, '/projects/material/src/app/foo/foo.component.ts');
+      const requiredModules = ['MatTreeModule', 'MatButtonModule', 'MatIconModule'];
+
+      requiredModules.forEach(name => {
+        expect(module).withContext('Module should import dependencies').toContain(name);
+        expect(component)
+          .withContext('Component should not import dependencies')
+          .not.toContain(name);
+      });
+
+      expect(component).toContain('standalone: false');
+      expect(component).not.toContain('imports: [');
     });
 
     it('should infer the standalone option from the project structure', async () => {
@@ -75,7 +92,6 @@ describe('Material tree schematic', () => {
       );
 
       expect(tree.exists('/projects/material/src/app/app.module.ts')).toBe(false);
-      expect(componentContent).toContain('standalone: true');
       expect(componentContent).toContain('imports: [');
     });
   });


### PR DESCRIPTION
since v19 Angular components are standalone by default so we don't have to add `standalone` flag to be true explicitly in schematics