### PR TITLE
docs(material/chips-form-control): fix aria-label binding of chips-form-control-example

### DIFF
--- a/src/components-examples/material/chips/chips-form-control/chips-form-control-example.html
+++ b/src/components-examples/material/chips/chips-form-control/chips-form-control-example.html
@@ -11,7 +11,7 @@
     @for (keyword of keywords(); track keyword) {
       <mat-chip-row (removed)="removeKeyword(keyword)">
         {{keyword}}
-        <button matChipRemove aria-label="'remove ' + keyword">
+        <button matChipRemove [attr.aria-label]="'remove ' + keyword">
           <mat-icon>cancel</mat-icon>
         </button>
       </mat-chip-row>


### PR DESCRIPTION
Fixes the aria-label binding of the remove keyword button in chips-form-control-example html. The aria-label used string concatenation with an attribute instead of a property binding.