### PR TITLE
fix(material/schematics): remove NoopAnimationsModule from generated tests

### DIFF
--- a/src/cdk/schematics/ng-generate/drag-drop/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.spec.ts.template
+++ b/src/cdk/schematics/ng-generate/drag-drop/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.spec.ts.template
@@ -10,7 +10,7 @@ describe('<%= classify(name) %>Component', () => {
     TestBed.configureTestingModule({
       declarations: [<%= classify(name) %>Component],
       imports: [DragDropModule]
-    }).compileComponents();
+    });
   }));<% } %>
 
   beforeEach(() => {

--- a/src/material/schematics/ng-generate/address-form/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.spec.ts.template
+++ b/src/material/schematics/ng-generate/address-form/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.spec.ts.template
@@ -1,5 +1,4 @@
-import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';<% if(!standalone) { %>
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';<% if(!standalone) { %>
 import { ReactiveFormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
@@ -11,23 +10,21 @@ import { <%= classify(name) %>Component } from './<%= dasherize(name) %>.compone
 
 describe('<%= classify(name) %>Component', () => {
   let component: <%= classify(name) %>Component;
-  let fixture: ComponentFixture<<%= classify(name) %>Component>;
+  let fixture: ComponentFixture<<%= classify(name) %>Component>;<% if(!standalone) { %>
 
   beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({<% if(standalone) { %>
-      imports: [NoopAnimationsModule]<% } else { %>
+    TestBed.configureTestingModule({
       declarations: [<%= classify(name) %>Component],
       imports: [
-        NoopAnimationsModule,
         ReactiveFormsModule,
         MatButtonModule,
         MatCardModule,
         MatInputModule,
         MatRadioModule,
         MatSelectModule,
-      ]<% } %>
-    }).compileComponents();
-  }));
+      ]
+    });
+  }));<% } %>
 
   beforeEach(() => {
     fixture = TestBed.createComponent(<%= classify(name) %>Component);

--- a/src/material/schematics/ng-generate/dashboard/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.spec.ts.template
+++ b/src/material/schematics/ng-generate/dashboard/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.spec.ts.template
@@ -1,5 +1,4 @@
-import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';<% if(!standalone) { %>
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';<% if(!standalone) { %>
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatGridListModule } from '@angular/material/grid-list';
@@ -10,22 +9,20 @@ import { <%= classify(name) %>Component } from './<%= dasherize(name) %>.compone
 
 describe('<%= classify(name) %>Component', () => {
   let component: <%= classify(name) %>Component;
-  let fixture: ComponentFixture<<%= classify(name) %>Component>;
+  let fixture: ComponentFixture<<%= classify(name) %>Component>;<% if(!standalone) { %>
 
   beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({<% if(standalone) { %>
-      imports: [NoopAnimationsModule]<% } else { %>
+    TestBed.configureTestingModule({
       declarations: [<%= classify(name) %>Component],
       imports: [
-        NoopAnimationsModule,
         MatButtonModule,
         MatCardModule,
         MatGridListModule,
         MatIconModule,
         MatMenuModule,
-      ]<% } %>
-    }).compileComponents();
-  }));
+      ]
+    });
+  }));<% } %>
 
   beforeEach(() => {
     fixture = TestBed.createComponent(<%= classify(name) %>Component);

--- a/src/material/schematics/ng-generate/navigation/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.spec.ts.template
+++ b/src/material/schematics/ng-generate/navigation/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.spec.ts.template
@@ -1,5 +1,4 @@
-import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';<% if(!standalone) { %>
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';<% if(!standalone) { %>
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatListModule } from '@angular/material/list';
@@ -10,22 +9,20 @@ import { <%= classify(name) %>Component } from './<%= dasherize(name) %>.compone
 
 describe('<%= classify(name) %>Component', () => {
   let component: <%= classify(name) %>Component;
-  let fixture: ComponentFixture<<%= classify(name) %>Component>;
+  let fixture: ComponentFixture<<%= classify(name) %>Component>;<% if(standalone) { %>
 
   beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({<% if(standalone) { %>
-      imports: [NoopAnimationsModule]<% } else { %>
+    TestBed.configureTestingModule({
       declarations: [<%= classify(name) %>Component],
       imports: [
-        NoopAnimationsModule,
         MatButtonModule,
         MatIconModule,
         MatListModule,
         MatSidenavModule,
         MatToolbarModule,
-      ]<% } %>
-    }).compileComponents();
-  }));
+      ]
+    });
+  }));<% } %>
 
   beforeEach(() => {
     fixture = TestBed.createComponent(<%= classify(name) %>Component);

--- a/src/material/schematics/ng-generate/table/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.spec.ts.template
+++ b/src/material/schematics/ng-generate/table/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.spec.ts.template
@@ -1,5 +1,4 @@
-import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';<% if(!standalone) { %>
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';<% if(!standalone) { %>
 import { MatPaginatorModule } from '@angular/material/paginator';
 import { MatSortModule } from '@angular/material/sort';
 import { MatTableModule } from '@angular/material/table';<% } %>
@@ -8,20 +7,18 @@ import { <%= classify(name) %>Component } from './<%= dasherize(name) %>.compone
 
 describe('<%= classify(name) %>Component', () => {
   let component: <%= classify(name) %>Component;
-  let fixture: ComponentFixture<<%= classify(name) %>Component>;
+  let fixture: ComponentFixture<<%= classify(name) %>Component>;<% if(!standalone) { %>
 
   beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({<% if(standalone) { %>
-      imports: [NoopAnimationsModule]<% } else { %>
+    TestBed.configureTestingModule({
       declarations: [<%= classify(name) %>Component],
       imports: [
-        NoopAnimationsModule,
         MatPaginatorModule,
         MatSortModule,
         MatTableModule,
-      ]<% } %>
-    }).compileComponents();
-  }));
+      ]
+    });
+  }));<% } %>
 
   beforeEach(() => {
     fixture = TestBed.createComponent(<%= classify(name) %>Component);

--- a/src/material/schematics/ng-generate/tree/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.spec.ts.template
+++ b/src/material/schematics/ng-generate/tree/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.spec.ts.template
@@ -17,7 +17,7 @@ describe('<%= classify(name) %>Component', () => {
         MatIconModule,
         MatTreeModule,
       ]
-    }).compileComponents();
+    });
   }));<% } %>
 
   beforeEach(() => {


### PR DESCRIPTION
Removes the `NoopAnimationsModule` from the tests generated by `ng generate` since it requires the animations module to be installed.

Fixes #30560.