### PR TITLE
fix(material/sidenav): fix tabindex issue on side mode

### DIFF
--- a/src/material/sidenav/drawer.ts
+++ b/src/material/sidenav/drawer.ts
@@ -165,7 +165,7 @@ export class MatDrawerContent extends CdkScrollable implements AfterContentInit 
     // this was also done by the animations module which some internal tests seem to depend on.
     // Simulate it by toggling the `hidden` attribute instead.
     '[style.visibility]': '(!_container && !opened) ? "hidden" : null',
-    'tabIndex': '-1',
+    '[attr.tabindex]': 'mode === "side" ? null : "-1"',
   },
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,


### PR DESCRIPTION
remove tabindex=-1 from mat-drawer when in mode="side" so mobile screen readers like TalkBack does not focus on the container

fixes b/286459024