### PR TITLE
fix(material/core): remove animations from ng add

### DIFF
--- a/src/material/schematics/ng-add/index.spec.ts
+++ b/src/material/schematics/ng-add/index.spec.ts
@@ -45,19 +45,7 @@ describe('ng-add schematic', () => {
       .toContain(filePath);
   }
 
-  /** Removes the specified dependency from the /package.json in the given tree. */
-  function removePackageJsonDependency(tree: Tree, dependencyName: string) {
-    const packageContent = JSON.parse(getFileContent(tree, '/package.json')) as PackageJson;
-    delete packageContent.dependencies[dependencyName];
-    tree.overwrite('/package.json', JSON.stringify(packageContent, null, 2));
-  }
-
   it('should update package.json', async () => {
-    // By default, the Angular workspace schematic sets up "@angular/animations". In order
-    // to verify that we would set up the dependency properly if someone doesn't have the
-    // animations installed already, we remove the animations dependency explicitly.
-    removePackageJsonDependency(appTree, '@angular/animations');
-
     const tree = await runner.runSchematic('ng-add', baseOptions, appTree);
     const packageJson = JSON.parse(getFileContent(tree, '/package.json')) as PackageJson;
     const dependencies = packageJson.dependencies;
@@ -67,11 +55,6 @@ describe('ng-add schematic', () => {
     expect(dependencies['@angular/cdk']).toBe('~0.0.0-PLACEHOLDER');
     expect(dependencies['@angular/forms'])
       .withContext('Expected the @angular/forms package to have the same version as @angular/core.')
-      .toBe(angularCoreVersion);
-    expect(dependencies['@angular/animations'])
-      .withContext(
-        'Expected the @angular/animations package to have the same ' + 'version as @angular/core.',
-      )
       .toBe(angularCoreVersion);
 
     expect(Object.keys(dependencies))
@@ -183,73 +166,6 @@ describe('ng-add schematic', () => {
     expect(htmlContent).toContain(
       'body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }',
     );
-  });
-
-  it('should add provideAnimationsAsync to the project module', async () => {
-    const tree = await runner.runSchematic('ng-add-setup-project', baseOptions, appTree);
-    const fileContent = getFileContent(tree, '/projects/material/src/app/app.module.ts');
-
-    expect(fileContent).toContain('provideAnimationsAsync()');
-    expect(fileContent).toContain(
-      `import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';`,
-    );
-  });
-
-  it('should add the provideAnimationsAsync to a bootstrapApplication call', async () => {
-    appTree.delete('/projects/material/src/app/app.module.ts');
-    appTree.create(
-      '/projects/material/src/app/app.config.ts',
-      `
-      export const appConfig = {
-        providers: [{ provide: 'foo', useValue: 1 }]
-      };
-    `,
-    );
-    appTree.overwrite(
-      '/projects/material/src/main.ts',
-      `
-        import { bootstrapApplication } from '@angular/platform-browser';
-        import { AppComponent } from './app/app.component';
-        import { appConfig } from './app/app.config';
-
-        bootstrapApplication(AppComponent, appConfig);
-      `,
-    );
-
-    const tree = await runner.runSchematic('ng-add-setup-project', baseOptions, appTree);
-    const fileContent = getFileContent(tree, '/projects/material/src/app/app.config.ts');
-
-    expect(fileContent).toContain(
-      `import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';`,
-    );
-    expect(fileContent).toContain(`[{ provide: 'foo', useValue: 1 }, provideAnimationsAsync()]`);
-  });
-
-  it("should add the provideAnimationAsync('noop') to the project module if animations are disabled", async () => {
-    const tree = await runner.runSchematic(
-      'ng-add-setup-project',
-      {...baseOptions, animations: 'disabled'},
-      appTree,
-    );
-    const fileContent = getFileContent(tree, '/projects/material/src/app/app.module.ts');
-
-    expect(fileContent).toContain(`provideAnimationsAsync('noop')`);
-    expect(fileContent).toContain(
-      `import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';`,
-    );
-  });
-
-  it('should not add any animations code if animations are excluded', async () => {
-    const tree = await runner.runSchematic(
-      'ng-add-setup-project',
-      {...baseOptions, animations: 'excluded'},
-      appTree,
-    );
-    const fileContent = getFileContent(tree, '/projects/material/src/app/app.module.ts');
-
-    expect(fileContent).not.toContain('provideAnimationsAsync');
-    expect(fileContent).not.toContain('@angular/platform-browser/animations');
-    expect(fileContent).not.toContain('@angular/animations');
   });
 
   describe('custom project builders', () => {
@@ -576,16 +492,6 @@ describe('ng-add schematic', () => {
         'body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }',
       );
     });
-
-    it('should add the provideAnimationsAsync to the project module', async () => {
-      const tree = await runner.runSchematic('ng-add-setup-project', baseOptions, appTree);
-      const fileContent = getFileContent(tree, '/projects/material/src/app/app.module.ts');
-
-      expect(fileContent).toContain('provideAnimationsAsync()');
-      expect(fileContent).toContain(
-        `import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';`,
-      );
-    });
   });
 
   describe('using browser-esbuild builder', () => {
@@ -646,16 +552,6 @@ describe('ng-add schematic', () => {
         'body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }',
       );
     });
-
-    it('should add the provideAnimationsAsync to the project module', async () => {
-      const tree = await runner.runSchematic('ng-add-setup-project', baseOptions, appTree);
-      const fileContent = getFileContent(tree, '/projects/material/src/app/app.module.ts');
-
-      expect(fileContent).toContain('provideAnimationsAsync()');
-      expect(fileContent).toContain(
-        `import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';`,
-      );
-    });
   });
 
   describe('using lower dependency builder', () => {
@@ -692,30 +588,6 @@ describe('ng-add schematic', () => {
       const project = getProjectFromWorkspace(workspace, baseOptions.project);
 
       expectProjectStyleFile(project, '@angular/material/prebuilt-themes/azure-blue.css');
-    });
-
-    it('should add material app styles', async () => {
-      const tree = await runner.runSchematic('ng-add-setup-project', baseOptions, appTree);
-      const workspace = await getWorkspace(tree);
-      const project = getProjectFromWorkspace(workspace, baseOptions.project);
-
-      const defaultStylesPath = getProjectStyleFile(project)!;
-      const htmlContent = tree.read(defaultStylesPath)!.toString();
-
-      expect(htmlContent).toContain('html, body { height: 100%; }');
-      expect(htmlContent).toContain(
-        'body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }',
-      );
-    });
-
-    it('should add the provideAnimationsAsync to the project module', async () => {
-      const tree = await runner.runSchematic('ng-add-setup-project', baseOptions, appTree);
-      const fileContent = getFileContent(tree, '/projects/material/src/app/app.module.ts');
-
-      expect(fileContent).toContain('provideAnimationsAsync()');
-      expect(fileContent).toContain(
-        `import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';`,
-      );
     });
   });
 });

--- a/src/material/schematics/ng-add/index.ts
+++ b/src/material/schematics/ng-add/index.ts
@@ -53,7 +53,6 @@ export default function (options: Schema): Rule {
       materialVersionRange || fallbackMaterialVersionRange,
     );
     addPackageToPackageJson(host, '@angular/forms', angularDependencyVersion);
-    addPackageToPackageJson(host, '@angular/animations', angularDependencyVersion);
 
     // Since the Angular Material schematics depend on the schematic utility functions from the
     // CDK, we need to install the CDK before loading the schematic files that import from the CDK.

--- a/src/material/schematics/ng-add/schema.json
+++ b/src/material/schematics/ng-add/schema.json
@@ -44,20 +44,6 @@
       "default": false,
       "description": "Whether to set up global typography styles.",
       "x-prompt": "Set up global Angular Material typography styles?"
-    },
-    "animations": {
-      "type": "string",
-      "default": "enabled",
-      "description": "Whether Angular browser animations should be included.",
-      "x-prompt": {
-        "message": "Include the Angular animations module?",
-        "type": "list",
-        "items": [
-          {"value": "enabled", "label": "Include and enable animations"},
-          {"value": "disabled", "label": "Include, but disable animations"},
-          {"value": "excluded", "label": "Do not include"}
-        ]
-      }
     }
   },
   "required": []

--- a/src/material/schematics/ng-add/schema.ts
+++ b/src/material/schematics/ng-add/schema.ts
@@ -10,9 +10,6 @@ export interface Schema {
   /** Name of the project. */
   project: string;
 
-  /** Whether the Angular browser animations module should be included and enabled. */
-  animations: 'enabled' | 'disabled' | 'excluded';
-
   /** Name of pre-built theme to install. */
   theme: 'azure-blue' | 'rose-red' | 'magenta-violet' | 'cyan-orange' | 'custom';
 


### PR DESCRIPTION
Since we no longer depend on the animations module, we can remove the prompt and its related code from the `ng add` schematic.