### PR TITLE
docs(material/chips): fix aria label binding for reactive and template driven form

### DIFF
--- a/src/components-examples/material/chips/chips-reactive-form/chips-reactive-form-example.html
+++ b/src/components-examples/material/chips/chips-reactive-form/chips-reactive-form-example.html
@@ -6,7 +6,7 @@
     @for (keyword of reactiveKeywords(); track keyword) {
       <mat-chip-row (removed)="removeReactiveKeyword(keyword)">
         {{keyword}}
-      <button matChipRemove aria-label="'remove reactive form' + keyword">
+      <button matChipRemove [attr.aria-label]="'remove reactive form' + keyword">
         <mat-icon>cancel</mat-icon>
       </button>
       </mat-chip-row>

--- a/src/components-examples/material/chips/chips-template-form/chips-template-form-example.html
+++ b/src/components-examples/material/chips/chips-template-form/chips-template-form-example.html
@@ -6,7 +6,7 @@
     @for (keyword of templateKeywords(); track keyword) {
       <mat-chip-row (removed)="removeTemplateKeyword(keyword)">
         {{keyword}}
-      <button matChipRemove aria-label="'remove template form' + keyword">
+      <button matChipRemove [attr.aria-label]="'remove template form' + keyword">
         <mat-icon>cancel</mat-icon>
       </button>
       </mat-chip-row>


### PR DESCRIPTION
Fixes the aria-label binding of the remove keyword button in chips reative and template driven form. The aria-label used string concatenation with an attribute instead of a property binding.