### PR TITLE
refactor(cdk-experimental/ui-patterns): move active index operations …

### DIFF
--- a/src/cdk-experimental/ui-patterns/behaviors/list-focus/BUILD.bazel
+++ b/src/cdk-experimental/ui-patterns/behaviors/list-focus/BUILD.bazel
@@ -10,7 +10,7 @@ ts_project(
         exclude = ["**/*.spec.ts"],
     ),
     deps = [
-        "//src/cdk-experimental/ui-patterns/behaviors/list-navigation",
+        "//:node_modules/@angular/core",
         "//src/cdk-experimental/ui-patterns/behaviors/signal-like",
     ],
 )
@@ -22,8 +22,6 @@ ts_project(
     deps = [
         ":list-focus",
         "//:node_modules/@angular/core",
-        "//src/cdk-experimental/ui-patterns/behaviors/list-navigation",
-        "//src/cdk-experimental/ui-patterns/behaviors/signal-like",
     ],
 )
 

--- a/src/cdk-experimental/ui-patterns/behaviors/list-focus/list-focus.spec.ts
+++ b/src/cdk-experimental/ui-patterns/behaviors/list-focus/list-focus.spec.ts
@@ -6,152 +6,127 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {computed, signal} from '@angular/core';
-import {SignalLike} from '../signal-like/signal-like';
-import {ListNavigation, ListNavigationInputs} from '../list-navigation/list-navigation';
+import {Signal, signal, WritableSignal} from '@angular/core';
 import {ListFocus, ListFocusInputs, ListFocusItem} from './list-focus';
 
-describe('List Focus', () => {
-  interface TestItem extends ListFocusItem {
-    tabindex: SignalLike<-1 | 0>;
-  }
+type TestItem = ListFocusItem & {
+  disabled: WritableSignal<boolean>;
+};
 
-  function getItems(length: number): SignalLike<TestItem[]> {
-    return signal(
-      Array.from({length}).map((_, i) => ({
-        index: signal(i),
+type TestInputs = Partial<ListFocusInputs<ListFocusItem>> & {
+  numItems?: number;
+};
+
+export function getListFocus(inputs: TestInputs = {}): ListFocus<ListFocusItem> {
+  return new ListFocus({
+    activeIndex: signal(0),
+    disabled: signal(false),
+    skipDisabled: signal(false),
+    focusMode: signal('roving'),
+    items: getItems(inputs.numItems ?? 5),
+    ...inputs,
+  });
+}
+
+function getItems(length: number): Signal<ListFocusItem[]> {
+  return signal(
+    Array.from({length}).map((_, i) => {
+      return {
         id: signal(`${i}`),
-        tabindex: signal(-1),
         disabled: signal(false),
         element: signal({focus: () => {}} as HTMLElement),
-      })),
-    );
-  }
+      };
+    }),
+  );
+}
 
-  function getNavigation<T extends TestItem>(
-    items: SignalLike<T[]>,
-    args: Partial<ListNavigationInputs<T>> = {},
-  ): ListNavigation<T> {
-    return new ListNavigation({
-      items,
-      wrap: signal(false),
-      activeIndex: signal(0),
-      skipDisabled: signal(false),
-      textDirection: signal('ltr'),
-      orientation: signal('vertical'),
-      ...args,
-    });
-  }
-
-  function getFocus<T extends TestItem>(
-    navigation: ListNavigation<T>,
-    args: Partial<ListFocusInputs<T>> = {},
-  ): ListFocus<T> {
-    return new ListFocus({
-      navigation,
-      focusMode: signal('roving'),
-      ...args,
-    });
-  }
-
+describe('List Focus', () => {
   describe('roving', () => {
+    let focusManager: ListFocus<ListFocusItem>;
+
+    beforeEach(() => {
+      focusManager = getListFocus({focusMode: signal('roving')});
+    });
+
     it('should set the list tabindex to -1', () => {
-      const items = getItems(5);
-      const nav = getNavigation(items);
-      const focus = getFocus(nav);
-      const tabindex = computed(() => focus.getListTabindex());
-      expect(tabindex()).toBe(-1);
+      expect(focusManager.getListTabindex()).toBe(-1);
     });
 
     it('should set the activedescendant to undefined', () => {
-      const items = getItems(5);
-      const nav = getNavigation(items);
-      const focus = getFocus(nav);
-      expect(focus.getActiveDescendant()).toBeUndefined();
+      expect(focusManager.getActiveDescendant()).toBeUndefined();
     });
 
-    it('should set the first items tabindex to 0', () => {
-      const items = getItems(5);
-      const nav = getNavigation(items);
-      const focus = getFocus(nav);
-
-      items().forEach(i => {
-        i.tabindex = computed(() => focus.getItemTabindex(i));
-      });
-
-      expect(items()[0].tabindex()).toBe(0);
-      expect(items()[1].tabindex()).toBe(-1);
-      expect(items()[2].tabindex()).toBe(-1);
-      expect(items()[3].tabindex()).toBe(-1);
-      expect(items()[4].tabindex()).toBe(-1);
-    });
-
-    it('should update the tabindex of the active item when navigating', () => {
-      const items = getItems(5);
-      const nav = getNavigation(items);
-      const focus = getFocus(nav);
-
-      items().forEach(i => {
-        i.tabindex = computed(() => focus.getItemTabindex(i));
-      });
-
-      nav.next();
-
-      expect(items()[0].tabindex()).toBe(-1);
-      expect(items()[1].tabindex()).toBe(0);
-      expect(items()[2].tabindex()).toBe(-1);
-      expect(items()[3].tabindex()).toBe(-1);
-      expect(items()[4].tabindex()).toBe(-1);
+    it('should set the tabindex based on the active index', () => {
+      const items = focusManager.inputs.items() as TestItem[];
+      focusManager.inputs.activeIndex.set(2);
+      expect(focusManager.getItemTabindex(items[0])).toBe(-1);
+      expect(focusManager.getItemTabindex(items[1])).toBe(-1);
+      expect(focusManager.getItemTabindex(items[2])).toBe(0);
+      expect(focusManager.getItemTabindex(items[3])).toBe(-1);
+      expect(focusManager.getItemTabindex(items[4])).toBe(-1);
     });
   });
 
   describe('activedescendant', () => {
+    let focusManager: ListFocus<ListFocusItem>;
+
+    beforeEach(() => {
+      focusManager = getListFocus({focusMode: signal('activedescendant')});
+    });
+
     it('should set the list tabindex to 0', () => {
-      const items = getItems(5);
-      const nav = getNavigation(items);
-      const focus = getFocus(nav, {
-        focusMode: signal('activedescendant'),
-      });
-      const tabindex = computed(() => focus.getListTabindex());
-      expect(tabindex()).toBe(0);
+      expect(focusManager.getListTabindex()).toBe(0);
     });
 
     it('should set the activedescendant to the active items id', () => {
-      const items = getItems(5);
-      const nav = getNavigation(items);
-      const focus = getFocus(nav, {
-        focusMode: signal('activedescendant'),
-      });
-      expect(focus.getActiveDescendant()).toBe(items()[0].id());
+      expect(focusManager.getActiveDescendant()).toBe(focusManager.inputs.items()[0].id());
     });
 
     it('should set the tabindex of all items to -1', () => {
-      const items = getItems(5);
-      const nav = getNavigation(items);
-      const focus = getFocus(nav, {
-        focusMode: signal('activedescendant'),
-      });
-
-      items().forEach(i => {
-        i.tabindex = computed(() => focus.getItemTabindex(i));
-      });
-
-      expect(items()[0].tabindex()).toBe(-1);
-      expect(items()[1].tabindex()).toBe(-1);
-      expect(items()[2].tabindex()).toBe(-1);
-      expect(items()[3].tabindex()).toBe(-1);
-      expect(items()[4].tabindex()).toBe(-1);
+      const items = focusManager.inputs.items() as TestItem[];
+      focusManager.inputs.activeIndex.set(0);
+      expect(focusManager.getItemTabindex(items[0])).toBe(-1);
+      expect(focusManager.getItemTabindex(items[1])).toBe(-1);
+      expect(focusManager.getItemTabindex(items[2])).toBe(-1);
+      expect(focusManager.getItemTabindex(items[3])).toBe(-1);
+      expect(focusManager.getItemTabindex(items[4])).toBe(-1);
     });
 
     it('should update the activedescendant of the list when navigating', () => {
-      const items = getItems(5);
-      const nav = getNavigation(items);
-      const focus = getFocus(nav, {
-        focusMode: signal('activedescendant'),
-      });
-
-      nav.next();
-      expect(focus.getActiveDescendant()).toBe(items()[1].id());
+      focusManager.inputs.activeIndex.set(1);
+      expect(focusManager.getActiveDescendant()).toBe(focusManager.inputs.items()[1].id());
     });
   });
+
+  describe('#isFocusable', () => {
+    it('should return true for enabled items', () => {
+      const focusManager = getListFocus({skipDisabled: signal(true)});
+      const items = focusManager.inputs.items() as TestItem[];
+      expect(focusManager.isFocusable(items[0])).toBeTrue();
+      expect(focusManager.isFocusable(items[1])).toBeTrue();
+      expect(focusManager.isFocusable(items[2])).toBeTrue();
+    });
+
+    it('should return false for disabled items', () => {
+      const focusManager = getListFocus({skipDisabled: signal(true)});
+      const items = focusManager.inputs.items() as TestItem[];
+      items[1].disabled.set(true);
+
+      expect(focusManager.isFocusable(items[0])).toBeTrue();
+      expect(focusManager.isFocusable(items[1])).toBeFalse();
+      expect(focusManager.isFocusable(items[2])).toBeTrue();
+    });
+
+    it('should return true for disabled items if skip disabled is false', () => {
+      const focusManager = getListFocus({skipDisabled: signal(false)});
+      const items = focusManager.inputs.items() as TestItem[];
+      items[1].disabled.set(true);
+
+      expect(focusManager.isFocusable(items[0])).toBeTrue();
+      expect(focusManager.isFocusable(items[1])).toBeTrue();
+      expect(focusManager.isFocusable(items[2])).toBeTrue();
+    });
+  });
+
+  describe('#focus', () => {});
 });

--- a/src/cdk-experimental/ui-patterns/behaviors/list-focus/list-focus.ts
+++ b/src/cdk-experimental/ui-patterns/behaviors/list-focus/list-focus.ts
@@ -6,65 +6,104 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {SignalLike} from '../signal-like/signal-like';
-import {ListNavigation, ListNavigationItem} from '../list-navigation/list-navigation';
+import {computed, signal} from '@angular/core';
+import {SignalLike, WritableSignalLike} from '../signal-like/signal-like';
 
 /** Represents an item in a collection, such as a listbox option, than may receive focus. */
-export interface ListFocusItem extends ListNavigationItem {
+export interface ListFocusItem {
   /** A unique identifier for the item. */
   id: SignalLike<string>;
 
   /** The html element that should receive focus. */
   element: SignalLike<HTMLElement>;
+
+  /** Whether an item is disabled. */
+  disabled: SignalLike<boolean>;
 }
 
 /** Represents the required inputs for a collection that contains focusable items. */
 export interface ListFocusInputs<T extends ListFocusItem> {
   /** The focus strategy used by the list. */
   focusMode: SignalLike<'roving' | 'activedescendant'>;
+
+  /** Whether the list is disabled. */
+  disabled: SignalLike<boolean>;
+
+  /** The items in the list. */
+  items: SignalLike<T[]>;
+
+  /** The index of the current active item. */
+  activeIndex: WritableSignalLike<number>;
+
+  /** Whether disabled items in the list should be skipped when navigating. */
+  skipDisabled: SignalLike<boolean>;
 }
 
 /** Controls focus for a list of items. */
 export class ListFocus<T extends ListFocusItem> {
-  /** The navigation controller of the parent list. */
-  navigation: ListNavigation<ListFocusItem>;
+  /** The last index that was active. */
+  prevActiveIndex = signal(0);
 
-  constructor(readonly inputs: ListFocusInputs<T> & {navigation: ListNavigation<T>}) {
-    this.navigation = inputs.navigation;
+  /** The current active item. */
+  activeItem = computed(() => this.inputs.items()[this.inputs.activeIndex()]);
+
+  constructor(readonly inputs: ListFocusInputs<T>) {}
+
+  /** Whether the list is in a disabled state. */
+  isListDisabled(): boolean {
+    return this.inputs.disabled() || this.inputs.items().every(i => i.disabled());
   }
 
   /** The id of the current active item. */
   getActiveDescendant(): string | undefined {
+    if (this.isListDisabled()) {
+      return undefined;
+    }
     if (this.inputs.focusMode() === 'roving') {
       return undefined;
     }
-    if (this.navigation.inputs.items().length) {
-      return this.navigation.inputs.items()[this.navigation.inputs.activeIndex()].id();
-    }
-    return undefined;
+    return this.inputs.items()[this.inputs.activeIndex()].id();
   }
 
   /** The tabindex for the list. */
   getListTabindex(): -1 | 0 {
+    if (this.isListDisabled()) {
+      return 0;
+    }
     return this.inputs.focusMode() === 'activedescendant' ? 0 : -1;
   }
 
   /** Returns the tabindex for the given item. */
   getItemTabindex(item: T): -1 | 0 {
+    if (this.inputs.disabled()) {
+      return -1;
+    }
     if (this.inputs.focusMode() === 'activedescendant') {
       return -1;
     }
-    const index = this.navigation.inputs.items().indexOf(item);
-    return this.navigation.inputs.activeIndex() === index ? 0 : -1;
+    const index = this.inputs.items().indexOf(item);
+    return this.inputs.activeIndex() === index ? 0 : -1;
   }
 
   /** Focuses the current active item. */
-  focus() {
-    if (this.inputs.focusMode() === 'activedescendant') {
-      return;
+  focus(item: T): boolean {
+    if (this.isListDisabled() || !this.isFocusable(item)) {
+      return false;
     }
 
-    const item = this.navigation.inputs.items()[this.navigation.inputs.activeIndex()];
-    item.element().focus();
+    this.prevActiveIndex.set(this.inputs.activeIndex());
+    const index = this.inputs.items().indexOf(item);
+    this.inputs.activeIndex.set(index);
+
+    if (this.inputs.focusMode() === 'roving') {
+      item.element().focus();
+    }
+
+    return true;
+  }
+
+  /** Returns true if the given item can be navigated to. */
+  isFocusable(item: T): boolean {
+    return !item.disabled() || !this.inputs.skipDisabled();
   }
 }

--- a/src/cdk-experimental/ui-patterns/behaviors/list-navigation/BUILD.bazel
+++ b/src/cdk-experimental/ui-patterns/behaviors/list-navigation/BUILD.bazel
@@ -11,6 +11,7 @@ ts_project(
     ),
     deps = [
         "//:node_modules/@angular/core",
+        "//src/cdk-experimental/ui-patterns/behaviors/list-focus",
         "//src/cdk-experimental/ui-patterns/behaviors/signal-like",
     ],
 )
@@ -22,7 +23,7 @@ ts_project(
     deps = [
         ":list-navigation",
         "//:node_modules/@angular/core",
-        "//src/cdk-experimental/ui-patterns/behaviors/signal-like",
+        "//src/cdk-experimental/ui-patterns/behaviors/list-focus:unit_test_sources",
     ],
 )
 

--- a/src/cdk-experimental/ui-patterns/behaviors/list-navigation/list-navigation.ts
+++ b/src/cdk-experimental/ui-patterns/behaviors/list-navigation/list-navigation.ts
@@ -6,28 +6,16 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {computed, signal} from '@angular/core';
-import {SignalLike, WritableSignalLike} from '../signal-like/signal-like';
+import {SignalLike} from '../signal-like/signal-like';
+import {ListFocus, ListFocusInputs, ListFocusItem} from '../list-focus/list-focus';
 
 /** Represents an item in a collection, such as a listbox option, than can be navigated to. */
-export interface ListNavigationItem {
-  /** Whether an item is disabled. */
-  disabled: SignalLike<boolean>;
-}
+export interface ListNavigationItem extends ListFocusItem {}
 
 /** Represents the required inputs for a collection that has navigable items. */
-export interface ListNavigationInputs<T extends ListNavigationItem> {
+export interface ListNavigationInputs<T extends ListNavigationItem> extends ListFocusInputs<T> {
   /** Whether focus should wrap when navigating. */
   wrap: SignalLike<boolean>;
-
-  /** The items in the list. */
-  items: SignalLike<T[]>;
-
-  /** Whether disabled items in the list should be skipped when navigating. */
-  skipDisabled: SignalLike<boolean>;
-
-  /** The current index that has been navigated to. */
-  activeIndex: WritableSignalLike<number>;
 
   /** Whether the list is vertically or horizontally oriented. */
   orientation: SignalLike<'vertical' | 'horizontal'>;
@@ -38,23 +26,11 @@ export interface ListNavigationInputs<T extends ListNavigationItem> {
 
 /** Controls navigation for a list of items. */
 export class ListNavigation<T extends ListNavigationItem> {
-  /** The last index that was active. */
-  prevActiveIndex = signal(0);
-
-  /** The current active item. */
-  activeItem = computed(() => this.inputs.items()[this.inputs.activeIndex()]);
-
-  constructor(readonly inputs: ListNavigationInputs<T>) {}
+  constructor(readonly inputs: ListNavigationInputs<T> & {focusManager: ListFocus<T>}) {}
 
   /** Navigates to the given item. */
   goto(item?: T): boolean {
-    if (item && this.isFocusable(item)) {
-      this.prevActiveIndex.set(this.inputs.activeIndex());
-      const index = this.inputs.items().indexOf(item);
-      this.inputs.activeIndex.set(index);
-      return true;
-    }
-    return false;
+    return item ? this.inputs.focusManager.focus(item) : false;
   }
 
   /** Navigates to the next item in the list. */
@@ -69,7 +45,7 @@ export class ListNavigation<T extends ListNavigationItem> {
 
   /** Navigates to the first item in the list. */
   first(): boolean {
-    const item = this.inputs.items().find(i => this.isFocusable(i));
+    const item = this.inputs.items().find(i => this.inputs.focusManager.isFocusable(i));
     return item ? this.goto(item) : false;
   }
 
@@ -77,16 +53,11 @@ export class ListNavigation<T extends ListNavigationItem> {
   last(): boolean {
     const items = this.inputs.items();
     for (let i = items.length - 1; i >= 0; i--) {
-      if (this.isFocusable(items[i])) {
+      if (this.inputs.focusManager.isFocusable(items[i])) {
         return this.goto(items[i]);
       }
     }
     return false;
-  }
-
-  /** Returns true if the given item can be navigated to. */
-  isFocusable(item: T): boolean {
-    return !item.disabled() || !this.inputs.skipDisabled();
   }
 
   /** Advances to the next or previous focusable item in the list based on the given delta. */
@@ -101,7 +72,7 @@ export class ListNavigation<T extends ListNavigationItem> {
     // in the case that all options are disabled. If wrapping is disabled, the loop terminates
     // when the index goes out of bounds.
     for (let i = step(startIndex); i !== startIndex && i < itemCount && i >= 0; i = step(i)) {
-      if (this.isFocusable(items[i])) {
+      if (this.inputs.focusManager.isFocusable(items[i])) {
         return this.goto(items[i]);
       }
     }

--- a/src/cdk-experimental/ui-patterns/behaviors/list-selection/BUILD.bazel
+++ b/src/cdk-experimental/ui-patterns/behaviors/list-selection/BUILD.bazel
@@ -11,7 +11,7 @@ ts_project(
     ),
     deps = [
         "//:node_modules/@angular/core",
-        "//src/cdk-experimental/ui-patterns/behaviors/list-navigation",
+        "//src/cdk-experimental/ui-patterns/behaviors/list-focus",
         "//src/cdk-experimental/ui-patterns/behaviors/signal-like",
     ],
 )
@@ -23,8 +23,7 @@ ts_project(
     deps = [
         ":list-selection",
         "//:node_modules/@angular/core",
-        "//src/cdk-experimental/ui-patterns/behaviors/list-navigation",
-        "//src/cdk-experimental/ui-patterns/behaviors/signal-like",
+        "//src/cdk-experimental/ui-patterns/behaviors/list-focus:unit_test_sources",
     ],
 )
 

--- a/src/cdk-experimental/ui-patterns/behaviors/list-selection/list-selection.spec.ts
+++ b/src/cdk-experimental/ui-patterns/behaviors/list-selection/list-selection.spec.ts
@@ -6,151 +6,116 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {signal} from '@angular/core';
-import {SignalLike, WritableSignalLike} from '../signal-like/signal-like';
+import {Signal, signal, WritableSignal} from '@angular/core';
 import {ListSelectionItem, ListSelection, ListSelectionInputs} from './list-selection';
-import {ListNavigation, ListNavigationInputs} from '../list-navigation/list-navigation';
+import {getListFocus} from '../list-focus/list-focus.spec';
+import {ListFocus} from '../list-focus/list-focus';
+
+type TestItem = ListSelectionItem<number> & {
+  disabled: WritableSignal<boolean>;
+};
+type TestInputs = Partial<ListSelectionInputs<TestItem, number>> & {
+  numItems?: number;
+};
+
+function getSelection(inputs: TestInputs = {}): ListSelection<ListSelectionItem<number>, number> {
+  const items = getItems(inputs.numItems ?? 5);
+  const focusManager = getListFocus({...inputs, items}) as ListFocus<TestItem>;
+
+  return new ListSelection({
+    focusManager,
+    ...focusManager.inputs,
+    items,
+    value: signal([]),
+    multi: signal(false),
+    selectionMode: signal('follow'),
+    ...inputs,
+  });
+}
+
+function getItems(length: number): Signal<TestItem[]> {
+  return signal(
+    Array.from({length}).map((_, i) => {
+      return {
+        value: signal(i),
+        id: signal(`${i}`),
+        disabled: signal(false),
+        element: signal({focus: () => {}} as HTMLElement),
+      };
+    }),
+  );
+}
 
 describe('List Selection', () => {
-  interface TestItem<V> extends ListSelectionItem<V> {
-    disabled: WritableSignalLike<boolean>;
-  }
-
-  function getItems<V>(values: V[]): SignalLike<TestItem<V>[]> {
-    return signal(
-      values.map((value, i) => ({
-        index: signal(i),
-        value: signal(value),
-        disabled: signal(false),
-        isAnchor: signal(false),
-      })),
-    );
-  }
-
-  function getNavigation<T extends TestItem<V>, V>(
-    items: SignalLike<T[]>,
-    args: Partial<ListNavigationInputs<T>> = {},
-  ): ListNavigation<T> {
-    return new ListNavigation({
-      items,
-      wrap: signal(false),
-      activeIndex: signal(0),
-      skipDisabled: signal(false),
-      textDirection: signal('ltr'),
-      orientation: signal('vertical'),
-      ...args,
-    });
-  }
-
-  function getSelection<T extends TestItem<V>, V>(
-    items: SignalLike<T[]>,
-    navigation: ListNavigation<T>,
-    args: Partial<ListSelectionInputs<T, V>> = {},
-  ): ListSelection<T, V> {
-    return new ListSelection({
-      items,
-      navigation,
-      value: signal<V[]>([]),
-      multi: signal(true),
-      selectionMode: signal('explicit'),
-      ...args,
-    });
-  }
-
   describe('#select', () => {
     it('should select an item', () => {
-      const items = getItems([0, 1, 2, 3, 4]);
-      const nav = getNavigation(items);
-      const selection = getSelection(items, nav);
-
+      const selection = getSelection();
       selection.select(); // [0]
       expect(selection.inputs.value()).toEqual([0]);
     });
 
     it('should select multiple options', () => {
-      const items = getItems([0, 1, 2, 3, 4]);
-      const nav = getNavigation(items);
-      const selection = getSelection(items, nav);
+      const selection = getSelection({multi: signal(true)});
+      const items = selection.inputs.items() as TestItem[];
 
       selection.select(); // [0]
-      nav.next();
+      selection.inputs.focusManager.focus(items[1]);
       selection.select(); // [0, 1]
 
       expect(selection.inputs.value()).toEqual([0, 1]);
     });
 
     it('should not select multiple options', () => {
-      const items = getItems([0, 1, 2, 3, 4]);
-      const nav = getNavigation(items);
-      const selection = getSelection(items, nav, {
-        multi: signal(false),
-      });
-
+      const selection = getSelection({multi: signal(false)});
+      const items = selection.inputs.items() as TestItem[];
       selection.select(); // [0]
-      nav.next();
+      selection.inputs.focusManager.focus(items[1]);
       selection.select(); // [1]
-
       expect(selection.inputs.value()).toEqual([1]);
     });
 
     it('should not select disabled items', () => {
-      const items = getItems([0, 1, 2, 3, 4]);
-      const nav = getNavigation(items);
-      const selection = getSelection(items, nav);
-      items()[0].disabled.set(true);
-
+      const selection = getSelection();
+      const items = selection.inputs.items() as TestItem[];
+      items[0].disabled.set(true);
       selection.select(); // []
       expect(selection.inputs.value()).toEqual([]);
     });
 
     it('should do nothing to already selected items', () => {
-      const items = getItems([0, 1, 2, 3, 4]);
-      const nav = getNavigation(items);
-      const selection = getSelection(items, nav);
-
+      const selection = getSelection();
       selection.select(); // [0]
       selection.select(); // [0]
-
       expect(selection.inputs.value()).toEqual([0]);
     });
   });
 
   describe('#deselect', () => {
     it('should deselect an item', () => {
-      const items = getItems([0, 1, 2, 3, 4]);
-      const nav = getNavigation(items);
-      const selection = getSelection(items, nav);
+      const selection = getSelection();
       selection.deselect(); // []
       expect(selection.inputs.value().length).toBe(0);
     });
 
     it('should not deselect disabled items', () => {
-      const items = getItems([0, 1, 2, 3, 4]);
-      const nav = getNavigation(items);
-      const selection = getSelection(items, nav);
-
+      const selection = getSelection();
+      const items = selection.inputs.items() as TestItem[];
       selection.select(); // [0]
-      items()[0].disabled.set(true);
+      items[0].disabled.set(true);
       selection.deselect(); // [0]
-
       expect(selection.inputs.value()).toEqual([0]);
     });
   });
 
   describe('#toggle', () => {
     it('should select an unselected item', () => {
-      const items = getItems([0, 1, 2, 3, 4]);
-      const nav = getNavigation(items);
-      const selection = getSelection(items, nav);
-
+      const selection = getSelection();
       selection.toggle(); // [0]
       expect(selection.inputs.value()).toEqual([0]);
     });
 
     it('should deselect a selected item', () => {
-      const items = getItems([0, 1, 2, 3, 4]);
-      const nav = getNavigation(items);
-      const selection = getSelection(items, nav);
+      const selection = getSelection();
       selection.select(); // [0]
       selection.toggle(); // []
       expect(selection.inputs.value().length).toBe(0);
@@ -159,29 +124,23 @@ describe('List Selection', () => {
 
   describe('#toggleOne', () => {
     it('should select an unselected item', () => {
-      const items = getItems([0, 1, 2, 3, 4]);
-      const nav = getNavigation(items);
-      const selection = getSelection(items, nav);
-
+      const selection = getSelection({multi: signal(true)});
       selection.toggleOne(); // [0]
       expect(selection.inputs.value()).toEqual([0]);
     });
 
     it('should deselect a selected item', () => {
-      const items = getItems([0, 1, 2, 3, 4]);
-      const nav = getNavigation(items);
-      const selection = getSelection(items, nav);
+      const selection = getSelection({multi: signal(true)});
       selection.select(); // [0]
       selection.toggleOne(); // []
       expect(selection.inputs.value().length).toBe(0);
     });
 
     it('should only leave one item selected', () => {
-      const items = getItems([0, 1, 2, 3, 4]);
-      const nav = getNavigation(items);
-      const selection = getSelection(items, nav);
+      const selection = getSelection({multi: signal(true)});
+      const items = selection.inputs.items() as TestItem[];
       selection.select(); // [0]
-      nav.next();
+      selection.inputs.focusManager.focus(items[1]);
       selection.toggleOne(); // [1]
       expect(selection.inputs.value()).toEqual([1]);
     });
@@ -189,27 +148,22 @@ describe('List Selection', () => {
 
   describe('#selectAll', () => {
     it('should select all items', () => {
-      const items = getItems([0, 1, 2, 3, 4]);
-      const nav = getNavigation(items);
-      const selection = getSelection(items, nav);
+      const selection = getSelection({multi: signal(true)});
       selection.selectAll();
       expect(selection.inputs.value()).toEqual([0, 1, 2, 3, 4]);
     });
 
     it('should do nothing if a list is not multiselectable', () => {
-      const items = getItems([0, 1, 2, 3, 4]);
-      const nav = getNavigation(items);
-      const selection = getSelection(items, nav);
+      const selection = getSelection({multi: signal(false)});
       selection.selectAll();
-      expect(selection.inputs.value()).toEqual([0, 1, 2, 3, 4]);
+      expect(selection.inputs.value()).toEqual([]);
     });
   });
 
   describe('#deselectAll', () => {
     it('should deselect all items', () => {
-      const items = getItems([0, 1, 2, 3, 4]);
-      const nav = getNavigation(items);
-      const selection = getSelection(items, nav);
+      const selection = getSelection({multi: signal(true)});
+      selection.selectAll(); // [0, 1, 2, 3, 4]
       selection.deselectAll(); // []
       expect(selection.inputs.value().length).toBe(0);
     });
@@ -217,27 +171,22 @@ describe('List Selection', () => {
 
   describe('#toggleAll', () => {
     it('should select all items', () => {
-      const items = getItems([0, 1, 2, 3, 4]);
-      const nav = getNavigation(items);
-      const selection = getSelection(items, nav);
+      const selection = getSelection({multi: signal(true)});
       selection.toggleAll();
       expect(selection.inputs.value()).toEqual([0, 1, 2, 3, 4]);
     });
 
     it('should deselect all if all items are selected', () => {
-      const items = getItems([0, 1, 2, 3, 4]);
-      const nav = getNavigation(items);
-      const selection = getSelection(items, nav);
+      const selection = getSelection({multi: signal(true)});
       selection.selectAll();
       selection.toggleAll();
       expect(selection.inputs.value()).toEqual([]);
     });
 
     it('should ignore disabled items when determining if all items are selected', () => {
-      const items = getItems([0, 1, 2, 3, 4]);
-      const nav = getNavigation(items);
-      const selection = getSelection(items, nav);
-      items()[0].disabled.set(true);
+      const selection = getSelection({multi: signal(true)});
+      const items = selection.inputs.items() as TestItem[];
+      items[0].disabled.set(true);
       selection.toggleAll();
       expect(selection.inputs.value()).toEqual([1, 2, 3, 4]);
       selection.toggleAll();
@@ -247,123 +196,107 @@ describe('List Selection', () => {
 
   describe('#selectOne', () => {
     it('should select a single item', () => {
-      const items = getItems([0, 1, 2, 3, 4]);
-      const nav = getNavigation(items);
-      const selection = getSelection(items, nav);
-
+      const selection = getSelection({multi: signal(true)});
+      const items = selection.inputs.items() as TestItem[];
       selection.selectOne(); // [0]
-      nav.next();
+      selection.inputs.focusManager.focus(items[1]);
       selection.selectOne(); // [1]
       expect(selection.inputs.value()).toEqual([1]);
     });
 
     it('should not select disabled items', () => {
-      const items = getItems([0, 1, 2, 3, 4]);
-      const nav = getNavigation(items);
-      const selection = getSelection(items, nav);
-      items()[0].disabled.set(true);
+      const selection = getSelection({multi: signal(true)});
+      const items = selection.inputs.items() as TestItem[];
+      items[0].disabled.set(true);
 
       selection.select(); // []
       expect(selection.inputs.value()).toEqual([]);
     });
 
     it('should do nothing to already selected items', () => {
-      const items = getItems([0, 1, 2, 3, 4]);
-      const nav = getNavigation(items);
-      const selection = getSelection(items, nav);
-
+      const selection = getSelection({multi: signal(true)});
       selection.selectOne(); // [0]
       selection.selectOne(); // [0]
-
       expect(selection.inputs.value()).toEqual([0]);
     });
   });
 
   describe('#selectRange', () => {
     it('should select all items from an anchor at a lower index', () => {
-      const items = getItems([0, 1, 2, 3, 4]);
-      const nav = getNavigation(items);
-      const selection = getSelection(items, nav);
-
+      const selection = getSelection({multi: signal(true)});
+      const items = selection.inputs.items() as TestItem[];
       selection.select(); // [0]
-      nav.next();
-      nav.next();
+      selection.inputs.focusManager.focus(items[2]);
       selection.selectRange(); // [0, 1, 2]
-
       expect(selection.inputs.value()).toEqual([0, 1, 2]);
     });
 
     it('should select all items from an anchor at a higher index', () => {
-      const items = getItems([0, 1, 2, 3, 4]);
-      const nav = getNavigation(items, {
+      const selection = getSelection({
+        multi: signal(true),
         activeIndex: signal(3),
       });
-      const selection = getSelection(items, nav);
+      const items = selection.inputs.items() as TestItem[];
 
       selection.select(); // [3]
-      nav.prev();
-      nav.prev();
+      selection.inputs.focusManager.focus(items[1]);
       selection.selectRange(); // [3, 2, 1]
 
       expect(selection.inputs.value()).toEqual([3, 2, 1]);
     });
 
     it('should deselect items within the range when the range is changed', () => {
-      const items = getItems([0, 1, 2, 3, 4]);
-      const nav = getNavigation(items);
-      const selection = getSelection(items, nav);
+      const selection = getSelection({
+        multi: signal(true),
+        activeIndex: signal(2),
+      });
+      const items = selection.inputs.items() as TestItem[];
 
-      nav.next();
-      nav.next();
       selection.select(); // [2]
       expect(selection.inputs.value()).toEqual([2]);
 
-      nav.next();
-      nav.next();
+      selection.inputs.focusManager.focus(items[4]);
       selection.selectRange(); // [2, 3, 4]
       expect(selection.inputs.value()).toEqual([2, 3, 4]);
 
-      nav.first();
+      selection.inputs.focusManager.focus(items[0]);
       selection.selectRange(); // [2, 1, 0]
       expect(selection.inputs.value()).toEqual([2, 1, 0]);
     });
 
     it('should not select a disabled item', () => {
-      const items = getItems([0, 1, 2, 3, 4]);
-      const nav = getNavigation(items);
-      const selection = getSelection(items, nav);
-      items()[1].disabled.set(true);
+      const selection = getSelection({multi: signal(true)});
+      const items = selection.inputs.items() as TestItem[];
+      items[1].disabled.set(true);
 
       selection.select(); // [0]
       expect(selection.inputs.value()).toEqual([0]);
 
-      nav.next();
+      selection.inputs.focusManager.focus(items[1]);
       selection.selectRange(); // [0]
       expect(selection.inputs.value()).toEqual([0]);
 
-      nav.next();
+      selection.inputs.focusManager.focus(items[2]);
       selection.selectRange(); // [0, 2]
       expect(selection.inputs.value()).toEqual([0, 2]);
     });
 
     it('should not deselect a disabled item', () => {
-      const items = getItems([0, 1, 2, 3, 4]);
-      const nav = getNavigation(items);
-      const selection = getSelection(items, nav);
+      const selection = getSelection({multi: signal(true)});
+      const items = selection.inputs.items() as TestItem[];
 
-      selection.select(items()[1]);
-      items()[1].disabled.set(true);
+      selection.select(items[1]);
+      items[1].disabled.set(true);
 
       selection.select(); // [0]
+      selection.inputs.focusManager.focus(items[0]);
       expect(selection.inputs.value()).toEqual([1, 0]);
 
-      nav.next();
-      nav.next();
+      selection.inputs.focusManager.focus(items[2]);
       selection.selectRange(); // [0, 1, 2]
       expect(selection.inputs.value()).toEqual([1, 0, 2]);
 
-      nav.prev();
-      nav.prev();
+      selection.inputs.focusManager.focus(items[0]);
       selection.selectRange(); // [0]
       expect(selection.inputs.value()).toEqual([1, 0]);
     });
@@ -371,28 +304,22 @@ describe('List Selection', () => {
 
   describe('#beginRangeSelection', () => {
     it('should set where a range is starting from', () => {
-      const items = getItems([0, 1, 2, 3, 4]);
-      const nav = getNavigation(items);
-      const selection = getSelection(items, nav);
-
-      nav.next();
-      nav.next();
+      const selection = getSelection({multi: signal(true)});
+      const items = selection.inputs.items() as TestItem[];
+      selection.inputs.focusManager.focus(items[2]);
       selection.beginRangeSelection();
       expect(selection.inputs.value()).toEqual([]);
-      nav.next();
-      nav.next();
+      selection.inputs.focusManager.focus(items[4]);
       selection.selectRange(); // [2, 3, 4]
       expect(selection.inputs.value()).toEqual([2, 3, 4]);
     });
 
     it('should be able to select a range starting on a disabled item', () => {
-      const items = getItems([0, 1, 2, 3, 4]);
-      const nav = getNavigation(items);
-      const selection = getSelection(items, nav);
-      items()[0].disabled.set(true);
+      const selection = getSelection({multi: signal(true)});
+      const items = selection.inputs.items() as TestItem[];
+      items[0].disabled.set(true);
       selection.beginRangeSelection(0);
-      nav.next();
-      nav.next();
+      selection.inputs.focusManager.focus(items[2]);
       selection.selectRange();
       expect(selection.inputs.value()).toEqual([1, 2]);
     });

--- a/src/cdk-experimental/ui-patterns/behaviors/list-typeahead/BUILD.bazel
+++ b/src/cdk-experimental/ui-patterns/behaviors/list-typeahead/BUILD.bazel
@@ -11,7 +11,7 @@ ts_project(
     ),
     deps = [
         "//:node_modules/@angular/core",
-        "//src/cdk-experimental/ui-patterns/behaviors/list-navigation",
+        "//src/cdk-experimental/ui-patterns/behaviors/list-focus",
         "//src/cdk-experimental/ui-patterns/behaviors/signal-like",
     ],
 )
@@ -23,8 +23,7 @@ ts_project(
     deps = [
         ":list-typeahead",
         "//:node_modules/@angular/core",
-        "//src/cdk-experimental/ui-patterns/behaviors/list-navigation",
-        "//src/cdk-experimental/ui-patterns/behaviors/signal-like",
+        "//src/cdk-experimental/ui-patterns/behaviors/list-focus:unit_test_sources",
     ],
 )
 

--- a/src/cdk-experimental/ui-patterns/behaviors/list-typeahead/list-typeahead.spec.ts
+++ b/src/cdk-experimental/ui-patterns/behaviors/list-typeahead/list-typeahead.spec.ts
@@ -6,82 +6,89 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {signal} from '@angular/core';
-import {SignalLike, WritableSignalLike} from '../signal-like/signal-like';
-import {ListTypeaheadItem, ListTypeahead} from './list-typeahead';
+import {Signal, signal, WritableSignal} from '@angular/core';
+import {ListTypeaheadItem, ListTypeahead, ListTypeaheadInputs} from './list-typeahead';
 import {fakeAsync, tick} from '@angular/core/testing';
-import {ListNavigation} from '../list-navigation/list-navigation';
+import {getListFocus} from '../list-focus/list-focus.spec';
+import {ListFocus} from '../list-focus/list-focus';
+
+type TestItem = ListTypeaheadItem & {
+  disabled: WritableSignal<boolean>;
+};
+type TestInputs = Partial<ListTypeaheadInputs<TestItem>> & {
+  numItems?: number;
+};
+
+function getTypeahead(inputs: TestInputs = {}): ListTypeahead<TestItem> {
+  const items = getItems(inputs.numItems ?? 5);
+  const focusManager = getListFocus({...inputs, items}) as ListFocus<TestItem>;
+
+  return new ListTypeahead({
+    focusManager,
+    ...focusManager.inputs,
+    items,
+    typeaheadDelay: signal(0.5),
+    ...inputs,
+  });
+}
+
+function getItems(length: number): Signal<TestItem[]> {
+  return signal(
+    Array.from({length}).map((_, i) => {
+      return {
+        searchTerm: signal(`Item ${i}`),
+        id: signal(`${i}`),
+        disabled: signal(false),
+        element: signal({focus: () => {}} as HTMLElement),
+      };
+    }),
+  );
+}
 
 describe('List Typeahead', () => {
-  interface TestItem extends ListTypeaheadItem {
-    disabled: WritableSignalLike<boolean>;
-  }
-
-  function getItems(length: number): SignalLike<TestItem[]> {
-    return signal(
-      Array.from({length}).map((_, i) => ({
-        index: signal(i),
-        disabled: signal(false),
-        searchTerm: signal(`Item ${i}`),
-      })),
-    );
-  }
-
-  let items: SignalLike<TestItem[]>;
+  let items: TestItem[];
   let typeahead: ListTypeahead<TestItem>;
-  let navigation: ListNavigation<TestItem>;
 
   beforeEach(() => {
-    items = getItems(5);
-    navigation = new ListNavigation({
-      items,
-      wrap: signal(false),
-      activeIndex: signal(0),
-      skipDisabled: signal(false),
-      textDirection: signal('ltr'),
-      orientation: signal('vertical'),
-    });
-    typeahead = new ListTypeahead({
-      navigation,
-      typeaheadDelay: signal(0.5),
-    });
+    typeahead = getTypeahead();
+    items = typeahead.inputs.items();
   });
 
   describe('#search', () => {
     it('should navigate to an item', () => {
       typeahead.search('i');
-      expect(navigation.inputs.activeIndex()).toBe(1);
+      expect(typeahead.inputs.activeIndex()).toBe(1);
 
       typeahead.search('t');
       typeahead.search('e');
       typeahead.search('m');
       typeahead.search(' ');
       typeahead.search('3');
-      expect(navigation.inputs.activeIndex()).toBe(3);
+      expect(typeahead.inputs.activeIndex()).toBe(3);
     });
 
     it('should reset after a delay', fakeAsync(() => {
       typeahead.search('i');
-      expect(navigation.inputs.activeIndex()).toBe(1);
+      expect(typeahead.inputs.activeIndex()).toBe(1);
 
       tick(500);
 
       typeahead.search('i');
-      expect(navigation.inputs.activeIndex()).toBe(2);
+      expect(typeahead.inputs.activeIndex()).toBe(2);
     }));
 
     it('should skip disabled items', () => {
-      items()[1].disabled.set(true);
-      (navigation.inputs.skipDisabled as WritableSignalLike<boolean>).set(true);
+      items[1].disabled.set(true);
+      (typeahead.inputs.skipDisabled as WritableSignal<boolean>).set(true);
       typeahead.search('i');
-      expect(navigation.inputs.activeIndex()).toBe(2);
+      expect(typeahead.inputs.activeIndex()).toBe(2);
     });
 
     it('should not skip disabled items', () => {
-      items()[1].disabled.set(true);
-      (navigation.inputs.skipDisabled as WritableSignalLike<boolean>).set(false);
+      items[1].disabled.set(true);
+      (typeahead.inputs.skipDisabled as WritableSignal<boolean>).set(false);
       typeahead.search('i');
-      expect(navigation.inputs.activeIndex()).toBe(1);
+      expect(typeahead.inputs.activeIndex()).toBe(1);
     });
 
     it('should ignore keys like shift', () => {
@@ -94,7 +101,7 @@ describe('List Typeahead', () => {
       typeahead.search('m');
       typeahead.search(' ');
       typeahead.search('2');
-      expect(navigation.inputs.activeIndex()).toBe(2);
+      expect(typeahead.inputs.activeIndex()).toBe(2);
     });
 
     it('should not allow a query to begin with a space', () => {
@@ -105,7 +112,7 @@ describe('List Typeahead', () => {
       typeahead.search('m');
       typeahead.search(' ');
       typeahead.search('3');
-      expect(navigation.inputs.activeIndex()).toBe(3);
+      expect(typeahead.inputs.activeIndex()).toBe(3);
     });
   });
 });

--- a/src/cdk-experimental/ui-patterns/behaviors/list-typeahead/list-typeahead.ts
+++ b/src/cdk-experimental/ui-patterns/behaviors/list-typeahead/list-typeahead.ts
@@ -8,13 +8,13 @@
 
 import {computed, signal} from '@angular/core';
 import {SignalLike} from '../signal-like/signal-like';
-import {ListNavigationItem, ListNavigation} from '../list-navigation/list-navigation';
+import {ListFocus, ListFocusInputs, ListFocusItem} from '../list-focus/list-focus';
 
 /**
  * Represents an item in a collection, such as a listbox option, than can be navigated to by
  * typeahead.
  */
-export interface ListTypeaheadItem extends ListNavigationItem {
+export interface ListTypeaheadItem extends ListFocusItem {
   /** The text used by the typeahead search. */
   searchTerm: SignalLike<string>;
 }
@@ -23,7 +23,7 @@ export interface ListTypeaheadItem extends ListNavigationItem {
  * Represents the required inputs for a collection that contains items that can be navigated to by
  * typeahead.
  */
-export interface ListTypeaheadInputs {
+export interface ListTypeaheadInputs<T extends ListTypeaheadItem> extends ListFocusInputs<T> {
   /** The amount of time before the typeahead search is reset. */
   typeaheadDelay: SignalLike<number>;
 }
@@ -33,8 +33,8 @@ export class ListTypeahead<T extends ListTypeaheadItem> {
   /** A reference to the timeout for resetting the typeahead search. */
   timeout?: ReturnType<typeof setTimeout> | undefined;
 
-  /** The navigation controller of the parent list. */
-  navigation: ListNavigation<T>;
+  /** The focus controller of the parent list. */
+  focusManager: ListFocus<T>;
 
   /** Whether the user is actively typing a typeahead search query. */
   isTyping = computed(() => this._query().length > 0);
@@ -45,8 +45,8 @@ export class ListTypeahead<T extends ListTypeaheadItem> {
   /** The index where that the typeahead search was initiated from. */
   private _startIndex = signal<number | undefined>(undefined);
 
-  constructor(readonly inputs: ListTypeaheadInputs & {navigation: ListNavigation<T>}) {
-    this.navigation = inputs.navigation;
+  constructor(readonly inputs: ListTypeaheadInputs<T> & {focusManager: ListFocus<T>}) {
+    this.focusManager = inputs.focusManager;
   }
 
   /** Performs a typeahead search, appending the given character to the search string. */
@@ -60,7 +60,7 @@ export class ListTypeahead<T extends ListTypeaheadItem> {
     }
 
     if (this._startIndex() === undefined) {
-      this._startIndex.set(this.navigation.inputs.activeIndex());
+      this._startIndex.set(this.focusManager.inputs.activeIndex());
     }
 
     clearTimeout(this.timeout);
@@ -68,7 +68,7 @@ export class ListTypeahead<T extends ListTypeaheadItem> {
     const item = this._getItem();
 
     if (item) {
-      this.navigation.goto(item);
+      this.focusManager.focus(item);
     }
 
     this.timeout = setTimeout(() => {
@@ -84,15 +84,15 @@ export class ListTypeahead<T extends ListTypeaheadItem> {
    * current query starting from the the current anchor index.
    */
   private _getItem() {
-    let items = this.navigation.inputs.items();
+    let items = this.focusManager.inputs.items();
     const after = items.slice(this._startIndex()! + 1);
     const before = items.slice(0, this._startIndex()!);
-    items = this.navigation.inputs.wrap() ? after.concat(before) : after; // TODO: Always wrap?
-    items.push(this.navigation.inputs.items()[this._startIndex()!]);
+    items = after.concat(before);
+    items.push(this.inputs.items()[this._startIndex()!]);
 
     const focusableItems = [];
     for (const item of items) {
-      if (this.navigation.isFocusable(item)) {
+      if (this.focusManager.isFocusable(item)) {
         focusableItems.push(item);
       }
     }

--- a/src/cdk-experimental/ui-patterns/tabs/tabs.ts
+++ b/src/cdk-experimental/ui-patterns/tabs/tabs.ts
@@ -187,13 +187,13 @@ export class TabListPattern {
     this.disabled = inputs.disabled;
     this.orientation = inputs.orientation;
 
-    this.navigation = new ListNavigation(inputs);
+    this.focusManager = new ListFocus(inputs);
+    this.navigation = new ListNavigation({...inputs, focusManager: this.focusManager});
     this.selection = new ListSelection({
       ...inputs,
-      navigation: this.navigation,
       multi: signal(false),
+      focusManager: this.focusManager,
     });
-    this.focusManager = new ListFocus({...inputs, navigation: this.navigation});
   }
 
   /** Handles keydown events for the tablist. */
@@ -213,28 +213,24 @@ export class TabListPattern {
   /** Navigates to the first option in the tablist. */
   first(opts?: SelectOptions) {
     this.navigation.first();
-    this.focusManager.focus();
     this._updateSelection(opts);
   }
 
   /** Navigates to the last option in the tablist. */
   last(opts?: SelectOptions) {
     this.navigation.last();
-    this.focusManager.focus();
     this._updateSelection(opts);
   }
 
   /** Navigates to the next option in the tablist. */
   next(opts?: SelectOptions) {
     this.navigation.next();
-    this.focusManager.focus();
     this._updateSelection(opts);
   }
 
   /** Navigates to the previous option in the tablist. */
   prev(opts?: SelectOptions) {
     this.navigation.prev();
-    this.focusManager.focus();
     this._updateSelection(opts);
   }
 
@@ -244,7 +240,6 @@ export class TabListPattern {
 
     if (item) {
       this.navigation.goto(item);
-      this.focusManager.focus();
       this._updateSelection(opts);
     }
   }


### PR DESCRIPTION
…into list-focus

* Move focus-related things out of the `ListNavigation` behavior and into `ListFocus`. This includes `activeIndex` and `isFocusable`.
* Make behaviors that depend on other behaviors extend the inputs of those other behaviors. This is intended to stop us from needing to prop-drill.

Example:
```ts
// Before
this.inputs.navigation.inputs.activeIndex()

// After
this.inputs.activeIndex()
```