### PR TITLE
perf(cdk-experimental/column-resize): add debounce to column header h…

### DIFF
--- a/src/cdk-experimental/column-resize/event-dispatcher.ts
+++ b/src/cdk-experimental/column-resize/event-dispatcher.ts
@@ -8,7 +8,7 @@
 
 import {Injectable, NgZone, inject} from '@angular/core';
 import {combineLatest, MonoTypeOperatorFunction, Observable, Subject} from 'rxjs';
-import {distinctUntilChanged, map, share, skip, startWith} from 'rxjs/operators';
+import {distinctUntilChanged, map, share, skip, startWith, debounceTime} from 'rxjs/operators';
 
 import {_closest} from '../popover-edit';
 
@@ -33,7 +33,11 @@ export class HeaderRowEventDispatcher {
   readonly overlayHandleActiveForCell = new Subject<Element | null>();
 
   /** Distinct and shared version of headerCellHovered. */
-  readonly headerCellHoveredDistinct = this.headerCellHovered.pipe(distinctUntilChanged(), share());
+  readonly headerCellHoveredDistinct = this.headerCellHovered.pipe(
+    distinctUntilChanged(),
+    debounceTime(200),
+    share(),
+  );
 
   /**
    * Emits the header that is currently hovered or hosting an active resize event (with active

--- a/src/material-experimental/column-resize/column-resize.spec.ts
+++ b/src/material-experimental/column-resize/column-resize.spec.ts
@@ -9,7 +9,7 @@ import {
   Injectable,
   ViewChild,
 } from '@angular/core';
-import {ComponentFixture, TestBed, fakeAsync, flush} from '@angular/core/testing';
+import {ComponentFixture, TestBed, fakeAsync, flush, tick} from '@angular/core/testing';
 import {MatTableModule} from '@angular/material/table';
 import {BehaviorSubject, Observable, ReplaySubject} from 'rxjs';
 import {dispatchKeyboardEvent} from '../../cdk/testing/private';
@@ -401,6 +401,7 @@ describe('Material Popover Edit', () => {
 
         component.triggerHoverState();
         fixture.detectChanges();
+        tick(200);
 
         expect(
           component.getOverlayThumbElement(0).classList.contains('mat-column-resize-overlay-thumb'),
@@ -438,6 +439,7 @@ describe('Material Popover Edit', () => {
         component.completeResizeWithMouseInProgress(0);
         component.endHoverState();
         fixture.detectChanges();
+        tick(200);
         flush();
 
         expect(component.getOverlayThumbElement(0)).toBeUndefined();
@@ -451,6 +453,7 @@ describe('Material Popover Edit', () => {
 
         component.triggerHoverState();
         fixture.detectChanges();
+        tick(200);
         component.beginColumnResizeWithMouse(1);
 
         const initialThumbPosition = component.getOverlayThumbPosition(1);
@@ -500,6 +503,7 @@ describe('Material Popover Edit', () => {
 
         component.triggerHoverState();
         fixture.detectChanges();
+        tick(200);
         component.beginColumnResizeWithMouse(1);
 
         const initialThumbPosition = component.getOverlayThumbPosition(1);
@@ -535,6 +539,7 @@ describe('Material Popover Edit', () => {
 
         component.triggerHoverState();
         fixture.detectChanges();
+        tick(200);
         component.beginColumnResizeWithMouse(1, 2);
 
         const initialPosition = component.getOverlayThumbPosition(1);
@@ -552,6 +557,7 @@ describe('Material Popover Edit', () => {
 
         component.triggerHoverState();
         fixture.detectChanges();
+        tick(200);
         component.beginColumnResizeWithMouse(1);
 
         const initialThumbPosition = component.getOverlayThumbPosition(1);
@@ -589,6 +595,7 @@ describe('Material Popover Edit', () => {
 
         component.triggerHoverState();
         fixture.detectChanges();
+        tick(200);
 
         expect(resize).toBe(null);
 
@@ -610,6 +617,7 @@ describe('Material Popover Edit', () => {
 
         component.triggerHoverState();
         fixture.detectChanges();
+        tick(200);
         component.beginColumnResizeWithMouse(0);
 
         component.updateResizeWithMouseInProgress(5);
@@ -674,6 +682,7 @@ describe('Material Popover Edit', () => {
 
       component.triggerHoverState();
       fixture.detectChanges();
+      tick(200);
 
       component.resizeColumnWithMouse(1, 5);
       fixture.detectChanges();
@@ -699,6 +708,7 @@ describe('Material Popover Edit', () => {
 
       component.triggerHoverState();
       fixture.detectChanges();
+      tick(200);
 
       component.resizeColumnWithMouse(1, 5);
       fixture.detectChanges();


### PR DESCRIPTION
…over to prevent excessive handler rendering

This PR improves the user experience and performance of the `cdk-experimental` column resize feature by adding a `debounceTime` operator to the `headerCellHoveredDistinct` observable. Previously, the hover event triggered the handler immediately, which could result in unwanted handlers showing up when the user quickly moved their cursor over column headers. This change ensures that the handlers only appear if the user pauses (hovers for 300ms) over the column header, preventing handlers from rendering during fast cursor movements.

### Why this change is suggested:
The previous implementation immediately triggered the column resize handlers as soon as the user hovered over the column header, which could be distracting or lead to unnecessary renders when the user quickly moves the cursor across the page. By adding a `debounceTime(300)`, we ensure that the hover event only triggers the handler after the user has paused over the column header for at least 300ms, reducing the number of handler renders and making the interaction feel smoother.

This change prevents the handlers from appearing if the user is simply passing by the headers or trying to reach another element, improving the overall experience, especially when navigating fast through the UI.

### Changes:
- Added `debounceTime(300)` to the `headerCellHoveredDistinct` observable to delay the rendering of handlers until the user has hovered over the header for 300ms.