### PR TITLE
docs: release notes for the v19.2.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+<a name="19.2.1"></a>
+# 19.2.1 "neptunite-neptune" (2025-02-26)
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="19.2.0"></a>
 # 19.2.0 "pyrite-pacifier" (2025-02-26)
 ### cdk


### PR DESCRIPTION
Cherry-picks the changelog from the "19.2.x" branch to the next branch (main).