### PR TITLE
fix(material-angular-io): streamline directive and component metadata handling in dgeni

### DIFF
--- a/tools/dgeni/common/decorators.ts
+++ b/tools/dgeni/common/decorators.ts
@@ -30,7 +30,11 @@ export function isProperty(doc: MemberDoc): boolean {
 }
 
 export function isDirective(doc: ClassExportDoc): boolean {
-  return hasClassDecorator(doc, 'Component') || hasClassDecorator(doc, 'Directive');
+  return hasClassDecorator(doc, 'Directive');
+}
+
+export function isComponent(doc: ClassExportDoc): boolean {
+  return hasClassDecorator(doc, 'Component');
 }
 
 export function isService(doc: ClassExportDoc): boolean {
@@ -50,12 +54,12 @@ export function isPrimaryExportDoc(doc: ApiDoc): boolean {
   return hasJsDocTag(doc, 'docs-primary-export');
 }
 
-export function getDirectiveSelectors(classDoc: CategorizedClassDoc): string[] | undefined {
-  if (classDoc.directiveMetadata) {
-    const directiveSelectors: string = classDoc.directiveMetadata.get('selector');
+export function getSelectors(classDoc: CategorizedClassDoc): string[] | undefined {
+  if (classDoc.metadata) {
+    const selectors: string = classDoc.metadata.get('selector');
 
-    if (directiveSelectors) {
-      return directiveSelectors
+    if (selectors) {
+      return selectors
         .replace(/[\r\n]/g, '')
         .split(/\s*,\s*/)
         .filter(s => s !== '');

--- a/tools/dgeni/common/dgeni-definitions.ts
+++ b/tools/dgeni/common/dgeni-definitions.ts
@@ -29,12 +29,13 @@ export interface CategorizedClassLikeDoc extends ClassLikeExportDoc, Deprecation
 /** Extended Dgeni class document that includes extracted Angular metadata. */
 export interface CategorizedClassDoc extends ClassExportDoc, CategorizedClassLikeDoc {
   isDirective: boolean;
+  isComponent: boolean;
   isService: boolean;
   isNgModule: boolean;
   isTestHarness: boolean;
-  directiveExportAs?: string | null;
-  directiveSelectors?: string[];
-  directiveMetadata: Map<string, any> | null;
+  exportAs?: string | null;
+  selectors?: string[];
+  metadata: Map<string, any> | null;
   extendedDoc: ClassLikeExportDoc | undefined;
   inheritedDocs: ClassLikeExportDoc[];
 }
@@ -42,10 +43,10 @@ export interface CategorizedClassDoc extends ClassExportDoc, CategorizedClassLik
 /** Extended Dgeni property-member document that includes extracted Angular metadata. */
 export interface CategorizedPropertyMemberDoc extends PropertyMemberDoc, DeprecationInfo {
   description: string;
-  isDirectiveInput: boolean;
-  isDirectiveOutput: boolean;
-  directiveInputAlias: string;
-  directiveOutputAlias: string;
+  isInput: boolean;
+  isOutput: boolean;
+  inputAlias: string;
+  outputAlias: string;
 }
 
 /** Extended Dgeni method-member document that simplifies logic for the Dgeni template. */

--- a/tools/dgeni/common/directive-metadata.ts
+++ b/tools/dgeni/common/directive-metadata.ts
@@ -16,7 +16,7 @@ import {CategorizedClassDoc} from './dgeni-definitions';
  * export class MyComponent {}
  * ```
  */
-export function getDirectiveMetadata(classDoc: CategorizedClassDoc): Map<string, any> | null {
+export function getMetadata(classDoc: CategorizedClassDoc): Map<string, any> | null {
   const declaration = classDoc.symbol.valueDeclaration;
   const decorators =
     declaration && ts.isClassDeclaration(declaration) ? ts.getDecorators(declaration) : null;

--- a/tools/dgeni/common/sort-members.ts
+++ b/tools/dgeni/common/sort-members.ts
@@ -41,17 +41,11 @@ export function sortCategorizedPropertyMembers(
   }
 
   // Sort in the order of: Inputs, Outputs, neither
-  if (
-    (docA.isDirectiveInput && !docB.isDirectiveInput) ||
-    (docA.isDirectiveOutput && !docB.isDirectiveInput && !docB.isDirectiveOutput)
-  ) {
+  if ((docA.isInput && !docB.isInput) || (docA.isOutput && !docB.isInput && !docB.isOutput)) {
     return -1;
   }
 
-  if (
-    (docB.isDirectiveInput && !docA.isDirectiveInput) ||
-    (docB.isDirectiveOutput && !docA.isDirectiveInput && !docA.isDirectiveOutput)
-  ) {
+  if ((docB.isInput && !docA.isInput) || (docB.isOutput && !docA.isInput && !docA.isOutput)) {
     return 1;
   }
 

--- a/tools/dgeni/processors/entry-point-grouper.ts
+++ b/tools/dgeni/processors/entry-point-grouper.ts
@@ -47,6 +47,9 @@ export class EntryPointDoc {
   /** List of categorized class docs that are defining a directive. */
   directives: CategorizedClassDoc[] = [];
 
+  /** List of categorized class docs that are defining a directive. */
+  components: CategorizedClassDoc[] = [];
+
   /** List of categorized class docs that are defining a service. */
   services: CategorizedClassDoc[] = [];
 

--- a/tools/dgeni/templates/class.template.html
+++ b/tools/dgeni/templates/class.template.html
@@ -17,18 +17,27 @@
 <p class="docs-api-class-description">{$ class.description | marked | safe $}</p>
 {%- endif -%}
 
-{%- if class.directiveSelectors -%}
-<p class="docs-api-directive-selectors">
+{%- if class.selectors and class.isComponent -%}
+<p class="docs-api-component-selectors">
   <span class="docs-api-class-selector-label">Selector:</span>
-  {% for selector in class.directiveSelectors %}
+  {% for selector in class.selectors %}
     <span class="docs-api-class-selector-name">{$ selector $}</span>
   {% endfor %}
 </p>
 {%- endif -%}
 
-{%- if class.directiveExportAs -%}
+{%- if class.selectors and class.isDirective -%}
+<p class="docs-api-directive-selectors">
+  <span class="docs-api-class-selector-label">Selector:</span>
+  {% for selector in class.selectors %}
+    <span class="docs-api-class-selector-name">{$ selector $}</span>
+  {% endfor %}
+</p>
+{%- endif -%}
+
+{%- if class.exportAs -%}
 <span class="docs-api-class-export-label">Exported as:</span>
-<span class="docs-api-class-export-name">{$ class.directiveExportAs $}</span>
+<span class="docs-api-class-export-name">{$ class.exportAs $}</span>
 {%- endif -%}
 
 {%- if class.isDeprecated -%}

--- a/tools/dgeni/templates/entry-point.template.html
+++ b/tools/dgeni/templates/entry-point.template.html
@@ -60,6 +60,15 @@
     {% endfor %}
   {%- endif -%}
 
+  {%- if doc.components.length -%}
+    <h3 id="{$ doc.name $}-components" class="docs-header-link docs-api-h3">
+      <span header-link="components"></span>
+      Components
+    </h3>
+    {% for component in doc.components %}
+      {$ class(component) $}
+    {% endfor %}
+  {%- endif -%}
 
   {%- if doc.directives.length -%}
     <h3 id="{$ doc.name $}-directives" class="docs-header-link docs-api-h3">

--- a/tools/dgeni/templates/property.template.html
+++ b/tools/dgeni/templates/property.template.html
@@ -2,19 +2,19 @@
 
 <tr class="docs-api-properties-row">
   <td class="docs-api-properties-name-cell">
-    {%- if property.isDirectiveInput -%}
+    {%- if property.isInput -%}
       <div class="docs-api-input-marker">
-        {%- if property.directiveInputAlias -%}
-        @Input(<span class="docs-api-input-alias">{$ property.directiveInputAlias $}</span>)
+        {%- if property.inputAlias -%}
+        @Input(<span class="docs-api-input-alias">{$ property.inputAlias $}</span>)
         {% else %}
           @Input()
         {%- endif -%}
       </div>
     {%- endif -%}
-    {%- if property.isDirectiveOutput -%}
+    {%- if property.isOutput -%}
       <div class="docs-api-output-marker">
-        {%- if property.directiveOutputAlias -%}
-        @Output(<span class="docs-api-output-alias">{$ property.directiveOutputAlias $}</span>)
+        {%- if property.outputAlias -%}
+        @Output(<span class="docs-api-output-alias">{$ property.outputAlias $}</span>)
         {% else %}
           @Output()
         {%- endif -%}


### PR DESCRIPTION
Currently, docs is not grouped based on Components and Directives. This fix will separate those two sections.

Fixes #24093