### PR TITLE
fix(cdk/overlay): ensure re-exported transitive `Dir` directive can be imported

### DIFF
--- a/integration/module-tests/BUILD.bazel
+++ b/integration/module-tests/BUILD.bazel
@@ -20,6 +20,7 @@ module_test(
         "//src/cdk:npm_package": "src/cdk/npm_package",
         "//src/material:npm_package": "src/material/npm_package",
     },
+    shard_count = 4,
     skipped_entry_points = [
         # This entry-point is JIT and would fail the AOT test.
         "@angular/material/dialog/testing",

--- a/integration/module-tests/index.bzl
+++ b/integration/module-tests/index.bzl
@@ -1,7 +1,7 @@
 load("@aspect_rules_js//js:defs.bzl", "js_test")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 
-def module_test(name, npm_packages, skipped_entry_points = [], additional_deps = []):
+def module_test(name, npm_packages, skipped_entry_points = [], additional_deps = [], **kwargs):
     write_file(
         name = "%s_config" % name,
         out = "%s_config.json" % name,
@@ -21,4 +21,5 @@ def module_test(name, npm_packages, skipped_entry_points = [], additional_deps =
         ] + additional_deps + [pkg[0] for pkg in npm_packages.items()],
         entry_point = ":index.mjs",
         fixed_args = ["$(rootpath :%s_config)" % name],
+        **kwargs
     )

--- a/integration/module-tests/index.mts
+++ b/integration/module-tests/index.mts
@@ -17,27 +17,38 @@ async function main() {
     config.packages.map(pkgPath => findAllEntryPointsAndExportedModules(pkgPath)),
   );
 
-  const exports = packages
+  const allExports = packages
     .map(p => p.moduleExports)
     .flat()
-    .filter(e => !config.skipEntryPoints.includes(e.importPath));
+    .filter(e => !config.skipEntryPoints.includes(e.importPath))
+    .sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)));
 
-  const testFile = `
-    import {NgModule, Component} from '@angular/core';
-    ${exports.map(e => `import {${e.symbolName}} from '${e.importPath}';`).join('\n')}
+  // Distribute the exports based on the current test shard.
+  // Controlled via Bazel's `shard_count` attribute. See:
+  // https://bazel.build/reference/test-encyclopedia#initial-conditions.
+  const testShardIndex =
+    process.env['TEST_SHARD_INDEX'] !== undefined ? Number(process.env['TEST_SHARD_INDEX']) : 0;
+  const testMaxShards =
+    process.env['TEST_TOTAL_SHARDS'] !== undefined ? Number(process.env['TEST_TOTAL_SHARDS']) : 1;
+  const testChunkSize = Math.ceil(allExports.length / testMaxShards);
+  const testChunkStart = testChunkSize * testShardIndex;
+  const shardExports = allExports.slice(testChunkStart, testChunkStart + testChunkSize);
 
-    @NgModule({
-      exports: [
-        ${exports.map(e => e.symbolName).join(', ')}
-      ]
-    })
-    export class TestModule {}
+  const testFiles = shardExports.map(e => ({
+    content: `
+      import {NgModule, Component} from '@angular/core';
+      import {${e.symbolName}} from '${e.importPath}';
 
-    @Component({imports: [TestModule], template: ''})
-    export class TestComponent {}
-  `;
+      @NgModule({
+        exports: [${e.symbolName}]
+      })
+      export class TestModule {}
 
-  await fs.writeFile(path.join(tmpDir, 'test.ts'), testFile);
+      @Component({imports: [TestModule], template: ''})
+      export class TestComponent {}
+  `,
+    path: path.join(tmpDir, `${e.symbolName.toLowerCase()}.ts`),
+  }));
 
   // Prepare node modules to resolve e.g. `@angular/core`
   await fs.symlink(path.resolve('./node_modules'), path.join(tmpDir, 'node_modules'));
@@ -47,26 +58,34 @@ async function main() {
     await fs.symlink(path.resolve(packagePath), `./node_modules/${name}`);
   }
 
-  const result = performCompilation({
-    options: {
-      rootDir: tmpDir,
-      skipLibCheck: true,
-      noEmit: true,
-      module: ts.ModuleKind.ESNext,
-      moduleResolution: ts.ModuleResolutionKind.Bundler,
-      strictTemplates: true,
-      preserveSymlinks: true,
-      strict: true,
-      // Note: HMR is needed as it will disable the Angular compiler's tree-shaking of used
-      // directives/components. This is critical for this test as it allows us to simply all
-      // modules and automatically validate that all symbols are reachable/importable.
-      _enableHmr: true,
-    },
-    rootNames: [path.join(tmpDir, 'test.ts')],
-  });
+  const diagnostics: ts.Diagnostic[] = [];
+
+  for (const testFile of testFiles) {
+    await fs.writeFile(testFile.path, testFile.content);
+
+    const result = performCompilation({
+      options: {
+        rootDir: tmpDir,
+        skipLibCheck: true,
+        noEmit: true,
+        module: ts.ModuleKind.ESNext,
+        moduleResolution: ts.ModuleResolutionKind.Bundler,
+        strictTemplates: true,
+        preserveSymlinks: true,
+        strict: true,
+        // Note: HMR is needed as it will disable the Angular compiler's tree-shaking of used
+        // directives/components. This is critical for this test as it allows us to simply all
+        // modules and automatically validate that all symbols are reachable/importable.
+        _enableHmr: true,
+      },
+      rootNames: [testFile.path],
+    });
+
+    diagnostics.push(...result.diagnostics);
+  }
 
   console.error(
-    ts.formatDiagnosticsWithColorAndContext(result.diagnostics, {
+    ts.formatDiagnosticsWithColorAndContext(diagnostics, {
       getCanonicalFileName: f => f,
       getCurrentDirectory: () => '/',
       getNewLine: () => '\n',
@@ -75,7 +94,7 @@ async function main() {
 
   await fs.rm(tmpDir, {recursive: true, force: true, maxRetries: 2});
 
-  if (result.diagnostics.length > 0) {
+  if (diagnostics.length > 0) {
     process.exitCode = 1;
   }
 }

--- a/src/cdk/overlay/overlay-module.ts
+++ b/src/cdk/overlay/overlay-module.ts
@@ -36,3 +36,4 @@ export {
   CdkVirtualScrollableWindow as ɵɵCdkVirtualScrollableWindow,
   CdkVirtualScrollableElement as ɵɵCdkVirtualScrollableElement,
 } from '../scrolling';
+export {Dir as ɵɵDir} from '../bidi';


### PR DESCRIPTION
This is a follow-up to cb3b0a87a7528aa2f3525f951a021398821df970 which did miss this transitive re-export of the `Dir` directive. The compiler will try the last module import, so even if e.g. `./scrolling` re-exported `Dir` as of the initial commit, the compiler would try importing via `@angular/cdk/overlay`.

This commit fixes this remaining instance, and updates the new testing infrastructure to import/test every module in isolation. The tests didn't notice that issue because the compiler discovered the `Dir` directive/"Reference" already via another import that "worked".

Fixes #30663.