### PR TITLE
fix(material/sort): set cursor on entire clickable area

### DIFF
--- a/src/material/sort/sort-header.scss
+++ b/src/material/sort/sort-header.scss
@@ -2,9 +2,16 @@
 @use '../core/tokens/token-utils';
 @use '../core/focus-indicators/private';
 
+.mat-sort-header {
+  cursor: pointer;
+}
+
+.mat-sort-header-disabled {
+  cursor: default;
+}
+
 .mat-sort-header-container {
   display: flex;
-  cursor: pointer;
   align-items: center;
   letter-spacing: normal;
 
@@ -17,10 +24,6 @@
   [mat-sort-header].cdk-keyboard-focused &,
   [mat-sort-header].cdk-program-focused & {
     border-bottom: solid 1px currentColor;
-  }
-
-  .mat-sort-header-disabled & {
-    cursor: default;
   }
 
   // For the sort-header element, default inset/offset values are necessary to ensure that


### PR DESCRIPTION
Sets the `cursor` on the entire sort header, rather than the inner container, since the whole element is clickable.

Fixes #30690.