### PR TITLE
docs(material/dialog): remove default value from doc string

### DIFF
--- a/src/cdk/dialog/dialog-config.ts
+++ b/src/cdk/dialog/dialog-config.ts
@@ -74,7 +74,7 @@ export class DialogConfig<D = unknown, R = unknown, C extends BasePortalOutlet =
   /** Min-height of the dialog. If a number is provided, assumes pixel units. */
   minHeight?: number | string;
 
-  /** Max-width of the dialog. If a number is provided, assumes pixel units. Defaults to 80vw. */
+  /** Max-width of the dialog. If a number is provided, assumes pixel units. */
   maxWidth?: number | string;
 
   /** Max-height of the dialog. If a number is provided, assumes pixel units. */

--- a/src/material/dialog/dialog-config.ts
+++ b/src/material/dialog/dialog-config.ts
@@ -92,7 +92,7 @@ export class MatDialogConfig<D = any> {
   /** Min-height of the dialog. If a number is provided, assumes pixel units. */
   minHeight?: number | string;
 
-  /** Max-width of the dialog. If a number is provided, assumes pixel units. Defaults to 80vw. */
+  /** Max-width of the dialog. If a number is provided, assumes pixel units. */
   maxWidth?: number | string;
 
   /** Max-height of the dialog. If a number is provided, assumes pixel units. */


### PR DESCRIPTION
Removes the default value for the `maxWidth` from the doc string since it's different depending on if it's M2 or M3 and it tends to get out of sync.