### PR TITLE
build: add packageGroup to CDK

### DIFF
--- a/src/cdk/package.json
+++ b/src/cdk/package.json
@@ -57,7 +57,11 @@
   },
   "schematics": "./schematics/collection.json",
   "ng-update": {
-    "migrations": "./schematics/migration.json"
+    "migrations": "./schematics/migration.json",
+    "packageGroup": [
+      "@angular/material",
+      "@angular/cdk"
+    ]
   },
   "sideEffects": false
 }


### PR DESCRIPTION
Adds a `packageGroup` to the `package.json` of the CDK to avoid some warnings during `ng update`.

Fixes #30464.