### PR TITLE
fix(cdk/scrolling): use capturing for scroll event

### DIFF
--- a/src/cdk/scrolling/scroll-dispatcher.spec.ts
+++ b/src/cdk/scrolling/scroll-dispatcher.spec.ts
@@ -9,6 +9,7 @@ import {
 import {Component, ViewChild, ElementRef} from '@angular/core';
 import {CdkScrollable, ScrollDispatcher, ScrollingModule} from './public-api';
 import {dispatchFakeEvent} from '../testing/private';
+import {filter} from 'rxjs/operators';
 
 describe('ScrollDispatcher', () => {
   beforeEach(waitForAsync(() => {
@@ -106,7 +107,10 @@ describe('ScrollDispatcher', () => {
     it('should not register the same scrollable twice', () => {
       const scrollable = fixture.componentInstance.scrollable;
       const scrollSpy = jasmine.createSpy('scroll spy');
-      const scrollSubscription = scroll.scrolled(0).subscribe(scrollSpy);
+      const scrollSubscription = scroll
+        .scrolled(0)
+        .pipe(filter(target => target === scrollable))
+        .subscribe(scrollSpy);
 
       expect(scroll.scrollContainers.has(scrollable)).toBe(true);
 
@@ -118,6 +122,18 @@ describe('ScrollDispatcher', () => {
 
       expect(scrollSpy).not.toHaveBeenCalled();
       scrollSubscription.unsubscribe();
+    });
+
+    it('should register a capturing scroll event on the document', () => {
+      const spy = spyOn(document, 'addEventListener').and.callThrough();
+      const subscription = scroll.scrolled(0).subscribe();
+
+      expect(spy).toHaveBeenCalledWith(
+        'scroll',
+        jasmine.any(Function),
+        jasmine.objectContaining({capture: true}),
+      );
+      subscription.unsubscribe();
     });
   });
 


### PR DESCRIPTION
Historically we have asked users to indicate their scrollable regions with `CdkScrollable` so that we don't over-subscribe to scroll events, however the downside is that it's very easy to forget to add it or to misspell the name. This becomes an even larger issue with standalone, because users also have to import `CdkScrollable`. As a result, we've had lots of issue reports related to scrolling in the past, the most recent being https://github.com/angular/components/issues/30586#issuecomment-2706211575.

These changes switch to using a root capturing event on the `body` instead which will notify us of all scroll events automatically and will remove the need for users to set `cdkScrollable` in most cases.