### PR TITLE
[Patch port] fix(material/tabs): flicker when animationDuration is set to zero

### DIFF
--- a/goldens/material/tabs/index.api.md
+++ b/goldens/material/tabs/index.api.md
@@ -247,7 +247,7 @@ export class MatTabGroup implements AfterViewInit, AfterContentInit, AfterConten
     get animationDuration(): string;
     set animationDuration(value: string | number);
     // (undocumented)
-    _animationMode: "NoopAnimations" | "BrowserAnimations" | null;
+    protected _animationsDisabled(): boolean;
     ariaLabel: string;
     ariaLabelledby: string;
     // @deprecated

--- a/src/material/tabs/tab-group.html
+++ b/src/material/tabs/tab-group.html
@@ -65,7 +65,7 @@
 
 <div
   class="mat-mdc-tab-body-wrapper"
-  [class._mat-animation-noopable]="_animationMode === 'NoopAnimations'"
+  [class._mat-animation-noopable]="_animationsDisabled()"
   #tabBodyWrapper>
   @for (tab of _tabs; track tab;) {
     <mat-tab-body role="tabpanel"

--- a/src/material/tabs/tab-group.ts
+++ b/src/material/tabs/tab-group.ts
@@ -100,8 +100,8 @@ export class MatTabGroup
   private _tabsSubscription = Subscription.EMPTY;
   private _tabLabelSubscription = Subscription.EMPTY;
   private _tabBodySubscription = Subscription.EMPTY;
-
-  _animationMode = inject(ANIMATION_MODULE_TYPE, {optional: true});
+  private _diAnimationsDisabled =
+    inject(ANIMATION_MODULE_TYPE, {optional: true}) === 'NoopAnimations';
 
   /**
    * All tabs inside the tab group. This includes tabs that belong to groups that are nested
@@ -577,6 +577,14 @@ export class MatTabGroup
     if (isCenter) {
       this._tabBodies?.forEach((body, i) => body._setActiveClass(i === this._selectedIndex));
     }
+  }
+
+  protected _animationsDisabled(): boolean {
+    return (
+      this._diAnimationsDisabled ||
+      this.animationDuration === '0' ||
+      this.animationDuration === '0ms'
+    );
   }
 }
 


### PR DESCRIPTION
**Note:** this is a patch port of #30966

The tabs have a fallback that sets `transition-delay: 1ms` in case users disabled animations without going through one of our APIs. That was also applying when they set `animationDuration="0"` which is a supported API. The result was a slight flicker.

These changes resolve the flicker by treating `animationDuration="0"` in the same way as if animations were disabled globally.

Fixes #30964.