### PR TITLE
fix(material/select): added ecs click handling in host keydown

### DIFF
--- a/src/material/select/select.ts
+++ b/src/material/select/select.ts
@@ -1033,6 +1033,10 @@ export class MatSelect
           hasDeselectedOptions ? option.select() : option.deselect();
         }
       });
+    } else if (event.keyCode === ESCAPE && !hasModifierKey(event)) {
+      event.stopPropagation();
+      event.preventDefault();
+      this.close();
     } else {
       const previouslyFocusedIndex = manager.activeItemIndex;
 


### PR DESCRIPTION
The esc button was processed only in the overlay, which led to the container not closing in sidenav.

Fixes #30507