### PR TITLE
Update table.ts

### DIFF
--- a/src/material/table/table.ts
+++ b/src/material/table/table.ts
@@ -76,7 +76,7 @@ export class MatTable<T> extends CdkTable<T> implements OnInit {
     // this only applies to native tables, because we don't wrap the content of flexbox-based ones.
     if (this._isNativeHtmlTable) {
       const tbody = this._elementRef.nativeElement.querySelector('tbody');
-      tbody.classList.add('mdc-data-table__content');
+      tbody && tbody.classList.add('mdc-data-table__content');
     }
   }
 }


### PR DESCRIPTION
I'm using Angular version 18.2 with material version 15.2.x. In this combination, I'm trying to render table using mat-table.

"tbody" or "thead" is not created in the DOM and throwing error in the edited line. Hence I'm checking whether the "tbody" is available or not before adding a class to it.