### PR TITLE
fix(material/snack-bar): rename snackbar token prefix

### DIFF
--- a/material.angular.io/scenes/src/app/scenes/snack-bar/snack-bar-scene.scss
+++ b/material.angular.io/scenes/src/app/scenes/snack-bar/snack-bar-scene.scss
@@ -2,7 +2,7 @@
 // within the scene bounds.
 .mat-mdc-snack-bar-container {
   margin: 8px !important;
-  --mat-snackbar-container-color: red;
+  --mat-snack-bar-container-color: red;
   color: rgba(white, 0.87) !important;
 
   button {

--- a/src/material/core/tokens/_density.scss
+++ b/src/material/core/tokens/_density.scss
@@ -104,7 +104,6 @@ $_density-tokens: (
     (mat, slide-toggle): (),
     (mat, slider): (),
     (mat, snack-bar): (),
-    (mat, snackbar): (),
     (mat, sort): (),
     (mat, standard-button-toggle): (
       height: (40px, 40px, 40px, 36px, 24px),

--- a/src/material/core/tokens/m2/mdc/_snack-bar.scss
+++ b/src/material/core/tokens/m2/mdc/_snack-bar.scss
@@ -5,7 +5,7 @@
 @use '../../../style/sass-utils';
 
 // The prefix used to generate the fully qualified name for tokens in this file.
-$prefix: (mat, snackbar);
+$prefix: (mat, snack-bar);
 
 // Tokens that can't be configured through Angular Material's current theming API,
 // but may be in a future version of the theming API.

--- a/src/material/core/tokens/m3/mdc/_snack-bar.scss
+++ b/src/material/core/tokens/m3/mdc/_snack-bar.scss
@@ -2,7 +2,7 @@
 @use 'sass:map';
 
 // The prefix used to generate the fully qualified name for tokens in this file.
-$prefix: (mat, snackbar);
+$prefix: (mat, snack-bar);
 
 /// Generates the tokens for MDC snackbar
 /// @param {Map} $systems The MDC system tokens


### PR DESCRIPTION
BREAKING CHANGE:
- Some CSS variables are renamed from "--mat-snackbar-" to "--mat-snack-bar", aligning with the rest of snack bar tokens