### PR TITLE
fix(google-maps): update right-click event to use contextmenu for Adv…

### DIFF
--- a/src/google-maps/map-advanced-marker/map-advanced-marker.spec.ts
+++ b/src/google-maps/map-advanced-marker/map-advanced-marker.spec.ts
@@ -131,7 +131,7 @@ describe('MapAdvancedMarker', () => {
     expect(addSpy).toHaveBeenCalledWith('mouseout', jasmine.any(Function));
     expect(addSpy).toHaveBeenCalledWith('mouseover', jasmine.any(Function));
     expect(addSpy).toHaveBeenCalledWith('mouseup', jasmine.any(Function));
-    expect(addSpy).toHaveBeenCalledWith('rightclick', jasmine.any(Function));
+    expect(addSpy).toHaveBeenCalledWith('contextmenu', jasmine.any(Function));
     expect(addSpy).not.toHaveBeenCalledWith('drag', jasmine.any(Function));
     expect(addSpy).not.toHaveBeenCalledWith('dragend', jasmine.any(Function));
     expect(addSpy).not.toHaveBeenCalledWith('dragstart', jasmine.any(Function));

--- a/src/google-maps/map-advanced-marker/map-advanced-marker.ts
+++ b/src/google-maps/map-advanced-marker/map-advanced-marker.ts
@@ -163,7 +163,7 @@ export class MapAdvancedMarker
    * This event is fired when the AdvancedMarkerElement is right-clicked.
    */
   @Output() readonly mapRightclick: Observable<google.maps.MapMouseEvent> =
-    this._eventManager.getLazyEmitter<google.maps.MapMouseEvent>('rightclick');
+    this._eventManager.getLazyEmitter<google.maps.MapMouseEvent>('contextmenu');
 
   /**
    * This event is repeatedly fired while the user drags the AdvancedMarkerElement.


### PR DESCRIPTION
'rightclick' never triggers on advanced marker elements. nor within on gmp-click, as right-click events have been disabled for some reason on advanced markers within JS Maps.

This assumes that contextmenu is being opened via right clicking of a mouse, which is 99% of use cases. We can rename the emitter as well if deemed necessary to truly fit context, but I wanted to maintain backwards compatibility with <map-marker> and uniformity between the two.