### PR TITLE
fix(material/select): use flexible overlay dimensions

### DIFF
--- a/src/material/select/select.html
+++ b/src/material/select/select.html
@@ -39,6 +39,7 @@
   [cdkConnectedOverlayOrigin]="_preferredOverlayOrigin || fallbackOverlayOrigin"
   [cdkConnectedOverlayPositions]="_positions"
   [cdkConnectedOverlayWidth]="_overlayWidth"
+  [cdkConnectedOverlayFlexibleDimensions]="true"
   (backdropClick)="close()"
   (overlayKeydown)="_handleOverlayKeydown($event)">
   <div


### PR DESCRIPTION
When the browser window is small, the select's listbox panel does not shrink in size, which causes options to become unreachable.

With flexible positioning, the overlay is constrained in height causing the panel to shrink as well, rendering all available options with scrolling

## Example: Panel displayed underneath the select. 
### Observe that the Milk option was not fully visible when the panel is scrolled all the way down
Before:
![image](https://github.com/user-attachments/assets/4a2b3f29-39ff-4dc1-bacf-ab2c6c0f4d23)
After:
![image](https://github.com/user-attachments/assets/c2d37c2a-be13-49e2-bce2-b144f5ae58e3)

## Example: Panel displayed above the select. 
#### Observe the None option was not at all visible when scrolled up
Before: 
![image](https://github.com/user-attachments/assets/f723ce44-7771-4479-a910-b0fb76800249)
After:
![image](https://github.com/user-attachments/assets/eb84bb49-09a0-4568-845c-2a621870216c)

