### PR TITLE
fix(cdk-experimental/listbox): initial listbox focus state

### DIFF
--- a/src/cdk-experimental/listbox/listbox.ts
+++ b/src/cdk-experimental/listbox/listbox.ts
@@ -111,14 +111,14 @@ export class CdkListbox<V> implements AfterViewInit {
   });
 
   /** Whether the listbox has received focus yet. */
-  private _touched = signal(false);
+  private _hasFocused = signal(false);
 
   /** Whether the options in the listbox have been initialized. */
   private _isViewInitialized = signal(false);
 
   constructor() {
     effect(() => {
-      if (this._isViewInitialized() && !this._touched()) {
+      if (this._isViewInitialized() && !this._hasFocused()) {
         this.pattern.setDefaultState();
       }
     });
@@ -129,7 +129,7 @@ export class CdkListbox<V> implements AfterViewInit {
   }
 
   onFocus() {
-    this._touched.set(true);
+    this._hasFocused.set(true);
   }
 }
 

--- a/src/cdk-experimental/ui-patterns/behaviors/list-focus/list-focus.ts
+++ b/src/cdk-experimental/ui-patterns/behaviors/list-focus/list-focus.ts
@@ -75,7 +75,7 @@ export class ListFocus<T extends ListFocusItem> {
 
   /** Returns the tabindex for the given item. */
   getItemTabindex(item: T): -1 | 0 {
-    if (this.inputs.disabled()) {
+    if (this.isListDisabled()) {
       return -1;
     }
     if (this.inputs.focusMode() === 'activedescendant') {

--- a/src/cdk-experimental/ui-patterns/listbox/listbox.ts
+++ b/src/cdk-experimental/ui-patterns/listbox/listbox.ts
@@ -282,6 +282,36 @@ export class ListboxPattern<V> {
   }
 
   /**
+   * Sets the listbox to it's default initial state.
+   *
+   * Sets the active index of the listbox to the first focusable selected
+   * item if one exists. Otherwise, sets focus to the first focusable item.
+   *
+   * This method should be called once the listbox and it's options are properly initialized,
+   * meaning the ListboxPattern and OptionPatterns should have references to each other before this
+   * is called.
+   */
+  setDefaultState() {
+    let firstItem: OptionPattern<V> | null = null;
+
+    for (const item of this.inputs.items()) {
+      if (this.focusManager.isFocusable(item)) {
+        if (!firstItem) {
+          firstItem = item;
+        }
+        if (item.selected()) {
+          this.inputs.activeIndex.set(item.index());
+          return;
+        }
+      }
+    }
+
+    if (firstItem) {
+      this.inputs.activeIndex.set(firstItem.index());
+    }
+  }
+
+  /**
    * Safely performs a navigation operation.
    *
    * Handles conditionally disabling wrapping for when a navigation

--- a/src/components-examples/cdk-experimental/listbox/cdk-listbox/cdk-listbox-example.html
+++ b/src/components-examples/cdk-experimental/listbox/cdk-listbox/cdk-listbox-example.html
@@ -6,6 +6,15 @@
   <mat-checkbox [formControl]="skipDisabled">Skip Disabled</mat-checkbox>
 
   <mat-form-field subscriptSizing="dynamic" appearance="outline">
+    <mat-label>Selection</mat-label>
+    <mat-select [(value)]="selection" multiple>
+      @for (fruit of fruits; track fruit) {
+        <mat-option [value]="fruit">{{fruit}}</mat-option>
+      }
+    </mat-select>
+  </mat-form-field>
+
+  <mat-form-field subscriptSizing="dynamic" appearance="outline">
     <mat-label>Disabled Options</mat-label>
     <mat-select [(value)]="disabledOptions" multiple>
       @for (fruit of fruits; track fruit) {
@@ -42,6 +51,7 @@
 <!-- #docregion listbox -->
 <ul
   cdkListbox
+  [value]="selection"
   [wrap]="wrap.value"
   [multi]="multi.value"
   [readonly]="readonly.value"

--- a/src/components-examples/cdk-experimental/listbox/cdk-listbox/cdk-listbox-example.ts
+++ b/src/components-examples/cdk-experimental/listbox/cdk-listbox/cdk-listbox-example.ts
@@ -27,6 +27,7 @@ export class CdkListboxExample {
   focusMode: 'roving' | 'activedescendant' = 'roving';
   selectionMode: 'explicit' | 'follow' = 'explicit';
 
+  selection: string[] = ['Banana', 'Blackberry'];
   disabledOptions: string[] = ['Banana', 'Cantaloupe'];
 
   wrap = new FormControl(true, {nonNullable: true});


### PR DESCRIPTION
* The first option to receive focus in a listbox should be either the first selected option or the first option in the list if no option is selected.