### PR TITLE
docs: fix incorrect guide links after recent collision change

### DIFF
--- a/material.angular.io/src/app/shared/documentation-items/documentation-items.ts
+++ b/material.angular.io/src/app/shared/documentation-items/documentation-items.ts
@@ -269,7 +269,7 @@ const DOCS: {[key: string]: DocItem[]} = {
     {
       id: 'ripple',
       name: 'Ripples',
-      overviewPath: 'material/core/ripple/ripple.html',
+      overviewPath: 'material/core/ripple/ripple.md.html',
       summary: 'Directive for adding Material Design ripple effects',
       hasStyling: false, // Ripple styling is documented through `core`.
       exampleSpecs: {
@@ -545,7 +545,7 @@ const DOCS: {[key: string]: DocItem[]} = {
       exampleSpecs: {
         prefix: 'cdk-test-harnesses-',
       },
-      overviewPath: 'cdk/testing/test-harnesses.html',
+      overviewPath: 'cdk/testing/test-harnesses.md.html',
       apiDocId: 'cdk-testing',
       additionalApiDocs: [
         {

--- a/material.angular.io/src/app/shared/guide-items/guide-items.ts
+++ b/material.angular.io/src/app/shared/guide-items/guide-items.ts
@@ -13,19 +13,19 @@ const GUIDES: GuideItem[] = [
   {
     id: 'getting-started',
     name: 'Getting started',
-    document: '/docs-content/guides/getting-started.html',
+    document: '/docs-content/guides/getting-started.md.html',
     overview: 'Add Angular Material to your project!',
   },
   {
     id: 'schematics',
     name: 'Schematics',
-    document: '/docs-content/guides/schematics.html',
+    document: '/docs-content/guides/schematics.md.html',
     overview: 'Use schematics to quickly generate views with Material Design components.',
   },
   {
     id: 'theming',
     name: 'Theming Angular Material',
-    document: '/docs-content/guides/theming.html',
+    document: '/docs-content/guides/theming.md.html',
     overview: "Customize your application with Angular Material's theming system.",
   },
   {
@@ -37,25 +37,25 @@ const GUIDES: GuideItem[] = [
   {
     id: 'creating-a-custom-form-field-control',
     name: 'Custom form field control',
-    document: '/docs-content/guides/creating-a-custom-form-field-control.html',
+    document: '/docs-content/guides/creating-a-custom-form-field-control.md.html',
     overview: 'Build a custom control that integrates with `<mat-form-field>`.',
   },
   {
     id: 'creating-a-custom-stepper-using-the-cdk-stepper',
     name: 'Custom stepper using the CdkStepper',
-    document: '/docs-content/guides/creating-a-custom-stepper-using-the-cdk-stepper.html',
+    document: '/docs-content/guides/creating-a-custom-stepper-using-the-cdk-stepper.md.html',
     overview: 'Create a custom stepper components using Angular CDK.',
   },
   {
     id: 'using-component-harnesses',
     name: 'Testing with component harnesses',
-    document: '/docs-content/guides/using-component-harnesses.html',
+    document: '/docs-content/guides/using-component-harnesses.md.html',
     overview: 'Write tests with component harnesses for convenience and meaningful results.',
   },
   {
     id: 'material-2-theming',
     name: 'Theming Angular Material with Material 2',
-    document: '/docs-content/guides/material-2.html',
+    document: '/docs-content/guides/material-2.md.html',
     overview: "Customize your application with Angular Material's theming system.",
   },
 ];


### PR DESCRIPTION
We recently updated some of the filenames to avoid collisions. This commit fixes the rendering in the doc site. We already did this initially with the overviews; but guides apparently are handled separately.

We should explore why no tests fail here.
