### PR TITLE
fix(material/core): include density tokens in system theme

### DIFF
--- a/src/material/core/tokens/_m3-system.scss
+++ b/src/material/core/tokens/_m3-system.scss
@@ -298,6 +298,7 @@
 
   @return sass-utils.deep-merge-all(
       m3-tokens.generate-tokens($app-vars, true, true),
+      get-density-tokens(0),
   );
 }
 


### PR DESCRIPTION
This ensures component styles have a system fallback for density values