### PR TITLE
fix(material/checkbox): ensure native control receives clicks

### DIFF
--- a/src/material/checkbox/_checkbox-common.scss
+++ b/src/material/checkbox/_checkbox-common.scss
@@ -49,6 +49,7 @@ $_fallback-size: 40px;
       padding: 0;
       opacity: 0;
       cursor: inherit;
+      z-index: 1;
 
       @include token-utils.use-tokens($prefix, $slots) {
         $layer-size: token-utils.get-token-variable(state-layer-size, $fallback: $_fallback-size);


### PR DESCRIPTION
The `input` element inside the checkbox was stacked under some other elements which might prevent clicks. These changes ensure it's stacked on top.

Fixes #30494.