### PR TITLE
build: release script producing duplicate results

### DIFF
--- a/scripts/build-packages-dist.mts
+++ b/scripts/build-packages-dist.mts
@@ -24,8 +24,8 @@ const bazelCmd = process.env['BAZEL'] || `pnpm -s bazel`;
 
 /** Command that queries Bazel for all release package targets. */
 const queryPackagesCmd =
-  `${bazelCmd} query --output=label "attr('tags', '\\[.*${releaseTargetTag}.*\\]', //src/...) ` +
-  `intersect kind('.*_package', //src/...)"`;
+  `${bazelCmd} query --output=label "filter(':npm_package$', ` +
+  `attr('tags', '\\[.*${releaseTargetTag}.*\\]', //src/...))"`;
 
 /** Path for the default distribution output directory. */
 const defaultDistPath = join(projectDir, 'dist/releases');
@@ -93,16 +93,29 @@ function buildReleasePackages(distPath: string, isSnapshotBuild: boolean): Built
  * e.g. //src/material:npm_package = material
  */
 function getPackageNamesOfTargets(targets: string[]): string[] {
-  return targets.map(targetName => {
-    const matches = targetName.match(/\/\/src\/(.*):npm_package/);
-    if (matches === null) {
-      throw Error(
+  const seen = new Set<string>();
+
+  for (const targetName of targets) {
+    const match = targetName.match(/\/\/src\/(.*):npm_package/)?.[1];
+
+    if (!match) {
+      throw new Error(
         `Found Bazel target with "${releaseTargetTag}" tag, but could not ` +
           `determine release output name: ${targetName}`,
       );
     }
-    return matches[1];
-  });
+
+    if (seen.has(match)) {
+      throw new Error(
+        `Detected duplicate package "${match}". The duplication can cause issues when publishing ` +
+          `to npm and needs to be resolved.`,
+      );
+    }
+
+    seen.add(match);
+  }
+
+  return Array.from(seen);
 }
 
 /** Executes the given command in the project directory. */


### PR DESCRIPTION
The release script decides which packages to publish by looking for targets with the `release-package` tag, however with the latest infra changes there are actually two targets per package: `npm_package` and `npm_package_files`. This resulted in the release script trying to publish to npm twice which in turn caused an error since versions can't be published over.

These changes resolve the issue by:
1. Adjusting the query so it only returns the `npm_package` target.
2. Adding validation that we don't resolve the same package twice.