### PR TITLE
fix(google-maps): resolve mismatching types

### DIFF
--- a/src/google-maps/map-marker-clusterer/map-marker-clusterer-types.ts
+++ b/src/google-maps/map-marker-clusterer/map-marker-clusterer-types.ts
@@ -20,25 +20,15 @@ export interface ClusterOptions {
   markers?: Marker[];
 }
 
-export declare class Cluster {
+export interface Cluster {
   marker?: Marker;
   readonly markers?: Marker[];
-  protected _position: google.maps.LatLng;
-  constructor({markers, position}: ClusterOptions);
-  get bounds(): google.maps.LatLngBounds | undefined;
-  get position(): google.maps.LatLng;
-  /**
-   * Get the count of **visible** markers.
-   */
-  get count(): number;
-  /**
-   * Add a marker to the cluster.
-   */
+  bounds?: google.maps.LatLngBounds;
+  position: google.maps.LatLng;
+  count: number;
   push(marker: Marker): void;
-  /**
-   * Cleanup references and remove marker from map.
-   */
   delete(): void;
+  new (options: ClusterOptions): Cluster;
 }
 
 export declare class MarkerClusterer extends google.maps.OverlayView {
@@ -117,11 +107,11 @@ export interface Renderer {
   render(cluster: Cluster, stats: ClusterStats, map: google.maps.Map): Marker;
 }
 
-export declare class ClusterStats {
-  readonly markers: {
+export interface ClusterStats {
+  markers: {
     sum: number;
   };
-  readonly clusters: {
+  clusters: {
     count: number;
     markers: {
       mean: number;
@@ -130,7 +120,7 @@ export declare class ClusterStats {
       max: number;
     };
   };
-  constructor(markers: Marker[], clusters: Cluster[]);
+  new (markers: Marker[], clusters: Cluster[]): ClusterStats;
 }
 
 export interface Algorithm {

--- a/tools/public_api_guard/google-maps/google-maps.md
+++ b/tools/public_api_guard/google-maps/google-maps.md
@@ -49,20 +49,22 @@ export type AriaLabelFn = (text: string) => string;
 export type Calculator = (markers: google.maps.Marker[], clusterIconStylesCount: number) => ClusterIconInfo;
 
 // @public (undocumented)
-export class Cluster {
-    constructor({ markers, position }: ClusterOptions);
+export interface Cluster {
     // (undocumented)
-    get bounds(): google.maps.LatLngBounds | undefined;
-    get count(): number;
+    new (options: ClusterOptions): Cluster;
+    // (undocumented)
+    bounds?: google.maps.LatLngBounds;
+    // (undocumented)
+    count: number;
+    // (undocumented)
     delete(): void;
     // (undocumented)
     marker?: Marker;
     // (undocumented)
     readonly markers?: Marker[];
     // (undocumented)
-    get position(): google.maps.LatLng;
+    position: google.maps.LatLng;
     // (undocumented)
-    protected _position: google.maps.LatLng;
     push(marker: Marker): void;
 }
 
@@ -107,10 +109,11 @@ export interface ClusterOptions {
 }
 
 // @public (undocumented)
-export class ClusterStats {
-    constructor(markers: Marker[], clusters: Cluster[]);
+export interface ClusterStats {
     // (undocumented)
-    readonly clusters: {
+    new (markers: Marker[], clusters: Cluster[]): ClusterStats;
+    // (undocumented)
+    clusters: {
         count: number;
         markers: {
             mean: number;
@@ -120,7 +123,7 @@ export class ClusterStats {
         };
     };
     // (undocumented)
-    readonly markers: {
+    markers: {
         sum: number;
     };
 }


### PR DESCRIPTION
Due to some infrastructure issues, we can't import the real types for the marker clusterer. We work around it by copying some of them into the repository which has caused an issue where the external types no longer align with the internal ones. This change resolves the issue by converting a few classes to interfaces.

Fixes #30466.