### PR TITLE
fix(material/slide-toggle): rendering issue in Safari 18.3

### DIFF
--- a/src/material/slide-toggle/slide-toggle.scss
+++ b/src/material/slide-toggle/slide-toggle.scss
@@ -457,6 +457,9 @@ $_interactive-disabled-selector: '.mat-mdc-slide-toggle-disabled-interactive.mdc
   width: 100%;
   z-index: 1;
 
+  // Works around a rendering issue in Safari 18.3 (see #30487).
+  transform: translateZ(0);
+
   @include token-utils.use-tokens($_mdc-slots...) {
     .mdc-switch--disabled.mdc-switch--unselected & {
       @include token-utils.create-token-slot(opacity, disabled-unselected-icon-opacity);


### PR DESCRIPTION
Fixes a rendering issue that was causing the icon inside the slide toggle to flicker or not display at all.

Fixes #30487.