### PR TITLE
fix(material/chips): adds border on chip-action focus

### DIFF
--- a/src/material/chips/chip.scss
+++ b/src/material/chips/chip.scss
@@ -669,8 +669,9 @@ $fallbacks: m3-chip.get-tokens();
   // For the chip element, default inset/offset values are necessary to ensure that
   // the focus indicator is sufficiently contrastive and renders appropriately.
   $default-border-width: focus-indicators-private.$default-border-width;
+  // stylelint-disable-next-line max-line-length
+  $border-color: var(--mat-focus-indicator-border-color, #{focus-indicators-private.$default-border-color});
   $border-width: var(--mat-focus-indicator-border-width, #{$default-border-width});
-  $default-border-color: var(--mat-focus-indicator-border-color, #{focus-indicators-private.$default-border-color});
   $offset: calc(#{$border-width} + 2px);
 
   content: '';
@@ -680,7 +681,7 @@ $fallbacks: m3-chip.get-tokens();
   margin: calc(#{$offset} * -1);
   border-width: $border-width;
   border: solid;
-  border-color: $default-border-color;
+  border-color: $border-color;
   opacity: 0;
   height: auto;
 }

--- a/src/material/chips/chip.scss
+++ b/src/material/chips/chip.scss
@@ -659,7 +659,7 @@ $fallbacks: m3-chip.get-tokens();
     left: 0;
     pointer-events: none;
   }
-  
+
 }
 
 // Targets .mdc-evolution-chip__cell

--- a/src/material/chips/chip.scss
+++ b/src/material/chips/chip.scss
@@ -670,6 +670,7 @@ $fallbacks: m3-chip.get-tokens();
   // the focus indicator is sufficiently contrastive and renders appropriately.
   $default-border-width: focus-indicators-private.$default-border-width;
   $border-width: var(--mat-focus-indicator-border-width, #{$default-border-width});
+  $default-border-color: var(--mat-focus-indicator-border-color, #{focus-indicators-private.$default-border-color});
   $offset: calc(#{$border-width} + 2px);
 
   content: '';
@@ -679,7 +680,7 @@ $fallbacks: m3-chip.get-tokens();
   margin: calc(#{$offset} * -1);
   border-width: $border-width;
   border: solid;
-  border-color: var(--mat-focus-indicator-border-color), black;
+  border-color: $default-border-color;
   opacity: 0;
   height: auto;
 }

--- a/src/material/chips/chip.scss
+++ b/src/material/chips/chip.scss
@@ -659,15 +659,36 @@ $fallbacks: m3-chip.get-tokens();
     left: 0;
     pointer-events: none;
   }
+  
+}
 
+// Targets .mdc-evolution-chip__cell
+.mat-mdc-chip-action .mat-focus-indicator::before,
+// Targets mdc-evolution-chip__icon
+.mat-mdc-chip-action.mat-focus-indicator::before {
   // For the chip element, default inset/offset values are necessary to ensure that
   // the focus indicator is sufficiently contrastive and renders appropriately.
-  .mat-focus-indicator::before {
-    $default-border-width: focus-indicators-private.$default-border-width;
-    $border-width: var(--mat-focus-indicator-border-width, #{$default-border-width});
-    $offset: calc(#{$border-width} + 2px);
-    margin: calc(#{$offset} * -1);
-  }
+  $default-border-width: focus-indicators-private.$default-border-width;
+  $border-width: var(--mat-focus-indicator-border-width, #{$default-border-width});
+  $offset: calc(#{$border-width} + 2px);
+
+  content: '';
+  display: block;
+  position: absolute;
+  padding: $offset;
+  margin: calc(#{$offset} * -1);
+  border-width: $border-width;
+  border: solid;
+  border-color: var(--mat-focus-indicator-border-color), black;
+  opacity: 0;
+  height: auto;
+}
+
+// The chip has multiple focus targets so we have to put the indicator on
+// a separate element, rather than on the focusable element itself.
+.mat-mdc-chip-action:focus .mat-focus-indicator::before,
+.mat-mdc-chip-action.mat-focus-indicator:focus::before {
+  opacity: 1;
 }
 
 .mat-mdc-chip-edit, .mat-mdc-chip-remove {
@@ -723,12 +744,6 @@ $fallbacks: m3-chip.get-tokens();
   @include cdk.high-contrast {
     outline-width: 3px;
   }
-}
-
-// The chip has multiple focus targets so we have to put the indicator on
-// a separate element, rather than on the focusable element itself.
-.mat-mdc-chip-action:focus .mat-focus-indicator::before {
-  content: '';
 }
 
 // Prevents icon from being cut off when text spacing is increased.


### PR DESCRIPTION
Updates Angular Material Chips component so that when mat-mdc-chip-action is focused on a border appears around either the text of the chip or the action icon, whichever is being focused. This improves the accessibility by aiding the user in seeing which element/action is being focused on.

[Before fix screencast](https://screencast.googleplex.com/cast/NjA0Njk5MjM3NDQzMTc0NHwzMGQ3ZTA0MS0xMA)
[After fix screencast](https://screencast.googleplex.com/cast/NDkyNTM4Mjg3MTQ4MjM2OHxkZDc1NTMzZS1lZg)

Fixes b/286103414