### PR TITLE
feat(material/core): drop dependency on animations module

### DIFF
--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -27,10 +27,6 @@ determine which features to include:
 
    Whether to apply the global [typography](https://material.angular.io/guide/typography) styles to your application.
 
-3. Set up browser animations for Angular Material:
-
-   Importing the [`BrowserAnimationsModule`](https://angular.dev/api/platform-browser/animations/BrowserAnimationsModule) into your application enables Angular's [animation system](https://angular.dev/guide/animations). Declining this will disable most of Angular Material's animations.
-
 The `ng add` command will additionally perform the following actions:
 
 * Add project dependencies to `package.json`
@@ -48,7 +44,7 @@ You're done! Angular Material is now configured to be used in your application.
 Let's display a slide toggle component in your app and verify that everything works.
 
 You need to import the `MatSlideToggleModule` that you want to display by adding the following lines to
-your standalone component's imports, or otherwise your component's `NgModule`. 
+your standalone component's imports, or otherwise your component's `NgModule`.
 
 ```ts
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';

--- a/guides/schematics.md
+++ b/guides/schematics.md
@@ -25,7 +25,6 @@ ng add @angular/cdk
 The Angular Material `ng add` schematic helps you set up an Angular CLI project that uses Material. Running `ng add` will:
 
 - Ensure [project dependencies](./getting-started#step-1-install-angular-material-angular-cdk-and-angular-animations) are placed in `package.json`
-- Enable the [BrowserAnimationsModule](./getting-started#step-2-configure-animations) in your app module
 - Add either a prebuilt theme or a custom theme
 - Add Roboto fonts to your `index.html`
 - Add the [Material Icon font](./getting-started#step-6-optional-add-material-icons) to your `index.html`

--- a/src/material-experimental/package.json
+++ b/src/material-experimental/package.json
@@ -17,7 +17,6 @@
     }
   },
   "peerDependencies": {
-    "@angular/animations": "0.0.0-NG",
     "@angular/cdk": "0.0.0-PLACEHOLDER",
     "@angular/core": "0.0.0-NG",
     "@angular/common": "0.0.0-NG",

--- a/src/material/package.json
+++ b/src/material/package.json
@@ -56,7 +56,6 @@
     }
   },
   "peerDependencies": {
-    "@angular/animations": "0.0.0-NG",
     "@angular/cdk": "0.0.0-PLACEHOLDER",
     "@angular/core": "0.0.0-NG",
     "@angular/common": "0.0.0-NG",


### PR DESCRIPTION
All Material components have been moved away from requiring the `@angular/animations` module. These changes update the docs and `peerDependencies` not to require it.

This means that users can remove the BrowserAnimationsModule from their apps, if they weren't using Angular's animations system in their own code or in other dependencies. This has a few advantages:
1. It removes ~16kb of minified JS from production bundle.
2. It resolves a bunch of bugs and memory leaks that were caused by the animations. E.g. previously if there was an expansion panel inside a tab, it would be open while the animations are running and then snap into place.
3. It reduces some runtime overhead for Angular.
4. It causes fewer change detections.

### Notes
This change **does not** imply that the `@angular/animations` module is deprecated, it is **still supported**. We decided to move our library away from it, because it resolved a lot of bugs that our users were seeing and we felt that it wasn't fair to force another dependency upon them.

Furthermore, disabling animations using the `NoopAnimationsModule` (e.g. for tests) is still supported by Material.