### PR TITLE
refactor(multiple): switch DOCUMENT imports to core

### DIFF
--- a/src/cdk-experimental/column-resize/resize-strategy.ts
+++ b/src/cdk-experimental/column-resize/resize-strategy.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Injectable, OnDestroy, Provider, CSP_NONCE, inject} from '@angular/core';
-import {DOCUMENT} from '@angular/common';
+import {Injectable, OnDestroy, Provider, CSP_NONCE, inject, DOCUMENT} from '@angular/core';
+
 import {coerceCssPixelValue} from '@angular/cdk/coercion';
 import {CdkTable, _CoalescedStyleScheduler, _COALESCED_STYLE_SCHEDULER} from '@angular/cdk/table';
 

--- a/src/cdk-experimental/combobox/combobox.ts
+++ b/src/cdk-experimental/combobox/combobox.ts
@@ -17,7 +17,7 @@ import {
 } from '@angular/cdk/overlay';
 import {_getEventTarget} from '@angular/cdk/platform';
 import {TemplatePortal} from '@angular/cdk/portal';
-import {DOCUMENT} from '@angular/common';
+
 import {
   ChangeDetectorRef,
   Directive,
@@ -32,6 +32,7 @@ import {
   TemplateRef,
   ViewContainerRef,
   inject,
+  DOCUMENT,
 } from '@angular/core';
 
 export type AriaHasPopupValue = 'false' | 'true' | 'menu' | 'listbox' | 'tree' | 'grid' | 'dialog';

--- a/src/cdk-experimental/popover-edit/focus-escape-notifier.ts
+++ b/src/cdk-experimental/popover-edit/focus-escape-notifier.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Injectable, NgZone, inject} from '@angular/core';
-import {DOCUMENT} from '@angular/common';
+import {Injectable, NgZone, inject, DOCUMENT} from '@angular/core';
+
 import {FocusTrap, InteractivityChecker} from '@angular/cdk/a11y';
 import {Observable, Subject} from 'rxjs';
 

--- a/src/cdk-experimental/table-scroll-container/table-scroll-container.ts
+++ b/src/cdk-experimental/table-scroll-container/table-scroll-container.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {CSP_NONCE, Directive, ElementRef, OnDestroy, OnInit, inject} from '@angular/core';
+import {CSP_NONCE, Directive, ElementRef, OnDestroy, OnInit, inject, DOCUMENT} from '@angular/core';
 import {_IdGenerator} from '@angular/cdk/a11y';
-import {DOCUMENT} from '@angular/common';
+
 import {Directionality} from '@angular/cdk/bidi';
 import {_getShadowRoot} from '@angular/cdk/platform';
 import {

--- a/src/cdk/a11y/aria-describer/aria-describer.ts
+++ b/src/cdk/a11y/aria-describer/aria-describer.ts
@@ -6,8 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {DOCUMENT} from '@angular/common';
-import {Injectable, OnDestroy, APP_ID, inject} from '@angular/core';
+import {Injectable, OnDestroy, APP_ID, inject, DOCUMENT} from '@angular/core';
 import {Platform} from '../../platform';
 import {addAriaReferencedId, getAriaReferenceIds, removeAriaReferencedId} from './aria-reference';
 import {_CdkPrivateStyleLoader, _VisuallyHiddenLoader} from '../../private';

--- a/src/cdk/a11y/focus-monitor/focus-monitor.spec.ts
+++ b/src/cdk/a11y/focus-monitor/focus-monitor.spec.ts
@@ -1,7 +1,6 @@
 import {TAB} from '../../keycodes';
 import {Platform} from '../../platform';
-import {DOCUMENT} from '@angular/common';
-import {Component, ViewChild} from '@angular/core';
+import {Component, ViewChild, DOCUMENT} from '@angular/core';
 import {ComponentFixture, TestBed, fakeAsync, flush, tick} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {

--- a/src/cdk/a11y/focus-monitor/focus-monitor.ts
+++ b/src/cdk/a11y/focus-monitor/focus-monitor.ts
@@ -23,11 +23,12 @@ import {
   Output,
   AfterViewInit,
   inject,
+  DOCUMENT,
 } from '@angular/core';
 import {Observable, of as observableOf, Subject, Subscription} from 'rxjs';
 import {takeUntil} from 'rxjs/operators';
 import {coerceElement} from '../../coercion';
-import {DOCUMENT} from '@angular/common';
+
 import {InputModalityDetector, TOUCH_BUFFER_MS} from '../input-modality/input-modality-detector';
 
 export type FocusOrigin = 'touch' | 'mouse' | 'keyboard' | 'program' | null;

--- a/src/cdk/a11y/focus-trap/configurable-focus-trap-factory.ts
+++ b/src/cdk/a11y/focus-trap/configurable-focus-trap-factory.ts
@@ -6,8 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {DOCUMENT} from '@angular/common';
-import {Injectable, Injector, NgZone, inject} from '@angular/core';
+import {Injectable, Injector, NgZone, inject, DOCUMENT} from '@angular/core';
 import {InteractivityChecker} from '../interactivity-checker/interactivity-checker';
 import {ConfigurableFocusTrap} from './configurable-focus-trap';
 import {ConfigurableFocusTrapConfig} from './configurable-focus-trap-config';

--- a/src/cdk/a11y/focus-trap/focus-trap.ts
+++ b/src/cdk/a11y/focus-trap/focus-trap.ts
@@ -7,7 +7,7 @@
  */
 
 import {Platform, _getFocusedElementPierceShadowDom} from '../../platform';
-import {DOCUMENT} from '@angular/common';
+
 import {
   AfterContentInit,
   Directive,
@@ -23,6 +23,7 @@ import {
   afterNextRender,
   booleanAttribute,
   inject,
+  DOCUMENT,
 } from '@angular/core';
 import {InteractivityChecker} from '../interactivity-checker/interactivity-checker';
 import {_CdkPrivateStyleLoader, _VisuallyHiddenLoader} from '../../private';

--- a/src/cdk/a11y/high-contrast-mode/high-contrast-mode-detector.spec.ts
+++ b/src/cdk/a11y/high-contrast-mode/high-contrast-mode-detector.spec.ts
@@ -7,9 +7,8 @@ import {
 } from './high-contrast-mode-detector';
 import {Platform} from '../../platform';
 import {TestBed} from '@angular/core/testing';
-import {Provider} from '@angular/core';
+import {Provider, DOCUMENT} from '@angular/core';
 import {A11yModule} from '../a11y-module';
-import {DOCUMENT} from '@angular/common';
 
 describe('HighContrastModeDetector', () => {
   function getDetector(document: unknown, platform?: Platform) {

--- a/src/cdk/a11y/high-contrast-mode/high-contrast-mode-detector.ts
+++ b/src/cdk/a11y/high-contrast-mode/high-contrast-mode-detector.ts
@@ -6,10 +6,10 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {inject, Injectable, OnDestroy} from '@angular/core';
+import {inject, Injectable, OnDestroy, DOCUMENT} from '@angular/core';
 import {BreakpointObserver} from '../../layout';
 import {Platform} from '../../platform';
-import {DOCUMENT} from '@angular/common';
+
 import {Subscription} from 'rxjs';
 
 /** Set of possible high-contrast mode backgrounds. */

--- a/src/cdk/a11y/input-modality/input-modality-detector.ts
+++ b/src/cdk/a11y/input-modality/input-modality-detector.ts
@@ -14,9 +14,10 @@ import {
   NgZone,
   inject,
   RendererFactory2,
+  DOCUMENT,
 } from '@angular/core';
 import {Platform, _getEventTarget} from '../../platform';
-import {DOCUMENT} from '@angular/common';
+
 import {BehaviorSubject, Observable} from 'rxjs';
 import {distinctUntilChanged, skip} from 'rxjs/operators';
 import {

--- a/src/cdk/a11y/live-announcer/live-announcer.ts
+++ b/src/cdk/a11y/live-announcer/live-announcer.ts
@@ -7,8 +7,17 @@
  */
 
 import {ContentObserver} from '../../observers';
-import {DOCUMENT} from '@angular/common';
-import {Directive, ElementRef, Injectable, Input, NgZone, OnDestroy, inject} from '@angular/core';
+
+import {
+  Directive,
+  ElementRef,
+  Injectable,
+  Input,
+  NgZone,
+  OnDestroy,
+  inject,
+  DOCUMENT,
+} from '@angular/core';
 import {Subscription} from 'rxjs';
 import {
   AriaLivePoliteness,

--- a/src/cdk/bidi/dir-document-token.ts
+++ b/src/cdk/bidi/dir-document-token.ts
@@ -6,8 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {DOCUMENT} from '@angular/common';
-import {inject, InjectionToken} from '@angular/core';
+import {inject, InjectionToken, DOCUMENT} from '@angular/core';
 
 /**
  * Injection token used to inject the document into Directionality.

--- a/src/cdk/clipboard/clipboard.spec.ts
+++ b/src/cdk/clipboard/clipboard.spec.ts
@@ -1,4 +1,4 @@
-import {DOCUMENT} from '@angular/common';
+import {DOCUMENT} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {Clipboard} from './clipboard';
 import {PendingCopy} from './pending-copy';

--- a/src/cdk/clipboard/clipboard.ts
+++ b/src/cdk/clipboard/clipboard.ts
@@ -6,8 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {DOCUMENT} from '@angular/common';
-import {Injectable, inject} from '@angular/core';
+import {Injectable, inject, DOCUMENT} from '@angular/core';
 import {PendingCopy} from './pending-copy';
 
 /**

--- a/src/cdk/dialog/dialog-container.ts
+++ b/src/cdk/dialog/dialog-container.ts
@@ -22,7 +22,7 @@ import {
   DomPortal,
   TemplatePortal,
 } from '../portal';
-import {DOCUMENT} from '@angular/common';
+
 import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
@@ -38,6 +38,7 @@ import {
   ViewEncapsulation,
   afterNextRender,
   inject,
+  DOCUMENT,
 } from '@angular/core';
 import {DialogConfig} from './dialog-config';
 

--- a/src/cdk/drag-drop/drag-drop-registry.ts
+++ b/src/cdk/drag-drop/drag-drop-registry.ts
@@ -18,8 +18,9 @@ import {
   WritableSignal,
   inject,
   signal,
+  DOCUMENT,
 } from '@angular/core';
-import {DOCUMENT} from '@angular/common';
+
 import {_CdkPrivateStyleLoader} from '../private';
 import {Observable, Observer, Subject, merge} from 'rxjs';
 import type {DropListRef} from './drop-list-ref';

--- a/src/cdk/drag-drop/drag-drop.ts
+++ b/src/cdk/drag-drop/drag-drop.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Injectable, NgZone, ElementRef, inject, RendererFactory2} from '@angular/core';
-import {DOCUMENT} from '@angular/common';
+import {Injectable, NgZone, ElementRef, inject, RendererFactory2, DOCUMENT} from '@angular/core';
+
 import {ViewportRuler} from '../scrolling';
 import {DragRef, DragRefConfig} from './drag-ref';
 import {DropListRef} from './drop-list-ref';

--- a/src/cdk/overlay/dispatchers/base-overlay-dispatcher.ts
+++ b/src/cdk/overlay/dispatchers/base-overlay-dispatcher.ts
@@ -6,8 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {DOCUMENT} from '@angular/common';
-import {Injectable, OnDestroy, inject} from '@angular/core';
+import {Injectable, OnDestroy, inject, DOCUMENT} from '@angular/core';
 import type {OverlayRef} from '../overlay-ref';
 
 /**

--- a/src/cdk/overlay/fullscreen-overlay-container.spec.ts
+++ b/src/cdk/overlay/fullscreen-overlay-container.spec.ts
@@ -1,6 +1,5 @@
-import {DOCUMENT} from '@angular/common';
 import {waitForAsync, TestBed} from '@angular/core/testing';
-import {Component, NgModule, ViewChild, ViewContainerRef, inject} from '@angular/core';
+import {Component, NgModule, ViewChild, ViewContainerRef, inject, DOCUMENT} from '@angular/core';
 import {PortalModule, CdkPortal} from '../portal';
 import {Overlay, OverlayContainer, OverlayModule, FullscreenOverlayContainer} from './index';
 import {TemplatePortalDirective} from '../portal/portal-directives';

--- a/src/cdk/overlay/overlay-container.ts
+++ b/src/cdk/overlay/overlay-container.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {DOCUMENT} from '@angular/common';
 import {
   Injectable,
   OnDestroy,
@@ -14,6 +13,7 @@ import {
   ChangeDetectionStrategy,
   ViewEncapsulation,
   inject,
+  DOCUMENT,
 } from '@angular/core';
 import {_CdkPrivateStyleLoader} from '../private';
 import {Platform, _isTestEnvironment} from '../platform';

--- a/src/cdk/overlay/overlay.ts
+++ b/src/cdk/overlay/overlay.ts
@@ -8,7 +8,7 @@
 
 import {Directionality} from '../bidi';
 import {DomPortalOutlet} from '../portal';
-import {DOCUMENT, Location} from '@angular/common';
+import {Location} from '@angular/common';
 import {
   ApplicationRef,
   Injectable,
@@ -18,6 +18,7 @@ import {
   EnvironmentInjector,
   inject,
   RendererFactory2,
+  DOCUMENT,
 } from '@angular/core';
 import {_IdGenerator} from '../a11y';
 import {_CdkPrivateStyleLoader} from '../private';

--- a/src/cdk/overlay/position/overlay-position-builder.ts
+++ b/src/cdk/overlay/position/overlay-position-builder.ts
@@ -8,8 +8,8 @@
 
 import {Platform} from '../../platform';
 import {ViewportRuler} from '../../scrolling';
-import {DOCUMENT} from '@angular/common';
-import {Injectable, inject} from '@angular/core';
+
+import {Injectable, inject, DOCUMENT} from '@angular/core';
 import {OverlayContainer} from '../overlay-container';
 import {
   FlexibleConnectedPositionStrategy,

--- a/src/cdk/overlay/scroll/scroll-strategy-options.ts
+++ b/src/cdk/overlay/scroll/scroll-strategy-options.ts
@@ -7,8 +7,8 @@
  */
 
 import {ScrollDispatcher, ViewportRuler} from '../../scrolling';
-import {DOCUMENT} from '@angular/common';
-import {Injectable, NgZone, inject} from '@angular/core';
+
+import {Injectable, NgZone, inject, DOCUMENT} from '@angular/core';
 import {BlockScrollStrategy} from './block-scroll-strategy';
 import {CloseScrollStrategy, CloseScrollStrategyConfig} from './close-scroll-strategy';
 import {NoopScrollStrategy} from './noop-scroll-strategy';

--- a/src/cdk/portal/portal-directives.ts
+++ b/src/cdk/portal/portal-directives.ts
@@ -20,8 +20,9 @@ import {
   Input,
   inject,
   NgModuleRef,
+  DOCUMENT,
 } from '@angular/core';
-import {DOCUMENT} from '@angular/common';
+
 import {BasePortalOutlet, ComponentPortal, Portal, TemplatePortal, DomPortal} from './portal';
 
 /**

--- a/src/cdk/scrolling/viewport-ruler.ts
+++ b/src/cdk/scrolling/viewport-ruler.ts
@@ -7,10 +7,9 @@
  */
 
 import {Platform} from '../platform';
-import {Injectable, NgZone, OnDestroy, RendererFactory2, inject} from '@angular/core';
+import {Injectable, NgZone, OnDestroy, RendererFactory2, inject, DOCUMENT} from '@angular/core';
 import {Observable, Subject} from 'rxjs';
 import {auditTime} from 'rxjs/operators';
-import {DOCUMENT} from '@angular/common';
 
 /** Time in ms to throttle the resize events by default. */
 export const DEFAULT_RESIZE_TIME = 20;

--- a/src/cdk/scrolling/virtual-scrollable-window.ts
+++ b/src/cdk/scrolling/virtual-scrollable-window.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Directive, ElementRef, inject} from '@angular/core';
-import {DOCUMENT} from '@angular/common';
+import {Directive, ElementRef, inject, DOCUMENT} from '@angular/core';
+
 import {CdkVirtualScrollable, VIRTUAL_SCROLLABLE} from './virtual-scrollable';
 
 /**

--- a/src/cdk/table/table.ts
+++ b/src/cdk/table/table.ts
@@ -21,7 +21,7 @@ import {
 } from '../collections';
 import {Platform} from '../platform';
 import {ViewportRuler} from '../scrolling';
-import {DOCUMENT} from '@angular/common';
+
 import {
   AfterContentChecked,
   AfterContentInit,
@@ -50,6 +50,7 @@ import {
   inject,
   Injector,
   HostAttributeToken,
+  DOCUMENT,
 } from '@angular/core';
 import {
   BehaviorSubject,

--- a/src/cdk/text-field/autosize.ts
+++ b/src/cdk/text-field/autosize.ts
@@ -18,8 +18,9 @@ import {
   booleanAttribute,
   inject,
   Renderer2,
+  DOCUMENT,
 } from '@angular/core';
-import {DOCUMENT} from '@angular/common';
+
 import {Platform} from '../platform';
 import {_CdkPrivateStyleLoader} from '../private';
 import {auditTime} from 'rxjs/operators';

--- a/src/dev-app/dev-app/dev-app-layout.ts
+++ b/src/dev-app/dev-app/dev-app-layout.ts
@@ -7,7 +7,7 @@
  */
 
 import {Direction, Directionality} from '@angular/cdk/bidi';
-import {DOCUMENT} from '@angular/common';
+
 import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
@@ -17,6 +17,7 @@ import {
   ViewEncapsulation,
   inject,
   ɵNoopNgZone,
+  DOCUMENT,
 } from '@angular/core';
 import {MatButtonModule} from '@angular/material/button';
 import {MatIconModule, MatIconRegistry} from '@angular/material/icon';

--- a/src/dev-app/dialog/dialog-demo.ts
+++ b/src/dev-app/dialog/dialog-demo.ts
@@ -7,7 +7,7 @@
  */
 
 import {DragDropModule} from '@angular/cdk/drag-drop';
-import {DOCUMENT, JsonPipe} from '@angular/common';
+import {JsonPipe} from '@angular/common';
 import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
@@ -16,6 +16,7 @@ import {
   ViewChild,
   ViewEncapsulation,
   inject,
+  DOCUMENT,
 } from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {MatButtonModule} from '@angular/material/button';

--- a/src/material-experimental/column-resize/overlay-handle.ts
+++ b/src/material-experimental/column-resize/overlay-handle.ts
@@ -14,8 +14,9 @@ import {
   ViewChild,
   ViewEncapsulation,
   inject,
+  DOCUMENT,
 } from '@angular/core';
-import {DOCUMENT} from '@angular/common';
+
 import {
   CdkColumnDef,
   _CoalescedStyleScheduler,

--- a/src/material-experimental/column-resize/resizable-directives/default-enabled-resizable.ts
+++ b/src/material-experimental/column-resize/resizable-directives/default-enabled-resizable.ts
@@ -14,8 +14,9 @@ import {
   ViewContainerRef,
   ChangeDetectorRef,
   inject,
+  DOCUMENT,
 } from '@angular/core';
-import {DOCUMENT} from '@angular/common';
+
 import {Directionality} from '@angular/cdk/bidi';
 import {Overlay} from '@angular/cdk/overlay';
 import {

--- a/src/material-experimental/column-resize/resizable-directives/resizable.ts
+++ b/src/material-experimental/column-resize/resizable-directives/resizable.ts
@@ -14,8 +14,9 @@ import {
   ViewContainerRef,
   ChangeDetectorRef,
   inject,
+  DOCUMENT,
 } from '@angular/core';
-import {DOCUMENT} from '@angular/common';
+
 import {Directionality} from '@angular/cdk/bidi';
 import {Overlay} from '@angular/cdk/overlay';
 import {

--- a/src/material/badge/badge.ts
+++ b/src/material/badge/badge.ts
@@ -7,7 +7,7 @@
  */
 
 import {_IdGenerator, AriaDescriber, InteractivityChecker} from '@angular/cdk/a11y';
-import {DOCUMENT} from '@angular/common';
+
 import {
   booleanAttribute,
   ChangeDetectionStrategy,
@@ -22,6 +22,7 @@ import {
   Renderer2,
   ViewEncapsulation,
   HOST_TAG_NAME,
+  DOCUMENT,
 } from '@angular/core';
 import {_animationsDisabled, ThemePalette} from '../core';
 import {_CdkPrivateStyleLoader, _VisuallyHiddenLoader} from '@angular/cdk/private';

--- a/src/material/chips/chip-edit-input.ts
+++ b/src/material/chips/chip-edit-input.ts
@@ -6,8 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Directive, ElementRef, inject} from '@angular/core';
-import {DOCUMENT} from '@angular/common';
+import {Directive, ElementRef, inject, DOCUMENT} from '@angular/core';
 
 /**
  * A directive that makes a span editable and exposes functions to modify and retrieve the

--- a/src/material/chips/chip.ts
+++ b/src/material/chips/chip.ts
@@ -9,7 +9,7 @@
 import {FocusMonitor, _IdGenerator} from '@angular/cdk/a11y';
 import {BACKSPACE, DELETE} from '@angular/cdk/keycodes';
 import {_CdkPrivateStyleLoader, _VisuallyHiddenLoader} from '@angular/cdk/private';
-import {DOCUMENT} from '@angular/common';
+
 import {
   AfterContentInit,
   AfterViewInit,
@@ -33,6 +33,7 @@ import {
   ViewEncapsulation,
   booleanAttribute,
   inject,
+  DOCUMENT,
 } from '@angular/core';
 import {
   MAT_RIPPLE_GLOBAL_OPTIONS,

--- a/src/material/core/private/ripple-loader.ts
+++ b/src/material/core/private/ripple-loader.ts
@@ -6,8 +6,15 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {DOCUMENT} from '@angular/common';
-import {Injectable, Injector, NgZone, OnDestroy, RendererFactory2, inject} from '@angular/core';
+import {
+  Injectable,
+  Injector,
+  NgZone,
+  OnDestroy,
+  RendererFactory2,
+  inject,
+  DOCUMENT,
+} from '@angular/core';
 import {
   MAT_RIPPLE_GLOBAL_OPTIONS,
   RippleRenderer,

--- a/src/material/datepicker/datepicker-base.ts
+++ b/src/material/datepicker/datepicker-base.ts
@@ -29,7 +29,7 @@ import {
 } from '@angular/cdk/overlay';
 import {_getFocusedElementPierceShadowDom} from '@angular/cdk/platform';
 import {CdkPortalOutlet, ComponentPortal, ComponentType, TemplatePortal} from '@angular/cdk/portal';
-import {DOCUMENT} from '@angular/common';
+
 import {
   afterNextRender,
   AfterViewInit,
@@ -54,6 +54,7 @@ import {
   ViewChild,
   ViewContainerRef,
   ViewEncapsulation,
+  DOCUMENT,
 } from '@angular/core';
 import {MatButton} from '../button';
 import {_animationsDisabled, DateAdapter, ThemePalette} from '../core';

--- a/src/material/expansion/expansion-panel.ts
+++ b/src/material/expansion/expansion-panel.ts
@@ -9,7 +9,7 @@
 import {CdkAccordionItem} from '@angular/cdk/accordion';
 import {UniqueSelectionDispatcher} from '@angular/cdk/collections';
 import {CdkPortalOutlet, TemplatePortal} from '@angular/cdk/portal';
-import {DOCUMENT} from '@angular/common';
+
 import {
   AfterContentInit,
   ChangeDetectionStrategy,
@@ -31,6 +31,7 @@ import {
   inject,
   NgZone,
   Renderer2,
+  DOCUMENT,
 } from '@angular/core';
 import {_IdGenerator} from '@angular/cdk/a11y';
 import {Subject} from 'rxjs';

--- a/src/material/icon/icon-registry.ts
+++ b/src/material/icon/icon-registry.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {DOCUMENT} from '@angular/common';
 import {HttpClient, HttpErrorResponse} from '@angular/common/http';
 import {
   ErrorHandler,
@@ -17,6 +16,7 @@ import {
   Optional,
   SecurityContext,
   SkipSelf,
+  DOCUMENT,
 } from '@angular/core';
 import {DomSanitizer, SafeHtml, SafeResourceUrl} from '@angular/platform-browser';
 import {forkJoin, Observable, of as observableOf, throwError as observableThrow} from 'rxjs';

--- a/src/material/icon/icon.ts
+++ b/src/material/icon/icon.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {DOCUMENT} from '@angular/common';
 import {
   AfterViewChecked,
   booleanAttribute,
@@ -21,6 +20,7 @@ import {
   OnInit,
   ViewEncapsulation,
   HostAttributeToken,
+  DOCUMENT,
 } from '@angular/core';
 import {ThemePalette} from '../core';
 import {Subscription} from 'rxjs';

--- a/src/material/menu/menu-content.ts
+++ b/src/material/menu/menu-content.ts
@@ -7,7 +7,7 @@
  */
 
 import {DomPortalOutlet, TemplatePortal} from '@angular/cdk/portal';
-import {DOCUMENT} from '@angular/common';
+
 import {
   ApplicationRef,
   ChangeDetectorRef,
@@ -18,6 +18,7 @@ import {
   TemplateRef,
   ViewContainerRef,
   inject,
+  DOCUMENT,
 } from '@angular/core';
 import {Subject} from 'rxjs';
 

--- a/src/material/menu/menu-item.ts
+++ b/src/material/menu/menu-item.ts
@@ -17,10 +17,11 @@ import {
   ChangeDetectorRef,
   booleanAttribute,
   inject,
+  DOCUMENT,
 } from '@angular/core';
 import {FocusableOption, FocusMonitor, FocusOrigin} from '@angular/cdk/a11y';
 import {Subject} from 'rxjs';
-import {DOCUMENT} from '@angular/common';
+
 import {MatMenuPanel, MAT_MENU_PANEL} from './menu-panel';
 import {_StructuralStylesLoader, MatRipple} from '../core';
 import {_CdkPrivateStyleLoader} from '@angular/cdk/private';

--- a/src/material/progress-bar/progress-bar.ts
+++ b/src/material/progress-bar/progress-bar.ts
@@ -22,8 +22,9 @@ import {
   inject,
   numberAttribute,
   Renderer2,
+  DOCUMENT,
 } from '@angular/core';
-import {DOCUMENT} from '@angular/common';
+
 import {_animationsDisabled, ThemePalette} from '../core';
 
 /** Last animation end data. */

--- a/src/material/sidenav/drawer.ts
+++ b/src/material/sidenav/drawer.ts
@@ -17,7 +17,7 @@ import {BooleanInput, coerceBooleanProperty} from '@angular/cdk/coercion';
 import {ESCAPE, hasModifierKey} from '@angular/cdk/keycodes';
 import {Platform} from '@angular/cdk/platform';
 import {CdkScrollable, ScrollDispatcher, ViewportRuler} from '@angular/cdk/scrolling';
-import {DOCUMENT} from '@angular/common';
+
 import {
   AfterContentInit,
   afterNextRender,
@@ -41,6 +41,7 @@ import {
   Renderer2,
   ViewChild,
   ViewEncapsulation,
+  DOCUMENT,
 } from '@angular/core';
 import {fromEvent, merge, Observable, Subject} from 'rxjs';
 import {debounceTime, filter, map, mapTo, startWith, take, takeUntil} from 'rxjs/operators';

--- a/src/material/snack-bar/snack-bar-container.ts
+++ b/src/material/snack-bar/snack-bar-container.ts
@@ -15,7 +15,7 @@ import {
   DomPortal,
   TemplatePortal,
 } from '@angular/cdk/portal';
-import {DOCUMENT} from '@angular/common';
+
 import {
   afterNextRender,
   ChangeDetectionStrategy,
@@ -30,6 +30,7 @@ import {
   OnDestroy,
   ViewChild,
   ViewEncapsulation,
+  DOCUMENT,
 } from '@angular/core';
 import {Observable, of, Subject} from 'rxjs';
 import {_animationsDisabled} from '../core';

--- a/src/material/toolbar/toolbar.ts
+++ b/src/material/toolbar/toolbar.ts
@@ -7,7 +7,7 @@
  */
 
 import {Platform} from '@angular/cdk/platform';
-import {DOCUMENT} from '@angular/common';
+
 import {
   AfterViewInit,
   ChangeDetectionStrategy,
@@ -19,6 +19,7 @@ import {
   QueryList,
   ViewEncapsulation,
   inject,
+  DOCUMENT,
 } from '@angular/core';
 
 @Directive({

--- a/src/material/tooltip/tooltip.ts
+++ b/src/material/tooltip/tooltip.ts
@@ -30,8 +30,9 @@ import {
   inject,
   afterNextRender,
   Injector,
+  DOCUMENT,
 } from '@angular/core';
-import {DOCUMENT, NgClass} from '@angular/common';
+import {NgClass} from '@angular/common';
 import {normalizePassiveListenerOptions, Platform} from '@angular/cdk/platform';
 import {AriaDescriber, FocusMonitor} from '@angular/cdk/a11y';
 import {Directionality} from '@angular/cdk/bidi';

--- a/src/universal-app/kitchen-sink/kitchen-sink.ts
+++ b/src/universal-app/kitchen-sink/kitchen-sink.ts
@@ -4,9 +4,9 @@ import {DragDropModule} from '@angular/cdk/drag-drop';
 import {CdkListboxModule} from '@angular/cdk/listbox';
 import {ScrollingModule, ViewportRuler} from '@angular/cdk/scrolling';
 import {CdkTableModule, DataSource} from '@angular/cdk/table';
-import {DOCUMENT} from '@angular/common';
+
 import {CdkPopoverEditCdkTableExample} from '@angular/components-examples/cdk-experimental/popover-edit';
-import {Component, ElementRef, InjectionToken, inject} from '@angular/core';
+import {Component, ElementRef, InjectionToken, inject, DOCUMENT} from '@angular/core';
 import {
   GoogleMap,
   MapBicyclingLayer,


### PR DESCRIPTION
Switches all the places where we import `DOCUMENT` from `@angular/common` to be from `@angular/core` instead.