### PR TITLE
build: fix docs site styling token loading

### DIFF
--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -43,7 +43,7 @@ ng_app(
         "//docs:node_modules/@stackblitz/sdk",
         "//docs:node_modules/moment",
         "//docs:node_modules/path-normalize",
-        "//src/material:tokens",
+        "//docs/src/assets/tokens",
     ],
 )
 


### PR DESCRIPTION
Looks like due to some rebasing, the incorrect target was used, so that the token assets wasn't available.