### PR TITLE
fix(cdk/overlay): scroll was blocked when zoomed out even if scrolling wasn't an option

### DIFF
--- a/src/cdk/overlay/scroll/block-scroll-strategy.spec.ts
+++ b/src/cdk/overlay/scroll/block-scroll-strategy.spec.ts
@@ -157,6 +157,57 @@ describe('BlockScrollStrategy', () => {
     }),
   );
 
+  it(
+    `should't do anything if the page isn't scrollable while zoomed out`,
+    skipIOS(() => {
+      if (platform.FIREFOX) {
+        // style.zoom is only supported from Firefox 126
+        return;
+      }
+
+      forceScrollElement.style.display = 'none';
+      document.body.style.zoom = '75%';
+      overlayRef.attach(componentPortal);
+      expect(document.body.scrollWidth).toBeGreaterThan(window.innerWidth);
+      expect(documentElement.classList).not.toContain('cdk-global-scrollblock');
+      overlayRef.detach();
+      document.body.style.zoom = '100%';
+
+      document.documentElement.style.zoom = '75%';
+      overlayRef.attach(componentPortal);
+      expect(document.body.scrollWidth).toBeGreaterThan(window.innerWidth);
+      expect(documentElement.classList).not.toContain('cdk-global-scrollblock');
+      document.documentElement.style.zoom = '100%';
+    }),
+  );
+
+  it(
+    `should add cdk-global-scrollblock while zoomed in`,
+    skipIOS(() => {
+      if (platform.FIREFOX) {
+        // style.zoom is only supported from Firefox 126
+        return;
+      }
+
+      forceScrollElement.style.width = window.innerWidth - 20 + 'px';
+      forceScrollElement.style.height = window.innerHeight - 20 + 'px';
+      overlayRef.attach(componentPortal);
+      expect(documentElement.classList).not.toContain('cdk-global-scrollblock');
+      overlayRef.detach();
+
+      document.body.style.zoom = '200%';
+      overlayRef.attach(componentPortal);
+      expect(documentElement.classList).toContain('cdk-global-scrollblock');
+      document.body.style.zoom = '100%';
+      overlayRef.detach();
+
+      document.documentElement.style.zoom = '200%';
+      overlayRef.attach(componentPortal);
+      expect(documentElement.classList).toContain('cdk-global-scrollblock');
+      document.documentElement.style.zoom = '100%';
+    }),
+  );
+
   it('should keep the content width', () => {
     forceScrollElement.style.width = '100px';
 

--- a/src/cdk/overlay/scroll/block-scroll-strategy.ts
+++ b/src/cdk/overlay/scroll/block-scroll-strategy.ts
@@ -96,8 +96,8 @@ export class BlockScrollStrategy implements ScrollStrategy {
       return false;
     }
 
-    const body = this._document.body;
+    const rootElement = this._document.documentElement;
     const viewport = this._viewportRuler.getViewportSize();
-    return body.scrollHeight > viewport.height || body.scrollWidth > viewport.width;
+    return rootElement.scrollHeight > viewport.height || rootElement.scrollWidth > viewport.width;
   }
 }


### PR DESCRIPTION
Fixes that an unnecessary disabled scroll bar was added when zoomed out during opening dialogs.

Fixes #25054.

When you zoom out using the browser (not the style.zoom css), dimensions can become non-whole numbers. window.innerHeight/innerWidth uses Math.floor to round these dimensions, while body.scrollHeight/scrollWidth uses Math.round (at least that's what I assume), so in case you zoom out and your browser shows that your width is 1000.66px for example, the previous implementation returned false positives if there were no scroll bars, as the scrollWidth was 1001px while innerWidth was only 1000.

Another thing I've ran into is using the style.zoom css api, while the innerHeight and innerWidth remains unchanged during zoom, [working as intended](https://issues.chromium.org/issues/335337924) body.scrollWidth can outgrow window.innerWidth without a scroll bar appearing (easily testable with the Google home page).

Relying on the root documentElement's scrollWidth and scrollHeight seems to fix both cases.