### PR TITLE
fix(material/select): select shrinking after scroll

### DIFF
--- a/src/material/select/select.html
+++ b/src/material/select/select.html
@@ -40,6 +40,7 @@
   [cdkConnectedOverlayPositions]="_positions"
   [cdkConnectedOverlayWidth]="_overlayWidth"
   [cdkConnectedOverlayFlexibleDimensions]="true"
+  [cdkConnectedOverlayGrowAfterOpen]="true"
   (detach)="close()"
   (backdropClick)="close()"
   (overlayKeydown)="_handleOverlayKeydown($event)">


### PR DESCRIPTION
i added growAfterOpen to the position strategy of the overlay, matching the behaviour of the mat-menu

Fixes #30901
