### PR TITLE
feat(material/testing): Extend Angular harness testing functionality 

### DIFF
--- a/src/cdk/testing/component-harness.ts
+++ b/src/cdk/testing/component-harness.ts
@@ -542,7 +542,7 @@ export abstract class ContentContainerComponentHarness<S extends string = string
     return (await this.getRootHarnessLoader()).getAllHarnesses(query);
   }
 
- /**
+  /**
    * Returns the number of matching harnesses for the given query within the current harness's
    * content.
    *

--- a/src/cdk/testing/component-harness.ts
+++ b/src/cdk/testing/component-harness.ts
@@ -120,12 +120,31 @@ export interface HarnessLoader {
   getHarnessOrNull<T extends ComponentHarness>(query: HarnessQuery<T>): Promise<T | null>;
 
   /**
+   * Searches for an instance of the component corresponding to the given harness type under the
+   * `HarnessLoader`'s root element, and returns a `ComponentHarness` for the instance on the page
+   * at the given index. If no matching component exists at that index, an error is thrown.
+   * @param query A query for a harness to create
+   * @param index The zero-indexed offset of the matching component instance to return
+   * @return An instance of the given harness type.
+   * @throws If a matching component instance can't be found at the given index.
+   */
+  getHarnessAtIndex<T extends ComponentHarness>(query: HarnessQuery<T>, index: number): Promise<T>;
+
+  /**
    * Searches for all instances of the component corresponding to the given harness type under the
    * `HarnessLoader`'s root element, and returns a list `ComponentHarness` for each instance.
    * @param query A query for a harness to create
    * @return A list instances of the given harness type.
    */
   getAllHarnesses<T extends ComponentHarness>(query: HarnessQuery<T>): Promise<T[]>;
+
+  /**
+   * Searches for all instances of the component corresponding to the given harness type under the
+   * `HarnessLoader`'s root element, and returns the total count of all matching components.
+   * @param query A query for a harness to create
+   * @return An integer indicating the number of instances that were found.
+   */
+  countHarnesses<T extends ComponentHarness>(query: HarnessQuery<T>): Promise<number>;
 
   /**
    * Searches for an instance of the component corresponding to the given harness type under the
@@ -501,6 +520,20 @@ export abstract class ContentContainerComponentHarness<S extends string = string
   }
 
   /**
+   * Gets a matching harness for the given query and index within the current harness's content.
+   * @param query The harness query to search for.
+   * @param index The zero-indexed offset of the component to find.
+   * @returns The first harness matching the given query.
+   * @throws If no matching harness is found.
+   */
+  async getHarnessAtIndex<T extends ComponentHarness>(
+    query: HarnessQuery<T>,
+    index: number,
+  ): Promise<T> {
+    return (await this.getRootHarnessLoader()).getHarnessAtIndex(query, index);
+  }
+
+  /**
    * Gets all matching harnesses for the given query within the current harness's content.
    * @param query The harness query to search for.
    * @returns The list of harness matching the given query.
@@ -509,12 +542,23 @@ export abstract class ContentContainerComponentHarness<S extends string = string
     return (await this.getRootHarnessLoader()).getAllHarnesses(query);
   }
 
+ /**
+   * Returns the number of matching harnesses for the given query within the current harness's
+   * content.
+   *
+   * @param query The harness query to search for.
+   * @returns The number of matching harnesses for the given query.
+   */
+  async countHarnesses<T extends ComponentHarness>(query: HarnessQuery<T>): Promise<number> {
+    return (await this.getRootHarnessLoader()).countHarnesses(query);
+  }
+
   /**
    * Checks whether there is a matching harnesses for the given query within the current harness's
    * content.
    *
    * @param query The harness query to search for.
-   * @returns Whetehr there is matching harnesses for the given query.
+   * @returns Whether there is matching harnesses for the given query.
    */
   async hasHarness<T extends ComponentHarness>(query: HarnessQuery<T>): Promise<boolean> {
     return (await this.getRootHarnessLoader()).hasHarness(query);

--- a/src/cdk/testing/harness-environment.ts
+++ b/src/cdk/testing/harness-environment.ts
@@ -248,6 +248,30 @@ export abstract class HarnessEnvironment<E> implements HarnessLoader, LocatorFac
     return this.locatorForOptional(query)();
   }
 
+ /**
+   * Searches for an instance of the component corresponding to the given harness type and index 
+   * under the `HarnessEnvironment`'s root element, and returns a `ComponentHarness` for that 
+   * instance. The index specifies the offset of the component to find. If no matching
+   * component is found at that index, an error is thrown.
+   * @param query A query for a harness to create
+   * @param index The zero-indexed offset of the component to find
+   * @return An instance of the given harness type
+   * @throws If a matching component instance can't be found.
+   */
+  async getHarnessAtIndex<T extends ComponentHarness>(
+    query: HarnessQuery<T>,
+    offset: number,
+  ): Promise<T> {
+    if (offset < 0) {
+      throw Error('Index must not be negative');
+    }
+    const harnesses = await this.locatorForAll(query)();
+    if (offset >= harnesses.length) {
+      throw Error(`No harness was located at index ${offset}`);
+    }
+    return harnesses[offset];
+  }
+
   /**
    * Searches for all instances of the component corresponding to the given harness type under the
    * `HarnessEnvironment`'s root element, and returns a list `ComponentHarness` for each instance.
@@ -256,6 +280,16 @@ export abstract class HarnessEnvironment<E> implements HarnessLoader, LocatorFac
    */
   getAllHarnesses<T extends ComponentHarness>(query: HarnessQuery<T>): Promise<T[]> {
     return this.locatorForAll(query)();
+  }
+
+  /**
+   * Searches for all instance of the component corresponding to the given harness type under the
+   * `HarnessEnvironment`'s root element, and returns the number that were found.
+   * @param query A query for a harness to create
+   * @return The number of instances that were found.
+   */
+  async countHarnesses<T extends ComponentHarness>(query: HarnessQuery<T>): Promise<number> {
+    return (await this.locatorForAll(query)()).length;
   }
 
   /**

--- a/src/cdk/testing/harness-environment.ts
+++ b/src/cdk/testing/harness-environment.ts
@@ -248,9 +248,9 @@ export abstract class HarnessEnvironment<E> implements HarnessLoader, LocatorFac
     return this.locatorForOptional(query)();
   }
 
- /**
-   * Searches for an instance of the component corresponding to the given harness type and index 
-   * under the `HarnessEnvironment`'s root element, and returns a `ComponentHarness` for that 
+  /**
+   * Searches for an instance of the component corresponding to the given harness type and index
+   * under the `HarnessEnvironment`'s root element, and returns a `ComponentHarness` for that
    * instance. The index specifies the offset of the component to find. If no matching
    * component is found at that index, an error is thrown.
    * @param query A query for a harness to create

--- a/src/cdk/testing/test-harnesses.md
+++ b/src/cdk/testing/test-harnesses.md
@@ -134,9 +134,12 @@ are used to create `ComponentHarness` instances for elements under this root ele
 | `getChildLoader(selector: string): Promise<HarnessLoader>` | Searches for an element matching the given selector below the root element of this `HarnessLoader`, and returns a new `HarnessLoader` rooted at the first matching element |
 | `getAllChildLoaders(selector: string): Promise<HarnessLoader[]>` | Acts like `getChildLoader`, but returns an array of `HarnessLoader` instances, one for each matching element, rather than just the first matching element |
 | `getHarness<T extends ComponentHarness>(harnessType: ComponentHarnessConstructor<T> \| HarnessPredicate<T>): Promise<T>` | Searches for an instance of the given `ComponentHarness` class or `HarnessPredicate` below the root element of this `HarnessLoader` and returns an instance of the harness corresponding to the first matching element |
+| `getHarnessAtIndex<T extends ComponentHarness>(harnessType: ComponentHarnessConstructor<T> \| HarnessPredicate<T>, index: number): Promise<T>` | Acts like `getHarness`, but returns an instance of the harness corresponding to the matching element with the given index (zero-indexed) |
 | `getAllHarnesses<T extends ComponentHarness>(harnessType: ComponentHarnessConstructor<T> \| HarnessPredicate<T>): Promise<T[]>` | Acts like `getHarness`, but returns an array of harness instances, one for each matching element, rather than just the first matching element  |
+| `countHarnesses<T extends ComponentHarness>(harnessType: ComponentHarnessConstructor<T> \| HarnessPredicate<T>): Promise<number>` | Counts the number of instances of the given `ComponentHarness` class or `HarnessPredicate` below the root element of this `HarnessLoader`, and returns the result. |
+| `hasHarness<T extends ComponentHarness>(harnessType: ComponentHarnessConstructor<T> \| HarnessPredicate<T>): Promise<boolean>` | Returns true if an instance of the given `ComponentHarness` class or `HarnessPredicate` exists below the root element of this `HarnessLoader` |
 
-Calls to `getHarness` and `getAllHarnesses` can either take `ComponentHarness` subclass or a
+Calls to the harness functions can either take `ComponentHarness` subclass or a
 `HarnessPredicate`. `HarnessPredicate` applies additional restrictions to the search (e.g. searching
 for a button that has some particular text, etc). The
 [details of `HarnessPredicate`](#filtering-harness-instances-with-harnesspredicate) are discussed in

--- a/src/material/datepicker/testing/date-range-input-harness.spec.ts
+++ b/src/material/datepicker/testing/date-range-input-harness.spec.ts
@@ -11,6 +11,7 @@ import {
   MatEndDate,
   MatStartDate,
 } from '../../datepicker';
+import {MatFormFieldModule} from '../../form-field';
 import {MatCalendarHarness} from './calendar-harness';
 import {
   MatDateRangeInputHarness,
@@ -34,7 +35,14 @@ describe('matDateRangeInputHarness', () => {
 
   it('should load all date range input harnesses', async () => {
     const inputs = await loader.getAllHarnesses(MatDateRangeInputHarness);
-    expect(inputs.length).toBe(2);
+    expect(inputs.length).toBe(3);
+  });
+
+  it('should load date range input with a specific label', async () => {
+    const inputs = await loader.getAllHarnesses(
+      MatDateRangeInputHarness.with({label: 'Date range'}),
+    );
+    expect(inputs.length).toBe(1);
   });
 
   it('should get whether the input is disabled', async () => {
@@ -261,6 +269,14 @@ describe('matDateRangeInputHarness', () => {
       <input matStartDate>
       <input matEndDate>
     </mat-date-range-input>
+
+    <mat-form-field>
+      <mat-label>Date range</mat-label>
+      <mat-date-range-input basic>
+      <input matStartDate>
+      <input matEndDate>
+    </mat-date-range-input>
+    </mat-form-field>
   `,
   imports: [
     MatNativeDateModule,
@@ -268,6 +284,7 @@ describe('matDateRangeInputHarness', () => {
     MatStartDate,
     MatEndDate,
     MatDateRangePicker,
+    MatFormFieldModule,
     FormsModule,
   ],
 })

--- a/src/material/datepicker/testing/date-range-input-harness.ts
+++ b/src/material/datepicker/testing/date-range-input-harness.ts
@@ -93,7 +93,7 @@ export class MatDateRangeInputHarness extends DatepickerTriggerHarnessBase {
 
   /** Gets the floating label text for the range input, if it exists. */
   async getLabel(): Promise<string | null> {
-    // Copied from MatFormFieldControlHarness since this class cannot extend two classes
+    // Copied from MatFormFieldControlHarnessBase since this class cannot extend two classes
     const documentRootLocator = await this.documentRootLocatorFactory();
     const labelId = await (await this.host()).getAttribute('aria-labelledby');
     const hostId = await (await this.host()).getAttribute('id');

--- a/src/material/datepicker/testing/datepicker-harness-filters.ts
+++ b/src/material/datepicker/testing/datepicker-harness-filters.ts
@@ -6,10 +6,11 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import {MatFormFieldControlHarnessFilters} from '@angular/material/form-field/testing/control';
 import {BaseHarnessFilters} from '@angular/cdk/testing';
 
 /** A set of criteria that can be used to filter a list of datepicker input instances. */
-export interface DatepickerInputHarnessFilters extends BaseHarnessFilters {
+export interface DatepickerInputHarnessFilters extends MatFormFieldControlHarnessFilters {
   /** Filters based on the value of the input. */
   value?: string | RegExp;
   /** Filters based on the placeholder text of the input. */
@@ -43,7 +44,7 @@ export interface CalendarCellHarnessFilters extends BaseHarnessFilters {
 }
 
 /** A set of criteria that can be used to filter a list of date range input instances. */
-export interface DateRangeInputHarnessFilters extends BaseHarnessFilters {
+export interface DateRangeInputHarnessFilters extends MatFormFieldControlHarnessFilters {
   /** Filters based on the value of the input. */
   value?: string | RegExp;
 }

--- a/src/material/datepicker/testing/datepicker-input-harness-base.ts
+++ b/src/material/datepicker/testing/datepicker-input-harness-base.ts
@@ -7,7 +7,7 @@
  */
 
 import {ComponentHarnessConstructor, HarnessPredicate} from '@angular/cdk/testing';
-import {MatFormFieldControlHarness} from '@angular/material/form-field/testing/control';
+import {MatFormFieldControlHarnessBase} from '@angular/material/form-field/testing/control';
 import {DatepickerInputHarnessFilters} from './datepicker-harness-filters';
 
 /** Sets up the filter predicates for a datepicker input harness. */
@@ -28,7 +28,7 @@ export function getInputPredicate<T extends MatDatepickerInputHarnessBase>(
 }
 
 /** Base class for datepicker input harnesses. */
-export abstract class MatDatepickerInputHarnessBase extends MatFormFieldControlHarness {
+export abstract class MatDatepickerInputHarnessBase extends MatFormFieldControlHarnessBase {
   /** Whether the input is disabled. */
   async isDisabled(): Promise<boolean> {
     return (await this.host()).getProperty<boolean>('disabled');
@@ -37,11 +37,6 @@ export abstract class MatDatepickerInputHarnessBase extends MatFormFieldControlH
   /** Whether the input is required. */
   async isRequired(): Promise<boolean> {
     return (await this.host()).getProperty<boolean>('required');
-  }
-
-  /** Gets the floating label text for the input, if it exists. */
-  async getLabel(): Promise<string | null> {
-    return await this._getFloatingLabelText();
   }
 
   /** Gets the value of the input. */

--- a/src/material/datepicker/testing/datepicker-input-harness-base.ts
+++ b/src/material/datepicker/testing/datepicker-input-harness-base.ts
@@ -7,7 +7,7 @@
  */
 
 import {ComponentHarnessConstructor, HarnessPredicate} from '@angular/cdk/testing';
-import {MatFormFieldControlHarness} from '../../form-field/testing/control';
+import {MatFormFieldControlHarness} from '@angular/material/form-field/testing/control';
 import {DatepickerInputHarnessFilters} from './datepicker-harness-filters';
 
 /** Sets up the filter predicates for a datepicker input harness. */
@@ -21,6 +21,9 @@ export function getInputPredicate<T extends MatDatepickerInputHarnessBase>(
     })
     .addOption('placeholder', options.placeholder, (harness, placeholder) => {
       return HarnessPredicate.stringMatches(harness.getPlaceholder(), placeholder);
+    })
+    .addOption('label', options.label, (harness, label) => {
+      return HarnessPredicate.stringMatches(harness.getLabel(), label);
     });
 }
 
@@ -34,6 +37,11 @@ export abstract class MatDatepickerInputHarnessBase extends MatFormFieldControlH
   /** Whether the input is required. */
   async isRequired(): Promise<boolean> {
     return (await this.host()).getProperty<boolean>('required');
+  }
+
+  /** Gets the floating label text for the input, if it exists. */
+  async getLabel(): Promise<string | null> {
+    return await this._getFloatingLabelText();
   }
 
   /** Gets the value of the input. */

--- a/src/material/datepicker/testing/datepicker-input-harness.spec.ts
+++ b/src/material/datepicker/testing/datepicker-input-harness.spec.ts
@@ -5,6 +5,8 @@ import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {FormsModule} from '@angular/forms';
 import {DateAdapter, MATERIAL_ANIMATIONS, MatNativeDateModule} from '../../core';
 import {MatDatepickerModule} from '../../datepicker';
+import {MatFormFieldModule} from '../../form-field';
+import {MatInputModule} from '../../input';
 import {MatCalendarHarness} from './calendar-harness';
 import {MatDatepickerInputHarness} from './datepicker-input-harness';
 
@@ -25,6 +27,13 @@ describe('MatDatepickerInputHarness', () => {
   it('should load all datepicker input harnesses', async () => {
     const inputs = await loader.getAllHarnesses(MatDatepickerInputHarness);
     expect(inputs.length).toBe(2);
+  });
+
+  it('should load datepicker input with a specific label', async () => {
+    const selects = await loader.getAllHarnesses(
+      MatDatepickerInputHarness.with({label: 'Pick a date'}),
+    );
+    expect(selects.length).toBe(1);
   });
 
   it('should filter inputs based on their value', async () => {
@@ -187,21 +196,31 @@ describe('MatDatepickerInputHarness', () => {
 
 @Component({
   template: `
-    <input
-      id="basic"
-      matInput
-      [matDatepicker]="picker"
-      (dateChange)="dateChangeCount = dateChangeCount + 1"
-      [(ngModel)]="date"
-      [min]="minDate"
-      [max]="maxDate"
-      [disabled]="disabled"
-      [required]="required"
-      placeholder="Type a date">
-    <mat-datepicker #picker [touchUi]="touchUi"></mat-datepicker>
+    <mat-form-field>
+      <mat-label>Pick a date</mat-label>
+      <input
+        id="basic"
+        matInput
+        [matDatepicker]="picker"
+        (dateChange)="dateChangeCount = dateChangeCount + 1"
+        [(ngModel)]="date"
+        [min]="minDate"
+        [max]="maxDate"
+        [disabled]="disabled"
+        [required]="required"
+        placeholder="Type a date">
+      <mat-datepicker #picker [touchUi]="touchUi"></mat-datepicker>
+    </mat-form-field>
+
     <input id="no-datepicker" matDatepicker>
   `,
-  imports: [MatNativeDateModule, MatDatepickerModule, FormsModule],
+  imports: [
+    MatNativeDateModule,
+    MatDatepickerModule,
+    MatFormFieldModule,
+    MatInputModule,
+    FormsModule,
+  ],
 })
 class DatepickerInputHarnessTest {
   date: Date | null = null;

--- a/src/material/form-field/testing/control/form-field-control-harness-filters.ts
+++ b/src/material/form-field/testing/control/form-field-control-harness-filters.ts
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {BaseHarnessFilters} from '@angular/cdk/testing';
+
+/**
+ * A set of criteria shared by any class derived from `MatFormFieldControlHarness`, that can be
+ * used to filter a list of those components.
+ */
+export interface MatFormFieldControlHarnessFilters extends BaseHarnessFilters {
+  /** Filters based on the text of the form field's floating label. */
+  label?: string | RegExp;
+}

--- a/src/material/form-field/testing/control/form-field-control-harness.ts
+++ b/src/material/form-field/testing/control/form-field-control-harness.ts
@@ -12,11 +12,16 @@ import {ComponentHarness} from '@angular/cdk/testing';
  * Base class for custom form-field control harnesses. Harnesses for
  * custom controls with form-fields need to implement this interface.
  */
-export abstract class MatFormFieldControlHarness extends ComponentHarness {
+export abstract class MatFormFieldControlHarness extends ComponentHarness {}
+
+/**
+ * Shared behavior for `MatFormFieldControlHarness` implementations
+ */
+export abstract class MatFormFieldControlHarnessBase extends MatFormFieldControlHarness {
   private readonly floatingLabelSelector = '.mdc-floating-label';
 
   /** Gets the text content of the floating label, if it exists. */
-  protected async _getFloatingLabelText(): Promise<string | null> {
+  public async getLabel(): Promise<string | null> {
     const documentRootLocator = await this.documentRootLocatorFactory();
     const labelId = await (await this.host()).getAttribute('aria-labelledby');
     const hostId = await (await this.host()).getAttribute('id');

--- a/src/material/form-field/testing/control/form-field-control-harness.ts
+++ b/src/material/form-field/testing/control/form-field-control-harness.ts
@@ -12,4 +12,30 @@ import {ComponentHarness} from '@angular/cdk/testing';
  * Base class for custom form-field control harnesses. Harnesses for
  * custom controls with form-fields need to implement this interface.
  */
-export abstract class MatFormFieldControlHarness extends ComponentHarness {}
+export abstract class MatFormFieldControlHarness extends ComponentHarness {
+  private readonly floatingLabelSelector = '.mdc-floating-label';
+
+  /** Gets the text content of the floating label, if it exists. */
+  protected async _getFloatingLabelText(): Promise<string | null> {
+    const documentRootLocator = await this.documentRootLocatorFactory();
+    const labelId = await (await this.host()).getAttribute('aria-labelledby');
+    const hostId = await (await this.host()).getAttribute('id');
+
+    if (labelId) {
+      // First option, try to fetch the label using the `aria-labelledby`
+      // attribute.
+      const labelEl = await await documentRootLocator.locatorForOptional(
+        `${this.floatingLabelSelector}[id="${labelId}"]`,
+      )();
+      return labelEl ? labelEl.text() : null;
+    } else if (hostId) {
+      // Fallback option, try to match the id of the input with the `for`
+      // attribute of the label.
+      const labelEl = await await documentRootLocator.locatorForOptional(
+        `${this.floatingLabelSelector}[for="${hostId}"]`,
+      )();
+      return labelEl ? labelEl.text() : null;
+    }
+    return null;
+  }
+}

--- a/src/material/form-field/testing/control/index.ts
+++ b/src/material/form-field/testing/control/index.ts
@@ -7,3 +7,4 @@
  */
 
 export * from './form-field-control-harness';
+export * from './form-field-control-harness-filters';

--- a/src/material/input/testing/input-harness-filters.ts
+++ b/src/material/input/testing/input-harness-filters.ts
@@ -6,10 +6,10 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {BaseHarnessFilters} from '@angular/cdk/testing';
+import {MatFormFieldControlHarnessFilters} from '@angular/material/form-field/testing/control';
 
 /** A set of criteria that can be used to filter a list of `MatInputHarness` instances. */
-export interface InputHarnessFilters extends BaseHarnessFilters {
+export interface InputHarnessFilters extends MatFormFieldControlHarnessFilters {
   /** Filters based on the value of the input. */
   value?: string | RegExp;
   /** Filters based on the placeholder text of the input. */

--- a/src/material/input/testing/input-harness.spec.ts
+++ b/src/material/input/testing/input-harness.spec.ts
@@ -18,8 +18,7 @@ describe('MatInputHarness', () => {
   });
 
   it('should load all input harnesses', async () => {
-    const inputs = await loader.getAllHarnesses(MatInputHarness);
-    expect(inputs.length).toBe(7);
+    expect(await loader.countHarnesses(MatInputHarness)).toBe(7);
   });
 
   it('should load input with specific id', async () => {

--- a/src/material/input/testing/input-harness.spec.ts
+++ b/src/material/input/testing/input-harness.spec.ts
@@ -39,6 +39,11 @@ describe('MatInputHarness', () => {
     expect(inputs.length).toBe(1);
   });
 
+  it('should load input with a specific label', async () => {
+    const inputs = await loader.getAllHarnesses(MatInputHarness.with({label: 'Favorite food'}));
+    expect(inputs.length).toBe(1);
+  });
+
   it('should load input with a value that matches a regex', async () => {
     const inputs = await loader.getAllHarnesses(MatInputHarness.with({value: /shi$/}));
     expect(inputs.length).toBe(1);
@@ -231,6 +236,7 @@ describe('MatInputHarness', () => {
 @Component({
   template: `
     <mat-form-field>
+      <mat-label>Favorite food</mat-label>
       <input matInput placeholder="Favorite food" value="Sushi" name="favorite-food">
     </mat-form-field>
 

--- a/src/material/input/testing/input-harness.ts
+++ b/src/material/input/testing/input-harness.ts
@@ -13,8 +13,6 @@ import {InputHarnessFilters} from './input-harness-filters';
 
 /** Harness for interacting with a standard Material inputs in tests. */
 export class MatInputHarness extends MatFormFieldControlHarnessBase {
-  private readonly _documentRootLocator = this.documentRootLocatorFactory();
-
   // TODO: We do not want to handle `select` elements with `matNativeControl` because
   // not all methods of this harness work reasonably for native select elements.
   // For more details. See: https://github.com/angular/components/pull/18221.

--- a/src/material/input/testing/input-harness.ts
+++ b/src/material/input/testing/input-harness.ts
@@ -7,12 +7,12 @@
  */
 
 import {HarnessPredicate, parallel} from '@angular/cdk/testing';
-import {MatFormFieldControlHarness} from '@angular/material/form-field/testing/control';
+import {MatFormFieldControlHarnessBase} from '@angular/material/form-field/testing/control';
 import {coerceBooleanProperty} from '@angular/cdk/coercion';
 import {InputHarnessFilters} from './input-harness-filters';
 
 /** Harness for interacting with a standard Material inputs in tests. */
-export class MatInputHarness extends MatFormFieldControlHarness {
+export class MatInputHarness extends MatFormFieldControlHarnessBase {
   private readonly _documentRootLocator = this.documentRootLocatorFactory();
 
   // TODO: We do not want to handle `select` elements with `matNativeControl` because
@@ -97,11 +97,6 @@ export class MatInputHarness extends MatFormFieldControlHarness {
     // The input directive always assigns a unique id to the input in
     // case no id has been explicitly specified.
     return await (await this.host()).getProperty<string>('id');
-  }
-
-  /** Gets the floating label text for the input, if it exists. */
-  async getLabel(): Promise<string | null> {
-    return await this._getFloatingLabelText();
   }
 
   /**

--- a/src/material/input/testing/input-harness.ts
+++ b/src/material/input/testing/input-harness.ts
@@ -7,12 +7,14 @@
  */
 
 import {HarnessPredicate, parallel} from '@angular/cdk/testing';
-import {MatFormFieldControlHarness} from '../../form-field/testing/control';
+import {MatFormFieldControlHarness} from '@angular/material/form-field/testing/control';
 import {coerceBooleanProperty} from '@angular/cdk/coercion';
 import {InputHarnessFilters} from './input-harness-filters';
 
 /** Harness for interacting with a standard Material inputs in tests. */
 export class MatInputHarness extends MatFormFieldControlHarness {
+  private readonly _documentRootLocator = this.documentRootLocatorFactory();
+
   // TODO: We do not want to handle `select` elements with `matNativeControl` because
   // not all methods of this harness work reasonably for native select elements.
   // For more details. See: https://github.com/angular/components/pull/18221.
@@ -31,6 +33,9 @@ export class MatInputHarness extends MatFormFieldControlHarness {
       })
       .addOption('placeholder', options.placeholder, (harness, placeholder) => {
         return HarnessPredicate.stringMatches(harness.getPlaceholder(), placeholder);
+      })
+      .addOption('label', options.label, (harness, label) => {
+        return HarnessPredicate.stringMatches(harness.getLabel(), label);
       });
   }
 
@@ -92,6 +97,11 @@ export class MatInputHarness extends MatFormFieldControlHarness {
     // The input directive always assigns a unique id to the input in
     // case no id has been explicitly specified.
     return await (await this.host()).getProperty<string>('id');
+  }
+
+  /** Gets the floating label text for the input, if it exists. */
+  async getLabel(): Promise<string | null> {
+    return await this._getFloatingLabelText();
   }
 
   /**

--- a/src/material/input/testing/native-select-harness-filters.ts
+++ b/src/material/input/testing/native-select-harness-filters.ts
@@ -7,9 +7,10 @@
  */
 
 import {BaseHarnessFilters} from '@angular/cdk/testing';
+import {MatFormFieldControlHarnessFilters} from '@angular/material/form-field/testing/control';
 
 /** A set of criteria that can be used to filter a list of `MatNativeSelectHarness` instances. */
-export interface NativeSelectHarnessFilters extends BaseHarnessFilters {}
+export interface NativeSelectHarnessFilters extends MatFormFieldControlHarnessFilters {}
 
 /** A set of criteria that can be used to filter a list of `MatNativeOptionHarness` instances. */
 export interface NativeOptionHarnessFilters extends BaseHarnessFilters {

--- a/src/material/input/testing/native-select-harness.spec.ts
+++ b/src/material/input/testing/native-select-harness.spec.ts
@@ -21,6 +21,13 @@ describe('MatNativeSelectHarness', () => {
     expect(selects.length).toBe(2);
   });
 
+  it('should load select with a specific label', async () => {
+    const inputs = await loader.getAllHarnesses(
+      MatNativeSelectHarness.with({label: 'Favorite food'}),
+    );
+    expect(inputs.length).toBe(1);
+  });
+
   it('should get the id of a select', async () => {
     const selects = await loader.getAllHarnesses(MatNativeSelectHarness);
     expect(await parallel(() => selects.map(select => select.getId()))).toEqual(['food', 'drink']);
@@ -187,6 +194,7 @@ describe('MatNativeSelectHarness', () => {
 @Component({
   template: `
     <mat-form-field>
+      <mat-label>Favorite food</mat-label>
       <select
         id="food"
         matNativeControl

--- a/src/material/input/testing/native-select-harness.ts
+++ b/src/material/input/testing/native-select-harness.ts
@@ -25,7 +25,13 @@ export class MatNativeSelectHarness extends MatFormFieldControlHarness {
    * @return a `HarnessPredicate` configured with the given options.
    */
   static with(options: NativeSelectHarnessFilters = {}): HarnessPredicate<MatNativeSelectHarness> {
-    return new HarnessPredicate(MatNativeSelectHarness, options);
+    return new HarnessPredicate(MatNativeSelectHarness, options).addOption(
+      'label',
+      options.label,
+      (harness, label) => {
+        return HarnessPredicate.stringMatches(harness.getLabel(), label);
+      },
+    );
   }
 
   /** Gets a boolean promise indicating if the select is disabled. */
@@ -53,6 +59,11 @@ export class MatNativeSelectHarness extends MatFormFieldControlHarness {
   async getId(): Promise<string> {
     // We're guaranteed to have an id, because the `matNativeControl` always assigns one.
     return await (await this.host()).getProperty<string>('id');
+  }
+
+  /** Gets the floating label text for the input, if it exists. */
+  async getLabel(): Promise<string | null> {
+    return await this._getFloatingLabelText();
   }
 
   /** Focuses the select and returns a void promise that indicates when the action is complete. */

--- a/src/material/input/testing/native-select-harness.ts
+++ b/src/material/input/testing/native-select-harness.ts
@@ -7,7 +7,7 @@
  */
 
 import {HarnessPredicate, parallel} from '@angular/cdk/testing';
-import {MatFormFieldControlHarness} from '../../form-field/testing/control';
+import {MatFormFieldControlHarnessBase} from '../../form-field/testing/control';
 import {MatNativeOptionHarness} from './native-option-harness';
 import {
   NativeOptionHarnessFilters,
@@ -15,7 +15,7 @@ import {
 } from './native-select-harness-filters';
 
 /** Harness for interacting with a native `select` in tests. */
-export class MatNativeSelectHarness extends MatFormFieldControlHarness {
+export class MatNativeSelectHarness extends MatFormFieldControlHarnessBase {
   static hostSelector = 'select[matNativeControl]';
 
   /**
@@ -59,11 +59,6 @@ export class MatNativeSelectHarness extends MatFormFieldControlHarness {
   async getId(): Promise<string> {
     // We're guaranteed to have an id, because the `matNativeControl` always assigns one.
     return await (await this.host()).getProperty<string>('id');
-  }
-
-  /** Gets the floating label text for the input, if it exists. */
-  async getLabel(): Promise<string | null> {
-    return await this._getFloatingLabelText();
   }
 
   /** Focuses the select and returns a void promise that indicates when the action is complete. */

--- a/src/material/select/testing/select-harness-filters.ts
+++ b/src/material/select/testing/select-harness-filters.ts
@@ -7,9 +7,10 @@
  */
 
 import {BaseHarnessFilters} from '@angular/cdk/testing';
+import {MatFormFieldControlHarnessFilters} from '@angular/material/form-field/testing/control';
 
 /** A set of criteria that can be used to filter a list of `MatSelectHarness` instances. */
-export interface SelectHarnessFilters extends BaseHarnessFilters {
+export interface SelectHarnessFilters extends MatFormFieldControlHarnessFilters {
   /** Only find instances which match the given disabled state. */
   disabled?: boolean;
 }

--- a/src/material/select/testing/select-harness.spec.ts
+++ b/src/material/select/testing/select-harness.spec.ts
@@ -52,6 +52,11 @@ describe('MatSelectHarness', () => {
     expect(disabledSelects.length).toBe(1);
   });
 
+  it('should load select with a specific label', async () => {
+    const selects = await loader.getAllHarnesses(MatSelectHarness.with({label: 'US States'}));
+    expect(selects.length).toBe(1);
+  });
+
   it('should be able to check whether a select is in multi-selection mode', async () => {
     const singleSelection = await loader.getHarness(
       MatSelectHarness.with({
@@ -265,6 +270,7 @@ describe('MatSelectHarness', () => {
 @Component({
   template: `
     <mat-form-field>
+      <mat-label>US States</mat-label>
       <mat-select [disabled]="isDisabled()" [required]="isRequired()" id="single-selection">
         @for (state of states; track state) {
           <mat-option [value]="state.code">{{ state.name }}</mat-option>

--- a/src/material/select/testing/select-harness.ts
+++ b/src/material/select/testing/select-harness.ts
@@ -13,11 +13,11 @@ import {
   OptionHarnessFilters,
   OptgroupHarnessFilters,
 } from '@angular/material/core/testing';
-import {MatFormFieldControlHarness} from '@angular/material/form-field/testing/control';
+import {MatFormFieldControlHarnessBase} from '@angular/material/form-field/testing/control';
 import {SelectHarnessFilters} from './select-harness-filters';
 
 /** Harness for interacting with a mat-select in tests. */
-export class MatSelectHarness extends MatFormFieldControlHarness {
+export class MatSelectHarness extends MatFormFieldControlHarnessBase {
   static hostSelector = '.mat-mdc-select';
   private _prefix = 'mat-mdc';
   private _optionClass = MatOptionHarness;
@@ -72,11 +72,6 @@ export class MatSelectHarness extends MatFormFieldControlHarness {
   async getValueText(): Promise<string> {
     const value = await this.locatorFor(`.${this._prefix}-select-value`)();
     return value.text();
-  }
-
-  /** Gets the floating label text for the select, if it exists. */
-  async getLabel(): Promise<string | null> {
-    return await this._getFloatingLabelText();
   }
 
   /** Focuses the select and returns a void promise that indicates when the action is complete. */

--- a/src/material/select/testing/select-harness.ts
+++ b/src/material/select/testing/select-harness.ts
@@ -12,8 +12,8 @@ import {
   MatOptgroupHarness,
   OptionHarnessFilters,
   OptgroupHarnessFilters,
-} from '../../core/testing';
-import {MatFormFieldControlHarness} from '../../form-field/testing/control';
+} from '@angular/material/core/testing';
+import {MatFormFieldControlHarness} from '@angular/material/form-field/testing/control';
 import {SelectHarnessFilters} from './select-harness-filters';
 
 /** Harness for interacting with a mat-select in tests. */
@@ -34,13 +34,13 @@ export class MatSelectHarness extends MatFormFieldControlHarness {
     this: ComponentHarnessConstructor<T>,
     options: SelectHarnessFilters = {},
   ): HarnessPredicate<T> {
-    return new HarnessPredicate(this, options).addOption(
-      'disabled',
-      options.disabled,
-      async (harness, disabled) => {
+    return new HarnessPredicate(this, options)
+      .addOption('disabled', options.disabled, async (harness, disabled) => {
         return (await harness.isDisabled()) === disabled;
-      },
-    );
+      })
+      .addOption('label', options.label, (harness, label) => {
+        return HarnessPredicate.stringMatches(harness.getLabel(), label);
+      });
   }
 
   /** Gets a boolean promise indicating if the select is disabled. */
@@ -72,6 +72,11 @@ export class MatSelectHarness extends MatFormFieldControlHarness {
   async getValueText(): Promise<string> {
     const value = await this.locatorFor(`.${this._prefix}-select-value`)();
     return value.text();
+  }
+
+  /** Gets the floating label text for the select, if it exists. */
+  async getLabel(): Promise<string | null> {
+    return await this._getFloatingLabelText();
   }
 
   /** Focuses the select and returns a void promise that indicates when the action is complete. */


### PR DESCRIPTION
This pull request adds the following functionalities to the harness test kit

### getHarnessAtIndex

This new function works acts like `getHarness`, but returns an instance of the harness corresponding to the matching element at the given index. This throws an error if the index is out of bounds.

Example usage:
```
// Retrieves the 4th option on screen
const option = await loader.getHarnessAtIndex(MatOptionHarness, 3);
```

### countHarnesses

This new function counts the number of matching component instances and returns the result.  

Example usage:
```
// Expect there to be five options on the screen
expect(await loader.countHarnesses(MatOptionHarness)).toBe(5);
```

### Filter by Label

New functionality makes it possible to fetch harnesses for certain form components using their floating label text. Previously, the user would have to either label the component with an id or class, or locate it in a form field using `MatFormFieldHarness.getControl()`.

This affects the following harnesses:
- MatInputHarness
- MatSelectHarness
- MatNativeSelectHarness
- MatDatepickerInputHarness
- MatDateRangeInputHarness

Example usage:
```
// template
<mat-form-field>
  <mat-label>Favorite food</mat-label>
  <input matInput value="Pizza"/>
</mat-form-field>

// test.ts
const input = await loader.getHarness(MatInputHarness.with({label: 'Favorite food'}));
```