### PR TITLE
fix(cdk/overlay): reduce touch interaction delay on backdrop

### DIFF
--- a/src/cdk/overlay/_index.scss
+++ b/src/cdk/overlay/_index.scss
@@ -95,6 +95,9 @@ $backdrop-animation-timing-function: cubic-bezier(0.25, 0.8, 0.25, 1) !default;
     -webkit-tap-highlight-color: transparent;
     opacity: 0;
 
+    // Removes the tap delay on touch devices (see #30965).
+    touch-action: manipulation;
+
     @include _conditional-layer($wrap-customizable-styles) {
       z-index: $overlay-backdrop-z-index;
       transition: opacity $backdrop-animation-duration $backdrop-animation-timing-function;


### PR DESCRIPTION
Sets `touch-action: manipulation` on the overlay backdrop to reduced the tap delay on touch devices.

Fixes #30965.