### PR TITLE
build: update dev-infra to version with `http_server` fix

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -223,7 +223,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 git_repository(
     name = "devinfra",
-    commit = "c4f7d3cdec164044284139182b709dfd4be339ed",
+    commit = "35131fc980ce5451fb89d8c033efc827ad39ca68",
     remote = "https://github.com/angular/dev-infra.git",
 )
 


### PR DESCRIPTION
Updates dev-infra to a version that includes the `http_server` runfile fix.