### PR TITLE
build: fix docs deployment directory

### DIFF
--- a/.github/workflows/docs-preview-deploy.yml
+++ b/.github/workflows/docs-preview-deploy.yml
@@ -45,6 +45,6 @@ jobs:
           github-token: '${{secrets.GITHUB_TOKEN}}'
           workflow-artifact-name: 'docs-preview'
           firebase-config-dir: './docs'
-          firebase-public-dir: './docs/dist/material-angular-io.production'
+          firebase-public-dir: './docs/dist'
           firebase-project-id: '${{env.PREVIEW_PROJECT}}'
           firebase-service-key: '${{secrets.FIREBASE_PREVIEW_SERVICE_TOKEN}}'

--- a/docs/firebase.json
+++ b/docs/firebase.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/firebase/firebase-tools/master/schema/firebase-config.json",
   "hosting": {
     "target": "mat-aio",
-    "public": "./dist/material-angular-io.production",
+    "public": "./dist",
     "cleanUrls": true,
     "rewrites": [
       {


### PR DESCRIPTION
The `material-angular-io` project name is no longer part of the `dist` directory, so we need to remove it.