### PR TITLE
fix(material/core): deprecate AnimationCurves and AnimationDurations

### DIFF
--- a/src/material/core/animation/animation.ts
+++ b/src/material/core/animation/animation.ts
@@ -6,7 +6,11 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-/** @docs-private */
+/**
+ * @deprecated No longer used, will be removed.
+ * @breaking-change 21.0.0
+ * @docs-private
+ */
 export class AnimationCurves {
   static STANDARD_CURVE = 'cubic-bezier(0.4,0.0,0.2,1)';
   static DECELERATION_CURVE = 'cubic-bezier(0.0,0.0,0.2,1)';
@@ -14,7 +18,11 @@ export class AnimationCurves {
   static SHARP_CURVE = 'cubic-bezier(0.4,0.0,0.6,1)';
 }
 
-/** @docs-private */
+/**
+ * @deprecated No longer used, will be removed.
+ * @breaking-change 21.0.0
+ * @docs-private
+ */
 export class AnimationDurations {
   static COMPLEX = '375ms';
   static ENTERING = '225ms';

--- a/tools/public_api_guard/material/core.md
+++ b/tools/public_api_guard/material/core.md
@@ -29,7 +29,7 @@ import { Signal } from '@angular/core';
 import { Subject } from 'rxjs';
 import { Version } from '@angular/core';
 
-// @public
+// @public @deprecated (undocumented)
 export class AnimationCurves {
     // (undocumented)
     static ACCELERATION_CURVE: string;
@@ -41,7 +41,7 @@ export class AnimationCurves {
     static STANDARD_CURVE: string;
 }
 
-// @public
+// @public @deprecated (undocumented)
 export class AnimationDurations {
     // (undocumented)
     static COMPLEX: string;


### PR DESCRIPTION
The `AnimationCurves` and `AnimationDurations` were exposed from `material/core`, because some Material components were using them to define JavaScript-based animations. That's no longer the case so they can be removed.