### PR TITLE
fix(cdk/drag-drop): incorrect type DragConstrainPosition

### DIFF
--- a/src/cdk/drag-drop/directives/config.ts
+++ b/src/cdk/drag-drop/directives/config.ts
@@ -7,21 +7,13 @@
  */
 
 import {InjectionToken} from '@angular/core';
-import {DragRefConfig, Point, DragRef} from '../drag-ref';
+import {DragRefConfig, DragConstrainPosition} from '../drag-ref';
 
 /** Possible values that can be used to configure the drag start delay. */
 export type DragStartDelay = number | {touch: number; mouse: number};
 
 /** Possible axis along which dragging can be locked. */
 export type DragAxis = 'x' | 'y';
-
-/** Function that can be used to constrain the position of a dragged element. */
-export type DragConstrainPosition = (
-  userPointerPosition: Point,
-  dragRef: DragRef,
-  dimensions: DOMRect,
-  pickupPositionInElement: Point,
-) => Point;
 
 /** Possible orientations for a drop list. */
 export type DropListOrientation = 'horizontal' | 'vertical' | 'mixed';

--- a/src/cdk/drag-drop/directives/config.ts
+++ b/src/cdk/drag-drop/directives/config.ts
@@ -16,7 +16,12 @@ export type DragStartDelay = number | {touch: number; mouse: number};
 export type DragAxis = 'x' | 'y';
 
 /** Function that can be used to constrain the position of a dragged element. */
-export type DragConstrainPosition = (point: Point, dragRef: DragRef) => Point;
+export type DragConstrainPosition = (
+  userPointerPosition: Point,
+  dragRef: DragRef,
+  dimensions: DOMRect,
+  pickupPositionInElement: Point,
+) => Point;
 
 /** Possible orientations for a drop list. */
 export type DropListOrientation = 'horizontal' | 'vertical' | 'mixed';

--- a/src/cdk/drag-drop/directives/drag.ts
+++ b/src/cdk/drag-drop/directives/drag.ts
@@ -43,16 +43,10 @@ import {CDK_DRAG_HANDLE, CdkDragHandle} from './drag-handle';
 import {CdkDragPlaceholder} from './drag-placeholder';
 import {CdkDragPreview} from './drag-preview';
 import {CDK_DRAG_PARENT} from '../drag-parent';
-import {DragRef, Point, PreviewContainer} from '../drag-ref';
+import {DragRef, Point, PreviewContainer, DragConstrainPosition} from '../drag-ref';
 import type {CdkDropList} from './drop-list';
 import {DragDrop} from '../drag-drop';
-import {
-  CDK_DRAG_CONFIG,
-  DragDropConfig,
-  DragStartDelay,
-  DragAxis,
-  DragConstrainPosition,
-} from './config';
+import {CDK_DRAG_CONFIG, DragDropConfig, DragStartDelay, DragAxis} from './config';
 import {assertElementNode} from './assertions';
 import {DragDropRegistry} from '../drag-drop-registry';
 

--- a/src/cdk/drag-drop/directives/drag.ts
+++ b/src/cdk/drag-drop/directives/drag.ts
@@ -46,7 +46,13 @@ import {CDK_DRAG_PARENT} from '../drag-parent';
 import {DragRef, Point, PreviewContainer} from '../drag-ref';
 import type {CdkDropList} from './drop-list';
 import {DragDrop} from '../drag-drop';
-import {CDK_DRAG_CONFIG, DragDropConfig, DragStartDelay, DragAxis} from './config';
+import {
+  CDK_DRAG_CONFIG,
+  DragDropConfig,
+  DragStartDelay,
+  DragAxis,
+  DragConstrainPosition,
+} from './config';
 import {assertElementNode} from './assertions';
 import {DragDropRegistry} from '../drag-drop-registry';
 
@@ -137,12 +143,7 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
    * of the user's pointer on the page, a reference to the item being dragged and its dimensions.
    * Should return a point describing where the item should be rendered.
    */
-  @Input('cdkDragConstrainPosition') constrainPosition?: (
-    userPointerPosition: Point,
-    dragRef: DragRef,
-    dimensions: DOMRect,
-    pickupPositionInElement: Point,
-  ) => Point;
+  @Input('cdkDragConstrainPosition') constrainPosition?: DragConstrainPosition;
 
   /** Class to be added to the preview element. */
   @Input('cdkDragPreviewClass') previewClass: string | string[];

--- a/src/cdk/drag-drop/drag-ref.ts
+++ b/src/cdk/drag-drop/drag-ref.ts
@@ -35,6 +35,7 @@ import {
 import {DragDropRegistry} from './drag-drop-registry';
 import type {DropListRef} from './drop-list-ref';
 import {DragPreviewTemplate, PreviewRef} from './preview-ref';
+import {DragConstrainPosition} from './directives/config';
 
 /** Object that can be used to configure the behavior of DragRef. */
 export interface DragRefConfig {
@@ -364,12 +365,7 @@ export class DragRef<T = any> {
    * of the user's pointer on the page, a reference to the item being dragged and its dimensions.
    * Should return a point describing where the item should be rendered.
    */
-  constrainPosition?: (
-    userPointerPosition: Point,
-    dragRef: DragRef,
-    dimensions: DOMRect,
-    pickupPositionInElement: Point,
-  ) => Point;
+  constrainPosition?: DragConstrainPosition;
 
   constructor(
     element: ElementRef<HTMLElement> | HTMLElement,

--- a/src/cdk/drag-drop/drag-ref.ts
+++ b/src/cdk/drag-drop/drag-ref.ts
@@ -35,7 +35,6 @@ import {
 import {DragDropRegistry} from './drag-drop-registry';
 import type {DropListRef} from './drop-list-ref';
 import {DragPreviewTemplate, PreviewRef} from './preview-ref';
-import {DragConstrainPosition} from './directives/config';
 
 /** Object that can be used to configure the behavior of DragRef. */
 export interface DragRefConfig {
@@ -57,6 +56,14 @@ export interface DragRefConfig {
   /** Ref that the current drag item is nested in. */
   parentDragRef?: DragRef;
 }
+
+/** Function that can be used to constrain the position of a dragged element. */
+export type DragConstrainPosition = (
+  userPointerPosition: Point,
+  dragRef: DragRef,
+  dimensions: DOMRect,
+  pickupPositionInElement: Point,
+) => Point;
 
 /** Options that can be used to bind a passive event listener. */
 const passiveEventListenerOptions = {passive: true};

--- a/src/cdk/drag-drop/public-api.ts
+++ b/src/cdk/drag-drop/public-api.ts
@@ -7,7 +7,7 @@
  */
 
 export {DragDrop} from './drag-drop';
-export {DragRef, DragRefConfig, Point, PreviewContainer} from './drag-ref';
+export {DragRef, DragRefConfig, Point, PreviewContainer, DragConstrainPosition} from './drag-ref';
 export {DropListRef} from './drop-list-ref';
 export {CDK_DRAG_PARENT} from './drag-parent';
 

--- a/tools/public_api_guard/cdk/drag-drop.md
+++ b/tools/public_api_guard/cdk/drag-drop.md
@@ -381,7 +381,7 @@ export class DragDropRegistry<_ = unknown, __ = unknown> implements OnDestroy {
 export class DragRef<T = any> {
     constructor(element: ElementRef<HTMLElement> | HTMLElement, _config: DragRefConfig, _document: Document, _ngZone: NgZone, _viewportRuler: ViewportRuler, _dragDropRegistry: DragDropRegistry, _renderer: Renderer2);
     readonly beforeStarted: Subject<void>;
-    constrainPosition?: (userPointerPosition: Point, dragRef: DragRef, dimensions: DOMRect, pickupPositionInElement: Point) => Point;
+    constrainPosition?: DragConstrainPosition;
     data: T;
     get disabled(): boolean;
     set disabled(value: boolean);

--- a/tools/public_api_guard/cdk/drag-drop.md
+++ b/tools/public_api_guard/cdk/drag-drop.md
@@ -300,7 +300,7 @@ export function copyArrayItem<T = any>(currentArray: T[], targetArray: T[], curr
 export type DragAxis = 'x' | 'y';
 
 // @public
-export type DragConstrainPosition = (point: Point, dragRef: DragRef) => Point;
+export type DragConstrainPosition = (userPointerPosition: Point, dragRef: DragRef, dimensions: DOMRect, pickupPositionInElement: Point) => Point;
 
 // @public
 export class DragDrop {

--- a/tools/public_api_guard/cdk/drag-drop.md
+++ b/tools/public_api_guard/cdk/drag-drop.md
@@ -50,7 +50,7 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
     // (undocumented)
     _addHandle(handle: CdkDragHandle): void;
     boundaryElement: string | ElementRef<HTMLElement> | HTMLElement;
-    constrainPosition?: (userPointerPosition: Point, dragRef: DragRef, dimensions: DOMRect, pickupPositionInElement: Point) => Point;
+    constrainPosition?: DragConstrainPosition;
     data: T;
     get disabled(): boolean;
     set disabled(value: boolean);


### PR DESCRIPTION
Fixes type DragConstrainPosition, which of сorrect configuration of CdkDrag  is not possible when using in providers

Fixes #30509