### PR TITLE
fix(multiple): resolve host binding issues

### DIFF
--- a/src/material/chips/chip-listbox.ts
+++ b/src/material/chips/chip-listbox.ts
@@ -68,8 +68,6 @@ export const MAT_CHIP_LISTBOX_CONTROL_VALUE_ACCESSOR: any = {
     'class': 'mdc-evolution-chip-set mat-mdc-chip-listbox',
     '[attr.role]': 'role',
     '[tabIndex]': '(disabled || empty) ? -1 : tabIndex',
-    // TODO: replace this binding with use of AriaDescriber
-    '[attr.aria-describedby]': '_ariaDescribedby || null',
     '[attr.aria-required]': 'role ? required : null',
     '[attr.aria-disabled]': 'disabled.toString()',
     '[attr.aria-multiselectable]': 'multiple',

--- a/src/material/chips/chip-row.ts
+++ b/src/material/chips/chip-row.ts
@@ -59,7 +59,7 @@ export interface MatChipEditedEvent extends MatChipEvent {
     '[attr.aria-label]': 'null',
     '[attr.aria-description]': 'null',
     '[attr.role]': 'role',
-    '(focus)': '_handleFocus($event)',
+    '(focus)': '_handleFocus()',
     '(dblclick)': '_handleDoubleclick($event)',
   },
   providers: [

--- a/src/material/list/list-option.ts
+++ b/src/material/list/list-option.ts
@@ -100,7 +100,7 @@ export interface SelectionList extends MatListBase {
   imports: [NgTemplateOutlet, CdkObserveContent],
 })
 export class MatListOption extends MatListItemBase implements ListOption, OnInit, OnDestroy {
-  private _selectionList = inject<SelectionList>(SELECTION_LIST);
+  protected _selectionList = inject<SelectionList>(SELECTION_LIST);
   private _changeDetectorRef = inject(ChangeDetectorRef);
 
   @ContentChildren(MatListItemLine, {descendants: true}) _lines: QueryList<MatListItemLine>;

--- a/src/material/sort/sort-header.ts
+++ b/src/material/sort/sort-header.ts
@@ -84,7 +84,7 @@ interface MatSortHeaderColumnDef {
     'class': 'mat-sort-header',
     '(click)': '_toggleOnInteraction()',
     '(keydown)': '_handleKeydown($event)',
-    '(mouseleave)': '_recentlyCleared.set(false)',
+    '(mouseleave)': '_recentlyCleared.set(null)',
     '[attr.aria-sort]': '_getAriaSortAttribute()',
     '[class.mat-sort-header-disabled]': '_isDisabled()',
   },

--- a/tools/public_api_guard/material/list.md
+++ b/tools/public_api_guard/material/list.md
@@ -183,6 +183,8 @@ export class MatListOption extends MatListItemBase implements ListOption, OnInit
     get selected(): boolean;
     set selected(value: BooleanInput);
     readonly selectedChange: EventEmitter<boolean>;
+    // (undocumented)
+    protected _selectionList: SelectionList;
     _setSelected(selected: boolean): boolean;
     _setTabindex(value: number): void;
     // (undocumented)


### PR DESCRIPTION
Resolves the following issues with host bindings that weren't caught due to a lack of type checking:
* The `aria-describedby` binding on `mat-chip-listbox` was doing nothing, because the `_ariaDescribedBy` property does not exist.
* The `focus` handler on `mat-chip-row` was passing an event to `_handleFocus` even though one isn't required.
* `MatListOption` was referencing a private method.
* `mat-sort-header` was setting an invalid value to the `_recentlyCleared` signal.