### PR TITLE
fix(material/button): prevents mat-icon being cut off by text-spacing

### DIFF
--- a/src/material/button/button.scss
+++ b/src/material/button/button.scss
@@ -7,6 +7,10 @@
 
 .mat-mdc-button-base {
   text-decoration: none;
+  // Makes button icon not cut off/shrink vertically making the icon visible to fix b/250063405
+  & .mat-icon {
+    min-height: min-content;
+  }
 }
 
 .mdc-button {

--- a/src/material/button/button.scss
+++ b/src/material/button/button.scss
@@ -7,9 +7,10 @@
 
 .mat-mdc-button-base {
   text-decoration: none;
-  // Makes button icon not cut off/shrink vertically making the icon visible to fix b/250063405
+  // Makes button icon not cut off/shrink making the icon visible to fix b/411228600
   & .mat-icon {
-    min-height: min-content;
+    min-height: fit-content;
+    flex-shrink: 0;
   }
 }
 

--- a/src/material/button/button.scss
+++ b/src/material/button/button.scss
@@ -9,6 +9,7 @@
   text-decoration: none;
   // Makes button icon not cut off/shrink making the icon visible to fix b/411228600
   & .mat-icon {
+    // stylelint-disable material/no-prefixes
     min-height: fit-content;
     flex-shrink: 0;
   }


### PR DESCRIPTION
Updates Angular Components Button component specifically for .mat-icon buttons to add a min-height of min-content to avoid the icon from being cut off on the bottom when text-spacing is applied.

Fixes b/411228600

[BEFORE screenshot](https://screenshot.googleplex.com/7LDWZxpgLr6oqHh)
[AFTER screenshot](https://screenshot.googleplex.com/7U3oWSLTAJnwWdM)