### PR TITLE
build: disable minification in the dev app

### DIFF
--- a/src/dev-app/BUILD.bazel
+++ b/src/dev-app/BUILD.bazel
@@ -106,7 +106,6 @@ esbuild(
         ":main.js",
         ":polyfills.js",
     ] + ["%s:index.js" % e for e in ALL_EXAMPLES],
-    minify = True,
     platform = "browser",
     sourcemap = "linked",
     sources_content = True,


### PR DESCRIPTION
Disables minification in the dev app to make errors easier to debug and since we don't really care about performance when developing locally.