### PR TITLE
fix(multiple): remove remaining references to ComponentFactoryResolver

### DIFF
--- a/src/cdk/dialog/dialog-config.ts
+++ b/src/cdk/dialog/dialog-config.ts
@@ -139,13 +139,6 @@ export class DialogConfig<D = unknown, R = unknown, C extends BasePortalOutlet =
   closeOnOverlayDetachments?: boolean = true;
 
   /**
-   * Alternate `ComponentFactoryResolver` to use when resolving the associated component.
-   * @deprecated No longer used. Will be removed.
-   * @breaking-change 20.0.0
-   */
-  componentFactoryResolver?: unknown;
-
-  /**
    * Providers that will be exposed to the contents of the dialog. Can also
    * be provided as a function in order to generate the providers lazily.
    */

--- a/src/cdk/overlay/overlay.ts
+++ b/src/cdk/overlay/overlay.ts
@@ -138,6 +138,6 @@ export class Overlay {
       this._appRef = this._injector.get<ApplicationRef>(ApplicationRef);
     }
 
-    return new DomPortalOutlet(pane, null, this._appRef, this._injector, this._document);
+    return new DomPortalOutlet(pane, this._appRef, this._injector);
   }
 }

--- a/src/cdk/portal/dom-portal-outlet.ts
+++ b/src/cdk/portal/dom-portal-outlet.ts
@@ -21,38 +21,20 @@ import {BasePortalOutlet, ComponentPortal, DomPortal, TemplatePortal} from './po
  * application context.
  */
 export class DomPortalOutlet extends BasePortalOutlet {
-  private _document: Document;
-
   /**
    * @param outletElement Element into which the content is projected.
-   * @param _unusedComponentFactoryResolver Used to resolve the component factory.
-   *   Only required when attaching component portals.
    * @param _appRef Reference to the application. Only used in component portals when there
    *   is no `ViewContainerRef` available.
    * @param _defaultInjector Injector to use as a fallback when the portal being attached doesn't
    *   have one. Only used for component portals.
-   * @param _document Reference to the document. Used when attaching a DOM portal. Will eventually
-   *   become a required parameter.
    */
   constructor(
     /** Element into which the content is projected. */
     public outletElement: Element,
-    /**
-     * @deprecated No longer in use. To be removed.
-     * @breaking-change 18.0.0
-     */
-    _unusedComponentFactoryResolver?: any,
     private _appRef?: ApplicationRef,
     private _defaultInjector?: Injector,
-
-    /**
-     * @deprecated `_document` Parameter to be made required.
-     * @breaking-change 10.0.0
-     */
-    _document?: any,
   ) {
     super();
-    this._document = _document;
   }
 
   /**
@@ -157,7 +139,7 @@ export class DomPortalOutlet extends BasePortalOutlet {
 
     // Anchor used to save the element's previous position so
     // that we can restore it when the portal is detached.
-    const anchorNode = this._document.createComment('dom-portal');
+    const anchorNode = this.outletElement.ownerDocument.createComment('dom-portal');
 
     element.parentNode!.insertBefore(anchorNode, element);
     this.outletElement.appendChild(element);

--- a/src/cdk/portal/portal.spec.ts
+++ b/src/cdk/portal/portal.spec.ts
@@ -459,7 +459,7 @@ describe('Portals', () => {
     it('should be able to pass projectable nodes to portal', () => {
       // Set the selectedHost to be a ComponentPortal.
       const testAppComponent = fixture.componentInstance;
-      const componentPortal = new ComponentPortal(PizzaMsg, undefined, undefined, undefined, [
+      const componentPortal = new ComponentPortal(PizzaMsg, undefined, undefined, [
         [document.createTextNode('Projectable node')],
       ]);
 
@@ -484,7 +484,7 @@ describe('Portals', () => {
       injector = TestBed.inject(Injector);
       appRef = TestBed.inject(ApplicationRef);
       someDomElement = document.createElement('div');
-      host = new DomPortalOutlet(someDomElement, null, appRef, injector, document);
+      host = new DomPortalOutlet(someDomElement, appRef, injector);
       someFixture = TestBed.createComponent(ArbitraryViewContainerRefComponent);
       someViewContainerRef = someFixture.componentInstance.viewContainerRef;
       someInjector = someFixture.componentInstance.injector;

--- a/src/cdk/portal/portal.ts
+++ b/src/cdk/portal/portal.ts
@@ -95,12 +95,6 @@ export class ComponentPortal<T> extends Portal<ComponentRef<T>> {
   injector?: Injector | null;
 
   /**
-   * @deprecated No longer in use. To be removed.
-   * @breaking-change 18.0.0
-   */
-  componentFactoryResolver?: any;
-
-  /**
    * List of DOM nodes that should be projected through `<ng-content>` of the attached component.
    */
   projectableNodes?: Node[][] | null;
@@ -109,11 +103,6 @@ export class ComponentPortal<T> extends Portal<ComponentRef<T>> {
     component: ComponentType<T>,
     viewContainerRef?: ViewContainerRef | null,
     injector?: Injector | null,
-    /**
-     * @deprecated No longer in use. To be removed.
-     * @breaking-change 18.0.0
-     */
-    _componentFactoryResolver?: any,
     projectableNodes?: Node[][] | null,
   ) {
     super();

--- a/src/material/dialog/dialog-config.ts
+++ b/src/material/dialog/dialog-config.ts
@@ -138,13 +138,6 @@ export class MatDialogConfig<D = any> {
   closeOnNavigation?: boolean = true;
 
   /**
-   * Alternate `ComponentFactoryResolver` to use when resolving the associated component.
-   * @deprecated No longer used. Will be removed.
-   * @breaking-change 20.0.0
-   */
-  componentFactoryResolver?: unknown;
-
-  /**
    * Duration of the enter animation in ms.
    * Should be a number, string type is deprecated.
    * @breaking-change 17.0.0 Remove string signature.

--- a/src/material/menu/menu-content.ts
+++ b/src/material/menu/menu-content.ts
@@ -65,7 +65,6 @@ export class MatMenuContent implements OnDestroy {
     if (!this._outlet) {
       this._outlet = new DomPortalOutlet(
         this._document.createElement('div'),
-        null,
         this._appRef,
         this._injector,
       );

--- a/tools/public_api_guard/cdk/dialog.md
+++ b/tools/public_api_guard/cdk/dialog.md
@@ -133,8 +133,6 @@ export class DialogConfig<D = unknown, R = unknown, C extends BasePortalOutlet =
     closeOnDestroy?: boolean;
     closeOnNavigation?: boolean;
     closeOnOverlayDetachments?: boolean;
-    // @deprecated
-    componentFactoryResolver?: unknown;
     container?: Type<C> | {
         type: Type<C>;
         providers: (config: DialogConfig<D, R, C>) => StaticProvider[];

--- a/tools/public_api_guard/cdk/portal.md
+++ b/tools/public_api_guard/cdk/portal.md
@@ -76,11 +76,8 @@ export type CdkPortalOutletAttachedRef = ComponentRef<any> | EmbeddedViewRef<any
 
 // @public
 export class ComponentPortal<T> extends Portal<ComponentRef<T>> {
-    constructor(component: ComponentType<T>, viewContainerRef?: ViewContainerRef | null, injector?: Injector | null,
-    _componentFactoryResolver?: any, projectableNodes?: Node[][] | null);
+    constructor(component: ComponentType<T>, viewContainerRef?: ViewContainerRef | null, injector?: Injector | null, projectableNodes?: Node[][] | null);
     component: ComponentType<T>;
-    // @deprecated (undocumented)
-    componentFactoryResolver?: any;
     injector?: Injector | null;
     projectableNodes?: Node[][] | null;
     viewContainerRef?: ViewContainerRef | null;
@@ -105,9 +102,7 @@ export class DomPortalHost extends DomPortalOutlet {
 // @public
 export class DomPortalOutlet extends BasePortalOutlet {
     constructor(
-    outletElement: Element,
-    _unusedComponentFactoryResolver?: any, _appRef?: ApplicationRef | undefined, _defaultInjector?: Injector | undefined,
-    _document?: any);
+    outletElement: Element, _appRef?: ApplicationRef | undefined, _defaultInjector?: Injector | undefined);
     attachComponentPortal<T>(portal: ComponentPortal<T>): ComponentRef<T>;
     // @deprecated
     attachDomPortal: (portal: DomPortal) => void;

--- a/tools/public_api_guard/material/dialog.md
+++ b/tools/public_api_guard/material/dialog.md
@@ -149,8 +149,6 @@ export class MatDialogConfig<D = any> {
     autoFocus?: AutoFocusTarget | string | boolean;
     backdropClass?: string | string[];
     closeOnNavigation?: boolean;
-    // @deprecated
-    componentFactoryResolver?: unknown;
     data?: D | null;
     delayFocusTrap?: boolean;
     direction?: Direction;


### PR DESCRIPTION
Removes the remaining APIs that were referencing `ComponentFactoryResolver`. These were all placeholders since we removed the code that was passing the values along a couple major versions ago.

BREAKING CHANGE:
* `DialogConfig.componentFactoryResolver` has been removed.
* The constructor of `DomPortalOutlet` has changed.
* `ComponentPortal.componentFactoryResolver` has been removed.
* The constructor signature of `ComponentPortal` has changed.
* `MatDialogConfig.componentFactoryResolver` has been removed.