### PR TITLE
fix(material/form-field): enhance error handling for multiple form field controls

### DIFF
--- a/goldens/material/form-field/index.api.md
+++ b/goldens/material/form-field/index.api.md
@@ -79,6 +79,8 @@ export class MatFormField implements FloatingLabelParent, AfterContentInit, Afte
     _forceDisplayInfixLabel(): boolean | 0;
     // (undocumented)
     _formFieldControl: MatFormFieldControl_2<any>;
+    // (undocumented)
+    _formFieldControls: QueryList<MatFormFieldControl_2<any>>;
     getConnectedOverlayOrigin(): ElementRef;
     getLabelId: i0.Signal<string | null>;
     _getSubscriptMessageType(): 'error' | 'hint';
@@ -121,6 +123,8 @@ export class MatFormField implements FloatingLabelParent, AfterContentInit, Afte
     ngOnDestroy(): void;
     // (undocumented)
     _notchedOutline: MatFormFieldNotchedOutline | undefined;
+    get otherFormFieldControls(): MatFormFieldControl_2<any>[];
+    get otherFormFieldControlsErrorState(): boolean;
     // (undocumented)
     _prefixChildren: QueryList<MatPrefix>;
     _refreshOutlineNotchWidth(): void;
@@ -139,7 +143,7 @@ export class MatFormField implements FloatingLabelParent, AfterContentInit, Afte
     // (undocumented)
     _textSuffixContainer: ElementRef<HTMLElement>;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<MatFormField, "mat-form-field", ["matFormField"], { "hideRequiredMarker": { "alias": "hideRequiredMarker"; "required": false; }; "color": { "alias": "color"; "required": false; }; "floatLabel": { "alias": "floatLabel"; "required": false; }; "appearance": { "alias": "appearance"; "required": false; }; "subscriptSizing": { "alias": "subscriptSizing"; "required": false; }; "hintLabel": { "alias": "hintLabel"; "required": false; }; }, {}, ["_labelChild", "_formFieldControl", "_prefixChildren", "_suffixChildren", "_errorChildren", "_hintChildren"], ["mat-label", "[matPrefix], [matIconPrefix]", "[matTextPrefix]", "*", "[matTextSuffix]", "[matSuffix], [matIconSuffix]", "mat-error, [matError]", "mat-hint:not([align='end'])", "mat-hint[align='end']"], true, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MatFormField, "mat-form-field", ["matFormField"], { "hideRequiredMarker": { "alias": "hideRequiredMarker"; "required": false; }; "color": { "alias": "color"; "required": false; }; "floatLabel": { "alias": "floatLabel"; "required": false; }; "appearance": { "alias": "appearance"; "required": false; }; "subscriptSizing": { "alias": "subscriptSizing"; "required": false; }; "hintLabel": { "alias": "hintLabel"; "required": false; }; }, {}, ["_labelChild", "_formFieldControl", "_formFieldControls", "_prefixChildren", "_suffixChildren", "_errorChildren", "_hintChildren"], ["mat-label", "[matPrefix], [matIconPrefix]", "[matTextPrefix]", "*", "[matTextSuffix]", "[matSuffix], [matIconSuffix]", "mat-error, [matError]", "mat-hint:not([align='end'])", "mat-hint[align='end']"], true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatFormField, never>;
 }

--- a/goldens/material/input/index.api.md
+++ b/goldens/material/input/index.api.md
@@ -72,6 +72,8 @@ export class MatFormField implements FloatingLabelParent, AfterContentInit, Afte
     _forceDisplayInfixLabel(): boolean | 0;
     // (undocumented)
     _formFieldControl: MatFormFieldControl<any>;
+    // (undocumented)
+    _formFieldControls: QueryList<MatFormFieldControl<any>>;
     getConnectedOverlayOrigin(): ElementRef;
     getLabelId: i0.Signal<string | null>;
     _getSubscriptMessageType(): 'error' | 'hint';
@@ -114,6 +116,8 @@ export class MatFormField implements FloatingLabelParent, AfterContentInit, Afte
     ngOnDestroy(): void;
     // (undocumented)
     _notchedOutline: MatFormFieldNotchedOutline | undefined;
+    get otherFormFieldControls(): MatFormFieldControl<any>[];
+    get otherFormFieldControlsErrorState(): boolean;
     // (undocumented)
     _prefixChildren: QueryList<MatPrefix>;
     _refreshOutlineNotchWidth(): void;
@@ -132,7 +136,7 @@ export class MatFormField implements FloatingLabelParent, AfterContentInit, Afte
     // (undocumented)
     _textSuffixContainer: ElementRef<HTMLElement>;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<MatFormField, "mat-form-field", ["matFormField"], { "hideRequiredMarker": { "alias": "hideRequiredMarker"; "required": false; }; "color": { "alias": "color"; "required": false; }; "floatLabel": { "alias": "floatLabel"; "required": false; }; "appearance": { "alias": "appearance"; "required": false; }; "subscriptSizing": { "alias": "subscriptSizing"; "required": false; }; "hintLabel": { "alias": "hintLabel"; "required": false; }; }, {}, ["_labelChild", "_formFieldControl", "_prefixChildren", "_suffixChildren", "_errorChildren", "_hintChildren"], ["mat-label", "[matPrefix], [matIconPrefix]", "[matTextPrefix]", "*", "[matTextSuffix]", "[matSuffix], [matIconSuffix]", "mat-error, [matError]", "mat-hint:not([align='end'])", "mat-hint[align='end']"], true, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MatFormField, "mat-form-field", ["matFormField"], { "hideRequiredMarker": { "alias": "hideRequiredMarker"; "required": false; }; "color": { "alias": "color"; "required": false; }; "floatLabel": { "alias": "floatLabel"; "required": false; }; "appearance": { "alias": "appearance"; "required": false; }; "subscriptSizing": { "alias": "subscriptSizing"; "required": false; }; "hintLabel": { "alias": "hintLabel"; "required": false; }; }, {}, ["_labelChild", "_formFieldControl", "_formFieldControls", "_prefixChildren", "_suffixChildren", "_errorChildren", "_hintChildren"], ["mat-label", "[matPrefix], [matIconPrefix]", "[matTextPrefix]", "*", "[matTextSuffix]", "[matSuffix], [matIconSuffix]", "mat-error, [matError]", "mat-hint:not([align='end'])", "mat-hint[align='end']"], true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatFormField, never>;
 }

--- a/goldens/material/select/index.api.md
+++ b/goldens/material/select/index.api.md
@@ -95,6 +95,8 @@ export class MatFormField implements FloatingLabelParent, AfterContentInit, Afte
     _forceDisplayInfixLabel(): boolean | 0;
     // (undocumented)
     _formFieldControl: MatFormFieldControl_2<any>;
+    // (undocumented)
+    _formFieldControls: QueryList<MatFormFieldControl_2<any>>;
     getConnectedOverlayOrigin(): ElementRef;
     getLabelId: i0.Signal<string | null>;
     _getSubscriptMessageType(): 'error' | 'hint';
@@ -137,6 +139,8 @@ export class MatFormField implements FloatingLabelParent, AfterContentInit, Afte
     ngOnDestroy(): void;
     // (undocumented)
     _notchedOutline: MatFormFieldNotchedOutline | undefined;
+    get otherFormFieldControls(): MatFormFieldControl_2<any>[];
+    get otherFormFieldControlsErrorState(): boolean;
     // (undocumented)
     _prefixChildren: QueryList<MatPrefix>;
     _refreshOutlineNotchWidth(): void;
@@ -155,7 +159,7 @@ export class MatFormField implements FloatingLabelParent, AfterContentInit, Afte
     // (undocumented)
     _textSuffixContainer: ElementRef<HTMLElement>;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<MatFormField, "mat-form-field", ["matFormField"], { "hideRequiredMarker": { "alias": "hideRequiredMarker"; "required": false; }; "color": { "alias": "color"; "required": false; }; "floatLabel": { "alias": "floatLabel"; "required": false; }; "appearance": { "alias": "appearance"; "required": false; }; "subscriptSizing": { "alias": "subscriptSizing"; "required": false; }; "hintLabel": { "alias": "hintLabel"; "required": false; }; }, {}, ["_labelChild", "_formFieldControl", "_prefixChildren", "_suffixChildren", "_errorChildren", "_hintChildren"], ["mat-label", "[matPrefix], [matIconPrefix]", "[matTextPrefix]", "*", "[matTextSuffix]", "[matSuffix], [matIconSuffix]", "mat-error, [matError]", "mat-hint:not([align='end'])", "mat-hint[align='end']"], true, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MatFormField, "mat-form-field", ["matFormField"], { "hideRequiredMarker": { "alias": "hideRequiredMarker"; "required": false; }; "color": { "alias": "color"; "required": false; }; "floatLabel": { "alias": "floatLabel"; "required": false; }; "appearance": { "alias": "appearance"; "required": false; }; "subscriptSizing": { "alias": "subscriptSizing"; "required": false; }; "hintLabel": { "alias": "hintLabel"; "required": false; }; }, {}, ["_labelChild", "_formFieldControl", "_formFieldControls", "_prefixChildren", "_suffixChildren", "_errorChildren", "_hintChildren"], ["mat-label", "[matPrefix], [matIconPrefix]", "[matTextPrefix]", "*", "[matTextSuffix]", "[matSuffix], [matIconSuffix]", "mat-error, [matError]", "mat-hint:not([align='end'])", "mat-hint[align='end']"], true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatFormField, never>;
 }

--- a/src/material/form-field/form-field.html
+++ b/src/material/form-field/form-field.html
@@ -42,7 +42,7 @@
   [class.mdc-text-field--outlined]="_hasOutline()"
   [class.mdc-text-field--no-label]="!_hasFloatingLabel()"
   [class.mdc-text-field--disabled]="_control.disabled"
-  [class.mdc-text-field--invalid]="_control.errorState"
+  [class.mdc-text-field--invalid]="_control.errorState || otherFormFieldControlsErrorState"
   (click)="_control.onContainerClick($event)"
 >
   @if (!_hasOutline() && !_control.disabled) {
@@ -96,9 +96,8 @@
 </div>
 
 <div
-    class="mat-mdc-form-field-subscript-wrapper mat-mdc-form-field-bottom-align"
-    [class.mat-mdc-form-field-subscript-dynamic-size]="subscriptSizing === 'dynamic'"
->
+  class="mat-mdc-form-field-subscript-wrapper mat-mdc-form-field-bottom-align"
+  [class.mat-mdc-form-field-subscript-dynamic-size]="subscriptSizing === 'dynamic'">
   @let subscriptMessageType = _getSubscriptMessageType();
 
   <!-- 
@@ -106,10 +105,11 @@
     as having it appear post render will not consistently work. We also do not want to add
     additional divs as it causes styling regressions.
     -->
-  <div aria-atomic="true" aria-live="polite" 
-      [class.mat-mdc-form-field-error-wrapper]="subscriptMessageType === 'error'"
-      [class.mat-mdc-form-field-hint-wrapper]="subscriptMessageType === 'hint'"
-    >
+  <div
+    aria-atomic="true"
+    aria-live="polite"
+    [class.mat-mdc-form-field-error-wrapper]="subscriptMessageType === 'error'"
+    [class.mat-mdc-form-field-hint-wrapper]="subscriptMessageType === 'hint'">
     @switch (subscriptMessageType) {
       @case ('error') {
         <ng-content select="mat-error, [matError]"></ng-content>


### PR DESCRIPTION
Currently, when multiple mat form fields are used together, the error is taken for the first control only, this take into consideration other controls too if they exist

Fixes #28887