### PR TITLE
fix(material/select): close panel on detach output event

### DIFF
--- a/src/material/select/select.html
+++ b/src/material/select/select.html
@@ -40,6 +40,7 @@
   [cdkConnectedOverlayPositions]="_positions"
   [cdkConnectedOverlayWidth]="_overlayWidth"
   [cdkConnectedOverlayFlexibleDimensions]="true"
+  (detach)="close()"
   (backdropClick)="close()"
   (overlayKeydown)="_handleOverlayKeydown($event)">
   <div

--- a/src/material/select/select.spec.ts
+++ b/src/material/select/select.spec.ts
@@ -15,7 +15,7 @@ import {
   TAB,
   UP_ARROW,
 } from '@angular/cdk/keycodes';
-import {OverlayContainer, OverlayModule} from '@angular/cdk/overlay';
+import {CloseScrollStrategy, Overlay, OverlayContainer, OverlayModule} from '@angular/cdk/overlay';
 import {ScrollDispatcher} from '@angular/cdk/scrolling';
 import {
   createKeyboardEvent,
@@ -56,15 +56,15 @@ import {
   ReactiveFormsModule,
   Validators,
 } from '@angular/forms';
-import {ErrorStateMatcher, MatOption, MatOptionSelectionChange} from '../core';
-import {FloatLabelType, MAT_FORM_FIELD_DEFAULT_OPTIONS, MatFormFieldModule} from '../form-field';
-import {MAT_SELECT_CONFIG, MatSelectConfig} from '../select';
 import {By} from '@angular/platform-browser';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {EMPTY, Observable, Subject, Subscription} from 'rxjs';
 import {map} from 'rxjs/operators';
+import {ErrorStateMatcher, MatOption, MatOptionSelectionChange} from '../core';
+import {FloatLabelType, MAT_FORM_FIELD_DEFAULT_OPTIONS, MatFormFieldModule} from '../form-field';
+import {MAT_SELECT_CONFIG, MatSelectConfig} from '../select';
 import {MatSelectModule} from './index';
-import {MatSelect} from './select';
+import {MAT_SELECT_SCROLL_STRATEGY, MatSelect} from './select';
 import {
   getMatSelectDynamicMultipleError,
   getMatSelectNonArrayValueError,
@@ -1781,6 +1781,44 @@ describe('MatSelect', () => {
         expect(selectInstance.focused)
           .withContext('Expected select element to remain focused.')
           .toBe(true);
+      }));
+
+      it('should close the panel on scroll event when MAT_SELECT_SCROLL_STRATEGY token was defined with CloseScrollStrategy', fakeAsync(() => {
+        // Need to recreate the testing module, because the issue we're
+        // testing for only the MAT_SELECT_SCROLL_STRATEGY is defined with thw
+        // is defined with the CloseScrollStrategy
+
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+          imports: [MatFormFieldModule, MatSelectModule],
+          declarations: [BasicSelect],
+          providers: [
+            {
+              provide: MAT_SELECT_SCROLL_STRATEGY,
+              useFactory: (overlay: Overlay) => (): CloseScrollStrategy =>
+                overlay.scrollStrategies.close(),
+              deps: [Overlay],
+            },
+            {
+              provide: ScrollDispatcher,
+              useFactory: () => ({
+                scrolled: () => scrolledSubject,
+              }),
+            },
+          ],
+        });
+
+        fixture = TestBed.createComponent(BasicSelect);
+        fixture.detectChanges();
+
+        const select = fixture.componentInstance.select;
+        select.open();
+
+        scrolledSubject.next();
+        fixture.detectChanges();
+        flush();
+
+        expect(select.panelOpen).toBe(false);
       }));
     });
 


### PR DESCRIPTION
Enable detection of the detach output event on the panel of the mat-select component. This ensures that when CloseScrollStrategy is set via MAT_SELECT_SCROLL_STRATEGY, the panel correctly closes on scroll, updating the panelOpen property to false.

Fixes #30620