### PR TITLE
feature for feat(MENU) #31014

### DIFF
--- a/src/material/menu/menu-trigger.ts
+++ b/src/material/menu/menu-trigger.ts
@@ -187,6 +187,17 @@ export class MatMenuTrigger implements AfterContentInit, OnDestroy {
 
     this._menuItemInstance?._setTriggersSubmenu(this.triggersSubmenu());
   }
+  private _pressedWhileOpen: boolean = false;
+  @Input()
+  set pressedWhileOpen(value: boolean) {
+    this._pressedWhileOpen = value;
+    if (value) {
+      this._element.nativeElement.classList.add('stay-open-while-press');
+    }
+  }
+  get pressedWhileOpen(): boolean {
+    return this._pressedWhileOpen;
+  }
   private _menu: MatMenuPanel | null;
 
   /** Data to be passed along to any lazily-rendered content. */

--- a/src/material/menu/menu.scss
+++ b/src/material/menu/menu.scss
@@ -12,6 +12,11 @@ $token-slots: m2-menu.get-token-slots();
 mat-menu {
   display: none;
 }
+.mat-mdc-menu-trigger.stay-open-while-press[aria-expanded='true'] {
+  .mat-mdc-button-persistent-ripple:before {
+    opacity: var(--mat-icon-button-pressed-state-layer-opacity);
+  }
+}
 
 .mat-mdc-menu-content {
   margin: 0;

--- a/src/material/menu/menu.scss
+++ b/src/material/menu/menu.scss
@@ -17,7 +17,7 @@ mat-menu {
     opacity: var(--mat-icon-button-pressed-state-layer-opacity);
   }
 }
-
+ 
 .mat-mdc-menu-content {
   margin: 0;
   padding: 8px 0;


### PR DESCRIPTION
issue from : https://github.com/angular/components/issues/31014
adding new feature for stay button pressed state when menu is opened.

I added a variable called _pressedWhileOpen default false, the setter will detect if it passed a true value. if [pressedWhileOpen]="true" this is detect on the trigger button for menu, the button will stay the pressd state when menu is opened.

This is my first time working on the open resource project, I did minimal change as I could. 
When I checked the official document and I realized the is a place for contributors to work on  like 'good first issure' or 'help wanted'. And I'm not sure if I'm allowed to directly work on this issue, but I saw this when I half done, so I finished it and create a pull request if i cannot get approved on this, it is totally fine.
