### PR TITLE
feat(cdk/drag-drop): support immediate drag with preview snapped to cursor on mousedown

### DIFF
--- a/src/cdk/drag-drop/directives/drag-preview.ts
+++ b/src/cdk/drag-drop/directives/drag-preview.ts
@@ -43,6 +43,9 @@ export class CdkDragPreview<T = any> implements OnDestroy {
   /** Whether the preview should preserve the same size as the item that is being dragged. */
   @Input({transform: booleanAttribute}) matchSize: boolean = false;
 
+  /** Whether the preview should snap the starting position centered under the cursor. */
+  @Input({transform: booleanAttribute}) snapToCursor: boolean = false;
+
   constructor(...args: unknown[]);
 
   constructor() {

--- a/src/cdk/drag-drop/directives/drag.ts
+++ b/src/cdk/drag-drop/directives/drag.ts
@@ -437,6 +437,7 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
               template: this._previewTemplate.templateRef,
               context: this._previewTemplate.data,
               matchSize: this._previewTemplate.matchSize,
+              snapToCursor: this._previewTemplate.snapToCursor,
               viewContainer: this._viewContainerRef,
             }
           : null;

--- a/src/cdk/drag-drop/drag-ref.ts
+++ b/src/cdk/drag-drop/drag-ref.ts
@@ -981,7 +981,7 @@ export class DragRef<T = any> {
 
     // when pixel threshold = 0 and dragStartDelay = 0 and a preview container/position exists we immediately drag
     if (
-      event.type == 'mousedown' &&
+      (event.type == 'mousedown' || event.type == 'touchstart') &&
       previewTemplate &&
       this._config.dragStartThreshold === 0 &&
       this._getDragStartDelay(event) === 0

--- a/src/cdk/drag-drop/preview-ref.ts
+++ b/src/cdk/drag-drop/preview-ref.ts
@@ -21,6 +21,7 @@ import {getTransformTransitionDurationInMs} from './dom/transition-duration';
 /** Template that can be used to create a drag preview element. */
 export interface DragPreviewTemplate<T = any> {
   matchSize?: boolean;
+  snapToCursor?: boolean;
   template: TemplateRef<T> | null;
   viewContainer: ViewContainerRef;
   context: T;


### PR DESCRIPTION
The existing implementation of the CDK drag-drop is restricted such that there is no workaround for situations where the drag object should be snapped to the cursor. 

1. Even when dragStartDelay = 0 and dragStartThreshold = 0 (indicating no mouse movement is required to start) the existing implementation will not start actually dragging (and rendering preview) until after movement by >= 1px.
2. There is no existing way to center the preview under the cursor b/c of hardcoded translate3d( ) calls with pre-computed offsets designed fix preview location to an offset position to start the Preview display in the position of the dragging element.
3. Using cdkDragConstrainPosition does not retain the dragEntered/dragExited behavior of the existing droplist and so is unusable for these purposes as well.


For an example use case:

Consider the chess-boards that are present on Lichess/Chess.com -- clicking on a chess piece to drag immediately snaps the piece centered on the cursor immediately after the mouse is pressed. Waiting until the mouse is moved 1px is problematic for speed, for visible immediate visible selection, and for accuracy based on touch/mouse movement for high-speed games. 

This PR is simple - it introduces a new input snapToCursor that places the preview directly in the center of the cursor and hooks 'mousedown' event in to immediate trigger an initial drag state when dragStartDelay = 0 and dragStartThreshold = 0 & a preview is available.

Thanks for your support

