### PR TITLE
refactor(material-angular-io): remove explicit standalone flags

### DIFF
--- a/material.angular.io/scenes/src/app/app.component.ts
+++ b/material.angular.io/scenes/src/app/app.component.ts
@@ -5,7 +5,6 @@ import {RouterOutlet} from '@angular/router';
   selector: 'app-root',
   template: '<router-outlet></router-outlet>',
   styleUrls: ['./app.component.scss'],
-  standalone: true,
   imports: [RouterOutlet],
 })
 export class AppComponent {}

--- a/material.angular.io/scenes/src/app/scene-viewer/scene-viewer.ts
+++ b/material.angular.io/scenes/src/app/scene-viewer/scene-viewer.ts
@@ -16,7 +16,6 @@ import {DomSanitizer, SafeStyle} from '@angular/platform-browser';
   selector: 'app-scene-viewer',
   templateUrl: './scene-viewer.html',
   styleUrls: ['./scene-viewer.scss'],
-  standalone: true,
 })
 export class SceneViewer implements OnInit {
   private route = inject(ActivatedRoute);

--- a/material.angular.io/scenes/src/app/scenes/autocomplete/autocomplete-scene.ts
+++ b/material.angular.io/scenes/src/app/scenes/autocomplete/autocomplete-scene.ts
@@ -8,7 +8,6 @@ import {MatAutocompleteModule} from '@angular/material/autocomplete';
   encapsulation: ViewEncapsulation.None,
   selector: 'app-autocomplete-scene',
   templateUrl: './autocomplete-scene.html',
-  standalone: true,
   imports: [
     ReactiveFormsModule,
     FormsModule,

--- a/material.angular.io/scenes/src/app/scenes/badge/badge-scene.ts
+++ b/material.angular.io/scenes/src/app/scenes/badge/badge-scene.ts
@@ -7,7 +7,6 @@ import {MatBadgeModule} from '@angular/material/badge';
   selector: 'app-badge-scene',
   templateUrl: './badge-scene.html',
   styleUrls: ['./badge-scene.scss'],
-  standalone: true,
   imports: [MatIconModule, MatBadgeModule],
 })
 export class BadgeScene {}

--- a/material.angular.io/scenes/src/app/scenes/bottom-sheet/bottom-sheet-scene.ts
+++ b/material.angular.io/scenes/src/app/scenes/bottom-sheet/bottom-sheet-scene.ts
@@ -8,7 +8,6 @@ import {MatListModule} from '@angular/material/list';
   template: '',
   styleUrls: ['./bottom-sheet-scene.scss'],
   encapsulation: ViewEncapsulation.None,
-  standalone: true,
 })
 export class BottomSheetScene implements AfterViewInit {
   private _bottomSheet = inject(MatBottomSheet);
@@ -23,7 +22,6 @@ export class BottomSheetScene implements AfterViewInit {
   selector: 'app-bottom-sheet-scene',
   templateUrl: './bottom-sheet-scene.html',
   styleUrls: ['./bottom-sheet-scene.scss'],
-  standalone: true,
   imports: [MatListModule, MatIconModule],
 })
 export class SampleBottomSheet {}

--- a/material.angular.io/scenes/src/app/scenes/button-toggle/button-toggle-scene.ts
+++ b/material.angular.io/scenes/src/app/scenes/button-toggle/button-toggle-scene.ts
@@ -7,7 +7,6 @@ import {MatIconModule} from '@angular/material/icon';
   selector: 'app-button-toggle-scene',
   templateUrl: './button-toggle-scene.html',
   styleUrls: ['./button-toggle-scene.scss'],
-  standalone: true,
   imports: [MatButtonToggleModule, MatIconModule],
 })
 export class ButtonToggleScene {}

--- a/material.angular.io/scenes/src/app/scenes/button/button-scene.ts
+++ b/material.angular.io/scenes/src/app/scenes/button/button-scene.ts
@@ -7,7 +7,6 @@ import {MatIconModule} from '@angular/material/icon';
   selector: 'app-button-scene',
   templateUrl: './button-scene.html',
   styleUrls: ['./button-scene.scss'],
-  standalone: true,
   imports: [MatButtonModule, MatIconModule],
 })
 export class ButtonScene {}

--- a/material.angular.io/scenes/src/app/scenes/card/card-scene.ts
+++ b/material.angular.io/scenes/src/app/scenes/card/card-scene.ts
@@ -5,7 +5,6 @@ import {MatCardModule} from '@angular/material/card';
   selector: 'app-card-scene',
   templateUrl: './card-scene.html',
   styleUrls: ['./card-scene.scss'],
-  standalone: true,
   imports: [MatCardModule],
 })
 export class CardScene {}

--- a/material.angular.io/scenes/src/app/scenes/checkbox/checkbox-scene.ts
+++ b/material.angular.io/scenes/src/app/scenes/checkbox/checkbox-scene.ts
@@ -6,7 +6,6 @@ import {MatCheckboxModule} from '@angular/material/checkbox';
   selector: 'app-checkbox-scene',
   templateUrl: './checkbox-scene.html',
   styleUrls: ['./checkbox-scene.scss'],
-  standalone: true,
   imports: [MatCheckboxModule],
 })
 export class CheckboxScene {}

--- a/material.angular.io/scenes/src/app/scenes/chips/chips-scene.ts
+++ b/material.angular.io/scenes/src/app/scenes/chips/chips-scene.ts
@@ -6,7 +6,6 @@ import {MatChipsModule} from '@angular/material/chips';
   selector: 'app-chips-scene',
   templateUrl: './chips-scene.html',
   styleUrls: ['./chips-scene.scss'],
-  standalone: true,
   imports: [MatChipsModule],
 })
 export class ChipsScene {}

--- a/material.angular.io/scenes/src/app/scenes/core/core-scene.ts
+++ b/material.angular.io/scenes/src/app/scenes/core/core-scene.ts
@@ -6,7 +6,6 @@ import {MatIconModule} from '@angular/material/icon';
   selector: 'app-core-scene',
   templateUrl: './core-scene.html',
   styleUrls: ['./core-scene.scss'],
-  standalone: true,
   imports: [MatIconModule],
 })
 export class CoreScene {}

--- a/material.angular.io/scenes/src/app/scenes/datepicker/datepicker-scene.ts
+++ b/material.angular.io/scenes/src/app/scenes/datepicker/datepicker-scene.ts
@@ -6,7 +6,6 @@ import {MatDatepickerModule} from '@angular/material/datepicker';
   selector: 'app-datepicker-scene',
   templateUrl: './datepicker-scene.html',
   styleUrls: ['./datepicker-scene.scss'],
-  standalone: true,
   imports: [MatDatepickerModule],
 })
 export class DatepickerScene {

--- a/material.angular.io/scenes/src/app/scenes/dialog/dialog-scene.ts
+++ b/material.angular.io/scenes/src/app/scenes/dialog/dialog-scene.ts
@@ -6,7 +6,6 @@ import {MatDialog, MatDialogModule} from '@angular/material/dialog';
   encapsulation: ViewEncapsulation.None,
   selector: 'app-dialog-scene',
   template: '',
-  standalone: true,
 })
 export class DialogScene {
   dialog = inject(MatDialog);
@@ -28,7 +27,6 @@ export class DialogScene {
       <button mat-button mat-dialog-close>Cancel</button>
       <button mat-button mat-dialog-close>Discard</button>
     </div>`,
-  standalone: true,
   imports: [MatDialogModule, MatButtonModule],
 })
 export class DialogSceneExampleDialog {}

--- a/material.angular.io/scenes/src/app/scenes/divider/divider-scene.ts
+++ b/material.angular.io/scenes/src/app/scenes/divider/divider-scene.ts
@@ -8,7 +8,6 @@ import {MatDividerModule} from '@angular/material/divider';
   selector: 'app-divider-scene',
   templateUrl: './divider-scene.html',
   styleUrls: ['./divider-scene.scss'],
-  standalone: true,
   imports: [MatListModule, MatIconModule, MatDividerModule],
 })
 export class DividerScene {}

--- a/material.angular.io/scenes/src/app/scenes/expansion/expansion-scene.ts
+++ b/material.angular.io/scenes/src/app/scenes/expansion/expansion-scene.ts
@@ -7,7 +7,6 @@ import {MatIconModule} from '@angular/material/icon';
   selector: 'app-expansion-scene',
   templateUrl: './expansion-scene.html',
   styleUrls: ['./expansion-scene.scss'],
-  standalone: true,
   imports: [MatExpansionModule, MatIconModule],
 })
 export class ExpansionScene {}

--- a/material.angular.io/scenes/src/app/scenes/form-field/form-field-scene.ts
+++ b/material.angular.io/scenes/src/app/scenes/form-field/form-field-scene.ts
@@ -7,7 +7,6 @@ import {MatFormFieldModule} from '@angular/material/form-field';
   encapsulation: ViewEncapsulation.None,
   selector: 'app-form-field-scene',
   templateUrl: './form-field-scene.html',
-  standalone: true,
   imports: [MatFormFieldModule, MatInputModule, MatIconModule],
 })
 export class FormFieldScene {}

--- a/material.angular.io/scenes/src/app/scenes/grid-list/grid-list-scene.ts
+++ b/material.angular.io/scenes/src/app/scenes/grid-list/grid-list-scene.ts
@@ -6,7 +6,6 @@ import {MatGridListModule} from '@angular/material/grid-list';
   templateUrl: './grid-list-scene.html',
   styleUrls: ['./grid-list-scene.scss'],
   encapsulation: ViewEncapsulation.None,
-  standalone: true,
   imports: [MatGridListModule],
 })
 export class GridListScene {

--- a/material.angular.io/scenes/src/app/scenes/icon/icon-scene.ts
+++ b/material.angular.io/scenes/src/app/scenes/icon/icon-scene.ts
@@ -6,7 +6,6 @@ import {MatIconModule} from '@angular/material/icon';
   selector: 'app-icon-scene',
   templateUrl: './icon-scene.html',
   styleUrls: ['./icon-scene.scss'],
-  standalone: true,
   imports: [MatIconModule],
 })
 export class IconScene {}

--- a/material.angular.io/scenes/src/app/scenes/input/input-scene.ts
+++ b/material.angular.io/scenes/src/app/scenes/input/input-scene.ts
@@ -7,7 +7,6 @@ import {MatInputModule} from '@angular/material/input';
   selector: 'app-input-scene',
   templateUrl: './input-scene.html',
   styleUrls: ['./input-scene.scss'],
-  standalone: true,
   imports: [MatFormFieldModule, MatInputModule],
 })
 export class InputScene {}

--- a/material.angular.io/scenes/src/app/scenes/list/list-scene.ts
+++ b/material.angular.io/scenes/src/app/scenes/list/list-scene.ts
@@ -7,7 +7,6 @@ import {MatIconModule} from '@angular/material/icon';
   selector: 'app-list-scene',
   templateUrl: './list-scene.html',
   styleUrls: ['./list-scene.scss'],
-  standalone: true,
   imports: [MatListModule, MatIconModule],
 })
 export class ListScene {}

--- a/material.angular.io/scenes/src/app/scenes/menu/menu-scene.ts
+++ b/material.angular.io/scenes/src/app/scenes/menu/menu-scene.ts
@@ -8,7 +8,6 @@ import {MatMenuModule, MatMenuTrigger} from '@angular/material/menu';
   selector: 'app-button-scene',
   templateUrl: './menu-scene.html',
   styleUrls: ['./menu-scene.scss'],
-  standalone: true,
   imports: [MatButtonModule, MatMenuModule, MatIconModule],
 })
 export class MenuScene implements AfterViewInit {

--- a/material.angular.io/scenes/src/app/scenes/paginator/paginator-scene.ts
+++ b/material.angular.io/scenes/src/app/scenes/paginator/paginator-scene.ts
@@ -6,7 +6,6 @@ import {MatPaginatorModule} from '@angular/material/paginator';
   selector: 'app-paginator-scene',
   templateUrl: './paginator-scene.html',
   styleUrls: ['./paginator-scene.scss'],
-  standalone: true,
   imports: [MatPaginatorModule],
 })
 export class PaginatorScene {}

--- a/material.angular.io/scenes/src/app/scenes/placeholder/placeholder-scene.ts
+++ b/material.angular.io/scenes/src/app/scenes/placeholder/placeholder-scene.ts
@@ -5,6 +5,5 @@ import {Component, ViewEncapsulation} from '@angular/core';
   selector: 'app-button-toggle-scene',
   templateUrl: './placeholder-scene.html',
   styleUrls: ['./placeholder-scene.scss'],
-  standalone: true,
 })
 export class PlaceHolderScene {}

--- a/material.angular.io/scenes/src/app/scenes/progress-bar/progress-bar-scene.ts
+++ b/material.angular.io/scenes/src/app/scenes/progress-bar/progress-bar-scene.ts
@@ -6,7 +6,6 @@ import {MatProgressBarModule} from '@angular/material/progress-bar';
   selector: 'app-progress-bar-scene',
   templateUrl: './progress-bar-scene.html',
   styleUrls: ['./progress-bar-scene.scss'],
-  standalone: true,
   imports: [MatProgressBarModule],
 })
 export class ProgressBarScene {}

--- a/material.angular.io/scenes/src/app/scenes/progress-spinner/progress-spinner-scene.ts
+++ b/material.angular.io/scenes/src/app/scenes/progress-spinner/progress-spinner-scene.ts
@@ -6,7 +6,6 @@ import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
   selector: 'app-input-scene',
   templateUrl: './progress-spinner-scene.html',
   styleUrls: ['./progress-spinner-scene.scss'],
-  standalone: true,
   imports: [MatProgressSpinnerModule],
 })
 export class ProgressSpinnerScene {}

--- a/material.angular.io/scenes/src/app/scenes/radio/radio-scene.ts
+++ b/material.angular.io/scenes/src/app/scenes/radio/radio-scene.ts
@@ -6,7 +6,6 @@ import {MatRadioModule} from '@angular/material/radio';
   selector: 'app-radio-scene',
   templateUrl: './radio-scene.html',
   styleUrls: ['./radio-scene.scss'],
-  standalone: true,
   imports: [MatRadioModule],
 })
 export class RadioScene {}

--- a/material.angular.io/scenes/src/app/scenes/ripples/ripples-scene.ts
+++ b/material.angular.io/scenes/src/app/scenes/ripples/ripples-scene.ts
@@ -7,7 +7,6 @@ import {MatRipple, MatRippleModule} from '@angular/material/core';
   selector: 'app-ripple-scene',
   templateUrl: './ripples-scene.html',
   styleUrls: ['./ripples-scene.scss'],
-  standalone: true,
   imports: [MatRippleModule, MatButtonModule],
 })
 export class RipplesScene implements AfterViewInit {

--- a/material.angular.io/scenes/src/app/scenes/select/select-scene.ts
+++ b/material.angular.io/scenes/src/app/scenes/select/select-scene.ts
@@ -8,7 +8,6 @@ import {MatOptionModule} from '@angular/material/core';
   selector: 'app-select-scene',
   templateUrl: './select-scene.html',
   styleUrls: ['./select-scene.scss'],
-  standalone: true,
   imports: [MatFormFieldModule, MatSelectModule, MatOptionModule],
 })
 export class SelectScene implements AfterViewInit {

--- a/material.angular.io/scenes/src/app/scenes/sidenav/sidenav-scene.ts
+++ b/material.angular.io/scenes/src/app/scenes/sidenav/sidenav-scene.ts
@@ -8,7 +8,6 @@ import {MatListModule} from '@angular/material/list';
   selector: 'app-sidenav-scene',
   templateUrl: './sidenav-scene.html',
   styleUrls: ['./sidenav-scene.scss'],
-  standalone: true,
   imports: [MatSidenavModule, MatListModule, MatIconModule],
 })
 export class SidenavScene {}

--- a/material.angular.io/scenes/src/app/scenes/slide-toggle/slide-toggle-scene.ts
+++ b/material.angular.io/scenes/src/app/scenes/slide-toggle/slide-toggle-scene.ts
@@ -7,7 +7,6 @@ import {MatSlideToggleModule} from '@angular/material/slide-toggle';
   selector: 'app-slide-toggle-scene',
   templateUrl: './slide-toggle-scene.html',
   styleUrls: ['./slide-toggle-scene.scss'],
-  standalone: true,
   imports: [MatIconModule, MatSlideToggleModule],
 })
 export class SlideToggleScene {}

--- a/material.angular.io/scenes/src/app/scenes/slider/slider-scene.ts
+++ b/material.angular.io/scenes/src/app/scenes/slider/slider-scene.ts
@@ -7,7 +7,6 @@ import {MatSliderModule} from '@angular/material/slider';
   selector: 'app-slider-scene',
   templateUrl: './slider-scene.html',
   styleUrls: ['./slider-scene.scss'],
-  standalone: true,
   imports: [MatIconModule, MatSliderModule],
 })
 export class SliderScene implements AfterViewInit {

--- a/material.angular.io/scenes/src/app/scenes/snack-bar/snack-bar-scene.ts
+++ b/material.angular.io/scenes/src/app/scenes/snack-bar/snack-bar-scene.ts
@@ -6,7 +6,6 @@ import {MatSnackBar} from '@angular/material/snack-bar';
   template: '<div class="docs-scene-snackbar-background"></div>',
   styleUrls: ['./snack-bar-scene.scss'],
   encapsulation: ViewEncapsulation.None,
-  standalone: true,
 })
 export class SnackBarScene {
   constructor() {

--- a/material.angular.io/scenes/src/app/scenes/sort/sort-scene.ts
+++ b/material.angular.io/scenes/src/app/scenes/sort/sort-scene.ts
@@ -14,7 +14,6 @@ export interface Dessert {
   selector: 'app-sort-scene',
   templateUrl: './sort-scene.html',
   styleUrls: ['./sort-scene.scss'],
-  standalone: true,
   imports: [MatSortModule],
 })
 export class SortScene {

--- a/material.angular.io/scenes/src/app/scenes/stepper/stepper-scene.ts
+++ b/material.angular.io/scenes/src/app/scenes/stepper/stepper-scene.ts
@@ -8,7 +8,6 @@ import {MatFormFieldModule} from '@angular/material/form-field';
   selector: 'app-stepper-scene',
   templateUrl: './stepper-scene.html',
   styleUrls: ['./stepper-scene.scss'],
-  standalone: true,
   imports: [MatStepperModule, MatFormFieldModule, MatInputModule],
 })
 export class StepperScene {}

--- a/material.angular.io/scenes/src/app/scenes/table/table-scene.ts
+++ b/material.angular.io/scenes/src/app/scenes/table/table-scene.ts
@@ -20,7 +20,6 @@ const ELEMENT_DATA: PeriodicElement[] = [
   selector: 'app-table-scene',
   templateUrl: './table-scene.html',
   styleUrls: ['./table-scene.scss'],
-  standalone: true,
   imports: [MatCardModule, MatTableModule],
 })
 export class TableScene {

--- a/material.angular.io/scenes/src/app/scenes/tabs/tabs-scene.ts
+++ b/material.angular.io/scenes/src/app/scenes/tabs/tabs-scene.ts
@@ -5,7 +5,6 @@ import {MatTabsModule} from '@angular/material/tabs';
   selector: 'app-tabs-scene',
   templateUrl: './tabs-scene.html',
   styleUrls: ['./tabs-scene.scss'],
-  standalone: true,
   imports: [MatTabsModule],
 })
 export class TabsScene {}

--- a/material.angular.io/scenes/src/app/scenes/timepicker/timepicker-scene.ts
+++ b/material.angular.io/scenes/src/app/scenes/timepicker/timepicker-scene.ts
@@ -8,7 +8,6 @@ import {MatTimepickerModule, MatTimepicker} from '@angular/material/timepicker';
   selector: 'app-timepicker-scene',
   templateUrl: './timepicker-scene.html',
   styleUrls: ['./timepicker-scene.scss'],
-  standalone: true,
   imports: [MatTimepickerModule, MatFormFieldModule, MatInputModule],
 })
 export class TimepickerScene implements AfterViewInit {

--- a/material.angular.io/scenes/src/app/scenes/toolbar/toolbar-scene.ts
+++ b/material.angular.io/scenes/src/app/scenes/toolbar/toolbar-scene.ts
@@ -7,7 +7,6 @@ import {MatToolbarModule} from '@angular/material/toolbar';
   selector: 'app-toolbar-scene',
   templateUrl: './toolbar-scene.html',
   styleUrls: ['./toolbar-scene.scss'],
-  standalone: true,
   imports: [MatToolbarModule, MatIconModule],
 })
 export class ToolbarScene {}

--- a/material.angular.io/scenes/src/app/scenes/tooltip/tooltip-scene.ts
+++ b/material.angular.io/scenes/src/app/scenes/tooltip/tooltip-scene.ts
@@ -8,7 +8,6 @@ import {MatIconModule} from '@angular/material/icon';
   selector: 'app-tooltip-scene',
   templateUrl: './tooltip-scene.html',
   styleUrls: ['./tooltip-scene.scss'],
-  standalone: true,
   imports: [MatButtonModule, MatTooltipModule, MatIconModule],
 })
 export class TooltipScene implements AfterViewInit {

--- a/material.angular.io/scenes/src/app/scenes/tree/tree-scene.ts
+++ b/material.angular.io/scenes/src/app/scenes/tree/tree-scene.ts
@@ -35,7 +35,6 @@ interface FileFlatNode {
   selector: 'app-tree-scene',
   templateUrl: './tree-scene.html',
   styleUrls: ['./tree-scene.scss'],
-  standalone: true,
   imports: [MatTreeModule, MatIconModule, MatButtonModule],
 })
 export class TreeScene {

--- a/material.angular.io/src/app/material-docs-app.ts
+++ b/material.angular.io/src/app/material-docs-app.ts
@@ -17,7 +17,6 @@ import {CookiePopup} from './shared/cookie-popup/cookie-popup';
   `,
   styleUrls: ['./material-docs-app.scss'],
   encapsulation: ViewEncapsulation.None,
-  standalone: true,
   imports: [NavBar, RouterOutlet, CookiePopup],
 })
 export class MaterialDocsApp implements OnDestroy {

--- a/material.angular.io/src/app/pages/component-category-list/component-category-list.ts
+++ b/material.angular.io/src/app/pages/component-category-list/component-category-list.ts
@@ -16,7 +16,6 @@ import {ComponentPageTitle} from '../page-title/page-title';
   selector: 'app-component-category-list',
   templateUrl: './component-category-list.html',
   styleUrls: ['./component-category-list.scss'],
-  standalone: true,
   imports: [NavigationFocus, RouterLink, MatRipple],
 })
 export class ComponentCategoryList implements OnInit, OnDestroy {

--- a/material.angular.io/src/app/pages/component-page-header/component-page-header.ts
+++ b/material.angular.io/src/app/pages/component-page-header/component-page-header.ts
@@ -7,7 +7,6 @@ import {MatIcon} from '@angular/material/icon';
   selector: 'component-page-header',
   templateUrl: './component-page-header.html',
   styleUrls: ['./component-page-header.scss'],
-  standalone: true,
   imports: [MatButton, MatIcon],
 })
 export class ComponentPageHeader {

--- a/material.angular.io/src/app/pages/component-sidenav/component-sidenav.ts
+++ b/material.angular.io/src/app/pages/component-sidenav/component-sidenav.ts
@@ -54,7 +54,6 @@ const SMALL_WIDTH_BREAKPOINT = 959;
   templateUrl: './component-sidenav.html',
   styleUrls: ['./component-sidenav.scss'],
   encapsulation: ViewEncapsulation.None,
-  standalone: true,
   imports: [
     MatSidenav,
     MatSidenavContainer,
@@ -117,7 +116,6 @@ export class ComponentSidenav implements OnInit, OnDestroy {
 @Component({
   selector: 'app-component-nav',
   templateUrl: './component-nav.html',
-  standalone: true,
   imports: [MatNavList, MatListItem, RouterLinkActive, RouterLink, AsyncPipe],
 })
 export class ComponentNav {

--- a/material.angular.io/src/app/pages/component-viewer/component-styling.ts
+++ b/material.angular.io/src/app/pages/component-viewer/component-styling.ts
@@ -39,7 +39,6 @@ class TokenService {
 @Component({
   selector: 'component-styling',
   templateUrl: './component-styling.html',
-  standalone: true,
   imports: [AsyncPipe, TokenTable],
 })
 export class ComponentStyling {

--- a/material.angular.io/src/app/pages/component-viewer/component-viewer.ts
+++ b/material.angular.io/src/app/pages/component-viewer/component-viewer.ts
@@ -28,7 +28,6 @@ import {MatTabLink, MatTabNav, MatTabNavPanel} from '@angular/material/tabs';
   templateUrl: './component-viewer.html',
   styleUrls: ['./component-viewer.scss'],
   encapsulation: ViewEncapsulation.None,
-  standalone: true,
   imports: [
     MatTabNav,
     MatTabLink,
@@ -160,7 +159,6 @@ export class ComponentBaseView implements OnInit, OnDestroy {
   selector: 'component-overview',
   templateUrl: './component-overview.html',
   encapsulation: ViewEncapsulation.None,
-  standalone: true,
   imports: [DocViewer, TableOfContents, AsyncPipe],
 })
 export class ComponentOverview extends ComponentBaseView {
@@ -180,7 +178,6 @@ export class ComponentOverview extends ComponentBaseView {
   templateUrl: './component-api.html',
   styleUrls: ['./component-api.scss'],
   encapsulation: ViewEncapsulation.None,
-  standalone: true,
   imports: [DocViewer, TableOfContents, AsyncPipe],
 })
 export class ComponentApi extends ComponentBaseView {
@@ -194,7 +191,6 @@ export class ComponentApi extends ComponentBaseView {
   selector: 'component-examples',
   templateUrl: './component-examples.html',
   encapsulation: ViewEncapsulation.None,
-  standalone: true,
   imports: [ExampleViewer, AsyncPipe],
 })
 export class ComponentExamples extends ComponentBaseView {}

--- a/material.angular.io/src/app/pages/component-viewer/token-name.ts
+++ b/material.angular.io/src/app/pages/component-viewer/token-name.ts
@@ -7,7 +7,6 @@ import {MatTooltip} from '@angular/material/tooltip';
 
 @Component({
   selector: 'token-name',
-  standalone: true,
   template: `
     <code>{{name()}}</code>
     <button

--- a/material.angular.io/src/app/pages/guide-viewer/guide-viewer.ts
+++ b/material.angular.io/src/app/pages/guide-viewer/guide-viewer.ts
@@ -12,7 +12,6 @@ import {DocViewer} from '../../shared/doc-viewer/doc-viewer';
   selector: 'guide-viewer',
   templateUrl: './guide-viewer.html',
   styleUrls: ['./guide-viewer.scss'],
-  standalone: true,
   imports: [DocViewer, NavigationFocus, TableOfContents, Footer],
   host: {
     'class': 'main-content',

--- a/material.angular.io/src/app/pages/homepage/homepage.ts
+++ b/material.angular.io/src/app/pages/homepage/homepage.ts
@@ -22,7 +22,6 @@ const TOP_COMPONENTS = ['datepicker', 'input', 'slide-toggle', 'slider', 'button
   selector: 'app-homepage',
   templateUrl: './homepage.html',
   styleUrls: ['./homepage.scss'],
-  standalone: true,
   imports: [
     NavigationFocus,
     MatAnchor,

--- a/material.angular.io/src/app/pages/not-found/not-found.ts
+++ b/material.angular.io/src/app/pages/not-found/not-found.ts
@@ -7,7 +7,6 @@ import {RouterLink} from '@angular/router';
   selector: 'app-not-found',
   templateUrl: './not-found.html',
   styleUrls: ['./not-found.scss'],
-  standalone: true,
   imports: [MatAnchor, RouterLink, Footer],
   host: {
     'class': 'main-content',

--- a/material.angular.io/src/app/shared/carousel/carousel.spec.ts
+++ b/material.angular.io/src/app/shared/carousel/carousel.spec.ts
@@ -60,7 +60,6 @@ describe('HorizontalCarousel', () => {
     }
   `,
   ],
-  standalone: true,
   imports: [Carousel, CarouselItem],
 })
 class CarouselTestComponent {

--- a/material.angular.io/src/app/shared/carousel/carousel.ts
+++ b/material.angular.io/src/app/shared/carousel/carousel.ts
@@ -37,7 +37,6 @@ export class CarouselItem implements FocusableOption {
   templateUrl: './carousel.html',
   styleUrls: ['./carousel.scss'],
   encapsulation: ViewEncapsulation.None,
-  standalone: true,
   imports: [MatIconButton, MatIcon],
   host: {
     '[class.animations-disabled]': 'animationsDisabled',

--- a/material.angular.io/src/app/shared/doc-viewer/deprecated-tooltip.ts
+++ b/material.angular.io/src/app/shared/doc-viewer/deprecated-tooltip.ts
@@ -27,7 +27,6 @@ import {MatTooltip} from '@angular/material/tooltip';
   template: `<div class="deprecated-content"
     [matTooltip]="message">
   </div>`,
-  standalone: true,
   imports: [MatTooltip],
 })
 export class DeprecatedFieldComponent {

--- a/material.angular.io/src/app/shared/doc-viewer/doc-viewer.spec.ts
+++ b/material.angular.io/src/app/shared/doc-viewer/doc-viewer.spec.ts
@@ -213,7 +213,6 @@ describe('DocViewer', () => {
 @Component({
   selector: 'test',
   template: `<doc-viewer [document]="documentUrl"></doc-viewer>`,
-  standalone: true,
   imports: [DocViewer],
 })
 class DocViewerTestComponent {
@@ -265,14 +264,12 @@ const FAKE_DOCS: {[key: string]: string} = {
 
 @Component({
   template: `TEST_COMPONENT_GUIDE`,
-  standalone: true,
 })
 class TestComponent {}
 
 @Component({
   selector: 'test',
   template: `<doc-viewer [document]="component"></doc-viewer>`,
-  standalone: true,
   imports: [DocViewer, TestComponent],
 })
 class DocViewerWithCompTestComponent {

--- a/material.angular.io/src/app/shared/doc-viewer/header-link.ts
+++ b/material.angular.io/src/app/shared/doc-viewer/header-link.ts
@@ -23,7 +23,6 @@ import {MatIcon} from '@angular/material/icon';
       <mat-icon>link</mat-icon>
     </a>
   `,
-  standalone: true,
   imports: [MatIcon],
 })
 export class HeaderLink {

--- a/material.angular.io/src/app/shared/doc-viewer/module-import-copy-button.ts
+++ b/material.angular.io/src/app/shared/doc-viewer/module-import-copy-button.ts
@@ -16,7 +16,6 @@ import {Clipboard} from '@angular/cdk/clipboard';
   (click)="copy()">
   <mat-icon>content_copy</mat-icon>
 </button>`,
-  standalone: true,
   imports: [MatIconButton, MatIcon, MatTooltip],
 })
 export class ModuleImportCopyButton {

--- a/material.angular.io/src/app/shared/example-viewer/code-snippet.ts
+++ b/material.angular.io/src/app/shared/example-viewer/code-snippet.ts
@@ -6,7 +6,6 @@ import {DocViewer} from '../doc-viewer/doc-viewer';
   templateUrl: './code-snippet.html',
   styleUrls: ['./example-viewer.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  standalone: true,
   imports: [forwardRef(() => DocViewer)],
 })
 export class CodeSnippet {

--- a/material.angular.io/src/app/shared/footer/footer.ts
+++ b/material.angular.io/src/app/shared/footer/footer.ts
@@ -6,7 +6,6 @@ import {AppLogo} from '../logo/logo';
   templateUrl: './footer.html',
   styleUrls: ['./footer.scss'],
   imports: [AppLogo],
-  standalone: true,
 })
 export class Footer {
   year = new Date().getFullYear();

--- a/material.angular.io/src/app/shared/logo/logo.ts
+++ b/material.angular.io/src/app/shared/logo/logo.ts
@@ -4,7 +4,6 @@ import {Component, HostBinding} from '@angular/core';
   selector: 'app-logo',
   styleUrl: 'logo.scss',
   templateUrl: './logo.html',
-  standalone: true,
 })
 export class AppLogo {
   @HostBinding('attr.aria-hidden')

--- a/material.angular.io/src/app/shared/navbar/navbar.ts
+++ b/material.angular.io/src/app/shared/navbar/navbar.ts
@@ -16,7 +16,6 @@ const SECTIONS_KEYS = Object.keys(SECTIONS);
   selector: 'app-navbar',
   templateUrl: './navbar.html',
   styleUrls: ['./navbar.scss'],
-  standalone: true,
   imports: [
     MatAnchor,
     RouterLink,

--- a/material.angular.io/src/app/shared/navigation-focus/navigation-focus.ts
+++ b/material.angular.io/src/app/shared/navigation-focus/navigation-focus.ts
@@ -4,7 +4,6 @@ import {NavigationFocusService} from './navigation-focus.service';
 let uid = 0;
 @Directive({
   selector: '[focusOnNavigation]',
-  standalone: true,
 })
 export class NavigationFocus implements OnDestroy {
   private el = inject(ElementRef);

--- a/material.angular.io/src/app/shared/stack-blitz/stack-blitz-button.ts
+++ b/material.angular.io/src/app/shared/stack-blitz/stack-blitz-button.ts
@@ -9,7 +9,6 @@ import {MatSnackBar} from '@angular/material/snack-bar';
 @Component({
   selector: 'stack-blitz-button',
   templateUrl: './stack-blitz-button.html',
-  standalone: true,
   imports: [MatIconButton, MatTooltip, MatIcon],
 })
 export class StackBlitzButton {

--- a/material.angular.io/src/app/shared/support/support.ts
+++ b/material.angular.io/src/app/shared/support/support.ts
@@ -5,7 +5,6 @@ import {AppLogo} from '../logo/logo';
   selector: 'app-support',
   templateUrl: './support.html',
   styleUrls: ['./support.scss'],
-  standalone: true,
   imports: [AppLogo],
 })
 export class Support {}

--- a/material.angular.io/src/app/shared/svg-viewer/svg-viewer.ts
+++ b/material.angular.io/src/app/shared/svg-viewer/svg-viewer.ts
@@ -4,7 +4,6 @@ import {Component, ElementRef, Input, OnInit, inject} from '@angular/core';
 @Component({
   selector: 'docs-svg-viewer',
   template: '<div class="docs-svg-viewer" aria-hidden="true"></div>',
-  standalone: true,
 })
 export class SvgViewer implements OnInit {
   private elementRef = inject(ElementRef);

--- a/material.angular.io/src/app/shared/table-of-contents/table-of-contents.ts
+++ b/material.angular.io/src/app/shared/table-of-contents/table-of-contents.ts
@@ -41,7 +41,6 @@ interface Link {
   selector: 'table-of-contents',
   styleUrls: ['./table-of-contents.scss'],
   templateUrl: './table-of-contents.html',
-  standalone: true,
 })
 export class TableOfContents implements OnInit, AfterViewInit, OnDestroy {
   private _router = inject(Router);


### PR DESCRIPTION
Removes the `standalone: true` flags from the docs site since it's not necessary anymore.