### PR TITLE
fix(multiple): deprecate exported factories

### DIFF
--- a/src/cdk/a11y/key-manager/tree-key-manager.ts
+++ b/src/cdk/a11y/key-manager/tree-key-manager.ts
@@ -411,7 +411,11 @@ export class TreeKeyManager<T extends TreeKeyManagerItem> implements TreeKeyMana
   }
 }
 
-/** @docs-private */
+/**
+ * @docs-private
+ * @deprecated No longer used, will be removed.
+ * @breaking-change 21.0.0
+ */
 export function TREE_KEY_MANAGER_FACTORY<T extends TreeKeyManagerItem>(): TreeKeyManagerFactory<T> {
   return (items, options) => new TreeKeyManager(items, options);
 }
@@ -422,7 +426,11 @@ export const TREE_KEY_MANAGER = new InjectionToken<TreeKeyManagerFactory<any>>('
   factory: TREE_KEY_MANAGER_FACTORY,
 });
 
-/** @docs-private */
+/**
+ * @docs-private
+ * @deprecated No longer used, will be removed.
+ * @breaking-change 21.0.0
+ */
 export const TREE_KEY_MANAGER_FACTORY_PROVIDER = {
   provide: TREE_KEY_MANAGER,
   useFactory: TREE_KEY_MANAGER_FACTORY,

--- a/src/cdk/a11y/live-announcer/live-announcer-tokens.ts
+++ b/src/cdk/a11y/live-announcer/live-announcer-tokens.ts
@@ -22,7 +22,11 @@ export const LIVE_ANNOUNCER_ELEMENT_TOKEN = new InjectionToken<HTMLElement | nul
   },
 );
 
-/** @docs-private */
+/**
+ * @docs-private
+ * @deprecated No longer used, will be removed.
+ * @breaking-change 21.0.0
+ */
 export function LIVE_ANNOUNCER_ELEMENT_TOKEN_FACTORY(): null {
   return null;
 }

--- a/src/cdk/bidi/dir-document-token.ts
+++ b/src/cdk/bidi/dir-document-token.ts
@@ -29,7 +29,11 @@ export const DIR_DOCUMENT = new InjectionToken<Document>('cdk-dir-doc', {
   factory: DIR_DOCUMENT_FACTORY,
 });
 
-/** @docs-private */
+/**
+ * @docs-private
+ * @deprecated No longer used, will be removed.
+ * @breaking-change 21.0.0
+ */
 export function DIR_DOCUMENT_FACTORY(): Document {
   return inject(DOCUMENT);
 }

--- a/src/cdk/overlay/overlay-directives.ts
+++ b/src/cdk/overlay/overlay-directives.ts
@@ -457,14 +457,22 @@ export class CdkConnectedOverlay implements OnDestroy, OnChanges {
   }
 }
 
-/** @docs-private */
+/**
+ * @docs-private
+ * @deprecated No longer used, will be removed.
+ * @breaking-change 21.0.0
+ */
 export function CDK_CONNECTED_OVERLAY_SCROLL_STRATEGY_PROVIDER_FACTORY(
   overlay: Overlay,
 ): () => RepositionScrollStrategy {
   return () => overlay.scrollStrategies.reposition();
 }
 
-/** @docs-private */
+/**
+ * @docs-private
+ * @deprecated No longer used, will be removed.
+ * @breaking-change 21.0.0
+ */
 export const CDK_CONNECTED_OVERLAY_SCROLL_STRATEGY_PROVIDER = {
   provide: CDK_CONNECTED_OVERLAY_SCROLL_STRATEGY,
   deps: [Overlay],

--- a/src/material-luxon-adapter/adapter/luxon-date-adapter.ts
+++ b/src/material-luxon-adapter/adapter/luxon-date-adapter.ts
@@ -45,7 +45,11 @@ export const MAT_LUXON_DATE_ADAPTER_OPTIONS = new InjectionToken<MatLuxonDateAda
   },
 );
 
-/** @docs-private */
+/**
+ * @docs-private
+ * @deprecated No longer used, will be removed.
+ * @breaking-change 21.0.0
+ */
 export function MAT_LUXON_DATE_ADAPTER_OPTIONS_FACTORY(): MatLuxonDateAdapterOptions {
   return {
     useUtc: false,

--- a/src/material-moment-adapter/adapter/moment-date-adapter.ts
+++ b/src/material-moment-adapter/adapter/moment-date-adapter.ts
@@ -44,7 +44,11 @@ export const MAT_MOMENT_DATE_ADAPTER_OPTIONS = new InjectionToken<MatMomentDateA
   },
 );
 
-/** @docs-private */
+/**
+ * @docs-private
+ * @deprecated No longer used, will be removed.
+ * @breaking-change 21.0.0
+ */
 export function MAT_MOMENT_DATE_ADAPTER_OPTIONS_FACTORY(): MatMomentDateAdapterOptions {
   return {
     useUtc: false,

--- a/src/material/autocomplete/autocomplete-trigger.ts
+++ b/src/material/autocomplete/autocomplete-trigger.ts
@@ -93,12 +93,20 @@ export const MAT_AUTOCOMPLETE_SCROLL_STRATEGY = new InjectionToken<() => ScrollS
   },
 );
 
-/** @docs-private */
+/**
+ * @docs-private
+ * @deprecated No longer used, will be removed.
+ * @breaking-change 21.0.0
+ */
 export function MAT_AUTOCOMPLETE_SCROLL_STRATEGY_FACTORY(overlay: Overlay): () => ScrollStrategy {
   return () => overlay.scrollStrategies.reposition();
 }
 
-/** @docs-private */
+/**
+ * @docs-private
+ * @deprecated No longer used, will be removed.
+ * @breaking-change 21.0.0
+ */
 export const MAT_AUTOCOMPLETE_SCROLL_STRATEGY_FACTORY_PROVIDER = {
   provide: MAT_AUTOCOMPLETE_SCROLL_STRATEGY,
   deps: [Overlay],

--- a/src/material/autocomplete/autocomplete.ts
+++ b/src/material/autocomplete/autocomplete.ts
@@ -86,7 +86,11 @@ export const MAT_AUTOCOMPLETE_DEFAULT_OPTIONS = new InjectionToken<MatAutocomple
   },
 );
 
-/** @docs-private */
+/**
+ * @docs-private
+ * @deprecated No longer used, will be removed.
+ * @breaking-change 21.0.0
+ */
 export function MAT_AUTOCOMPLETE_DEFAULT_OPTIONS_FACTORY(): MatAutocompleteDefaultOptions {
   return {
     autoActiveFirstOption: false,

--- a/src/material/button-toggle/button-toggle.ts
+++ b/src/material/button-toggle/button-toggle.ts
@@ -77,6 +77,11 @@ export const MAT_BUTTON_TOGGLE_DEFAULT_OPTIONS = new InjectionToken<MatButtonTog
   },
 );
 
+/**
+ * @docs-private
+ * @deprecated No longer used, will be removed.
+ * @breaking-change 21.0.0
+ */
 export function MAT_BUTTON_TOGGLE_GROUP_DEFAULT_OPTIONS_FACTORY(): MatButtonToggleDefaultOptions {
   return {
     hideSingleSelectionIndicator: false,

--- a/src/material/button/fab.ts
+++ b/src/material/button/fab.ts
@@ -40,7 +40,11 @@ export const MAT_FAB_DEFAULT_OPTIONS = new InjectionToken<MatFabDefaultOptions>(
   },
 );
 
-/** @docs-private */
+/**
+ * @docs-private
+ * @deprecated No longer used, will be removed.
+ * @breaking-change 21.0.0
+ */
 export function MAT_FAB_DEFAULT_OPTIONS_FACTORY(): MatFabDefaultOptions {
   return {
     // The FAB by default has its color set to accent.

--- a/src/material/checkbox/checkbox-config.ts
+++ b/src/material/checkbox/checkbox-config.ts
@@ -35,7 +35,11 @@ export const MAT_CHECKBOX_DEFAULT_OPTIONS = new InjectionToken<MatCheckboxDefaul
   },
 );
 
-/** @docs-private */
+/**
+ * @docs-private
+ * @deprecated No longer used, will be removed.
+ * @breaking-change 21.0.0
+ */
 export function MAT_CHECKBOX_DEFAULT_OPTIONS_FACTORY(): MatCheckboxDefaultOptions {
   return {
     color: 'accent',

--- a/src/material/core/datetime/date-adapter.ts
+++ b/src/material/core/datetime/date-adapter.ts
@@ -15,7 +15,11 @@ export const MAT_DATE_LOCALE = new InjectionToken<{}>('MAT_DATE_LOCALE', {
   factory: MAT_DATE_LOCALE_FACTORY,
 });
 
-/** @docs-private */
+/**
+ * @docs-private
+ * @deprecated No longer used, will be removed.
+ * @breaking-change 21.0.0
+ */
 export function MAT_DATE_LOCALE_FACTORY(): {} {
   return inject(LOCALE_ID);
 }

--- a/src/material/datepicker/date-range-selection-strategy.ts
+++ b/src/material/datepicker/date-range-selection-strategy.ts
@@ -131,7 +131,11 @@ export class DefaultMatCalendarRangeStrategy<D> implements MatDateRangeSelection
   }
 }
 
-/** @docs-private */
+/**
+ * @docs-private
+ * @deprecated No longer used, will be removed.
+ * @breaking-change 21.0.0
+ */
 export function MAT_CALENDAR_RANGE_STRATEGY_PROVIDER_FACTORY(
   parent: MatDateRangeSelectionStrategy<unknown>,
   adapter: DateAdapter<unknown>,
@@ -139,7 +143,11 @@ export function MAT_CALENDAR_RANGE_STRATEGY_PROVIDER_FACTORY(
   return parent || new DefaultMatCalendarRangeStrategy(adapter);
 }
 
-/** @docs-private */
+/**
+ * @docs-private
+ * @deprecated No longer used, will be removed.
+ * @breaking-change 21.0.0
+ */
 export const MAT_CALENDAR_RANGE_STRATEGY_PROVIDER: FactoryProvider = {
   provide: MAT_DATE_RANGE_SELECTION_STRATEGY,
   deps: [[new Optional(), new SkipSelf(), MAT_DATE_RANGE_SELECTION_STRATEGY], DateAdapter],

--- a/src/material/datepicker/date-selection-model.ts
+++ b/src/material/datepicker/date-selection-model.ts
@@ -211,7 +211,11 @@ export class MatRangeDateSelectionModel<D> extends MatDateSelectionModel<DateRan
   }
 }
 
-/** @docs-private */
+/**
+ * @docs-private
+ * @deprecated No longer used, will be removed.
+ * @breaking-change 21.0.0
+ */
 export function MAT_SINGLE_DATE_SELECTION_MODEL_FACTORY(
   parent: MatSingleDateSelectionModel<unknown>,
   adapter: DateAdapter<unknown>,
@@ -222,6 +226,8 @@ export function MAT_SINGLE_DATE_SELECTION_MODEL_FACTORY(
 /**
  * Used to provide a single selection model to a component.
  * @docs-private
+ * @deprecated No longer used, will be removed.
+ * @breaking-change 21.0.0
  */
 export const MAT_SINGLE_DATE_SELECTION_MODEL_PROVIDER: FactoryProvider = {
   provide: MatDateSelectionModel,
@@ -229,7 +235,11 @@ export const MAT_SINGLE_DATE_SELECTION_MODEL_PROVIDER: FactoryProvider = {
   useFactory: MAT_SINGLE_DATE_SELECTION_MODEL_FACTORY,
 };
 
-/** @docs-private */
+/**
+ * @docs-private
+ * @deprecated No longer used, will be removed.
+ * @breaking-change 21.0.0
+ */
 export function MAT_RANGE_DATE_SELECTION_MODEL_FACTORY(
   parent: MatSingleDateSelectionModel<unknown>,
   adapter: DateAdapter<unknown>,
@@ -240,6 +250,8 @@ export function MAT_RANGE_DATE_SELECTION_MODEL_FACTORY(
 /**
  * Used to provide a range selection model to a component.
  * @docs-private
+ * @deprecated No longer used, will be removed.
+ * @breaking-change 21.0.0
  */
 export const MAT_RANGE_DATE_SELECTION_MODEL_PROVIDER: FactoryProvider = {
   provide: MatDateSelectionModel,

--- a/src/material/datepicker/datepicker-base.ts
+++ b/src/material/datepicker/datepicker-base.ts
@@ -88,7 +88,11 @@ export const MAT_DATEPICKER_SCROLL_STRATEGY = new InjectionToken<() => ScrollStr
   },
 );
 
-/** @docs-private */
+/**
+ * @docs-private
+ * @deprecated No longer used, will be removed.
+ * @breaking-change 21.0.0
+ */
 export function MAT_DATEPICKER_SCROLL_STRATEGY_FACTORY(overlay: Overlay): () => ScrollStrategy {
   return () => overlay.scrollStrategies.reposition();
 }
@@ -99,7 +103,11 @@ export type DatepickerDropdownPositionX = 'start' | 'end';
 /** Possible positions for the datepicker dropdown along the Y axis. */
 export type DatepickerDropdownPositionY = 'above' | 'below';
 
-/** @docs-private */
+/**
+ * @docs-private
+ * @deprecated No longer used, will be removed.
+ * @breaking-change 21.0.0
+ */
 export const MAT_DATEPICKER_SCROLL_STRATEGY_FACTORY_PROVIDER = {
   provide: MAT_DATEPICKER_SCROLL_STRATEGY,
   deps: [Overlay],

--- a/src/material/icon/icon-registry.ts
+++ b/src/material/icon/icon-registry.ts
@@ -728,7 +728,11 @@ export class MatIconRegistry implements OnDestroy {
   }
 }
 
-/** @docs-private */
+/**
+ * @docs-private
+ * @deprecated No longer used, will be removed.
+ * @breaking-change 21.0.0
+ */
 export function ICON_REGISTRY_PROVIDER_FACTORY(
   parentRegistry: MatIconRegistry,
   httpClient: HttpClient,
@@ -739,7 +743,11 @@ export function ICON_REGISTRY_PROVIDER_FACTORY(
   return parentRegistry || new MatIconRegistry(httpClient, sanitizer, document, errorHandler);
 }
 
-/** @docs-private */
+/**
+ * @docs-private
+ * @deprecated No longer used, will be removed.
+ * @breaking-change 21.0.0
+ */
 export const ICON_REGISTRY_PROVIDER = {
   // If there is already an MatIconRegistry available, use that. Otherwise, provide a new one.
   provide: MatIconRegistry,

--- a/src/material/icon/icon.ts
+++ b/src/material/icon/icon.ts
@@ -65,7 +65,11 @@ export interface MatIconLocation {
   getPathname: () => string;
 }
 
-/** @docs-private */
+/**
+ * @docs-private
+ * @deprecated No longer used, will be removed.
+ * @breaking-change 21.0.0
+ */
 export function MAT_ICON_LOCATION_FACTORY(): MatIconLocation {
   const _document = inject(DOCUMENT);
   const _location = _document ? _document.location : null;

--- a/src/material/menu/menu-trigger.ts
+++ b/src/material/menu/menu-trigger.ts
@@ -60,12 +60,20 @@ export const MAT_MENU_SCROLL_STRATEGY = new InjectionToken<() => ScrollStrategy>
   },
 );
 
-/** @docs-private */
+/**
+ * @docs-private
+ * @deprecated No longer used, will be removed.
+ * @breaking-change 21.0.0
+ */
 export function MAT_MENU_SCROLL_STRATEGY_FACTORY(overlay: Overlay): () => ScrollStrategy {
   return () => overlay.scrollStrategies.reposition();
 }
 
-/** @docs-private */
+/**
+ * @docs-private
+ * @deprecated No longer used, will be removed.
+ * @breaking-change 21.0.0
+ */
 export const MAT_MENU_SCROLL_STRATEGY_FACTORY_PROVIDER = {
   provide: MAT_MENU_SCROLL_STRATEGY,
   deps: [Overlay],

--- a/src/material/menu/menu.ts
+++ b/src/material/menu/menu.ts
@@ -82,7 +82,11 @@ export const MAT_MENU_DEFAULT_OPTIONS = new InjectionToken<MatMenuDefaultOptions
   },
 );
 
-/** @docs-private */
+/**
+ * @docs-private
+ * @deprecated No longer used, will be removed.
+ * @breaking-change 21.0.0
+ */
 export function MAT_MENU_DEFAULT_OPTIONS_FACTORY(): MatMenuDefaultOptions {
   return {
     overlapTrigger: false,

--- a/src/material/paginator/paginator-intl.ts
+++ b/src/material/paginator/paginator-intl.ts
@@ -58,12 +58,20 @@ export class MatPaginatorIntl {
   };
 }
 
-/** @docs-private */
+/**
+ * @docs-private
+ * @deprecated No longer used, will be removed.
+ * @breaking-change 21.0.0
+ */
 export function MAT_PAGINATOR_INTL_PROVIDER_FACTORY(parentIntl: MatPaginatorIntl) {
   return parentIntl || new MatPaginatorIntl();
 }
 
-/** @docs-private */
+/**
+ * @docs-private
+ * @deprecated No longer used, will be removed.
+ * @breaking-change 21.0.0
+ */
 export const MAT_PAGINATOR_INTL_PROVIDER = {
   // If there is already an MatPaginatorIntl available, use that. Otherwise, provide a new one.
   provide: MatPaginatorIntl,

--- a/src/material/progress-bar/progress-bar.ts
+++ b/src/material/progress-bar/progress-bar.ts
@@ -70,7 +70,11 @@ export interface MatProgressBarLocation {
   getPathname: () => string;
 }
 
-/** @docs-private */
+/**
+ * @docs-private
+ * @deprecated No longer used, will be removed.
+ * @breaking-change 21.0.0
+ */
 export function MAT_PROGRESS_BAR_LOCATION_FACTORY(): MatProgressBarLocation {
   const _document = inject(DOCUMENT);
   const _location = _document ? _document.location : null;

--- a/src/material/progress-spinner/progress-spinner.ts
+++ b/src/material/progress-spinner/progress-spinner.ts
@@ -52,7 +52,11 @@ export const MAT_PROGRESS_SPINNER_DEFAULT_OPTIONS =
     factory: MAT_PROGRESS_SPINNER_DEFAULT_OPTIONS_FACTORY,
   });
 
-/** @docs-private */
+/**
+ * @docs-private
+ * @deprecated No longer used, will be removed.
+ * @breaking-change 21.0.0
+ */
 export function MAT_PROGRESS_SPINNER_DEFAULT_OPTIONS_FACTORY(): MatProgressSpinnerDefaultOptions {
   return {diameter: BASE_SIZE};
 }

--- a/src/material/radio/radio.ts
+++ b/src/material/radio/radio.ts
@@ -98,6 +98,11 @@ export const MAT_RADIO_DEFAULT_OPTIONS = new InjectionToken<MatRadioDefaultOptio
   },
 );
 
+/**
+ * @docs-private
+ * @deprecated No longer used, will be removed.
+ * @breaking-change 21.0.0
+ */
 export function MAT_RADIO_DEFAULT_OPTIONS_FACTORY(): MatRadioDefaultOptions {
   return {
     color: 'accent',

--- a/src/material/select/select.ts
+++ b/src/material/select/select.ts
@@ -103,7 +103,11 @@ export const MAT_SELECT_SCROLL_STRATEGY = new InjectionToken<() => ScrollStrateg
   },
 );
 
-/** @docs-private */
+/**
+ * @docs-private
+ * @deprecated No longer used, will be removed.
+ * @breaking-change 21.0.0
+ */
 export function MAT_SELECT_SCROLL_STRATEGY_PROVIDER_FACTORY(
   overlay: Overlay,
 ): () => ScrollStrategy {
@@ -140,7 +144,11 @@ export interface MatSelectConfig {
 /** Injection token that can be used to provide the default options the select module. */
 export const MAT_SELECT_CONFIG = new InjectionToken<MatSelectConfig>('MAT_SELECT_CONFIG');
 
-/** @docs-private */
+/**
+ * @docs-private
+ * @deprecated No longer used, will be removed.
+ * @breaking-change 21.0.0
+ */
 export const MAT_SELECT_SCROLL_STRATEGY_PROVIDER = {
   provide: MAT_SELECT_SCROLL_STRATEGY,
   deps: [Overlay],

--- a/src/material/sidenav/drawer.ts
+++ b/src/material/sidenav/drawer.ts
@@ -78,7 +78,11 @@ export const MAT_DRAWER_DEFAULT_AUTOSIZE = new InjectionToken<boolean>(
  */
 export const MAT_DRAWER_CONTAINER = new InjectionToken('MAT_DRAWER_CONTAINER');
 
-/** @docs-private */
+/**
+ * @docs-private
+ * @deprecated No longer used, will be removed.
+ * @breaking-change 21.0.0
+ */
 export function MAT_DRAWER_DEFAULT_AUTOSIZE_FACTORY(): boolean {
   return false;
 }

--- a/src/material/snack-bar/snack-bar.ts
+++ b/src/material/snack-bar/snack-bar.ts
@@ -26,7 +26,11 @@ import {MatSnackBarRef} from './snack-bar-ref';
 import {ComponentPortal, TemplatePortal} from '@angular/cdk/portal';
 import {takeUntil} from 'rxjs/operators';
 
-/** @docs-private */
+/**
+ * @docs-private
+ * @deprecated No longer used, will be removed.
+ * @breaking-change 21.0.0
+ */
 export function MAT_SNACK_BAR_DEFAULT_OPTIONS_FACTORY(): MatSnackBarConfig {
   return new MatSnackBarConfig();
 }

--- a/src/material/sort/sort-header-intl.ts
+++ b/src/material/sort/sort-header-intl.ts
@@ -22,12 +22,20 @@ export class MatSortHeaderIntl {
   readonly changes: Subject<void> = new Subject<void>();
 }
 
-/** @docs-private */
+/**
+ * @docs-private
+ * @deprecated No longer used, will be removed.
+ * @breaking-change 21.0.0
+ */
 export function MAT_SORT_HEADER_INTL_PROVIDER_FACTORY(parentIntl: MatSortHeaderIntl) {
   return parentIntl || new MatSortHeaderIntl();
 }
 
-/** @docs-private */
+/**
+ * @docs-private
+ * @deprecated No longer used, will be removed.
+ * @breaking-change 21.0.0
+ */
 export const MAT_SORT_HEADER_INTL_PROVIDER = {
   // If there is already an MatSortHeaderIntl available, use that. Otherwise, provide a new one.
   provide: MatSortHeaderIntl,

--- a/src/material/stepper/stepper-intl.ts
+++ b/src/material/stepper/stepper-intl.ts
@@ -28,12 +28,20 @@ export class MatStepperIntl {
   editableLabel: string = 'Editable';
 }
 
-/** @docs-private */
+/**
+ * @docs-private
+ * @deprecated No longer used, will be removed.
+ * @breaking-change 21.0.0
+ */
 export function MAT_STEPPER_INTL_PROVIDER_FACTORY(parentIntl: MatStepperIntl) {
   return parentIntl || new MatStepperIntl();
 }
 
-/** @docs-private */
+/**
+ * @docs-private
+ * @deprecated No longer used, will be removed.
+ * @breaking-change 21.0.0
+ */
 export const MAT_STEPPER_INTL_PROVIDER = {
   provide: MatStepperIntl,
   deps: [[new Optional(), new SkipSelf(), MatStepperIntl]],

--- a/src/material/tabs/ink-bar.ts
+++ b/src/material/tabs/ink-bar.ts
@@ -192,6 +192,8 @@ export interface _MatInkBarPositioner {
 /**
  * The default positioner function for the MatInkBar.
  * @docs-private
+ * @deprecated No longer used, will be removed.
+ * @breaking-change 21.0.0
  */
 export function _MAT_INK_BAR_POSITIONER_FACTORY(): _MatInkBarPositioner {
   const method = (element: HTMLElement) => ({

--- a/src/material/tooltip/tooltip.ts
+++ b/src/material/tooltip/tooltip.ts
@@ -87,19 +87,31 @@ export const MAT_TOOLTIP_SCROLL_STRATEGY = new InjectionToken<() => ScrollStrate
   },
 );
 
-/** @docs-private */
+/**
+ * @docs-private
+ * @deprecated No longer used, will be removed.
+ * @breaking-change 21.0.0
+ */
 export function MAT_TOOLTIP_SCROLL_STRATEGY_FACTORY(overlay: Overlay): () => ScrollStrategy {
   return () => overlay.scrollStrategies.reposition({scrollThrottle: SCROLL_THROTTLE_MS});
 }
 
-/** @docs-private */
+/**
+ * @docs-private
+ * @deprecated No longer used, will be removed.
+ * @breaking-change 21.0.0
+ */
 export const MAT_TOOLTIP_SCROLL_STRATEGY_FACTORY_PROVIDER = {
   provide: MAT_TOOLTIP_SCROLL_STRATEGY,
   deps: [Overlay],
   useFactory: MAT_TOOLTIP_SCROLL_STRATEGY_FACTORY,
 };
 
-/** @docs-private */
+/**
+ * @docs-private
+ * @deprecated No longer used, will be removed.
+ * @breaking-change 21.0.0
+ */
 export function MAT_TOOLTIP_DEFAULT_OPTIONS_FACTORY(): MatTooltipDefaultOptions {
   return {
     showDelay: 0,

--- a/tools/public_api_guard/cdk/a11y.md
+++ b/tools/public_api_guard/cdk/a11y.md
@@ -399,7 +399,7 @@ export const LIVE_ANNOUNCER_DEFAULT_OPTIONS: InjectionToken<LiveAnnouncerDefault
 // @public (undocumented)
 export const LIVE_ANNOUNCER_ELEMENT_TOKEN: InjectionToken<HTMLElement | null>;
 
-// @public
+// @public @deprecated
 export function LIVE_ANNOUNCER_ELEMENT_TOKEN_FACTORY(): null;
 
 // @public (undocumented)
@@ -463,10 +463,10 @@ export function removeAriaReferencedId(el: Element, attr: `aria-${string}`, id: 
 // @public
 export const TREE_KEY_MANAGER: InjectionToken<TreeKeyManagerFactory<any>>;
 
-// @public
+// @public @deprecated
 export function TREE_KEY_MANAGER_FACTORY<T extends TreeKeyManagerItem>(): TreeKeyManagerFactory<T>;
 
-// @public
+// @public @deprecated
 export const TREE_KEY_MANAGER_FACTORY_PROVIDER: {
     provide: InjectionToken<TreeKeyManagerFactory<any>>;
     useFactory: typeof TREE_KEY_MANAGER_FACTORY;

--- a/tools/public_api_guard/material/autocomplete.md
+++ b/tools/public_api_guard/material/autocomplete.md
@@ -34,16 +34,16 @@ export function getMatAutocompleteMissingPanelError(): Error;
 // @public
 export const MAT_AUTOCOMPLETE_DEFAULT_OPTIONS: InjectionToken<MatAutocompleteDefaultOptions>;
 
-// @public
+// @public @deprecated
 export function MAT_AUTOCOMPLETE_DEFAULT_OPTIONS_FACTORY(): MatAutocompleteDefaultOptions;
 
 // @public
 export const MAT_AUTOCOMPLETE_SCROLL_STRATEGY: InjectionToken<() => ScrollStrategy>;
 
-// @public
+// @public @deprecated
 export function MAT_AUTOCOMPLETE_SCROLL_STRATEGY_FACTORY(overlay: Overlay): () => ScrollStrategy;
 
-// @public
+// @public @deprecated
 export const MAT_AUTOCOMPLETE_SCROLL_STRATEGY_FACTORY_PROVIDER: {
     provide: InjectionToken<() => ScrollStrategy>;
     deps: (typeof Overlay)[];

--- a/tools/public_api_guard/material/button-toggle.md
+++ b/tools/public_api_guard/material/button-toggle.md
@@ -23,7 +23,7 @@ export const MAT_BUTTON_TOGGLE_DEFAULT_OPTIONS: InjectionToken<MatButtonToggleDe
 // @public
 export const MAT_BUTTON_TOGGLE_GROUP: InjectionToken<MatButtonToggleGroup>;
 
-// @public (undocumented)
+// @public @deprecated
 export function MAT_BUTTON_TOGGLE_GROUP_DEFAULT_OPTIONS_FACTORY(): MatButtonToggleDefaultOptions;
 
 // @public

--- a/tools/public_api_guard/material/button.md
+++ b/tools/public_api_guard/material/button.md
@@ -21,7 +21,7 @@ export const MAT_BUTTON_CONFIG: InjectionToken<MatButtonConfig>;
 // @public
 export const MAT_FAB_DEFAULT_OPTIONS: InjectionToken<MatFabDefaultOptions>;
 
-// @public
+// @public @deprecated
 export function MAT_FAB_DEFAULT_OPTIONS_FACTORY(): MatFabDefaultOptions;
 
 // @public

--- a/tools/public_api_guard/material/checkbox.md
+++ b/tools/public_api_guard/material/checkbox.md
@@ -22,7 +22,7 @@ import { Validator } from '@angular/forms';
 // @public
 export const MAT_CHECKBOX_DEFAULT_OPTIONS: InjectionToken<MatCheckboxDefaultOptions>;
 
-// @public
+// @public @deprecated
 export function MAT_CHECKBOX_DEFAULT_OPTIONS_FACTORY(): MatCheckboxDefaultOptions;
 
 // @public (undocumented)

--- a/tools/public_api_guard/material/core.md
+++ b/tools/public_api_guard/material/core.md
@@ -143,7 +143,7 @@ export const MAT_DATE_FORMATS: InjectionToken<MatDateFormats>;
 // @public
 export const MAT_DATE_LOCALE: InjectionToken<{}>;
 
-// @public
+// @public @deprecated
 export function MAT_DATE_LOCALE_FACTORY(): {};
 
 // @public (undocumented)

--- a/tools/public_api_guard/material/datepicker.md
+++ b/tools/public_api_guard/material/datepicker.md
@@ -98,10 +98,10 @@ export const MAT_DATE_RANGE_SELECTION_STRATEGY: InjectionToken<MatDateRangeSelec
 // @public
 export const MAT_DATEPICKER_SCROLL_STRATEGY: InjectionToken<() => ScrollStrategy>;
 
-// @public
+// @public @deprecated
 export function MAT_DATEPICKER_SCROLL_STRATEGY_FACTORY(overlay: Overlay): () => ScrollStrategy;
 
-// @public
+// @public @deprecated
 export const MAT_DATEPICKER_SCROLL_STRATEGY_FACTORY_PROVIDER: {
     provide: InjectionToken<() => ScrollStrategy>;
     deps: (typeof Overlay)[];
@@ -114,16 +114,16 @@ export const MAT_DATEPICKER_VALIDATORS: any;
 // @public
 export const MAT_DATEPICKER_VALUE_ACCESSOR: any;
 
-// @public
+// @public @deprecated
 export function MAT_RANGE_DATE_SELECTION_MODEL_FACTORY(parent: MatSingleDateSelectionModel<unknown>, adapter: DateAdapter<unknown>): MatSingleDateSelectionModel<unknown>;
 
-// @public
+// @public @deprecated
 export const MAT_RANGE_DATE_SELECTION_MODEL_PROVIDER: FactoryProvider;
 
-// @public
+// @public @deprecated
 export function MAT_SINGLE_DATE_SELECTION_MODEL_FACTORY(parent: MatSingleDateSelectionModel<unknown>, adapter: DateAdapter<unknown>): MatSingleDateSelectionModel<unknown>;
 
-// @public
+// @public @deprecated
 export const MAT_SINGLE_DATE_SELECTION_MODEL_PROVIDER: FactoryProvider;
 
 // @public

--- a/tools/public_api_guard/material/icon.md
+++ b/tools/public_api_guard/material/icon.md
@@ -32,14 +32,14 @@ export function getMatIconNameNotFoundError(iconName: string): Error;
 // @public
 export function getMatIconNoHttpProviderError(): Error;
 
-// @public
+// @public @deprecated
 export const ICON_REGISTRY_PROVIDER: {
     provide: typeof MatIconRegistry;
     deps: (Optional[] | typeof DomSanitizer | typeof ErrorHandler)[];
     useFactory: typeof ICON_REGISTRY_PROVIDER_FACTORY;
 };
 
-// @public
+// @public @deprecated
 export function ICON_REGISTRY_PROVIDER_FACTORY(parentRegistry: MatIconRegistry, httpClient: HttpClient, sanitizer: DomSanitizer, errorHandler: ErrorHandler, document?: any): MatIconRegistry;
 
 // @public
@@ -57,7 +57,7 @@ export const MAT_ICON_DEFAULT_OPTIONS: InjectionToken<MatIconDefaultOptions>;
 // @public
 export const MAT_ICON_LOCATION: InjectionToken<MatIconLocation>;
 
-// @public
+// @public @deprecated
 export function MAT_ICON_LOCATION_FACTORY(): MatIconLocation;
 
 // @public

--- a/tools/public_api_guard/material/menu.md
+++ b/tools/public_api_guard/material/menu.md
@@ -39,7 +39,7 @@ export const MAT_MENU_PANEL: InjectionToken<MatMenuPanel<any>>;
 // @public
 export const MAT_MENU_SCROLL_STRATEGY: InjectionToken<() => ScrollStrategy>;
 
-// @public
+// @public @deprecated
 export const MAT_MENU_SCROLL_STRATEGY_FACTORY_PROVIDER: {
     provide: InjectionToken<() => ScrollStrategy>;
     deps: (typeof Overlay)[];

--- a/tools/public_api_guard/material/paginator.md
+++ b/tools/public_api_guard/material/paginator.md
@@ -21,14 +21,14 @@ import { ThemePalette } from '@angular/material/core';
 // @public
 export const MAT_PAGINATOR_DEFAULT_OPTIONS: InjectionToken<MatPaginatorDefaultOptions>;
 
-// @public
+// @public @deprecated
 export const MAT_PAGINATOR_INTL_PROVIDER: {
     provide: typeof MatPaginatorIntl;
     deps: Optional[][];
     useFactory: typeof MAT_PAGINATOR_INTL_PROVIDER_FACTORY;
 };
 
-// @public
+// @public @deprecated
 export function MAT_PAGINATOR_INTL_PROVIDER_FACTORY(parentIntl: MatPaginatorIntl): MatPaginatorIntl;
 
 // @public

--- a/tools/public_api_guard/material/progress-bar.md
+++ b/tools/public_api_guard/material/progress-bar.md
@@ -19,7 +19,7 @@ export const MAT_PROGRESS_BAR_DEFAULT_OPTIONS: InjectionToken<MatProgressBarDefa
 // @public
 export const MAT_PROGRESS_BAR_LOCATION: InjectionToken<MatProgressBarLocation>;
 
-// @public
+// @public @deprecated
 export function MAT_PROGRESS_BAR_LOCATION_FACTORY(): MatProgressBarLocation;
 
 // @public (undocumented)

--- a/tools/public_api_guard/material/progress-spinner.md
+++ b/tools/public_api_guard/material/progress-spinner.md
@@ -13,7 +13,7 @@ import { ThemePalette } from '@angular/material/core';
 // @public
 export const MAT_PROGRESS_SPINNER_DEFAULT_OPTIONS: InjectionToken<MatProgressSpinnerDefaultOptions>;
 
-// @public
+// @public @deprecated
 export function MAT_PROGRESS_SPINNER_DEFAULT_OPTIONS_FACTORY(): MatProgressSpinnerDefaultOptions;
 
 // @public (undocumented)

--- a/tools/public_api_guard/material/radio.md
+++ b/tools/public_api_guard/material/radio.md
@@ -22,7 +22,7 @@ import { ThemePalette } from '@angular/material/core';
 // @public (undocumented)
 export const MAT_RADIO_DEFAULT_OPTIONS: InjectionToken<MatRadioDefaultOptions>;
 
-// @public (undocumented)
+// @public @deprecated
 export function MAT_RADIO_DEFAULT_OPTIONS_FACTORY(): MatRadioDefaultOptions;
 
 // @public

--- a/tools/public_api_guard/material/select.md
+++ b/tools/public_api_guard/material/select.md
@@ -50,14 +50,14 @@ export const MAT_SELECT_CONFIG: InjectionToken<MatSelectConfig>;
 // @public
 export const MAT_SELECT_SCROLL_STRATEGY: InjectionToken<() => ScrollStrategy>;
 
-// @public
+// @public @deprecated
 export const MAT_SELECT_SCROLL_STRATEGY_PROVIDER: {
     provide: InjectionToken<() => ScrollStrategy>;
     deps: (typeof Overlay)[];
     useFactory: typeof MAT_SELECT_SCROLL_STRATEGY_PROVIDER_FACTORY;
 };
 
-// @public
+// @public @deprecated
 export function MAT_SELECT_SCROLL_STRATEGY_PROVIDER_FACTORY(overlay: Overlay): () => ScrollStrategy;
 
 // @public

--- a/tools/public_api_guard/material/sidenav.md
+++ b/tools/public_api_guard/material/sidenav.md
@@ -25,7 +25,7 @@ import { Subject } from 'rxjs';
 // @public
 export const MAT_DRAWER_DEFAULT_AUTOSIZE: InjectionToken<boolean>;
 
-// @public
+// @public @deprecated
 export function MAT_DRAWER_DEFAULT_AUTOSIZE_FACTORY(): boolean;
 
 // @public

--- a/tools/public_api_guard/material/snack-bar.md
+++ b/tools/public_api_guard/material/snack-bar.md
@@ -34,7 +34,7 @@ export const MAT_SNACK_BAR_DATA: InjectionToken<any>;
 // @public
 export const MAT_SNACK_BAR_DEFAULT_OPTIONS: InjectionToken<MatSnackBarConfig<any>>;
 
-// @public
+// @public @deprecated
 export function MAT_SNACK_BAR_DEFAULT_OPTIONS_FACTORY(): MatSnackBarConfig;
 
 // @public

--- a/tools/public_api_guard/material/sort.md
+++ b/tools/public_api_guard/material/sort.md
@@ -31,14 +31,14 @@ export interface ArrowViewStateTransition {
 // @public
 export const MAT_SORT_DEFAULT_OPTIONS: InjectionToken<MatSortDefaultOptions>;
 
-// @public
+// @public @deprecated
 export const MAT_SORT_HEADER_INTL_PROVIDER: {
     provide: typeof MatSortHeaderIntl;
     deps: Optional[][];
     useFactory: typeof MAT_SORT_HEADER_INTL_PROVIDER_FACTORY;
 };
 
-// @public
+// @public @deprecated
 export function MAT_SORT_HEADER_INTL_PROVIDER_FACTORY(parentIntl: MatSortHeaderIntl): MatSortHeaderIntl;
 
 // @public

--- a/tools/public_api_guard/material/stepper.md
+++ b/tools/public_api_guard/material/stepper.md
@@ -35,14 +35,14 @@ import { TemplateRef } from '@angular/core';
 import { ThemePalette } from '@angular/material/core';
 import { WritableSignal } from '@angular/core';
 
-// @public
+// @public @deprecated
 export const MAT_STEPPER_INTL_PROVIDER: {
     provide: typeof MatStepperIntl;
     deps: Optional[][];
     useFactory: typeof MAT_STEPPER_INTL_PROVIDER_FACTORY;
 };
 
-// @public
+// @public @deprecated
 export function MAT_STEPPER_INTL_PROVIDER_FACTORY(parentIntl: MatStepperIntl): MatStepperIntl;
 
 // @public (undocumented)

--- a/tools/public_api_guard/material/tabs.md
+++ b/tools/public_api_guard/material/tabs.md
@@ -35,7 +35,7 @@ import { ThemePalette } from '@angular/material/core';
 // @public
 export const _MAT_INK_BAR_POSITIONER: InjectionToken<_MatInkBarPositioner>;
 
-// @public
+// @public @deprecated
 export function _MAT_INK_BAR_POSITIONER_FACTORY(): _MatInkBarPositioner;
 
 // @public

--- a/tools/public_api_guard/material/tooltip.md
+++ b/tools/public_api_guard/material/tooltip.md
@@ -30,16 +30,16 @@ export function getMatTooltipInvalidPositionError(position: string): Error;
 // @public
 export const MAT_TOOLTIP_DEFAULT_OPTIONS: InjectionToken<MatTooltipDefaultOptions>;
 
-// @public
+// @public @deprecated
 export function MAT_TOOLTIP_DEFAULT_OPTIONS_FACTORY(): MatTooltipDefaultOptions;
 
 // @public
 export const MAT_TOOLTIP_SCROLL_STRATEGY: InjectionToken<() => ScrollStrategy>;
 
-// @public
+// @public @deprecated
 export function MAT_TOOLTIP_SCROLL_STRATEGY_FACTORY(overlay: Overlay): () => ScrollStrategy;
 
-// @public
+// @public @deprecated
 export const MAT_TOOLTIP_SCROLL_STRATEGY_FACTORY_PROVIDER: {
     provide: InjectionToken<() => ScrollStrategy>;
     deps: (typeof Overlay)[];


### PR DESCRIPTION
There are a bunch of factory functions that made it into our public API as a result of an old ViewEngine limitation where the factories had to be separate variables and had to be exported. With Ivy this isn't necessary and the factories can be inlined. Also they were never meant to be public APIs.

These changes mark them as deprecated so they can be dropped from the public API in v21.