### PR TITLE
fix(cdk/table): remove private symbols from public API

### DIFF
--- a/goldens/cdk/table/index.api.md
+++ b/goldens/cdk/table/index.api.md
@@ -13,7 +13,6 @@ import { ElementRef } from '@angular/core';
 import { EventEmitter } from '@angular/core';
 import * as i0 from '@angular/core';
 import { InjectionToken } from '@angular/core';
-import { Injector } from '@angular/core';
 import { IterableChangeRecord } from '@angular/core';
 import { IterableChanges } from '@angular/core';
 import { IterableDiffer } from '@angular/core';
@@ -57,20 +56,10 @@ export abstract class BaseRowDef implements OnChanges {
 }
 
 // @public
-export interface CanStick {
-    hasStickyChanged(): boolean;
-    resetStickyChanged(): void;
-    sticky: boolean;
-}
-
-// @public
 export const CDK_ROW_TEMPLATE = "<ng-container cdkCellOutlet></ng-container>";
 
 // @public
 export const CDK_TABLE: InjectionToken<any>;
-
-// @public
-export const CDK_TABLE_TEMPLATE = "\n  <ng-content select=\"caption\"/>\n  <ng-content select=\"colgroup, col\"/>\n\n  <!--\n    Unprojected content throws a hydration error so we need this to capture it.\n    It gets removed on the client so it doesn't affect the layout.\n  -->\n  @if (_isServer) {\n    <ng-content/>\n  }\n\n  @if (_isNativeHtmlTable) {\n    <thead role=\"rowgroup\">\n      <ng-container headerRowOutlet/>\n    </thead>\n    <tbody role=\"rowgroup\">\n      <ng-container rowOutlet/>\n      <ng-container noDataRowOutlet/>\n    </tbody>\n    <tfoot role=\"rowgroup\">\n      <ng-container footerRowOutlet/>\n    </tfoot>\n  } @else {\n    <ng-container headerRowOutlet/>\n    <ng-container rowOutlet/>\n    <ng-container noDataRowOutlet/>\n    <ng-container footerRowOutlet/>\n  }\n";
 
 // @public
 export class CdkCell extends BaseCdkCell {
@@ -526,13 +515,7 @@ export class _Schedule {
 }
 
 // @public
-export const STICKY_DIRECTIONS: StickyDirection[];
-
-// @public
 export const STICKY_POSITIONING_LISTENER: InjectionToken<StickyPositioningListener>;
-
-// @public
-export type StickyDirection = 'top' | 'bottom' | 'left' | 'right';
 
 // @public (undocumented)
 export type StickyOffset = number | null | undefined;
@@ -547,24 +530,6 @@ export interface StickyPositioningListener {
 
 // @public (undocumented)
 export type StickySize = number | null | undefined;
-
-// @public
-export class StickyStyler {
-    constructor(_isNativeHtmlTable: boolean, _stickCellCss: string, direction: Direction, _coalescedStyleScheduler: _CoalescedStyleScheduler, _isBrowser?: boolean, _needsPositionStickyOnElement?: boolean, _positionListener?: StickyPositioningListener | undefined, _tableInjector?: Injector | undefined);
-    _addStickyStyle(element: HTMLElement, dir: StickyDirection, dirValue: number, isBorderElement: boolean): void;
-    clearStickyPositioning(rows: HTMLElement[], stickyDirections: StickyDirection[]): void;
-    destroy(): void;
-    // (undocumented)
-    direction: Direction;
-    _getCalculatedZIndex(element: HTMLElement): string;
-    _getCellWidths(row: HTMLElement, recalculateCellWidths?: boolean): number[];
-    _getStickyEndColumnPositions(widths: number[], stickyStates: boolean[]): number[];
-    _getStickyStartColumnPositions(widths: number[], stickyStates: boolean[]): number[];
-    _removeStickyStyle(element: HTMLElement, stickyDirections: StickyDirection[]): void;
-    stickRows(rowsToStick: HTMLElement[], stickyStates: boolean[], position: 'top' | 'bottom'): void;
-    updateStickyColumns(rows: HTMLElement[], stickyStartStates: boolean[], stickyEndStates: boolean[], recalculateCellWidths?: boolean, replay?: boolean): void;
-    updateStickyFooterContainer(tableElement: Element, stickyStates: boolean[]): void;
-}
 
 // @public (undocumented)
 export interface StickyUpdate {

--- a/src/cdk/table/public-api.ts
+++ b/src/cdk/table/public-api.ts
@@ -11,9 +11,7 @@ export * from './cell';
 export * from './coalesced-style-scheduler';
 export * from './row';
 export * from './table-module';
-export * from './sticky-styler';
 export * from './sticky-position-listener';
-export * from './can-stick';
 export * from './text-column';
 export * from './tokens';
 

--- a/src/cdk/table/table.ts
+++ b/src/cdk/table/table.ts
@@ -185,45 +185,6 @@ export class NoDataRowOutlet implements RowOutlet {
 }
 
 /**
- * The table template that can be used by the mat-table. Should not be used outside of the
- * material library.
- * @docs-private
- */
-export const CDK_TABLE_TEMPLATE =
-  // Note that according to MDN, the `caption` element has to be projected as the **first**
-  // element in the table. See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/caption
-  `
-  <ng-content select="caption"/>
-  <ng-content select="colgroup, col"/>
-
-  <!--
-    Unprojected content throws a hydration error so we need this to capture it.
-    It gets removed on the client so it doesn't affect the layout.
-  -->
-  @if (_isServer) {
-    <ng-content/>
-  }
-
-  @if (_isNativeHtmlTable) {
-    <thead role="rowgroup">
-      <ng-container headerRowOutlet/>
-    </thead>
-    <tbody role="rowgroup">
-      <ng-container rowOutlet/>
-      <ng-container noDataRowOutlet/>
-    </tbody>
-    <tfoot role="rowgroup">
-      <ng-container footerRowOutlet/>
-    </tfoot>
-  } @else {
-    <ng-container headerRowOutlet/>
-    <ng-container rowOutlet/>
-    <ng-container noDataRowOutlet/>
-    <ng-container footerRowOutlet/>
-  }
-`;
-
-/**
  * Interface used to conveniently type the possible context interfaces for the render row.
  * @docs-private
  */
@@ -265,7 +226,36 @@ export interface RenderRow<T> {
 @Component({
   selector: 'cdk-table, table[cdk-table]',
   exportAs: 'cdkTable',
-  template: CDK_TABLE_TEMPLATE,
+  template: `
+    <ng-content select="caption"/>
+    <ng-content select="colgroup, col"/>
+
+    <!--
+      Unprojected content throws a hydration error so we need this to capture it.
+      It gets removed on the client so it doesn't affect the layout.
+    -->
+    @if (_isServer) {
+      <ng-content/>
+    }
+
+    @if (_isNativeHtmlTable) {
+      <thead role="rowgroup">
+        <ng-container headerRowOutlet/>
+      </thead>
+      <tbody role="rowgroup">
+        <ng-container rowOutlet/>
+        <ng-container noDataRowOutlet/>
+      </tbody>
+      <tfoot role="rowgroup">
+        <ng-container footerRowOutlet/>
+      </tfoot>
+    } @else {
+      <ng-container headerRowOutlet/>
+      <ng-container rowOutlet/>
+      <ng-container noDataRowOutlet/>
+      <ng-container footerRowOutlet/>
+    }
+  `,
   styleUrl: 'table.css',
   host: {
     'class': 'cdk-table',

--- a/src/material/table/table.ts
+++ b/src/material/table/table.ts
@@ -39,7 +39,6 @@ export class MatRecycleRows {}
   exportAs: 'matTable',
   // Note that according to MDN, the `caption` element has to be projected as the **first**
   // element in the table. See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/caption
-  // We can't reuse `CDK_TABLE_TEMPLATE` because it's incompatible with local compilation mode.
   template: `
     <ng-content select="caption"/>
     <ng-content select="colgroup, col"/>


### PR DESCRIPTION
Removes some symbols that are only constructed privately in the table from the public API. These shouldn't be exported or depended upon, because there's no way to actually pass them back into the table.

I also ended up removing the `CDK_TABLE_TEMPLATE` variable, because it doesn't work in local compilation and it may become a problem in the future if we end up having single-file compilation in the framework.

BREAKING CHANGE:
* `CanStick` has been removed.
* `CDK_TABLE_TEMPLATE` has been removed.
* `StickyDirection` has been removed.
* `StickyStyler` has been removed.