### PR TITLE
test(multiple): remove noop module from tests

### DIFF
--- a/src/cdk/text-field/autosize.spec.ts
+++ b/src/cdk/text-field/autosize.spec.ts
@@ -9,7 +9,6 @@ import {
 } from '@angular/core/testing';
 import {FormsModule} from '@angular/forms';
 import {By} from '@angular/platform-browser';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {dispatchFakeEvent} from '../testing/private';
 import {CdkTextareaAutosize} from './autosize';
 import {TextFieldModule} from './text-field-module';
@@ -24,7 +23,6 @@ describe('CdkTextareaAutosize', () => {
       imports: [
         FormsModule,
         TextFieldModule,
-        NoopAnimationsModule,
         AutosizeTextAreaWithContent,
         AutosizeTextAreaWithValue,
         AutosizeTextareaWithNgModel,

--- a/src/material/autocomplete/autocomplete.spec.ts
+++ b/src/material/autocomplete/autocomplete.spec.ts
@@ -35,10 +35,9 @@ import {
 } from '@angular/core/testing';
 import {FormControl, FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {By} from '@angular/platform-browser';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {EMPTY, Observable, Subject, Subscription} from 'rxjs';
 import {map, startWith} from 'rxjs/operators';
-import {MatOption, MatOptionSelectionChange} from '../core';
+import {MATERIAL_ANIMATIONS, MatOption, MatOptionSelectionChange} from '../core';
 import {MatFormField, MatFormFieldModule} from '../form-field';
 import {MatInputModule} from '../input';
 import {
@@ -65,10 +64,12 @@ describe('MatAutocomplete', () => {
         MatInputModule,
         FormsModule,
         ReactiveFormsModule,
-        NoopAnimationsModule,
         OverlayModule,
       ],
-      providers,
+      providers: [
+        ...providers,
+        {provide: MATERIAL_ANIMATIONS, useValue: {animationsDisabled: true}},
+      ],
       declarations: [component],
     });
 

--- a/src/material/autocomplete/autocomplete.zone.spec.ts
+++ b/src/material/autocomplete/autocomplete.zone.spec.ts
@@ -13,9 +13,8 @@ import {
 } from '@angular/core';
 import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 import {FormControl, FormsModule, ReactiveFormsModule} from '@angular/forms';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {Subscription} from 'rxjs';
-import {MatOption} from '../core';
+import {MATERIAL_ANIMATIONS, MatOption} from '../core';
 import {MatFormField, MatFormFieldModule} from '../form-field';
 import {MatInputModule} from '../input';
 import {MatAutocomplete} from './autocomplete';
@@ -32,10 +31,13 @@ describe('MatAutocomplete Zone.js integration', () => {
         MatInputModule,
         FormsModule,
         ReactiveFormsModule,
-        NoopAnimationsModule,
         OverlayModule,
       ],
-      providers: [provideZoneChangeDetection(), ...providers],
+      providers: [
+        provideZoneChangeDetection(),
+        ...providers,
+        {provide: MATERIAL_ANIMATIONS, useValue: {animationsDisabled: true}},
+      ],
       declarations: [component],
     });
 

--- a/src/material/autocomplete/testing/autocomplete-harness.spec.ts
+++ b/src/material/autocomplete/testing/autocomplete-harness.spec.ts
@@ -2,7 +2,6 @@ import {Component} from '@angular/core';
 import {MatAutocompleteModule} from '../module';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatAutocompleteHarness} from './autocomplete-harness';
 
@@ -11,10 +10,6 @@ describe('MatAutocompleteHarness', () => {
   let loader: HarnessLoader;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [NoopAnimationsModule, MatAutocompleteModule, AutocompleteHarnessTest],
-    });
-
     fixture = TestBed.createComponent(AutocompleteHarnessTest);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.loader(fixture);

--- a/src/material/bottom-sheet/bottom-sheet.spec.ts
+++ b/src/material/bottom-sheet/bottom-sheet.spec.ts
@@ -30,12 +30,12 @@ import {
   tick,
 } from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 
 import {MAT_BOTTOM_SHEET_DEFAULT_OPTIONS, MatBottomSheet} from './bottom-sheet';
 import {MAT_BOTTOM_SHEET_DATA, MatBottomSheetConfig} from './bottom-sheet-config';
 import {MatBottomSheetModule} from './bottom-sheet-module';
 import {MatBottomSheetRef} from './bottom-sheet-ref';
+import {MATERIAL_ANIMATIONS} from '../core';
 
 describe('MatBottomSheet', () => {
   let bottomSheet: MatBottomSheet;
@@ -50,7 +50,6 @@ describe('MatBottomSheet', () => {
     TestBed.configureTestingModule({
       imports: [
         MatBottomSheetModule,
-        NoopAnimationsModule,
         ComponentWithChildViewContainer,
         ComponentWithTemplateRef,
         ContentElementDialog,
@@ -60,7 +59,10 @@ describe('MatBottomSheet', () => {
         BottomSheetWithInjectedData,
         ShadowDomComponent,
       ],
-      providers: [{provide: Location, useClass: SpyLocation}],
+      providers: [
+        {provide: Location, useClass: SpyLocation},
+        {provide: MATERIAL_ANIMATIONS, useValue: {animationsDisabled: true}},
+      ],
     });
 
     bottomSheet = TestBed.inject(MatBottomSheet);
@@ -877,7 +879,8 @@ describe('MatBottomSheet with parent MatBottomSheet', () => {
 
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
-      imports: [MatBottomSheetModule, NoopAnimationsModule, ComponentThatProvidesMatBottomSheet],
+      imports: [MatBottomSheetModule, ComponentThatProvidesMatBottomSheet],
+      providers: [{provide: MATERIAL_ANIMATIONS, useValue: {animationsDisabled: true}}],
     });
 
     parentBottomSheet = TestBed.inject(MatBottomSheet);
@@ -957,13 +960,11 @@ describe('MatBottomSheet with default options', () => {
     };
 
     TestBed.configureTestingModule({
-      imports: [
-        MatBottomSheetModule,
-        NoopAnimationsModule,
-        ComponentWithChildViewContainer,
-        DirectiveWithViewContainer,
+      imports: [MatBottomSheetModule, ComponentWithChildViewContainer, DirectiveWithViewContainer],
+      providers: [
+        {provide: MAT_BOTTOM_SHEET_DEFAULT_OPTIONS, useValue: defaultConfig},
+        {provide: MATERIAL_ANIMATIONS, useValue: {animationsDisabled: true}},
       ],
-      providers: [{provide: MAT_BOTTOM_SHEET_DEFAULT_OPTIONS, useValue: defaultConfig}],
     });
 
     bottomSheet = TestBed.inject(MatBottomSheet);

--- a/src/material/bottom-sheet/testing/bottom-sheet-harness.spec.ts
+++ b/src/material/bottom-sheet/testing/bottom-sheet-harness.spec.ts
@@ -3,7 +3,6 @@ import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatBottomSheet, MatBottomSheetConfig, MatBottomSheetModule} from '../../bottom-sheet';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {MatBottomSheetHarness} from './bottom-sheet-harness';
 
 describe('MatBottomSheetHarness', () => {
@@ -11,10 +10,6 @@ describe('MatBottomSheetHarness', () => {
   let loader: HarnessLoader;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [MatBottomSheetModule, NoopAnimationsModule, BottomSheetHarnessTest],
-    });
-
     fixture = TestBed.createComponent(BottomSheetHarnessTest);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.documentRootLoader(fixture);

--- a/src/material/chips/chip-grid.spec.ts
+++ b/src/material/chips/chip-grid.spec.ts
@@ -38,6 +38,7 @@ import {MatFormFieldModule} from '../form-field';
 import {MatInputModule} from '../input';
 import {By} from '@angular/platform-browser';
 import {MatChipEvent, MatChipGrid, MatChipInputEvent, MatChipRow, MatChipsModule} from './index';
+import {MATERIAL_ANIMATIONS} from '../core';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 
 describe('MatChipGrid', () => {
@@ -121,13 +122,8 @@ describe('MatChipGrid', () => {
     });
 
     describe('focus behaviors', () => {
-      let fixture: ComponentFixture<StandardChipGrid>;
-
-      beforeEach(() => {
-        fixture = createComponent(StandardChipGrid);
-      });
-
       it('should focus the first chip on focus', () => {
+        const fixture = createComponent(StandardChipGrid);
         chipGridInstance.focus();
         fixture.detectChanges();
 
@@ -135,6 +131,7 @@ describe('MatChipGrid', () => {
       });
 
       it('should focus the primary action when calling the `focus` method', () => {
+        const fixture = createComponent(StandardChipGrid);
         chips.last.focus();
         fixture.detectChanges();
 
@@ -142,6 +139,8 @@ describe('MatChipGrid', () => {
       });
 
       it('should not be able to become focused when disabled', () => {
+        const fixture = createComponent(StandardChipGrid);
+
         expect(chipGridInstance.focused)
           .withContext('Expected grid to not be focused.')
           .toBe(false);
@@ -159,6 +158,7 @@ describe('MatChipGrid', () => {
       });
 
       it('should remove the tabindex from the grid if it is disabled', () => {
+        const fixture = createComponent(StandardChipGrid);
         expect(chipGridNativeElement.getAttribute('tabindex')).toBe('0');
 
         chipGridInstance.disabled = true;
@@ -170,6 +170,9 @@ describe('MatChipGrid', () => {
 
       describe('on chip destroy', () => {
         it('should focus the next item', () => {
+          // TODO(crisbeto): this test fails without the NoopAnimationsModule for some reason.
+          // It can indicate a deeper issue with the chips.
+          const fixture = createComponent(StandardChipGrid, undefined, [NoopAnimationsModule]);
           const midItem = chips.get(2)!;
 
           // Focus the middle item
@@ -185,6 +188,9 @@ describe('MatChipGrid', () => {
         });
 
         it('should focus the previous item', () => {
+          // TODO(crisbeto): this test fails without the NoopAnimationsModule for some reason.
+          // It can indicate a deeper issue with the chips.
+          const fixture = createComponent(StandardChipGrid, undefined, [NoopAnimationsModule]);
           // Focus the last item
           chips.last.focus();
 
@@ -198,6 +204,9 @@ describe('MatChipGrid', () => {
         });
 
         it('should not focus if chip grid is not focused', fakeAsync(() => {
+          // TODO(crisbeto): this test fails without the NoopAnimationsModule for some reason.
+          // It can indicate a deeper issue with the chips.
+          const fixture = createComponent(StandardChipGrid, undefined, [NoopAnimationsModule]);
           const midItem = chips.get(2)!;
 
           // Focus and blur the middle item
@@ -216,6 +225,9 @@ describe('MatChipGrid', () => {
         }));
 
         it('should focus the grid if the last focused item is removed', () => {
+          // TODO(crisbeto): this test fails without the NoopAnimationsModule for some reason.
+          // It can indicate a deeper issue with the chips.
+          const fixture = createComponent(StandardChipGrid, undefined, [NoopAnimationsModule]);
           testComponent.chips = [0];
           fixture.changeDetectorRef.markForCheck();
 
@@ -232,6 +244,7 @@ describe('MatChipGrid', () => {
       });
 
       it('should have a focus indicator', () => {
+        createComponent(StandardChipGrid, undefined, [NoopAnimationsModule]);
         const focusIndicators = chipGridNativeElement.querySelectorAll(
           '.mat-mdc-chip-primary-focus-indicator',
         );
@@ -488,14 +501,11 @@ describe('MatChipGrid', () => {
   });
 
   describe('FormFieldChipGrid', () => {
-    let fixture: ComponentFixture<FormFieldChipGrid>;
-
-    beforeEach(() => {
-      fixture = createComponent(FormFieldChipGrid);
-    });
-
     describe('keyboard behavior', () => {
       it('should maintain focus if the active chip is deleted', () => {
+        // TODO(crisbeto): this test fails without the NoopAnimationsModule for some reason.
+        // It can indicate a deeper issue with the chips.
+        const fixture = createComponent(FormFieldChipGrid, undefined, [NoopAnimationsModule]);
         const secondChip = fixture.nativeElement.querySelectorAll('.mat-mdc-chip')[1];
         const secondChipAction = secondChip.querySelector('.mdc-evolution-chip__action--primary');
 
@@ -512,6 +522,7 @@ describe('MatChipGrid', () => {
 
       describe('when the input has focus', () => {
         it('should not focus the last chip when press DELETE', () => {
+          const fixture = createComponent(FormFieldChipGrid);
           let nativeInput = fixture.nativeElement.querySelector('input');
 
           // Focus the input
@@ -527,6 +538,7 @@ describe('MatChipGrid', () => {
         });
 
         it('should focus the last chip when press BACKSPACE', () => {
+          const fixture = createComponent(FormFieldChipGrid);
           let nativeInput = fixture.nativeElement.querySelector('input');
 
           // Focus the input
@@ -542,6 +554,7 @@ describe('MatChipGrid', () => {
         });
 
         it('should not focus the last chip when pressing BACKSPACE on a non-empty input', () => {
+          const fixture = createComponent(FormFieldChipGrid);
           const nativeInput = fixture.nativeElement.querySelector('input');
           nativeInput.value = 'hello';
           nativeInput.focus();
@@ -558,6 +571,7 @@ describe('MatChipGrid', () => {
     });
 
     it('should complete the stateChanges stream on destroy', () => {
+      const fixture = createComponent(FormFieldChipGrid);
       const spy = jasmine.createSpy('stateChanges complete');
       const subscription = chipGridInstance.stateChanges.subscribe({complete: spy});
 
@@ -568,18 +582,14 @@ describe('MatChipGrid', () => {
   });
 
   describe('with chip remove', () => {
-    let fixture: ComponentFixture<ChipGridWithRemove>;
-    let trailingActions: NodeListOf<HTMLElement>;
-
-    beforeEach(fakeAsync(() => {
-      fixture = createComponent(ChipGridWithRemove);
+    it('should properly focus next item if chip is removed through click', fakeAsync(() => {
+      // TODO(crisbeto): this test fails without the NoopAnimationsModule for some reason.
+      // It can indicate a deeper issue with the chips.
+      const fixture = createComponent(ChipGridWithRemove, undefined, [NoopAnimationsModule]);
       flush();
-      trailingActions = chipGridNativeElement.querySelectorAll(
+      const trailingActions = chipGridNativeElement.querySelectorAll<HTMLElement>(
         '.mdc-evolution-chip__action--trailing',
       );
-    }));
-
-    it('should properly focus next item if chip is removed through click', fakeAsync(() => {
       const chip = chips.get(2)!;
       chip.focus();
       fixture.detectChanges();
@@ -1018,6 +1028,7 @@ describe('MatChipGrid', () => {
   function createComponent<T>(
     component: Type<T>,
     direction: Direction = 'ltr',
+    additionalImports: Type<unknown>[] = [],
   ): ComponentFixture<T> {
     directionality = {
       value: direction,
@@ -1031,9 +1042,12 @@ describe('MatChipGrid', () => {
         MatChipsModule,
         MatFormFieldModule,
         MatInputModule,
-        NoopAnimationsModule,
+        ...additionalImports,
       ],
-      providers: [{provide: Directionality, useValue: directionality}],
+      providers: [
+        {provide: Directionality, useValue: directionality},
+        {provide: MATERIAL_ANIMATIONS, useValue: {animationsDisabled: true}},
+      ],
       declarations: [component],
     });
 

--- a/src/material/chips/chip-input.spec.ts
+++ b/src/material/chips/chip-input.spec.ts
@@ -10,7 +10,6 @@ import {Component, DebugElement, ViewChild} from '@angular/core';
 import {ComponentFixture, TestBed, fakeAsync, flush, waitForAsync} from '@angular/core/testing';
 import {MatFormFieldModule} from '../form-field';
 import {By} from '@angular/platform-browser';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {Subject} from 'rxjs';
 import {
   MAT_CHIPS_DEFAULT_OPTIONS,
@@ -20,6 +19,7 @@ import {
   MatChipsDefaultOptions,
   MatChipsModule,
 } from './index';
+import {MATERIAL_ANIMATIONS} from '../core';
 
 describe('MatChipInput', () => {
   let fixture: ComponentFixture<TestChipInput>;
@@ -31,7 +31,7 @@ describe('MatChipInput', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [PlatformModule, MatChipsModule, MatFormFieldModule, NoopAnimationsModule],
+      imports: [PlatformModule, MatChipsModule, MatFormFieldModule],
       providers: [
         {
           provide: Directionality,
@@ -42,6 +42,7 @@ describe('MatChipInput', () => {
             };
           },
         },
+        {provide: MATERIAL_ANIMATIONS, useValue: {animationsDisabled: true}},
       ],
       declarations: [TestChipInput],
     });
@@ -216,13 +217,14 @@ describe('MatChipInput', () => {
       fixture.destroy();
 
       TestBed.resetTestingModule().configureTestingModule({
-        imports: [MatChipsModule, MatFormFieldModule, PlatformModule, NoopAnimationsModule],
+        imports: [MatChipsModule, MatFormFieldModule, PlatformModule],
         declarations: [TestChipInput],
         providers: [
           {
             provide: MAT_CHIPS_DEFAULT_OPTIONS,
             useValue: {separatorKeyCodes: [COMMA]} as MatChipsDefaultOptions,
           },
+          {provide: MATERIAL_ANIMATIONS, useValue: {animationsDisabled: true}},
         ],
       });
 

--- a/src/material/core/ripple/ripple.spec.ts
+++ b/src/material/core/ripple/ripple.spec.ts
@@ -7,9 +7,8 @@ import {
   dispatchMouseEvent,
   dispatchTouchEvent,
 } from '@angular/cdk/testing/private';
-import {Component, ViewChild, ViewEncapsulation} from '@angular/core';
+import {Component, Provider, ViewChild, ViewEncapsulation} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {
   MAT_RIPPLE_GLOBAL_OPTIONS,
   MatRipple,
@@ -18,6 +17,7 @@ import {
   RippleGlobalOptions,
   RippleState,
 } from './index';
+import {MATERIAL_ANIMATIONS} from '../animation/animation';
 
 describe('MatRipple', () => {
   let fixture: ComponentFixture<any>;
@@ -494,14 +494,17 @@ describe('MatRipple', () => {
     function createTestComponent(
       rippleConfig: RippleGlobalOptions,
       testComponent: any = BasicRippleContainer,
-      extraImports: any[] = [],
+      extraProviders: Provider[] = [],
     ) {
       // Reset the previously configured testing module to be able set new providers.
       // The testing module has been initialized in the root describe group for the ripples.
       TestBed.resetTestingModule();
       TestBed.configureTestingModule({
-        imports: [MatRippleModule, ...extraImports, testComponent],
-        providers: [{provide: MAT_RIPPLE_GLOBAL_OPTIONS, useValue: rippleConfig}],
+        imports: [MatRippleModule, testComponent],
+        providers: [
+          {provide: MAT_RIPPLE_GLOBAL_OPTIONS, useValue: rippleConfig},
+          ...extraProviders,
+        ],
       });
 
       fixture = TestBed.createComponent(testComponent);
@@ -585,10 +588,12 @@ describe('MatRipple', () => {
       expect(rippleTarget.querySelectorAll('.mat-ripple-element').length).toBe(0);
     });
 
-    it('should not mutate the global options when NoopAnimationsModule is present', () => {
+    it('should not mutate the global options when animations are disabled', () => {
       const options: RippleGlobalOptions = {};
 
-      createTestComponent(options, RippleContainerWithoutBindings, [NoopAnimationsModule]);
+      createTestComponent(options, RippleContainerWithoutBindings, [
+        {provide: MATERIAL_ANIMATIONS, useValue: {animationsDisabled: true}},
+      ]);
 
       expect(options.animation).toBeFalsy();
     });
@@ -600,7 +605,8 @@ describe('MatRipple', () => {
     beforeEach(() => {
       TestBed.resetTestingModule();
       TestBed.configureTestingModule({
-        imports: [NoopAnimationsModule, MatRippleModule, BasicRippleContainer],
+        imports: [MatRippleModule, BasicRippleContainer],
+        providers: [{provide: MATERIAL_ANIMATIONS, useValue: {animationsDisabled: true}}],
       });
 
       fixture = TestBed.createComponent(BasicRippleContainer);

--- a/src/material/datepicker/date-range-input.spec.ts
+++ b/src/material/datepicker/date-range-input.spec.ts
@@ -15,9 +15,8 @@ import {
   Validator,
   Validators,
 } from '@angular/forms';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {Subscription} from 'rxjs';
-import {ErrorStateMatcher, MatNativeDateModule} from '../core';
+import {ErrorStateMatcher, MATERIAL_ANIMATIONS, MatNativeDateModule} from '../core';
 import {MatFormField, MatFormFieldModule, MatLabel} from '../form-field';
 import {MatInputModule} from '../input';
 import {MatDateRangeInput} from './date-range-input';
@@ -33,12 +32,14 @@ describe('MatDateRangeInput', () => {
         MatDatepickerModule,
         MatFormFieldModule,
         MatInputModule,
-        NoopAnimationsModule,
         ReactiveFormsModule,
         MatNativeDateModule,
         component,
       ],
-      providers,
+      providers: [
+        ...providers,
+        {provide: MATERIAL_ANIMATIONS, useValue: {animationsDisabled: true}},
+      ],
     });
 
     return TestBed.createComponent(component);

--- a/src/material/datepicker/datepicker-actions.spec.ts
+++ b/src/material/datepicker/datepicker-actions.spec.ts
@@ -1,10 +1,9 @@
 import {Component, ElementRef, Type, ViewChild} from '@angular/core';
 import {ComponentFixture, TestBed, fakeAsync, flush, tick} from '@angular/core/testing';
 import {FormControl, FormsModule, ReactiveFormsModule} from '@angular/forms';
-import {MatNativeDateModule} from '../core';
+import {MATERIAL_ANIMATIONS, MatNativeDateModule} from '../core';
 import {MatFormFieldModule} from '../form-field';
 import {MatInputModule} from '../input';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {MatDatepicker} from './datepicker';
 import {MatDatepickerModule} from './datepicker-module';
 
@@ -17,10 +16,10 @@ describe('MatDatepickerActions', () => {
         MatDatepickerModule,
         MatFormFieldModule,
         MatInputModule,
-        NoopAnimationsModule,
         ReactiveFormsModule,
         MatNativeDateModule,
       ],
+      providers: [{provide: MATERIAL_ANIMATIONS, useValue: {animationsDisabled: true}}],
     });
 
     return TestBed.createComponent(component);

--- a/src/material/datepicker/datepicker.spec.ts
+++ b/src/material/datepicker/datepicker.spec.ts
@@ -30,11 +30,10 @@ import {
   ReactiveFormsModule,
   Validator,
 } from '@angular/forms';
-import {MAT_DATE_LOCALE, MatNativeDateModule, NativeDateModule} from '../core';
+import {MAT_DATE_LOCALE, MATERIAL_ANIMATIONS, MatNativeDateModule, NativeDateModule} from '../core';
 import {MatFormField, MatFormFieldModule} from '../form-field';
 import {MatInputModule} from '../input';
 import {By} from '@angular/platform-browser';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {Subject} from 'rxjs';
 import {DEC, JAN, JUL, JUN, SEP} from '../testing';
 import {MatDatepicker} from './datepicker';
@@ -64,11 +63,13 @@ describe('MatDatepicker', () => {
         MatDatepickerModule,
         MatFormFieldModule,
         MatInputModule,
-        NoopAnimationsModule,
         ReactiveFormsModule,
         ...imports,
       ],
-      providers,
+      providers: [
+        ...providers,
+        {provide: MATERIAL_ANIMATIONS, useValue: {animationsDisabled: true}},
+      ],
       declarations: [component, ...declarations],
     });
 

--- a/src/material/datepicker/testing/date-range-input-harness.spec.ts
+++ b/src/material/datepicker/testing/date-range-input-harness.spec.ts
@@ -3,15 +3,14 @@ import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {Component} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {FormsModule} from '@angular/forms';
-import {MatNativeDateModule} from '../../core';
+import {MATERIAL_ANIMATIONS, MatNativeDateModule} from '../../core';
 import {
+  MatDatepickerModule,
   MatDateRangeInput,
   MatDateRangePicker,
-  MatDatepickerModule,
   MatEndDate,
   MatStartDate,
 } from '../../datepicker';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {MatCalendarHarness} from './calendar-harness';
 import {
   MatDateRangeInputHarness,
@@ -25,15 +24,9 @@ describe('matDateRangeInputHarness', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [
-        NoopAnimationsModule,
-        MatNativeDateModule,
-        MatDatepickerModule,
-        FormsModule,
-        DateRangeInputHarnessTest,
-      ],
+      imports: [MatNativeDateModule, MatDatepickerModule, FormsModule, DateRangeInputHarnessTest],
+      providers: [{provide: MATERIAL_ANIMATIONS, useValue: {animationsDisabled: true}}],
     });
-
     fixture = TestBed.createComponent(DateRangeInputHarnessTest);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.loader(fixture);

--- a/src/material/datepicker/testing/datepicker-input-harness.spec.ts
+++ b/src/material/datepicker/testing/datepicker-input-harness.spec.ts
@@ -3,9 +3,8 @@ import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {Component} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {FormsModule} from '@angular/forms';
-import {DateAdapter, MatNativeDateModule} from '../../core';
+import {DateAdapter, MATERIAL_ANIMATIONS, MatNativeDateModule} from '../../core';
 import {MatDatepickerModule} from '../../datepicker';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {MatCalendarHarness} from './calendar-harness';
 import {MatDatepickerInputHarness} from './datepicker-input-harness';
 
@@ -15,15 +14,9 @@ describe('MatDatepickerInputHarness', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [
-        NoopAnimationsModule,
-        MatNativeDateModule,
-        MatDatepickerModule,
-        FormsModule,
-        DatepickerInputHarnessTest,
-      ],
+      imports: [MatNativeDateModule],
+      providers: [{provide: MATERIAL_ANIMATIONS, useValue: {animationsDisabled: true}}],
     });
-
     fixture = TestBed.createComponent(DatepickerInputHarnessTest);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.loader(fixture);

--- a/src/material/datepicker/testing/datepicker-toggle-harness.spec.ts
+++ b/src/material/datepicker/testing/datepicker-toggle-harness.spec.ts
@@ -2,9 +2,8 @@ import {HarnessLoader, parallel} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {Component} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
-import {MatNativeDateModule} from '../../core';
+import {MATERIAL_ANIMATIONS, MatNativeDateModule} from '../../core';
 import {MatDatepickerModule} from '../../datepicker';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {MatCalendarHarness} from './calendar-harness';
 import {MatDatepickerToggleHarness} from './datepicker-toggle-harness';
 
@@ -14,14 +13,9 @@ describe('MatDatepickerToggleHarness', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [
-        NoopAnimationsModule,
-        MatNativeDateModule,
-        MatDatepickerModule,
-        DatepickerToggleHarnessTest,
-      ],
+      imports: [MatNativeDateModule],
+      providers: [{provide: MATERIAL_ANIMATIONS, useValue: {animationsDisabled: true}}],
     });
-
     fixture = TestBed.createComponent(DatepickerToggleHarnessTest);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.loader(fixture);

--- a/src/material/dialog/dialog.spec.ts
+++ b/src/material/dialog/dialog.spec.ts
@@ -38,7 +38,6 @@ import {
   tick,
 } from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {Subject} from 'rxjs';
 import {CLOSE_ANIMATION_DURATION, OPEN_ANIMATION_DURATION} from './dialog-container';
 import {
@@ -53,6 +52,7 @@ import {
   MatDialogState,
   MatDialogTitle,
 } from './index';
+import {MATERIAL_ANIMATIONS} from '../core';
 
 describe('MatDialog', () => {
   let dialog: MatDialog;
@@ -68,7 +68,6 @@ describe('MatDialog', () => {
     TestBed.configureTestingModule({
       imports: [
         MatDialogModule,
-        NoopAnimationsModule,
         ComponentWithChildViewContainer,
         ComponentWithTemplateRef,
         PizzaMsg,
@@ -80,6 +79,7 @@ describe('MatDialog', () => {
       ],
       providers: [
         {provide: Location, useClass: SpyLocation},
+        {provide: MATERIAL_ANIMATIONS, useValue: {animationsDisabled: true}},
         {
           provide: ScrollDispatcher,
           useFactory: () => ({
@@ -1871,7 +1871,7 @@ describe('MatDialog with a parent MatDialog', () => {
 
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
-      imports: [MatDialogModule, NoopAnimationsModule, ComponentThatProvidesMatDialog],
+      imports: [MatDialogModule, ComponentThatProvidesMatDialog],
       providers: [
         {
           provide: OverlayContainer,
@@ -1881,6 +1881,7 @@ describe('MatDialog with a parent MatDialog', () => {
           },
         },
         {provide: Location, useClass: SpyLocation},
+        {provide: MATERIAL_ANIMATIONS, useValue: {animationsDisabled: true}},
       ],
     });
 
@@ -1979,13 +1980,11 @@ describe('MatDialog with default options', () => {
     };
 
     TestBed.configureTestingModule({
-      imports: [
-        MatDialogModule,
-        NoopAnimationsModule,
-        ComponentWithChildViewContainer,
-        DirectiveWithViewContainer,
+      imports: [MatDialogModule, ComponentWithChildViewContainer, DirectiveWithViewContainer],
+      providers: [
+        {provide: MAT_DIALOG_DEFAULT_OPTIONS, useValue: defaultConfig},
+        {provide: MATERIAL_ANIMATIONS, useValue: {animationsDisabled: true}},
       ],
-      providers: [{provide: MAT_DIALOG_DEFAULT_OPTIONS, useValue: defaultConfig}],
     });
 
     dialog = TestBed.inject(MatDialog);

--- a/src/material/dialog/dialog.zone.spec.ts
+++ b/src/material/dialog/dialog.zone.spec.ts
@@ -13,8 +13,8 @@ import {
 } from '@angular/core';
 import {ComponentFixture, TestBed, fakeAsync, flush} from '@angular/core/testing';
 import {MatDialog, MatDialogModule, MatDialogRef} from '../dialog';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {Subject} from 'rxjs';
+import {MATERIAL_ANIMATIONS} from '../core';
 
 describe('MatDialog', () => {
   let dialog: MatDialog;
@@ -28,7 +28,6 @@ describe('MatDialog', () => {
     TestBed.configureTestingModule({
       imports: [
         MatDialogModule,
-        NoopAnimationsModule,
         ComponentWithChildViewContainer,
         PizzaMsg,
         DirectiveWithViewContainer,
@@ -36,6 +35,7 @@ describe('MatDialog', () => {
       providers: [
         provideZoneChangeDetection(),
         {provide: Location, useClass: SpyLocation},
+        {provide: MATERIAL_ANIMATIONS, useValue: {animationsDisabled: true}},
         {
           provide: ScrollDispatcher,
           useFactory: () => ({

--- a/src/material/dialog/testing/dialog-harness.spec.ts
+++ b/src/material/dialog/testing/dialog-harness.spec.ts
@@ -9,8 +9,8 @@ import {
   MatDialogContent,
   MatDialogTitle,
 } from '../../dialog';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {MatDialogHarness} from './dialog-harness';
+import {MATERIAL_ANIMATIONS} from '../../core';
 
 describe('MatDialogHarness', () => {
   let fixture: ComponentFixture<DialogHarnessTest>;
@@ -18,7 +18,7 @@ describe('MatDialogHarness', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [NoopAnimationsModule],
+      providers: [{provide: MATERIAL_ANIMATIONS, useValue: {animationsDisabled: true}}],
     });
 
     fixture = TestBed.createComponent(DialogHarnessTest);

--- a/src/material/dialog/testing/dialog-opener.spec.ts
+++ b/src/material/dialog/testing/dialog-opener.spec.ts
@@ -1,16 +1,9 @@
 import {Component, inject} from '@angular/core';
 import {TestBed, fakeAsync, flush} from '@angular/core/testing';
 import {MAT_DIALOG_DATA, MatDialogRef, MatDialogState} from '../../dialog';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
-import {MatTestDialogOpener, MatTestDialogOpenerModule} from './dialog-opener';
+import {MatTestDialogOpener} from './dialog-opener';
 
 describe('MatTestDialogOpener', () => {
-  beforeEach(fakeAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [MatTestDialogOpenerModule, NoopAnimationsModule, ExampleComponent],
-    });
-  }));
-
   it('should open a dialog when created', fakeAsync(() => {
     const fixture = TestBed.createComponent(MatTestDialogOpener.withComponent(ExampleComponent));
     flush();

--- a/src/material/expansion/expansion.spec.ts
+++ b/src/material/expansion/expansion.spec.ts
@@ -14,20 +14,19 @@ import {
   waitForAsync,
 } from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {
   MAT_EXPANSION_PANEL_DEFAULT_OPTIONS,
   MatExpansionModule,
   MatExpansionPanel,
   MatExpansionPanelHeader,
 } from './index';
+import {MATERIAL_ANIMATIONS} from '../core';
 
 describe('MatExpansionPanel', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [
         MatExpansionModule,
-        NoopAnimationsModule,
         PanelWithContent,
         PanelWithContentInNgIf,
         PanelWithCustomMargin,
@@ -36,6 +35,12 @@ describe('MatExpansionPanel', () => {
         PanelWithTwoWayBinding,
         PanelWithHeaderTabindex,
         NestedLazyPanelWithContent,
+      ],
+      providers: [
+        {
+          provide: MATERIAL_ANIMATIONS,
+          useValue: {animationsDisabled: true},
+        },
       ],
     });
   }));
@@ -383,7 +388,7 @@ describe('MatExpansionPanel', () => {
 
   it('should be able to set the default options through the injection token', () => {
     TestBed.resetTestingModule().configureTestingModule({
-      imports: [MatExpansionModule, NoopAnimationsModule],
+      imports: [MatExpansionModule],
       providers: [
         {
           provide: MAT_EXPANSION_PANEL_DEFAULT_OPTIONS,

--- a/src/material/expansion/testing/expansion-harness.spec.ts
+++ b/src/material/expansion/testing/expansion-harness.spec.ts
@@ -3,7 +3,6 @@ import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {Component} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatAccordionTogglePosition, MatExpansionModule} from '../../expansion';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {MatAccordionHarness} from './accordion-harness';
 import {MatExpansionPanelHarness} from './expansion-harness';
 
@@ -12,10 +11,6 @@ describe('MatExpansionHarness', () => {
   let loader: HarnessLoader;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [MatExpansionModule, NoopAnimationsModule, ExpansionHarnessTestComponent],
-    });
-
     fixture = TestBed.createComponent(ExpansionHarnessTestComponent);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.loader(fixture);

--- a/src/material/form-field/testing/form-field-harness.spec.ts
+++ b/src/material/form-field/testing/form-field-harness.spec.ts
@@ -4,12 +4,11 @@ import {ComponentHarness, HarnessLoader, HarnessPredicate, parallel} from '@angu
 import {createFakeEvent, dispatchFakeEvent} from '@angular/cdk/testing/private';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {FormControl, ReactiveFormsModule, Validators} from '@angular/forms';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {MatError, MatFormField, MatHint, MatLabel, MatPrefix, MatSuffix} from '../../form-field';
 import {MatAutocomplete, MatAutocompleteTrigger} from '../../autocomplete';
 import {MatInput} from '../../input';
 import {MatSelect} from '../../select';
-import {MatNativeDateModule, MatOption} from '../../core';
+import {MATERIAL_ANIMATIONS, MatNativeDateModule, MatOption} from '../../core';
 import {
   MatDateRangeInput,
   MatDateRangePicker,
@@ -31,12 +30,8 @@ describe('MatFormFieldHarness', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [
-        NoopAnimationsModule,
-        MatNativeDateModule,
-        FormFieldHarnessTest,
-        MatDatepickerModule,
-      ],
+      imports: [MatNativeDateModule, FormFieldHarnessTest, MatDatepickerModule],
+      providers: [{provide: MATERIAL_ANIMATIONS, useValue: {animationsDisabled: true}}],
     });
 
     fixture = TestBed.createComponent(FormFieldHarnessTest);

--- a/src/material/grid-list/testing/grid-list-harness.spec.ts
+++ b/src/material/grid-list/testing/grid-list-harness.spec.ts
@@ -2,7 +2,6 @@ import {Component, signal} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {HarnessLoader, parallel} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {MatGridListModule} from '../../grid-list';
 import {MatGridListHarness} from './grid-list-harness';
 import {MatGridTileHarness} from './grid-tile-harness';
@@ -12,10 +11,6 @@ describe('MatGridListHarness', () => {
   let loader: HarnessLoader;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [MatGridListModule, NoopAnimationsModule, GridListHarnessTest],
-    });
-
     fixture = TestBed.createComponent(GridListHarnessTest);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.documentRootLoader(fixture);

--- a/src/material/input/testing/input-harness.spec.ts
+++ b/src/material/input/testing/input-harness.spec.ts
@@ -5,7 +5,6 @@ import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {FormsModule} from '@angular/forms';
 import {MatInputModule} from '../module';
 import {getSupportedInputTypes} from '@angular/cdk/platform';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {MatInputHarness} from './input-harness';
 
 describe('MatInputHarness', () => {
@@ -13,10 +12,6 @@ describe('MatInputHarness', () => {
   let loader: HarnessLoader;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [NoopAnimationsModule, MatInputModule, FormsModule, InputHarnessTest],
-    });
-
     fixture = TestBed.createComponent(InputHarnessTest);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.loader(fixture);

--- a/src/material/input/testing/native-select-harness.spec.ts
+++ b/src/material/input/testing/native-select-harness.spec.ts
@@ -4,7 +4,6 @@ import {HarnessLoader, parallel} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {FormsModule} from '@angular/forms';
 import {MatInputModule} from '../module';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {MatNativeSelectHarness} from './native-select-harness';
 
 describe('MatNativeSelectHarness', () => {
@@ -12,10 +11,6 @@ describe('MatNativeSelectHarness', () => {
   let loader: HarnessLoader;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [NoopAnimationsModule, MatInputModule, FormsModule, SelectHarnessTest],
-    });
-
     fixture = TestBed.createComponent(SelectHarnessTest);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.loader(fixture);

--- a/src/material/menu/menu.spec.ts
+++ b/src/material/menu/menu.spec.ts
@@ -29,7 +29,7 @@ import {
   ViewChildren,
 } from '@angular/core';
 import {ComponentFixture, TestBed, fakeAsync, flush, tick} from '@angular/core/testing';
-import {MatRipple} from '../core';
+import {MATERIAL_ANIMATIONS, MatRipple} from '../core';
 import {By} from '@angular/platform-browser';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {Subject} from 'rxjs';
@@ -63,10 +63,14 @@ describe('MatMenu', () => {
     component: Type<T>,
     providers: Provider[] = [],
     declarations: any[] = [],
+    imports: Type<unknown>[] = [],
   ): ComponentFixture<T> {
     TestBed.configureTestingModule({
-      providers,
-      imports: [MatMenuModule, NoopAnimationsModule],
+      providers: [
+        ...providers,
+        {provide: MATERIAL_ANIMATIONS, useValue: {animationsDisabled: true}},
+      ],
+      imports: [MatMenuModule, ...imports],
       declarations: [component, ...declarations],
     });
 
@@ -262,7 +266,9 @@ describe('MatMenu', () => {
   }));
 
   it('should move focus to another item if the active item is destroyed', fakeAsync(() => {
-    const fixture = createComponent(MenuWithRepeatedItems, [], [FakeIcon]);
+    // TODO(crisbeto): figure out why NoopAnimationsModule is necessary
+    // here and our token isn't enough. Likely indicates an issue.
+    const fixture = createComponent(MenuWithRepeatedItems, [], [FakeIcon], [NoopAnimationsModule]);
     fixture.detectChanges();
     const triggerEl = fixture.componentInstance.triggerEl.nativeElement;
 
@@ -2582,12 +2588,13 @@ describe('MatMenu', () => {
 describe('MatMenu default overrides', () => {
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
-      imports: [MatMenuModule, NoopAnimationsModule],
+      imports: [MatMenuModule],
       providers: [
         {
           provide: MAT_MENU_DEFAULT_OPTIONS,
           useValue: {overlapTrigger: true, xPosition: 'before', yPosition: 'above'},
         },
+        {provide: MATERIAL_ANIMATIONS, useValue: {animationsDisabled: true}},
       ],
       declarations: [SimpleMenu, FakeIcon],
     });

--- a/src/material/menu/testing/menu-harness.spec.ts
+++ b/src/material/menu/testing/menu-harness.spec.ts
@@ -3,7 +3,6 @@ import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatMenuModule} from '../module';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {MatMenuHarness} from './menu-harness';
 
 describe('MatMenuHarness', () => {
@@ -12,10 +11,6 @@ describe('MatMenuHarness', () => {
     let loader: HarnessLoader;
 
     beforeEach(() => {
-      TestBed.configureTestingModule({
-        imports: [MatMenuModule, NoopAnimationsModule, MenuHarnessTest],
-      });
-
       fixture = TestBed.createComponent(MenuHarnessTest);
       fixture.detectChanges();
       loader = TestbedHarnessEnvironment.loader(fixture);
@@ -92,10 +87,6 @@ describe('MatMenuHarness', () => {
     let loader: HarnessLoader;
 
     beforeEach(() => {
-      TestBed.configureTestingModule({
-        imports: [MatMenuModule, NoopAnimationsModule, NestedMenuHarnessTest],
-      });
-
       fixture = TestBed.createComponent(NestedMenuHarnessTest);
       fixture.detectChanges();
       loader = TestbedHarnessEnvironment.loader(fixture);

--- a/src/material/paginator/paginator.spec.ts
+++ b/src/material/paginator/paginator.spec.ts
@@ -3,7 +3,6 @@ import {ComponentFixture, TestBed, fakeAsync, tick} from '@angular/core/testing'
 import {ThemePalette} from '../core';
 import {MatSelect} from '../select';
 import {By} from '@angular/platform-browser';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {
   MatPaginator,
   MatPaginatorIntl,
@@ -15,7 +14,7 @@ import {MAT_PAGINATOR_DEFAULT_OPTIONS, MatPaginatorDefaultOptions} from './pagin
 describe('MatPaginator', () => {
   function createComponent<T>(type: Type<T>, providers: Provider[] = []): ComponentFixture<T> {
     TestBed.configureTestingModule({
-      imports: [MatPaginatorModule, NoopAnimationsModule],
+      imports: [MatPaginatorModule],
       providers: [MatPaginatorIntl, ...providers],
       declarations: [type],
     });

--- a/src/material/paginator/testing/paginator-harness.spec.ts
+++ b/src/material/paginator/testing/paginator-harness.spec.ts
@@ -2,7 +2,6 @@ import {Component, signal} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {MatPaginatorModule, PageEvent} from '../../paginator';
 import {MatPaginatorHarness} from './paginator-harness';
 
@@ -12,10 +11,6 @@ describe('MatPaginatorHarness', () => {
   let instance: PaginatorHarnessTest;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [MatPaginatorModule, NoopAnimationsModule, PaginatorHarnessTest],
-    });
-
     fixture = TestBed.createComponent(PaginatorHarnessTest);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.loader(fixture);

--- a/src/material/select/select.spec.ts
+++ b/src/material/select/select.spec.ts
@@ -57,10 +57,9 @@ import {
   Validators,
 } from '@angular/forms';
 import {By} from '@angular/platform-browser';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {EMPTY, Observable, Subject, Subscription} from 'rxjs';
 import {map} from 'rxjs/operators';
-import {ErrorStateMatcher, MatOption, MatOptionSelectionChange} from '../core';
+import {ErrorStateMatcher, MATERIAL_ANIMATIONS, MatOption, MatOptionSelectionChange} from '../core';
 import {FloatLabelType, MAT_FORM_FIELD_DEFAULT_OPTIONS, MatFormFieldModule} from '../form-field';
 import {MAT_SELECT_CONFIG, MatSelectConfig} from '../select';
 import {MatSelectModule} from './index';
@@ -93,10 +92,10 @@ describe('MatSelect', () => {
         MatSelectModule,
         ReactiveFormsModule,
         FormsModule,
-        NoopAnimationsModule,
         OverlayModule,
       ],
       providers: [
+        {provide: MATERIAL_ANIMATIONS, useValue: {animationsDisabled: true}},
         {provide: Directionality, useFactory: () => (dir = {value: 'ltr', change: EMPTY})},
         {
           provide: ScrollDispatcher,
@@ -2940,13 +2939,7 @@ describe('MatSelect', () => {
     it('should default to global floating label type', () => {
       TestBed.resetTestingModule();
       TestBed.configureTestingModule({
-        imports: [
-          MatFormFieldModule,
-          MatSelectModule,
-          ReactiveFormsModule,
-          FormsModule,
-          NoopAnimationsModule,
-        ],
+        imports: [MatFormFieldModule, MatSelectModule, ReactiveFormsModule, FormsModule],
         providers: [{provide: MAT_FORM_FIELD_DEFAULT_OPTIONS, useValue: {floatLabel: 'always'}}],
         declarations: [FloatLabelSelect],
       });
@@ -3330,7 +3323,7 @@ describe('MatSelect', () => {
       fixture.destroy();
 
       TestBed.resetTestingModule().configureTestingModule({
-        imports: [MatSelectModule, ReactiveFormsModule, FormsModule, NoopAnimationsModule],
+        imports: [MatSelectModule, ReactiveFormsModule, FormsModule],
         declarations: [SelectInsideFormGroup],
         providers: [{provide: ErrorStateMatcher, useValue: errorStateMatcher}],
       });

--- a/src/material/select/testing/select-harness.spec.ts
+++ b/src/material/select/testing/select-harness.spec.ts
@@ -4,9 +4,9 @@ import {OverlayContainer} from '@angular/cdk/overlay';
 import {HarnessLoader, parallel} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {FormControl, ReactiveFormsModule, Validators} from '@angular/forms';
+import {MATERIAL_ANIMATIONS} from '../../core';
 import {MatFormFieldModule} from '../../form-field';
 import {MatSelectModule} from '../module';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {MatSelectHarness} from './select-harness';
 
 describe('MatSelectHarness', () => {
@@ -16,15 +16,8 @@ describe('MatSelectHarness', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [
-        MatSelectModule,
-        MatFormFieldModule,
-        NoopAnimationsModule,
-        ReactiveFormsModule,
-        SelectHarnessTest,
-      ],
+      providers: [{provide: MATERIAL_ANIMATIONS, useValue: {animationsDisabled: true}}],
     });
-
     fixture = TestBed.createComponent(SelectHarnessTest);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.loader(fixture);

--- a/src/material/sidenav/drawer.spec.ts
+++ b/src/material/sidenav/drawer.spec.ts
@@ -18,16 +18,16 @@ import {
   waitForAsync,
 } from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {MatDrawer, MatDrawerContainer, MatSidenavModule} from './index';
+import {MATERIAL_ANIMATIONS} from '../core';
 
 describe('MatDrawer', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
+      providers: [{provide: MATERIAL_ANIMATIONS, useValue: {animationsDisabled: true}}],
       imports: [
         MatSidenavModule,
         A11yModule,
-        NoopAnimationsModule,
         BasicTestApp,
         DrawerContainerNoDrawerTestApp,
         DrawerSetToOpenedFalse,
@@ -894,7 +894,6 @@ describe('MatDrawerContainer', () => {
       imports: [
         MatSidenavModule,
         A11yModule,
-        NoopAnimationsModule,
         DrawerContainerTwoDrawerTestApp,
         DrawerDelayed,
         DrawerSetToOpenedTrue,

--- a/src/material/sidenav/sidenav.spec.ts
+++ b/src/material/sidenav/sidenav.spec.ts
@@ -1,7 +1,6 @@
 import {Component, ViewChild} from '@angular/core';
 import {TestBed, fakeAsync, tick, waitForAsync} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {MatSidenav, MatSidenavContainer, MatSidenavModule} from './index';
 
 describe('MatSidenav', () => {
@@ -9,7 +8,6 @@ describe('MatSidenav', () => {
     TestBed.configureTestingModule({
       imports: [
         MatSidenavModule,
-        NoopAnimationsModule,
         SidenavWithFixedPosition,
         IndirectDescendantSidenav,
         NestedSidenavContainers,

--- a/src/material/sidenav/testing/sidenav-harness.spec.ts
+++ b/src/material/sidenav/testing/sidenav-harness.spec.ts
@@ -3,7 +3,6 @@ import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {HarnessLoader, parallel} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatSidenavModule} from '../../sidenav';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {MatDrawerContainerHarness} from './drawer-container-harness';
 import {MatDrawerContentHarness} from './drawer-content-harness';
 import {MatDrawerHarness} from './drawer-harness';
@@ -17,10 +16,6 @@ describe('MatSidenavHarness', () => {
     let loader: HarnessLoader;
 
     beforeEach(() => {
-      TestBed.configureTestingModule({
-        imports: [MatSidenavModule, NoopAnimationsModule, DrawerHarnessTest],
-      });
-
       fixture = TestBed.createComponent(DrawerHarnessTest);
       fixture.detectChanges();
       loader = TestbedHarnessEnvironment.loader(fixture);
@@ -109,10 +104,6 @@ describe('MatSidenavHarness', () => {
     let loader: HarnessLoader;
 
     beforeEach(() => {
-      TestBed.configureTestingModule({
-        imports: [MatSidenavModule, NoopAnimationsModule, SidenavHarnessTest],
-      });
-
       fixture = TestBed.createComponent(SidenavHarnessTest);
       fixture.detectChanges();
       loader = TestbedHarnessEnvironment.loader(fixture);

--- a/src/material/snack-bar/snack-bar.spec.ts
+++ b/src/material/snack-bar/snack-bar.spec.ts
@@ -12,7 +12,6 @@ import {
   inject,
 } from '@angular/core';
 import {ComponentFixture, TestBed, fakeAsync, flush, tick} from '@angular/core/testing';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {
   MAT_SNACK_BAR_DATA,
   MatSnackBar,
@@ -22,6 +21,7 @@ import {
   SimpleSnackBar,
 } from './index';
 import {MAT_SNACK_BAR_DEFAULT_OPTIONS} from './snack-bar';
+import {MATERIAL_ANIMATIONS} from '../core';
 
 describe('MatSnackBar', () => {
   let snackBar: MatSnackBar;
@@ -41,11 +41,11 @@ describe('MatSnackBar', () => {
     TestBed.configureTestingModule({
       imports: [
         MatSnackBarModule,
-        NoopAnimationsModule,
         ComponentWithChildViewContainer,
         BurritosNotification,
         DirectiveWithViewContainer,
       ],
+      providers: [{provide: MATERIAL_ANIMATIONS, useValue: {animationsDisabled: true}}],
     });
 
     snackBar = TestBed.inject(MatSnackBar);
@@ -515,12 +515,10 @@ describe('MatSnackBar', () => {
   it('should be able to override the default config', fakeAsync(() => {
     viewContainerFixture.destroy();
 
-    TestBed.resetTestingModule()
-      .overrideProvider(MAT_SNACK_BAR_DEFAULT_OPTIONS, {
-        deps: [],
-        useFactory: () => ({panelClass: 'custom-class'}),
-      })
-      .configureTestingModule({imports: [MatSnackBarModule, NoopAnimationsModule]});
+    TestBed.resetTestingModule().overrideProvider(MAT_SNACK_BAR_DEFAULT_OPTIONS, {
+      deps: [],
+      useFactory: () => ({panelClass: 'custom-class'}),
+    });
 
     snackBar = TestBed.inject(MatSnackBar);
     overlayContainerElement = TestBed.inject(OverlayContainer).getContainerElement();
@@ -674,12 +672,7 @@ describe('MatSnackBar with parent MatSnackBar', () => {
 
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
-      imports: [
-        MatSnackBarModule,
-        NoopAnimationsModule,
-        ComponentThatProvidesMatSnackBar,
-        DirectiveWithViewContainer,
-      ],
+      imports: [MatSnackBarModule, ComponentThatProvidesMatSnackBar, DirectiveWithViewContainer],
     });
 
     parentSnackBar = TestBed.inject(MatSnackBar);
@@ -749,12 +742,7 @@ describe('MatSnackBar Positioning', () => {
 
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
-      imports: [
-        MatSnackBarModule,
-        NoopAnimationsModule,
-        ComponentWithChildViewContainer,
-        DirectiveWithViewContainer,
-      ],
+      imports: [MatSnackBarModule, ComponentWithChildViewContainer, DirectiveWithViewContainer],
     });
 
     snackBar = TestBed.inject(MatSnackBar);

--- a/src/material/snack-bar/snack-bar.zone.spec.ts
+++ b/src/material/snack-bar/snack-bar.zone.spec.ts
@@ -9,10 +9,10 @@ import {
   inject,
 } from '@angular/core';
 import {ComponentFixture, TestBed, fakeAsync, flush, tick} from '@angular/core/testing';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {MatSnackBarModule} from './module';
 import {MatSnackBar} from './snack-bar';
 import {MatSnackBarConfig} from './snack-bar-config';
+import {MATERIAL_ANIMATIONS} from '../core';
 
 describe('MatSnackBar Zone.js integration', () => {
   let snackBar: MatSnackBar;
@@ -20,13 +20,11 @@ describe('MatSnackBar Zone.js integration', () => {
 
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
-      imports: [
-        MatSnackBarModule,
-        NoopAnimationsModule,
-        ComponentWithChildViewContainer,
-        DirectiveWithViewContainer,
+      imports: [MatSnackBarModule, ComponentWithChildViewContainer, DirectiveWithViewContainer],
+      providers: [
+        provideZoneChangeDetection(),
+        {provide: MATERIAL_ANIMATIONS, useValue: {animationsDisabled: true}},
       ],
-      providers: [provideZoneChangeDetection()],
     });
 
     snackBar = TestBed.inject(MatSnackBar);

--- a/src/material/snack-bar/testing/snack-bar-harness.spec.ts
+++ b/src/material/snack-bar/testing/snack-bar-harness.spec.ts
@@ -9,8 +9,8 @@ import {
   MatSnackBarConfig,
   MatSnackBarLabel,
 } from '../../snack-bar';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {MatSnackBarHarness} from './snack-bar-harness';
+import {MATERIAL_ANIMATIONS} from '../../core';
 
 describe('MatSnackBarHarness', () => {
   let fixture: ComponentFixture<SnackbarHarnessTest>;
@@ -18,7 +18,7 @@ describe('MatSnackBarHarness', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [NoopAnimationsModule],
+      providers: [{provide: MATERIAL_ANIMATIONS, useValue: {animationsDisabled: true}}],
     });
 
     fixture = TestBed.createComponent(SnackbarHarnessTest);

--- a/src/material/sort/sort.spec.ts
+++ b/src/material/sort/sort.spec.ts
@@ -5,7 +5,6 @@ import {Component, ElementRef, ViewChild, inject} from '@angular/core';
 import {ComponentFixture, TestBed, fakeAsync, tick, waitForAsync} from '@angular/core/testing';
 import {MatTableModule} from '../table';
 import {By} from '@angular/platform-browser';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {Observable} from 'rxjs';
 import {map} from 'rxjs/operators';
 import {
@@ -34,7 +33,6 @@ describe('MatSort', () => {
           MatSortModule,
           MatTableModule,
           CdkTableModule,
-          NoopAnimationsModule,
           SimpleMatSortApp,
           CdkTableMatSortApp,
           MatTableMatSortApp,
@@ -359,13 +357,7 @@ describe('MatSort', () => {
 
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
-        imports: [
-          MatSortModule,
-          MatTableModule,
-          CdkTableModule,
-          NoopAnimationsModule,
-          MatSortWithoutExplicitInputs,
-        ],
+        imports: [MatSortModule, MatTableModule, CdkTableModule, MatSortWithoutExplicitInputs],
         providers: [
           {
             provide: MAT_SORT_DEFAULT_OPTIONS,
@@ -398,13 +390,7 @@ describe('MatSort', () => {
 
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
-        imports: [
-          MatSortModule,
-          MatTableModule,
-          CdkTableModule,
-          NoopAnimationsModule,
-          MatSortWithoutInputs,
-        ],
+        imports: [MatSortModule, MatTableModule, CdkTableModule, MatSortWithoutInputs],
         providers: [
           {
             provide: MAT_SORT_DEFAULT_OPTIONS,

--- a/src/material/sort/testing/sort-harness.spec.ts
+++ b/src/material/sort/testing/sort-harness.spec.ts
@@ -3,7 +3,6 @@ import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {HarnessLoader, parallel} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatSortModule, Sort} from '../../sort';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {MatSortHarness} from './sort-harness';
 
 describe('MatSortHarness', () => {
@@ -11,10 +10,6 @@ describe('MatSortHarness', () => {
   let loader: HarnessLoader;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [MatSortModule, NoopAnimationsModule, SortHarnessTest],
-    });
-
     fixture = TestBed.createComponent(SortHarnessTest);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.loader(fixture);

--- a/src/material/stepper/stepper.spec.ts
+++ b/src/material/stepper/stepper.spec.ts
@@ -45,11 +45,10 @@ import {
   ValidationErrors,
   Validators,
 } from '@angular/forms';
-import {MatRipple, ThemePalette} from '../core';
+import {MATERIAL_ANIMATIONS, MatRipple, ThemePalette} from '../core';
 import {MatFormFieldModule} from '../form-field';
 import {MatInputModule} from '../input';
 import {By} from '@angular/platform-browser';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {Observable, Subject, merge} from 'rxjs';
 import {map, take} from 'rxjs/operators';
 import {MatStepHeader, MatStepperModule} from './index';
@@ -1828,8 +1827,12 @@ function createComponent<T>(
   declarations = [component],
 ): ComponentFixture<T> {
   TestBed.configureTestingModule({
-    imports: [MatStepperModule, NoopAnimationsModule, ReactiveFormsModule, ...imports],
-    providers: [{provide: Directionality, useFactory: () => dir}, ...providers],
+    imports: [MatStepperModule, ReactiveFormsModule, ...imports],
+    providers: [
+      {provide: Directionality, useFactory: () => dir},
+      {provide: MATERIAL_ANIMATIONS, useValue: {animationsDisabled: true}},
+      ...providers,
+    ],
     declarations,
   });
 

--- a/src/material/stepper/testing/stepper-harness.spec.ts
+++ b/src/material/stepper/testing/stepper-harness.spec.ts
@@ -5,7 +5,6 @@ import {HarnessLoader, parallel} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatStepperModule} from '../../stepper';
 import {STEPPER_GLOBAL_OPTIONS} from '@angular/cdk/stepper';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {MatStepperHarness} from './stepper-harness';
 import {MatStepperNextHarness, MatStepperPreviousHarness} from './stepper-button-harnesses';
 import {StepperOrientation} from './step-harness-filters';
@@ -16,7 +15,6 @@ describe('MatStepperHarness', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [MatStepperModule, NoopAnimationsModule, ReactiveFormsModule, StepperHarnessTest],
       providers: [
         {
           provide: STEPPER_GLOBAL_OPTIONS,

--- a/src/material/table/table.spec.ts
+++ b/src/material/table/table.spec.ts
@@ -12,7 +12,6 @@ import {DataSource} from '@angular/cdk/table';
 import {BehaviorSubject, Observable} from 'rxjs';
 import {MatSort, MatSortHeader, MatSortModule} from '../sort';
 import {MatPaginator, MatPaginatorModule} from '../paginator';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 
 describe('MatTable', () => {
   beforeEach(waitForAsync(() => {
@@ -21,7 +20,6 @@ describe('MatTable', () => {
         MatTableModule,
         MatPaginatorModule,
         MatSortModule,
-        NoopAnimationsModule,
         MatTableApp,
         MatTableWithWhenRowApp,
         ArrayDataSourceMatTableApp,

--- a/src/material/tabs/tab-body.spec.ts
+++ b/src/material/tabs/tab-body.spec.ts
@@ -13,7 +13,6 @@ import {
 import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 import {MatRippleModule} from '../core';
 import {By} from '@angular/platform-browser';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {Subject} from 'rxjs';
 import {MatTabBody, MatTabBodyPortal} from './tab-body';
 
@@ -24,14 +23,7 @@ describe('MatTabBody', () => {
   beforeEach(waitForAsync(() => {
     dir = 'ltr';
     TestBed.configureTestingModule({
-      imports: [
-        PortalModule,
-        MatRippleModule,
-        NoopAnimationsModule,
-        MatTabBody,
-        MatTabBodyPortal,
-        SimpleTabBodyApp,
-      ],
+      imports: [PortalModule, MatRippleModule, MatTabBody, MatTabBodyPortal, SimpleTabBodyApp],
       providers: [{provide: Directionality, useFactory: () => ({value: dir, change: dirChange})}],
     });
   }));
@@ -130,13 +122,7 @@ describe('MatTabBody', () => {
 
   it('should mark the tab body content as a scrollable container', () => {
     TestBed.resetTestingModule().configureTestingModule({
-      imports: [
-        PortalModule,
-        MatRippleModule,
-        NoopAnimationsModule,
-        ScrollingModule,
-        SimpleTabBodyApp,
-      ],
+      imports: [PortalModule, MatRippleModule, ScrollingModule, SimpleTabBodyApp],
     });
 
     const fixture = TestBed.createComponent(SimpleTabBodyApp);

--- a/src/material/tabs/tab-group.spec.ts
+++ b/src/material/tabs/tab-group.spec.ts
@@ -11,7 +11,6 @@ import {
   waitForAsync,
 } from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {Observable} from 'rxjs';
 import {
   MAT_TABS_CONFIG,
@@ -21,13 +20,13 @@ import {
   MatTabHeaderPosition,
   MatTabsModule,
 } from './index';
+import {MATERIAL_ANIMATIONS} from '../core';
 
 describe('MatTabGroup', () => {
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
       imports: [
         MatTabsModule,
-        NoopAnimationsModule,
         SimpleTabsTestApp,
         SimpleDynamicTabsTestApp,
         BindedTabsTestApp,
@@ -43,6 +42,7 @@ describe('MatTabGroup', () => {
         NestedTabGroupWithLabel,
         TabsWithClassesTestApp,
       ],
+      providers: [{provide: MATERIAL_ANIMATIONS, useValue: {animationsDisabled: true}}],
     });
   }));
 

--- a/src/material/tabs/testing/tab-group-harness.spec.ts
+++ b/src/material/tabs/testing/tab-group-harness.spec.ts
@@ -3,7 +3,6 @@ import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {ComponentHarness, HarnessLoader, parallel} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatTabsModule} from '../module';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {MatTabGroupHarness} from './tab-group-harness';
 import {MatTabHarness} from './tab-harness';
 
@@ -12,10 +11,6 @@ describe('MatTabGroupHarness', () => {
   let loader: HarnessLoader;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [MatTabsModule, NoopAnimationsModule, TabGroupHarnessTest],
-    });
-
     fixture = TestBed.createComponent(TabGroupHarnessTest);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.loader(fixture);

--- a/src/material/tabs/testing/tab-nav-bar-harness.spec.ts
+++ b/src/material/tabs/testing/tab-nav-bar-harness.spec.ts
@@ -3,7 +3,6 @@ import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatTabsModule} from '../module';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {MatTabNavBarHarness} from './tab-nav-bar-harness';
 
 describe('MatTabNavBarHarness', () => {
@@ -11,10 +10,6 @@ describe('MatTabNavBarHarness', () => {
   let loader: HarnessLoader;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [MatTabsModule, NoopAnimationsModule, TabNavBarHarnessTest],
-    });
-
     fixture = TestBed.createComponent(TabNavBarHarnessTest);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.loader(fixture);

--- a/src/material/timepicker/testing/timepicker-harness.spec.ts
+++ b/src/material/timepicker/testing/timepicker-harness.spec.ts
@@ -1,9 +1,8 @@
 import {Component, signal} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {HarnessLoader, parallel} from '@angular/cdk/testing';
-import {DateAdapter, provideNativeDateAdapter} from '../../core';
+import {DateAdapter, MATERIAL_ANIMATIONS, provideNativeDateAdapter} from '../../core';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {MatTimepicker, MatTimepickerInput} from '../../timepicker';
 import {MatTimepickerHarness} from './timepicker-harness';
 import {MatTimepickerInputHarness} from './timepicker-input-harness';
@@ -14,10 +13,11 @@ describe('MatTimepickerHarness', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [provideNativeDateAdapter()],
-      imports: [NoopAnimationsModule, TimepickerHarnessTest],
+      providers: [
+        provideNativeDateAdapter(),
+        {provide: MATERIAL_ANIMATIONS, useValue: {animationsDisabled: true}},
+      ],
     });
-
     const adapter = TestBed.inject(DateAdapter);
     adapter.setLocale('en-US');
     fixture = TestBed.createComponent(TimepickerHarnessTest);

--- a/src/material/timepicker/testing/timepicker-input-harness.spec.ts
+++ b/src/material/timepicker/testing/timepicker-input-harness.spec.ts
@@ -2,7 +2,6 @@ import {HarnessLoader, parallel} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {Component, signal} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {DateAdapter, provideNativeDateAdapter} from '../../core';
 import {MatTimepicker, MatTimepickerInput} from '../../timepicker';
 import {MatTimepickerHarness} from './timepicker-harness';
@@ -14,11 +13,7 @@ describe('MatTimepickerInputHarness', () => {
   let adapter: DateAdapter<Date>;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [provideNativeDateAdapter()],
-      imports: [NoopAnimationsModule, TimepickerInputHarnessTest],
-    });
-
+    TestBed.configureTestingModule({providers: [provideNativeDateAdapter()]});
     adapter = TestBed.inject(DateAdapter);
     adapter.setLocale('en-US');
     fixture = TestBed.createComponent(TimepickerInputHarnessTest);

--- a/src/material/timepicker/testing/timepicker-toggle-harness.spec.ts
+++ b/src/material/timepicker/testing/timepicker-toggle-harness.spec.ts
@@ -3,7 +3,6 @@ import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
 import {DateAdapter, provideNativeDateAdapter} from '../../core';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {MatTimepicker, MatTimepickerInput, MatTimepickerToggle} from '../../timepicker';
 import {MatTimepickerToggleHarness} from './timepicker-toggle-harness';
 
@@ -12,11 +11,7 @@ describe('MatTimepickerToggleHarness', () => {
   let loader: HarnessLoader;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [provideNativeDateAdapter()],
-      imports: [NoopAnimationsModule, TimepickerHarnessTest],
-    });
-
+    TestBed.configureTestingModule({providers: [provideNativeDateAdapter()]});
     const adapter = TestBed.inject(DateAdapter);
     adapter.setLocale('en-US');
     fixture = TestBed.createComponent(TimepickerHarnessTest);

--- a/src/material/timepicker/timepicker.spec.ts
+++ b/src/material/timepicker/timepicker.spec.ts
@@ -1,7 +1,6 @@
 import {Component, inject, Provider, signal, ViewChild, ViewEncapsulation} from '@angular/core';
 import {ComponentFixture, fakeAsync, flush, TestBed} from '@angular/core/testing';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
-import {DateAdapter, provideNativeDateAdapter} from '../core';
+import {DateAdapter, MATERIAL_ANIMATIONS, provideNativeDateAdapter} from '../core';
 import {
   clearElement,
   dispatchFakeEvent,
@@ -1274,8 +1273,11 @@ describe('MatTimepicker', () => {
 
   function configureTestingModule(additionalProviders: Provider[] = []): void {
     TestBed.configureTestingModule({
-      imports: [NoopAnimationsModule],
-      providers: [provideNativeDateAdapter(), ...additionalProviders],
+      providers: [
+        provideNativeDateAdapter(),
+        {provide: MATERIAL_ANIMATIONS, useValue: {animationsDisabled: true}},
+        ...additionalProviders,
+      ],
     });
     adapter = TestBed.inject(DateAdapter);
     adapter.setLocale('en-US');

--- a/src/material/tooltip/testing/tooltip-harness.spec.ts
+++ b/src/material/tooltip/testing/tooltip-harness.spec.ts
@@ -3,7 +3,6 @@ import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatTooltipModule} from '../module';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {MatTooltipHarness} from './tooltip-harness';
 
 describe('MatTooltipHarness', () => {
@@ -16,10 +15,6 @@ describe('MatTooltipHarness', () => {
   });
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [MatTooltipModule, NoopAnimationsModule, TooltipHarnessTest],
-    });
-
     fixture = TestBed.createComponent(TooltipHarnessTest);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.loader(fixture);

--- a/src/material/tooltip/tooltip.spec.ts
+++ b/src/material/tooltip/tooltip.spec.ts
@@ -29,7 +29,6 @@ import {
   waitForAsync,
 } from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {Subject} from 'rxjs';
 import {
   MAT_TOOLTIP_DEFAULT_OPTIONS,
@@ -351,7 +350,7 @@ describe('MatTooltip', () => {
 
     it('should be able to disable tooltip interactivity', fakeAsync(() => {
       TestBed.resetTestingModule().configureTestingModule({
-        imports: [MatTooltipModule, OverlayModule, NoopAnimationsModule],
+        imports: [MatTooltipModule, OverlayModule],
         declarations: [TooltipDemoWithoutPositionBinding],
         providers: [
           {


### PR DESCRIPTION
Removes the `NoopAnimationsModule` from all tests since it's not necessary in most cases. For the cases where it's relevant, it has been replaced with our own token for disabling animations.