### PR TITLE
fix(google-maps): implicitly include google.maps types instead of the triple slash workaround

### DIFF
--- a/src/google-maps/BUILD.bazel
+++ b/src/google-maps/BUILD.bazel
@@ -15,6 +15,15 @@ rules_js_tsconfig(
     ],
 )
 
+rules_js_tsconfig(
+    name = "tsconfig",
+    src = "tsconfig-build.json",
+    deps = [
+        "//:node_modules/@types/google.maps",
+        "//src:build-tsconfig",
+    ],
+)
+
 ng_project(
     name = "google-maps",
     srcs = glob(
@@ -23,6 +32,7 @@ ng_project(
             "**/*.spec.ts",
         ],
     ),
+    tsconfig = ":tsconfig",
     deps = [
         "//:node_modules/@angular/common",
         "//:node_modules/@angular/core",

--- a/src/google-maps/deprecated-map-marker-clusterer/deprecated-map-marker-clusterer.ts
+++ b/src/google-maps/deprecated-map-marker-clusterer/deprecated-map-marker-clusterer.ts
@@ -6,9 +6,6 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-// Workaround for: https://github.com/bazelbuild/rules_nodejs/issues/1265
-/// <reference types="google.maps" preserve="true" />
-
 import {
   AfterContentInit,
   ChangeDetectionStrategy,

--- a/src/google-maps/google-map/google-map.ts
+++ b/src/google-maps/google-map/google-map.ts
@@ -6,9 +6,6 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-// Workaround for: https://github.com/bazelbuild/rules_nodejs/issues/1265
-/// <reference types="google.maps" preserve="true" />
-
 import {
   ChangeDetectionStrategy,
   Component,

--- a/src/google-maps/map-advanced-marker/map-advanced-marker.ts
+++ b/src/google-maps/map-advanced-marker/map-advanced-marker.ts
@@ -6,9 +6,6 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-// Workaround for: https://github.com/bazelbuild/rules_nodejs/issues/1265
-/// <reference types="google.maps" preserve="true" />
-
 import {
   Input,
   OnDestroy,

--- a/src/google-maps/map-anchor-point.ts
+++ b/src/google-maps/map-anchor-point.ts
@@ -6,9 +6,6 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-// Workaround for: https://github.com/bazelbuild/rules_nodejs/issues/1265
-/// <reference types="google.maps" preserve="true" />
-
 export interface MapAnchorPoint {
   getAnchor(): google.maps.MVCObject | google.maps.marker.AdvancedMarkerElement;
 }

--- a/src/google-maps/map-base-layer.ts
+++ b/src/google-maps/map-base-layer.ts
@@ -6,9 +6,6 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-// Workaround for: https://github.com/bazelbuild/rules_nodejs/issues/1265
-/// <reference types="google.maps" preserve="true" />
-
 import {Directive, NgZone, OnDestroy, OnInit, inject} from '@angular/core';
 
 import {GoogleMap} from './google-map/google-map';

--- a/src/google-maps/map-bicycling-layer/map-bicycling-layer.ts
+++ b/src/google-maps/map-bicycling-layer/map-bicycling-layer.ts
@@ -6,9 +6,6 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-// Workaround for: https://github.com/bazelbuild/rules_nodejs/issues/1265
-/// <reference types="google.maps" preserve="true" />
-
 import {Directive, EventEmitter, NgZone, OnDestroy, OnInit, Output, inject} from '@angular/core';
 
 import {GoogleMap} from '../google-map/google-map';

--- a/src/google-maps/map-circle/map-circle.ts
+++ b/src/google-maps/map-circle/map-circle.ts
@@ -6,9 +6,6 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-// Workaround for: https://github.com/bazelbuild/rules_nodejs/issues/1265
-/// <reference types="google.maps" preserve="true" />
-
 import {
   Directive,
   EventEmitter,

--- a/src/google-maps/map-directions-renderer/map-directions-renderer.ts
+++ b/src/google-maps/map-directions-renderer/map-directions-renderer.ts
@@ -6,9 +6,6 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-// Workaround for: https://github.com/bazelbuild/rules_nodejs/issues/1265
-/// <reference types="google.maps" preserve="true" />
-
 import {
   Directive,
   EventEmitter,

--- a/src/google-maps/map-directions-renderer/map-directions-service.ts
+++ b/src/google-maps/map-directions-renderer/map-directions-service.ts
@@ -6,9 +6,6 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-// Workaround for: https://github.com/bazelbuild/rules_nodejs/issues/1265
-/// <reference types="google.maps" preserve="true" />
-
 import {Injectable, NgZone, inject} from '@angular/core';
 import {Observable} from 'rxjs';
 

--- a/src/google-maps/map-geocoder/map-geocoder.ts
+++ b/src/google-maps/map-geocoder/map-geocoder.ts
@@ -6,9 +6,6 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-// Workaround for: https://github.com/bazelbuild/rules_nodejs/issues/1265
-/// <reference types="google.maps" preserve="true" />
-
 import {Injectable, NgZone, inject} from '@angular/core';
 import {Observable} from 'rxjs';
 

--- a/src/google-maps/map-ground-overlay/map-ground-overlay.ts
+++ b/src/google-maps/map-ground-overlay/map-ground-overlay.ts
@@ -6,9 +6,6 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-// Workaround for: https://github.com/bazelbuild/rules_nodejs/issues/1265
-/// <reference types="google.maps" preserve="true" />
-
 import {
   Directive,
   EventEmitter,

--- a/src/google-maps/map-heatmap-layer/map-heatmap-layer.ts
+++ b/src/google-maps/map-heatmap-layer/map-heatmap-layer.ts
@@ -6,9 +6,6 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-// Workaround for: https://github.com/bazelbuild/rules_nodejs/issues/1265
-/// <reference types="google.maps" preserve="true" />
-
 import {
   Input,
   OnDestroy,

--- a/src/google-maps/map-info-window/map-info-window.ts
+++ b/src/google-maps/map-info-window/map-info-window.ts
@@ -6,9 +6,6 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-// Workaround for: https://github.com/bazelbuild/rules_nodejs/issues/1265
-/// <reference types="google.maps" preserve="true" />
-
 import {
   Directive,
   ElementRef,

--- a/src/google-maps/map-kml-layer/map-kml-layer.ts
+++ b/src/google-maps/map-kml-layer/map-kml-layer.ts
@@ -6,9 +6,6 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-// Workaround for: https://github.com/bazelbuild/rules_nodejs/issues/1265
-/// <reference types="google.maps" preserve="true" />
-
 import {
   Directive,
   EventEmitter,

--- a/src/google-maps/map-marker-clusterer/map-marker-clusterer.ts
+++ b/src/google-maps/map-marker-clusterer/map-marker-clusterer.ts
@@ -6,9 +6,6 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-// Workaround for: https://github.com/bazelbuild/rules_nodejs/issues/1265
-/// <reference types="google.maps" preserve="true" />
-
 import {
   ChangeDetectionStrategy,
   Component,

--- a/src/google-maps/map-marker/map-marker.ts
+++ b/src/google-maps/map-marker/map-marker.ts
@@ -6,9 +6,6 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-// Workaround for: https://github.com/bazelbuild/rules_nodejs/issues/1265
-/// <reference types="google.maps" preserve="true" />
-
 import {
   Input,
   OnDestroy,

--- a/src/google-maps/map-polygon/map-polygon.ts
+++ b/src/google-maps/map-polygon/map-polygon.ts
@@ -6,9 +6,6 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-// Workaround for: https://github.com/bazelbuild/rules_nodejs/issues/1265
-/// <reference types="google.maps" preserve="true" />
-
 import {
   Directive,
   Input,

--- a/src/google-maps/map-polyline/map-polyline.ts
+++ b/src/google-maps/map-polyline/map-polyline.ts
@@ -6,9 +6,6 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-// Workaround for: https://github.com/bazelbuild/rules_nodejs/issues/1265
-/// <reference types="google.maps" preserve="true" />
-
 import {
   Directive,
   Input,

--- a/src/google-maps/map-rectangle/map-rectangle.ts
+++ b/src/google-maps/map-rectangle/map-rectangle.ts
@@ -6,9 +6,6 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-// Workaround for: https://github.com/bazelbuild/rules_nodejs/issues/1265
-/// <reference types="google.maps" preserve="true" />
-
 import {
   Directive,
   Input,

--- a/src/google-maps/map-traffic-layer/map-traffic-layer.ts
+++ b/src/google-maps/map-traffic-layer/map-traffic-layer.ts
@@ -6,9 +6,6 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-// Workaround for: https://github.com/bazelbuild/rules_nodejs/issues/1265
-/// <reference types="google.maps" preserve="true" />
-
 import {
   Directive,
   EventEmitter,

--- a/src/google-maps/map-transit-layer/map-transit-layer.ts
+++ b/src/google-maps/map-transit-layer/map-transit-layer.ts
@@ -6,9 +6,6 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-// Workaround for: https://github.com/bazelbuild/rules_nodejs/issues/1265
-/// <reference types="google.maps" preserve="true" />
-
 import {Directive, EventEmitter, NgZone, OnDestroy, OnInit, Output, inject} from '@angular/core';
 
 import {GoogleMap} from '../google-map/google-map';

--- a/src/google-maps/tsconfig-build.json
+++ b/src/google-maps/tsconfig-build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../bazel-tsconfig-build.json",
+  "compilerOptions": {
+    "types": ["google.maps"]
+  }
+}

--- a/src/google-maps/tsconfig.json
+++ b/src/google-maps/tsconfig.json
@@ -5,7 +5,7 @@
     "rootDir": "..",
     "baseUrl": ".",
     "paths": {},
-    "types": ["jasmine"]
+    "types": ["jasmine", "google.maps"]
   },
   "include": ["./**/*.ts", "../dev-mode-types.d.ts"]
 }


### PR DESCRIPTION
Previously, due to an issue with the `rules_nodejs` toolchain we had to include the `google.maps` namespace types via a triple slash comment with preserve set to true, this changes to instead include the types in the tsconfig as normal