### PR TITLE
fix(material/timepicker): wrong default scroll strategy

### DIFF
--- a/src/material/timepicker/timepicker.ts
+++ b/src/material/timepicker/timepicker.ts
@@ -70,7 +70,7 @@ export const MAT_TIMEPICKER_SCROLL_STRATEGY = new InjectionToken<() => ScrollStr
     providedIn: 'root',
     factory: () => {
       const overlay = inject(Overlay);
-      return () => overlay.scrollStrategies.close();
+      return () => overlay.scrollStrategies.reposition();
     },
   },
 );


### PR DESCRIPTION
#30561 accidentally switched the default scroll strategy for the timepicker to be `close` instead of `reposition`. It was unintentional so these changes switch it back to `reposition`.