### PR TITLE
fix(material/timepicker): unable to reopen if closed by scroll strategy

### DIFF
--- a/src/material/timepicker/BUILD.bazel
+++ b/src/material/timepicker/BUILD.bazel
@@ -54,12 +54,15 @@ ng_test_library(
     deps = [
         ":timepicker",
         "//src/cdk/keycodes",
+        "//src/cdk/overlay",
+        "//src/cdk/scrolling",
         "//src/cdk/testing/private",
         "//src/material/core",
         "//src/material/form-field",
         "//src/material/input",
         "@npm//@angular/forms",
         "@npm//@angular/platform-browser",
+        "@npm//rxjs",
     ],
 )
 

--- a/src/material/timepicker/timepicker.ts
+++ b/src/material/timepicker/timepicker.ts
@@ -70,7 +70,7 @@ export const MAT_TIMEPICKER_SCROLL_STRATEGY = new InjectionToken<() => ScrollStr
     providedIn: 'root',
     factory: () => {
       const overlay = inject(Overlay);
-      return () => overlay.scrollStrategies.reposition();
+      return () => overlay.scrollStrategies.close();
     },
   },
 );
@@ -340,10 +340,8 @@ export class MatTimepicker<D> implements OnDestroy, MatOptionParentComponent {
       hasBackdrop: false,
     });
 
-    this._overlayRef.keydownEvents().subscribe(event => {
-      this._handleKeydown(event);
-    });
-
+    this._overlayRef.detachments().subscribe(() => this.close());
+    this._overlayRef.keydownEvents().subscribe(event => this._handleKeydown(event));
     this._overlayRef.outsidePointerEvents().subscribe(event => {
       const target = _getEventTarget(event) as HTMLElement;
       const origin = this._input()?.getOverlayOrigin().nativeElement;


### PR DESCRIPTION
The timepicker wasn't updating its internal state when it gets closed through the overlay which meant that the user can't reopen it.

Fixes #30558.