### PR TITLE
feat(material/button): allow appearance to be set dynamically

### DIFF
--- a/integration/yarn-pnp-compat/src/app/app.component.html
+++ b/integration/yarn-pnp-compat/src/app/app.component.html
@@ -1,1 +1,1 @@
-<button mat-button>Click here</button>
+<button matButton>Click here</button>

--- a/src/cdk/schematics/ng-update/html-parsing/angular.ts
+++ b/src/cdk/schematics/ng-update/html-parsing/angular.ts
@@ -23,7 +23,7 @@ export function findInputsOnElementWithTag(html: string, inputName: string, tagN
 /** Finds the specified Angular @Input in elements that have one of the specified attributes. */
 export function findInputsOnElementWithAttr(html: string, inputName: string, attrs: string[]) {
   return [
-    // Inputs can be also used without brackets (e.g. `<button mat-button color="primary">`)
+    // Inputs can be also used without brackets (e.g. `<button matButton color="primary">`)
     ...findAttributeOnElementWithAttrs(html, inputName, attrs),
     // Add one column to the mapped offset because the first bracket for the @Input
     // is part of the attribute and therefore also part of the offset. We only want to return

--- a/src/components-examples/cdk/text-field/text-field-autofill-directive/text-field-autofill-directive-example.html
+++ b/src/components-examples/cdk/text-field/text-field-autofill-directive/text-field-autofill-directive-example.html
@@ -13,5 +13,5 @@
       <mat-hint>Autofilled!</mat-hint>
     }
   </mat-form-field>
-  <button mat-raised-button>Submit</button>
+  <button matButton="elevated">Submit</button>
 </form>

--- a/src/components-examples/cdk/text-field/text-field-autofill-monitor/text-field-autofill-monitor-example.html
+++ b/src/components-examples/cdk/text-field/text-field-autofill-monitor/text-field-autofill-monitor-example.html
@@ -13,5 +13,5 @@
       <mat-hint>Autofilled!</mat-hint>
     }
   </mat-form-field>
-  <button mat-raised-button>Submit</button>
+  <button matButton="elevated">Submit</button>
 </form>

--- a/src/components-examples/cdk/tree/cdk-tree-complex/cdk-tree-complex-example.html
+++ b/src/components-examples/cdk/tree/cdk-tree-complex/cdk-tree-complex-example.html
@@ -20,7 +20,7 @@
 
       @if (!node.areChildrenLoading() && node.isExpandable()) {
         <button
-            mat-icon-button
+            matIconButton
             cdkTreeNodeToggle
             [attr.aria-label]="'Toggle ' + node.raw.name">
           <mat-icon class="mat-icon-rtl-mirror">

--- a/src/components-examples/cdk/tree/cdk-tree-custom-key-manager/cdk-tree-custom-key-manager-example.html
+++ b/src/components-examples/cdk/tree/cdk-tree-custom-key-manager/cdk-tree-custom-key-manager-example.html
@@ -5,7 +5,7 @@
                  [isDisabled]="!shouldRender(node)"
                  class="example-tree-node">
     <!-- use a disabled button to provide padding for tree leaf -->
-    <button mat-icon-button disabled></button>
+    <button matIconButton disabled></button>
     {{node.name}}
   </cdk-tree-node>
   <!-- This is the tree node template for expandable nodes -->
@@ -17,7 +17,7 @@
                  (expandedChange)="node.isExpanded = $event"
                  class="example-tree-node"
                  tabindex="0">
-    <button mat-icon-button cdkTreeNodeToggle
+    <button matIconButton cdkTreeNodeToggle
             [attr.aria-label]="'Toggle ' + node.name"
             [style.visibility]="node.expandable ? 'visible' : 'hidden'">
       <mat-icon class="mat-icon-rtl-mirror">

--- a/src/components-examples/cdk/tree/cdk-tree-flat-children-accessor/cdk-tree-flat-children-accessor-example.html
+++ b/src/components-examples/cdk/tree/cdk-tree-flat-children-accessor/cdk-tree-flat-children-accessor-example.html
@@ -5,7 +5,7 @@
                  [isDisabled]="!shouldRender(node)"
                  class="example-tree-node">
     <!-- use a disabled button to provide padding for tree leaf -->
-    <button mat-icon-button disabled></button>
+    <button matIconButton disabled></button>
     {{node.name}}
   </cdk-tree-node>
   <!-- This is the tree node template for expandable nodes -->
@@ -16,7 +16,7 @@
                  [isDisabled]="!shouldRender(node)"
                  [isExpandable]="true"
                  class="example-tree-node">
-    <button mat-icon-button cdkTreeNodeToggle [attr.aria-label]="'Toggle ' + node.name">
+    <button matIconButton cdkTreeNodeToggle [attr.aria-label]="'Toggle ' + node.name">
       <mat-icon class="mat-icon-rtl-mirror">
         {{tree.isExpanded(node) ? 'expand_more' : 'chevron_right'}}
       </mat-icon>

--- a/src/components-examples/cdk/tree/cdk-tree-flat-level-accessor/cdk-tree-flat-level-accessor-example.html
+++ b/src/components-examples/cdk/tree/cdk-tree-flat-level-accessor/cdk-tree-flat-level-accessor-example.html
@@ -5,7 +5,7 @@
                  [isDisabled]="!shouldRender(node)"
                  class="example-tree-node">
     <!-- use a disabled button to provide padding for tree leaf -->
-    <button mat-icon-button disabled></button>
+    <button matIconButton disabled></button>
     {{node.name}}
   </cdk-tree-node>
   <!-- This is the tree node template for expandable nodes -->
@@ -16,7 +16,7 @@
                  [isDisabled]="!shouldRender(node)"
                  [isExpandable]="node.expandable"
                  class="example-tree-node">
-    <button mat-icon-button cdkTreeNodeToggle
+    <button matIconButton cdkTreeNodeToggle
             [attr.aria-label]="'Toggle ' + node.name"
             [style.visibility]="node.expandable ? 'visible' : 'hidden'">
       <mat-icon class="mat-icon-rtl-mirror">

--- a/src/components-examples/cdk/tree/cdk-tree-flat/cdk-tree-flat-example.html
+++ b/src/components-examples/cdk/tree/cdk-tree-flat/cdk-tree-flat-example.html
@@ -5,7 +5,7 @@
                  [isDisabled]="!shouldRender(node)"
                  class="example-tree-node">
     <!-- use a disabled button to provide padding for tree leaf -->
-    <button mat-icon-button disabled></button>
+    <button matIconButton disabled></button>
     {{node.name}}
   </cdk-tree-node>
   <!-- This is the tree node template for expandable nodes -->
@@ -15,7 +15,7 @@
                  [isDisabled]="!shouldRender(node)"
                  (expandedChange)="node.isExpanded = $event"
                  class="example-tree-node">
-    <button mat-icon-button cdkTreeNodeToggle
+    <button matIconButton cdkTreeNodeToggle
             [attr.aria-label]="'Toggle ' + node.name"
             [style.visibility]="node.expandable ? 'visible' : 'hidden'">
       <mat-icon class="mat-icon-rtl-mirror">

--- a/src/components-examples/cdk/tree/cdk-tree-nested-children-accessor/cdk-tree-nested-children-accessor-example.html
+++ b/src/components-examples/cdk/tree/cdk-tree-nested-children-accessor/cdk-tree-nested-children-accessor-example.html
@@ -3,7 +3,7 @@
   <cdk-nested-tree-node #treeNode="cdkNestedTreeNode" *cdkTreeNodeDef="let node"
       class="example-tree-node">
     <!-- use a disabled button to provide padding for tree leaf -->
-    <button mat-icon-button disabled></button>
+    <button matIconButton disabled></button>
     {{node.name}}
   </cdk-nested-tree-node>
   <!-- This is the tree node template for expandable nodes -->
@@ -13,7 +13,7 @@
     isExpandable
     class="example-tree-node">
     <button
-      mat-icon-button
+      matIconButton
       class="example-toggle"
       [attr.aria-label]="'Toggle ' + node.name"
       cdkTreeNodeToggle>

--- a/src/components-examples/cdk/tree/cdk-tree-nested-level-accessor/cdk-tree-nested-level-accessor-example.html
+++ b/src/components-examples/cdk/tree/cdk-tree-nested-level-accessor/cdk-tree-nested-level-accessor-example.html
@@ -3,7 +3,7 @@
   <cdk-nested-tree-node #treeNode="cdkNestedTreeNode" *cdkTreeNodeDef="let node"
       class="example-tree-node">
     <!-- use a disabled button to provide padding for tree leaf -->
-    <button mat-icon-button disabled></button>
+    <button matIconButton disabled></button>
     {{node.name}}
   </cdk-nested-tree-node>
   <!-- This is the tree node template for expandable nodes -->
@@ -14,7 +14,7 @@
     isExpandable
     class="example-tree-node">
     <button
-      mat-icon-button
+      matIconButton
       class="example-toggle"
       [attr.aria-label]="'Toggle ' + node.name"
       cdkTreeNodeToggle>

--- a/src/components-examples/cdk/tree/cdk-tree-nested/cdk-tree-nested-example.html
+++ b/src/components-examples/cdk/tree/cdk-tree-nested/cdk-tree-nested-example.html
@@ -3,7 +3,7 @@
   <cdk-nested-tree-node #treeNode="cdkNestedTreeNode" *cdkTreeNodeDef="let node"
       class="example-tree-node">
     <!-- use a disabled button to provide padding for tree leaf -->
-    <button mat-icon-button disabled></button>
+    <button matIconButton disabled></button>
     {{node.name}}
   </cdk-nested-tree-node>
   <!-- This is the tree node template for expandable nodes -->
@@ -13,7 +13,7 @@
     isExpandable
     class="example-tree-node">
     <button
-      mat-icon-button
+      matIconButton
       class="example-toggle"
       [attr.aria-label]="'Toggle ' + node.name"
       cdkTreeNodeToggle>

--- a/src/components-examples/material-experimental/popover-edit/popover-edit-cell-span-mat-table/popover-edit-cell-span-mat-table-example.html
+++ b/src/components-examples/material-experimental/popover-edit/popover-edit-cell-span-mat-table/popover-edit-cell-span-mat-table-example.html
@@ -22,9 +22,9 @@
         </div>
 
         <div mat-edit-actions>
-          <button mat-button type="submit">Confirm</button>
-          <button mat-button cdkEditRevert>Revert</button>
-          <button mat-button cdkEditClose>Close</button>
+          <button matButton type="submit">Confirm</button>
+          <button matButton cdkEditRevert>Revert</button>
+          <button matButton cdkEditClose>Close</button>
         </div>
       </form>
     </div>
@@ -46,7 +46,7 @@
       {{person.firstName}}
 
       <span *matRowHoverContent>
-        <button mat-icon-button matEditOpen><mat-icon>edit</mat-icon></button>
+        <button matIconButton matEditOpen><mat-icon>edit</mat-icon></button>
       </span>
     </td>
   </ng-container>
@@ -61,7 +61,7 @@
       {{person.middleName}}
 
       <span *matRowHoverContent>
-        <button mat-icon-button matEditOpen><mat-icon>edit</mat-icon></button>
+        <button matIconButton matEditOpen><mat-icon>edit</mat-icon></button>
       </span>
     </td>
   </ng-container>
@@ -76,7 +76,7 @@
       {{person.lastName}}
 
       <span *matRowHoverContent>
-        <button mat-icon-button matEditOpen><mat-icon>edit</mat-icon></button>
+        <button matIconButton matEditOpen><mat-icon>edit</mat-icon></button>
       </span>
     </td>
   </ng-container>

--- a/src/components-examples/material-experimental/popover-edit/popover-edit-mat-table-flex/popover-edit-mat-table-flex-example.html
+++ b/src/components-examples/material-experimental/popover-edit/popover-edit-mat-table-flex/popover-edit-mat-table-flex-example.html
@@ -47,16 +47,16 @@
               </mat-form-field>
             </div>
             <div mat-edit-actions>
-              <button mat-button type="submit">Confirm</button>
-              <button mat-button matEditRevert>Revert</button>
-              <button mat-button matEditClose>Close</button>
+              <button matButton type="submit">Confirm</button>
+              <button matButton matEditRevert>Revert</button>
+              <button matButton matEditClose>Close</button>
             </div>
           </form>
         </div>
       </ng-template>
 
       <span *matRowHoverContent>
-        <button mat-icon-button matEditOpen><mat-icon>edit</mat-icon></button>
+        <button matIconButton matEditOpen><mat-icon>edit</mat-icon></button>
       </span>
     </mat-cell>
   </ng-container>
@@ -69,7 +69,7 @@
       {{element.weight}}
 
       <span *matRowHoverContent>
-        <button mat-icon-button matEditOpen><mat-icon>edit</mat-icon></button>
+        <button matIconButton matEditOpen><mat-icon>edit</mat-icon></button>
       </span>
       </mat-cell>
   </ng-container>

--- a/src/components-examples/material-experimental/popover-edit/popover-edit-mat-table/popover-edit-mat-table-example.html
+++ b/src/components-examples/material-experimental/popover-edit/popover-edit-mat-table/popover-edit-mat-table-example.html
@@ -26,10 +26,10 @@
 
       <!-- Row hover content in a non-edit cell. -->
       <span *matRowHoverContent>
-        <button mat-icon-button (click)="goodJob(element)">
+        <button matIconButton (click)="goodJob(element)">
           <mat-icon>thumb_up</mat-icon>
         </button>
-        <button mat-icon-button (click)="badJob(element)">
+        <button matIconButton (click)="badJob(element)">
           <mat-icon>thumb_down</mat-icon>
         </button>
       </span>
@@ -62,9 +62,9 @@
               </mat-form-field>
             </div>
             <div mat-edit-actions>
-              <button mat-button type="submit">Confirm</button>
-              <button mat-button matEditRevert>Revert</button>
-              <button mat-button matEditClose>Close</button>
+              <button matButton type="submit">Confirm</button>
+              <button matButton matEditRevert>Revert</button>
+              <button matButton matEditClose>Close</button>
             </div>
           </form>
         </div>
@@ -72,7 +72,7 @@
 
       @if (nameEditEnabled) {
         <span *matRowHoverContent>
-          <button mat-icon-button matEditOpen><mat-icon>edit</mat-icon></button>
+          <button matIconButton matEditOpen><mat-icon>edit</mat-icon></button>
         </span>
       }
     </td>
@@ -109,7 +109,7 @@
       </ng-template>
 
       <span *matRowHoverContent>
-        <button mat-icon-button matEditOpen><mat-icon>arrow_drop_down</mat-icon></button>
+        <button matIconButton matEditOpen><mat-icon>arrow_drop_down</mat-icon></button>
       </span>
     </td>
   </ng-container>
@@ -122,7 +122,7 @@
       {{element.weight}}
 
       <span *matRowHoverContent>
-        <button mat-icon-button matEditOpen><mat-icon>edit</mat-icon></button>
+        <button matIconButton matEditOpen><mat-icon>edit</mat-icon></button>
       </span>
     </td>
   </ng-container>
@@ -162,15 +162,15 @@
               </mat-selection-list>
             </div>
             <div mat-edit-actions>
-              <button mat-button type="submit">Confirm</button>
-              <button mat-button matEditRevert>Revert</button>
+              <button matButton type="submit">Confirm</button>
+              <button matButton matEditRevert>Revert</button>
             </div>
           </form>
         </div>
       </ng-template>
 
       <span *matRowHoverContent>
-        <button mat-icon-button matEditOpen><mat-icon>arrow_drop_down</mat-icon></button>
+        <button matIconButton matEditOpen><mat-icon>arrow_drop_down</mat-icon></button>
       </span>
     </td>
   </ng-container>

--- a/src/components-examples/material/badge/badge-harness/badge-harness-example.html
+++ b/src/components-examples/material/badge/badge-harness/badge-harness-example.html
@@ -1,10 +1,10 @@
-<button mat-button id="simple" [matBadge]="simpleContent()">Simple</button>
-<button mat-button
+<button matButton id="simple" [matBadge]="simpleContent()">Simple</button>
+<button matButton
     id="overlapping"
     matBadge="O"
     [matBadgeOverlap]="overlap()">Overlapping</button>
 <button
-    mat-button
+    matButton
     id="disabled"
     matBadge="D"
     [matBadgeDisabled]="disabled()">Disabled</button>

--- a/src/components-examples/material/badge/badge-overview/badge-overview-example.html
+++ b/src/components-examples/material/badge/badge-overview/badge-overview-example.html
@@ -10,7 +10,7 @@
 <div class="demo-section">
   Button with a badge on the left
 <!-- #docregion mat-badge-position -->
-  <button mat-raised-button matBadge="8" matBadgePosition="before">
+  <button matButton="elevated" matBadge="8" matBadgePosition="before">
     Action
   </button>
 <!-- #enddocregion mat-badge-position -->
@@ -19,7 +19,7 @@
 <div class="demo-section">
     Button toggles badge visibility
 <!-- #docregion mat-badge-hide -->
-    <button mat-raised-button matBadge="7" [matBadgeHidden]="hidden" (click)="toggleBadgeVisibility()">
+    <button matButton="elevated" matBadge="7" [matBadgeHidden]="hidden" (click)="toggleBadgeVisibility()">
         Hide
     </button>
 <!-- #enddocregion mat-badge-hide -->

--- a/src/components-examples/material/bottom-sheet/bottom-sheet-overview/bottom-sheet-overview-example.html
+++ b/src/components-examples/material/bottom-sheet/bottom-sheet-overview/bottom-sheet-overview-example.html
@@ -1,3 +1,3 @@
 <p>You have received a file called "cat-picture.jpeg".</p>
 
-<button mat-raised-button (click)="openBottomSheet()">Open file</button>
+<button matButton="elevated" (click)="openBottomSheet()">Open file</button>

--- a/src/components-examples/material/button/button-disabled-interactive/button-disabled-interactive-example.html
+++ b/src/components-examples/material/button/button-disabled-interactive/button-disabled-interactive-example.html
@@ -1,10 +1,10 @@
 <button
-  mat-raised-button
+  matButton="elevated"
   disabled
   disabledInteractive
   matTooltip="This is a tooltip!">Disabled button allowing interactivity</button>
 
 <button
-  mat-raised-button
+  matButton="elevated"
   disabled
   matTooltip="This is a tooltip!">Default disabled button</button>

--- a/src/components-examples/material/button/button-harness/button-harness-example.html
+++ b/src/components-examples/material/button/button-harness/button-harness-example.html
@@ -1,3 +1,3 @@
-<button id="basic" type="button" mat-button (click)="clicked = true">
+<button id="basic" type="button" matButton (click)="clicked = true">
   Basic button
 </button>

--- a/src/components-examples/material/button/button-overview/button-overview-example.html
+++ b/src/components-examples/material/button/button-overview/button-overview-example.html
@@ -1,36 +1,36 @@
 <section>
-  <div class="example-label">Basic</div>
+  <div class="example-label">Text</div>
   <div class="example-button-row">
-    <button mat-button>Basic</button>
-    <button mat-button disabled>Disabled</button>
-    <a mat-button href="https://www.google.com/" target="_blank">Link</a>
+    <button matButton>Basic</button>
+    <button matButton disabled>Disabled</button>
+    <a matButton href="https://www.google.com/" target="_blank">Link</a>
   </div>
 </section>
 <mat-divider></mat-divider>
 <section>
-  <div class="example-label">Raised</div>
+  <div class="example-label">Elevated</div>
   <div class="example-button-row">
-    <button mat-raised-button>Basic</button>
-    <button mat-raised-button disabled>Disabled</button>
-    <a mat-raised-button href="https://www.google.com/" target="_blank">Link</a>
+    <button matButton="elevated">Basic</button>
+    <button matButton="elevated" disabled>Disabled</button>
+    <a matButton="elevated" href="https://www.google.com/" target="_blank">Link</a>
   </div>
 </section>
 <mat-divider></mat-divider>
 <section>
-  <div class="example-label">Stroked</div>
+  <div class="example-label">Outlined</div>
   <div class="example-button-row">
-    <button mat-stroked-button>Basic</button>
-    <button mat-stroked-button disabled>Disabled</button>
-    <a mat-stroked-button href="https://www.google.com/" target="_blank">Link</a>
+    <button matButton="outlined">Basic</button>
+    <button matButton="outlined" disabled>Disabled</button>
+    <a matButton="outlined" href="https://www.google.com/" target="_blank">Link</a>
   </div>
 </section>
 <mat-divider></mat-divider>
 <section>
-  <div class="example-label">Flat</div>
+  <div class="example-label">Filled</div>
   <div class="example-button-row">
-    <button mat-flat-button>Basic</button>
-    <button mat-flat-button disabled>Disabled</button>
-    <a mat-flat-button href="https://www.google.com/" target="_blank">Link</a>
+    <button matButton="filled" >Basic</button>
+    <button matButton="filled"  disabled>Disabled</button>
+    <a matButton="filled" href="https://www.google.com/" target="_blank">Link</a>
   </div>
 </section>
 <mat-divider></mat-divider>
@@ -38,10 +38,10 @@
   <div class="example-label">Icon</div>
   <div class="example-button-row">
     <div class="example-flex-container">
-      <button mat-icon-button aria-label="Example icon button with a vertical three dot icon">
+      <button matIconButton aria-label="Example icon button with a vertical three dot icon">
         <mat-icon>more_vert</mat-icon>
       </button>
-      <button mat-icon-button disabled aria-label="Example icon button with a open in new tab icon">
+      <button matIconButton disabled aria-label="Example icon button with a open in new tab icon">
         <mat-icon>open_in_new</mat-icon>
       </button>
     </div>
@@ -49,16 +49,16 @@
 </section>
 <mat-divider></mat-divider>
 <section>
-  <div class="example-label">FAB</div>
+  <div class="example-label">Floating Action Button (FAB)</div>
   <div class="example-button-row">
     <div class="example-flex-container">
       <div class="example-button-container">
-        <button mat-fab aria-label="Example icon button with a delete icon">
+        <button matFab aria-label="Example icon button with a delete icon">
           <mat-icon>delete</mat-icon>
         </button>
       </div>
       <div class="example-button-container">
-        <button mat-fab disabled aria-label="Example icon button with a heart icon">
+        <button matFab disabled aria-label="Example icon button with a heart icon">
           <mat-icon>favorite</mat-icon>
         </button>
       </div>
@@ -71,12 +71,12 @@
   <div class="example-button-row">
     <div class="example-flex-container">
       <div class="example-button-container">
-        <button mat-mini-fab aria-label="Example icon button with a menu icon">
+        <button matMiniFab aria-label="Example icon button with a menu icon">
           <mat-icon>menu</mat-icon>
         </button>
       </div>
       <div class="example-button-container">
-        <button mat-mini-fab disabled aria-label="Example icon button with a home icon">
+        <button matMiniFab disabled aria-label="Example icon button with a home icon">
           <mat-icon>home</mat-icon>
         </button>
       </div>
@@ -84,23 +84,23 @@
   </div>
 </section>
 <section>
-  <div class="example-label">Extended Fab</div>
+  <div class="example-label">Extended FAB</div>
   <div class="example-button-row">
     <div class="example-flex-container">
       <div class="example-button-container">
-        <button mat-fab extended>
+        <button matFab extended>
           <mat-icon>favorite</mat-icon>
           Basic
         </button>
       </div>
       <div class="example-button-container">
-        <button mat-fab extended disabled>
+        <button matFab extended disabled>
           <mat-icon>favorite</mat-icon>
           Disabled
         </button>
       </div>
       <div class="example-button-container">
-        <a mat-fab extended routerLink=".">
+        <a matFab extended routerLink=".">
           <mat-icon>favorite</mat-icon>
           Link
         </a>

--- a/src/components-examples/material/button/button-overview/button-overview-example.ts
+++ b/src/components-examples/material/button/button-overview/button-overview-example.ts
@@ -4,7 +4,7 @@ import {MatDividerModule} from '@angular/material/divider';
 import {MatButtonModule} from '@angular/material/button';
 
 /**
- * @title Basic buttons
+ * @title Button overview
  */
 @Component({
   selector: 'button-overview-example',

--- a/src/components-examples/material/card/card-actions/card-actions-example.html
+++ b/src/components-examples/material/card/card-actions/card-actions-example.html
@@ -4,7 +4,7 @@
     <mat-card-subtitle>Herding group</mat-card-subtitle>
   </mat-card-header>
   <mat-card-actions>
-    <button mat-button>Learn More</button>
+    <button matButton>Learn More</button>
   </mat-card-actions>
 </mat-card>
 <br>
@@ -14,6 +14,6 @@
     <mat-card-subtitle>Non-sporting group</mat-card-subtitle>
   </mat-card-header>
   <mat-card-actions align="end">
-    <button mat-button>Learn More</button>
+    <button matButton>Learn More</button>
   </mat-card-actions>
 </mat-card>

--- a/src/components-examples/material/card/card-fancy/card-fancy-example.html
+++ b/src/components-examples/material/card/card-fancy/card-fancy-example.html
@@ -13,7 +13,7 @@
     </p>
   </mat-card-content>
   <mat-card-actions>
-    <button mat-button>LIKE</button>
-    <button mat-button>SHARE</button>
+    <button matButton>LIKE</button>
+    <button matButton>SHARE</button>
   </mat-card-actions>
 </mat-card>

--- a/src/components-examples/material/card/card-harness/card-harness-example.html
+++ b/src/components-examples/material/card/card-harness/card-harness-example.html
@@ -15,7 +15,7 @@
     </p>
   </mat-card-content>
   <mat-card-actions>
-    <button mat-button>LIKE</button>
-    <button mat-button>SHARE</button>
+    <button matButton>LIKE</button>
+    <button matButton>SHARE</button>
   </mat-card-actions>
 </mat-card>

--- a/src/components-examples/material/chips/chips-form-control/chips-form-control-example.html
+++ b/src/components-examples/material/chips/chips-form-control/chips-form-control-example.html
@@ -1,6 +1,6 @@
 <div class="example-button-container">
-  <button mat-raised-button (click)="formControl.disable()">Disable form control</button>
-  <button mat-raised-button (click)="formControl.enable()">Enable form control</button>
+  <button matButton="elevated" (click)="formControl.disable()">Disable form control</button>
+  <button matButton="elevated" (click)="formControl.enable()">Enable form control</button>
 </div>
 <p>
   <em>Enter video keywords</em>

--- a/src/components-examples/material/core/elevation-overview/elevation-overview-example.html
+++ b/src/components-examples/material/core/elevation-overview/elevation-overview-example.html
@@ -4,4 +4,4 @@
   Example
 </div>
 
-<button mat-button (click)="isActive = !isActive">Toggle Elevation</button>
+<button matButton (click)="isActive = !isActive">Toggle Elevation</button>

--- a/src/components-examples/material/datepicker/datepicker-actions/datepicker-actions-example.html
+++ b/src/components-examples/material/datepicker/datepicker-actions/datepicker-actions-example.html
@@ -6,8 +6,8 @@
   <!-- #docregion datepicker-actions -->
   <mat-datepicker #datepicker>
     <mat-datepicker-actions>
-      <button mat-button matDatepickerCancel>Cancel</button>
-      <button mat-raised-button matDatepickerApply>Apply</button>
+      <button matButton matDatepickerCancel>Cancel</button>
+      <button matButton="elevated" matDatepickerApply>Apply</button>
     </mat-datepicker-actions>
   </mat-datepicker>
   <!-- #enddocregion datepicker-actions -->
@@ -24,8 +24,8 @@
   <!-- #docregion date-range-picker-actions -->
   <mat-date-range-picker #rangePicker>
     <mat-date-range-picker-actions>
-      <button mat-button matDateRangePickerCancel>Cancel</button>
-      <button mat-raised-button matDateRangePickerApply>Apply</button>
+      <button matButton matDateRangePickerCancel>Cancel</button>
+      <button matButton="elevated" matDateRangePickerApply>Apply</button>
     </mat-date-range-picker-actions>
   </mat-date-range-picker>
   <!-- #enddocregion date-range-picker-actions -->

--- a/src/components-examples/material/datepicker/datepicker-api/datepicker-api-example.html
+++ b/src/components-examples/material/datepicker/datepicker-api/datepicker-api-example.html
@@ -4,4 +4,4 @@
   <mat-hint>MM/DD/YYYY</mat-hint>
   <mat-datepicker #picker></mat-datepicker>
 </mat-form-field>
-<button mat-raised-button (click)="picker.open()">Open</button>
+<button matButton="elevated" (click)="picker.open()">Open</button>

--- a/src/components-examples/material/datepicker/datepicker-custom-header/datepicker-custom-header-example.ts
+++ b/src/components-examples/material/datepicker/datepicker-custom-header/datepicker-custom-header-example.ts
@@ -39,17 +39,17 @@ export class DatepickerCustomHeaderExample {
   `,
   template: `
     <div class="example-header">
-      <button mat-icon-button (click)="previousClicked('year')">
+      <button matIconButton (click)="previousClicked('year')">
         <mat-icon>keyboard_double_arrow_left</mat-icon>
       </button>
-      <button mat-icon-button (click)="previousClicked('month')">
+      <button matIconButton (click)="previousClicked('month')">
         <mat-icon>keyboard_arrow_left</mat-icon>
       </button>
       <span class="example-header-label">{{periodLabel()}}</span>
-      <button mat-icon-button (click)="nextClicked('month')">
+      <button matIconButton (click)="nextClicked('month')">
         <mat-icon>keyboard_arrow_right</mat-icon>
       </button>
-      <button mat-icon-button (click)="nextClicked('year')">
+      <button matIconButton (click)="nextClicked('year')">
         <mat-icon>keyboard_double_arrow_right</mat-icon>
       </button>
     </div>

--- a/src/components-examples/material/datepicker/datepicker-dialog/datepicker-dialog-example-dialog.html
+++ b/src/components-examples/material/datepicker/datepicker-dialog/datepicker-dialog-example-dialog.html
@@ -8,6 +8,6 @@
   </mat-form-field>
 </mat-dialog-content>
 <mat-dialog-actions>
-  <button mat-button mat-dialog-close>Clear</button>
-  <button mat-button [mat-dialog-close]="date.value" cdkFocusInitial>Ok</button>
+  <button matButton mat-dialog-close>Clear</button>
+  <button matButton [mat-dialog-close]="date.value" cdkFocusInitial>Ok</button>
 </mat-dialog-actions>

--- a/src/components-examples/material/datepicker/datepicker-dialog/datepicker-dialog-example.html
+++ b/src/components-examples/material/datepicker/datepicker-dialog/datepicker-dialog-example.html
@@ -1,2 +1,2 @@
 <p>Selected date: {{selectedDate()}}</p>
-<button mat-flat-button color="primary" (click)="openDialog()">Open Dialog</button>
+<button matButton="filled"  color="primary" (click)="openDialog()">Open Dialog</button>

--- a/src/components-examples/material/datepicker/datepicker-locale/datepicker-locale-example.html
+++ b/src/components-examples/material/datepicker/datepicker-locale/datepicker-locale-example.html
@@ -5,4 +5,4 @@
   <mat-datepicker-toggle matIconSuffix [for]="dp"></mat-datepicker-toggle>
   <mat-datepicker #dp></mat-datepicker>
 </mat-form-field>
-<button mat-button (click)="french()">Dynamically switch to French</button>
+<button matButton (click)="french()">Dynamically switch to French</button>

--- a/src/components-examples/material/dialog/dialog-animations/dialog-animations-example-dialog.html
+++ b/src/components-examples/material/dialog/dialog-animations/dialog-animations-example-dialog.html
@@ -3,6 +3,6 @@
   Would you like to delete cat.jpeg?
 </mat-dialog-content>
 <mat-dialog-actions>
-  <button mat-button mat-dialog-close>No</button>
-  <button mat-button mat-dialog-close cdkFocusInitial>Ok</button>
+  <button matButton mat-dialog-close>No</button>
+  <button matButton mat-dialog-close cdkFocusInitial>Ok</button>
 </mat-dialog-actions>

--- a/src/components-examples/material/dialog/dialog-animations/dialog-animations-example.html
+++ b/src/components-examples/material/dialog/dialog-animations/dialog-animations-example.html
@@ -1,2 +1,2 @@
-<button mat-raised-button (click)="openDialog('0ms', '0ms')">Open dialog without animation</button>
-<button mat-raised-button (click)="openDialog('3000ms', '1500ms')">Open dialog slowly</button>
+<button matButton="elevated" (click)="openDialog('0ms', '0ms')">Open dialog without animation</button>
+<button matButton="elevated" (click)="openDialog('3000ms', '1500ms')">Open dialog slowly</button>

--- a/src/components-examples/material/dialog/dialog-content/dialog-content-example-dialog.html
+++ b/src/components-examples/material/dialog/dialog-content/dialog-content-example-dialog.html
@@ -59,6 +59,6 @@
   sophisticated in-browser navigational capabilities.</p>
 </mat-dialog-content>
 <mat-dialog-actions align="end">
-  <button mat-button mat-dialog-close>Cancel</button>
-  <button mat-button [mat-dialog-close]="true" cdkFocusInitial>Install</button>
+  <button matButton mat-dialog-close>Cancel</button>
+  <button matButton [mat-dialog-close]="true" cdkFocusInitial>Install</button>
 </mat-dialog-actions>

--- a/src/components-examples/material/dialog/dialog-content/dialog-content-example.html
+++ b/src/components-examples/material/dialog/dialog-content/dialog-content-example.html
@@ -1,1 +1,1 @@
-<button mat-button (click)="openDialog()">Open dialog</button>
+<button matButton (click)="openDialog()">Open dialog</button>

--- a/src/components-examples/material/dialog/dialog-data/dialog-data-example.html
+++ b/src/components-examples/material/dialog/dialog-data/dialog-data-example.html
@@ -1,1 +1,1 @@
-<button mat-button (click)="openDialog()">Open dialog</button>
+<button matButton (click)="openDialog()">Open dialog</button>

--- a/src/components-examples/material/dialog/dialog-elements/dialog-elements-example-dialog.html
+++ b/src/components-examples/material/dialog/dialog-elements/dialog-elements-example-dialog.html
@@ -1,5 +1,5 @@
 <h2 mat-dialog-title>Dialog with elements</h2>
 <mat-dialog-content>This dialog showcases the title, close, content and actions elements.</mat-dialog-content>
 <mat-dialog-actions>
-  <button mat-button mat-dialog-close>Close</button>
+  <button matButton mat-dialog-close>Close</button>
 </mat-dialog-actions>

--- a/src/components-examples/material/dialog/dialog-elements/dialog-elements-example.html
+++ b/src/components-examples/material/dialog/dialog-elements/dialog-elements-example.html
@@ -1,1 +1,1 @@
-<button mat-button (click)="openDialog()">Launch dialog</button>
+<button matButton (click)="openDialog()">Launch dialog</button>

--- a/src/components-examples/material/dialog/dialog-from-menu/dialog-from-menu-example-dialog.html
+++ b/src/components-examples/material/dialog/dialog-from-menu/dialog-from-menu-example-dialog.html
@@ -2,5 +2,5 @@
   This is a dialog
 </mat-dialog-content>
 <mat-dialog-actions>
-  <button mat-button mat-dialog-close>Okay</button>
+  <button matButton mat-dialog-close>Okay</button>
 </mat-dialog-actions>

--- a/src/components-examples/material/dialog/dialog-from-menu/dialog-from-menu-example.html
+++ b/src/components-examples/material/dialog/dialog-from-menu/dialog-from-menu-example.html
@@ -1,4 +1,4 @@
-<button mat-button [matMenuTriggerFor]="menu" #menuTrigger>Menu</button>
+<button matButton [matMenuTriggerFor]="menu" #menuTrigger>Menu</button>
 <mat-menu #menu="matMenu">
   <button mat-menu-item (click)="openDialog()">Open dialog</button>
 </mat-menu>

--- a/src/components-examples/material/dialog/dialog-overview/dialog-overview-example-dialog.html
+++ b/src/components-examples/material/dialog/dialog-overview/dialog-overview-example-dialog.html
@@ -7,6 +7,6 @@
   </mat-form-field>
 </mat-dialog-content>
 <mat-dialog-actions>
-  <button mat-button (click)="onNoClick()">No Thanks</button>
-  <button mat-button [mat-dialog-close]="animal()" cdkFocusInitial>Ok</button>
+  <button matButton (click)="onNoClick()">No Thanks</button>
+  <button matButton [mat-dialog-close]="animal()" cdkFocusInitial>Ok</button>
 </mat-dialog-actions>

--- a/src/components-examples/material/dialog/dialog-overview/dialog-overview-example.html
+++ b/src/components-examples/material/dialog/dialog-overview/dialog-overview-example.html
@@ -6,7 +6,7 @@
     </mat-form-field>
   </li>
   <li>
-    <button mat-raised-button (click)="openDialog()">Pick one</button>
+    <button matButton="elevated" (click)="openDialog()">Pick one</button>
   </li>
   @if (animal()) {
     <li>

--- a/src/components-examples/material/expansion/expansion-expand-collapse-all/expansion-expand-collapse-all-example.html
+++ b/src/components-examples/material/expansion/expansion-expand-collapse-all/expansion-expand-collapse-all-example.html
@@ -1,6 +1,6 @@
 <div class="example-action-buttons">
-  <button mat-button (click)="accordion().openAll()">Expand All</button>
-  <button mat-button (click)="accordion().closeAll()">Collapse All</button>
+  <button matButton (click)="accordion().openAll()">Expand All</button>
+  <button matButton (click)="accordion().closeAll()">Collapse All</button>
 </div>
 <!-- #docregion multi -->
 <mat-accordion class="example-headers-align" multi>

--- a/src/components-examples/material/expansion/expansion-steps/expansion-steps-example.html
+++ b/src/components-examples/material/expansion/expansion-steps/expansion-steps-example.html
@@ -19,7 +19,7 @@
     </mat-form-field>
     <!-- #docregion action-bar -->
     <mat-action-row>
-      <button mat-button (click)="nextStep()">Next</button>
+      <button matButton (click)="nextStep()">Next</button>
     </mat-action-row>
     <!-- #enddocregion action-bar -->
   </mat-expansion-panel>
@@ -39,8 +39,8 @@
     </mat-form-field>
 
     <mat-action-row>
-      <button mat-button (click)="prevStep()">Previous</button>
-      <button mat-button (click)="nextStep()">Next</button>
+      <button matButton (click)="prevStep()">Previous</button>
+      <button matButton (click)="nextStep()">Next</button>
     </mat-action-row>
   </mat-expansion-panel>
 
@@ -60,8 +60,8 @@
     <mat-datepicker #picker></mat-datepicker>
 
     <mat-action-row>
-      <button mat-button (click)="prevStep()">Previous</button>
-      <button mat-button (click)="nextStep()">End</button>
+      <button matButton (click)="prevStep()">Previous</button>
+      <button matButton (click)="nextStep()">End</button>
     </mat-action-row>
   </mat-expansion-panel>
 </mat-accordion>

--- a/src/components-examples/material/form-field/form-field-prefix-suffix/form-field-prefix-suffix-example.html
+++ b/src/components-examples/material/form-field/form-field-prefix-suffix/form-field-prefix-suffix-example.html
@@ -3,7 +3,7 @@
     <mat-label>Enter your password</mat-label>
     <input matInput [type]="hide() ? 'password' : 'text'" />
     <button
-      mat-icon-button
+      matIconButton
       matSuffix
       (click)="clickEvent($event)"
       [attr.aria-label]="'Hide password'"

--- a/src/components-examples/material/input/input-clearable/input-clearable-example.html
+++ b/src/components-examples/material/input/input-clearable/input-clearable-example.html
@@ -2,7 +2,7 @@
   <mat-label>Clearable input</mat-label>
   <input matInput type="text" [(ngModel)]="value">
   @if (value) {
-    <button matSuffix mat-icon-button aria-label="Clear" (click)="value=''">
+    <button matSuffix matIconButton aria-label="Clear" (click)="value=''">
       <mat-icon>close</mat-icon>
     </button>
   }

--- a/src/components-examples/material/menu/menu-icons/menu-icons-example.html
+++ b/src/components-examples/material/menu/menu-icons/menu-icons-example.html
@@ -1,4 +1,4 @@
-<button mat-icon-button [matMenuTriggerFor]="menu" aria-label="Example icon-button with a menu">
+<button matIconButton [matMenuTriggerFor]="menu" aria-label="Example icon-button with a menu">
   <mat-icon>more_vert</mat-icon>
 </button>
 <mat-menu #menu="matMenu">

--- a/src/components-examples/material/menu/menu-nested/menu-nested-example.html
+++ b/src/components-examples/material/menu/menu-nested/menu-nested-example.html
@@ -1,4 +1,4 @@
-<button mat-button [matMenuTriggerFor]="animals">Animal index</button>
+<button matButton [matMenuTriggerFor]="animals">Animal index</button>
 <!-- #docregion sub-menu -->
 <mat-menu #animals="matMenu">
   <button mat-menu-item [matMenuTriggerFor]="vertebrates">Vertebrates</button>

--- a/src/components-examples/material/menu/menu-overview/menu-overview-example.html
+++ b/src/components-examples/material/menu/menu-overview/menu-overview-example.html
@@ -1,5 +1,5 @@
 <!-- #docregion mat-menu-trigger-for -->
-<button mat-button [matMenuTriggerFor]="menu">Menu</button>
+<button matButton [matMenuTriggerFor]="menu">Menu</button>
 <!-- #enddocregion mat-menu-trigger-for -->
 <mat-menu #menu="matMenu">
   <button mat-menu-item>Item 1</button>

--- a/src/components-examples/material/menu/menu-position/menu-position-example.html
+++ b/src/components-examples/material/menu/menu-position/menu-position-example.html
@@ -1,4 +1,4 @@
-<button mat-button [matMenuTriggerFor]="aboveMenu">Above</button>
+<button matButton [matMenuTriggerFor]="aboveMenu">Above</button>
 <!-- #docregion menu-position -->
 <mat-menu #aboveMenu="matMenu" yPosition="above">
 <!-- #enddocregion menu-position -->
@@ -6,20 +6,20 @@
   <button mat-menu-item>Item 2</button>
 </mat-menu>
 
-<button mat-button [matMenuTriggerFor]="belowMenu">Below</button>
+<button matButton [matMenuTriggerFor]="belowMenu">Below</button>
 <mat-menu #belowMenu="matMenu" yPosition="below">
   <button mat-menu-item>Item 1</button>
   <button mat-menu-item>Item 2</button>
 </mat-menu>
 
-<button mat-button [matMenuTriggerFor]="beforeMenu">Before</button>
+<button matButton [matMenuTriggerFor]="beforeMenu">Before</button>
 <mat-menu #beforeMenu="matMenu" xPosition="before">
   <button mat-menu-item>Item 1</button>
   <button mat-menu-item>Item 2</button>
 </mat-menu>
 
 
-<button mat-button [matMenuTriggerFor]="afterMenu">After</button>
+<button matButton [matMenuTriggerFor]="afterMenu">After</button>
 <mat-menu #afterMenu="matMenu" xPosition="after">
   <button mat-menu-item>Item 1</button>
   <button mat-menu-item>Item 2</button>

--- a/src/components-examples/material/sidenav/sidenav-autosize/sidenav-autosize-example.html
+++ b/src/components-examples/material/sidenav/sidenav-autosize/sidenav-autosize-example.html
@@ -4,13 +4,13 @@
     @if (showFiller) {
       <p>Lorem, ipsum dolor sit amet consectetur.</p>
     }
-    <button (click)="showFiller = !showFiller" mat-raised-button>
+    <button (click)="showFiller = !showFiller" matButton="elevated">
       Toggle extra text
     </button>
   </mat-drawer>
 
   <div class="example-sidenav-content">
-    <button type="button" mat-button (click)="drawer.toggle()">
+    <button type="button" matButton (click)="drawer.toggle()">
       Toggle sidenav
     </button>
   </div>

--- a/src/components-examples/material/sidenav/sidenav-backdrop/sidenav-backdrop-example.html
+++ b/src/components-examples/material/sidenav/sidenav-backdrop/sidenav-backdrop-example.html
@@ -17,6 +17,6 @@
         <mat-option [value]="false">False</mat-option>
       </mat-select>
     </mat-form-field>
-    <button mat-raised-button (click)="drawer.toggle()">Toggle drawer</button>
+    <button matButton="elevated" (click)="drawer.toggle()">Toggle drawer</button>
   </mat-drawer-content>
 </mat-drawer-container>

--- a/src/components-examples/material/sidenav/sidenav-configurable-focus-trap/sidenav-configurable-focus-trap-example.html
+++ b/src/components-examples/material/sidenav/sidenav-configurable-focus-trap/sidenav-configurable-focus-trap-example.html
@@ -1,14 +1,14 @@
 @if (shouldRun) {
   <mat-sidenav-container class="example-container" [hasBackdrop]="hasBackdrop.value">
     <mat-sidenav #sidenav [mode]="mode.value!" [position]="position.value!">
-      <p><button mat-button (click)="sidenav.toggle()">Toggle</button></p>
+      <p><button matButton (click)="sidenav.toggle()">Toggle</button></p>
       <p>
         <label>Test input for drawer<input/></label>
       </p>
     </mat-sidenav>
 
     <mat-sidenav-content>
-      <p><button mat-button (click)="sidenav.toggle()">Toggle</button></p>
+      <p><button matButton (click)="sidenav.toggle()">Toggle</button></p>
       <p>
         <mat-radio-group class="example-radio-group" [formControl]="mode">
           <label>Mode:</label>

--- a/src/components-examples/material/sidenav/sidenav-disable-close/sidenav-disable-close-example.html
+++ b/src/components-examples/material/sidenav/sidenav-disable-close/sidenav-disable-close-example.html
@@ -2,11 +2,11 @@
   <mat-sidenav-container
       class="example-container" (backdropClick)="close('backdrop')">
     <mat-sidenav #sidenav (keydown.escape)="close('escape')" disableClose>
-      <p><button mat-button (click)="close('toggle button')">Toggle</button></p>
+      <p><button matButton (click)="close('toggle button')">Toggle</button></p>
     </mat-sidenav>
 
     <mat-sidenav-content>
-      <p><button mat-button (click)="sidenav.open()">Open</button></p>
+      <p><button matButton (click)="sidenav.open()">Open</button></p>
       <p>Closed due to: {{reason}}</p>
     </mat-sidenav-content>
   </mat-sidenav-container>

--- a/src/components-examples/material/sidenav/sidenav-fixed/sidenav-fixed-example.html
+++ b/src/components-examples/material/sidenav/sidenav-fixed/sidenav-fixed-example.html
@@ -18,7 +18,7 @@
         <mat-label>Bottom gap</mat-label>
         <input matInput type="number" formControlName="bottom">
       </mat-form-field></p>
-      <p><button mat-button (click)="sidenav.toggle()">Toggle</button></p>
+      <p><button matButton (click)="sidenav.toggle()">Toggle</button></p>
     </mat-sidenav-content>
   </mat-sidenav-container>
 

--- a/src/components-examples/material/sidenav/sidenav-mode/sidenav-mode-example.html
+++ b/src/components-examples/material/sidenav/sidenav-mode/sidenav-mode-example.html
@@ -1,7 +1,7 @@
 @if (shouldRun) {
   <mat-sidenav-container class="example-container">
     <mat-sidenav #sidenav [mode]="mode.value || 'over'">
-      <p><button mat-button (click)="sidenav.toggle()">Toggle</button></p>
+      <p><button matButton (click)="sidenav.toggle()">Toggle</button></p>
       <p>
         <mat-radio-group class="example-radio-group" [formControl]="mode">
           <label>Mode:</label>
@@ -13,7 +13,7 @@
     </mat-sidenav>
 
     <mat-sidenav-content>
-      <p><button mat-button (click)="sidenav.toggle()">Toggle</button></p>
+      <p><button matButton (click)="sidenav.toggle()">Toggle</button></p>
       <p>
         <mat-radio-group class="example-radio-group" [formControl]="mode">
           <label>Mode:</label>

--- a/src/components-examples/material/sidenav/sidenav-open-close/sidenav-open-close-example.html
+++ b/src/components-examples/material/sidenav/sidenav-open-close/sidenav-open-close-example.html
@@ -7,7 +7,7 @@
 
     <mat-sidenav-content>
       <p><mat-checkbox [(ngModel)]="opened">sidenav.opened</mat-checkbox></p>
-      <p><button mat-button (click)="sidenav.toggle()">sidenav.toggle()</button></p>
+      <p><button matButton (click)="sidenav.toggle()">sidenav.toggle()</button></p>
       <p>Events:</p>
       <div class="example-events">
         @for (e of events; track e) {

--- a/src/components-examples/material/sidenav/sidenav-responsive/sidenav-responsive-example.html
+++ b/src/components-examples/material/sidenav/sidenav-responsive/sidenav-responsive-example.html
@@ -1,7 +1,7 @@
 @if (shouldRun) {
   <div class="example-container" [class.example-is-mobile]="isMobile()">
     <mat-toolbar class="example-toolbar">
-      <button mat-icon-button (click)="snav.toggle()"><mat-icon>menu</mat-icon></button>
+      <button matIconButton (click)="snav.toggle()"><mat-icon>menu</mat-icon></button>
       <h1 class="example-app-name">Responsive App</h1>
     </mat-toolbar>
 

--- a/src/components-examples/material/slide-toggle/slide-toggle-forms/slide-toggle-forms-example.html
+++ b/src/components-examples/material/slide-toggle/slide-toggle-forms/slide-toggle-forms-example.html
@@ -9,7 +9,7 @@
   <mat-slide-toggle ngModel name="enableWifi">Enable Wifi</mat-slide-toggle>
   <mat-slide-toggle ngModel name="acceptTerms" required>Accept Terms of Service</mat-slide-toggle>
 
-  <button mat-raised-button type="submit">Save Settings</button>
+  <button matButton="elevated" type="submit">Save Settings</button>
 </form>
 
 <p>Slide Toggle inside of a Reactive form</p>
@@ -21,5 +21,5 @@
 
   <p>Form Group Status: {{formGroup.status}}</p>
 
-  <button mat-raised-button type="submit">Save Settings</button>
+  <button matButton="elevated" type="submit">Save Settings</button>
 </form>

--- a/src/components-examples/material/snack-bar/snack-bar-annotated-component/snack-bar-annotated-component-example-snack.html
+++ b/src/components-examples/material/snack-bar/snack-bar-annotated-component/snack-bar-annotated-component-example-snack.html
@@ -2,6 +2,6 @@
   Pizza party!!!
 </span>
 <span matSnackBarActions>
-  <button mat-button matSnackBarAction (click)="snackBarRef.dismissWithAction()">🍕</button>
+  <button matButton matSnackBarAction (click)="snackBarRef.dismissWithAction()">🍕</button>
 </span>
 

--- a/src/components-examples/material/snack-bar/snack-bar-annotated-component/snack-bar-annotated-component-example.html
+++ b/src/components-examples/material/snack-bar/snack-bar-annotated-component/snack-bar-annotated-component-example.html
@@ -3,6 +3,6 @@
   <input type="number" [(ngModel)]="durationInSeconds" matInput>
 </mat-form-field>
 
-<button mat-stroked-button (click)="openSnackBar()" aria-label="Show an example snack-bar">
+<button matButton="outlined" (click)="openSnackBar()" aria-label="Show an example snack-bar">
   Pizza party
 </button>

--- a/src/components-examples/material/snack-bar/snack-bar-component/snack-bar-component-example.html
+++ b/src/components-examples/material/snack-bar/snack-bar-component/snack-bar-component-example.html
@@ -3,6 +3,6 @@
   <input type="number" [(ngModel)]="durationInSeconds" matInput>
 </mat-form-field>
 
-<button mat-stroked-button (click)="openSnackBar()" aria-label="Show an example snack-bar">
+<button matButton="outlined" (click)="openSnackBar()" aria-label="Show an example snack-bar">
   Pizza party
 </button>

--- a/src/components-examples/material/snack-bar/snack-bar-overview/snack-bar-overview-example.html
+++ b/src/components-examples/material/snack-bar/snack-bar-overview/snack-bar-overview-example.html
@@ -8,4 +8,4 @@
   <input matInput value="Dance" #action>
 </mat-form-field>
 
-<button mat-stroked-button (click)="openSnackBar(message.value, action.value)">Show snack-bar</button>
+<button matButton="outlined" (click)="openSnackBar(message.value, action.value)">Show snack-bar</button>

--- a/src/components-examples/material/snack-bar/snack-bar-position/snack-bar-position-example.html
+++ b/src/components-examples/material/snack-bar/snack-bar-position/snack-bar-position-example.html
@@ -16,6 +16,6 @@
   </mat-select>
 </mat-form-field>
 
-<button mat-stroked-button (click)="openSnackBar()" aria-label="Show an example snack-bar">
+<button matButton="outlined" (click)="openSnackBar()" aria-label="Show an example snack-bar">
   Pool party!
 </button>

--- a/src/components-examples/material/stepper/stepper-animations/stepper-animations-example.html
+++ b/src/components-examples/material/stepper/stepper-animations/stepper-animations-example.html
@@ -11,7 +11,7 @@
         <input matInput placeholder="Last name, First name" formControlName="firstCtrl" required>
       </mat-form-field>
       <div>
-        <button mat-button matStepperNext>Next</button>
+        <button matButton matStepperNext>Next</button>
       </div>
     </form>
   </mat-step>
@@ -22,8 +22,8 @@
         <input matInput placeholder="Address" formControlName="secondCtrl" required>
       </mat-form-field>
       <div>
-        <button mat-button matStepperPrevious>Back</button>
-        <button mat-button matStepperNext>Next</button>
+        <button matButton matStepperPrevious>Back</button>
+        <button matButton matStepperNext>Next</button>
       </div>
     </form>
   </mat-step>
@@ -31,8 +31,8 @@
     <ng-template matStepLabel>Done</ng-template>
     You are now done.
     <div>
-      <button mat-button matStepperPrevious>Back</button>
-      <button mat-button (click)="stepper.reset()">Reset</button>
+      <button matButton matStepperPrevious>Back</button>
+      <button matButton (click)="stepper.reset()">Reset</button>
     </div>
   </mat-step>
 </mat-vertical-stepper>

--- a/src/components-examples/material/stepper/stepper-editable/stepper-editable-example.html
+++ b/src/components-examples/material/stepper/stepper-editable/stepper-editable-example.html
@@ -1,4 +1,4 @@
-<button mat-raised-button (click)="isEditable = !isEditable">
+<button matButton="elevated" (click)="isEditable = !isEditable">
   {{!isEditable ? 'Enable edit mode' : 'Disable edit mode'}}
 </button>
 
@@ -15,7 +15,7 @@
         <input matInput formControlName="firstCtrl" placeholder="Last name, First name" required>
       </mat-form-field>
       <div>
-        <button mat-button matStepperNext>Next</button>
+        <button matButton matStepperNext>Next</button>
       </div>
     </form>
   </mat-step>
@@ -28,8 +28,8 @@
                required>
       </mat-form-field>
       <div>
-        <button mat-button matStepperPrevious>Back</button>
-        <button mat-button matStepperNext>Next</button>
+        <button matButton matStepperPrevious>Back</button>
+        <button matButton matStepperNext>Next</button>
       </div>
     </form>
   </mat-step>
@@ -37,8 +37,8 @@
     <ng-template matStepLabel>Done</ng-template>
     <p>You are now done.</p>
     <div>
-      <button mat-button matStepperPrevious>Back</button>
-      <button mat-button (click)="stepper.reset()">Reset</button>
+      <button matButton matStepperPrevious>Back</button>
+      <button matButton (click)="stepper.reset()">Reset</button>
     </div>
   </mat-step>
 </mat-stepper>

--- a/src/components-examples/material/stepper/stepper-errors/stepper-errors-example.html
+++ b/src/components-examples/material/stepper/stepper-errors/stepper-errors-example.html
@@ -8,7 +8,7 @@
       </mat-form-field>
       <div>
         <p>Go to a different step to see the error state</p>
-        <button mat-button matStepperNext>Next</button>
+        <button matButton matStepperNext>Next</button>
       </div>
     </form>
   </mat-step>
@@ -22,8 +22,8 @@
       </mat-form-field>
       <div>
         <p>Go to a different step to see the error state</p>
-        <button mat-button matStepperPrevious>Back</button>
-        <button mat-button matStepperNext>Next</button>
+        <button matButton matStepperPrevious>Back</button>
+        <button matButton matStepperNext>Next</button>
       </div>
     </form>
   </mat-step>
@@ -31,8 +31,8 @@
     <ng-template matStepLabel>Done</ng-template>
     <p>You are now done.</p>
     <div>
-      <button mat-button matStepperPrevious>Back</button>
-      <button mat-button (click)="stepper.reset()">Reset</button>
+      <button matButton matStepperPrevious>Back</button>
+      <button matButton (click)="stepper.reset()">Reset</button>
     </div>
   </mat-step>
 </mat-stepper>

--- a/src/components-examples/material/stepper/stepper-header-position/stepper-header-position-example.html
+++ b/src/components-examples/material/stepper/stepper-header-position/stepper-header-position-example.html
@@ -6,7 +6,7 @@
         <input matInput placeholder="Last name, First name" formControlName="firstCtrl" required>
       </mat-form-field>
       <div>
-        <button mat-button matStepperNext>Next</button>
+        <button matButton matStepperNext>Next</button>
       </div>
     </form>
   </mat-step>
@@ -17,8 +17,8 @@
         <input matInput placeholder="Address" formControlName="secondCtrl" required>
       </mat-form-field>
       <div>
-        <button mat-button matStepperPrevious>Back</button>
-        <button mat-button matStepperNext>Next</button>
+        <button matButton matStepperPrevious>Back</button>
+        <button matButton matStepperNext>Next</button>
       </div>
     </form>
   </mat-step>
@@ -26,8 +26,8 @@
     <ng-template matStepLabel>Done</ng-template>
     You are now done.
     <div>
-      <button mat-button matStepperPrevious>Back</button>
-      <button mat-button (click)="stepper.reset()">Reset</button>
+      <button matButton matStepperPrevious>Back</button>
+      <button matButton (click)="stepper.reset()">Reset</button>
     </div>
   </mat-step>
 </mat-stepper>

--- a/src/components-examples/material/stepper/stepper-intl/stepper-intl-example.html
+++ b/src/components-examples/material/stepper/stepper-intl/stepper-intl-example.html
@@ -24,7 +24,7 @@
         />
       </mat-form-field>
       <div>
-        <button mat-button matStepperNext>Next</button>
+        <button matButton matStepperNext>Next</button>
       </div>
     </form>
   </mat-step>
@@ -42,8 +42,8 @@
         />
       </mat-form-field>
       <div>
-        <button mat-button matStepperPrevious>Back</button>
-        <button mat-button matStepperNext>Next</button>
+        <button matButton matStepperPrevious>Back</button>
+        <button matButton matStepperNext>Next</button>
       </div>
     </form>
   </mat-step>
@@ -51,8 +51,8 @@
     <ng-template matStepLabel>Done</ng-template>
     <p>You are now done.</p>
     <div>
-      <button mat-button matStepperPrevious>Back</button>
-      <button mat-button (click)="stepper.reset()">Reset</button>
+      <button matButton matStepperPrevious>Back</button>
+      <button matButton (click)="stepper.reset()">Reset</button>
     </div>
   </mat-step>
 </mat-stepper>

--- a/src/components-examples/material/stepper/stepper-label-position-bottom/stepper-label-position-bottom-example.html
+++ b/src/components-examples/material/stepper/stepper-label-position-bottom/stepper-label-position-bottom-example.html
@@ -9,7 +9,7 @@
         <input matInput placeholder="Last name, First name" formControlName="firstCtrl" required>
       </mat-form-field>
       <div>
-        <button mat-button matStepperNext>Next</button>
+        <button matButton matStepperNext>Next</button>
       </div>
     </form>
   </mat-step>
@@ -23,8 +23,8 @@
       </mat-form-field>
       <div>
 <!-- #docregion buttons -->
-        <button mat-button matStepperPrevious>Back</button>
-        <button mat-button matStepperNext>Next</button>
+        <button matButton matStepperPrevious>Back</button>
+        <button matButton matStepperNext>Next</button>
 <!-- #enddocregion buttons -->
       </div>
     </form>
@@ -33,8 +33,8 @@
     <ng-template matStepLabel>Done</ng-template>
     <p>You are now done.</p>
     <div>
-      <button mat-button matStepperPrevious>Back</button>
-      <button mat-button (click)="stepper.reset()">Reset</button>
+      <button matButton matStepperPrevious>Back</button>
+      <button matButton (click)="stepper.reset()">Reset</button>
     </div>
   </mat-step>
 </mat-stepper>

--- a/src/components-examples/material/stepper/stepper-lazy-content/stepper-lazy-content-example.html
+++ b/src/components-examples/material/stepper/stepper-lazy-content/stepper-lazy-content-example.html
@@ -3,20 +3,20 @@
     <ng-template matStepLabel>Step 1</ng-template>
     <ng-template matStepContent>
       <p>This content was rendered lazily</p>
-      <button mat-button matStepperNext>Next</button>
+      <button matButton matStepperNext>Next</button>
     </ng-template>
   </mat-step>
   <mat-step>
     <ng-template matStepLabel>Step 2</ng-template>
     <ng-template matStepContent>
       <p>This content was also rendered lazily</p>
-      <button mat-button matStepperPrevious>Back</button>
-      <button mat-button matStepperNext>Next</button>
+      <button matButton matStepperPrevious>Back</button>
+      <button matButton matStepperNext>Next</button>
     </ng-template>
   </mat-step>
   <mat-step>
     <ng-template matStepLabel>Step 3</ng-template>
     <p>This content was rendered eagerly</p>
-    <button mat-button matStepperPrevious>Back</button>
+    <button matButton matStepperPrevious>Back</button>
   </mat-step>
 </mat-stepper>

--- a/src/components-examples/material/stepper/stepper-optional/stepper-optional-example.html
+++ b/src/components-examples/material/stepper/stepper-optional/stepper-optional-example.html
@@ -1,4 +1,4 @@
-<button mat-raised-button (click)="isOptional = !isOptional">
+<button matButton="elevated" (click)="isOptional = !isOptional">
   {{!isOptional ? 'Enable optional steps' : 'Disable optional steps'}}
 </button>
 
@@ -11,7 +11,7 @@
         <input matInput placeholder="Last name, First name" formControlName="firstCtrl" required>
       </mat-form-field>
       <div>
-        <button mat-button matStepperNext>Next</button>
+        <button matButton matStepperNext>Next</button>
       </div>
     </form>
   </mat-step>
@@ -26,8 +26,8 @@
                required>
       </mat-form-field>
       <div>
-        <button mat-button matStepperPrevious>Back</button>
-        <button mat-button matStepperNext>Next</button>
+        <button matButton matStepperPrevious>Back</button>
+        <button matButton matStepperNext>Next</button>
       </div>
     </form>
   </mat-step>
@@ -35,8 +35,8 @@
     <ng-template matStepLabel>Done</ng-template>
     <p>You are now done.</p>
     <div>
-      <button mat-button matStepperPrevious>Back</button>
-      <button mat-button (click)="stepper.reset()">Reset</button>
+      <button matButton matStepperPrevious>Back</button>
+      <button matButton (click)="stepper.reset()">Reset</button>
     </div>
   </mat-step>
 </mat-stepper>

--- a/src/components-examples/material/stepper/stepper-overview/stepper-overview-example.html
+++ b/src/components-examples/material/stepper/stepper-overview/stepper-overview-example.html
@@ -1,4 +1,4 @@
-<button mat-raised-button (click)="isLinear = !isLinear" id="toggle-linear">
+<button matButton="elevated" (click)="isLinear = !isLinear" id="toggle-linear">
   {{!isLinear ? 'Enable linear mode' : 'Disable linear mode'}}
 </button>
 <mat-stepper [linear]="isLinear" #stepper>
@@ -10,7 +10,7 @@
         <input matInput placeholder="Last name, First name" formControlName="firstCtrl" required>
       </mat-form-field>
       <div>
-        <button mat-button matStepperNext>Next</button>
+        <button matButton matStepperNext>Next</button>
       </div>
     </form>
   </mat-step>
@@ -24,8 +24,8 @@
                required>
       </mat-form-field>
       <div>
-        <button mat-button matStepperPrevious>Back</button>
-        <button mat-button matStepperNext>Next</button>
+        <button matButton matStepperPrevious>Back</button>
+        <button matButton matStepperNext>Next</button>
       </div>
     </form>
   </mat-step>
@@ -33,8 +33,8 @@
     <ng-template matStepLabel>Done</ng-template>
     <p>You are now done.</p>
     <div>
-      <button mat-button matStepperPrevious>Back</button>
-      <button mat-button (click)="stepper.reset()">Reset</button>
+      <button matButton matStepperPrevious>Back</button>
+      <button matButton (click)="stepper.reset()">Reset</button>
     </div>
   </mat-step>
 </mat-stepper>

--- a/src/components-examples/material/stepper/stepper-responsive/stepper-responsive-example.html
+++ b/src/components-examples/material/stepper/stepper-responsive/stepper-responsive-example.html
@@ -17,7 +17,7 @@
         <input matInput placeholder="Last name, First name" formControlName="firstCtrl" required>
       </mat-form-field>
       <div>
-        <button mat-button matStepperNext>Next</button>
+        <button matButton matStepperNext>Next</button>
       </div>
     </form>
   </mat-step>
@@ -29,8 +29,8 @@
                required>
       </mat-form-field>
       <div>
-        <button mat-button matStepperPrevious>Back</button>
-        <button mat-button matStepperNext>Next</button>
+        <button matButton matStepperPrevious>Back</button>
+        <button matButton matStepperNext>Next</button>
       </div>
     </form>
   </mat-step>
@@ -41,8 +41,8 @@
         <input matInput formControlName="thirdCtrl" placeholder="Ex. 12345678" required>
       </mat-form-field>
       <div>
-        <button mat-button matStepperPrevious>Back</button>
-        <button mat-button matStepperNext>Next</button>
+        <button matButton matStepperPrevious>Back</button>
+        <button matButton matStepperNext>Next</button>
       </div>
     </form>
   </mat-step>
@@ -50,7 +50,7 @@
     <ng-template matStepLabel>Done</ng-template>
     <p>You are now done.</p>
     <div>
-      <button mat-button matStepperPrevious>Back</button>
+      <button matButton matStepperPrevious>Back</button>
     </div>
   </mat-step>
 </mat-stepper>

--- a/src/components-examples/material/stepper/stepper-states/stepper-states-example.html
+++ b/src/components-examples/material/stepper/stepper-states/stepper-states-example.html
@@ -7,7 +7,7 @@
         <input matInput placeholder="Last name, First name" formControlName="firstCtrl" required>
       </mat-form-field>
       <div>
-        <button mat-button matStepperNext>Next</button>
+        <button matButton matStepperNext>Next</button>
       </div>
     </form>
   </mat-step>
@@ -20,8 +20,8 @@
                required>
       </mat-form-field>
       <div>
-        <button mat-button matStepperPrevious>Back</button>
-        <button mat-button matStepperNext>Next</button>
+        <button matButton matStepperPrevious>Back</button>
+        <button matButton matStepperNext>Next</button>
       </div>
     </form>
   </mat-step>
@@ -29,8 +29,8 @@
     <ng-template matStepLabel>Done</ng-template>
     <p>You are now done.</p>
     <div>
-      <button mat-button matStepperPrevious>Back</button>
-      <button mat-button (click)="stepper.reset()">Reset</button>
+      <button matButton matStepperPrevious>Back</button>
+      <button matButton (click)="stepper.reset()">Reset</button>
     </div>
   </mat-step>
 </mat-stepper>
@@ -41,15 +41,15 @@
   <mat-step label="Step 1" state="phone">
     <p>Put down your phones.</p>
     <div>
-      <button mat-button matStepperNext>Next</button>
+      <button matButton matStepperNext>Next</button>
     </div>
   </mat-step>
 <!-- #enddocregion label -->
   <mat-step label="Step 2" state="chat">
     <p>Socialize with each other.</p>
     <div>
-      <button mat-button matStepperPrevious>Back</button>
-      <button mat-button matStepperNext>Next</button>
+      <button matButton matStepperPrevious>Back</button>
+      <button matButton matStepperNext>Next</button>
     </div>
   </mat-step>
   <mat-step label="Step 3">

--- a/src/components-examples/material/stepper/stepper-vertical/stepper-vertical-example.html
+++ b/src/components-examples/material/stepper/stepper-vertical/stepper-vertical-example.html
@@ -1,4 +1,4 @@
-<button mat-raised-button (click)="isLinear = !isLinear" id="toggle-linear">
+<button matButton="elevated" (click)="isLinear = !isLinear" id="toggle-linear">
   {{!isLinear ? 'Enable linear mode' : 'Disable linear mode'}}
 </button>
 <mat-stepper orientation="vertical" [linear]="isLinear" #stepper>
@@ -10,7 +10,7 @@
         <input matInput placeholder="Last name, First name" formControlName="firstCtrl" required>
       </mat-form-field>
       <div>
-        <button mat-button matStepperNext>Next</button>
+        <button matButton matStepperNext>Next</button>
       </div>
     </form>
   </mat-step>
@@ -23,8 +23,8 @@
                required>
       </mat-form-field>
       <div>
-        <button mat-button matStepperPrevious>Back</button>
-        <button mat-button matStepperNext>Next</button>
+        <button matButton matStepperPrevious>Back</button>
+        <button matButton matStepperNext>Next</button>
       </div>
     </form>
   </mat-step>
@@ -32,8 +32,8 @@
     <ng-template matStepLabel>Done</ng-template>
     <p>You are now done.</p>
     <div>
-      <button mat-button matStepperPrevious>Back</button>
-      <button mat-button (click)="stepper.reset()">Reset</button>
+      <button matButton matStepperPrevious>Back</button>
+      <button matButton (click)="stepper.reset()">Reset</button>
     </div>
   </mat-step>
 </mat-stepper>

--- a/src/components-examples/material/table/table-dynamic-array-data/table-dynamic-array-data-example.html
+++ b/src/components-examples/material/table/table-dynamic-array-data/table-dynamic-array-data-example.html
@@ -1,9 +1,9 @@
 <div class="demo-button-container">
-  <button mat-raised-button (click)="addData()" class="demo-button">
+  <button matButton="elevated" (click)="addData()" class="demo-button">
     Add data
   </button>
   <button
-      mat-raised-button
+      matButton="elevated"
       [disabled]="!dataSource.length"
       (click)="removeData()"
       class="demo-button">

--- a/src/components-examples/material/table/table-dynamic-columns/table-dynamic-columns-example.html
+++ b/src/components-examples/material/table/table-dynamic-columns/table-dynamic-columns-example.html
@@ -1,6 +1,6 @@
-<button mat-raised-button (click)="addColumn()"> Add column </button>
-<button mat-raised-button (click)="removeColumn()"> Remove column </button>
-<button mat-raised-button (click)="shuffle()"> Shuffle </button>
+<button matButton="elevated" (click)="addColumn()"> Add column </button>
+<button matButton="elevated" (click)="removeColumn()"> Remove column </button>
+<button matButton="elevated" (click)="shuffle()"> Shuffle </button>
 
 <table mat-table [dataSource]="data" class="mat-elevation-z8">
   @for (column of displayedColumns; track column) {

--- a/src/components-examples/material/table/table-dynamic-observable-data/table-dynamic-observable-data-example.html
+++ b/src/components-examples/material/table/table-dynamic-observable-data/table-dynamic-observable-data-example.html
@@ -1,9 +1,9 @@
 <div class="demo-button-container">
-  <button mat-raised-button (click)="addData()" class="demo-button">
+  <button matButton="elevated" (click)="addData()" class="demo-button">
     Add data
   </button>
   <button
-      mat-raised-button
+      matButton="elevated"
       [disabled]="!dataToDisplay.length"
       (click)="removeData()"
       class="demo-button">

--- a/src/components-examples/material/table/table-expandable-rows/table-expandable-rows-example.html
+++ b/src/components-examples/material/table/table-expandable-rows/table-expandable-rows-example.html
@@ -11,7 +11,7 @@
     <th mat-header-cell *matHeaderCellDef aria-label="row actions">&nbsp;</th>
     <td mat-cell *matCellDef="let element">
       <button
-        mat-icon-button
+        matIconButton
         aria-label="expand row"
         (click)="toggle(element); $event.stopPropagation()"
         class="example-toggle-button"

--- a/src/components-examples/material/table/table-sticky-complex-flex/table-sticky-complex-flex-example.html
+++ b/src/components-examples/material/table/table-sticky-complex-flex/table-sticky-complex-flex-example.html
@@ -1,6 +1,6 @@
 <div>
-  <button mat-raised-button (click)="tables.push(tables.length)">Add table</button>
-  <button mat-raised-button (click)="tables.pop()">Remove table</button>
+  <button matButton="elevated" (click)="tables.push(tables.length)">Add table</button>
+  <button matButton="elevated" (click)="tables.pop()">Remove table</button>
 </div>
 
 <div>

--- a/src/components-examples/material/table/table-sticky-complex/table-sticky-complex-example.html
+++ b/src/components-examples/material/table/table-sticky-complex/table-sticky-complex-example.html
@@ -1,6 +1,6 @@
 <div>
-  <button mat-raised-button (click)="tables.push(tables.length)">Add table</button>
-  <button mat-raised-button (click)="tables.pop()">Remove table</button>
+  <button matButton="elevated" (click)="tables.push(tables.length)">Add table</button>
+  <button matButton="elevated" (click)="tables.pop()">Remove table</button>
 </div>
 
 <div>

--- a/src/components-examples/material/table/table-wrapped/table-wrapped-example.html
+++ b/src/components-examples/material/table/table-wrapped/table-wrapped-example.html
@@ -1,6 +1,6 @@
 <div>
-  <button mat-raised-button (click)="clearTable()">Clear table</button>
-  <button mat-raised-button (click)="addData()">Add data</button>
+  <button matButton="elevated" (click)="clearTable()">Clear table</button>
+  <button matButton="elevated" (click)="addData()">Add data</button>
 </div>
 
 <wrapper-table [dataSource]="dataSource" [columns]="displayedColumns"

--- a/src/components-examples/material/tabs/tab-group-dynamic/tab-group-dynamic-example.html
+++ b/src/components-examples/material/tabs/tab-group-dynamic/tab-group-dynamic-example.html
@@ -4,7 +4,7 @@
 </mat-form-field>
 
 <div>
-  <button mat-raised-button
+  <button matButton="elevated"
           class="example-add-tab-button"
           (click)="addTab(selectAfterAdding.checked)">
     Add new tab
@@ -18,7 +18,7 @@
     <mat-tab [label]="tab">
       Contents for {{tab}} tab
 
-      <button mat-raised-button
+      <button matButton="elevated"
               class="example-delete-tab-button"
               [disabled]="tabs.length === 1"
               (click)="removeTab(index)">

--- a/src/components-examples/material/tabs/tab-nav-bar-basic/tab-nav-bar-basic-example.html
+++ b/src/components-examples/material/tabs/tab-nav-bar-basic/tab-nav-bar-basic-example.html
@@ -10,6 +10,6 @@
 <mat-tab-nav-panel #tabPanel></mat-tab-nav-panel>
 <!-- #enddocregion mat-tab-nav -->
 
-<button mat-raised-button class="example-action-button" (click)="addLink()">
+<button matButton="elevated" class="example-action-button" (click)="addLink()">
   Add link
 </button>

--- a/src/components-examples/material/timepicker/timepicker-locale/timepicker-locale-example.html
+++ b/src/components-examples/material/timepicker/timepicker-locale/timepicker-locale-example.html
@@ -5,4 +5,4 @@
   <mat-timepicker #picker/>
 </mat-form-field>
 
-<button mat-button (click)="switchLocale()">Dynamically switch to Bulgarian</button>
+<button matButton (click)="switchLocale()">Dynamically switch to Bulgarian</button>

--- a/src/components-examples/material/toolbar/toolbar-basic/toolbar-basic-example.html
+++ b/src/components-examples/material/toolbar/toolbar-basic/toolbar-basic-example.html
@@ -1,13 +1,13 @@
 <mat-toolbar>
-  <button mat-icon-button class="example-icon" aria-label="Example icon-button with menu icon">
+  <button matIconButton class="example-icon" aria-label="Example icon-button with menu icon">
     <mat-icon>menu</mat-icon>
   </button>
   <span>My App</span>
   <span class="example-spacer"></span>
-  <button mat-icon-button class="example-icon favorite-icon" aria-label="Example icon-button with heart icon">
+  <button matIconButton class="example-icon favorite-icon" aria-label="Example icon-button with heart icon">
     <mat-icon>favorite</mat-icon>
   </button>
-  <button mat-icon-button class="example-icon" aria-label="Example icon-button with share icon">
+  <button matIconButton class="example-icon" aria-label="Example icon-button with share icon">
     <mat-icon>share</mat-icon>
   </button>
 </mat-toolbar>

--- a/src/components-examples/material/toolbar/toolbar-harness/toolbar-harness-example.html
+++ b/src/components-examples/material/toolbar/toolbar-harness/toolbar-harness-example.html
@@ -2,10 +2,10 @@
 <mat-toolbar>
   <mat-toolbar-row><span>Row 1</span></mat-toolbar-row>
   <mat-toolbar-row><span>Row 2</span>
-    <button mat-button>
+    <button matButton>
       Button 1
     </button>
-    <button mat-button>
+    <button matButton>
       Button 2
     </button>
   </mat-toolbar-row>

--- a/src/components-examples/material/toolbar/toolbar-overview/toolbar-overview-example.html
+++ b/src/components-examples/material/toolbar/toolbar-overview/toolbar-overview-example.html
@@ -1,13 +1,13 @@
 <mat-toolbar>
-  <button mat-icon-button class="example-icon" aria-label="Example icon-button with menu icon">
+  <button matIconButton class="example-icon" aria-label="Example icon-button with menu icon">
     <mat-icon>menu</mat-icon>
   </button>
   <span>My App</span>
   <span class="example-spacer"></span>
-  <button mat-icon-button class="example-icon favorite-icon" aria-label="Example icon-button with heart icon">
+  <button matIconButton class="example-icon favorite-icon" aria-label="Example icon-button with heart icon">
     <mat-icon>favorite</mat-icon>
   </button>
-  <button mat-icon-button class="example-icon" aria-label="Example icon-button with share icon">
+  <button matIconButton class="example-icon" aria-label="Example icon-button with share icon">
     <mat-icon>share</mat-icon>
   </button>
 </mat-toolbar>

--- a/src/components-examples/material/tooltip/tooltip-auto-hide/tooltip-auto-hide-example.html
+++ b/src/components-examples/material/tooltip/tooltip-auto-hide/tooltip-auto-hide-example.html
@@ -8,7 +8,7 @@
 </mat-form-field>
 
 <div class="example-container" cdkScrollable>
-  <button mat-raised-button #tooltip="matTooltip"
+  <button matButton="elevated" #tooltip="matTooltip"
           matTooltip="Info about the action"
           [matTooltipPosition]="position.value!"
           matTooltipHideDelay="100000"

--- a/src/components-examples/material/tooltip/tooltip-custom-class/tooltip-custom-class-example.html
+++ b/src/components-examples/material/tooltip/tooltip-custom-class/tooltip-custom-class-example.html
@@ -1,4 +1,4 @@
-<button mat-raised-button
+<button matButton="elevated"
         matTooltip="Info about the action"
         matTooltipClass="example-tooltip-uppercase"
         aria-label="Button that shows a red tooltip"

--- a/src/components-examples/material/tooltip/tooltip-delay/tooltip-delay-example.html
+++ b/src/components-examples/material/tooltip/tooltip-delay/tooltip-delay-example.html
@@ -12,7 +12,7 @@
   <mat-hint>milliseconds</mat-hint>
 </mat-form-field>
 
-<button mat-raised-button matTooltip="Info about the action"
+<button matButton="elevated" matTooltip="Info about the action"
         [matTooltipShowDelay]="showDelay.value"
         [matTooltipHideDelay]="hideDelay.value"
         aria-label="Button that displays a tooltip with a customized delay in showing and hiding">

--- a/src/components-examples/material/tooltip/tooltip-disabled/tooltip-disabled-example.html
+++ b/src/components-examples/material/tooltip/tooltip-disabled/tooltip-disabled-example.html
@@ -1,4 +1,4 @@
-<button mat-raised-button
+<button matButton="elevated"
         matTooltip="Info about the action"
         [matTooltipDisabled]="disabled.value"
         aria-label="Button that displays a tooltip that can be programmatically disabled">

--- a/src/components-examples/material/tooltip/tooltip-manual/tooltip-manual-example.html
+++ b/src/components-examples/material/tooltip/tooltip-manual/tooltip-manual-example.html
@@ -1,18 +1,18 @@
 <div>
   <span> Click the following buttons to... </span>
-  <button mat-button
+  <button matButton
           (click)="tooltip.show()"
           aria-label="Show tooltip on the button at the end of this section"
           class="example-action-button">
     show
   </button>
-  <button mat-button
+  <button matButton
           (click)="tooltip.hide()"
           aria-label="Hide tooltip on the button at the end of this section"
           class="example-action-button">
     hide
   </button>
-  <button mat-button
+  <button matButton
           (click)="tooltip.toggle()"
           aria-label="Show/Hide tooltip on the button at the end of this section"
           class="example-action-button">
@@ -20,7 +20,7 @@
   </button>
 </div>
 
-<button mat-raised-button #tooltip="matTooltip"
+<button matButton="elevated" #tooltip="matTooltip"
         matTooltip="Info about the action"
         matTooltipPosition="right"
         aria-tooltip="Button that displays and hides a tooltip triggered by other buttons">

--- a/src/components-examples/material/tooltip/tooltip-message/tooltip-message-example.html
+++ b/src/components-examples/material/tooltip/tooltip-message/tooltip-message-example.html
@@ -3,7 +3,7 @@
   <input matInput [formControl]="message">
 </mat-form-field>
 
-<button mat-raised-button
+<button matButton="elevated"
         [matTooltip]="message.value || ''"
         aria-label="Button that displays a tooltip with a custom message">
   Action

--- a/src/components-examples/material/tooltip/tooltip-modified-defaults/tooltip-modified-defaults-example.html
+++ b/src/components-examples/material/tooltip/tooltip-modified-defaults/tooltip-modified-defaults-example.html
@@ -1,4 +1,4 @@
-<button mat-raised-button
+<button matButton="elevated"
         matTooltip="By default, I delay"
         aria-label="Button that displays a tooltip that has custom delays through a default config">
   Button with delay-default tooltip

--- a/src/components-examples/material/tooltip/tooltip-overview/tooltip-overview-example.html
+++ b/src/components-examples/material/tooltip/tooltip-overview/tooltip-overview-example.html
@@ -1,4 +1,4 @@
-<button mat-raised-button
+<button matButton="elevated"
         matTooltip="Info about the action"
         aria-label="Button that displays a tooltip when focused or hovered over">
   Action

--- a/src/components-examples/material/tooltip/tooltip-position-at-origin/tooltip-position-at-origin-example.html
+++ b/src/components-examples/material/tooltip/tooltip-position-at-origin/tooltip-position-at-origin-example.html
@@ -1,4 +1,4 @@
-<button mat-raised-button
+<button matButton="elevated"
         class="demo-button"
         matTooltip="Info about the action"
         [matTooltipPositionAtOrigin]="enabled.value"

--- a/src/components-examples/material/tooltip/tooltip-position/tooltip-position-example.html
+++ b/src/components-examples/material/tooltip/tooltip-position/tooltip-position-example.html
@@ -7,7 +7,7 @@
   </mat-select>
 </mat-form-field>
 
-<button mat-raised-button
+<button matButton="elevated"
         matTooltip="Info about the action"
         [matTooltipPosition]="position.value!"
         aria-label="Button that displays a tooltip in various positions">

--- a/src/components-examples/material/tree/tree-dynamic/tree-dynamic-example.html
+++ b/src/components-examples/material/tree/tree-dynamic/tree-dynamic-example.html
@@ -1,11 +1,11 @@
 <mat-tree [dataSource]="dataSource" [treeControl]="treeControl">
   <mat-tree-node *matTreeNodeDef="let node" matTreeNodePadding>
-    <button mat-icon-button disabled></button>
+    <button matIconButton disabled></button>
     {{node.item}}
   </mat-tree-node>
   <mat-tree-node *matTreeNodeDef="let node; when: hasChild" matTreeNodePadding matTreeNodeToggle
                 [cdkTreeNodeTypeaheadLabel]="node.item">
-    <button mat-icon-button
+    <button matIconButton
             [attr.aria-label]="'Toggle ' + node.item" matTreeNodeToggle>
       <mat-icon class="mat-icon-rtl-mirror">
         {{treeControl.isExpanded(node) ? 'expand_more' : 'chevron_right'}}

--- a/src/components-examples/material/tree/tree-flat-child-accessor-overview/tree-flat-child-accessor-overview-example.html
+++ b/src/components-examples/material/tree/tree-flat-child-accessor-overview/tree-flat-child-accessor-overview-example.html
@@ -2,13 +2,13 @@
   <!-- This is the tree node template for leaf nodes -->
   <mat-tree-node *matTreeNodeDef="let node" matTreeNodePadding>
     <!-- use a disabled button to provide padding for tree leaf -->
-    <button mat-icon-button disabled></button>
+    <button matIconButton disabled></button>
     {{node.name}}
   </mat-tree-node>
   <!-- This is the tree node template for expandable nodes -->
   <mat-tree-node *matTreeNodeDef="let node;when: hasChild" matTreeNodePadding matTreeNodeToggle
                  [cdkTreeNodeTypeaheadLabel]="node.name">
-    <button mat-icon-button matTreeNodeToggle
+    <button matIconButton matTreeNodeToggle
             [attr.aria-label]="'Toggle ' + node.name">
       <mat-icon class="mat-icon-rtl-mirror">
         {{tree.isExpanded(node) ? 'expand_more' : 'chevron_right'}}

--- a/src/components-examples/material/tree/tree-flat-overview/tree-flat-overview-example.html
+++ b/src/components-examples/material/tree/tree-flat-overview/tree-flat-overview-example.html
@@ -2,13 +2,13 @@
   <!-- This is the tree node template for leaf nodes -->
   <mat-tree-node *matTreeNodeDef="let node" matTreeNodePadding>
     <!-- use a disabled button to provide padding for tree leaf -->
-    <button mat-icon-button disabled></button>
+    <button matIconButton disabled></button>
     {{node.name}}
   </mat-tree-node>
   <!-- This is the tree node template for expandable nodes -->
   <mat-tree-node *matTreeNodeDef="let node;when: hasChild" matTreeNodePadding matTreeNodeToggle
                  [cdkTreeNodeTypeaheadLabel]="node.name">
-    <button mat-icon-button matTreeNodeToggle
+    <button matIconButton matTreeNodeToggle
             [attr.aria-label]="'Toggle ' + node.name">
       <mat-icon class="mat-icon-rtl-mirror">
         {{treeControl.isExpanded(node) ? 'expand_more' : 'chevron_right'}}

--- a/src/components-examples/material/tree/tree-harness/tree-harness-example.html
+++ b/src/components-examples/material/tree/tree-harness/tree-harness-example.html
@@ -2,13 +2,13 @@
   <!-- This is the tree node template for leaf nodes -->
   <mat-tree-node *matTreeNodeDef="let node" matTreeNodePadding>
     <!-- use a disabled button to provide padding for tree leaf -->
-    <button mat-icon-button disabled></button>
+    <button matIconButton disabled></button>
     {{node.name}}
   </mat-tree-node>
   <!-- This is the tree node template for expandable nodes -->
   <mat-tree-node *matTreeNodeDef="let node;when: hasChild" matTreeNodePadding matTreeNodeToggle
                  [cdkTreeNodeTypeaheadLabel]="node.name">
-    <button mat-icon-button matTreeNodeToggle
+    <button matIconButton matTreeNodeToggle
             [attr.aria-label]="'Toggle ' + node.name">
       <mat-icon class="mat-icon-rtl-mirror">
         {{treeControl.isExpanded(node) ? 'expand_more' : 'chevron_right'}}

--- a/src/components-examples/material/tree/tree-legacy-keyboard-interface/tree-legacy-keyboard-interface-example.html
+++ b/src/components-examples/material/tree/tree-legacy-keyboard-interface/tree-legacy-keyboard-interface-example.html
@@ -4,7 +4,7 @@
                  class="example-tree-node"
                  tabindex="0">
     <!-- use a disabled button to provide padding for tree leaf -->
-    <button mat-icon-button disabled></button>
+    <button matIconButton disabled></button>
     {{node.name}}
   </mat-tree-node>
   <!-- This is the tree node template for expandable nodes -->

--- a/src/components-examples/material/tree/tree-loadmore/tree-loadmore-example.html
+++ b/src/components-examples/material/tree/tree-loadmore/tree-loadmore-example.html
@@ -1,14 +1,14 @@
 <mat-tree [dataSource]="dataSource" [treeControl]="treeControl">
   <!-- Leaf node -->
   <mat-tree-node *matTreeNodeDef="let node" matTreeNodePadding>
-    <button mat-icon-button disabled></button>
+    <button matIconButton disabled></button>
     {{node.name}}
   </mat-tree-node>
 
   <!-- expandable node -->
   <mat-tree-node *matTreeNodeDef="let node; when: hasChild" matTreeNodePadding matTreeNodeToggle
                  (expandedChange)="loadChildren(node)" [cdkTreeNodeTypeaheadLabel]="node.name">
-    <button mat-icon-button
+    <button matIconButton
             [attr.aria-label]="'Toggle ' + node.name"
             matTreeNodeToggle>
       <mat-icon class="mat-icon-rtl-mirror">

--- a/src/components-examples/material/tree/tree-nested-child-accessor-overview/tree-nested-child-accessor-overview-example.html
+++ b/src/components-examples/material/tree/tree-nested-child-accessor-overview/tree-nested-child-accessor-overview-example.html
@@ -1,7 +1,7 @@
 <mat-tree #tree [dataSource]="dataSource" [childrenAccessor]="childrenAccessor" class="example-tree">
   <!-- This is the tree node template for leaf nodes -->
   <!-- There is inline padding applied to this node using styles.
-    This padding value depends on the mat-icon-button width. -->
+    This padding value depends on the matIconButton width. -->
   <mat-nested-tree-node *matTreeNodeDef="let node">
     {{node.name}}
   </mat-nested-tree-node>
@@ -10,7 +10,7 @@
       *matTreeNodeDef="let node; when: hasChild"
       matTreeNodeToggle [cdkTreeNodeTypeaheadLabel]="node.name">
     <div class="mat-tree-node">
-      <button mat-icon-button matTreeNodeToggle
+      <button matIconButton matTreeNodeToggle
               [attr.aria-label]="'Toggle ' + node.name">
         <mat-icon class="mat-icon-rtl-mirror">
           {{tree.isExpanded(node) ? 'expand_more' : 'chevron_right'}}
@@ -19,7 +19,7 @@
       {{node.name}}
     </div>
     <!-- There is inline padding applied to this div using styles.
-        This padding value depends on the mat-icon-button width.  -->
+        This padding value depends on the matIconButton width.  -->
     <div [class.example-tree-invisible]="!tree.isExpanded(node)"
         role="group">
       <ng-container matTreeNodeOutlet></ng-container>

--- a/src/components-examples/material/tree/tree-nested-overview/tree-nested-overview-example.html
+++ b/src/components-examples/material/tree/tree-nested-overview/tree-nested-overview-example.html
@@ -1,7 +1,7 @@
 <mat-tree [dataSource]="dataSource" [treeControl]="treeControl" class="example-tree">
   <!-- This is the tree node template for leaf nodes -->
   <!-- There is inline padding applied to this node using styles.
-    This padding value depends on the mat-icon-button width. -->
+    This padding value depends on the matIconButton width. -->
   <mat-nested-tree-node *matTreeNodeDef="let node">
     {{node.name}}
   </mat-nested-tree-node>
@@ -10,7 +10,7 @@
       *matTreeNodeDef="let node; when: hasChild"
       matTreeNodeToggle [cdkTreeNodeTypeaheadLabel]="node.name">
     <div class="mat-tree-node">
-      <button mat-icon-button matTreeNodeToggle
+      <button matIconButton matTreeNodeToggle
               [attr.aria-label]="'Toggle ' + node.name">
         <mat-icon class="mat-icon-rtl-mirror">
           {{treeControl.isExpanded(node) ? 'expand_more' : 'chevron_right'}}
@@ -19,7 +19,7 @@
       {{node.name}}
     </div>
     <!-- There is inline padding applied to this div using styles.
-        This padding value depends on the mat-icon-button width.  -->
+        This padding value depends on the matIconButton width.  -->
     <div [class.example-tree-invisible]="!treeControl.isExpanded(node)"
         role="group">
       <ng-container matTreeNodeOutlet></ng-container>

--- a/src/dev-app/autocomplete/autocomplete-demo.html
+++ b/src/dev-app/autocomplete/autocomplete-demo.html
@@ -30,9 +30,9 @@ Space above cards: <input type="number" [formControl]="topHeightCtrl">
     </mat-autocomplete>
 
     <p>
-      <button mat-button (click)="stateCtrl.reset()">RESET</button>
-      <button mat-button (click)="stateCtrl.setValue(states[10])">SET VALUE</button>
-      <button mat-button (click)="stateCtrl.enabled ? stateCtrl.disable() : stateCtrl.enable()">
+      <button matButton (click)="stateCtrl.reset()">RESET</button>
+      <button matButton (click)="stateCtrl.setValue(states[10])">SET VALUE</button>
+      <button matButton (click)="stateCtrl.enabled ? stateCtrl.disable() : stateCtrl.enable()">
         TOGGLE DISABLED
       </button>
     </p>
@@ -88,9 +88,9 @@ Space above cards: <input type="number" [formControl]="topHeightCtrl">
     }
 
     <p>
-      <button mat-button (click)="clearTemplateState()">RESET</button>
-      <button mat-button (click)="currentState='California'">SET VALUE</button>
-      <button mat-button (click)="tdDisabled=!tdDisabled">
+      <button matButton (click)="clearTemplateState()">RESET</button>
+      <button matButton (click)="currentState='California'">SET VALUE</button>
+      <button matButton (click)="tdDisabled=!tdDisabled">
         TOGGLE DISABLED
       </button>
       <select [(ngModel)]="templateStatesTheme">
@@ -140,7 +140,7 @@ Space above cards: <input type="number" [formControl]="topHeightCtrl">
   <mat-card>
     <mat-card-subtitle>Autocomplete inside a Dialog</mat-card-subtitle>
     <mat-card-content>
-      <button mat-button (click)="openDialog()">Open dialog</button>
+      <button matButton (click)="openDialog()">Open dialog</button>
     </mat-card-content>
   </mat-card>
 </div>

--- a/src/dev-app/autocomplete/autocomplete-demo.ts
+++ b/src/dev-app/autocomplete/autocomplete-demo.ts
@@ -229,7 +229,7 @@ export class AutocompleteDemo {
         </mat-autocomplete>
       </mat-form-field>
 
-      <button type="submit" mat-button>Close</button>
+      <button type="submit" matButton>Close</button>
     </form>
   `,
   styles: `

--- a/src/dev-app/badge/badge-demo.html
+++ b/src/dev-app/badge/badge-demo.html
@@ -2,21 +2,21 @@
 
   <div class="demo-badge">
     <h3>Buttons</h3>
-    <button mat-stroked-button matBadge="7" matBadgeDescription="7 unread messages">
+    <button matButton="outlined" matBadge="7" matBadgeDescription="7 unread messages">
       Inbox
     </button>
 
-    <button mat-stroked-button matBadge="7" matBadgePosition="below after"
+    <button matButton="outlined" matBadge="7" matBadgePosition="below after"
         matBadgeDescription="7 unread messages">
       Inbox
     </button>
 
-    <button mat-stroked-button matBadge="7" disabled matBadgeDisabled
+    <button matButton="outlined" matBadge="7" disabled matBadgeDisabled
         matBadgeDescription="7 unread messages">
       Inbox
     </button>
 
-    <button mat-stroked-button matBadge="7" matBadgeColor="accent"
+    <button matButton="outlined" matBadge="7" matBadgeColor="accent"
         matBadgeDescription="7 unread messages">
       Inbox
     </button>

--- a/src/dev-app/bottom-sheet/bottom-sheet-demo.html
+++ b/src/dev-app/bottom-sheet/bottom-sheet-demo.html
@@ -1,7 +1,7 @@
 <h1>Bottom sheet demo</h1>
 
-<button mat-raised-button color="primary" (click)="openComponent()">Open component sheet</button>
-<button mat-raised-button color="accent" (click)="openTemplate()">Open template sheet</button>
+<button matButton="elevated" color="primary" (click)="openComponent()">Open component sheet</button>
+<button matButton="elevated" color="accent" (click)="openTemplate()">Open template sheet</button>
 
 <mat-card class="demo-dialog-card">
   <mat-card-content>

--- a/src/dev-app/button/button-demo.html
+++ b/src/dev-app/button/button-demo.html
@@ -1,66 +1,52 @@
 <div class="demo-button">
   <h4 class="demo-section-header">Buttons</h4>
   <section>
-    <button mat-button>normal</button>
-    <button mat-raised-button>raised</button>
-    <button mat-stroked-button>stroked</button>
-    <button mat-flat-button>flat</button>
-    <button mat-fab>
+    @for (appearance of appearances; track $index) {
+      <button [matButton]="appearance">{{appearance}}</button>
+    }
+    <button matFab>
       <mat-icon>check</mat-icon>
     </button>
-    <button mat-mini-fab>
+    <button matMiniFab>
       <mat-icon>check</mat-icon>
     </button>
-    <button mat-fab extended>Search</button>
-    <button mat-fab extended>
+    <button matFab extended>Search</button>
+    <button matFab extended>
       <mat-icon>check</mat-icon>
       Search
       <mat-icon iconPositionEnd>check</mat-icon>
     </button>
   </section>
   <section>
+    @for (appearance of appearances; track $index) {
+      <button
+        [matButton]="appearance"
+        disabled
+        [disabledInteractive]="disabledInteractive"
+        [matTooltip]="tooltipText">{{appearance}}</button>
+    }
     <button
-      mat-button
-      disabled
-      [disabledInteractive]="disabledInteractive"
-      [matTooltip]="tooltipText">normal</button>
-    <button
-      mat-raised-button
-      disabled
-      [disabledInteractive]="disabledInteractive"
-      [matTooltip]="tooltipText">raised</button>
-    <button
-      mat-stroked-button
-      disabled
-      [disabledInteractive]="disabledInteractive"
-      [matTooltip]="tooltipText">stroked</button>
-    <button
-      mat-flat-button
-      disabled
-      [disabledInteractive]="disabledInteractive"
-      [matTooltip]="tooltipText">flat</button>
-    <button
-      mat-fab
+      matFab
       disabled
       [disabledInteractive]="disabledInteractive"
       [matTooltip]="tooltipText">
       <mat-icon>check</mat-icon>
     </button>
     <button
-      mat-mini-fab
+      matMiniFab
       disabled
       [disabledInteractive]="disabledInteractive"
       [matTooltip]="tooltipText">
       <mat-icon>check</mat-icon>
     </button>
     <button
-      mat-fab
+      matFab
       extended
       disabled
       [disabledInteractive]="disabledInteractive"
       [matTooltip]="tooltipText">Search</button>
     <button
-      mat-fab
+      matFab
       extended
       disabled
       [disabledInteractive]="disabledInteractive"
@@ -73,18 +59,17 @@
 
   <h4 class="demo-section-header">Anchors</h4>
   <section>
-    <a href="//www.google.com" mat-button>SEARCH</a>
-    <a href="//www.google.com" mat-raised-button>SEARCH</a>
-    <a href="//www.google.com" mat-stroked-button>SEARCH</a>
-    <a href="//www.google.com" mat-flat-button>SEARCH</a>
-    <a href="//www.google.com" mat-fab>
+    @for (appearance of appearances; track $index) {
+      <a href="//www.google.com" [matButton]="appearance">SEARCH</a>
+    }
+    <a href="//www.google.com" matFab>
       <mat-icon>check</mat-icon>
     </a>
-    <a href="//www.google.com" mat-mini-fab>
+    <a href="//www.google.com" matMiniFab>
       <mat-icon>check</mat-icon>
     </a>
-    <a href="//www.google.com" mat-fab extended>Search</a>
-    <a href="//www.google.com" mat-fab extended>
+    <a href="//www.google.com" matFab extended>Search</a>
+    <a href="//www.google.com" matFab extended>
       <mat-icon>check</mat-icon>
       Search
       <mat-icon iconPositionEnd>check</mat-icon>
@@ -96,32 +81,33 @@
       disabled
       [disabledInteractive]="disabledInteractive"
       [matTooltip]="tooltipText"
-      mat-button
+      matButton
       color="primary">SEARCH</a>
     <a
       href="//www.google.com"
       disabled
       [disabledInteractive]="disabledInteractive"
       [matTooltip]="tooltipText"
-      mat-raised-button>SEARCH</a>
+      matButton="elevated">SEARCH</a>
     <a
       href="//www.google.com"
       disabled
       [disabledInteractive]="disabledInteractive"
       [matTooltip]="tooltipText"
-      mat-stroked-button color="primary">SEARCH</a>
+      matButton="outlined"
+      color="primary">SEARCH</a>
     <a
       href="//www.google.com"
       disabled
       [disabledInteractive]="disabledInteractive"
       [matTooltip]="tooltipText"
-      mat-flat-button>SEARCH</a>
+      matButton="filled">SEARCH</a>
     <a
       href="//www.google.com"
       disabled
       [disabledInteractive]="disabledInteractive"
       [matTooltip]="tooltipText"
-      mat-fab>
+      matFab>
       <mat-icon>check</mat-icon>
     </a>
     <a
@@ -129,7 +115,7 @@
       disabled
       [disabledInteractive]="disabledInteractive"
       [matTooltip]="tooltipText"
-      mat-mini-fab>
+      matMiniFab>
       <mat-icon>check</mat-icon>
     </a>
     <a
@@ -137,14 +123,14 @@
       disabled
       [disabledInteractive]="disabledInteractive"
       [matTooltip]="tooltipText"
-      mat-fab
+      matFab
       extended>Search</a>
     <a
       href="//www.google.com"
       disabled
       [disabledInteractive]="disabledInteractive"
       [matTooltip]="tooltipText"
-      mat-fab
+      matFab
       extended>
       <mat-icon>check</mat-icon>
       Search
@@ -152,110 +138,46 @@
     </a>
   </section>
 
-  <h4 class="demo-section-header">Text Buttons [mat-button]</h4>
-  <section>
-    <button mat-button>unthemed</button>
-    <button mat-button color="primary">primary</button>
-    <button mat-button color="accent">accent</button>
-    <button mat-button color="warn">warn</button>
-    <button
-      mat-button
-      disabled
-      [disabledInteractive]="disabledInteractive"
-      [matTooltip]="tooltipText">disabled</button>
-    <button mat-button>
-      <mat-icon>home</mat-icon>
-      with icons
-      <mat-icon iconPositionEnd>favorite</mat-icon>
-    </button>
-    <button mat-button>
-      <mat-icon>home</mat-icon>
-      with icons
-    </button>
-  </section>
+  @for (appearance of appearances; track $index) {
+    <h4 class="demo-section-header"><code>{{appearance}}</code> Appearance</h4>
+    <section>
+      <button [matButton]="appearance">unthemed</button>
+      <button [matButton]="appearance" color="primary">primary</button>
+      <button [matButton]="appearance" color="accent">accent</button>
+      <button [matButton]="appearance" color="warn">warn</button>
+      <button
+        [matButton]="appearance"
+        disabled
+        [disabledInteractive]="disabledInteractive"
+        [matTooltip]="tooltipText">disabled</button>
+      <button [matButton]="appearance">
+        <mat-icon>home</mat-icon>
+        with icons
+        <mat-icon iconPositionEnd>favorite</mat-icon>
+      </button>
+      <button [matButton]="appearance">
+        <mat-icon>home</mat-icon>
+        with icons
+      </button>
+    </section>
+  }
 
-  <h4 class="demo-section-header">Raised Buttons [mat-raised-button]</h4>
+  <h4 class="demo-section-header">Icon Buttons</h4>
   <section>
-    <button mat-raised-button>unthemed</button>
-    <button mat-raised-button color="primary">primary</button>
-    <button mat-raised-button color="accent">accent</button>
-    <button mat-raised-button color="warn">warn</button>
-    <button
-      mat-raised-button
-      disabled
-      [disabledInteractive]="disabledInteractive"
-      [matTooltip]="tooltipText">disabled</button>
-    <button mat-raised-button>
-      <mat-icon>home</mat-icon>
-      with icons
-      <mat-icon iconPositionEnd>favorite</mat-icon>
-    </button>
-    <button mat-raised-button>
-      <mat-icon>home</mat-icon>
-      with icons
-    </button>
-  </section>
-
-  <h4 class="demo-section-header">Stroked Buttons [mat-stroked-button]</h4>
-  <section>
-    <button mat-stroked-button>unthemed</button>
-    <button mat-stroked-button color="primary">primary</button>
-    <button mat-stroked-button color="accent">accent</button>
-    <button mat-stroked-button color="warn">warn</button>
-    <button
-      mat-stroked-button
-      disabled
-      [disabledInteractive]="disabledInteractive"
-      [matTooltip]="tooltipText">disabled</button>
-    <button mat-stroked-button>
-      <mat-icon>home</mat-icon>
-      with icons
-      <mat-icon iconPositionEnd>favorite</mat-icon>
-    </button>
-    <button mat-stroked-button>
-      <mat-icon>home</mat-icon>
-      with icons
-    </button>
-  </section>
-
-  <h4 class="demo-section-header">Flat Buttons [mat-flat-button]</h4>
-  <section>
-    <button mat-flat-button>unthemed</button>
-    <button mat-flat-button color="primary">primary</button>
-    <button mat-flat-button color="accent">accent</button>
-    <button mat-flat-button color="warn">warn</button>
-    <button
-      mat-flat-button
-      disabled
-      [disabledInteractive]="disabledInteractive"
-      [matTooltip]="tooltipText">disabled</button>
-    <button mat-flat-button>
-      <mat-icon>home</mat-icon>
-      with icons
-      <mat-icon iconPositionEnd>favorite</mat-icon>
-    </button>
-    <button mat-flat-button>
-      <mat-icon>home</mat-icon>
-      with icons
-    </button>
-  </section>
-
-  <h4 class="demo-section-header">Icon Buttons [mat-icon-button]</h4>
-  <section>
-    <button mat-icon-button>
+    <button matIconButton>
       <mat-icon>cached</mat-icon>
     </button>
-    <button mat-icon-button color="primary">
+    <button matIconButton color="primary">
       <mat-icon>cached</mat-icon>
     </button>
-    <button mat-icon-button color="accent">
+    <button matIconButton color="accent">
       <mat-icon>backup</mat-icon>
     </button>
-    <button mat-icon-button color="warn">
+    <button matIconButton color="warn">
       <mat-icon>trending_up</mat-icon>
     </button>
     <button
-      mat-icon-button
+      matIconButton
       disabled
       [disabledInteractive]="disabledInteractive"
       [matTooltip]="tooltipText">
@@ -263,23 +185,23 @@
     </button>
   </section>
 
-  <h4 class="demo-section-header">Icon Button Anchors [mat-icon-button]</h4>
+  <h4 class="demo-section-header">Icon Button Anchors</h4>
   <section>
-    <a href="#" mat-icon-button>
+    <a href="#" matIconButton>
       <mat-icon>cached</mat-icon>
     </a>
-    <a href="#" mat-icon-button color="primary">
+    <a href="#" matIconButton color="primary">
       <mat-icon>cached</mat-icon>
     </a>
-    <a href="#" mat-icon-button color="accent">
+    <a href="#" matIconButton color="accent">
       <mat-icon>backup</mat-icon>
     </a>
-    <a href="#" mat-icon-button color="warn">
+    <a href="#" matIconButton color="warn">
       <mat-icon>trending_up</mat-icon>
     </a>
     <a
       href="#"
-      mat-icon-button
+      matIconButton
       disabled
       [disabledInteractive]="disabledInteractive"
       [matTooltip]="tooltipText">
@@ -287,22 +209,22 @@
     </a>
   </section>
 
-  <h4 class="demo-section-header">Fab Buttons [mat-fab]</h4>
+  <h4 class="demo-section-header">FABs</h4>
   <section>
-    <button mat-fab>
+    <button matFab>
       <mat-icon>delete</mat-icon>
     </button>
-    <button mat-fab color="primary">
+    <button matFab color="primary">
       <mat-icon>delete</mat-icon>
     </button>
-    <button mat-fab color="accent">
+    <button matFab color="accent">
       <mat-icon>bookmark</mat-icon>
     </button>
-    <button mat-fab color="warn">
+    <button matFab color="warn">
       <mat-icon>home</mat-icon>
     </button>
     <button
-      mat-fab
+      matFab
       disabled
       [disabledInteractive]="disabledInteractive"
       [matTooltip]="tooltipText">
@@ -310,22 +232,22 @@
     </button>
   </section>
 
-  <h4 class="demo-section-header"> Mini Fab Buttons [mat-mini-fab]</h4>
+  <h4 class="demo-section-header">Mini FABs</h4>
   <section>
-    <button mat-mini-fab>
+    <button matMiniFab>
       <mat-icon>menu</mat-icon>
     </button>
-    <button mat-mini-fab color="primary">
+    <button matMiniFab color="primary">
       <mat-icon>menu</mat-icon>
     </button>
-    <button mat-mini-fab color="accent">
+    <button matMiniFab color="accent">
       <mat-icon>plus_one</mat-icon>
     </button>
-    <button mat-mini-fab color="warn">
+    <button matMiniFab color="warn">
       <mat-icon>filter_list</mat-icon>
     </button>
     <button
-      mat-mini-fab
+      matMiniFab
       disabled
       [disabledInteractive]="disabledInteractive"
       [matTooltip]="tooltipText">
@@ -344,31 +266,31 @@
       <p>
         <mat-checkbox [(ngModel)]="isDisabled">All disabled</mat-checkbox>
       </p>
-      <button mat-flat-button (click)="button1.focus()">Focus 1</button>
-      <button mat-flat-button (click)="button2.focus()">Focus 2</button>
-      <button mat-flat-button (click)="button3.focus()">Focus 3</button>
-      <button mat-flat-button (click)="button4.focus()">Focus 4</button>
+      <button matButton="filled" (click)="button1.focus()">Focus 1</button>
+      <button matButton="filled" (click)="button2.focus()">Focus 2</button>
+      <button matButton="filled" (click)="button3.focus()">Focus 3</button>
+      <button matButton="filled" (click)="button4.focus()">Focus 4</button>
     </div>
     <div>
-      <button mat-button #button1 [disabled]="isDisabled"
+      <button matButton #button1 [disabled]="isDisabled"
               (click)="clickCounter=clickCounter+1">
         Button 1
       </button>
-      <button mat-button #button2 color="primary" [disabled]="isDisabled">
+      <button matButton #button2 color="primary" [disabled]="isDisabled">
         Button 2
       </button>
-      <a href="//www.google.com" #button3 mat-button color="accent"
+      <a href="//www.google.com" #button3 matButton color="accent"
          [disabled]="isDisabled">
         Button 3
       </a>
-      <button mat-raised-button #button4 color="primary"
+      <button matButton="elevated" #button4 color="primary"
               [disabled]="isDisabled">
         Button 4
       </button>
-      <button mat-mini-fab [disabled]="isDisabled">
+      <button matMiniFab [disabled]="isDisabled">
         <mat-icon>check</mat-icon>
       </button>
-      <button mat-icon-button color="accent" [disabled]="isDisabled">
+      <button matIconButton color="accent" [disabled]="isDisabled">
         <mat-icon>favorite</mat-icon>
       </button>
     </div>

--- a/src/dev-app/button/button-demo.ts
+++ b/src/dev-app/button/button-demo.ts
@@ -11,6 +11,7 @@ import {FormsModule} from '@angular/forms';
 import {
   MatAnchor,
   MatButton,
+  MatButtonAppearance,
   MatFabAnchor,
   MatFabButton,
   MatIconAnchor,
@@ -48,4 +49,5 @@ export class ButtonDemo {
   toggleDisable = false;
   tooltipText = 'This is a button tooltip!';
   disabledInteractive = false;
+  appearances: MatButtonAppearance[] = ['text', 'elevated', 'outlined', 'filled'];
 }

--- a/src/dev-app/card/card-demo.html
+++ b/src/dev-app/card/card-demo.html
@@ -22,8 +22,8 @@
       <p>{{longText}}</p>
     </mat-card-content>
     <mat-card-actions>
-      <button mat-button>Like</button>
-      <button mat-button>Share</button>
+      <button matButton>Like</button>
+      <button matButton>Share</button>
     </mat-card-actions>
   </mat-card>
 
@@ -37,8 +37,8 @@
       <p>{{longText}}</p>
     </mat-card-content>
     <mat-card-actions>
-      <button mat-button>Like</button>
-      <button mat-button>Share</button>
+      <button matButton>Like</button>
+      <button matButton>Share</button>
     </mat-card-actions>
 
   </mat-card>
@@ -52,8 +52,8 @@
       <p>Here is some content</p>
     </mat-card-content>
     <mat-card-actions align="end">
-      <button mat-button>Like</button>
-      <button mat-button>Share</button>
+      <button matButton>Like</button>
+      <button matButton>Share</button>
     </mat-card-actions>
   </mat-card>
 
@@ -74,8 +74,8 @@
       <mat-card-title>Easily customizable</mat-card-title>
     </mat-card-header>
     <mat-card-actions>
-      <button mat-button>First</button>
-      <button mat-button>Second</button>
+      <button matButton>First</button>
+      <button matButton>Second</button>
     </mat-card-actions>
   </mat-card>
 

--- a/src/dev-app/chips/chips-demo.html
+++ b/src/dev-app/chips/chips-demo.html
@@ -114,10 +114,10 @@
     <mat-toolbar color="primary">Selectable Chips</mat-toolbar>
 
     <mat-card-content>
-      <button mat-button (click)="disabledListboxes = !disabledListboxes">
+      <button matButton (click)="disabledListboxes = !disabledListboxes">
        {{disabledListboxes ? "Enable" : "Disable"}}
       </button>
-      <button mat-button (click)="listboxesWithAvatar = !listboxesWithAvatar">
+      <button matButton (click)="listboxesWithAvatar = !listboxesWithAvatar">
        {{listboxesWithAvatar ? "Hide Avatar" : "Show Avatar"}}
       </button>
 
@@ -160,11 +160,11 @@
         They can be used inside a <code>&lt;mat-form-field&gt;</code>.
       </p>
 
-      <button mat-button (click)="disableInputs = !disableInputs">
+      <button matButton (click)="disableInputs = !disableInputs">
        {{disableInputs ? "Enable" : "Disable"}}
       </button>
 
-      <button mat-button (click)="editable = !editable">
+      <button matButton (click)="editable = !editable">
         {{editable ? "Disable editing" : "Enable editing"}}
       </button>
 

--- a/src/dev-app/connected-overlay/connected-overlay-demo.html
+++ b/src/dev-app/connected-overlay/connected-overlay-demo.html
@@ -94,12 +94,12 @@
   </div>
 
   <div>
-    <button mat-raised-button type="button" (click)="close()" [disabled]="!overlayRef">Close</button>
+    <button matButton="elevated" type="button" (click)="close()" [disabled]="!overlayRef">Close</button>
   </div>
 </div>
 
 <div class="demo-trigger-connected-overlay">
-  <button mat-raised-button
+  <button matButton="elevated"
       cdkOverlayOrigin
       type="button"
       [disabled]="!!overlayRef"

--- a/src/dev-app/datepicker/custom-header.html
+++ b/src/dev-app/datepicker/custom-header.html
@@ -1,15 +1,15 @@
 <div class="demo-calendar-header">
-  <button mat-icon-button (click)="previousClicked('year')">
+  <button matIconButton (click)="previousClicked('year')">
     <mat-icon>keyboard_double_arrow_left</mat-icon>
   </button>
-  <button mat-icon-button (click)="previousClicked('month')">
+  <button matIconButton (click)="previousClicked('month')">
     <mat-icon>keyboard_arrow_left</mat-icon>
   </button>
   <span class="demo-calendar-header-label">{{periodLabel}}</span>
-  <button mat-icon-button (click)="nextClicked('month')">
+  <button matIconButton (click)="nextClicked('month')">
     <mat-icon>keyboard_arrow_right</mat-icon>
   </button>
-  <button mat-icon-button (click)="nextClicked('year')">
+  <button matIconButton (click)="nextClicked('year')">
     <mat-icon>keyboard_double_arrow_right</mat-icon>
   </button>
 </div>

--- a/src/dev-app/datepicker/datepicker-demo.html
+++ b/src/dev-app/datepicker/datepicker-demo.html
@@ -23,8 +23,8 @@
     <mat-datepicker #minDatePicker [touchUi]="touch" [disabled]="datepickerDisabled">
       @if (showActions) {
         <mat-datepicker-actions>
-          <button mat-button matDatepickerCancel>Cancel</button>
-          <button mat-raised-button color="primary" matDatepickerApply>Apply</button>
+          <button matButton matDatepickerCancel>Cancel</button>
+          <button matButton="elevated" color="primary" matDatepickerApply>Apply</button>
         </mat-datepicker-actions>
       }
     </mat-datepicker>
@@ -37,8 +37,8 @@
     <mat-datepicker #maxDatePicker [touchUi]="touch" [disabled]="datepickerDisabled">
       @if (showActions) {
         <mat-datepicker-actions>
-          <button mat-button matDatepickerCancel>Cancel</button>
-          <button mat-raised-button color="primary" matDatepickerApply>Apply</button>
+          <button matButton matDatepickerCancel>Cancel</button>
+          <button matButton="elevated" color="primary" matDatepickerApply>Apply</button>
         </mat-datepicker-actions>
       }
     </mat-datepicker>
@@ -53,8 +53,8 @@
     <mat-datepicker #startAtPicker [touchUi]="touch" [disabled]="datepickerDisabled">
       @if (showActions) {
         <mat-datepicker-actions>
-          <button mat-button matDatepickerCancel>Cancel</button>
-          <button mat-raised-button color="primary" matDatepickerApply>Apply</button>
+          <button matButton matDatepickerCancel>Cancel</button>
+          <button matButton="elevated" color="primary" matDatepickerApply>Apply</button>
         </mat-datepicker-actions>
       }
     </mat-datepicker>
@@ -86,8 +86,8 @@
         [color]="color">
       @if (showActions) {
         <mat-datepicker-actions>
-          <button mat-button matDatepickerCancel>Cancel</button>
-          <button mat-raised-button color="primary" matDatepickerApply>Apply</button>
+          <button matButton matDatepickerCancel>Cancel</button>
+          <button matButton="elevated" color="primary" matDatepickerApply>Apply</button>
         </mat-datepicker-actions>
       }
     </mat-datepicker>
@@ -128,8 +128,8 @@
       [startView]="yearView ? 'year' : 'month'">
     @if (showActions) {
       <mat-datepicker-actions>
-        <button mat-button matDatepickerCancel>Cancel</button>
-        <button mat-raised-button color="primary" matDatepickerApply>Apply</button>
+        <button matButton matDatepickerCancel>Cancel</button>
+        <button matButton="elevated" color="primary" matDatepickerApply>Apply</button>
       </mat-datepicker-actions>
     }
   </mat-datepicker>
@@ -158,7 +158,7 @@
                     [startView]="yearView ? 'year' : 'month'"></mat-datepicker>
   </mat-form-field>
 
-  <button mat-button (click)="dateCtrl.disabled ? dateCtrl.enable() : dateCtrl.disable()">
+  <button matButton (click)="dateCtrl.disabled ? dateCtrl.enable() : dateCtrl.disable()">
     {{dateCtrl.disabled ? 'Enable' : 'Disable'}} FormControl
   </button>
 </p>
@@ -237,8 +237,8 @@
       #range1Picker>
       @if (showActions) {
         <mat-date-range-picker-actions>
-          <button mat-button matDateRangePickerCancel>Cancel</button>
-          <button mat-raised-button color="primary" matDateRangePickerApply>Apply</button>
+          <button matButton matDateRangePickerCancel>Cancel</button>
+          <button matButton="elevated" color="primary" matDateRangePickerApply>Apply</button>
         </mat-date-range-picker-actions>
       }
     </mat-date-range-picker>
@@ -269,8 +269,8 @@
       #range2Picker>
       @if (showActions) {
         <mat-date-range-picker-actions>
-          <button mat-button matDateRangePickerCancel>Cancel</button>
-          <button mat-raised-button color="primary" matDateRangePickerApply>Apply</button>
+          <button matButton matDateRangePickerCancel>Cancel</button>
+          <button matButton="elevated" color="primary" matDateRangePickerApply>Apply</button>
         </mat-date-range-picker-actions>
       }
     </mat-date-range-picker>
@@ -300,8 +300,8 @@
       #range3Picker>
       @if (showActions) {
         <mat-date-range-picker-actions>
-          <button mat-button matDateRangePickerCancel>Cancel</button>
-          <button mat-raised-button color="primary" matDateRangePickerApply>Apply</button>
+          <button matButton matDateRangePickerCancel>Cancel</button>
+          <button matButton="elevated" color="primary" matDateRangePickerApply>Apply</button>
         </mat-date-range-picker-actions>
       }
     </mat-date-range-picker>
@@ -322,8 +322,8 @@
     <mat-date-range-picker customRangeStrategy #range4Picker>
       @if (showActions) {
         <mat-date-range-picker-actions>
-          <button mat-button matDateRangePickerCancel>Cancel</button>
-          <button mat-raised-button color="primary" matDateRangePickerApply>Apply</button>
+          <button matButton matDateRangePickerCancel>Cancel</button>
+          <button matButton="elevated" color="primary" matDateRangePickerApply>Apply</button>
         </mat-date-range-picker-actions>
       }
     </mat-date-range-picker>

--- a/src/dev-app/datepicker/datepicker-demo.ts
+++ b/src/dev-app/datepicker/datepicker-demo.ts
@@ -148,7 +148,7 @@ export class CustomHeader<D> implements OnDestroy {
   selector: 'custom-header-ng-content',
   template: `
       <mat-calendar-header #header>
-        <button mat-button type="button" (click)="todayClicked()">TODAY</button>
+        <button matButton type="button" (click)="todayClicked()">TODAY</button>
       </mat-calendar-header>
     `,
   imports: [MatDatepickerModule],

--- a/src/dev-app/dev-app/dev-app-404.ts
+++ b/src/dev-app/dev-app/dev-app-404.ts
@@ -14,7 +14,7 @@ import {RouterModule} from '@angular/router';
   template: `
     <h1>404</h1>
     <p>This page does not exist</p>
-    <a mat-raised-button routerLink="/">Go back to the home page</a>
+    <a matButton="elevated" routerLink="/">Go back to the home page</a>
   `,
   host: {'class': 'mat-typography'},
   imports: [MatButtonModule, RouterModule],

--- a/src/dev-app/dev-app/dev-app-layout.html
+++ b/src/dev-app/dev-app/dev-app-layout.html
@@ -23,7 +23,7 @@
         Performance
       </a>
     </mat-nav-list>
-    <button mat-button tabindex="-1" (click)="navigation.close()">CLOSE</button>
+    <button matButton tabindex="-1" (click)="navigation.close()">CLOSE</button>
   </mat-sidenav>
   <!--
     Note that the setup with the directionality and density is a little convoluted, but it's
@@ -35,7 +35,7 @@
   <main [attr.dir]="state.direction" [class]="getDensityClass()" class="demo-main">
     <!-- The toolbar should always be in the LTR direction -->
     <mat-toolbar color="primary" dir="ltr">
-      <button mat-icon-button (click)="navigation.open('mouse')">
+      <button matIconButton (click)="navigation.open('mouse')">
         <mat-icon>menu</mat-icon>
       </button>
       <div class="demo-toolbar">
@@ -43,18 +43,18 @@
         <div class="demo-config-buttons">
           @if (state.m3Enabled) {
             <button
-              mat-icon-button
+              matIconButton
               (click)="toggleColorApiBackCompat()"
               matTooltip="{{state.colorApiBackCompat ? 'Disable' : 'Enable'}} color API back-compat"
             >
               <mat-icon>colorize</mat-icon>
             </button>
           }
-          <button mat-icon-button (click)="toggleFullscreen()" matTooltip="Toggle fullscreen">
+          <button matIconButton (click)="toggleFullscreen()" matTooltip="Toggle fullscreen">
             <mat-icon>fullscreen</mat-icon>
           </button>
           <button
-            mat-icon-button
+            matIconButton
             (click)="toggleM3()"
             [matTooltip]="state.m3Enabled ? 'Use M2 theme' : 'Use M3 theme'"
           >
@@ -65,7 +65,7 @@
             }
           </button>
           <button
-            mat-icon-button
+            matIconButton
             (click)="toggleZoneless()"
             [matTooltip]="isZoneless ? 'Use zones' : 'Use zoneless'"
           >
@@ -76,7 +76,7 @@
             }
           </button>
           <button
-            mat-icon-button
+            matIconButton
             (click)="toggleAnimations()"
             [matTooltip]="state.animations ? 'Disable animations' : 'Enable animations'"
           >
@@ -87,7 +87,7 @@
             }
           </button>
           <button
-            mat-icon-button
+            matIconButton
             (click)="toggleTheme()"
             [matTooltip]="state.darkTheme ? 'Switch to light theme' : 'Switch to dark theme'"
           >
@@ -98,7 +98,7 @@
             }
           </button>
           <button
-              mat-icon-button
+              matIconButton
               (click)="toggleSystemTheme()"
               [matTooltip]="state.systemTheme ? 'Switch to standard theme' : 'Switch to system theme'"
           >
@@ -109,7 +109,7 @@
             }
           </button>
           <button
-            mat-icon-button
+            matIconButton
             (click)="toggleRippleDisabled()"
             [matTooltip]="state.rippleDisabled ? 'Enable ripples' : 'Disable ripples'"
           >
@@ -120,7 +120,7 @@
             }
           </button>
           <button
-            mat-icon-button
+            matIconButton
             (click)="toggleStrongFocus()"
             [matTooltip]="state.strongFocusEnabled ? 'Disable strong focus' : 'Enable strong focus'"
           >
@@ -131,7 +131,7 @@
             }
           </button>
           <button
-            mat-icon-button
+            matIconButton
             (click)="toggleDirection()"
             [matTooltip]="state.direction === 'rtl' ? 'Switch to LTR' : 'Switch to RTL'"
           >
@@ -143,7 +143,7 @@
           </button>
           <button
             #densityTooltip="matTooltip"
-            mat-icon-button
+            matIconButton
             (click)="toggleDensity(undefined, densityTooltip)"
             [matTooltip]="'Density: ' + state.density"
           >

--- a/src/dev-app/dialog/dialog-demo.html
+++ b/src/dev-app/dialog/dialog-demo.html
@@ -1,12 +1,12 @@
 <h1>Dialog demo</h1>
 
-<button mat-raised-button color="primary" (click)="openJazz()" class="demo-dialog-button">
+<button matButton="elevated" color="primary" (click)="openJazz()" class="demo-dialog-button">
   Open dialog
 </button>
-<button mat-raised-button color="accent" (click)="openContentElement()" class="demo-dialog-button">
+<button matButton="elevated" color="accent" (click)="openContentElement()" class="demo-dialog-button">
   Open dialog with content elements
 </button>
-<button mat-raised-button color="accent" (click)="openTemplate()" class="demo-dialog-button">
+<button matButton="elevated" color="accent" (click)="openTemplate()" class="demo-dialog-button">
   Open dialog with template content
 </button>
 

--- a/src/dev-app/dialog/dialog-demo.ts
+++ b/src/dev-app/dialog/dialog-demo.ts
@@ -234,18 +234,18 @@ export class JazzDialog {
 
     <mat-dialog-actions [align]="actionsAlignment">
       <button
-        mat-button
+        matButton
         color="primary"
         mat-dialog-close>Close</button>
 
       <a
-        mat-button
+        matButton
         color="primary"
         href="https://en.wikipedia.org/wiki/Neptune"
         target="_blank">Read more on Wikipedia</a>
 
       <button
-        mat-button
+        matButton
         color="accent"
         (click)="showInStackedDialog()">
         Show in Dialog</button>
@@ -282,7 +282,7 @@ export class ContentElementDialog {
 
     <mat-dialog-actions>
       <button
-        mat-button
+        matButton
         color="primary"
         mat-dialog-close>Close</button>
     </mat-dialog-actions>

--- a/src/dev-app/drawer/drawer-demo.html
+++ b/src/dev-app/drawer/drawer-demo.html
@@ -4,11 +4,11 @@
   <mat-drawer #start (opened)="myinput.focus()" mode="side">
     Start Side Drawer
     <br>
-    <button mat-button (click)="start.close()">Close</button>
+    <button matButton (click)="start.close()">Close</button>
     <br>
-    <button mat-button (click)="end.open()">Open End Side</button>
+    <button matButton (click)="end.open()">Open End Side</button>
     <br>
-    <button mat-button
+    <button matButton
             (click)="start.mode = (start.mode === 'push' ? 'over' : (start.mode === 'over' ? 'side' : 'push'))">Toggle Mode</button>
     <div>Mode: {{start.mode}}</div>
     <br>
@@ -18,7 +18,7 @@
   <mat-drawer #end position="end">
     End Side Drawer
     <br>
-    <button mat-button (click)="end.close()">Close</button>
+    <button matButton (click)="end.close()">Close</button>
   </mat-drawer>
 
   <div class="demo-drawer-content">
@@ -26,13 +26,13 @@
 
     <div>
       <header>Drawer</header>
-      <button mat-button (click)="start.toggle()">Toggle Start Side Drawer</button>
-      <button mat-button (click)="end.toggle()">Toggle End Side Drawer</button>
+      <button matButton (click)="start.toggle()">Toggle Start Side Drawer</button>
+      <button matButton (click)="end.toggle()">Toggle End Side Drawer</button>
     </div>
 
-    <button mat-button>HELLO</button>
-    <button mat-raised-button class="mat-primary">HELLO</button>
-    <button mat-fab class="mat-accent">HI</button>
+    <button matButton>HELLO</button>
+    <button matButton="elevated" class="mat-primary">HELLO</button>
+    <button matFab class="mat-accent">HI</button>
   </div>
 </mat-drawer-container>
 
@@ -44,7 +44,7 @@
   </mat-drawer>
 
   <div class="demo-drawer-content">
-    <button mat-button (click)="start2.toggle()">Toggle Start Side Drawer</button>
+    <button matButton (click)="start2.toggle()">Toggle Start Side Drawer</button>
   </div>
 </mat-drawer-container>
 
@@ -81,7 +81,7 @@
 
     <div>
       <header>Drawer</header>
-      <button mat-button (click)="focusDrawer.toggle()">Toggle Drawer</button>
+      <button matButton (click)="focusDrawer.toggle()">Toggle Drawer</button>
     </div>
   </div>
 </mat-drawer-container>

--- a/src/dev-app/expansion/expansion-demo.html
+++ b/src/dev-app/expansion/expansion-demo.html
@@ -14,8 +14,8 @@
   </ng-template>
 
   <mat-action-row>
-    <button mat-button (click)="myPanel.expanded = false">CANCEL</button>
-    <button mat-button>SAVE</button>
+    <button matButton (click)="myPanel.expanded = false">CANCEL</button>
+    <button matButton>SAVE</button>
   </mat-action-row>
 </mat-expansion-panel>
 
@@ -60,8 +60,8 @@
   </mat-radio-group>
   <p>Accordion Actions <sup>('Multi Expansion' mode only)</sup></p>
   <div>
-    <button mat-button (click)="accordion.openAll()" [disabled]="!multi">Expand All</button>
-    <button mat-button (click)="accordion.closeAll()" [disabled]="!multi">Collapse All</button>
+    <button matButton (click)="accordion.openAll()" [disabled]="!multi">Expand All</button>
+    <button matButton (click)="accordion.closeAll()" [disabled]="!multi">Collapse All</button>
   </div>
   <p>Accordion Panel(s)</p>
   <div>
@@ -86,8 +86,8 @@
       <mat-checkbox #showButtons>Reveal Buttons Below</mat-checkbox>
       @if (showButtons.checked) {
         <mat-action-row>
-          <button mat-button (click)="panel2.expanded = true">OPEN SECTION 2</button>
-          <button mat-button (click)="panel3.expanded = false">CLOSE</button>
+          <button matButton (click)="panel2.expanded = true">OPEN SECTION 2</button>
+          <button matButton (click)="panel3.expanded = false">CLOSE</button>
         </mat-action-row>
       }
     </mat-expansion-panel>
@@ -105,8 +105,8 @@
   <cdk-accordion-item #item1="cdkAccordionItem">
     <p>
       Item 1:
-      <button mat-button (click)="item1.expanded = true">Expand</button>
-      <button mat-button (click)="item1.expanded = false">Collapse</button>
+      <button matButton (click)="item1.expanded = true">Expand</button>
+      <button matButton (click)="item1.expanded = false">Collapse</button>
     </p>
     @if (item1.expanded) {
       <p>I only show if item 1 is expanded</p>
@@ -115,8 +115,8 @@
   <cdk-accordion-item #item2="cdkAccordionItem">
     <p>
       Item 2:
-      <button mat-button (click)="item2.expanded = true">Expand</button>
-      <button mat-button (click)="item2.expanded = false">Collapse</button>
+      <button matButton (click)="item2.expanded = true">Expand</button>
+      <button matButton (click)="item2.expanded = false">Collapse</button>
     </p>
     @if (item2.expanded) {
       <p>I only show if item 2 is expanded</p>
@@ -125,8 +125,8 @@
   <cdk-accordion-item #item3="cdkAccordionItem">
     <p>
       Item 3:
-      <button mat-button (click)="item3.expanded = true">Expand</button>
-      <button mat-button (click)="item3.expanded = false">Collapse</button>
+      <button matButton (click)="item3.expanded = true">Expand</button>
+      <button matButton (click)="item3.expanded = false">Collapse</button>
     </p>
     @if (item3.expanded) {
       <p>I only show if item 3 is expanded</p>

--- a/src/dev-app/focus-trap/focus-trap-demo.html
+++ b/src/dev-app/focus-trap/focus-trap-demo.html
@@ -2,7 +2,7 @@
   <mat-card class="demo-mat-card">
     <mat-toolbar color="primary">Basic</mat-toolbar>
     <mat-card-content class="demo-mat-card-content">
-      <button mat-raised-button (click)="toggleFocus(basicFocusTrap)">
+      <button matButton="elevated" (click)="toggleFocus(basicFocusTrap)">
         {{basicFocusTrap && basicFocusTrap.enabled ? "Disable" : "Enable"}} FocusTrap
       </button>
       <div
@@ -19,7 +19,7 @@
   <mat-card class="demo-mat-card">
     <mat-toolbar color="primary">Nested</mat-toolbar>
     <mat-card-content class="demo-mat-card-content">
-      <button mat-raised-button (click)="toggleFocus(nestedOuterFocusTrap)">
+      <button matButton="elevated" (click)="toggleFocus(nestedOuterFocusTrap)">
         {{nestedOuterFocusTrap && nestedOuterFocusTrap.enabled ? "Disable" : "Enable"}} outer FocusTrap
       </button>
       <div class="demo-focus-trap-region"
@@ -28,7 +28,7 @@
         [class.demo-focus-trap-enabled]="nestedOuterFocusTrap && nestedOuterFocusTrap.enabled">
         <textarea class="demo-focus-trap-element" placeholder="One"></textarea>
         <textarea class="demo-focus-trap-element" placeholder="Two"></textarea>
-        <button mat-raised-button class="demo-focus-trap-element"
+        <button matButton="elevated" class="demo-focus-trap-element"
           (click)="toggleFocus(nestedInnerFocusTrap)">
           {{nestedInnerFocusTrap && nestedInnerFocusTrap.enabled ? "Disable" : "Enable"}} inner FocusTrap
         </button>
@@ -46,7 +46,7 @@
   <mat-card class="demo-mat-card">
     <mat-toolbar color="primary">Tabindex > 0</mat-toolbar>
       <mat-card-content class="demo-mat-card-content">
-      <button mat-raised-button (click)="toggleFocus(tabIndexFocusTrap)">
+      <button matButton="elevated" (click)="toggleFocus(tabIndexFocusTrap)">
         {{tabIndexFocusTrap && tabIndexFocusTrap.enabled ? "Disable" : "Enable"}} FocusTrap
        </button>
       <div class="demo-focus-trap-region"
@@ -67,7 +67,7 @@
     <mat-toolbar color="primary">Shadow DOMs</mat-toolbar>
     <mat-card-content class="demo-mat-card-content">
       @if (_supportsShadowDom) {
-        <button mat-raised-button (click)="toggleFocus(shadowDomFocusTrap)">
+        <button matButton="elevated" (click)="toggleFocus(shadowDomFocusTrap)">
           {{shadowDomFocusTrap && shadowDomFocusTrap.enabled ? "Disable" : "Enable"}} FocusTrap
         </button>
         <div class="demo-focus-trap-region"
@@ -92,7 +92,7 @@
   <mat-card class="demo-mat-card">
     <mat-toolbar color="primary">iframes</mat-toolbar>
     <mat-card-content class="demo-mat-card-content">
-      <button mat-raised-button (click)="toggleFocus(iframeFocusTrap)">
+      <button matButton="elevated" (click)="toggleFocus(iframeFocusTrap)">
         {{iframeFocusTrap && iframeFocusTrap.enabled ? "Disable" : "Enable"}} FocusTrap
       </button>
       <div class="demo-focus-trap-region"
@@ -112,7 +112,7 @@
   <mat-card class="demo-mat-card">
     <mat-toolbar color="primary">Dynamic page content</mat-toolbar>
     <mat-card-content class="demo-mat-card-content">
-      <button mat-raised-button (click)="toggleFocus(dynamicFocusTrap)">
+      <button matButton="elevated" (click)="toggleFocus(dynamicFocusTrap)">
         {{dynamicFocusTrap && dynamicFocusTrap.enabled ? "Disable" : "Enable"}} FocusTrap
       </button>
       <div class="demo-focus-trap-region"
@@ -121,7 +121,7 @@
            [class.demo-focus-trap-enabled]="dynamicFocusTrap && dynamicFocusTrap.enabled">
         <textarea class="demo-focus-trap-element" placeholder="One"></textarea>
         <textarea class="demo-focus-trap-element" placeholder="Two"></textarea>
-        <button mat-raised-button class="demo-focus-trap-element" (click)="addNewElement()">
+        <button matButton="elevated" class="demo-focus-trap-element" (click)="addNewElement()">
           Click to add more focusable elements to the page
         </button>
       </div>
@@ -132,7 +132,7 @@
   <mat-card class="demo-mat-card">
     <mat-toolbar color="primary">Dialog-on-dialog</mat-toolbar>
     <mat-card-content class="demo-mat-card-content">
-      <button mat-raised-button (click)="openDialog()">Open dialog</button>
+      <button matButton="elevated" (click)="openDialog()">Open dialog</button>
     </mat-card-content>
   </mat-card>
 </div>

--- a/src/dev-app/focus-trap/focus-trap-dialog-demo.html
+++ b/src/dev-app/focus-trap/focus-trap-dialog-demo.html
@@ -6,11 +6,11 @@
 </mat-dialog-content>
 
 <mat-dialog-actions>
-  <button mat-raised-button mat-dialog-close>
+  <button matButton="elevated" mat-dialog-close>
     Close
   </button>
 
-  <button mat-raised-button (click)="openAnotherDialog()">
+  <button matButton="elevated" (click)="openAnotherDialog()">
     Open another dialog
   </button>
 </mat-dialog-actions>

--- a/src/dev-app/google-map/google-map-demo.html
+++ b/src/dev-app/google-map/google-map-demo.html
@@ -221,7 +221,7 @@
     </div>
 
     <div>
-      <button mat-button (click)="calculateDirections()">
+      <button matButton (click)="calculateDirections()">
         Calculate directions between first two markers
       </button>
     </div>

--- a/src/dev-app/grid-list/grid-list-demo.html
+++ b/src/dev-app/grid-list/grid-list-demo.html
@@ -66,7 +66,7 @@
     <mat-card-actions>
       <p>Change list cols: <input type="number" [(ngModel)]="fixedCols"></p>
       <p>Change row height: <input type="number" [(ngModel)]="fixedRowHeight"></p>
-      <button mat-button (click)="addTileCols()" color="primary">ADD COLSPAN (THREE)</button>
+      <button matButton (click)="addTileCols()" color="primary">ADD COLSPAN (THREE)</button>
     </mat-card-actions>
   </mat-card>
 

--- a/src/dev-app/input-modality/input-modality-detector-demo.html
+++ b/src/dev-app/input-modality/input-modality-detector-demo.html
@@ -12,7 +12,7 @@
       <strong>{{_modality || '(unknown)'}}</strong>
     </p>
 
-    <button mat-raised-button>Launch</button>
+    <button matButton="elevated">Launch</button>
     <br><br>
 
     <mat-form-field appearance="outline">

--- a/src/dev-app/input/input-demo.html
+++ b/src/dev-app/input/input-demo.html
@@ -114,7 +114,7 @@
         <mat-error>This field is required</mat-error>
       </mat-form-field>
 
-      <button color="primary" mat-raised-button>Submit</button>
+      <button color="primary" matButton="elevated">Submit</button>
     </form>
 
     <h4>With a custom error function</h4>
@@ -166,11 +166,11 @@
       <mat-label>Amount</mat-label>
       <input matInput>
       @if (showPrefix) {
-        <button mat-icon-button matIconPrefix>
+        <button matIconButton matIconPrefix>
           <mat-icon>calendar_today</mat-icon>
         </button>
       }
-      <button mat-icon-button matIconSuffix>
+      <button matIconButton matIconSuffix>
         <mat-icon>mode_edit</mat-icon>
       </button>
     </mat-form-field>
@@ -182,11 +182,11 @@
       <span matTextPrefix>$</span>
       <span matTextSuffix>.00</span>
       @if (showPrefix) {
-        <button mat-icon-button matIconPrefix>
+        <button matIconButton matIconPrefix>
           <mat-icon>calendar_today</mat-icon>
         </button>
       }
-      <button mat-icon-button matIconSuffix>
+      <button matIconButton matIconSuffix>
         <mat-icon>mode_edit</mat-icon>
       </button>
     </mat-form-field>
@@ -544,11 +544,11 @@
       <mat-label>Template</mat-label>
       <input matInput [(ngModel)]="model" required [disabled]="ctrlDisabled">
     </mat-form-field>
-    <button mat-raised-button color="primary"
+    <button matButton="elevated" color="primary"
             (click)="formControl.enabled ? formControl.disable() : formControl.enable()">
       DISABLE REACTIVE CTRL
     </button>
-    <button mat-raised-button color="primary" (click)="ctrlDisabled = !ctrlDisabled">
+    <button matButton="elevated" color="primary" (click)="ctrlDisabled = !ctrlDisabled">
       DISABLE TD CTRL
     </button>
     <div>
@@ -596,12 +596,12 @@
     </div>
 
     <button
-      mat-raised-button
+      matButton="elevated"
       color="primary"
       (click)="togglePlaceholderTestValue()">Toggle value</button>
 
     <button
-      mat-raised-button
+      matButton="elevated"
       color="primary"
       (click)="togglePlaceholderTestTouched()">Toggle touched</button>
   </mat-card-content>
@@ -705,7 +705,7 @@
         <input matInput (cdkAutofill)="isAutofilled = $event.isAutofilled" name="autofill"
                [class.demo-custom-autofill-style]="customAutofillStyle">
       </mat-form-field>
-      <button color="primary" mat-raised-button>Submit</button>
+      <button color="primary" matButton="elevated">Submit</button>
       <span> is autofilled? {{isAutofilled ? 'yes' : 'no'}}</span>
     </form>
   </mat-card-content>

--- a/src/dev-app/list/list-demo.html
+++ b/src/dev-app/list/list-demo.html
@@ -1,8 +1,8 @@
 
 <h1>mat-list demo</h1>
 
-<button mat-raised-button (click)="thirdLine = !thirdLine">Show third line</button>
-<button mat-raised-button (click)="showBoxes = !showBoxes">Show item boxes</button>
+<button matButton="elevated" (click)="thirdLine = !thirdLine">Show third line</button>
+<button matButton="elevated" (click)="showBoxes = !showBoxes">Show item boxes</button>
 
 <div class="demo-list" [class.demo-show-boxes]="showBoxes">
 
@@ -57,7 +57,7 @@
       @for (link of links; track link) {
         <mat-list-item>
           <span matListItemTitle>{{ link.name }}</span>
-          <button matListItemMeta mat-icon-button (click)="infoClicked=!infoClicked">
+          <button matListItemMeta matIconButton (click)="infoClicked=!infoClicked">
             <mat-icon>info</mat-icon>
           </button>
         </mat-list-item>
@@ -99,7 +99,7 @@
       @for (link of links; track link) {
         <mat-list-item>
           <span matListItemTitle>{{ link.name }}</span>
-          <button matListItemMeta mat-icon-button (click)="infoClicked=!infoClicked">
+          <button matListItemMeta matIconButton (click)="infoClicked=!infoClicked">
             <mat-icon class="material-icons">info</mat-icon>
           </button>
         </mat-list-item>
@@ -191,8 +191,8 @@
       </label>
     </p>
     <p>
-      <button mat-raised-button (click)="groceries.selectAll()">Select all</button>
-      <button mat-raised-button (click)="groceries.deselectAll()">Deselect all</button>
+      <button matButton="elevated" (click)="groceries.selectAll()">Select all</button>
+      <button matButton="elevated" (click)="groceries.deselectAll()">Deselect all</button>
     </p>
   </div>
 
@@ -223,7 +223,7 @@
         }
       </mat-selection-list>
       <p>
-         Option selected: {{shoesControl.value ? shoesControl.value[0] : 'None'}} 
+         Option selected: {{shoesControl.value ? shoesControl.value[0] : 'None'}}
       </p>
     </form>
   </div>
@@ -281,7 +281,7 @@
       </mat-list-option>
     </mat-selection-list>
 
-    <button mat-raised-button (click)="showBoxes = !showBoxes">Show item boxes</button>
+    <button matButton="elevated" (click)="showBoxes = !showBoxes">Show item boxes</button>
   </div>
 
   <div>
@@ -327,7 +327,7 @@
       </mat-list-option>
     </mat-selection-list>
 
-    <button mat-raised-button (click)="toggleCheckboxPosition()">
+    <button matButton="elevated" (click)="toggleCheckboxPosition()">
       Toggle checkbox position
     </button>
   </div>

--- a/src/dev-app/live-announcer/live-announcer-demo.html
+++ b/src/dev-app/live-announcer/live-announcer-demo.html
@@ -1,12 +1,12 @@
 <p>
   <button
-    mat-raised-button
+    matButton="elevated"
     color="primary"
     (click)="announceText('Hey Google')">Announce Text</button>
 </p>
 <p>
   <button
-    mat-raised-button
+    matButton="elevated"
     color="primary"
     (click)="openDialog()">Open Dialog</button>
 </p>
@@ -16,12 +16,12 @@
   <p>Test LiveAnnouncer inside an aria modal.</p>
   <p>
     <button
-      mat-raised-button
+      matButton="elevated"
       color="primary"
       (click)="announceText('Hey Google')">Announce Text</button>
   </p>
   <button type="button" cdkFocusInitial
-    mat-button
+    matButton
     (click)="dialogRef.close()">
     Close
   </button>

--- a/src/dev-app/menu/menu-demo.html
+++ b/src/dev-app/menu/menu-demo.html
@@ -3,7 +3,7 @@
     <p>You clicked on: {{ selected }}</p>
 
     <mat-toolbar>
-      <button mat-icon-button [matMenuTriggerFor]="menu" aria-label="Open basic menu">
+      <button matIconButton [matMenuTriggerFor]="menu" aria-label="Open basic menu">
         <mat-icon>more_vert</mat-icon>
       </button>
     </mat-toolbar>
@@ -20,7 +20,7 @@
     <p>Menu with divider</p>
 
     <mat-toolbar>
-      <button mat-icon-button [matMenuTriggerFor]="divider" aria-label="Open basic menu">
+      <button matIconButton [matMenuTriggerFor]="divider" aria-label="Open basic menu">
         <mat-icon>more_vert</mat-icon>
       </button>
     </mat-toolbar>
@@ -38,7 +38,7 @@
     <p>Nested menu</p>
 
     <mat-toolbar>
-      <button mat-icon-button [matMenuTriggerFor]="animals">
+      <button matIconButton [matMenuTriggerFor]="animals">
         <mat-icon>more_vert</mat-icon>
       </button>
     </mat-toolbar>
@@ -91,7 +91,7 @@
   <div class="demo-menu-section">
     <p>Clicking these will navigate:</p>
     <mat-toolbar>
-      <button mat-icon-button [matMenuTriggerFor]="anchorMenu" aria-label="Open anchor menu">
+      <button matIconButton [matMenuTriggerFor]="anchorMenu" aria-label="Open anchor menu">
         <mat-icon>more_vert</mat-icon>
       </button>
     </mat-toolbar>
@@ -109,7 +109,7 @@
       Position x: before
     </p>
     <mat-toolbar class="demo-end-icon">
-      <button mat-icon-button [matMenuTriggerFor]="posXMenu" aria-label="Open x-positioned menu">
+      <button matIconButton [matMenuTriggerFor]="posXMenu" aria-label="Open x-positioned menu">
         <mat-icon>more_vert</mat-icon>
       </button>
     </mat-toolbar>
@@ -128,7 +128,7 @@
       Position y: above
     </p>
     <mat-toolbar>
-      <button mat-icon-button [matMenuTriggerFor]="posYMenu" aria-label="Open y-positioned menu">
+      <button matIconButton [matMenuTriggerFor]="posYMenu" aria-label="Open y-positioned menu">
         <mat-icon>more_vert</mat-icon>
       </button>
     </mat-toolbar>
@@ -146,7 +146,7 @@
     <p>overlapTrigger: true</p>
 
     <mat-toolbar>
-      <button mat-icon-button [mat-menu-trigger-for]="menuOverlay">
+      <button matIconButton [mat-menu-trigger-for]="menuOverlay">
         <mat-icon>more_vert</mat-icon>
       </button>
     </mat-toolbar>
@@ -162,7 +162,7 @@
       Position x: before, overlapTrigger: true
     </p>
     <mat-toolbar class="demo-end-icon">
-      <button mat-icon-button [mat-menu-trigger-for]="posXMenuOverlay">
+      <button matIconButton [mat-menu-trigger-for]="posXMenuOverlay">
         <mat-icon>more_vert</mat-icon>
       </button>
     </mat-toolbar>
@@ -181,7 +181,7 @@
       Position y: above, overlapTrigger: true
     </p>
     <mat-toolbar>
-      <button mat-icon-button [mat-menu-trigger-for]="posYMenuOverlay">
+      <button matIconButton [mat-menu-trigger-for]="posYMenuOverlay">
         <mat-icon>more_vert</mat-icon>
       </button>
     </mat-toolbar>

--- a/src/dev-app/performance/performance-demo.html
+++ b/src/dev-app/performance/performance-demo.html
@@ -39,10 +39,10 @@
           @if (allSamples.length) {
 
             <strong>Average render time</strong>
-          
+
 }
           @if (!allSamples.length) {
- No data yet 
+ No data yet
 }
         </td>
       </ng-container>
@@ -72,29 +72,29 @@
 @if (allSamples.length) {
 <button
   color="accent"
-  mat-button
+  matButton
   (click)="clearMetrics()"
   [disabled]="isRunningBenchmark"
   style="margin-right: 32px"
- 
+
 >
   Clear Metrics
 </button>
 }
 
-<button color="primary" mat-raised-button (click)="runBenchmark()" [disabled]="isRunningBenchmark">
+<button color="primary" matButton="elevated" (click)="runBenchmark()" [disabled]="isRunningBenchmark">
   Run Benchmark
 </button>
 
 @if (show) {
 
   @for (_ of componentArray; track _) {
-  
+
     <mat-form-field>
       <mat-label>Input</mat-label>
       <input matInput />
     </mat-form-field>
-  
+
 }
 
 }

--- a/src/dev-app/progress-bar/progress-bar-demo.html
+++ b/src/dev-app/progress-bar/progress-bar-demo.html
@@ -10,8 +10,8 @@
   <span>Value: {{determinateProgressValue}}</span>
   <br/>
   <span>Last animation complete value: {{determinateAnimationEndValue}}</span>
-  <button mat-raised-button (click)="stepDeterminateProgressVal(10)">Increase</button>
-  <button mat-raised-button (click)="stepDeterminateProgressVal(-10)">Decrease</button>
+  <button matButton="elevated" (click)="stepDeterminateProgressVal(10)">Increase</button>
+  <button matButton="elevated" (click)="stepDeterminateProgressVal(-10)">Decrease</button>
 </div>
 
 <div class="demo-progress-bar-container">
@@ -26,12 +26,12 @@
   <span>Value: {{bufferProgressValue}}</span>
   <br/>
   <span>Last animation complete value: {{bufferAnimationEndValue}}</span>
-  <button mat-raised-button (click)="stepBufferProgressVal(10)">Increase</button>
-  <button mat-raised-button (click)="stepBufferProgressVal(-10)">Decrease</button>
+  <button matButton="elevated" (click)="stepBufferProgressVal(10)">Increase</button>
+  <button matButton="elevated" (click)="stepBufferProgressVal(-10)">Decrease</button>
   <span class="demo-progress-bar-spacer"></span>
   <span>Buffer Value: {{bufferBufferValue}}</span>
-  <button mat-raised-button (click)="stepBufferBufferVal(10)">Increase</button>
-  <button mat-raised-button (click)="stepBufferBufferVal(-10)">Decrease</button>
+  <button matButton="elevated" (click)="stepBufferBufferVal(10)">Increase</button>
+  <button matButton="elevated" (click)="stepBufferBufferVal(-10)">Decrease</button>
 </div>
 
 <div class="demo-progress-bar-container">

--- a/src/dev-app/progress-spinner/progress-spinner-demo.html
+++ b/src/dev-app/progress-spinner/progress-spinner-demo.html
@@ -2,8 +2,8 @@
 
 <div class="demo-progress-spinner-controls">
   <p>Value: {{progressValue}}</p>
-  <button mat-raised-button (click)="step(10)">Increase</button>
-  <button mat-raised-button (click)="step(-10)">Decrease</button>
+  <button matButton="elevated" (click)="step(10)">Increase</button>
+  <button matButton="elevated" (click)="step(-10)">Decrease</button>
   <mat-checkbox [(ngModel)]="isDeterminate">Is determinate</mat-checkbox>
 </div>
 

--- a/src/dev-app/radio/radio-demo.html
+++ b/src/dev-app/radio/radio-demo.html
@@ -27,13 +27,13 @@
 <section class="demo-section">
   <div>
     <span>isDisabled: {{isDisabled}}</span>
-    <button mat-raised-button (click)="isDisabled=!isDisabled" class="demo-button">
+    <button matButton="elevated" (click)="isDisabled=!isDisabled" class="demo-button">
       Disable buttons
     </button>
   </div>
   <div>
     <span>isRequired: {{isRequired}}</span>
-    <button mat-raised-button (click)="isRequired=!isRequired" class="demo-button">
+    <button matButton="elevated" (click)="isRequired=!isRequired" class="demo-button">
       Require buttons
     </button>
   </div>

--- a/src/dev-app/ripple/ripple-demo.html
+++ b/src/dev-app/ripple/ripple-demo.html
@@ -1,12 +1,12 @@
 <div class="demo-ripple">
   <section>
     <mat-checkbox [(ngModel)]="disableButtonRipples">Disable button ripples</mat-checkbox>
-    <button mat-button [disableRipple]="disableButtonRipples">flat</button>
-    <button mat-raised-button [disableRipple]="disableButtonRipples">raised</button>
-    <button mat-fab [disableRipple]="disableButtonRipples">
+    <button matButton [disableRipple]="disableButtonRipples">flat</button>
+    <button matButton="elevated" [disableRipple]="disableButtonRipples">raised</button>
+    <button matFab [disableRipple]="disableButtonRipples">
       <mat-icon>check</mat-icon>
     </button>
-    <button mat-mini-fab [disableRipple]="disableButtonRipples">
+    <button matMiniFab [disableRipple]="disableButtonRipples">
       <mat-icon>check</mat-icon>
     </button>
   </section>

--- a/src/dev-app/select/select-demo.html
+++ b/src/dev-app/select/select-demo.html
@@ -1,5 +1,5 @@
 Space above cards: <input type="number" [formControl]="topHeightCtrl">
-<button mat-button (click)="showSelect=!showSelect">SHOW SELECT</button>
+<button matButton (click)="showSelect=!showSelect">SHOW SELECT</button>
 <div [style.height.px]="topHeightCtrl.value"></div>
 
 <div class="demo-select">
@@ -60,10 +60,10 @@ Space above cards: <input type="number" [formControl]="topHeightCtrl">
         </select>
       </p>
 
-      <button mat-button (click)="currentDrink='water-2'">SET VALUE</button>
-      <button mat-button (click)="drinksRequired=!drinksRequired">TOGGLE REQUIRED</button>
-      <button mat-button (click)="drinksDisabled=!drinksDisabled">TOGGLE DISABLED</button>
-      <button mat-button (click)="drinkControl.reset()">RESET</button>
+      <button matButton (click)="currentDrink='water-2'">SET VALUE</button>
+      <button matButton (click)="drinksRequired=!drinksRequired">TOGGLE REQUIRED</button>
+      <button matButton (click)="drinksDisabled=!drinksDisabled">TOGGLE DISABLED</button>
+      <button matButton (click)="drinkControl.reset()">RESET</button>
     </mat-card-content>
   </mat-card>
 
@@ -94,11 +94,11 @@ Space above cards: <input type="number" [formControl]="topHeightCtrl">
           }
         </select>
       </p>
-      <button mat-button (click)="setPokemonValue()">SET VALUE</button>
-      <button mat-button (click)="pokemonRequired=!pokemonRequired">TOGGLE REQUIRED</button>
-      <button mat-button (click)="pokemonDisabled=!pokemonDisabled">TOGGLE DISABLED</button>
-      <button mat-button (click)="pokemonOptionsDisabled=!pokemonOptionsDisabled">TOGGLE DISABLED OPTIONS</button>
-      <button mat-button (click)="pokemonControl.reset()">RESET</button>
+      <button matButton (click)="setPokemonValue()">SET VALUE</button>
+      <button matButton (click)="pokemonRequired=!pokemonRequired">TOGGLE REQUIRED</button>
+      <button matButton (click)="pokemonDisabled=!pokemonDisabled">TOGGLE DISABLED</button>
+      <button matButton (click)="pokemonOptionsDisabled=!pokemonOptionsDisabled">TOGGLE DISABLED OPTIONS</button>
+      <button matButton (click)="pokemonControl.reset()">RESET</button>
     </mat-card-content>
   </mat-card>
 
@@ -118,8 +118,8 @@ Space above cards: <input type="number" [formControl]="topHeightCtrl">
 
       <p>Value: {{ currentDigimon }}</p>
 
-      <button mat-button (click)="currentDigimon='pajiramon-3'">SET VALUE</button>
-      <button mat-button (click)="currentDigimon=''">RESET</button>
+      <button matButton (click)="currentDigimon='pajiramon-3'">SET VALUE</button>
+      <button matButton (click)="currentDigimon=''">RESET</button>
     </mat-card-content>
   </mat-card>
 
@@ -163,13 +163,13 @@ Space above cards: <input type="number" [formControl]="topHeightCtrl">
       <p> Status: {{ drinkObjectControl.status }} </p>
       <p> Comparison Mode: {{ compareByValue ? 'VALUE' : 'REFERENCE' }} </p>
 
-      <button mat-button (click)="reassignDrinkByCopy()"
+      <button matButton (click)="reassignDrinkByCopy()"
               matTooltip="This action should clear the display value when comparing by reference.">
         REASSIGN DRINK BY COPY
       </button>
-      <button mat-button (click)="drinkObjectRequired=!drinkObjectRequired">TOGGLE REQUIRED</button>
-      <button mat-button (click)="compareByValue=!compareByValue">TOGGLE COMPARE BY VALUE</button>
-      <button mat-button (click)="drinkObjectControl.reset()">RESET</button>
+      <button matButton (click)="drinkObjectRequired=!drinkObjectRequired">TOGGLE REQUIRED</button>
+      <button matButton (click)="compareByValue=!compareByValue">TOGGLE COMPARE BY VALUE</button>
+      <button matButton (click)="drinkObjectControl.reset()">RESET</button>
     </mat-card-content>
   </mat-card>
 
@@ -200,7 +200,7 @@ Space above cards: <input type="number" [formControl]="topHeightCtrl">
         </mat-form-field>
       </p>
 
-      <button mat-button (click)="toggleSelected()">TOGGLE SELECTED</button>
+      <button matButton (click)="toggleSelected()">TOGGLE SELECTED</button>
     </mat-card-content>
   </mat-card>
 
@@ -222,9 +222,9 @@ Space above cards: <input type="number" [formControl]="topHeightCtrl">
           <p> Touched: {{ foodControl.touched }} </p>
           <p> Dirty: {{ foodControl.dirty }} </p>
           <p> Status: {{ foodControl.status }} </p>
-          <button mat-button (click)="foodControl.setValue('pizza-1')">SET VALUE</button>
-          <button mat-button (click)="toggleDisabled()">TOGGLE DISABLED</button>
-          <button mat-button (click)="foodControl.reset()">RESET</button>
+          <button matButton (click)="foodControl.setValue('pizza-1')">SET VALUE</button>
+          <button matButton (click)="toggleDisabled()">TOGGLE DISABLED</button>
+          <button matButton (click)="foodControl.reset()">RESET</button>
         </mat-card-content>
       </mat-card>
     </div>
@@ -376,7 +376,7 @@ Space above cards: <input type="number" [formControl]="topHeightCtrl">
         }
         <mat-hint>You can pick up your favorite car here</mat-hint>
       </mat-form-field>
-      <button color="primary" mat-raised-button>Submit</button>
+      <button color="primary" matButton="elevated">Submit</button>
     </form>
   </mat-card-content>
 </mat-card>

--- a/src/dev-app/sidenav/sidenav-demo.html
+++ b/src/dev-app/sidenav/sidenav-demo.html
@@ -8,11 +8,11 @@
                  [fixedInViewport]="fixed" [fixedTopGap]="fixedTop" [fixedBottomGap]="fixedBottom">
       Start Side Sidenav
       <br>
-      <button mat-button (click)="start.close()">Close</button>
+      <button matButton (click)="start.close()">Close</button>
       <br>
-      <button mat-button (click)="end.open('keyboard')">Open End Side</button>
+      <button matButton (click)="end.open('keyboard')">Open End Side</button>
       <br>
-      <button mat-button (click)="modeIndex = (modeIndex + 1) % 3">Toggle Mode</button>
+      <button matButton (click)="modeIndex = (modeIndex + 1) % 3">Toggle Mode</button>
       <div>Mode: {{start.mode}}</div>
       <br>
       <input #myinput>
@@ -25,7 +25,7 @@
                  [fixedInViewport]="fixed" [fixedTopGap]="fixedTop" [fixedBottomGap]="fixedBottom">
       End Side Sidenav
       <br>
-      <button mat-button (click)="end.close()">Close</button>
+      <button matButton (click)="end.close()">Close</button>
       @for (c of fillerContent; track c) {
         <div class="demo-filler-content">Filler Content</div>
       }
@@ -37,15 +37,15 @@
       }
       <div class="demo-sidenav-content">
         <div>
-          <button mat-raised-button (click)="isLaunched = false">
+          <button matButton="elevated" (click)="isLaunched = false">
             Exit Fullscreen Sidenav Demo
           </button>
         </div>
 
         <div>
           <h3>Sidenav</h3>
-          <button mat-button (click)="start.toggle(undefined, 'mouse')">Toggle Start Side Sidenav</button>
-          <button mat-button (click)="end.toggle(undefined, 'mouse')">Toggle End Side Sidenav</button>
+          <button matButton (click)="start.toggle(undefined, 'mouse')">Toggle Start Side Sidenav</button>
+          <button matButton (click)="end.toggle(undefined, 'mouse')">Toggle End Side Sidenav</button>
           <mat-checkbox [(ngModel)]="hasBackdrop">Has backdrop</mat-checkbox>
           <mat-checkbox [(ngModel)]="fixed">Fixed mode</mat-checkbox>
           <mat-checkbox [(ngModel)]="coverHeader">Sidenav covers header/footer</mat-checkbox>
@@ -71,7 +71,7 @@
   }
 </div>
 } @else {
-  <button mat-raised-button (click)="isLaunched = true" color="primary">
+  <button matButton="elevated" (click)="isLaunched = true" color="primary">
     Launch Fullscreen Sidenav Demo
   </button>
 }

--- a/src/dev-app/slide-toggle/slide-toggle-demo.html
+++ b/src/dev-app/slide-toggle/slide-toggle-demo.html
@@ -17,7 +17,7 @@
   <form #form="ngForm" (ngSubmit)="onFormSubmit()">
     <mat-slide-toggle name="slideToggle" [(ngModel)]="formToggle">Slide Toggle</mat-slide-toggle>
     <p>
-      <button mat-raised-button type="submit">Submit Form</button>
+      <button matButton="elevated" type="submit">Submit Form</button>
     </p>
   </form>
 </div>

--- a/src/dev-app/slider/slider-demo.html
+++ b/src/dev-app/slider/slider-demo.html
@@ -33,7 +33,7 @@
         <td class="demo-value-cell">{{ngStartThumb1.disabled}} : {{ngEndThumb1.disabled}}</td>
       </tr>
     </table>
-    
+
     <input class="demo-native-slider" type="range" [formControl]="control" #nativeSlider1 />
     <mat-slider [discrete]="discrete" [showTickMarks]="showTickMarks" [color]="colorModel">
       <input matSliderThumb [formControl]="control" #ngThumb1 />
@@ -89,7 +89,7 @@
         <td class="demo-value-cell">{{ngStartThumb2.disabled}} : {{ngEndThumb2.disabled}}</td>
       </tr>
     </table>
-    
+
     <input class="demo-native-slider" type="range" #nativeSlider2 [(ngModel)]="valueModel" [min]="minModel" [max]="maxModel" [step]="stepModel" [disabled]="disabledModel" />
     <mat-slider [discrete]="discrete" [showTickMarks]="showTickMarks" [color]="colorModel" [min]="minModel" [max]="maxModel" [step]="stepModel" [disabled]="disabledModel">
       <input matSliderThumb #ngThumb2 [(ngModel)]="valueModel" />
@@ -171,7 +171,7 @@
         <td class="demo-value-cell">{{ngStartThumb4.value}} : {{ngEndThumb4.value}}</td>
       </tr>
     </table>
-    
+
       <mat-slider [discrete]="discrete" [showTickMarks]="showTickMarks" [color]="colorModel">
         <input matSliderThumb #ngThumb4 [(value)]="twoWayValue" />
       </mat-slider>
@@ -183,7 +183,7 @@
 
   <mat-tab label="Slider in a dialog">
     <div class="demo-dialog-trigger-container">
-      <button mat-raised-button [color]="colorModel" (click)="openDialog()">Open dialog</button>
+      <button matButton="elevated" [color]="colorModel" (click)="openDialog()">Open dialog</button>
     </div>
   </mat-tab>
 </mat-tab-group>

--- a/src/dev-app/snack-bar/snack-bar-demo.html
+++ b/src/dev-app/snack-bar/snack-bar-demo.html
@@ -57,10 +57,10 @@
 </div>
 
 <p>
-  <button mat-raised-button (click)="open()">OPEN</button>
+  <button matButton="elevated" (click)="open()">OPEN</button>
 </p>
 
-<button mat-raised-button (click)="openTemplate()">OPEN TEMPLATE</button>
+<button matButton="elevated" (click)="openTemplate()">OPEN TEMPLATE</button>
 
 <ng-template #template>
   Template snack bar: {{message}}

--- a/src/dev-app/stepper/stepper-demo.html
+++ b/src/dev-app/stepper/stepper-demo.html
@@ -8,7 +8,7 @@
   <mat-checkbox [(ngModel)]="isVertical">Vertical</mat-checkbox>
 </p>
 <p>
-  <button mat-stroked-button (click)="showLabelBottom = !showLabelBottom">
+  <button matButton="outlined" (click)="showLabelBottom = !showLabelBottom">
     Toggle label position
   </button>
 </p>
@@ -46,7 +46,7 @@
         <mat-error>This field is required</mat-error>
       </mat-form-field>
       <div>
-        <button mat-button matStepperNext>Next</button>
+        <button matButton matStepperNext>Next</button>
       </div>
     </mat-step>
 
@@ -61,8 +61,8 @@
         <mat-error>The input is invalid.</mat-error>
       </mat-form-field>
       <div>
-        <button mat-button matStepperPrevious>Back</button>
-        <button mat-button matStepperNext>Next</button>
+        <button matButton matStepperPrevious>Back</button>
+        <button matButton matStepperNext>Next</button>
       </div>
     </mat-step>
 
@@ -70,8 +70,8 @@
       <ng-template matStepLabel>Confirm your information</ng-template>
       Everything seems correct.
       <div>
-        <button mat-button>Done</button>
-        <button type="button" mat-button (click)="linearStepper.reset()">Reset</button>
+        <button matButton>Done</button>
+        <button type="button" matButton (click)="linearStepper.reset()">Reset</button>
       </div>
     </mat-step>
   </mat-stepper>
@@ -96,7 +96,7 @@
         <mat-error>This field is required</mat-error>
       </mat-form-field>
       <div>
-        <button mat-button matStepperNext>Next</button>
+        <button matButton matStepperNext>Next</button>
       </div>
     </form>
   </mat-step>
@@ -110,8 +110,8 @@
         <mat-error>The input is invalid</mat-error>
       </mat-form-field>
       <div>
-        <button mat-button matStepperPrevious>Back</button>
-        <button mat-button matStepperNext>Next</button>
+        <button matButton matStepperPrevious>Back</button>
+        <button matButton matStepperNext>Next</button>
       </div>
     </form>
   </mat-step>
@@ -121,8 +121,8 @@
       <ng-template matStepLabel>Confirm your information</ng-template>
       Everything seems correct.
       <div>
-        <button mat-button>Done</button>
-        <button type="button" mat-button (click)="linearHorizontalStepper.reset()">Reset</button>
+        <button matButton>Done</button>
+        <button type="button" matButton (click)="linearHorizontalStepper.reset()">Reset</button>
       </div>
     </form>
   </mat-step>
@@ -143,7 +143,7 @@
       <input matInput>
     </mat-form-field>
     <div>
-      <button mat-button matStepperNext>Next</button>
+      <button matButton matStepperNext>Next</button>
     </div>
   </mat-step>
 
@@ -156,8 +156,8 @@
       <input matInput>
     </mat-form-field>
     <div>
-      <button mat-button matStepperPrevious>Back</button>
-      <button mat-button matStepperNext>Next</button>
+      <button matButton matStepperPrevious>Back</button>
+      <button matButton matStepperNext>Next</button>
     </div>
   </mat-step>
 
@@ -170,8 +170,8 @@
       <input matInput>
     </mat-form-field>
     <div>
-      <button mat-button matStepperPrevious>Back</button>
-      <button mat-button matStepperNext>Next</button>
+      <button matButton matStepperPrevious>Back</button>
+      <button matButton matStepperNext>Next</button>
     </div>
   </mat-step>
 
@@ -179,7 +179,7 @@
     <ng-template matStepLabel>Confirm your information</ng-template>
     Everything seems correct.
     <div>
-      <button mat-button>Done</button>
+      <button matButton>Done</button>
     </div>
   </mat-step>
 </mat-stepper>
@@ -197,7 +197,7 @@
       <input matInput>
     </mat-form-field>
     <div>
-      <button mat-button matStepperNext>Next</button>
+      <button matButton matStepperNext>Next</button>
     </div>
   </mat-step>
 
@@ -207,8 +207,8 @@
       <input matInput>
     </mat-form-field>
     <div>
-      <button mat-button matStepperPrevious>Back</button>
-      <button mat-button matStepperNext>Next</button>
+      <button matButton matStepperPrevious>Back</button>
+      <button matButton matStepperNext>Next</button>
     </div>
   </mat-step>
 
@@ -218,15 +218,15 @@
       <input matInput>
     </mat-form-field>
     <div>
-      <button mat-button matStepperPrevious>Back</button>
-      <button mat-button matStepperNext>Next</button>
+      <button matButton matStepperPrevious>Back</button>
+      <button matButton matStepperNext>Next</button>
     </div>
   </mat-step>
 
   <mat-step label="Confirm your information">
     Everything seems correct.
     <div>
-      <button mat-button>Done</button>
+      <button matButton>Done</button>
     </div>
   </mat-step>
 </mat-stepper>
@@ -241,8 +241,8 @@
         <input matInput [(ngModel)]="step.content">
       </mat-form-field>
       <div>
-        <button mat-button matStepperPrevious>Back</button>
-        <button mat-button matStepperNext>Next</button>
+        <button matButton matStepperPrevious>Back</button>
+        <button matButton matStepperNext>Next</button>
       </div>
     </mat-step>
   }

--- a/src/dev-app/table-scroll-container/table-scroll-container-demo.html
+++ b/src/dev-app/table-scroll-container/table-scroll-container-demo.html
@@ -1,6 +1,6 @@
 <div>
-  <button mat-raised-button (click)="tables.push(tables.length)">Add table</button>
-  <button mat-raised-button (click)="tables.pop()">Remove table</button>
+  <button matButton="elevated" (click)="tables.push(tables.length)">Add table</button>
+  <button matButton="elevated" (click)="tables.pop()">Remove table</button>
 </div>
 
 <div>

--- a/src/dev-app/timepicker/timepicker-demo.html
+++ b/src/dev-app/timepicker/timepicker-demo.html
@@ -18,7 +18,7 @@
       <p>Dirty: {{control.dirty}}</p>
       <p>Touched: {{control.touched}}</p>
       <p>Errors: {{control.errors | json}}</p>
-      <button mat-button (click)="randomizeValue()">Assign a random value</button>
+      <button matButton (click)="randomizeValue()">Assign a random value</button>
     </div>
 
     <div>

--- a/src/dev-app/toolbar/toolbar-demo.html
+++ b/src/dev-app/toolbar/toolbar-demo.html
@@ -9,20 +9,20 @@
 
   <p>
     <mat-toolbar>
-      <button mat-icon-button>
+      <button matIconButton>
         <mat-icon>menu</mat-icon>
       </button>
 
       <span>Default Toolbar</span>
       <span class="demo-fill-remaining"></span>
 
-      <button mat-button color="accent">Text</button>
-      <button mat-button>Text</button>
-      <button mat-icon-button>
+      <button matButton color="accent">Text</button>
+      <button matButton>Text</button>
+      <button matIconButton>
         <mat-icon>code</mat-icon>
       </button>
 
-      <button mat-icon-button color="warn">
+      <button matIconButton color="warn">
         <mat-icon>code</mat-icon>
       </button>
     </mat-toolbar>
@@ -30,34 +30,34 @@
 
   <p>
     <mat-toolbar color="primary">
-      <button mat-icon-button>
+      <button matIconButton>
         <mat-icon>menu</mat-icon>
       </button>
 
       <span>Primary Toolbar</span>
       <span class="demo-fill-remaining"></span>
 
-      <button mat-raised-button>Text</button>
-      <button mat-raised-button color="accent">Accent</button>
-      <button mat-stroked-button>Stroked</button>
+      <button matButton="elevated">Text</button>
+      <button matButton="elevated" color="accent">Accent</button>
+      <button matButton="outlined">Stroked</button>
     </mat-toolbar>
   </p>
 
   <p>
     <mat-toolbar color="accent">
-      <button mat-icon-button>
+      <button matIconButton>
         <mat-icon>menu</mat-icon>
       </button>
 
       <span>Accent Toolbar</span>
       <span class="demo-fill-remaining"></span>
 
-      <button mat-button>Text</button>
-      <button mat-flat-button>Flat</button>
-      <button mat-mini-fab>
+      <button matButton>Text</button>
+      <button matButton="filled" >Flat</button>
+      <button matMiniFab>
         <mat-icon>done</mat-icon>
       </button>
-      <button mat-mini-fab color="primary">
+      <button matMiniFab color="primary">
         <mat-icon>done</mat-icon>
       </button>
     </mat-toolbar>

--- a/src/dev-app/virtual-scroll/virtual-scroll-demo.html
+++ b/src/dev-app/virtual-scroll/virtual-scroll-demo.html
@@ -46,7 +46,7 @@
   <mat-label>Offset</mat-label>
   <input matInput type="number" [(ngModel)]="scrollToOffset">
 </mat-form-field>
-<button mat-button (click)="viewport1.scrollToOffset(scrollToOffset, scrollToBehavior);
+<button matButton (click)="viewport1.scrollToOffset(scrollToOffset, scrollToBehavior);
                             viewport2.scrollToOffset(scrollToOffset, scrollToBehavior)">
   Go to offset
 </button>
@@ -54,7 +54,7 @@
   <mat-label>Index</mat-label>
   <input matInput type="number" [(ngModel)]="scrollToIndex">
 </mat-form-field>
-<button mat-button (click)="viewport1.scrollToIndex(scrollToIndex, scrollToBehavior);
+<button matButton (click)="viewport1.scrollToIndex(scrollToIndex, scrollToBehavior);
                             viewport2.scrollToIndex(scrollToIndex, scrollToBehavior)">
   Go to index
 </button>

--- a/src/dev-app/youtube-player/youtube-player-demo.html
+++ b/src/dev-app/youtube-player/youtube-player-demo.html
@@ -16,7 +16,7 @@
       <mat-checkbox [(ngModel)]="startAt30s">Start at 30s</mat-checkbox>
     </div>
     <div class="demo-video-selection">
-      <button mat-button (click)="player.requestFullscreen()">Make fullscreen</button>
+      <button matButton (click)="player.requestFullscreen()">Make fullscreen</button>
     </div>
     <youtube-player
       #player

--- a/src/material/button/button.md
+++ b/src/material/button/button.md
@@ -1,5 +1,5 @@
 Angular Material buttons are native `<button>` or `<a>` elements enhanced with Material Design
-styling and ink ripples.
+styling.
 
 <!-- example(button-overview) -->
 
@@ -9,26 +9,34 @@ is performed. An `<a>` element should be used whenever the user will _navigate_ 
 
 
 There are several button variants, each applied as an attribute:
-
 | Attribute            | Description                                                              |
 |----------------------|--------------------------------------------------------------------------|
-| `mat-button`         | Rectangular text button w/ no elevation and rounded corners                                 |
-| `mat-raised-button`  | Rectangular contained button w/ elevation and rounded corners                               |
-| `mat-flat-button`    | Rectangular contained button w/ no elevation and rounded corners                            |
-| `mat-stroked-button` | Rectangular outlined button w/ no elevation and rounded corners                             |
-| `mat-icon-button`    | Circular button with a transparent background, meant to contain an icon  |
-| `mat-fab`            | Square button w/ elevation and rounded corners, meant to contain an icon. Can be [extended](https://material.angular.io/components/button/overview#extended-fab-buttons) to a rectangle to also fit a label           |
-| `mat-mini-fab`       | Same as `mat-fab` but smaller                                            |
+| `matButton`          | Rectangular button that can contain text and icons                       |
+| `matIconButton`      | Smaller, circular button, meant to contain an icon and no text           |
+| `matFab`             | Rectangular button w/ elevation and rounded corners, meant to contain an icon. Can be [extended](https://material.angular.io/components/button/overview#extended-fab-buttons) to a rectangle to also fit a label               |
+| `matMiniFab`         | Smaller variant of `matFab`                                              |
 
 
-### Extended fab buttons
-Traditional fab buttons are circular and only have space for a single icon. However, you can add the
-`extended` attribute to allow the fab to expand into a rounded rectangle shape with space for a text
-label in addition to the icon. Only full sized fabs support the `extended` attribute, mini fabs do
-not.
+Additionally, the `matButton` has several appearances that can be set using the `matButton`
+attribute, for example `matButton="outlined"`:
+
+
+| Appearance   | Description                                                                      |
+|--------------|----------------------------------------------------------------------------------|
+| `text`       | Default appearance. Does not have a background until the user interacts with it. |
+| `elevated`   | Has a background color, elevation and rounded corners.                           |
+| `filled`     | Has a flat appearance with rounded corners and no elevation.                     |
+| `outlined`   | Has an outline, rounded corners and a transparent background.                    |
+
+
+### Extended FAB buttons
+Traditional floating action buttons (FAB) buttons are circular and only have space for a single
+icon. However, you can add the `extended` attribute to allow the fab to expand into a rounded
+rectangle shape with space for a text label in addition to the icon. Only full sized fabs support
+the `extended` attribute, mini FABs do not.
 
 ```html
-<button mat-fab extended>
+<button matFab extended>
   <mat-icon>home</mat-icon>
   Home
 </button>
@@ -65,7 +73,7 @@ We recommend not changing the default capitalization for the button text.
 with any assistive technology your application supports.
 
 #### Buttons with icons
-Buttons or links containing only icons (such as `mat-fab`, `mat-mini-fab`, and `mat-icon-button`)
+Buttons or links containing only icons (such as `matFab`, `matMiniFab`, and `matIconButton`)
 should be given a meaningful label via `aria-label` or `aria-labelledby`. [See the documentation
 for `MatIcon`](https://material.angular.io/components/icon) for more
 information on using icons in buttons. Additionally, to be fully accessible the icon should have a minimum touch-target of 48x48 to ensure that the icon is easily clickable particularly on mobile devices and small screens.

--- a/src/material/button/button.spec.ts
+++ b/src/material/button/button.spec.ts
@@ -1,22 +1,18 @@
 import {createMouseEvent, dispatchEvent} from '@angular/cdk/testing/private';
 import {ApplicationRef, Component} from '@angular/core';
-import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {ThemePalette} from '../core';
 import {By} from '@angular/platform-browser';
 import {
   MAT_BUTTON_CONFIG,
   MAT_FAB_DEFAULT_OPTIONS,
+  MatButtonAppearance,
+  MatButtonConfig,
   MatButtonModule,
   MatFabDefaultOptions,
 } from './index';
 
 describe('MatButton', () => {
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [MatButtonModule, TestApp],
-    });
-  }));
-
   // General button tests
   it('should apply class based on color attribute', () => {
     let fixture = TestBed.createComponent(TestApp);
@@ -82,6 +78,45 @@ describe('MatButton', () => {
     expect(buttonDebugElement.nativeElement.classList.contains('mat-primary')).toBe(false);
     expect(buttonDebugElement.nativeElement.classList.contains('mat-accent')).toBe(true);
     expect(buttonDebugElement.nativeElement.classList.contains('custom-class')).toBe(true);
+  });
+
+  it('should be able to change the button appearance dynamically', () => {
+    const fixture = TestBed.createComponent(TestApp);
+    const button = fixture.nativeElement.querySelector('.dynamic') as HTMLElement;
+    fixture.detectChanges();
+
+    expect(button.classList).toContain('mat-mdc-button');
+    expect(button.classList).not.toContain('mat-mdc-outlined-button');
+    expect(button.classList).not.toContain('mat-mdc-raised-button');
+
+    fixture.componentInstance.appearance = 'outlined';
+    fixture.changeDetectorRef.markForCheck();
+    fixture.detectChanges();
+    expect(button.classList).not.toContain('mat-mdc-button');
+    expect(button.classList).toContain('mat-mdc-outlined-button');
+    expect(button.classList).not.toContain('mat-mdc-raised-button');
+
+    fixture.componentInstance.appearance = 'elevated';
+    fixture.changeDetectorRef.markForCheck();
+    fixture.detectChanges();
+    expect(button.classList).not.toContain('mat-mdc-button');
+    expect(button.classList).not.toContain('mat-mdc-outlined-button');
+    expect(button.classList).toContain('mat-mdc-raised-button');
+  });
+
+  it('should be able to configure the default button appearance', () => {
+    const config: MatButtonConfig = {
+      defaultAppearance: 'outlined',
+    };
+
+    TestBed.configureTestingModule({
+      providers: [{provide: MAT_BUTTON_CONFIG, useValue: config}],
+    });
+
+    const fixture = TestBed.createComponent(TestApp);
+    const button = fixture.nativeElement.querySelector('.default-appearance') as HTMLElement;
+    fixture.detectChanges();
+    expect(button.classList).toContain('mat-mdc-outlined-button');
   });
 
   describe('button[mat-fab]', () => {
@@ -422,6 +457,8 @@ describe('MatFabDefaultOptions', () => {
     <button mat-fab>Fab Button</button>
     <button mat-fab [extended]="extended" class="extended-fab-test">Extended</button>
     <button mat-mini-fab>Mini Fab Button</button>
+    <button class="dynamic" [matButton]="appearance">Dynamic button</button>
+    <button class="default-appearance" matButton>Dynamic button</button>
   `,
   imports: [MatButtonModule],
 })
@@ -433,6 +470,7 @@ class TestApp {
   tabIndex: number;
   extended = false;
   disabledInteractive = false;
+  appearance: MatButtonAppearance = 'text';
 
   increment() {
     this.clickCount++;

--- a/src/material/button/button.ts
+++ b/src/material/button/button.ts
@@ -6,23 +6,29 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ChangeDetectionStrategy, Component, ViewEncapsulation} from '@angular/core';
-import {MAT_BUTTON_HOST, MatButtonBase} from './button-base';
+import {ChangeDetectionStrategy, Component, Input, ViewEncapsulation} from '@angular/core';
+import {MAT_BUTTON_HOST, MatButtonAppearance, MatButtonBase} from './button-base';
+
+/**
+ * Classes that need to be set for each appearance of the button.
+ * Note that we use a `Map` here to avoid issues with property renaming.
+ */
+const APPEARANCE_CLASSES: Map<MatButtonAppearance, readonly string[]> = new Map([
+  ['text', ['mat-mdc-button']],
+  ['filled', ['mdc-button--unelevated', 'mat-mdc-unelevated-button']],
+  ['elevated', ['mdc-button--raised', 'mat-mdc-raised-button']],
+  ['outlined', ['mdc-button--outlined', 'mat-mdc-outlined-button']],
+]);
 
 /**
  * Material Design button component. Users interact with a button to perform an action.
- * See https://material.io/components/buttons
- *
- * The `MatButton` class applies to native button elements and captures the appearances for
- * "text button", "outlined button", and "contained button" per the Material Design
- * specification. `MatButton` additionally captures an additional "flat" appearance, which matches
- * "contained" but without elevation.
+ * See https://m3.material.io/components/buttons/overview
  */
 @Component({
   selector: `
-    button[mat-button], button[mat-raised-button], button[mat-flat-button],
-    button[mat-stroked-button], a[mat-button], a[mat-raised-button], a[mat-flat-button],
-    a[mat-stroked-button]
+    button[matButton], a[matButton], button[mat-button], button[mat-raised-button],
+    button[mat-flat-button], button[mat-stroked-button], a[mat-button], a[mat-raised-button],
+    a[mat-flat-button], a[mat-stroked-button]
   `,
   templateUrl: 'button.html',
   styleUrls: ['button.css', 'button-high-contrast.css'],
@@ -31,18 +37,87 @@ import {MAT_BUTTON_HOST, MatButtonBase} from './button-base';
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class MatButton extends MatButtonBase {}
+export class MatButton extends MatButtonBase {
+  /** Appearance of the button. */
+  @Input('matButton')
+  get appearance(): MatButtonAppearance | null {
+    return this._appearance;
+  }
+  set appearance(value: MatButtonAppearance | '') {
+    // Allow empty string so users can do `<button matButton></button>`
+    // without having to write out `="text"` every time.
+    this.setAppearance(value || this._config?.defaultAppearance || 'text');
+  }
+  private _appearance: MatButtonAppearance | null = null;
+
+  constructor(...args: unknown[]);
+
+  constructor() {
+    super();
+    const element = this._elementRef.nativeElement;
+    const inferredAppearance = _inferAppearance(element);
+
+    // This class is common across all the appearances so we add it ahead of time.
+    element.classList.add('mdc-button');
+
+    // Only set the appearance if we managed to infer it from the static attributes, rather than
+    // doing something like `setAppearance(inferredAppearance || 'text')`, because doing so can
+    // cause the fallback appearance's classes to be set and then immediately replaced when
+    // the input value is assigned.
+    if (inferredAppearance) {
+      this.setAppearance(inferredAppearance);
+    }
+  }
+
+  /** Programmatically sets the appearance of the button. */
+  setAppearance(appearance: MatButtonAppearance): void {
+    if (appearance === this._appearance) {
+      return;
+    }
+
+    const classList = this._elementRef.nativeElement.classList;
+    const previousClasses = this._appearance ? APPEARANCE_CLASSES.get(this._appearance) : null;
+    const newClasses = APPEARANCE_CLASSES.get(appearance)!;
+
+    if ((typeof ngDevMode === 'undefined' || ngDevMode) && !newClasses) {
+      throw new Error(`Unsupported MatButton appearance "${appearance}"`);
+    }
+
+    if (previousClasses) {
+      classList.remove(...previousClasses);
+    }
+
+    classList.add(...newClasses);
+    this._appearance = appearance;
+  }
+}
+
+/** Infers the button's appearance from its static attributes. */
+function _inferAppearance(button: HTMLElement): MatButtonAppearance | null {
+  if (button.hasAttribute('mat-raised-button')) {
+    return 'elevated';
+  }
+
+  if (button.hasAttribute('mat-stroked-button')) {
+    return 'outlined';
+  }
+
+  if (button.hasAttribute('mat-flat-button')) {
+    return 'filled';
+  }
+
+  if (button.hasAttribute('mat-button')) {
+    return 'text';
+  }
+
+  return null;
+}
 
 // tslint:disable:variable-name
 /**
  * Material Design button component for anchor elements. Anchor elements are used to provide
  * links for the user to navigate across different routes or pages.
- * See https://material.io/components/buttons
- *
- * The `MatAnchor` class applies to native anchor elements and captures the appearances for
- * "text button", "outlined button", and "contained button" per the Material Design
- * specification. `MatAnchor` additionally captures an additional "flat" appearance, which matches
- * "contained" but without elevation.
+ * See https://m3.material.io/components/buttons/overview
  */
 export const MatAnchor = MatButton;
 export type MatAnchor = MatButton;

--- a/src/material/button/fab.ts
+++ b/src/material/button/fab.ts
@@ -58,12 +58,12 @@ const defaults = MAT_FAB_DEFAULT_OPTIONS_FACTORY();
 /**
  * Material Design floating action button (FAB) component. These buttons represent the primary
  * or most common action for users to interact with.
- * See https://material.io/components/buttons-floating-action-button/
+ * See https://m3.material.io/components/floating-action-button/overview
  *
  * The `MatFabButton` class has two appearances: normal and extended.
  */
 @Component({
-  selector: `button[mat-fab], a[mat-fab]`,
+  selector: `button[mat-fab], a[mat-fab], button[matFab], a[matFab]`,
   templateUrl: 'button.html',
   styleUrl: 'fab.css',
   host: {
@@ -86,6 +86,8 @@ export class MatFabButton extends MatButtonBase {
 
   constructor() {
     super();
+    const element = this._elementRef.nativeElement;
+    element.classList.add('mdc-fab', 'mat-mdc-fab-base', 'mat-mdc-fab');
     this._options = this._options || defaults;
     this.color = this._options!.color || defaults.color;
   }
@@ -94,10 +96,10 @@ export class MatFabButton extends MatButtonBase {
 /**
  * Material Design mini floating action button (FAB) component. These buttons represent the primary
  * or most common action for users to interact with.
- * See https://material.io/components/buttons-floating-action-button/
+ * See https://m3.material.io/components/floating-action-button/overview
  */
 @Component({
-  selector: `button[mat-mini-fab], a[mat-mini-fab]`,
+  selector: `button[mat-mini-fab], a[mat-mini-fab], button[matMiniFab], a[matMiniFab]`,
   templateUrl: 'button.html',
   styleUrl: 'fab.css',
   host: MAT_BUTTON_HOST,
@@ -114,6 +116,8 @@ export class MatMiniFabButton extends MatButtonBase {
 
   constructor() {
     super();
+    const element = this._elementRef.nativeElement;
+    element.classList.add('mdc-fab', 'mat-mdc-fab-base', 'mdc-fab--mini', 'mat-mdc-mini-fab');
     this._options = this._options || defaults;
     this.color = this._options!.color || defaults.color;
   }
@@ -123,7 +127,7 @@ export class MatMiniFabButton extends MatButtonBase {
 /**
  * Material Design floating action button (FAB) component for anchor elements. Anchor elements
  * are used to provide links for the user to navigate across different routes or pages.
- * See https://material.io/components/buttons-floating-action-button/
+ * See https://m3.material.io/components/floating-action-button/overview
  *
  * The `MatFabAnchor` class has two appearances: normal and extended.
  */
@@ -133,7 +137,7 @@ export type MatFabAnchor = MatFabButton;
 /**
  * Material Design mini floating action button (FAB) component for anchor elements. Anchor elements
  * are used to provide links for the user to navigate across different routes or pages.
- * See https://material.io/components/buttons-floating-action-button/
+ * See https://m3.material.io/components/floating-action-button/overview
  */
 export const MatMiniFabAnchor = MatMiniFabButton;
 export type MatMiniFabAnchor = MatMiniFabButton;

--- a/src/material/button/icon-button.ts
+++ b/src/material/button/icon-button.ts
@@ -15,7 +15,7 @@ import {MAT_BUTTON_HOST, MatButtonBase} from './button-base';
  * See https://material.io/develop/web/components/buttons/icon-buttons/
  */
 @Component({
-  selector: `button[mat-icon-button], a[mat-icon-button]`,
+  selector: `button[mat-icon-button], a[mat-icon-button], button[matIconButton], a[matIconButton]`,
   templateUrl: 'icon-button.html',
   styleUrls: ['icon-button.css', 'button-high-contrast.css'],
   host: MAT_BUTTON_HOST,
@@ -28,7 +28,9 @@ export class MatIconButton extends MatButtonBase {
 
   constructor() {
     super();
-    this._rippleLoader.configureRipple(this._elementRef.nativeElement, {centered: true});
+    const element = this._elementRef.nativeElement;
+    element.classList.add('mdc-icon-button', 'mat-mdc-icon-button');
+    this._rippleLoader.configureRipple(element, {centered: true});
   }
 }
 

--- a/src/material/button/public-api.ts
+++ b/src/material/button/public-api.ts
@@ -10,4 +10,4 @@ export * from './button';
 export * from './fab';
 export * from './icon-button';
 export * from './module';
-export {MAT_BUTTON_CONFIG, MatButtonConfig} from './button-base';
+export {MAT_BUTTON_CONFIG, MatButtonAppearance, MatButtonConfig} from './button-base';

--- a/src/material/button/testing/button-harness-filters.ts
+++ b/src/material/button/testing/button-harness-filters.ts
@@ -8,8 +8,11 @@
 
 import {BaseHarnessFilters} from '@angular/cdk/testing';
 
+/** Possible button variants. */
+export type ButtonVariant = 'basic' | 'icon' | 'fab' | 'mini-fab';
+
 /** Possible button appearances. */
-export type ButtonVariant = 'basic' | 'raised' | 'flat' | 'icon' | 'stroked' | 'fab' | 'mini-fab';
+export type ButtonAppearance = 'text' | 'filled' | 'elevated' | 'outlined';
 
 /** A set of criteria that can be used to filter a list of button harness instances. */
 export interface ButtonHarnessFilters extends BaseHarnessFilters {
@@ -18,6 +21,9 @@ export interface ButtonHarnessFilters extends BaseHarnessFilters {
 
   /** Only find instances with a variant. */
   variant?: ButtonVariant;
+
+  /** Only find instances with a specific appearance. */
+  appearance?: ButtonAppearance;
 
   /** Only find instances which match the given disabled state. */
   disabled?: boolean;

--- a/src/material/button/testing/button-harness.spec.ts
+++ b/src/material/button/testing/button-harness.spec.ts
@@ -1,6 +1,6 @@
 import {Component} from '@angular/core';
-import {ComponentFixture, inject, TestBed} from '@angular/core/testing';
-import {Platform, PlatformModule} from '@angular/cdk/platform';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {Platform} from '@angular/cdk/platform';
 import {HarnessLoader, parallel} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatButtonModule} from '../module';
@@ -14,18 +14,11 @@ describe('MatButtonHarness', () => {
   let platform: Platform;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [MatButtonModule, MatIconModule, PlatformModule, ButtonHarnessTest],
-    });
-
     fixture = TestBed.createComponent(ButtonHarnessTest);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.loader(fixture);
+    platform = TestBed.inject(Platform);
   });
-
-  beforeEach(inject([Platform], (p: Platform) => {
-    platform = p;
-  }));
 
   it('should load all button harnesses', async () => {
     const buttons = await loader.getAllHarnesses(MatButtonHarness);
@@ -53,24 +46,24 @@ describe('MatButtonHarness', () => {
   });
 
   it('should get disabled state', async () => {
-    // Grab each combination of [enabled, disabled] ⨯ [button, anchor]
-    const [disabledFlatButton, enabledFlatAnchor] = await loader.getAllHarnesses(
-      MatButtonHarness.with({text: /flat/i}),
+    // Grab each combination of [enabled, disabled] x [button, anchor]
+    const [disabledFilledButton, enabledFilledAnchor] = await loader.getAllHarnesses(
+      MatButtonHarness.with({text: /filled/i}),
     );
-    const [enabledRaisedButton, disabledRaisedAnchor] = await loader.getAllHarnesses(
-      MatButtonHarness.with({text: /raised/i}),
+    const [enabledElevatedButton, disabledElevatedAnchor] = await loader.getAllHarnesses(
+      MatButtonHarness.with({text: /elevated/i}),
     );
 
-    expect(await enabledFlatAnchor.isDisabled()).toBe(false);
-    expect(await disabledFlatButton.isDisabled()).toBe(true);
-    expect(await enabledRaisedButton.isDisabled()).toBe(false);
-    expect(await disabledRaisedAnchor.isDisabled()).toBe(true);
+    expect(await enabledFilledAnchor.isDisabled()).toBe(false);
+    expect(await disabledFilledButton.isDisabled()).toBe(true);
+    expect(await enabledElevatedButton.isDisabled()).toBe(false);
+    expect(await disabledElevatedAnchor.isDisabled()).toBe(true);
   });
 
   it('should get button text', async () => {
     const [firstButton, secondButton] = await loader.getAllHarnesses(MatButtonHarness);
     expect(await firstButton.getText()).toBe('Basic button');
-    expect(await secondButton.getText()).toBe('Flat button');
+    expect(await secondButton.getText()).toBe('Filled button');
   });
 
   it('should focus and blur a button', async () => {
@@ -99,7 +92,7 @@ describe('MatButtonHarness', () => {
       return;
     }
 
-    const button = await loader.getHarness(MatButtonHarness.with({text: 'Flat button'}));
+    const button = await loader.getHarness(MatButtonHarness.with({text: 'Filled button'}));
     await button.click();
 
     expect(fixture.componentInstance.clicked).toBe(false);
@@ -116,32 +109,60 @@ describe('MatButtonHarness', () => {
     expect(await favIcon.getName()).toBe('favorite');
   });
 
-  it('should load all button harnesses', async () => {
+  it('should be able to ge the type variant of the button', async () => {
     const buttons = await loader.getAllHarnesses(MatButtonHarness);
     const variants = await parallel(() => buttons.map(button => button.getVariant()));
 
     expect(variants).toEqual([
       'basic',
-      'flat',
-      'raised',
-      'stroked',
+      'basic',
+      'basic',
+      'basic',
       'icon',
       'icon',
       'fab',
       'mini-fab',
       'basic',
-      'flat',
-      'raised',
-      'stroked',
+      'basic',
+      'basic',
+      'basic',
       'icon',
       'fab',
       'mini-fab',
     ]);
   });
 
+  it('should be able to get the appearance of the button', async () => {
+    const buttons = await loader.getAllHarnesses(MatButtonHarness);
+    const appearances = await parallel(() => buttons.map(button => button.getAppearance()));
+
+    expect(appearances).toEqual([
+      'text',
+      'filled',
+      'elevated',
+      'outlined',
+      null,
+      null,
+      null,
+      null,
+      'text',
+      'filled',
+      'elevated',
+      'outlined',
+      null,
+      null,
+      null,
+    ]);
+  });
+
   it('should be able to filter buttons based on their variant', async () => {
-    const button = await loader.getHarness(MatButtonHarness.with({variant: 'flat'}));
-    expect(await button.getText()).toBe('Flat button');
+    const button = await loader.getHarness(MatButtonHarness.with({variant: 'fab'}));
+    expect(await button.getText()).toBe('Fab button');
+  });
+
+  it('should be able to filter buttons based on their appearance', async () => {
+    const button = await loader.getHarness(MatButtonHarness.with({appearance: 'filled'}));
+    expect(await button.getText()).toBe('Filled button');
   });
 });
 
@@ -149,32 +170,32 @@ describe('MatButtonHarness', () => {
   // Include one of each type of button selector to ensure that they're all captured by
   // the harness's selector.
   template: `
-    <button id="basic" type="button" mat-button (click)="clicked = true">
+    <button id="basic" type="button" matButton (click)="clicked = true">
       Basic button
     </button>
-    <button id="flat" type="button" mat-flat-button disabled (click)="clicked = true">
-      Flat button
+    <button id="flat" type="button" matButton="filled" disabled (click)="clicked = true">
+      Filled button
     </button>
-    <button id="raised" type="button" mat-raised-button>Raised button</button>
-    <button id="stroked" type="button" mat-stroked-button>Stroked button</button>
-    <button id="home-icon" type="button" mat-icon-button>
+    <button id="raised" type="button" matButton="elevated">Elevated button</button>
+    <button id="stroked" type="button" matButton="outlined">Outlined button</button>
+    <button id="home-icon" type="button" matIconButton>
       <mat-icon>home</mat-icon>
     </button>
-    <button id="favorite-icon" type="button" mat-icon-button>
+    <button id="favorite-icon" type="button" matIconButton>
       <mat-icon>favorite</mat-icon>
     </button>
-    <button id="fab" type="button" mat-fab>Fab button</button>
-    <button id="mini-fab" type="button" mat-mini-fab>Mini Fab button</button>
+    <button id="fab" type="button" matFab>Fab button</button>
+    <button id="mini-fab" type="button" matMiniFab>Mini Fab button</button>
 
-    <a id="anchor-basic" mat-button>Basic anchor</a>
-    <a id="anchor-flat" mat-flat-button>Flat anchor</a>
-    <a id="anchor-raised" mat-raised-button disabled>Raised anchor</a>
-    <a id="anchor-stroked" mat-stroked-button>Stroked anchor</a>
-    <a id="anchor-icon" mat-icon-button>Icon anchor</a>
-    <a id="anchor-fab" mat-fab>Fab anchor</a>
-    <a id="anchor-mini-fab" mat-mini-fab>Mini Fab anchor</a>
+    <a id="anchor-basic" matButton>Basic anchor</a>
+    <a id="anchor-flat" matButton="filled">Filled anchor</a>
+    <a id="anchor-raised" matButton="elevated" disabled>Elevated anchor</a>
+    <a id="anchor-stroked" matButton="outlined">Stroked anchor</a>
+    <a id="anchor-icon" matIconButton>Icon anchor</a>
+    <a id="anchor-fab" matFab>Fab anchor</a>
+    <a id="anchor-mini-fab" matMiniFab>Mini Fab anchor</a>
   `,
-  imports: [MatButtonModule, MatIconModule, PlatformModule],
+  imports: [MatButtonModule, MatIconModule],
 })
 class ButtonHarnessTest {
   disabled = true;

--- a/src/material/button/testing/button-harness.ts
+++ b/src/material/button/testing/button-harness.ts
@@ -12,13 +12,14 @@ import {
   ContentContainerComponentHarness,
   HarnessPredicate,
 } from '@angular/cdk/testing';
-import {ButtonHarnessFilters, ButtonVariant} from './button-harness-filters';
+import {ButtonAppearance, ButtonHarnessFilters, ButtonVariant} from './button-harness-filters';
 
 /** Harness for interacting with a mat-button in tests. */
 export class MatButtonHarness extends ContentContainerComponentHarness {
   // TODO(jelbourn) use a single class, like `.mat-button-base`
-  static hostSelector = `[mat-button], [mat-raised-button], [mat-flat-button],
-                         [mat-icon-button], [mat-stroked-button], [mat-fab], [mat-mini-fab]`;
+  static hostSelector = `[matButton], [mat-button], [matIconButton], [matFab], [matMiniFab],
+    [mat-raised-button], [mat-flat-button], [mat-icon-button], [mat-stroked-button], [mat-fab],
+    [mat-mini-fab]`;
 
   /**
    * Gets a `HarnessPredicate` that can be used to search for a button with specific attributes.
@@ -26,6 +27,7 @@ export class MatButtonHarness extends ContentContainerComponentHarness {
    *   - `selector` finds a button whose host element matches the given selector.
    *   - `text` finds a button with specific text content.
    *   - `variant` finds buttons matching a specific variant.
+   *   - `appearance` finds buttons matching a specific appearance.
    * @return a `HarnessPredicate` configured with the given options.
    */
   static with<T extends MatButtonHarness>(
@@ -38,6 +40,9 @@ export class MatButtonHarness extends ContentContainerComponentHarness {
       )
       .addOption('variant', options.variant, (harness, variant) =>
         HarnessPredicate.stringMatches(harness.getVariant(), variant),
+      )
+      .addOption('appearance', options.appearance, (harness, appearance) =>
+        HarnessPredicate.stringMatches(harness.getAppearance(), appearance),
       )
       .addOption('disabled', options.disabled, async (harness, disabled) => {
         return (await harness.isDisabled()) === disabled;
@@ -91,20 +96,50 @@ export class MatButtonHarness extends ContentContainerComponentHarness {
   async getVariant(): Promise<ButtonVariant> {
     const host = await this.host();
 
-    if ((await host.getAttribute('mat-raised-button')) != null) {
-      return 'raised';
-    } else if ((await host.getAttribute('mat-flat-button')) != null) {
-      return 'flat';
-    } else if ((await host.getAttribute('mat-icon-button')) != null) {
+    // TODO(crisbeto): we're checking both classes and attributes for backwards compatibility
+    // with some internal apps that were applying the attribute without importing the directive.
+    // Really we should be only targeting the classes.
+    if (
+      (await host.hasClass('mat-mdc-icon-button')) ||
+      (await host.getAttribute('mat-icon-button')) != null
+    ) {
       return 'icon';
-    } else if ((await host.getAttribute('mat-stroked-button')) != null) {
-      return 'stroked';
-    } else if ((await host.getAttribute('mat-fab')) != null) {
-      return 'fab';
-    } else if ((await host.getAttribute('mat-mini-fab')) != null) {
+    }
+
+    if (
+      (await host.hasClass('mat-mdc-mini-fab')) ||
+      (await host.getAttribute('mat-mini-fab')) != null
+    ) {
       return 'mini-fab';
     }
 
+    if ((await host.hasClass('mat-mdc-fab')) || (await host.getAttribute('mat-fab')) != null) {
+      return 'fab';
+    }
+
     return 'basic';
+  }
+
+  /** Gets the appearance of the button. */
+  async getAppearance(): Promise<ButtonAppearance | null> {
+    const host = await this.host();
+
+    if (await host.hasClass('mat-mdc-outlined-button')) {
+      return 'outlined';
+    }
+
+    if (await host.hasClass('mat-mdc-raised-button')) {
+      return 'elevated';
+    }
+
+    if (await host.hasClass('mat-mdc-unelevated-button')) {
+      return 'filled';
+    }
+
+    if (await host.hasClass('mat-mdc-button')) {
+      return 'text';
+    }
+
+    return null;
   }
 }

--- a/src/material/card/testing/card-harness.spec.ts
+++ b/src/material/card/testing/card-harness.spec.ts
@@ -115,8 +115,8 @@ describe('MatCardHarness', () => {
           </p>
         </mat-card-content>
         <mat-card-actions>
-          <button mat-button>LIKE</button>
-          <button mat-button>SHARE</button>
+          <button matButton>LIKE</button>
+          <button matButton>SHARE</button>
         </mat-card-actions>
         <mat-card-footer>
           <div>Woof woof!</div>

--- a/src/material/datepicker/calendar-header.html
+++ b/src/material/datepicker/calendar-header.html
@@ -4,7 +4,7 @@
       Relocated label next to related button and made visually hidden via cdk-visually-hidden
       to enable label to appear in a11y tree for SR when using Firefox -->
     <span [id]="_periodButtonLabelId" class="cdk-visually-hidden" aria-live="polite">{{periodButtonDescription}}</span>
-    <button mat-button type="button" class="mat-calendar-period-button"
+    <button matButton type="button" class="mat-calendar-period-button"
             (click)="currentPeriodClicked()" [attr.aria-label]="periodButtonLabel"
             [attr.aria-describedby]="_periodButtonLabelId">
       <span aria-hidden="true">{{periodButtonText}}</span>
@@ -18,7 +18,7 @@
 
     <ng-content></ng-content>
 
-    <button mat-icon-button type="button" class="mat-calendar-previous-button"
+    <button matIconButton type="button" class="mat-calendar-previous-button"
             [disabled]="!previousEnabled()" (click)="previousClicked()"
             [attr.aria-label]="prevButtonLabel">
       <svg viewBox="0 0 24 24" focusable="false" aria-hidden="true">
@@ -26,7 +26,7 @@
        </svg>
     </button>
 
-    <button mat-icon-button type="button" class="mat-calendar-next-button"
+    <button matIconButton type="button" class="mat-calendar-next-button"
             [disabled]="!nextEnabled()" (click)="nextClicked()"
             [attr.aria-label]="nextButtonLabel">
       <svg viewBox="0 0 24 24" focusable="false" aria-hidden="true">

--- a/src/material/datepicker/datepicker-actions.spec.ts
+++ b/src/material/datepicker/datepicker-actions.spec.ts
@@ -297,8 +297,8 @@ describe('MatDatepickerActions', () => {
       <mat-datepicker #picker [touchUi]="touchUi" [startAt]="startAt">
         @if (renderActions) {
           <mat-datepicker-actions>
-            <button mat-button class="cancel" matDatepickerCancel>Cancel</button>
-            <button mat-raised-button class="apply" matDatepickerApply>Apply</button>
+            <button matButton class="cancel" matDatepickerCancel>Cancel</button>
+            <button matButton="elevated" class="apply" matDatepickerApply>Apply</button>
           </mat-datepicker-actions>
         }
       </mat-datepicker>

--- a/src/material/datepicker/datepicker-content.html
+++ b/src/material/datepicker/datepicker-content.html
@@ -32,7 +32,7 @@
   <!-- Invisible close button for screen reader users. -->
   <button
     type="button"
-    mat-raised-button
+    matButton="elevated"
     [color]="color || 'primary'"
     class="mat-datepicker-close-button"
     [class.cdk-visually-hidden]="!_closeButtonFocused"

--- a/src/material/datepicker/datepicker-toggle.html
+++ b/src/material/datepicker/datepicker-toggle.html
@@ -1,6 +1,6 @@
 <button
   #button
-  mat-icon-button
+  matIconButton
   type="button"
   [attr.aria-haspopup]="datepicker ? 'dialog' : null"
   [attr.aria-label]="ariaLabel || _intl.openCalendarLabel"

--- a/src/material/dialog/dialog.md
+++ b/src/material/dialog/dialog.md
@@ -102,9 +102,9 @@ For example:
 <h2 mat-dialog-title>Delete all elements?</h2>
 <mat-dialog-content>This will delete all elements that are currently on this page and cannot be undone.</mat-dialog-content>
 <mat-dialog-actions>
-  <button mat-button mat-dialog-close>Cancel</button>
+  <button matButton mat-dialog-close>Cancel</button>
   <!-- The mat-dialog-close directive optionally accepts a value as a result for the dialog. -->
-  <button mat-button [mat-dialog-close]="true">Delete</button>
+  <button matButton [mat-dialog-close]="true">Delete</button>
 </mat-dialog-actions>
 ```
 
@@ -113,7 +113,7 @@ Once a dialog opens, the dialog will automatically focus the first tabbable elem
 You can control which elements are tab stops with the `tabindex` attribute
 
 ```html
-<button mat-button tabindex="-1">Not Tabbable</button>
+<button matButton tabindex="-1">Not Tabbable</button>
 ```
 
 <!-- example(dialog-content) -->

--- a/src/material/list/list.md
+++ b/src/material/list/list.md
@@ -76,7 +76,7 @@ element in an `<mat-list-item>`.
   @for (link of links; track link) {
     <mat-list-item [activated]="link.isActive">
        <a matListItemTitle href="...">{{ link }}</a>
-       <button mat-icon-button (click)="showInfo(link)" matListItemMeta>
+       <button matIconButton (click)="showInfo(link)" matListItemMeta>
           <mat-icon>info</mat-icon>
        </button>
     </mat-list-item>

--- a/src/material/menu/menu.md
+++ b/src/material/menu/menu.md
@@ -62,7 +62,7 @@ with the `matMenuContent` attribute:
   </ng-template>
 </mat-menu>
 
-<button mat-icon-button [matMenuTriggerFor]="appMenu">
+<button matIconButton [matMenuTriggerFor]="appMenu">
   <mat-icon>more_vert</mat-icon>
 </button>
 ```
@@ -80,11 +80,11 @@ with a different set of data, depending on the trigger that opened it:
   </ng-template>
 </mat-menu>
 
-<button mat-icon-button [matMenuTriggerFor]="appMenu" [matMenuTriggerData]="{name: 'Sally'}">
+<button matIconButton [matMenuTriggerFor]="appMenu" [matMenuTriggerData]="{name: 'Sally'}">
   <mat-icon>more_vert</mat-icon>
 </button>
 
-<button mat-icon-button [matMenuTriggerFor]="appMenu" [matMenuTriggerData]="{name: 'Bob'}">
+<button matIconButton [matMenuTriggerFor]="appMenu" [matMenuTriggerData]="{name: 'Bob'}">
   <mat-icon>more_vert</mat-icon>
 </button>
 ```
@@ -109,7 +109,7 @@ The menu trigger is a standard button element augmented with `aria-haspopup`, `a
 The pop-up menu implements the `role="menu"` pattern, handling keyboard interaction and focus
 management. Upon opening, the trigger will focus the first focusable menu item. Upon close, the menu
 will return focus to its trigger. Avoid creating a menu in which all items are disabled, instead
-hiding or disabling the menu trigger. 
+hiding or disabling the menu trigger.
 
 Angular Material does not support the `menuitemcheckbox` or `menuitemradio` roles.
 

--- a/src/material/paginator/paginator.html
+++ b/src/material/paginator/paginator.html
@@ -42,7 +42,7 @@
       </div>
 
       @if (showFirstLastButtons) {
-        <button mat-icon-button type="button"
+        <button matIconButton type="button"
                 class="mat-mdc-paginator-navigation-first"
                 (click)="_buttonClicked(0, _previousButtonsDisabled())"
                 [attr.aria-label]="_intl.firstPageLabel"
@@ -59,7 +59,7 @@
           </svg>
         </button>
       }
-      <button mat-icon-button type="button"
+      <button matIconButton type="button"
               class="mat-mdc-paginator-navigation-previous"
               (click)="_buttonClicked(pageIndex - 1, _previousButtonsDisabled())"
               [attr.aria-label]="_intl.previousPageLabel"
@@ -75,7 +75,7 @@
           <path d="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"/>
         </svg>
       </button>
-      <button mat-icon-button type="button"
+      <button matIconButton type="button"
               class="mat-mdc-paginator-navigation-next"
               (click)="_buttonClicked(pageIndex + 1, _nextButtonsDisabled())"
               [attr.aria-label]="_intl.nextPageLabel"
@@ -92,7 +92,7 @@
         </svg>
       </button>
       @if (showFirstLastButtons) {
-        <button mat-icon-button type="button"
+        <button matIconButton type="button"
                 class="mat-mdc-paginator-navigation-last"
                 (click)="_buttonClicked(getNumberOfPages() - 1, _nextButtonsDisabled())"
                 [attr.aria-label]="_intl.lastPageLabel"

--- a/src/material/schematics/ng-generate/address-form/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.html.template
+++ b/src/material/schematics/ng-generate/address-form/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.html.template
@@ -46,7 +46,7 @@
               <textarea matInput placeholder="Address 2" formControlName="address2"></textarea>
             </mat-form-field>
           } @else {
-            <button mat-button type="button" (click)="hasUnitNumber = !hasUnitNumber">
+            <button matButton type="button" (click)="hasUnitNumber = !hasUnitNumber">
               + Add C/O, Apt, Suite, Unit
             </button>
           }
@@ -93,7 +93,7 @@
       </div>
     </mat-card-content>
     <mat-card-actions>
-      <button mat-raised-button color="primary" type="submit">Submit</button>
+      <button matButton="elevated" color="primary" type="submit">Submit</button>
     </mat-card-actions>
   </mat-card>
 </form>

--- a/src/material/schematics/ng-generate/dashboard/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.html.template
+++ b/src/material/schematics/ng-generate/dashboard/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.html.template
@@ -7,7 +7,7 @@
           <mat-card-header>
             <mat-card-title>
               {{card.title}}
-              <button mat-icon-button class="more-button" [matMenuTriggerFor]="menu" aria-label="Toggle menu">
+              <button matIconButton class="more-button" [matMenuTriggerFor]="menu" aria-label="Toggle menu">
                 <mat-icon>more_vert</mat-icon>
               </button>
               <mat-menu #menu="matMenu" xPosition="before">

--- a/src/material/schematics/ng-generate/navigation/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.html.template
+++ b/src/material/schematics/ng-generate/navigation/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.html.template
@@ -16,7 +16,7 @@
         <button
           type="button"
           aria-label="Toggle sidenav"
-          mat-icon-button
+          matIconButton
           (click)="drawer.toggle()">
           <mat-icon aria-label="Side nav toggle icon">menu</mat-icon>
         </button>

--- a/src/material/schematics/ng-generate/tree/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.html.template
+++ b/src/material/schematics/ng-generate/tree/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.html.template
@@ -1,6 +1,6 @@
 <mat-tree [dataSource]="dataSource" [treeControl]="treeControl">
   <mat-tree-node *matTreeNodeDef="let node" matTreeNodeToggle matTreeNodePadding>
-    <button mat-icon-button disabled></button>
+    <button matIconButton disabled></button>
     <mat-icon class="type-icon" [attr.aria-label]="node.type + 'icon'">
       {{ node.type === 'file' ? 'description' : 'folder' }}
     </mat-icon>
@@ -8,7 +8,7 @@
   </mat-tree-node>
 
   <mat-tree-node *matTreeNodeDef="let node; when: hasChild" matTreeNodePadding>
-    <button mat-icon-button matTreeNodeToggle
+    <button matIconButton matTreeNodeToggle
             [attr.aria-label]="'Toggle ' + node.name">
       <mat-icon class="mat-icon-rtl-mirror">
         {{treeControl.isExpanded(node) ? 'expand_more' : 'chevron_right'}}

--- a/src/material/snack-bar/simple-snack-bar.html
+++ b/src/material/snack-bar/simple-snack-bar.html
@@ -4,7 +4,7 @@
 
 @if (hasAction) {
   <div matSnackBarActions>
-    <button mat-button matSnackBarAction (click)="action()">
+    <button matButton matSnackBarAction (click)="action()">
       {{data.action}}
     </button>
   </div>

--- a/src/material/stepper/stepper.md
+++ b/src/material/stepper/stepper.md
@@ -71,14 +71,14 @@ are completed.
     <mat-step formGroupName="0" [stepControl]="formArray.get([0])">
       ...
       <div>
-        <button mat-button matStepperNext type="button">Next</button>
+        <button matButton matStepperNext type="button">Next</button>
       </div>
     </mat-step>
     <mat-step formGroupName="1" [stepControl]="formArray.get([1])">
       ...
       <div>
-        <button mat-button matStepperPrevious type="button">Back</button>
-        <button mat-button matStepperNext type="button">Next</button>
+        <button matButton matStepperPrevious type="button">Back</button>
+        <button matButton matStepperNext type="button">Next</button>
       </div>
     </mat-step>
     ...

--- a/src/material/stepper/stepper.spec.ts
+++ b/src/material/stepper/stepper.spec.ts
@@ -1855,16 +1855,16 @@ function createComponent<T>(
           <mat-error>This field is required</mat-error>
         </mat-form-field>
         <div>
-          <button mat-button matStepperPrevious>Back</button>
-          <button mat-button matStepperNext>Next</button>
+          <button matButton matStepperPrevious>Back</button>
+          <button matButton matStepperNext>Next</button>
         </div>
       </mat-step>
       <mat-step>
         <ng-template matStepLabel>Step 2</ng-template>
         Content 2
         <div>
-          <button mat-button matStepperPrevious>Back</button>
-          <button mat-button matStepperNext>Next</button>
+          <button matButton matStepperPrevious>Back</button>
+          <button matButton matStepperNext>Next</button>
         </div>
       </mat-step>
     </mat-stepper>
@@ -1891,23 +1891,23 @@ class MatHorizontalStepperWithErrorsApp {
         <ng-template matStepLabel>Step 1</ng-template>
         Content 1
         <div>
-          <button mat-button matStepperPrevious>Back</button>
-          <button mat-button matStepperNext>Next</button>
+          <button matButton matStepperPrevious>Back</button>
+          <button matButton matStepperNext>Next</button>
         </div>
       </mat-step>
       <mat-step [color]="secondStepTheme()">
         <ng-template matStepLabel>Step 2</ng-template>
         Content 2
         <div>
-          <button mat-button matStepperPrevious>Back</button>
-          <button mat-button matStepperNext>Next</button>
+          <button matButton matStepperPrevious>Back</button>
+          <button matButton matStepperNext>Next</button>
         </div>
       </mat-step>
       <mat-step [label]="inputLabel" optional>
         Content 3
         <div>
-          <button mat-button matStepperPrevious>Back</button>
-          <button mat-button matStepperNext>Next</button>
+          <button matButton matStepperPrevious>Back</button>
+          <button matButton matStepperNext>Next</button>
         </div>
       </mat-step>
     </mat-stepper>
@@ -1929,8 +1929,8 @@ class SimpleMatHorizontalStepperApp {
         <ng-template matStepLabel>Step 1</ng-template>
         Content 1
         <div>
-          <button mat-button matStepperPrevious>Back</button>
-          <button mat-button matStepperNext>Next</button>
+          <button matButton matStepperPrevious>Back</button>
+          <button matButton matStepperNext>Next</button>
         </div>
       </mat-step>
       @if (showStepTwo()) {
@@ -1938,16 +1938,16 @@ class SimpleMatHorizontalStepperApp {
           <ng-template matStepLabel>Step 2</ng-template>
           Content 2
           <div>
-            <button mat-button matStepperPrevious>Back</button>
-            <button mat-button matStepperNext>Next</button>
+            <button matButton matStepperPrevious>Back</button>
+            <button matButton matStepperNext>Next</button>
           </div>
         </mat-step>
       }
       <mat-step [label]="inputLabel()">
         Content 3
         <div>
-          <button mat-button matStepperPrevious>Back</button>
-          <button mat-button matStepperNext>Next</button>
+          <button matButton matStepperPrevious>Back</button>
+          <button matButton matStepperNext>Next</button>
         </div>
       </mat-step>
     </mat-stepper>

--- a/src/material/timepicker/timepicker-toggle.html
+++ b/src/material/timepicker/timepicker-toggle.html
@@ -1,5 +1,5 @@
 <button
-  mat-icon-button
+  matIconButton
   type="button"
   aria-haspopup="listbox"
   [attr.aria-label]="getAriaLabel()"

--- a/src/material/toolbar/testing/toolbar-harness.spec.ts
+++ b/src/material/toolbar/testing/toolbar-harness.spec.ts
@@ -65,10 +65,10 @@ describe('MatToolbarHarness', () => {
     <mat-toolbar>
       <mat-toolbar-row><span>Row 1</span></mat-toolbar-row>
       <mat-toolbar-row><span>Row 2</span>
-        <button mat-button>
+        <button matButton>
           Button 1
         </button>
-        <button mat-button>
+        <button matButton>
           Button 2
         </button>
       </mat-toolbar-row>

--- a/src/universal-app/kitchen-sink/kitchen-sink.html
+++ b/src/universal-app/kitchen-sink/kitchen-sink.html
@@ -12,21 +12,21 @@
 </mat-autocomplete>
 
 <h2>Bottom sheet</h2>
-<button mat-raised-button (click)="openBottomSheet()">Open bottom sheet</button>
+<button matButton="elevated" (click)="openBottomSheet()">Open bottom sheet</button>
 
 <h2>Button</h2>
 
-<button mat-button>go</button>
-<button mat-icon-button><mat-icon>search</mat-icon></button>
-<button mat-raised-button>go</button>
-<button mat-fab><mat-icon>home</mat-icon></button>
-<button mat-mini-fab><mat-icon>favorite</mat-icon></button>
+<button matButton>go</button>
+<button matIconButton><mat-icon>search</mat-icon></button>
+<button matButton="elevated">go</button>
+<button matFab><mat-icon>home</mat-icon></button>
+<button matMiniFab><mat-icon>favorite</mat-icon></button>
 
-<a mat-button href="https://google.com">Google</a>
-<a mat-icon-button href="https://google.com"><mat-icon>search</mat-icon></a>
-<a mat-raised-button href="https://google.com">Google</a>
-<a mat-fab href="https://google.com"><mat-icon>home</mat-icon></a>
-<a mat-mini-fab href="https://google.com"><mat-icon>favorite</mat-icon></a>
+<a matButton href="https://google.com">Google</a>
+<a matIconButton href="https://google.com"><mat-icon>search</mat-icon></a>
+<a matButton="elevated" href="https://google.com">Google</a>
+<a matFab href="https://google.com"><mat-icon>home</mat-icon></a>
+<a matMiniFab href="https://google.com"><mat-icon>favorite</mat-icon></a>
 
 <h2>Button toggle</h2>
 
@@ -59,8 +59,8 @@
     <p>And more stuff</p>
   </mat-card-content>
   <mat-card-actions>
-    <button mat-button>LIKE</button>
-    <button mat-button>SHARE</button>
+    <button matButton>LIKE</button>
+    <button matButton>SHARE</button>
   </mat-card-actions>
   <mat-card-footer> Hurray </mat-card-footer>
 </mat-card>
@@ -111,7 +111,7 @@
 </mat-form-field>
 
 <h2>Dialog</h2>
-<button mat-raised-button (click)="openDialog()">Open dialog</button>
+<button matButton="elevated" (click)="openDialog()">Open dialog</button>
 
 <h2>Grid list</h2>
 
@@ -211,7 +211,7 @@
 
 <h2>Menu</h2>
 
-<button mat-button [matMenuTriggerFor]="menu">Open</button>
+<button matButton [matMenuTriggerFor]="menu">Open</button>
 <mat-menu #menu="matMenu">
   <button mat-menu-item>Mercy</button>
   <button mat-menu-item>Lucio</button>
@@ -299,7 +299,7 @@
 </mat-slider>
 
 <h2>Snack bar</h2>
-<button mat-raised-button (click)="openSnackbar()">Open snackbar</button>
+<button matButton="elevated" (click)="openSnackbar()">Open snackbar</button>
 
 <h2>Tabs</h2>
 
@@ -325,7 +325,7 @@
       atque iste doloremque dolor? Ullam, aspernatur? Alias, fuga! At dolorum odio molestiae
       laudantium nihil alias inventore veritatis voluptatum.
     </p>
-    <button mat-raised-button color="primary">See the overview</button>
+    <button matButton="elevated" color="primary">See the overview</button>
   </mat-tab>
   <mat-tab>
     <ng-template mat-tab-label>API docs</ng-template>
@@ -340,7 +340,7 @@
       officiis molestias, excepturi odio, autem magni dignissimos perspiciatis, amet qui! Dolorem
       molestiae similique necessitatibus cupiditate ipsa aspernatur?
     </p>
-    <button mat-raised-button color="accent">See the API docs</button>
+    <button matButton="elevated" color="accent">See the API docs</button>
   </mat-tab>
 
   <mat-tab>
@@ -351,7 +351,7 @@
       accusantium, eos perspiciatis reprehenderit, nobis exercitationem sunt ducimus molestiae
       laborum inventore itaque incidunt. Neque dolorum adipisci quidem.
     </p>
-    <button mat-raised-button color="warn">See the examples</button>
+    <button matButton="elevated" color="warn">See the examples</button>
   </mat-tab>
 </mat-tab-group>
 
@@ -553,7 +553,7 @@
 
 <h2>Badge</h2>
 
-<button mat-raised-button matBadge="99">Clicky thing</button>
+<button matButton="elevated" matBadge="99">Clicky thing</button>
 
 <h2>Drag and Drop</h2>
 <button cdkDrag>Drag me around</button>

--- a/tools/public_api_guard/material/button-testing.md
+++ b/tools/public_api_guard/material/button-testing.md
@@ -10,14 +10,18 @@ import { ContentContainerComponentHarness } from '@angular/cdk/testing';
 import { HarnessPredicate } from '@angular/cdk/testing';
 
 // @public
+export type ButtonAppearance = 'text' | 'filled' | 'elevated' | 'outlined';
+
+// @public
 export interface ButtonHarnessFilters extends BaseHarnessFilters {
+    appearance?: ButtonAppearance;
     disabled?: boolean;
     text?: string | RegExp;
     variant?: ButtonVariant;
 }
 
 // @public
-export type ButtonVariant = 'basic' | 'raised' | 'flat' | 'icon' | 'stroked' | 'fab' | 'mini-fab';
+export type ButtonVariant = 'basic' | 'icon' | 'fab' | 'mini-fab';
 
 // @public
 export class MatButtonHarness extends ContentContainerComponentHarness {
@@ -26,6 +30,7 @@ export class MatButtonHarness extends ContentContainerComponentHarness {
     click(location: 'center'): Promise<void>;
     click(): Promise<void>;
     focus(): Promise<void>;
+    getAppearance(): Promise<ButtonAppearance | null>;
     getText(): Promise<string>;
     getVariant(): Promise<ButtonVariant>;
     // (undocumented)

--- a/tools/public_api_guard/material/button.md
+++ b/tools/public_api_guard/material/button.md
@@ -33,15 +33,23 @@ export type MatAnchor = MatButton;
 
 // @public
 export class MatButton extends MatButtonBase {
+    constructor(...args: unknown[]);
+    get appearance(): MatButtonAppearance | null;
+    set appearance(value: MatButtonAppearance | '');
+    setAppearance(appearance: MatButtonAppearance): void;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<MatButton, "    button[mat-button], button[mat-raised-button], button[mat-flat-button],    button[mat-stroked-button], a[mat-button], a[mat-raised-button], a[mat-flat-button],    a[mat-stroked-button]  ", ["matButton", "matAnchor"], {}, {}, never, [".material-icons:not([iconPositionEnd]), mat-icon:not([iconPositionEnd]), [matButtonIcon]:not([iconPositionEnd])", "*", ".material-icons[iconPositionEnd], mat-icon[iconPositionEnd], [matButtonIcon][iconPositionEnd]"], true, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MatButton, "    button[matButton], a[matButton], button[mat-button], button[mat-raised-button],    button[mat-flat-button], button[mat-stroked-button], a[mat-button], a[mat-raised-button],    a[mat-flat-button], a[mat-stroked-button]  ", ["matButton", "matAnchor"], { "appearance": { "alias": "matButton"; "required": false; }; }, {}, never, [".material-icons:not([iconPositionEnd]), mat-icon:not([iconPositionEnd]), [matButtonIcon]:not([iconPositionEnd])", "*", ".material-icons[iconPositionEnd], mat-icon[iconPositionEnd], [matButtonIcon][iconPositionEnd]"], true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatButton, never>;
 }
 
 // @public
+export type MatButtonAppearance = 'text' | 'filled' | 'elevated' | 'outlined';
+
+// @public
 export interface MatButtonConfig {
     color?: ThemePalette;
+    defaultAppearance?: MatButtonAppearance;
     disabledInteractive?: boolean;
 }
 
@@ -71,7 +79,7 @@ export class MatFabButton extends MatButtonBase {
     // (undocumented)
     static ngAcceptInputType_extended: unknown;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<MatFabButton, "button[mat-fab], a[mat-fab]", ["matButton", "matAnchor"], { "extended": { "alias": "extended"; "required": false; }; }, {}, never, [".material-icons:not([iconPositionEnd]), mat-icon:not([iconPositionEnd]), [matButtonIcon]:not([iconPositionEnd])", "*", ".material-icons[iconPositionEnd], mat-icon[iconPositionEnd], [matButtonIcon][iconPositionEnd]"], true, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MatFabButton, "button[mat-fab], a[mat-fab], button[matFab], a[matFab]", ["matButton", "matAnchor"], { "extended": { "alias": "extended"; "required": false; }; }, {}, never, [".material-icons:not([iconPositionEnd]), mat-icon:not([iconPositionEnd]), [matButtonIcon]:not([iconPositionEnd])", "*", ".material-icons[iconPositionEnd], mat-icon[iconPositionEnd], [matButtonIcon][iconPositionEnd]"], true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatFabButton, never>;
 }
@@ -91,7 +99,7 @@ export type MatIconAnchor = MatIconButton;
 export class MatIconButton extends MatButtonBase {
     constructor(...args: unknown[]);
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<MatIconButton, "button[mat-icon-button], a[mat-icon-button]", ["matButton", "matAnchor"], {}, {}, never, ["*"], true, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MatIconButton, "button[mat-icon-button], a[mat-icon-button], button[matIconButton], a[matIconButton]", ["matButton", "matAnchor"], {}, {}, never, ["*"], true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatIconButton, never>;
 }
@@ -108,7 +116,7 @@ export class MatMiniFabButton extends MatButtonBase {
     // (undocumented)
     _isFab: boolean;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<MatMiniFabButton, "button[mat-mini-fab], a[mat-mini-fab]", ["matButton", "matAnchor"], {}, {}, never, [".material-icons:not([iconPositionEnd]), mat-icon:not([iconPositionEnd]), [matButtonIcon]:not([iconPositionEnd])", "*", ".material-icons[iconPositionEnd], mat-icon[iconPositionEnd], [matButtonIcon][iconPositionEnd]"], true, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MatMiniFabButton, "button[mat-mini-fab], a[mat-mini-fab], button[matMiniFab], a[matMiniFab]", ["matButton", "matAnchor"], {}, {}, never, [".material-icons:not([iconPositionEnd]), mat-icon:not([iconPositionEnd]), [matButtonIcon]:not([iconPositionEnd])", "*", ".material-icons[iconPositionEnd], mat-icon[iconPositionEnd], [matButtonIcon][iconPositionEnd]"], true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatMiniFabButton, never>;
 }


### PR DESCRIPTION
Adds the following features to the button:
* Allows the appearance of a button to be set dynamically using the `matButton` input.
* Aligns the terminology with the M3 spec. Currently the names are derived from an old spec.
* Adds the ability to set the default appearance for buttons.
* Adds a `matIconButton` selector to the icon button for consistency.
* Adds a `matFab` selector to the FAB for consistency.
* Adds a `matMiniFab` selector to the mini FAB for consistency.

All of these changes are backwards-compatible and allow us to evolve the button in the future.

BREAKING CHANGE:
* `ButtonVariant` which is returned by `MatButtonHarness.getVariant` no longer includes the appearance of the button. Use `MatButtonHarness.getAppearance` instead.

Fixes #15367.
Fixes #29841.