### PR TITLE
fix(material/chips): provide ability to edit for all screen readers with a click on already focused chip

### DIFF
--- a/goldens/material/chips/index.api.md
+++ b/goldens/material/chips/index.api.md
@@ -423,6 +423,8 @@ export class MatChipRow extends MatChip implements AfterViewInit {
     editable: boolean;
     readonly edited: EventEmitter<MatChipEditedEvent>;
     // (undocumented)
+    _handleClick(event: MouseEvent): void;
+    // (undocumented)
     _handleDoubleclick(event: MouseEvent): void;
     _handleFocus(): void;
     // (undocumented)
@@ -433,6 +435,8 @@ export class MatChipRow extends MatChip implements AfterViewInit {
     _isEditing: boolean;
     // (undocumented)
     _isRippleDisabled(): boolean;
+    // (undocumented)
+    ngAfterViewInit(): void;
     // (undocumented)
     static ɵcmp: i0.ɵɵComponentDeclaration<MatChipRow, "mat-chip-row, [mat-chip-row], mat-basic-chip-row, [mat-basic-chip-row]", never, { "editable": { "alias": "editable"; "required": false; }; }, { "edited": "edited"; }, ["contentEditInput"], ["mat-chip-avatar, [matChipAvatar]", "[matChipEditInput]", "*", "mat-chip-trailing-icon,[matChipRemove],[matChipTrailingIcon]"], true, never>;
     // (undocumented)

--- a/src/material/chips/chip-row.spec.ts
+++ b/src/material/chips/chip-row.spec.ts
@@ -4,6 +4,7 @@ import {
   dispatchEvent,
   dispatchFakeEvent,
   dispatchKeyboardEvent,
+  dispatchMouseEvent,
   provideFakeDirectionality,
 } from '@angular/cdk/testing/private';
 import {Component, DebugElement, ElementRef, ViewChild} from '@angular/core';
@@ -233,6 +234,90 @@ describe('Row Chips', () => {
         dispatchKeyboardEvent(chipNativeElement, 'keydown', ENTER);
         fixture.detectChanges();
         expect(chipNativeElement.querySelector('.mat-chip-edit-input')).toBeTruthy();
+      });
+
+      it('should not begin editing on single click', () => {
+        expect(chipNativeElement.querySelector('.mat-chip-edit-input')).toBeFalsy();
+        dispatchMouseEvent(chipNativeElement, 'click');
+        fixture.detectChanges();
+        expect(chipNativeElement.querySelector('.mat-chip-edit-input')).toBeFalsy();
+      });
+
+      it('should begin editing on single click when focused', fakeAsync(() => {
+        expect(chipNativeElement.querySelector('.mat-chip-edit-input')).toBeFalsy();
+        chipNativeElement.focus();
+
+        // Need to also simulate the mousedown as that sets the already focused flag.
+        dispatchMouseEvent(chipNativeElement, 'mousedown');
+        dispatchMouseEvent(chipNativeElement, 'click');
+        fixture.detectChanges();
+        expect(chipNativeElement.querySelector('.mat-chip-edit-input')).toBeTruthy();
+      }));
+
+      describe('when disabled', () => {
+        beforeEach(() => {
+          testComponent.disabled = true;
+          fixture.changeDetectorRef.markForCheck();
+          fixture.detectChanges();
+        });
+
+        it('should not begin editing on double click', () => {
+          expect(chipNativeElement.querySelector('.mat-chip-edit-input')).toBeFalsy();
+          dispatchFakeEvent(chipNativeElement, 'dblclick');
+          fixture.detectChanges();
+          expect(chipNativeElement.querySelector('.mat-chip-edit-input')).toBeFalsy();
+        });
+
+        it('should not begin editing on ENTER', () => {
+          expect(chipNativeElement.querySelector('.mat-chip-edit-input')).toBeFalsy();
+          dispatchKeyboardEvent(chipNativeElement, 'keydown', ENTER);
+          fixture.detectChanges();
+          expect(chipNativeElement.querySelector('.mat-chip-edit-input')).toBeFalsy();
+        });
+
+        it('should not begin editing on single click when focused', fakeAsync(() => {
+          expect(chipNativeElement.querySelector('.mat-chip-edit-input')).toBeFalsy();
+          chipNativeElement.focus();
+
+          // Need to also simulate the mousedown as that sets the already focused flag.
+          dispatchMouseEvent(chipNativeElement, 'mousedown');
+          dispatchMouseEvent(chipNativeElement, 'click');
+          fixture.detectChanges();
+          expect(chipNativeElement.querySelector('.mat-chip-edit-input')).toBeFalsy();
+        }));
+      });
+
+      describe('when not editable', () => {
+        beforeEach(() => {
+          testComponent.editable = false;
+          fixture.changeDetectorRef.markForCheck();
+          fixture.detectChanges();
+        });
+
+        it('should not begin editing on double click', () => {
+          expect(chipNativeElement.querySelector('.mat-chip-edit-input')).toBeFalsy();
+          dispatchFakeEvent(chipNativeElement, 'dblclick');
+          fixture.detectChanges();
+          expect(chipNativeElement.querySelector('.mat-chip-edit-input')).toBeFalsy();
+        });
+
+        it('should not begin editing on ENTER', () => {
+          expect(chipNativeElement.querySelector('.mat-chip-edit-input')).toBeFalsy();
+          dispatchKeyboardEvent(chipNativeElement, 'keydown', ENTER);
+          fixture.detectChanges();
+          expect(chipNativeElement.querySelector('.mat-chip-edit-input')).toBeFalsy();
+        });
+
+        it('should not begin editing on single click when focused', fakeAsync(() => {
+          expect(chipNativeElement.querySelector('.mat-chip-edit-input')).toBeFalsy();
+          chipNativeElement.focus();
+
+          // Need to also simulate the mousedown as that sets the already focused flag.
+          dispatchMouseEvent(chipNativeElement, 'mousedown');
+          dispatchMouseEvent(chipNativeElement, 'click');
+          fixture.detectChanges();
+          expect(chipNativeElement.querySelector('.mat-chip-edit-input')).toBeFalsy();
+        }));
       });
     });
 


### PR DESCRIPTION
Some screen readers have difficulty with allowing users to say double click or enter with voice control, preventing them from being able to edit a chip which currently requires a double click or an enter key event.

Single click conflicts with other behaviors, but allowing a click when the chips has already been focused is a natural way to edit the chip and does not affect other current behaviors.

Fixes b/290806246.