### PR TITLE
build: add missing `packageGroup` fields and packages in `package.json`

### DIFF
--- a/packages.bzl
+++ b/packages.bzl
@@ -4,10 +4,27 @@
 TSLIB_PACKAGE_VERSION = "^2.3.0"
 RXJS_PACKAGE_VERSION = "^6.5.3 || ^7.4.0"
 
+# Packages which are versioned together on npm
+ANGULAR_COMPONENTS_SCOPED_PACKAGES = ["@angular/%s" % p for p in [
+    "material",
+    "cdk",
+    "cdk-experimental",
+    "material-experimental",
+    "material-luxon-adapter",
+    "material-moment-adapter",
+    "material-date-fns-adapter",
+]]
+
+PKG_GROUP_REPLACEMENTS = {
+    "\"NG_UPDATE_PACKAGE_GROUP\"": """[
+      %s
+    ]""" % ",\n      ".join(["\"%s\"" % s for s in ANGULAR_COMPONENTS_SCOPED_PACKAGES]),
+}
+
 # Each placeholder is used to stamp versions during the build process, replacing the key with its
 # value pair. These replacements occur during building of `npm_package` and `ng_package` stamping in
 # the peer dependencies and versions, primarily in `package.json`s.
-NPM_PACKAGE_SUBSTITUTIONS = {
+NPM_PACKAGE_SUBSTITUTIONS = dict(PKG_GROUP_REPLACEMENTS, **{
     # Peer dependency version on the Angular framework.
     "0.0.0-NG": "{STABLE_FRAMEWORK_PEER_DEP_RANGE}",
     # Version of `tslib`
@@ -16,7 +33,7 @@ NPM_PACKAGE_SUBSTITUTIONS = {
     "0.0.0-PLACEHOLDER": "{STABLE_PROJECT_VERSION}",
     # Version of `rxjs`
     "0.0.0-RXJS": RXJS_PACKAGE_VERSION,
-}
+})
 
 NO_STAMP_NPM_PACKAGE_SUBSTITUTIONS = dict(NPM_PACKAGE_SUBSTITUTIONS, **{
     # When building NPM packages for tests (where stamping is disabled),

--- a/src/cdk-experimental/package.json
+++ b/src/cdk-experimental/package.json
@@ -18,5 +18,8 @@
   "dependencies": {
     "tslib": "0.0.0-TSLIB"
   },
+  "ng-update": {
+    "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
+  },
   "sideEffects": false
 }

--- a/src/cdk/package.json
+++ b/src/cdk/package.json
@@ -58,10 +58,7 @@
   "schematics": "./schematics/collection.json",
   "ng-update": {
     "migrations": "./schematics/migration.json",
-    "packageGroup": [
-      "@angular/material",
-      "@angular/cdk"
-    ]
+    "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   },
   "sideEffects": false
 }

--- a/src/material-date-fns-adapter/package.json
+++ b/src/material-date-fns-adapter/package.json
@@ -20,11 +20,7 @@
     "tslib": "0.0.0-TSLIB"
   },
   "ng-update": {
-    "packageGroup": [
-      "@angular/material",
-      "@angular/cdk",
-      "@angular/material-date-fns-adapter"
-    ]
+    "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   },
   "schematics": "./schematics/collection.json",
   "sideEffects": false

--- a/src/material-experimental/package.json
+++ b/src/material-experimental/package.json
@@ -27,5 +27,8 @@
   "dependencies": {
     "tslib": "0.0.0-TSLIB"
   },
+  "ng-update": {
+    "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
+  },
   "sideEffects": false
 }

--- a/src/material-luxon-adapter/package.json
+++ b/src/material-luxon-adapter/package.json
@@ -20,11 +20,7 @@
     "tslib": "0.0.0-TSLIB"
   },
   "ng-update": {
-    "packageGroup": [
-      "@angular/material",
-      "@angular/cdk",
-      "@angular/material-luxon-adapter"
-    ]
+    "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   },
   "schematics": "./schematics/collection.json",
   "sideEffects": false

--- a/src/material-moment-adapter/package.json
+++ b/src/material-moment-adapter/package.json
@@ -20,11 +20,7 @@
     "tslib": "0.0.0-TSLIB"
   },
   "ng-update": {
-    "packageGroup": [
-      "@angular/material",
-      "@angular/cdk",
-      "@angular/material-moment-adapter"
-    ]
+    "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   },
   "schematics": "./schematics/collection.json",
   "sideEffects": false

--- a/src/material/package.json
+++ b/src/material/package.json
@@ -69,13 +69,7 @@
   "schematics": "./schematics/collection.json",
   "ng-update": {
     "migrations": "./schematics/migration.json",
-    "packageGroup": [
-      "@angular/material",
-      "@angular/cdk",
-      "@angular/material-moment-adapter",
-      "@angular/material-luxon-adapter",
-      "@angular/material-date-fns-adapter"
-    ]
+    "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   },
   "sideEffects": false
 }


### PR DESCRIPTION
This commit fixes multiple `package.json` files by adding the missing `packageGroup` field. Additionally, it ensures that all required packages are included within `packageGroup`. These updates are necessary because the affected packages have peer dependencies on `@angular/cdk` or `@angular/material`, and updating them individually.