### PR TITLE
docs(cdk/testing): cleanup apis for landing on adev

### DIFF
--- a/goldens/cdk/testing/index.api.md
+++ b/goldens/cdk/testing/index.api.md
@@ -4,7 +4,7 @@
 
 ```ts
 
-// @public
+// @public @deprecated
 export type AsyncFactoryFn<T> = () => Promise<T>;
 
 // @public
@@ -33,9 +33,9 @@ export abstract class ComponentHarness {
     host(): Promise<TestElement>;
     // (undocumented)
     protected readonly locatorFactory: LocatorFactory;
-    protected locatorFor<T extends (HarnessQuery<any> | string)[]>(...queries: T): AsyncFactoryFn<LocatorFnResult<T>>;
-    protected locatorForAll<T extends (HarnessQuery<any> | string)[]>(...queries: T): AsyncFactoryFn<LocatorFnResult<T>[]>;
-    protected locatorForOptional<T extends (HarnessQuery<any> | string)[]>(...queries: T): AsyncFactoryFn<LocatorFnResult<T> | null>;
+    protected locatorFor<T extends (HarnessQuery<any> | string)[]>(...queries: T): () => Promise<LocatorFnResult<T>>;
+    protected locatorForAll<T extends (HarnessQuery<any> | string)[]>(...queries: T): () => Promise<LocatorFnResult<T>[]>;
+    protected locatorForOptional<T extends (HarnessQuery<any> | string)[]>(...queries: T): () => Promise<LocatorFnResult<T> | null>;
     protected waitForTasksOutsideAngular(): Promise<void>;
 }
 
@@ -48,30 +48,20 @@ export interface ComponentHarnessConstructor<T extends ComponentHarness> {
 
 // @public
 export abstract class ContentContainerComponentHarness<S extends string = string> extends ComponentHarness implements HarnessLoader {
-    // (undocumented)
     getAllChildLoaders(selector: S): Promise<HarnessLoader[]>;
-    // (undocumented)
     getAllHarnesses<T extends ComponentHarness>(query: HarnessQuery<T>): Promise<T[]>;
-    // (undocumented)
     getChildLoader(selector: S): Promise<HarnessLoader>;
-    // (undocumented)
     getHarness<T extends ComponentHarness>(query: HarnessQuery<T>): Promise<T>;
-    // (undocumented)
     getHarnessOrNull<T extends ComponentHarness>(query: HarnessQuery<T>): Promise<T | null>;
     protected getRootHarnessLoader(): Promise<HarnessLoader>;
-    // (undocumented)
     hasHarness<T extends ComponentHarness>(query: HarnessQuery<T>): Promise<boolean>;
 }
 
 // @public
 export interface ElementDimensions {
-    // (undocumented)
     height: number;
-    // (undocumented)
     left: number;
-    // (undocumented)
     top: number;
-    // (undocumented)
     width: number;
 }
 
@@ -91,48 +81,31 @@ export function handleAutoChangeDetectionStatus(handler: (status: AutoChangeDete
 
 // @public
 export abstract class HarnessEnvironment<E> implements HarnessLoader, LocatorFactory {
-    protected constructor(rawRootElement: E);
+    protected constructor(
+    rawRootElement: E);
     protected createComponentHarness<T extends ComponentHarness>(harnessType: ComponentHarnessConstructor<T>, element: E): T;
     protected abstract createEnvironment(element: E): HarnessEnvironment<E>;
     protected abstract createTestElement(element: E): TestElement;
-    // (undocumented)
     documentRootLocatorFactory(): LocatorFactory;
-    // (undocumented)
     abstract forceStabilize(): Promise<void>;
-    // (undocumented)
     getAllChildLoaders(selector: string): Promise<HarnessLoader[]>;
-    // (undocumented)
     getAllHarnesses<T extends ComponentHarness>(query: HarnessQuery<T>): Promise<T[]>;
     protected abstract getAllRawElements(selector: string): Promise<E[]>;
-    // (undocumented)
     getChildLoader(selector: string): Promise<HarnessLoader>;
     protected abstract getDocumentRoot(): E;
-    // (undocumented)
     getHarness<T extends ComponentHarness>(query: HarnessQuery<T>): Promise<T>;
-    // (undocumented)
     getHarnessOrNull<T extends ComponentHarness>(query: HarnessQuery<T>): Promise<T | null>;
-    // (undocumented)
     harnessLoaderFor(selector: string): Promise<HarnessLoader>;
-    // (undocumented)
     harnessLoaderForAll(selector: string): Promise<HarnessLoader[]>;
-    // (undocumented)
     harnessLoaderForOptional(selector: string): Promise<HarnessLoader | null>;
-    // (undocumented)
     hasHarness<T extends ComponentHarness>(query: HarnessQuery<T>): Promise<boolean>;
-    // (undocumented)
-    locatorFor<T extends (HarnessQuery<any> | string)[]>(...queries: T): AsyncFactoryFn<LocatorFnResult<T>>;
-    // (undocumented)
-    locatorForAll<T extends (HarnessQuery<any> | string)[]>(...queries: T): AsyncFactoryFn<LocatorFnResult<T>[]>;
-    // (undocumented)
-    locatorForOptional<T extends (HarnessQuery<any> | string)[]>(...queries: T): AsyncFactoryFn<LocatorFnResult<T> | null>;
-    // (undocumented)
+    locatorFor<T extends (HarnessQuery<any> | string)[]>(...queries: T): () => Promise<LocatorFnResult<T>>;
+    locatorForAll<T extends (HarnessQuery<any> | string)[]>(...queries: T): () => Promise<LocatorFnResult<T>[]>;
+    locatorForOptional<T extends (HarnessQuery<any> | string)[]>(...queries: T): () => Promise<LocatorFnResult<T> | null>;
     protected rawRootElement: E;
-    // (undocumented)
     get rootElement(): TestElement;
     set rootElement(element: TestElement);
-    // (undocumented)
     rootHarnessLoader(): Promise<HarnessLoader>;
-    // (undocumented)
     abstract waitForTasksOutsideAngular(): Promise<void>;
 }
 
@@ -170,9 +143,9 @@ export interface LocatorFactory {
     harnessLoaderFor(selector: string): Promise<HarnessLoader>;
     harnessLoaderForAll(selector: string): Promise<HarnessLoader[]>;
     harnessLoaderForOptional(selector: string): Promise<HarnessLoader | null>;
-    locatorFor<T extends (HarnessQuery<any> | string)[]>(...queries: T): AsyncFactoryFn<LocatorFnResult<T>>;
-    locatorForAll<T extends (HarnessQuery<any> | string)[]>(...queries: T): AsyncFactoryFn<LocatorFnResult<T>[]>;
-    locatorForOptional<T extends (HarnessQuery<any> | string)[]>(...queries: T): AsyncFactoryFn<LocatorFnResult<T> | null>;
+    locatorFor<T extends (HarnessQuery<any> | string)[]>(...queries: T): () => Promise<LocatorFnResult<T>>;
+    locatorForAll<T extends (HarnessQuery<any> | string)[]>(...queries: T): () => Promise<LocatorFnResult<T>[]>;
+    locatorForOptional<T extends (HarnessQuery<any> | string)[]>(...queries: T): () => Promise<LocatorFnResult<T> | null>;
     rootElement: TestElement;
     rootHarnessLoader(): Promise<HarnessLoader>;
     waitForTasksOutsideAngular(): Promise<void>;
@@ -322,7 +295,7 @@ export enum TestKey {
     UP_ARROW = 12
 }
 
-// @public (undocumented)
+// @public
 export interface TextOptions {
     exclude?: string;
 }

--- a/goldens/material/checkbox/testing/index.api.md
+++ b/goldens/material/checkbox/testing/index.api.md
@@ -31,7 +31,7 @@ export class MatCheckboxHarness extends ComponentHarness {
     // (undocumented)
     static hostSelector: string;
     // (undocumented)
-    _input: _angular_cdk_testing.AsyncFactoryFn<_angular_cdk_testing.TestElement>;
+    _input: () => Promise<_angular_cdk_testing.TestElement>;
     isChecked(): Promise<boolean>;
     isDisabled(): Promise<boolean>;
     isFocused(): Promise<boolean>;

--- a/goldens/material/chips/testing/index.api.md
+++ b/goldens/material/chips/testing/index.api.md
@@ -96,7 +96,7 @@ export class MatChipHarness extends ContentContainerComponentHarness {
     static hostSelector: string;
     isDisabled(): Promise<boolean>;
     // (undocumented)
-    protected _primaryAction: _angular_cdk_testing.AsyncFactoryFn<_angular_cdk_testing.TestElement>;
+    protected _primaryAction: () => Promise<_angular_cdk_testing.TestElement>;
     remove(): Promise<void>;
     static with<T extends MatChipHarness>(this: ComponentHarnessConstructor<T>, options?: ChipHarnessFilters): HarnessPredicate<T>;
 }

--- a/goldens/material/dialog/testing/index.api.md
+++ b/goldens/material/dialog/testing/index.api.md
@@ -34,10 +34,10 @@ export interface DialogHarnessFilters extends BaseHarnessFilters {
 // @public
 export class MatDialogHarness extends ContentContainerComponentHarness<MatDialogSection | string> {
     // (undocumented)
-    protected _actions: _angular_cdk_testing.AsyncFactoryFn<_angular_cdk_testing.TestElement | null>;
+    protected _actions: () => Promise<_angular_cdk_testing.TestElement | null>;
     close(): Promise<void>;
     // (undocumented)
-    protected _content: _angular_cdk_testing.AsyncFactoryFn<_angular_cdk_testing.TestElement | null>;
+    protected _content: () => Promise<_angular_cdk_testing.TestElement | null>;
     getActionsText(): Promise<string>;
     getAriaDescribedby(): Promise<string | null>;
     getAriaLabel(): Promise<string | null>;
@@ -49,7 +49,7 @@ export class MatDialogHarness extends ContentContainerComponentHarness<MatDialog
     getTitleText(): Promise<string>;
     static hostSelector: string;
     // (undocumented)
-    protected _title: _angular_cdk_testing.AsyncFactoryFn<_angular_cdk_testing.TestElement | null>;
+    protected _title: () => Promise<_angular_cdk_testing.TestElement | null>;
     static with<T extends MatDialogHarness>(this: ComponentHarnessConstructor<T>, options?: DialogHarnessFilters): HarnessPredicate<T>;
 }
 

--- a/goldens/material/paginator/testing/index.api.md
+++ b/goldens/material/paginator/testing/index.api.md
@@ -24,9 +24,9 @@ export class MatPaginatorHarness extends ComponentHarness {
     // (undocumented)
     isPreviousPageDisabled(): Promise<boolean>;
     // (undocumented)
-    _rangeLabel: _angular_cdk_testing.AsyncFactoryFn<_angular_cdk_testing.TestElement>;
+    _rangeLabel: () => Promise<_angular_cdk_testing.TestElement>;
     // (undocumented)
-    _select: _angular_cdk_testing.AsyncFactoryFn<MatSelectHarness | null>;
+    _select: () => Promise<MatSelectHarness | null>;
     setPageSize(size: number): Promise<void>;
     static with<T extends MatPaginatorHarness>(this: ComponentHarnessConstructor<T>, options?: PaginatorHarnessFilters): HarnessPredicate<T>;
 }

--- a/goldens/material/radio/testing/index.api.md
+++ b/goldens/material/radio/testing/index.api.md
@@ -15,7 +15,7 @@ export class MatRadioButtonHarness extends ComponentHarness {
     blur(): Promise<void>;
     check(): Promise<void>;
     // (undocumented)
-    protected _clickLabel: _angular_cdk_testing.AsyncFactoryFn<_angular_cdk_testing.TestElement>;
+    protected _clickLabel: () => Promise<_angular_cdk_testing.TestElement>;
     focus(): Promise<void>;
     getId(): Promise<string | null>;
     getLabelText(): Promise<string>;
@@ -27,7 +27,7 @@ export class MatRadioButtonHarness extends ComponentHarness {
     isFocused(): Promise<boolean>;
     isRequired(): Promise<boolean>;
     // (undocumented)
-    protected _textLabel: _angular_cdk_testing.AsyncFactoryFn<_angular_cdk_testing.TestElement>;
+    protected _textLabel: () => Promise<_angular_cdk_testing.TestElement>;
     static with<T extends MatRadioButtonHarness>(this: ComponentHarnessConstructor<T>, options?: RadioButtonHarnessFilters): HarnessPredicate<T>;
 }
 

--- a/goldens/material/slide-toggle/testing/index.api.md
+++ b/goldens/material/slide-toggle/testing/index.api.md
@@ -27,7 +27,7 @@ export class MatSlideToggleHarness extends ComponentHarness {
     isRequired(): Promise<boolean>;
     isValid(): Promise<boolean>;
     // (undocumented)
-    _nativeElement: _angular_cdk_testing.AsyncFactoryFn<_angular_cdk_testing.TestElement>;
+    _nativeElement: () => Promise<_angular_cdk_testing.TestElement>;
     toggle(): Promise<void>;
     uncheck(): Promise<void>;
     static with<T extends MatSlideToggleHarness>(this: ComponentHarnessConstructor<T>, options?: SlideToggleHarnessFilters): HarnessPredicate<T>;

--- a/goldens/material/tree/testing/index.api.md
+++ b/goldens/material/tree/testing/index.api.md
@@ -30,7 +30,7 @@ export class MatTreeNodeHarness extends ContentContainerComponentHarness<string>
     isExpanded(): Promise<boolean>;
     toggle(): Promise<void>;
     // (undocumented)
-    _toggle: _angular_cdk_testing.AsyncFactoryFn<_angular_cdk_testing.TestElement | null>;
+    _toggle: () => Promise<_angular_cdk_testing.TestElement | null>;
     static with(options?: TreeNodeHarnessFilters): HarnessPredicate<MatTreeNodeHarness>;
 }
 

--- a/src/cdk/testing/BUILD.bazel
+++ b/src/cdk/testing/BUILD.bazel
@@ -58,4 +58,5 @@ extract_api_to_json(
     module_name = "@angular/cdk/testing",
     output_name = "cdk_testing.json",
     private_modules = [""],
+    repo = "angular/components",
 )

--- a/src/cdk/testing/change-detection.ts
+++ b/src/cdk/testing/change-detection.ts
@@ -8,7 +8,11 @@
 
 import {BehaviorSubject, Subscription} from 'rxjs';
 
-/** Represents the status of auto change detection. */
+/**
+ * The status of the test harness auto change detection. If not diabled test harnesses will
+ * automatically trigger change detection after every action (such as a click) and before every read
+ * (such as getting the text of an element).
+ */
 export interface AutoChangeDetectionStatus {
   /** Whether auto change detection is disabled. */
   isDisabled: boolean;

--- a/src/cdk/testing/component-harness.ts
+++ b/src/cdk/testing/component-harness.ts
@@ -43,15 +43,23 @@ export type HarnessQuery<T extends ComponentHarness> =
  * Since we don't know for sure which query will match, the result type if the union of the types
  * for all possible results.
  *
- * e.g.
+ * @usageNotes
+ * ### Example
+ *
  * The type:
- * `LocatorFnResult&lt;[
- *   ComponentHarnessConstructor&lt;MyHarness&gt;,
- *   HarnessPredicate&lt;MyOtherHarness&gt;,
+ * ```ts
+ * LocatorFnResult<[
+ *   ComponentHarnessConstructor<MyHarness>,
+ *   HarnessPredicate<MyOtherHarness>,
  *   string
- * ]&gt;`
+ * ]>
+ * ```
+ *
  * is equivalent to:
- * `MyHarness | MyOtherHarness | TestElement`.
+ *
+ * ```ts
+ * MyHarness | MyOtherHarness | TestElement
+ * ```
  */
 export type LocatorFnResult<T extends (HarnessQuery<any> | string)[]> = {
   [I in keyof T]: T[I] extends new (...args: any[]) => infer C // Map `ComponentHarnessConstructor<C>` to `C`.
@@ -545,8 +553,8 @@ export interface BaseHarnessFilters {
 }
 
 /**
- * A class used to associate a ComponentHarness class with predicates functions that can be used to
- * filter instances of the class.
+ * A class used to associate a ComponentHarness class with predicate functions that can be used to
+ * filter instances of the class to be matched.
  */
 export class HarnessPredicate<T extends ComponentHarness> {
   private _predicates: AsyncPredicate<T>[] = [];

--- a/src/cdk/testing/element-dimensions.ts
+++ b/src/cdk/testing/element-dimensions.ts
@@ -10,8 +10,12 @@
  * Dimensions for element size and its position relative to the viewport.
  */
 export interface ElementDimensions {
+  /** The distance from the top of the viewport in pixels */
   top: number;
+  /** The distance from the left of the viewport in pixels */
   left: number;
+  /** The width of the element in pixels */
   width: number;
+  /** The height of the element in pixels */
   height: number;
 }

--- a/src/cdk/testing/harness-environment.ts
+++ b/src/cdk/testing/harness-environment.ts
@@ -8,7 +8,6 @@
 
 import {parallel} from './change-detection';
 import {
-  AsyncFactoryFn,
   ComponentHarness,
   ComponentHarnessConstructor,
   HarnessLoader,
@@ -64,7 +63,7 @@ export abstract class HarnessEnvironment<E> implements HarnessLoader, LocatorFac
   // Implemented as part of the `LocatorFactory` interface.
   locatorFor<T extends (HarnessQuery<any> | string)[]>(
     ...queries: T
-  ): AsyncFactoryFn<LocatorFnResult<T>> {
+  ): () => Promise<LocatorFnResult<T>> {
     return () =>
       _assertResultFound(
         this._getAllHarnessesAndTestElements(queries),
@@ -75,14 +74,14 @@ export abstract class HarnessEnvironment<E> implements HarnessLoader, LocatorFac
   // Implemented as part of the `LocatorFactory` interface.
   locatorForOptional<T extends (HarnessQuery<any> | string)[]>(
     ...queries: T
-  ): AsyncFactoryFn<LocatorFnResult<T> | null> {
+  ): () => Promise<LocatorFnResult<T> | null> {
     return async () => (await this._getAllHarnessesAndTestElements(queries))[0] || null;
   }
 
   // Implemented as part of the `LocatorFactory` interface.
   locatorForAll<T extends (HarnessQuery<any> | string)[]>(
     ...queries: T
-  ): AsyncFactoryFn<LocatorFnResult<T>[]> {
+  ): () => Promise<LocatorFnResult<T>[]> {
     return () => this._getAllHarnessesAndTestElements(queries);
   }
 

--- a/src/cdk/testing/harness-environment.ts
+++ b/src/cdk/testing/harness-environment.ts
@@ -43,7 +43,7 @@ type ParsedQueries<T extends ComponentHarness> = {
  * element type, `E`, used by the particular test environment.
  */
 export abstract class HarnessEnvironment<E> implements HarnessLoader, LocatorFactory {
-  // Implemented as part of the `LocatorFactory` interface.
+  /** The root element of this `HarnessEnvironment` as a `TestElement`. */
   get rootElement(): TestElement {
     this._rootElement = this._rootElement || this.createTestElement(this.rawRootElement);
     return this._rootElement;
@@ -53,14 +53,46 @@ export abstract class HarnessEnvironment<E> implements HarnessLoader, LocatorFac
   }
   private _rootElement: TestElement | undefined;
 
-  protected constructor(protected rawRootElement: E) {}
+  protected constructor(
+    /** The native root element of this `HarnessEnvironment`. */
+    protected rawRootElement: E,
+  ) {}
 
-  // Implemented as part of the `LocatorFactory` interface.
+  /** Gets a locator factory rooted at the document root. */
   documentRootLocatorFactory(): LocatorFactory {
     return this.createEnvironment(this.getDocumentRoot());
   }
 
-  // Implemented as part of the `LocatorFactory` interface.
+  /**
+   * Creates an asynchronous locator function that can be used to find a `ComponentHarness` instance
+   * or element under the root element of this `HarnessEnvironment`.
+   *
+   * For example, given the following DOM and assuming `DivHarness.hostSelector` is `'div'`
+   *
+   * ```html
+   * <div id="d1"></div><div id="d2"></div>
+   * ```
+   *
+   * then we expect:
+   *
+   * ```ts
+   * await lf.locatorFor(DivHarness, 'div')() // Gets a `DivHarness` instance for #d1
+   * await lf.locatorFor('div', DivHarness)() // Gets a `TestElement` instance for #d1
+   * await lf.locatorFor('span')()            // Throws because the `Promise` rejects
+   * ```
+   *
+   * @param queries A list of queries specifying which harnesses and elements to search for:
+   *   - A `string` searches for elements matching the CSS selector specified by the string.
+   *   - A `ComponentHarness` constructor searches for `ComponentHarness` instances matching the
+   *     given class.
+   *   - A `HarnessPredicate` searches for `ComponentHarness` instances matching the given
+   *     predicate.
+   * @return An asynchronous locator function that searches for and returns a `Promise` for the
+   *   first element or harness matching the given search criteria. Matches are ordered first by
+   *   order in the DOM, and second by order in the queries list. If no matches are found, the
+   *   `Promise` rejects. The type that the `Promise` resolves to is a union of all result types for
+   *   each query.
+   */
   locatorFor<T extends (HarnessQuery<any> | string)[]>(
     ...queries: T
   ): () => Promise<LocatorFnResult<T>> {
@@ -71,26 +103,97 @@ export abstract class HarnessEnvironment<E> implements HarnessLoader, LocatorFac
       );
   }
 
-  // Implemented as part of the `LocatorFactory` interface.
+  /**
+   * Creates an asynchronous locator function that can be used to find a `ComponentHarness` instance
+   * or element under the root element of this `HarnessEnvironmnet`.
+   *
+   * For example, given the following DOM and assuming `DivHarness.hostSelector` is `'div'`
+   *
+   * ```html
+   * <div id="d1"></div><div id="d2"></div>
+   * ```
+   *
+   * then we expect:
+   *
+   * ```ts
+   * await lf.locatorForOptional(DivHarness, 'div')() // Gets a `DivHarness` instance for #d1
+   * await lf.locatorForOptional('div', DivHarness)() // Gets a `TestElement` instance for #d1
+   * await lf.locatorForOptional('span')()            // Gets `null`
+   * ```
+   *
+   * @param queries A list of queries specifying which harnesses and elements to search for:
+   *   - A `string` searches for elements matching the CSS selector specified by the string.
+   *   - A `ComponentHarness` constructor searches for `ComponentHarness` instances matching the
+   *     given class.
+   *   - A `HarnessPredicate` searches for `ComponentHarness` instances matching the given
+   *     predicate.
+   * @return An asynchronous locator function that searches for and returns a `Promise` for the
+   *   first element or harness matching the given search criteria. Matches are ordered first by
+   *   order in the DOM, and second by order in the queries list. If no matches are found, the
+   *   `Promise` is resolved with `null`. The type that the `Promise` resolves to is a union of all
+   *   result types for each query or null.
+   */
   locatorForOptional<T extends (HarnessQuery<any> | string)[]>(
     ...queries: T
   ): () => Promise<LocatorFnResult<T> | null> {
     return async () => (await this._getAllHarnessesAndTestElements(queries))[0] || null;
   }
 
-  // Implemented as part of the `LocatorFactory` interface.
+  /**
+   * Creates an asynchronous locator function that can be used to find `ComponentHarness` instances
+   * or elements under the root element of this `HarnessEnvironment`.
+   *
+   * For example, given the following DOM and assuming `DivHarness.hostSelector` is `'div'` and
+   * `IdIsD1Harness.hostSelector` is `'#d1'`
+   *
+   * ```html
+   * <div id="d1"></div><div id="d2"></div>
+   * ```
+   *
+   * then we expect:
+   *
+   * ```ts
+   * // Gets [DivHarness for #d1, TestElement for #d1, DivHarness for #d2, TestElement for #d2]
+   * await lf.locatorForAll(DivHarness, 'div')()
+   * // Gets [TestElement for #d1, TestElement for #d2]
+   * await lf.locatorForAll('div', '#d1')()
+   * // Gets [DivHarness for #d1, IdIsD1Harness for #d1, DivHarness for #d2]
+   * await lf.locatorForAll(DivHarness, IdIsD1Harness)()
+   * // Gets []
+   * await lf.locatorForAll('span')()
+   * ```
+   *
+   * @param queries A list of queries specifying which harnesses and elements to search for:
+   *   - A `string` searches for elements matching the CSS selector specified by the string.
+   *   - A `ComponentHarness` constructor searches for `ComponentHarness` instances matching the
+   *     given class.
+   *   - A `HarnessPredicate` searches for `ComponentHarness` instances matching the given
+   *     predicate.
+   * @return An asynchronous locator function that searches for and returns a `Promise` for all
+   *   elements and harnesses matching the given search criteria. Matches are ordered first by
+   *   order in the DOM, and second by order in the queries list. If an element matches more than
+   *   one `ComponentHarness` class, the locator gets an instance of each for the same element. If
+   *   an element matches multiple `string` selectors, only one `TestElement` instance is returned
+   *   for that element. The type that the `Promise` resolves to is an array where each element is
+   *   the union of all result types for each query.
+   */
   locatorForAll<T extends (HarnessQuery<any> | string)[]>(
     ...queries: T
   ): () => Promise<LocatorFnResult<T>[]> {
     return () => this._getAllHarnessesAndTestElements(queries);
   }
 
-  // Implemented as part of the `LocatorFactory` interface.
+  /** @return A `HarnessLoader` rooted at the root element of this `HarnessEnvironment`. */
   async rootHarnessLoader(): Promise<HarnessLoader> {
     return this;
   }
 
-  // Implemented as part of the `LocatorFactory` interface.
+  /**
+   * Gets a `HarnessLoader` instance for an element under the root of this `HarnessEnvironment`.
+   * @param selector The selector for the root element.
+   * @return A `HarnessLoader` rooted at the first element matching the given selector.
+   * @throws If no matching element is found for the given selector.
+   */
   async harnessLoaderFor(selector: string): Promise<HarnessLoader> {
     return this.createEnvironment(
       await _assertResultFound(this.getAllRawElements(selector), [
@@ -99,39 +202,80 @@ export abstract class HarnessEnvironment<E> implements HarnessLoader, LocatorFac
     );
   }
 
-  // Implemented as part of the `LocatorFactory` interface.
+  /**
+   * Gets a `HarnessLoader` instance for an element under the root of this `HarnessEnvironment`.
+   * @param selector The selector for the root element.
+   * @return A `HarnessLoader` rooted at the first element matching the given selector, or null if
+   *     no matching element is found.
+   */
   async harnessLoaderForOptional(selector: string): Promise<HarnessLoader | null> {
     const elements = await this.getAllRawElements(selector);
     return elements[0] ? this.createEnvironment(elements[0]) : null;
   }
 
-  // Implemented as part of the `LocatorFactory` interface.
+  /**
+   * Gets a list of `HarnessLoader` instances, one for each matching element.
+   * @param selector The selector for the root element.
+   * @return A list of `HarnessLoader`, one rooted at each element matching the given selector.
+   */
   async harnessLoaderForAll(selector: string): Promise<HarnessLoader[]> {
     const elements = await this.getAllRawElements(selector);
     return elements.map(element => this.createEnvironment(element));
   }
 
-  // Implemented as part of the `HarnessLoader` interface.
+  /**
+   * Searches for an instance of the component corresponding to the given harness type under the
+   * `HarnessEnvironment`'s root element, and returns a `ComponentHarness` for that instance. If
+   * multiple matching components are found, a harness for the first one is returned. If no matching
+   * component is found, an error is thrown.
+   * @param query A query for a harness to create
+   * @return An instance of the given harness type
+   * @throws If a matching component instance can't be found.
+   */
   getHarness<T extends ComponentHarness>(query: HarnessQuery<T>): Promise<T> {
     return this.locatorFor(query)();
   }
 
-  // Implemented as part of the `HarnessLoader` interface.
+  /**
+   * Searches for an instance of the component corresponding to the given harness type under the
+   * `HarnessEnvironment`'s root element, and returns a `ComponentHarness` for that instance. If
+   * multiple matching components are found, a harness for the first one is returned. If no matching
+   * component is found, null is returned.
+   * @param query A query for a harness to create
+   * @return An instance of the given harness type (or null if not found).
+   */
   getHarnessOrNull<T extends ComponentHarness>(query: HarnessQuery<T>): Promise<T | null> {
     return this.locatorForOptional(query)();
   }
 
-  // Implemented as part of the `HarnessLoader` interface.
+  /**
+   * Searches for all instances of the component corresponding to the given harness type under the
+   * `HarnessEnvironment`'s root element, and returns a list `ComponentHarness` for each instance.
+   * @param query A query for a harness to create
+   * @return A list instances of the given harness type.
+   */
   getAllHarnesses<T extends ComponentHarness>(query: HarnessQuery<T>): Promise<T[]> {
     return this.locatorForAll(query)();
   }
 
-  // Implemented as part of the `HarnessLoader` interface.
+  /**
+   * Searches for an instance of the component corresponding to the given harness type under the
+   * `HarnessEnvironment`'s root element, and returns a boolean indicating if any were found.
+   * @param query A query for a harness to create
+   * @return A boolean indicating if an instance was found.
+   */
   async hasHarness<T extends ComponentHarness>(query: HarnessQuery<T>): Promise<boolean> {
     return (await this.locatorForOptional(query)()) !== null;
   }
 
-  // Implemented as part of the `HarnessLoader` interface.
+  /**
+   * Searches for an element with the given selector under the evironment's root element,
+   * and returns a `HarnessLoader` rooted at the matching element. If multiple elements match the
+   * selector, the first is used. If no elements match, an error is thrown.
+   * @param selector The selector for the root element of the new `HarnessLoader`
+   * @return A `HarnessLoader` rooted at the element matching the given selector.
+   * @throws If a matching element can't be found.
+   */
   async getChildLoader(selector: string): Promise<HarnessLoader> {
     return this.createEnvironment(
       await _assertResultFound(this.getAllRawElements(selector), [
@@ -140,7 +284,13 @@ export abstract class HarnessEnvironment<E> implements HarnessLoader, LocatorFac
     );
   }
 
-  // Implemented as part of the `HarnessLoader` interface.
+  /**
+   * Searches for all elements with the given selector under the environment's root element,
+   * and returns an array of `HarnessLoader`s, one for each matching element, rooted at that
+   * element.
+   * @param selector The selector for the root element of the new `HarnessLoader`
+   * @return A list of `HarnessLoader`s, one for each matching element, rooted at that element.
+   */
   async getAllChildLoaders(selector: string): Promise<HarnessLoader[]> {
     return (await this.getAllRawElements(selector)).map(e => this.createEnvironment(e));
   }
@@ -153,10 +303,19 @@ export abstract class HarnessEnvironment<E> implements HarnessLoader, LocatorFac
     return new harnessType(this.createEnvironment(element));
   }
 
-  // Part of LocatorFactory interface, subclasses will implement.
+  /**
+   * Flushes change detection and async tasks captured in the Angular zone.
+   * In most cases it should not be necessary to call this manually. However, there may be some edge
+   * cases where it is needed to fully flush animation events.
+   * This is an abstrct method that must be implemented by subclasses.
+   */
   abstract forceStabilize(): Promise<void>;
 
-  // Part of LocatorFactory interface, subclasses will implement.
+  /**
+   * Waits for all scheduled or running async tasks to complete. This allows harness
+   * authors to wait for async tasks outside of the Angular zone.
+   * This is an abstrct method that must be implemented by subclasses.
+   */
   abstract waitForTasksOutsideAngular(): Promise<void>;
 
   /** Gets the root element for the document. */
@@ -165,7 +324,7 @@ export abstract class HarnessEnvironment<E> implements HarnessLoader, LocatorFac
   /** Creates a `TestElement` from a raw element. */
   protected abstract createTestElement(element: E): TestElement;
 
-  /** Creates a `HarnessLoader` rooted at the given raw element. */
+  /** Creates a `HarnessEnvironment` rooted at the given raw element. */
   protected abstract createEnvironment(element: E): HarnessEnvironment<E>;
 
   /**

--- a/src/cdk/testing/protractor/BUILD.bazel
+++ b/src/cdk/testing/protractor/BUILD.bazel
@@ -31,4 +31,5 @@ extract_api_to_json(
     module_name = "@angular/cdk/testing/protractor",
     output_name = "cdk_testing_protractor.json",
     private_modules = [""],
+    repo = "angular/components",
 )

--- a/src/cdk/testing/selenium-webdriver/BUILD.bazel
+++ b/src/cdk/testing/selenium-webdriver/BUILD.bazel
@@ -27,7 +27,7 @@ extract_api_to_json(
         ":source-files",
     ],
     entry_point = ":index.ts",
-    module_name = "@angular/cdk//selenium-webdriver",
+    module_name = "@angular/cdk/testing/selenium-webdriver",
     output_name = "cdk_testing_selenium_webdriver.json",
     private_modules = [""],
 )

--- a/src/cdk/testing/selenium-webdriver/BUILD.bazel
+++ b/src/cdk/testing/selenium-webdriver/BUILD.bazel
@@ -30,4 +30,5 @@ extract_api_to_json(
     module_name = "@angular/cdk/testing/selenium-webdriver",
     output_name = "cdk_testing_selenium_webdriver.json",
     private_modules = [""],
+    repo = "angular/components",
 )

--- a/src/cdk/testing/test-element.ts
+++ b/src/cdk/testing/test-element.ts
@@ -180,7 +180,10 @@ export interface TestElement {
   dispatchEvent(name: string, data?: Record<string, EventData>): Promise<void>;
 }
 
+/**
+ * Options that affect the text returned by `TestElement.text`.
+ */
 export interface TextOptions {
-  /** Optional selector for elements to exclude. */
+  /** Optional selector for elements whose content should be excluded from the text string. */
   exclude?: string;
 }

--- a/src/cdk/testing/testbed/BUILD.bazel
+++ b/src/cdk/testing/testbed/BUILD.bazel
@@ -46,4 +46,5 @@ extract_api_to_json(
     module_name = "@angular/cdk/testing/testbed",
     output_name = "cdk_testing_testbed.json",
     private_modules = [""],
+    repo = "angular/components",
 )

--- a/tools/adev-api-extraction/extract_api_to_json.bzl
+++ b/tools/adev-api-extraction/extract_api_to_json.bzl
@@ -10,6 +10,9 @@ def _extract_api_to_json(ctx):
     args.set_param_file_format("multiline")
     args.use_param_file("%s", use_always = True)
 
+    # Pass the repo name for the extracted APIs. This will be something like "angular/angular".
+    args.add(ctx.attr.repo)
+
     # Pass the module_name for the extracted APIs. This will be something like "@angular/core".
     args.add(ctx.attr.module_name)
 
@@ -96,6 +99,10 @@ extract_api_to_json = rule(
         ),
         "module_label": attr.string(
             doc = """Module label to be used for the extracted symbols. To be used as display name, for example in API docs""",
+        ),
+        "repo": attr.string(
+            doc = """The name of the github repository the api belongs to""",
+            mandatory = True,
         ),
         "extra_entries": attr.label_list(
             doc = """JSON files that contain extra entries to append to the final collection.""",

--- a/tools/adev-api-extraction/index.mts
+++ b/tools/adev-api-extraction/index.mts
@@ -26,6 +26,7 @@ function main() {
   const rawParamLines = readFileSync(paramFilePath, {encoding: 'utf8'}).split('\n');
 
   const [
+    repo,
     moduleName,
     moduleLabel,
     serializedPrivateModules,
@@ -92,6 +93,7 @@ function main() {
   const normalized = moduleName.replace('@', '').replace(/[\/]/g, '_');
 
   const output = JSON.stringify({
+    repo,
     moduleLabel: moduleLabel || moduleName,
     moduleName: moduleName,
     normalizedModuleName: normalized,


### PR DESCRIPTION
Demo:
[api index](https://ng-dev-previews-fw--pr-angular-angular-60853-adev-prev-qbx2pg5n.web.app/api)
[cdk/testing](https://ng-dev-previews-fw--pr-angular-angular-60853-adev-prev-qbx2pg5n.web.app/api/cdk/testing/AsyncOptionPredicate)
[cdk/testing/testbed](https://ng-dev-previews-fw--pr-angular-angular-60853-adev-prev-qbx2pg5n.web.app/api/cdk/testing/testbed/TestbedHarnessEnvironment)
[cdk/testing/selenium-webdriver](https://ng-dev-previews-fw--pr-angular-angular-60853-adev-prev-qbx2pg5n.web.app/api/cdk/testing/selenium-webdriver/SeleniumWebDriverElement)
[cdk/testing/protractor](https://ng-dev-previews-fw--pr-angular-angular-60853-adev-prev-qbx2pg5n.web.app/api/cdk/testing/protractor/ProtractorElement)