### PR TITLE
fix(cdk/listbox): avoid resetting scroll position when using mouse

### DIFF
--- a/src/material/select/select.html
+++ b/src/material/select/select.html
@@ -40,6 +40,7 @@
   [cdkConnectedOverlayPositions]="_positions"
   [cdkConnectedOverlayWidth]="_overlayWidth"
   [cdkConnectedOverlayFlexibleDimensions]="true"
+  [cdkConnectedOverlayGrowAfterOpen]="true"
   (detach)="close()"
   (backdropClick)="close()"
   (overlayKeydown)="_handleOverlayKeydown($event)">


### PR DESCRIPTION
The CDK listbox has some logic that forwards focus to the first item when the host is focused. The problem is that every time the user clicks on the scrollbar, they blur the current item and focus the listbox which then forwards focus back to the first item which in turn causes the scroll position to jump to the top. These changes add some logic to not forward focus when focus comes from a mouse interaction.

Fixes #30900