### PR TITLE
test(multiple): remove animations module from tests

### DIFF
--- a/src/cdk/accordion/accordion-item.spec.ts
+++ b/src/cdk/accordion/accordion-item.spec.ts
@@ -1,19 +1,12 @@
 import {waitForAsync, TestBed, ComponentFixture} from '@angular/core/testing';
 import {Component} from '@angular/core';
 import {By} from '@angular/platform-browser';
-import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {CdkAccordionModule, CdkAccordionItem} from './public-api';
 
 describe('CdkAccordionItem', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [
-        BrowserAnimationsModule,
-        CdkAccordionModule,
-        SingleItem,
-        ItemGroupWithoutAccordion,
-        ItemGroupWithAccordion,
-      ],
+      imports: [CdkAccordionModule, SingleItem, ItemGroupWithoutAccordion, ItemGroupWithAccordion],
     });
   }));
 

--- a/src/cdk/accordion/accordion.spec.ts
+++ b/src/cdk/accordion/accordion.spec.ts
@@ -1,7 +1,6 @@
 import {waitForAsync, TestBed} from '@angular/core/testing';
 import {Component, QueryList, ViewChild, ViewChildren} from '@angular/core';
 import {By} from '@angular/platform-browser';
-import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {CdkAccordion} from './accordion';
 import {CdkAccordionItem} from './accordion-item';
 import {CdkAccordionModule} from './accordion-module';
@@ -9,7 +8,7 @@ import {CdkAccordionModule} from './accordion-module';
 describe('CdkAccordion', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [BrowserAnimationsModule, CdkAccordionModule, SetOfItems, NestedItems],
+      imports: [CdkAccordionModule, SetOfItems, NestedItems],
     });
   }));
 

--- a/src/material/chips/chip-grid.spec.ts
+++ b/src/material/chips/chip-grid.spec.ts
@@ -37,8 +37,8 @@ import {FormControl, FormsModule, NgForm, ReactiveFormsModule, Validators} from 
 import {MatFormFieldModule} from '@angular/material/form-field';
 import {MatInputModule} from '@angular/material/input';
 import {By} from '@angular/platform-browser';
-import {BrowserAnimationsModule, NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {MatChipEvent, MatChipGrid, MatChipInputEvent, MatChipRow, MatChipsModule} from './index';
+import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 
 describe('MatChipGrid', () => {
   let chipGridDebugElement: DebugElement;
@@ -339,7 +339,7 @@ describe('MatChipGrid', () => {
         let fixture: ComponentFixture<StandardChipGrid>;
 
         beforeEach(() => {
-          fixture = createComponent(StandardChipGrid, undefined, 'rtl');
+          fixture = createComponent(StandardChipGrid, 'rtl');
         });
 
         it('should focus previous column when press RIGHT ARROW', () => {
@@ -1015,9 +1015,6 @@ describe('MatChipGrid', () => {
 
   function createComponent<T>(
     component: Type<T>,
-    animationsModule:
-      | Type<NoopAnimationsModule>
-      | Type<BrowserAnimationsModule> = NoopAnimationsModule,
     direction: Direction = 'ltr',
   ): ComponentFixture<T> {
     directionality = {
@@ -1032,7 +1029,7 @@ describe('MatChipGrid', () => {
         MatChipsModule,
         MatFormFieldModule,
         MatInputModule,
-        animationsModule,
+        NoopAnimationsModule,
       ],
       providers: [{provide: Directionality, useValue: directionality}],
       declarations: [component],

--- a/src/material/dialog/dialog.spec.ts
+++ b/src/material/dialog/dialog.spec.ts
@@ -38,7 +38,7 @@ import {
   tick,
 } from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
-import {BrowserAnimationsModule, NoopAnimationsModule} from '@angular/platform-browser/animations';
+import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {Subject} from 'rxjs';
 import {CLOSE_ANIMATION_DURATION, OPEN_ANIMATION_DURATION} from './dialog-container';
 import {
@@ -2043,12 +2043,7 @@ describe('MatDialog with animations enabled', () => {
 
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
-      imports: [
-        MatDialogModule,
-        BrowserAnimationsModule,
-        ComponentWithChildViewContainer,
-        DirectiveWithViewContainer,
-      ],
+      imports: [MatDialogModule, ComponentWithChildViewContainer, DirectiveWithViewContainer],
     });
 
     dialog = TestBed.inject(MatDialog);
@@ -2102,7 +2097,7 @@ describe('MatDialog with explicit injector provided', () => {
 
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
-      imports: [MatDialogModule, BrowserAnimationsModule, ModuleBoundDialogParentComponent],
+      imports: [MatDialogModule, ModuleBoundDialogParentComponent],
     });
 
     overlayContainerElement = TestBed.inject(OverlayContainer).getContainerElement();

--- a/src/material/expansion/accordion.spec.ts
+++ b/src/material/expansion/accordion.spec.ts
@@ -8,7 +8,6 @@ import {
 import {Component, QueryList, ViewChild, ViewChildren} from '@angular/core';
 import {TestBed, inject, waitForAsync} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
-import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {
   MatAccordion,
   MatExpansionModule,
@@ -22,7 +21,6 @@ describe('MatAccordion', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [
-        BrowserAnimationsModule,
         MatExpansionModule,
         AccordionWithHideToggle,
         AccordionWithTogglePosition,

--- a/src/material/input/input.spec.ts
+++ b/src/material/input/input.spec.ts
@@ -36,7 +36,6 @@ import {
 } from '@angular/material/form-field';
 import {MatIconModule} from '@angular/material/icon';
 import {By} from '@angular/platform-browser';
-import {BrowserAnimationsModule, NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {MAT_INPUT_VALUE_ACCESSOR, MatInput, MatInputModule} from './index';
 
 describe('MatMdcInput without forms', () => {
@@ -1656,17 +1655,15 @@ function configureTestingModule(
     providers?: Provider[];
     imports?: any[];
     declarations?: any[];
-    animations?: boolean;
   } = {},
 ) {
-  const {providers = [], imports = [], declarations = [], animations = true} = options;
+  const {providers = [], imports = [], declarations = []} = options;
   TestBed.configureTestingModule({
     imports: [
       FormsModule,
       MatFormFieldModule,
       MatIconModule,
       MatInputModule,
-      animations ? BrowserAnimationsModule : NoopAnimationsModule,
       ReactiveFormsModule,
       ...imports,
     ],

--- a/src/material/sidenav/drawer.spec.ts
+++ b/src/material/sidenav/drawer.spec.ts
@@ -18,7 +18,7 @@ import {
   waitForAsync,
 } from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
-import {BrowserAnimationsModule, NoopAnimationsModule} from '@angular/platform-browser/animations';
+import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {MatDrawer, MatDrawerContainer, MatSidenavModule} from './index';
 
 describe('MatDrawer', () => {
@@ -517,14 +517,12 @@ describe('MatDrawer', () => {
 
     it('should not throw when a two-way binding is toggled quickly while animating', fakeAsync(() => {
       TestBed.resetTestingModule().configureTestingModule({
-        imports: [MatSidenavModule, BrowserAnimationsModule, DrawerOpenBinding],
+        imports: [MatSidenavModule, DrawerOpenBinding],
       });
 
       const fixture = TestBed.createComponent(DrawerOpenBinding);
       fixture.detectChanges();
 
-      // Note that we need actual timeouts and the `BrowserAnimationsModule`
-      // in order to test it correctly.
       setTimeout(() => {
         fixture.componentInstance.isOpen = !fixture.componentInstance.isOpen;
         fixture.changeDetectorRef.markForCheck();
@@ -1019,7 +1017,7 @@ describe('MatDrawerContainer', () => {
 
   it('should not animate when the sidenav is open on load', fakeAsync(() => {
     TestBed.resetTestingModule().configureTestingModule({
-      imports: [MatSidenavModule, BrowserAnimationsModule, DrawerSetToOpenedTrue],
+      imports: [MatSidenavModule, DrawerSetToOpenedTrue],
     });
 
     const fixture = TestBed.createComponent(DrawerSetToOpenedTrue);

--- a/src/material/tabs/tab-group.spec.ts
+++ b/src/material/tabs/tab-group.spec.ts
@@ -11,7 +11,7 @@ import {
   waitForAsync,
 } from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
-import {BrowserAnimationsModule, NoopAnimationsModule} from '@angular/platform-browser/animations';
+import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {Observable} from 'rxjs';
 import {
   MAT_TABS_CONFIG,
@@ -1026,12 +1026,7 @@ describe('MatTabGroup', () => {
 describe('nested MatTabGroup with enabled animations', () => {
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
-      imports: [
-        MatTabsModule,
-        BrowserAnimationsModule,
-        NestedTabs,
-        TabsWithCustomAnimationDuration,
-      ],
+      imports: [MatTabsModule, NestedTabs, TabsWithCustomAnimationDuration],
     });
   }));
 
@@ -1066,7 +1061,7 @@ describe('MatTabGroup with ink bar fit to content', () => {
 
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
-      imports: [MatTabsModule, BrowserAnimationsModule, TabGroupWithInkBarFitToContent],
+      imports: [MatTabsModule, TabGroupWithInkBarFitToContent],
     });
   }));
 
@@ -1108,7 +1103,7 @@ describe('MatTabNavBar with a default config', () => {
 
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
-      imports: [MatTabsModule, BrowserAnimationsModule, SimpleTabsTestApp],
+      imports: [MatTabsModule, SimpleTabsTestApp],
       providers: [
         {
           provide: MAT_TABS_CONFIG,
@@ -1139,7 +1134,7 @@ describe('MatTabNavBar with a default config', () => {
 describe('MatTabGroup labels aligned with a config', () => {
   it('should work with start align', () => {
     const fixture = TestBed.configureTestingModule({
-      imports: [MatTabsModule, BrowserAnimationsModule, TabsWithAlignConfig],
+      imports: [MatTabsModule, TabsWithAlignConfig],
       providers: [
         {
           provide: MAT_TABS_CONFIG,
@@ -1155,7 +1150,7 @@ describe('MatTabGroup labels aligned with a config', () => {
 
   it('should work with center align', () => {
     const fixture = TestBed.configureTestingModule({
-      imports: [MatTabsModule, BrowserAnimationsModule, TabsWithAlignConfig],
+      imports: [MatTabsModule, TabsWithAlignConfig],
       providers: [
         {
           provide: MAT_TABS_CONFIG,
@@ -1171,7 +1166,7 @@ describe('MatTabGroup labels aligned with a config', () => {
 
   it('should work with end align', () => {
     const fixture = TestBed.configureTestingModule({
-      imports: [MatTabsModule, BrowserAnimationsModule, TabsWithAlignConfig],
+      imports: [MatTabsModule, TabsWithAlignConfig],
       providers: [
         {
           provide: MAT_TABS_CONFIG,
@@ -1187,7 +1182,7 @@ describe('MatTabGroup labels aligned with a config', () => {
 
   it('should not add align if default config doesnt set align', () => {
     const fixture = TestBed.configureTestingModule({
-      imports: [MatTabsModule, BrowserAnimationsModule, TabsWithAlignConfig],
+      imports: [MatTabsModule, TabsWithAlignConfig],
     }).createComponent(TabsWithAlignConfig);
     fixture.detectChanges();
 
@@ -1206,7 +1201,7 @@ describe('MatTabGroup labels aligned with a config', () => {
 
   it('should not break if config sets align on already aligned tabs', () => {
     const fixture = TestBed.configureTestingModule({
-      imports: [MatTabsModule, BrowserAnimationsModule, TabsWithAlignCenter],
+      imports: [MatTabsModule, TabsWithAlignCenter],
       providers: [{provide: MAT_TABS_CONFIG, useValue: {alignTabs: 'end'}}],
     }).createComponent(TabsWithAlignCenter);
     fixture.detectChanges();

--- a/src/material/tabs/tab-nav-bar/tab-nav-bar.spec.ts
+++ b/src/material/tabs/tab-nav-bar/tab-nav-bar.spec.ts
@@ -10,7 +10,6 @@ import {Component, QueryList, ViewChild, ViewChildren} from '@angular/core';
 import {ComponentFixture, TestBed, fakeAsync, tick, waitForAsync} from '@angular/core/testing';
 import {MAT_RIPPLE_GLOBAL_OPTIONS, RippleGlobalOptions} from '@angular/material/core';
 import {By} from '@angular/platform-browser';
-import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {Subject} from 'rxjs';
 import {MAT_TABS_CONFIG} from '../index';
 import {MatTabsModule} from '../module';
@@ -512,7 +511,7 @@ describe('MatTabNavBar with a default config', () => {
 
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
-      imports: [MatTabsModule, BrowserAnimationsModule, TabLinkWithNgIf],
+      imports: [MatTabsModule, TabLinkWithNgIf],
       providers: [{provide: MAT_TABS_CONFIG, useValue: {fitInkBarToContent: true}}],
     });
   }));
@@ -534,7 +533,7 @@ describe('MatTabNavBar with a default config', () => {
 describe('MatTabNavBar with enabled animations', () => {
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
-      imports: [MatTabsModule, BrowserAnimationsModule, TabsWithCustomAnimationDuration],
+      imports: [MatTabsModule, TabsWithCustomAnimationDuration],
     });
   }));
 


### PR DESCRIPTION
Removes the `BrowserAnimationsModule` from all of our unit tests.