### PR TITLE
perf(cdk/table): Short circuit _removeStickyStyle calls against eleme…

### DIFF
--- a/src/cdk/table/sticky-styler.ts
+++ b/src/cdk/table/sticky-styler.ts
@@ -330,6 +330,10 @@ export class StickyStyler {
    * sticky position if there are no more directions.
    */
   _removeStickyStyle(element: HTMLElement, stickyDirections: StickyDirection[]) {
+    if (!element.classList.contains(this._stickCellCss)) {
+      return;
+    }
+
     for (const dir of stickyDirections) {
       element.style[dir] = '';
       element.classList.remove(this._borderCellCss[dir]);


### PR DESCRIPTION
…nts with no sticky styles

In my profiling run of a very large table, this cuts render time by about 3.5% or 70ms.