### PR TITLE
docs: release notes for the v19.2.9 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+<a name="19.2.9"></a>
+# 19.2.9 "abellaite-apron" (2025-04-09)
+### cdk
+| Commit | Type | Description |
+| -- | -- | -- |
+| [111b0c65a](https://github.com/angular/components/commit/111b0c65a26e4fe0f7db41a00f53ba20105aa888) | fix | **table:** error if data is accessed too early ([#30817](https://github.com/angular/components/pull/30817)) |
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="20.0.0-next.5"></a>
 # 20.0.0-next.5 "chitin-enigma" (2025-04-02)
 ### cdk


### PR DESCRIPTION
Cherry-picks the changelog from the "19.2.x" branch to the next branch (main).