### PR TITLE
fix(material/datepicker): changed after checked error when assigning end value

### DIFF
--- a/src/material/datepicker/date-range-input-parts.ts
+++ b/src/material/datepicker/date-range-input-parts.ts
@@ -193,6 +193,12 @@ abstract class MatDateRangeInputPartBase<D>
     opposite?._validatorOnChange();
   }
 
+  protected override _formatValue(value: D | null) {
+    super._formatValue(value);
+    // Any time the input value is reformatted we need to tell the parent.
+    this._rangeInput._handleChildValueChange();
+  }
+
   /** return the ARIA accessible name of the input element */
   _getAccessibleName(): string {
     return _computeAriaAccessibleName(this._elementRef.nativeElement);
@@ -264,14 +270,8 @@ export class MatStartDate<D> extends MatDateRangeInputPartBase<D> {
     if (this._model) {
       const range = new DateRange(value, this._model.selection.end);
       this._model.updateSelection(range, this);
+      this._rangeInput._handleChildValueChange();
     }
-  }
-
-  protected override _formatValue(value: D | null) {
-    super._formatValue(value);
-
-    // Any time the input value is reformatted we need to tell the parent.
-    this._rangeInput._handleChildValueChange();
   }
 
   override _onKeydown(event: KeyboardEvent) {

--- a/tools/public_api_guard/material/datepicker.md
+++ b/tools/public_api_guard/material/datepicker.md
@@ -828,8 +828,6 @@ export class MatStartDate<D> extends MatDateRangeInputPartBase<D> {
     // (undocumented)
     protected _assignValueToModel(value: D | null): void;
     // (undocumented)
-    protected _formatValue(value: D | null): void;
-    // (undocumented)
     protected _getValueFromModel(modelValue: DateRange<D>): D | null;
     // (undocumented)
     _onKeydown(event: KeyboardEvent): void;


### PR DESCRIPTION
Fixes that there was a hidden "changed after checked" error in the range picker when the secondary value was being assinged without notifying Angular.

Fixes #30526.