### PR TITLE
fix(material/schematics): some options missing from schema

### DIFF
--- a/src/material/schematics/ng-generate/theme-color/schema.json
+++ b/src/material/schematics/ng-generate/theme-color/schema.json
@@ -24,6 +24,16 @@
       "description": "Color for neutral color palette",
       "x-prompt": "What HEX color should be used represent the neutral color palette? (Leave blank to use generated colors from Material)"
     },
+    "neutralVariantColor": {
+      "type": "string",
+      "description": "Color for the neutral variant palette",
+      "x-prompt": "What HEX color should be used represent the neutral variant palette? (Leave blank to use generated colors from Material)"
+    },
+    "errorColor": {
+      "type": "string",
+      "description": "Color for the error palette",
+      "x-prompt": "What HEX color should be used represent the error palette? (Leave blank to use generated colors from Material)"
+    },
     "includeHighContrast": {
       "type": "boolean",
       "default": false,


### PR DESCRIPTION
Fixes that the `neutralVariantColor` and `errorColor` were missing from the schema which meant that users can't pass them in.

Fixes #30571.