### PR TITLE
docs: remove noop module from harness examples

### DIFF
--- a/src/components-examples/material/autocomplete/autocomplete-harness/autocomplete-harness-example.spec.ts
+++ b/src/components-examples/material/autocomplete/autocomplete-harness/autocomplete-harness-example.spec.ts
@@ -3,17 +3,12 @@ import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatAutocompleteHarness} from '@angular/material/autocomplete/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
 import {AutocompleteHarnessExample} from './autocomplete-harness-example';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
-import {MatAutocompleteModule} from '@angular/material/autocomplete';
 
 describe('AutocompleteHarnessExample', () => {
   let fixture: ComponentFixture<AutocompleteHarnessExample>;
   let loader: HarnessLoader;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [MatAutocompleteModule, NoopAnimationsModule],
-    });
     fixture = TestBed.createComponent(AutocompleteHarnessExample);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.loader(fixture);

--- a/src/components-examples/material/bottom-sheet/bottom-sheet-harness/bottom-sheet-harness-example.spec.ts
+++ b/src/components-examples/material/bottom-sheet/bottom-sheet-harness/bottom-sheet-harness-example.spec.ts
@@ -3,8 +3,7 @@ import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatBottomSheetHarness} from '@angular/material/bottom-sheet/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
 import {BottomSheetHarnessExample} from './bottom-sheet-harness-example';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
-import {MatBottomSheetModule} from '@angular/material/bottom-sheet';
+import {MATERIAL_ANIMATIONS} from '@angular/material/core';
 
 describe('BottomSheetHarnessExample', () => {
   let fixture: ComponentFixture<BottomSheetHarnessExample>;
@@ -12,7 +11,7 @@ describe('BottomSheetHarnessExample', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [MatBottomSheetModule, NoopAnimationsModule],
+      providers: [{provide: MATERIAL_ANIMATIONS, useValue: {animationsDisabled: true}}],
     });
     fixture = TestBed.createComponent(BottomSheetHarnessExample);
     fixture.detectChanges();

--- a/src/components-examples/material/datepicker/datepicker-harness/datepicker-harness-example.spec.ts
+++ b/src/components-examples/material/datepicker/datepicker-harness/datepicker-harness-example.spec.ts
@@ -3,9 +3,7 @@ import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatDatepickerInputHarness} from '@angular/material/datepicker/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
 import {DatepickerHarnessExample} from './datepicker-harness-example';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
-import {MatDatepickerModule} from '@angular/material/datepicker';
-import {MatNativeDateModule} from '@angular/material/core';
+import {MATERIAL_ANIMATIONS, MatNativeDateModule} from '@angular/material/core';
 
 describe('DatepickerHarnessExample', () => {
   let fixture: ComponentFixture<DatepickerHarnessExample>;
@@ -13,7 +11,8 @@ describe('DatepickerHarnessExample', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [MatDatepickerModule, NoopAnimationsModule, MatNativeDateModule],
+      imports: [MatNativeDateModule],
+      providers: [{provide: MATERIAL_ANIMATIONS, useValue: {animationsDisabled: true}}],
     });
     fixture = TestBed.createComponent(DatepickerHarnessExample);
     fixture.detectChanges();

--- a/src/components-examples/material/dialog/dialog-harness/dialog-harness-example.spec.ts
+++ b/src/components-examples/material/dialog/dialog-harness/dialog-harness-example.spec.ts
@@ -1,9 +1,9 @@
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
+import {MATERIAL_ANIMATIONS} from '@angular/material/core';
 import {MatDialogHarness} from '@angular/material/dialog/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
 import {DialogHarnessExample} from './dialog-harness-example';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 
 describe('DialogHarnessExample', () => {
   let fixture: ComponentFixture<DialogHarnessExample>;
@@ -11,7 +11,7 @@ describe('DialogHarnessExample', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [NoopAnimationsModule],
+      providers: [{provide: MATERIAL_ANIMATIONS, useValue: {animationsDisabled: true}}],
     });
     fixture = TestBed.createComponent(DialogHarnessExample);
     fixture.detectChanges();

--- a/src/components-examples/material/expansion/expansion-harness/expansion-harness-example.spec.ts
+++ b/src/components-examples/material/expansion/expansion-harness/expansion-harness-example.spec.ts
@@ -2,7 +2,6 @@ import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatAccordionHarness, MatExpansionPanelHarness} from '@angular/material/expansion/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {ExpansionHarnessExample} from './expansion-harness-example';
 
 describe('ExpansionHarnessExample', () => {
@@ -10,9 +9,6 @@ describe('ExpansionHarnessExample', () => {
   let loader: HarnessLoader;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [NoopAnimationsModule],
-    });
     fixture = TestBed.createComponent(ExpansionHarnessExample);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.loader(fixture);

--- a/src/components-examples/material/form-field/form-field-harness/form-field-harness-example.spec.ts
+++ b/src/components-examples/material/form-field/form-field-harness/form-field-harness-example.spec.ts
@@ -3,7 +3,6 @@ import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatFormFieldHarness} from '@angular/material/form-field/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
 import {FormFieldHarnessExample} from './form-field-harness-example';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {MatInputHarness} from '@angular/material/input/testing';
 
 describe('FormFieldHarnessExample', () => {
@@ -11,9 +10,6 @@ describe('FormFieldHarnessExample', () => {
   let loader: HarnessLoader;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [NoopAnimationsModule],
-    });
     fixture = TestBed.createComponent(FormFieldHarnessExample);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.loader(fixture);

--- a/src/components-examples/material/input/input-harness/input-harness-example.spec.ts
+++ b/src/components-examples/material/input/input-harness/input-harness-example.spec.ts
@@ -3,16 +3,12 @@ import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatInputHarness} from '@angular/material/input/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
 import {InputHarnessExample} from './input-harness-example';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 
 describe('InputHarnessExample', () => {
   let fixture: ComponentFixture<InputHarnessExample>;
   let loader: HarnessLoader;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [NoopAnimationsModule],
-    });
     fixture = TestBed.createComponent(InputHarnessExample);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.loader(fixture);

--- a/src/components-examples/material/menu/menu-harness/menu-harness-example.spec.ts
+++ b/src/components-examples/material/menu/menu-harness/menu-harness-example.spec.ts
@@ -2,9 +2,8 @@ import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatMenuHarness} from '@angular/material/menu/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
-import {MatMenuModule} from '@angular/material/menu';
+import {MATERIAL_ANIMATIONS} from '@angular/material/core';
 import {MenuHarnessExample} from './menu-harness-example';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 
 describe('MenuHarnessExample', () => {
   let fixture: ComponentFixture<MenuHarnessExample>;
@@ -12,7 +11,7 @@ describe('MenuHarnessExample', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [MatMenuModule, NoopAnimationsModule, MenuHarnessExample],
+      providers: [{provide: MATERIAL_ANIMATIONS, useValue: {animationsDisabled: true}}],
     });
     fixture = TestBed.createComponent(MenuHarnessExample);
     fixture.detectChanges();

--- a/src/components-examples/material/paginator/paginator-harness/paginator-harness-example.spec.ts
+++ b/src/components-examples/material/paginator/paginator-harness/paginator-harness-example.spec.ts
@@ -3,8 +3,6 @@ import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatPaginatorHarness} from '@angular/material/paginator/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
 import {PaginatorHarnessExample} from './paginator-harness-example';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
-import {MatPaginatorModule} from '@angular/material/paginator';
 
 describe('PaginatorHarnessExample', () => {
   let fixture: ComponentFixture<PaginatorHarnessExample>;
@@ -12,9 +10,6 @@ describe('PaginatorHarnessExample', () => {
   let instance: PaginatorHarnessExample;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [MatPaginatorModule, NoopAnimationsModule],
-    });
     fixture = TestBed.createComponent(PaginatorHarnessExample);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.loader(fixture);

--- a/src/components-examples/material/select/select-harness/select-harness-example.spec.ts
+++ b/src/components-examples/material/select/select-harness/select-harness-example.spec.ts
@@ -1,10 +1,9 @@
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatSelectHarness} from '@angular/material/select/testing';
+import {MATERIAL_ANIMATIONS} from '@angular/material/core';
 import {HarnessLoader} from '@angular/cdk/testing';
 import {SelectHarnessExample} from './select-harness-example';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
-import {MatSelectModule} from '@angular/material/select';
 
 describe('SelectHarnessExample', () => {
   let fixture: ComponentFixture<SelectHarnessExample>;
@@ -12,7 +11,7 @@ describe('SelectHarnessExample', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [MatSelectModule, NoopAnimationsModule],
+      providers: [{provide: MATERIAL_ANIMATIONS, useValue: {animationsDisabled: true}}],
     });
     fixture = TestBed.createComponent(SelectHarnessExample);
     fixture.detectChanges();

--- a/src/components-examples/material/sidenav/sidenav-harness/sidenav-harness-example.spec.ts
+++ b/src/components-examples/material/sidenav/sidenav-harness/sidenav-harness-example.spec.ts
@@ -7,17 +7,12 @@ import {
 } from '@angular/material/sidenav/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
 import {SidenavHarnessExample} from './sidenav-harness-example';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 
 describe('SidenavHarnessExample', () => {
   let fixture: ComponentFixture<SidenavHarnessExample>;
   let loader: HarnessLoader;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [NoopAnimationsModule],
-    });
-
     fixture = TestBed.createComponent(SidenavHarnessExample);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.loader(fixture);

--- a/src/components-examples/material/snack-bar/snack-bar-harness/snack-bar-harness-example.spec.ts
+++ b/src/components-examples/material/snack-bar/snack-bar-harness/snack-bar-harness-example.spec.ts
@@ -1,8 +1,8 @@
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
+import {MATERIAL_ANIMATIONS} from '@angular/material/core';
 import {HarnessLoader} from '@angular/cdk/testing';
 import {SnackBarHarnessExample} from './snack-bar-harness-example';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {MatSnackBarHarness} from '@angular/material/snack-bar/testing';
 
 describe('SnackBarHarnessExample', () => {
@@ -11,7 +11,7 @@ describe('SnackBarHarnessExample', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [NoopAnimationsModule],
+      providers: [{provide: MATERIAL_ANIMATIONS, useValue: {animationsDisabled: true}}],
     });
     fixture = TestBed.createComponent(SnackBarHarnessExample);
     fixture.detectChanges();

--- a/src/components-examples/material/sort/sort-harness/sort-harness-example.spec.ts
+++ b/src/components-examples/material/sort/sort-harness/sort-harness-example.spec.ts
@@ -3,16 +3,12 @@ import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatSortHarness} from '@angular/material/sort/testing';
 import {HarnessLoader, parallel} from '@angular/cdk/testing';
 import {SortHarnessExample} from './sort-harness-example';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 
 describe('SortHarnessExample', () => {
   let fixture: ComponentFixture<SortHarnessExample>;
   let loader: HarnessLoader;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [NoopAnimationsModule],
-    });
     fixture = TestBed.createComponent(SortHarnessExample);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.loader(fixture);

--- a/src/components-examples/material/stepper/stepper-harness/stepper-harness-example.spec.ts
+++ b/src/components-examples/material/stepper/stepper-harness/stepper-harness-example.spec.ts
@@ -3,16 +3,12 @@ import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatStepperHarness, MatStepperNextHarness} from '@angular/material/stepper/testing';
 import {HarnessLoader, parallel} from '@angular/cdk/testing';
 import {StepperHarnessExample} from './stepper-harness-example';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 
 describe('StepperHarnessExample', () => {
   let fixture: ComponentFixture<StepperHarnessExample>;
   let loader: HarnessLoader;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [NoopAnimationsModule],
-    });
     fixture = TestBed.createComponent(StepperHarnessExample);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.loader(fixture);

--- a/src/components-examples/material/tabs/tab-group-harness/tab-group-harness-example.spec.ts
+++ b/src/components-examples/material/tabs/tab-group-harness/tab-group-harness-example.spec.ts
@@ -3,16 +3,12 @@ import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatTabGroupHarness} from '@angular/material/tabs/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
 import {TabGroupHarnessExample} from './tab-group-harness-example';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 
 describe('TabGroupHarnessExample', () => {
   let fixture: ComponentFixture<TabGroupHarnessExample>;
   let loader: HarnessLoader;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [NoopAnimationsModule],
-    });
     fixture = TestBed.createComponent(TabGroupHarnessExample);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.loader(fixture);

--- a/src/components-examples/material/timepicker/timepicker-harness/timepicker-harness-example.spec.ts
+++ b/src/components-examples/material/timepicker/timepicker-harness/timepicker-harness-example.spec.ts
@@ -3,15 +3,17 @@ import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatTimepickerInputHarness} from '@angular/material/timepicker/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
 import {TimepickerHarnessExample} from './timepicker-harness-example';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
-import {DateAdapter, MatNativeDateModule} from '@angular/material/core';
+import {DateAdapter, MATERIAL_ANIMATIONS, MatNativeDateModule} from '@angular/material/core';
 
 describe('TimepickerHarnessExample', () => {
   let fixture: ComponentFixture<TimepickerHarnessExample>;
   let loader: HarnessLoader;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({imports: [NoopAnimationsModule, MatNativeDateModule]});
+    TestBed.configureTestingModule({
+      imports: [MatNativeDateModule],
+      providers: [{provide: MATERIAL_ANIMATIONS, useValue: {animationsDisabled: true}}],
+    });
     TestBed.inject(DateAdapter).setLocale('en-US'); // Set the locale to en-US to guarantee consistent tests.
     fixture = TestBed.createComponent(TimepickerHarnessExample);
     fixture.detectChanges();

--- a/src/components-examples/material/tooltip/tooltip-harness/tooltip-harness-example.spec.ts
+++ b/src/components-examples/material/tooltip/tooltip-harness/tooltip-harness-example.spec.ts
@@ -1,10 +1,9 @@
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatTooltipHarness} from '@angular/material/tooltip/testing';
+import {MATERIAL_ANIMATIONS} from '@angular/material/core';
 import {HarnessLoader} from '@angular/cdk/testing';
 import {TooltipHarnessExample} from './tooltip-harness-example';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
-import {MatTooltipModule} from '@angular/material/tooltip';
 
 describe('TooltipHarnessExample', () => {
   let fixture: ComponentFixture<TooltipHarnessExample>;
@@ -12,7 +11,7 @@ describe('TooltipHarnessExample', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [MatTooltipModule, NoopAnimationsModule],
+      providers: [{provide: MATERIAL_ANIMATIONS, useValue: {animationsDisabled: true}}],
     });
     fixture = TestBed.createComponent(TooltipHarnessExample);
     fixture.detectChanges();


### PR DESCRIPTION
Removes the `NoopAnimationsModule` from the harness examples since it isn't necessary for most of them. The rest of the examples have been switched to our token for disabling animations.