### PR TITLE
fix(material/tooltip): regression when injecting ViewContainerRef

### DIFF
--- a/src/material/tooltip/tooltip.ts
+++ b/src/material/tooltip/tooltip.ts
@@ -194,6 +194,7 @@ export class MatTooltip implements OnDestroy, AfterViewInit {
   private _focusMonitor = inject(FocusMonitor);
   protected _dir = inject(Directionality);
   private _injector = inject(Injector);
+  private _viewContainerRef = inject(ViewContainerRef);
   private _defaultOptions = inject<MatTooltipDefaultOptions>(MAT_TOOLTIP_DEFAULT_OPTIONS, {
     optional: true,
   });
@@ -455,8 +456,7 @@ export class MatTooltip implements OnDestroy, AfterViewInit {
     const overlayRef = this._createOverlay(origin);
     this._detach();
     this._portal =
-      this._portal ||
-      new ComponentPortal(this._tooltipComponent, this._injector.get(ViewContainerRef));
+      this._portal || new ComponentPortal(this._tooltipComponent, this._viewContainerRef);
     const instance = (this._tooltipInstance = overlayRef.attach(this._portal).instance);
     instance._triggerElement = this._elementRef.nativeElement;
     instance._mouseLeaveHideDelay = this._hideDelay;


### PR DESCRIPTION
#30440 deferred the injection of some dependencies in the tooltip, including `ViewContainerRef`. This is problematic, because the act of injecting `ViewContainerRef` changes the shape of some internal data structures in the framework's runtime. As a result, hovering over a tooltip that has been hydrated will throw a runtime error because the structure from the server no longer matches the structure on the client.

Fixes #30498.