### PR TITLE
build: remove miscellaneous usages of the noop animations module

### DIFF
--- a/docs/scenes/src/app/scene-overlay-container.ts
+++ b/docs/scenes/src/app/scene-overlay-container.ts
@@ -1,5 +1,7 @@
+import {Injectable} from '@angular/core';
 import {OverlayContainer} from '@angular/cdk/overlay';
 
+@Injectable({providedIn: 'root'})
 export class SceneOverlayContainer extends OverlayContainer {
   _createContainer(): void {
     const container = this._document.createElement('div');

--- a/docs/scenes/src/main.ts
+++ b/docs/scenes/src/main.ts
@@ -1,23 +1,21 @@
-import {importProvidersFrom} from '@angular/core';
-
 import {AppComponent} from './app/app.component';
-import {MatNativeDateModule} from '@angular/material/core';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
+import {provideNativeDateAdapter, MATERIAL_ANIMATIONS} from '@angular/material/core';
 import {routes} from './app/app-routes';
-import {BrowserModule, bootstrapApplication} from '@angular/platform-browser';
-import {DOCUMENT} from '@angular/common';
+import {bootstrapApplication} from '@angular/platform-browser';
 import {SceneOverlayContainer} from './app/scene-overlay-container';
-import {Platform} from '@angular/cdk/platform';
 import {OverlayContainer} from '@angular/cdk/overlay';
 import {provideRouter} from '@angular/router';
 
 bootstrapApplication(AppComponent, {
   providers: [
-    importProvidersFrom(BrowserModule, MatNativeDateModule, NoopAnimationsModule),
+    provideNativeDateAdapter(),
     {
       provide: OverlayContainer,
-      useFactory: (doc: any, platform: Platform) => new SceneOverlayContainer(doc, platform),
-      deps: [DOCUMENT, Platform],
+      useClass: SceneOverlayContainer,
+    },
+    {
+      provide: MATERIAL_ANIMATIONS,
+      useValue: {animationsDisabled: true},
     },
     provideRouter(routes),
   ],

--- a/integration/harness-e2e-cli/src/app/app.module.ts
+++ b/integration/harness-e2e-cli/src/app/app.module.ts
@@ -1,13 +1,19 @@
 import {NgModule} from '@angular/core';
 import {BrowserModule} from '@angular/platform-browser';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
+import {MATERIAL_ANIMATIONS} from '@angular/material/core';
 
 import {AppComponent} from './app.component';
 import {MatRadioModule} from '@angular/material/radio';
 
 @NgModule({
   declarations: [AppComponent],
-  imports: [MatRadioModule, NoopAnimationsModule, BrowserModule],
+  imports: [MatRadioModule, BrowserModule],
   bootstrap: [AppComponent],
+  providers: [
+    {
+      provide: MATERIAL_ANIMATIONS,
+      useValue: {animationsDisabled: true},
+    },
+  ],
 })
 export class AppModule {}


### PR DESCRIPTION
Removes the `NoopAnimationsModule` from the docs site and integration tests.