### PR TITLE
refactor(multiple): eliminate usages of `any` type (batch 2)

### DIFF
--- a/src/google-maps/map-event-manager.ts
+++ b/src/google-maps/map-event-manager.ts
@@ -12,9 +12,9 @@ import {switchMap} from 'rxjs/operators';
 
 type MapEventManagerTarget =
   | {
-      addListener<T>(
+      addListener<T extends unknown[]>(
         name: string,
-        callback: (args: T) => void,
+        callback: (...args: T) => void,
       ): google.maps.MapsEventListener | undefined;
     }
   | undefined;

--- a/src/google-maps/map-event-manager.ts
+++ b/src/google-maps/map-event-manager.ts
@@ -12,10 +12,10 @@ import {switchMap} from 'rxjs/operators';
 
 type MapEventManagerTarget =
   | {
-      addListener: (
+      addListener<T>(
         name: string,
-        callback: (...args: unknown[]) => void,
-      ) => google.maps.MapsEventListener | undefined;
+        callback: (args: T) => void,
+      ): google.maps.MapsEventListener | undefined;
     }
   | undefined;
 
@@ -48,8 +48,8 @@ export class MapEventManager {
             return undefined;
           }
 
-          const listener = target.addListener(name, (event: unknown) => {
-            this._ngZone.run(() => observer.next(event as T));
+          const listener = target.addListener(name, (event: T) => {
+            this._ngZone.run(() => observer.next(event));
           });
 
           // If there's an error when initializing the Maps API (e.g. a wrong API key), it will

--- a/src/google-maps/map-event-manager.ts
+++ b/src/google-maps/map-event-manager.ts
@@ -14,7 +14,7 @@ type MapEventManagerTarget =
   | {
       addListener: (
         name: string,
-        callback: (...args: any[]) => void,
+        callback: (...args: unknown[]) => void,
       ) => google.maps.MapsEventListener | undefined;
     }
   | undefined;
@@ -22,7 +22,7 @@ type MapEventManagerTarget =
 /** Manages event on a Google Maps object, ensuring that events are added only when necessary. */
 export class MapEventManager {
   /** Pending listeners that were added before the target was set. */
-  private _pending: {observable: Observable<any>; observer: Subscriber<any>}[] = [];
+  private _pending: {observable: Observable<unknown>; observer: Subscriber<unknown>}[] = [];
   private _listeners: google.maps.MapsEventListener[] = [];
   private _targetStream = new BehaviorSubject<MapEventManagerTarget>(undefined);
 
@@ -48,8 +48,8 @@ export class MapEventManager {
             return undefined;
           }
 
-          const listener = target.addListener(name, (event: T) => {
-            this._ngZone.run(() => observer.next(event));
+          const listener = target.addListener(name, (event: unknown) => {
+            this._ngZone.run(() => observer.next(event as T));
           });
 
           // If there's an error when initializing the Maps API (e.g. a wrong API key), it will

--- a/src/material-date-fns-adapter/adapter/date-fns-adapter.ts
+++ b/src/material-date-fns-adapter/adapter/date-fns-adapter.ts
@@ -161,7 +161,7 @@ export class DateFnsAdapter extends DateAdapter<Date, Locale> {
     return new Date();
   }
 
-  parse(value: any, parseFormat: string | string[]): Date | null {
+  parse(value: unknown, parseFormat: string | string[]): Date | null {
     if (typeof value == 'string' && value.length > 0) {
       const iso8601Date = parseISO(value);
 
@@ -222,7 +222,7 @@ export class DateFnsAdapter extends DateAdapter<Date, Locale> {
    * (https://www.ietf.org/rfc/rfc3339.txt) into valid Dates and empty string into null. Returns an
    * invalid date for all other values.
    */
-  override deserialize(value: any): Date | null {
+  override deserialize(value: unknown): Date | null {
     if (typeof value === 'string') {
       if (!value) {
         return null;
@@ -235,7 +235,7 @@ export class DateFnsAdapter extends DateAdapter<Date, Locale> {
     return super.deserialize(value);
   }
 
-  isDateInstance(obj: any): boolean {
+  isDateInstance(obj: unknown): obj is Date {
     return isDate(obj);
   }
 
@@ -277,7 +277,7 @@ export class DateFnsAdapter extends DateAdapter<Date, Locale> {
     return getSeconds(date);
   }
 
-  override parseTime(value: any, parseFormat: string | string[]): Date | null {
+  override parseTime(value: unknown, parseFormat: string | string[]): Date | null {
     return this.parse(value, parseFormat);
   }
 

--- a/src/material-experimental/column-resize/column-resize.spec.ts
+++ b/src/material-experimental/column-resize/column-resize.spec.ts
@@ -333,7 +333,7 @@ class ElementDataSource extends DataSource<PeriodicElement> {
 }
 
 // There's 1px of variance between different browsers in terms of positioning.
-const approximateMatcher = {
+const approximateMatcher: jasmine.CustomMatcherFactories = {
   isApproximately: () => ({
     compare: (actual: number, expected: number) => {
       const result = {
@@ -347,6 +347,14 @@ const approximateMatcher = {
     },
   }),
 };
+
+interface NumberMatchers extends jasmine.Matchers<number> {
+  isApproximately(expected: number): void;
+  not: NumberMatchers;
+}
+declare global {
+  function expect(actual: number): NumberMatchers;
+}
 
 const testCases = [
   [MatColumnResizeModule, MatResizeTest, 'opt-in table-based mat-table'],
@@ -409,12 +417,8 @@ describe('Material Popover Edit', () => {
           component.getOverlayThumbElement(2).classList.contains('mat-column-resize-overlay-thumb'),
         ).toBe(true);
 
-        (expect(component.getOverlayThumbElement(0).offsetHeight) as any).isApproximately(
-          headerRowHeight,
-        );
-        (expect(component.getOverlayThumbElement(2).offsetHeight) as any).isApproximately(
-          headerRowHeight,
-        );
+        expect(component.getOverlayThumbElement(0).offsetHeight).isApproximately(headerRowHeight);
+        expect(component.getOverlayThumbElement(2).offsetHeight).isApproximately(headerRowHeight);
 
         component.beginColumnResizeWithMouse(0);
 
@@ -425,15 +429,11 @@ describe('Material Popover Edit', () => {
           component.getOverlayThumbElement(2).classList.contains('mat-column-resize-overlay-thumb'),
         ).toBe(true);
 
-        (expect(component.getOverlayThumbElement(0).offsetHeight) as any).isApproximately(
-          tableHeight,
-        );
-        (expect(component.getOverlayThumbTopElement(0).offsetHeight) as any).isApproximately(
+        expect(component.getOverlayThumbElement(0).offsetHeight).isApproximately(tableHeight);
+        expect(component.getOverlayThumbTopElement(0).offsetHeight).isApproximately(
           headerRowHeight,
         );
-        (expect(component.getOverlayThumbElement(2).offsetHeight) as any).isApproximately(
-          headerRowHeight,
-        );
+        expect(component.getOverlayThumbElement(2).offsetHeight).isApproximately(headerRowHeight);
 
         component.completeResizeWithMouseInProgress(0);
         component.endHoverState();
@@ -462,15 +462,15 @@ describe('Material Popover Edit', () => {
         let columnPositionDelta = component.getColumnOriginPosition(1) - initialColumnPosition;
         // let nextColumnPositionDelta =
         //   component.getColumnOriginPosition(2) - initialNextColumnPosition;
-        (expect(thumbPositionDelta) as any).isApproximately(columnPositionDelta);
+        expect(thumbPositionDelta).isApproximately(columnPositionDelta);
         // TODO: This was commented out after switching from the legacy table to the current
         // MDC-based table. This failed by being inaccurate by several pixels.
-        // (expect(nextColumnPositionDelta) as any).isApproximately(columnPositionDelta);
+        // expect(nextColumnPositionDelta).isApproximately(columnPositionDelta);
 
         // TODO: This was commented out after switching from the legacy table to the current
         // MDC-based table. This failed by being inaccurate by several pixels.
-        // (expect(component.getTableWidth()) as any).isApproximately(initialTableWidth + 5);
-        (expect(component.getColumnWidth(1)) as any).isApproximately(initialColumnWidth + 5);
+        // expect(component.getTableWidth()).isApproximately(initialTableWidth + 5);
+        expect(component.getColumnWidth(1)).isApproximately(initialColumnWidth + 5);
 
         component.updateResizeWithMouseInProgress(1);
         fixture.detectChanges();
@@ -478,15 +478,15 @@ describe('Material Popover Edit', () => {
 
         thumbPositionDelta = component.getOverlayThumbPosition(1) - initialThumbPosition;
         columnPositionDelta = component.getColumnOriginPosition(1) - initialColumnPosition;
-        (expect(thumbPositionDelta) as any).isApproximately(columnPositionDelta);
+        expect(thumbPositionDelta).isApproximately(columnPositionDelta);
 
-        (expect(component.getTableWidth()) as any).isApproximately(initialTableWidth + 1);
-        (expect(component.getColumnWidth(1)) as any).isApproximately(initialColumnWidth + 1);
+        expect(component.getTableWidth()).isApproximately(initialTableWidth + 1);
+        expect(component.getColumnWidth(1)).isApproximately(initialColumnWidth + 1);
 
         component.completeResizeWithMouseInProgress(1);
         flush();
 
-        (expect(component.getColumnWidth(1)) as any).isApproximately(initialColumnWidth + 1);
+        expect(component.getColumnWidth(1)).isApproximately(initialColumnWidth + 1);
 
         component.endHoverState();
         fixture.detectChanges();
@@ -508,8 +508,8 @@ describe('Material Popover Edit', () => {
         flush();
 
         let thumbPositionDelta = component.getOverlayThumbPosition(1) - initialThumbPosition;
-        (expect(thumbPositionDelta) as any).isApproximately(5);
-        (expect(component.getColumnWidth(1)) as any).toBe(initialColumnWidth);
+        expect(thumbPositionDelta).isApproximately(5);
+        expect(component.getColumnWidth(1)).toBe(initialColumnWidth);
 
         component.updateResizeWithMouseInProgress(1);
         fixture.detectChanges();
@@ -517,14 +517,14 @@ describe('Material Popover Edit', () => {
 
         thumbPositionDelta = component.getOverlayThumbPosition(1) - initialThumbPosition;
 
-        (expect(component.getTableWidth()) as any).toBe(initialTableWidth);
-        (expect(component.getColumnWidth(1)) as any).toBe(initialColumnWidth);
+        expect(component.getTableWidth()).toBe(initialTableWidth);
+        expect(component.getColumnWidth(1)).toBe(initialColumnWidth);
 
         component.completeResizeWithMouseInProgress(1);
         flush();
 
-        (expect(component.getTableWidth()) as any).isApproximately(initialTableWidth + 1);
-        (expect(component.getColumnWidth(1)) as any).isApproximately(initialColumnWidth + 1);
+        expect(component.getTableWidth()).isApproximately(initialTableWidth + 1);
+        expect(component.getColumnWidth(1)).isApproximately(initialColumnWidth + 1);
 
         component.endHoverState();
         fixture.detectChanges();
@@ -562,18 +562,18 @@ describe('Material Popover Edit', () => {
 
         let thumbPositionDelta = component.getOverlayThumbPosition(1) - initialThumbPosition;
         let columnPositionDelta = component.getColumnOriginPosition(1) - initialColumnPosition;
-        (expect(thumbPositionDelta) as any).isApproximately(columnPositionDelta);
+        expect(thumbPositionDelta).isApproximately(columnPositionDelta);
 
-        (expect(component.getColumnWidth(1)) as any).isApproximately(initialColumnWidth + 5);
+        expect(component.getColumnWidth(1)).isApproximately(initialColumnWidth + 5);
         // TODO: This was commented out after switching from the legacy table to the current
         // MDC-based table. This failed by being inaccurate by several pixels.
-        // (expect(component.getTableWidth()) as any).isApproximately(initialTableWidth + 5);
+        // expect(component.getTableWidth()).isApproximately(initialTableWidth + 5);
 
         dispatchKeyboardEvent(document, 'keyup', ESCAPE);
         flush();
 
-        (expect(component.getColumnWidth(1)) as any).isApproximately(initialColumnWidth);
-        (expect(component.getTableWidth()) as any).isApproximately(initialTableWidth);
+        expect(component.getColumnWidth(1)).isApproximately(initialColumnWidth);
+        expect(component.getTableWidth()).isApproximately(initialTableWidth);
 
         component.endHoverState();
         fixture.detectChanges();
@@ -582,7 +582,7 @@ describe('Material Popover Edit', () => {
       it('notifies subscribers of a completed resize via ColumnResizeNotifier', fakeAsync(() => {
         const initialColumnWidth = component.getColumnWidth(1);
 
-        let resize: ColumnSize | null = null;
+        let resize: ColumnSize | null = null as ColumnSize | null;
         component.columnResize.columnResizeNotifier.resizeCompleted.subscribe(size => {
           resize = size;
         });
@@ -596,7 +596,7 @@ describe('Material Popover Edit', () => {
         fixture.detectChanges();
         flush();
 
-        expect(resize).toEqual({columnId: 'name', size: initialColumnWidth + 5} as any);
+        expect(resize).toEqual({columnId: 'name', size: initialColumnWidth + 5});
 
         component.endHoverState();
         fixture.detectChanges();
@@ -626,12 +626,12 @@ describe('Material Popover Edit', () => {
 
       it('performs a column resize triggered via ColumnResizeNotifier', fakeAsync(() => {
         // Pre-verify that we are not updating the size to the initial size.
-        (expect(component.getColumnWidth(1)) as any).not.isApproximately(173);
+        expect(component.getColumnWidth(1)).not.isApproximately(173);
 
         component.columnResize.columnResizeNotifier.resize('name', 173);
         flush();
 
-        (expect(component.getColumnWidth(1)) as any).isApproximately(173);
+        expect(component.getColumnWidth(1)).isApproximately(173);
       }));
     });
   }
@@ -660,13 +660,13 @@ describe('Material Popover Edit', () => {
     }));
 
     it('applies the persisted size', fakeAsync(() => {
-      (expect(component.getColumnWidth(1)).not as any).isApproximately(300);
+      expect(component.getColumnWidth(1)).not.isApproximately(300);
 
       columnSizeStore.emitSize('theTable', 'name', 300);
 
       flush();
 
-      (expect(component.getColumnWidth(1)) as any).isApproximately(300);
+      expect(component.getColumnWidth(1)).isApproximately(300);
     }));
 
     it('persists the user-triggered size update', fakeAsync(() => {
@@ -689,7 +689,7 @@ describe('Material Popover Edit', () => {
       const {tableId, columnId, sizePx} = columnSizeStore.setSizeCalls[0];
       expect(tableId).toBe('theTable');
       expect(columnId).toBe('name');
-      (expect(sizePx) as any).isApproximately(initialColumnWidth + 5);
+      expect(sizePx).isApproximately(initialColumnWidth + 5);
     }));
 
     it('persists the user-triggered size update (live updates off)', fakeAsync(() => {
@@ -714,7 +714,7 @@ describe('Material Popover Edit', () => {
       const {tableId, columnId, sizePx} = columnSizeStore.setSizeCalls[0];
       expect(tableId).toBe('theTable');
       expect(columnId).toBe('name');
-      (expect(sizePx) as any).isApproximately(initialColumnWidth + 5);
+      expect(sizePx).isApproximately(initialColumnWidth + 5);
     }));
   });
 });

--- a/src/material-luxon-adapter/adapter/luxon-date-adapter.ts
+++ b/src/material-luxon-adapter/adapter/luxon-date-adapter.ts
@@ -177,7 +177,7 @@ export class LuxonDateAdapter extends DateAdapter<LuxonDateTime> {
     return this._useUTC ? LuxonDateTime.utc(options) : LuxonDateTime.local(options);
   }
 
-  parse(value: any, parseFormat: string | string[]): LuxonDateTime | null {
+  parse(value: unknown, parseFormat: string | string[]): LuxonDateTime | null {
     const options: LuxonDateTimeOptions = this._getOptions();
 
     if (typeof value == 'string' && value.length > 0) {
@@ -245,7 +245,7 @@ export class LuxonDateAdapter extends DateAdapter<LuxonDateTime> {
    * (https://www.ietf.org/rfc/rfc3339.txt) and valid Date objects into valid DateTime and empty
    * string into null. Returns an invalid date for all other values.
    */
-  override deserialize(value: any): LuxonDateTime | null {
+  override deserialize(value: unknown): LuxonDateTime | null {
     const options = this._getOptions();
     let date: LuxonDateTime | undefined;
     if (value instanceof Date) {
@@ -263,7 +263,7 @@ export class LuxonDateAdapter extends DateAdapter<LuxonDateTime> {
     return super.deserialize(value);
   }
 
-  isDateInstance(obj: any): boolean {
+  isDateInstance(obj: unknown): obj is LuxonDateTime {
     return obj instanceof LuxonDateTime;
   }
 
@@ -315,7 +315,7 @@ export class LuxonDateAdapter extends DateAdapter<LuxonDateTime> {
     return date.second;
   }
 
-  override parseTime(value: any, parseFormat: string | string[]): LuxonDateTime | null {
+  override parseTime(value: unknown, parseFormat: string | string[]): LuxonDateTime | null {
     const result = this.parse(value, parseFormat);
 
     if ((!result || !this.isValid(result)) && typeof value === 'string') {

--- a/src/material-moment-adapter/adapter/moment-date-adapter.ts
+++ b/src/material-moment-adapter/adapter/moment-date-adapter.ts
@@ -187,7 +187,7 @@ export class MomentDateAdapter extends DateAdapter<Moment> {
     return this._createMoment().locale(this.locale);
   }
 
-  parse(value: any, parseFormat: string | string[]): Moment | null {
+  parse(value: unknown, parseFormat: string | string[]): Moment | null {
     if (value && typeof value == 'string') {
       return this._createMoment(value, parseFormat, this.locale);
     }
@@ -223,7 +223,7 @@ export class MomentDateAdapter extends DateAdapter<Moment> {
    * (https://www.ietf.org/rfc/rfc3339.txt) and valid Date objects into valid Moments and empty
    * string into null. Returns an invalid date for all other values.
    */
-  override deserialize(value: any): Moment | null {
+  override deserialize(value: unknown): Moment | null {
     let date;
     if (value instanceof Date) {
       date = this._createMoment(value).locale(this.locale);
@@ -243,7 +243,7 @@ export class MomentDateAdapter extends DateAdapter<Moment> {
     return super.deserialize(value);
   }
 
-  isDateInstance(obj: any): boolean {
+  isDateInstance(obj: unknown): obj is Moment {
     return moment.isMoment(obj);
   }
 
@@ -285,7 +285,7 @@ export class MomentDateAdapter extends DateAdapter<Moment> {
     return date.seconds();
   }
 
-  override parseTime(value: any, parseFormat: string | string[]): Moment | null {
+  override parseTime(value: unknown, parseFormat: string | string[]): Moment | null {
     return this.parse(value, parseFormat);
   }
 

--- a/src/universal-app/hydration.e2e.spec.ts
+++ b/src/universal-app/hydration.e2e.spec.ts
@@ -1,5 +1,11 @@
 import {browser, by, element, ExpectedConditions} from 'protractor';
 
+// Expect `ngDevMode` to be always set:
+declare const ngDevMode: {
+  hydratedComponents: number;
+  componentsSkippedHydration: number;
+};
+
 describe('hydration e2e', () => {
   beforeEach(async () => {
     await browser.waitForAngularEnabled(false);
@@ -27,7 +33,7 @@ async function getHydrationState() {
     hydratedComponents: number;
     componentsSkippedHydration: number;
   }>(() => ({
-    hydratedComponents: (window as any).ngDevMode.hydratedComponents,
-    componentsSkippedHydration: (window as any).ngDevMode.componentsSkippedHydration,
+    hydratedComponents: ngDevMode.hydratedComponents,
+    componentsSkippedHydration: ngDevMode.componentsSkippedHydration,
   }));
 }

--- a/src/universal-app/hydration.e2e.spec.ts
+++ b/src/universal-app/hydration.e2e.spec.ts
@@ -1,10 +1,13 @@
 import {browser, by, element, ExpectedConditions} from 'protractor';
 
-// Expect `ngDevMode` to be always set:
-declare const ngDevMode: {
-  hydratedComponents: number;
-  componentsSkippedHydration: number;
-};
+declare global {
+  interface Window {
+    ngDevMode: {
+      hydratedComponents: number;
+      componentsSkippedHydration: number;
+    };
+  }
+}
 
 describe('hydration e2e', () => {
   beforeEach(async () => {
@@ -33,7 +36,7 @@ async function getHydrationState() {
     hydratedComponents: number;
     componentsSkippedHydration: number;
   }>(() => ({
-    hydratedComponents: ngDevMode.hydratedComponents,
-    componentsSkippedHydration: ngDevMode.componentsSkippedHydration,
+    hydratedComponents: window.ngDevMode.hydratedComponents,
+    componentsSkippedHydration: window.ngDevMode.componentsSkippedHydration,
   }));
 }

--- a/src/universal-app/kitchen-sink/kitchen-sink.ts
+++ b/src/universal-app/kitchen-sink/kitchen-sink.ts
@@ -62,8 +62,15 @@ import {MatTooltipModule} from '@angular/material/tooltip';
 import {YouTubePlayer} from '@angular/youtube-player';
 import {Observable, of as observableOf} from 'rxjs';
 
-export class TableDataSource extends DataSource<any> {
-  connect(): Observable<any> {
+interface ElementItem {
+  position: number;
+  name: string;
+  weight: number;
+  symbol: string;
+}
+
+export class TableDataSource extends DataSource<ElementItem> {
+  connect(): Observable<Array<ElementItem>> {
     return observableOf([
       {position: 1, name: 'Hydrogen', weight: 1.0079, symbol: 'H'},
       {position: 2, name: 'Helium', weight: 4.0026, symbol: 'He'},
@@ -78,7 +85,7 @@ export class TableDataSource extends DataSource<any> {
     ]);
   }
 
-  disconnect() {}
+  override disconnect() {}
 }
 
 export const AUTOMATED_KITCHEN_SINK = new InjectionToken<boolean>('AUTOMATED_KITCHEN_SINK');

--- a/src/universal-app/kitchen-sink/kitchen-sink.ts
+++ b/src/universal-app/kitchen-sink/kitchen-sink.ts
@@ -70,7 +70,7 @@ interface ElementItem {
 }
 
 export class TableDataSource extends DataSource<ElementItem> {
-  connect(): Observable<Array<ElementItem>> {
+  connect(): Observable<ElementItem[]> {
     return observableOf([
       {position: 1, name: 'Hydrogen', weight: 1.0079, symbol: 'H'},
       {position: 2, name: 'Helium', weight: 4.0026, symbol: 'He'},
@@ -85,7 +85,7 @@ export class TableDataSource extends DataSource<ElementItem> {
     ]);
   }
 
-  override disconnect() {}
+  disconnect() {}
 }
 
 export const AUTOMATED_KITCHEN_SINK = new InjectionToken<boolean>('AUTOMATED_KITCHEN_SINK');

--- a/src/youtube-player/youtube-player.spec.ts
+++ b/src/youtube-player/youtube-player.spec.ts
@@ -10,8 +10,10 @@ import {
 } from './youtube-player';
 import {PlaceholderImageQuality} from './youtube-player-placeholder';
 
+declare var window: Window;
+
 const VIDEO_ID = 'a12345';
-const YT_LOADING_STATE_MOCK = {loading: 1, loaded: 0};
+const YT_LOADING_STATE_MOCK = {loading: 1, loaded: 0} as unknown as typeof YT;
 const TEST_PROVIDERS: (Provider | EnvironmentProviders)[] = [
   {
     provide: YOUTUBE_PLAYER_CONFIG,
@@ -56,7 +58,7 @@ describe('YoutubePlayer', () => {
     });
 
     afterEach(() => {
-      (window as any).YT = undefined;
+      window.YT = undefined;
       window.onYouTubeIframeAPIReady = undefined;
     });
 
@@ -540,17 +542,17 @@ describe('YoutubePlayer', () => {
     let api: typeof YT;
 
     beforeEach(() => {
-      api = window.YT;
-      (window as any).YT = undefined;
+      api = window.YT!;
+      window.YT = undefined;
     });
 
     afterEach(() => {
-      (window as any).YT = undefined;
+      window.YT = undefined;
       window.onYouTubeIframeAPIReady = undefined;
     });
 
     it('waits until the api is ready before initializing', () => {
-      (window.YT as any) = YT_LOADING_STATE_MOCK;
+      window.YT = YT_LOADING_STATE_MOCK;
       TestBed.configureTestingModule({providers: TEST_PROVIDERS});
       fixture = TestBed.createComponent(TestApp);
       testComponent = fixture.debugElement.componentInstance;
@@ -560,7 +562,7 @@ describe('YoutubePlayer', () => {
 
       expect(playerCtorSpy).not.toHaveBeenCalled();
 
-      window.YT = api!;
+      window.YT = api;
       window.onYouTubeIframeAPIReady!();
 
       expect(playerCtorSpy).toHaveBeenCalledWith(
@@ -585,7 +587,7 @@ describe('YoutubePlayer', () => {
 
       expect(playerCtorSpy).not.toHaveBeenCalled();
 
-      window.YT = api!;
+      window.YT = api;
       window.onYouTubeIframeAPIReady!();
 
       expect(spy).toHaveBeenCalled();
@@ -601,7 +603,7 @@ describe('YoutubePlayer', () => {
     });
 
     afterEach(() => {
-      fixture = testComponent = (window as any).YT = window.onYouTubeIframeAPIReady = undefined!;
+      fixture = testComponent = window.YT = window.onYouTubeIframeAPIReady = undefined!;
     });
 
     it('should show a placeholder', () => {


### PR DESCRIPTION
- Replace `any` with `unknown` or more specific types
- ~Fix `ban-script-src-assignments` vulnerability in `youtube-player`~ submitted as a separate PR by andrewseguin (https://github.com/angular/components/pull/30773)