### PR TITLE
Update next branch to reflect new release-train "v20.1.0-next.0".

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+<a name="20.0.0-next.10"></a>
+# 20.0.0-next.10 "sodium-swallow" (2025-05-01)
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="20.0.0-next.9"></a>
 # 20.0.0-next.9 "sodium-salamander" (2025-05-01)
 ## Breaking Changes

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "ci-notify-slack-failure": "node --no-warnings=ExperimentalWarning --loader ts-node/esm/transpile-only scripts/circleci/notify-slack-job-failure.mts",
     "prepare": "husky"
   },
-  "version": "20.0.0-next.9",
+  "version": "20.1.0-next.0",
   "dependencies": {
     "@angular-devkit/core": "catalog:",
     "@angular-devkit/schematics": "catalog:",


### PR DESCRIPTION
The previous "next" release-train has moved into the feature-freeze phase. This PR updates the next branch to the subsequent release-train.

Also this PR cherry-picks the changelog for v20.0.0-next.10 into the main branch so that the changelog is up to date.