### PR TITLE
fix(material/button): tonal touch target token transgression

### DIFF
--- a/src/material/core/tokens/_density.scss
+++ b/src/material/core/tokens/_density.scss
@@ -40,6 +40,7 @@ $_density-tokens: (
   ),
   (mat, tonal-button): (
     container-height: (40px, 36px, 32px, 28px),
+    touch-target-display: (block, block, none, none),
   ),
   (mdc, outlined-button): (
     container-height: (40px, 36px, 32px, 28px),


### PR DESCRIPTION
Fixes that the `touch-target-display` token wasn't being set properly for the tonal button in M3.