### PR TITLE
fix(cdk/schematics): support project index file discovery for object-form and default

### DIFF
--- a/src/cdk/schematics/utils/project-index-file.ts
+++ b/src/cdk/schematics/utils/project-index-file.ts
@@ -6,16 +6,39 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Path} from '@angular-devkit/core';
+import {join} from 'node:path/posix';
 import {getProjectBuildTargets} from './project-targets';
 import {ProjectDefinition} from '@schematics/angular/utility';
 
-/** Gets the path of the index file in the given project. */
-export function getProjectIndexFiles(project: ProjectDefinition): Path[] {
-  const paths = getProjectBuildTargets(project)
-    .filter(t => t.options?.['index'])
-    .map(t => t.options!['index'] as Path);
+/**
+ * Gets the path of the index file in the given project.
+ * This only searches the base options for each target and not any defined target configurations.
+ */
+export function getProjectIndexFiles(project: ProjectDefinition): string[] {
+  // Use a Set to remove duplicate index files referenced in multiple build targets of a project.
+  const paths = new Set<string>();
 
-  // Use a set to remove duplicate index files referenced in multiple build targets of a project.
-  return Array.from(new Set(paths));
+  for (const target of getProjectBuildTargets(project)) {
+    const indexValue = target.options?.['index'];
+
+    switch (typeof indexValue) {
+      case 'string':
+        // "index": "src/index.html"
+        paths.add(indexValue);
+        break;
+      case 'object':
+        // "index": { "input": "src/index.html", ... }
+        if (indexValue && 'input' in indexValue) {
+          paths.add(indexValue['input'] as string);
+        }
+        break;
+      case 'undefined':
+        // v20+ supports an optional index field; default of `<project_source_root>/index.html`
+        // `project_source_root` is the project level `sourceRoot`; default of `<project_root>/src`
+        paths.add(join(project.sourceRoot ?? join(project.root, 'src'), 'index.html'));
+        break;
+    }
+  }
+
+  return Array.from(paths);
 }


### PR DESCRIPTION
The project index file discovery process now supports finding paths for projects that use the object-form of the `index` field and also for projects that do not explicitly specify an index. Starting with v20, the index field will default to `<project_source_root>/index.html` if not present in the build options for the `application` build system.