### PR TITLE
build: remove unused code from docs site

### DIFF
--- a/docs/src/app/pages/homepage/homepage.scss
+++ b/docs/src/app/pages/homepage/homepage.scss
@@ -180,10 +180,6 @@ a.docs-link:hover {
     img {
       transition: 0.3s ease-in-out;
       width: 100%;
-
-      :host(.docs-animations-disabled) & {
-        transition: none;
-      }
     }
 
     &:hover, &:focus {

--- a/docs/src/app/pages/homepage/homepage.ts
+++ b/docs/src/app/pages/homepage/homepage.ts
@@ -7,7 +7,6 @@
  */
 
 import {Component, OnInit, inject} from '@angular/core';
-import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 
 import {MatAnchor} from '@angular/material/button';
 import {MatRipple} from '@angular/material/core';
@@ -48,20 +47,11 @@ const TOP_COMPONENTS = ['datepicker', 'input', 'slide-toggle', 'slider', 'button
   ],
   host: {
     'class': 'docs-main-content',
-    '[class.docs-animations-disabled]': 'animationsDisabled',
   },
 })
 export class Homepage implements OnInit {
   _componentPageTitle = inject(ComponentPageTitle);
   guideItems = inject(GuideItems);
-
-  readonly animationsDisabled: boolean;
-
-  constructor() {
-    const animationsModule = inject(ANIMATION_MODULE_TYPE, {optional: true});
-
-    this.animationsDisabled = animationsModule === 'NoopAnimations';
-  }
 
   ngOnInit(): void {
     this._componentPageTitle.title = '';

--- a/docs/src/app/shared/carousel/carousel.scss
+++ b/docs/src/app/shared/carousel/carousel.scss
@@ -8,10 +8,6 @@ app-carousel {
   flex-direction: row;
   outline: none;
   transition: transform 0.5s ease-in-out;
-
-  .docs-animations-disabled & {
-    transition: none;
-  }
 }
 
 .docs-carousel-content-wrapper {

--- a/docs/src/app/shared/carousel/carousel.ts
+++ b/docs/src/app/shared/carousel/carousel.ts
@@ -19,7 +19,6 @@ import {
 } from '@angular/core';
 import {FocusableOption, FocusKeyManager} from '@angular/cdk/a11y';
 import {LEFT_ARROW, RIGHT_ARROW, TAB} from '@angular/cdk/keycodes';
-import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 import {MatIcon} from '@angular/material/icon';
 import {MatIconButton} from '@angular/material/button';
 
@@ -46,15 +45,11 @@ export class CarouselItem implements FocusableOption {
   styleUrls: ['./carousel.scss'],
   encapsulation: ViewEncapsulation.None,
   imports: [MatIconButton, MatIcon],
-  host: {
-    '[class.docs-animations-disabled]': 'animationsDisabled',
-  },
 })
 export class Carousel implements AfterContentInit {
   readonly ariaLabel = input<string | undefined>(undefined, {alias: 'aria-label'});
   readonly items = contentChildren(CarouselItem);
   readonly list = viewChild.required<ElementRef<HTMLElement>>('list');
-  readonly animationsDisabled: boolean;
   position = 0;
   showPrevArrow = false;
   showNextArrow = true;
@@ -81,12 +76,6 @@ export class Carousel implements AfterContentInit {
         this._scrollToActiveItem();
       }
     }
-  }
-
-  constructor() {
-    const animationsModule = inject(ANIMATION_MODULE_TYPE, {optional: true});
-
-    this.animationsDisabled = animationsModule === 'NoopAnimations';
   }
 
   ngAfterContentInit(): void {


### PR DESCRIPTION
There were a couple of places in the docs site where we were injecting the `ANIMATIONS_MODULE_TYPE`. They were both no-ops because we don't use the animations module for anything.