### PR TITLE
fix(cdk/dialog): avoid setting aria-hidden before focus has moved

### DIFF
--- a/goldens/cdk/dialog/index.api.md
+++ b/goldens/cdk/dialog/index.api.md
@@ -38,7 +38,7 @@ import { ViewContainerRef } from '@angular/core';
 export type AutoFocusTarget = 'dialog' | 'first-tabbable' | 'first-heading';
 
 // @public
-export class CdkDialogContainer<C extends DialogConfig = DialogConfig> extends BasePortalOutlet implements OnDestroy {
+export class CdkDialogContainer<C extends DialogConfig = DialogConfig> extends BasePortalOutlet implements DialogContainer, OnDestroy {
     constructor(...args: unknown[]);
     // (undocumented)
     _addAriaLabelledBy(id: string): void;
@@ -61,6 +61,8 @@ export class CdkDialogContainer<C extends DialogConfig = DialogConfig> extends B
     protected _elementRef: ElementRef<HTMLElement>;
     // (undocumented)
     protected _focusTrapFactory: FocusTrapFactory;
+    // (undocumented)
+    _focusTrapped: Observable<void>;
     // (undocumented)
     ngOnDestroy(): void;
     // (undocumented)
@@ -111,7 +113,7 @@ export interface DialogCloseOptions {
 }
 
 // @public
-export class DialogConfig<D = unknown, R = unknown, C extends BasePortalOutlet = BasePortalOutlet> {
+export class DialogConfig<D = unknown, R = unknown, C extends DialogContainer = BasePortalOutlet> {
     ariaDescribedBy?: string | null;
     ariaLabel?: string | null;
     ariaLabelledBy?: string | null;
@@ -149,6 +151,13 @@ export class DialogConfig<D = unknown, R = unknown, C extends BasePortalOutlet =
     width?: string;
 }
 
+// @public
+export type DialogContainer = BasePortalOutlet & {
+    _focusTrapped?: Observable<void>;
+    _closeInteractionType?: FocusOrigin;
+    _recaptureFocus?: () => void;
+};
+
 // @public (undocumented)
 export class DialogModule {
     // (undocumented)
@@ -161,7 +170,7 @@ export class DialogModule {
 
 // @public
 export class DialogRef<R = unknown, C = unknown> {
-    constructor(overlayRef: OverlayRef, config: DialogConfig<any, DialogRef<R, C>, BasePortalOutlet>);
+    constructor(overlayRef: OverlayRef, config: DialogConfig<any, DialogRef<R, C>, DialogContainer>);
     addPanelClass(classes: string | string[]): this;
     readonly backdropClick: Observable<MouseEvent>;
     close(result?: R, options?: DialogCloseOptions): void;
@@ -169,11 +178,8 @@ export class DialogRef<R = unknown, C = unknown> {
     readonly componentInstance: C | null;
     readonly componentRef: ComponentRef<C> | null;
     // (undocumented)
-    readonly config: DialogConfig<any, DialogRef<R, C>, BasePortalOutlet>;
-    readonly containerInstance: BasePortalOutlet & {
-        _closeInteractionType?: FocusOrigin;
-        _recaptureFocus?: () => void;
-    };
+    readonly config: DialogConfig<any, DialogRef<R, C>, DialogContainer>;
+    readonly containerInstance: DialogContainer;
     disableClose: boolean | undefined;
     readonly id: string;
     readonly keydownEvents: Observable<KeyboardEvent>;

--- a/src/cdk/dialog/dialog-config.ts
+++ b/src/cdk/dialog/dialog-config.ts
@@ -9,7 +9,9 @@
 import {ViewContainerRef, Injector, StaticProvider, Type} from '@angular/core';
 import {Direction} from '../bidi';
 import {PositionStrategy, ScrollStrategy} from '../overlay';
+import {Observable} from 'rxjs';
 import {BasePortalOutlet} from '../portal';
+import {FocusOrigin} from '../a11y';
 
 /** Options for where to set focus to automatically on dialog open */
 export type AutoFocusTarget = 'dialog' | 'first-tabbable' | 'first-heading';
@@ -17,8 +19,15 @@ export type AutoFocusTarget = 'dialog' | 'first-tabbable' | 'first-heading';
 /** Valid ARIA roles for a dialog. */
 export type DialogRole = 'dialog' | 'alertdialog';
 
+/** Component that can be used as the container for the dialog. */
+export type DialogContainer = BasePortalOutlet & {
+  _focusTrapped?: Observable<void>;
+  _closeInteractionType?: FocusOrigin;
+  _recaptureFocus?: () => void;
+};
+
 /** Configuration for opening a modal dialog. */
-export class DialogConfig<D = unknown, R = unknown, C extends BasePortalOutlet = BasePortalOutlet> {
+export class DialogConfig<D = unknown, R = unknown, C extends DialogContainer = BasePortalOutlet> {
   /**
    * Where the attached component should live in Angular's *logical* component tree.
    * This affects what is available for injection and the change detection order for the

--- a/src/cdk/dialog/dialog-ref.ts
+++ b/src/cdk/dialog/dialog-ref.ts
@@ -9,9 +9,8 @@
 import {OverlayRef} from '../overlay';
 import {ESCAPE, hasModifierKey} from '../keycodes';
 import {Observable, Subject, Subscription} from 'rxjs';
-import {DialogConfig} from './dialog-config';
+import {DialogConfig, DialogContainer} from './dialog-config';
 import {FocusOrigin} from '../a11y';
-import {BasePortalOutlet} from '../portal';
 import {ComponentRef} from '@angular/core';
 
 /** Additional options that can be passed in when closing a dialog. */
@@ -37,10 +36,7 @@ export class DialogRef<R = unknown, C = unknown> {
   readonly componentRef: ComponentRef<C> | null;
 
   /** Instance of the container that is rendering out the dialog content. */
-  readonly containerInstance: BasePortalOutlet & {
-    _closeInteractionType?: FocusOrigin;
-    _recaptureFocus?: () => void;
-  };
+  readonly containerInstance: DialogContainer;
 
   /** Whether the user is allowed to close the dialog. */
   disableClose: boolean | undefined;
@@ -65,7 +61,7 @@ export class DialogRef<R = unknown, C = unknown> {
 
   constructor(
     readonly overlayRef: OverlayRef,
-    readonly config: DialogConfig<any, DialogRef<R, C>, BasePortalOutlet>,
+    readonly config: DialogConfig<any, DialogRef<R, C>, DialogContainer>,
   ) {
     this.disableClose = config.disableClose;
     this.backdropClick = overlayRef.backdropClick();
@@ -114,7 +110,7 @@ export class DialogRef<R = unknown, C = unknown> {
       closedSubject.next(result);
       closedSubject.complete();
       (this as {componentInstance: C}).componentInstance = (
-        this as {containerInstance: BasePortalOutlet}
+        this as {containerInstance: DialogContainer}
       ).containerInstance = null!;
     }
   }
@@ -149,7 +145,7 @@ export class DialogRef<R = unknown, C = unknown> {
 
   /** Whether the dialog is allowed to close. */
   private _canClose(result?: R): boolean {
-    const config = this.config as DialogConfig<unknown, unknown, BasePortalOutlet>;
+    const config = this.config as DialogConfig<unknown, unknown, DialogContainer>;
 
     return (
       !!this.containerInstance &&

--- a/src/cdk/dialog/dialog.ts
+++ b/src/cdk/dialog/dialog.ts
@@ -19,7 +19,7 @@ import {
   signal,
 } from '@angular/core';
 import {Observable, Subject, defer} from 'rxjs';
-import {startWith} from 'rxjs/operators';
+import {startWith, take} from 'rxjs/operators';
 import {_IdGenerator} from '../a11y';
 import {Direction, Directionality} from '../bidi';
 import {
@@ -30,8 +30,8 @@ import {
   OverlayContainer,
   OverlayRef,
 } from '../overlay';
-import {BasePortalOutlet, ComponentPortal, TemplatePortal} from '../portal';
-import {DialogConfig} from './dialog-config';
+import {ComponentPortal, TemplatePortal} from '../portal';
+import {DialogConfig, DialogContainer} from './dialog-config';
 import {DialogRef} from './dialog-ref';
 
 import {CdkDialogContainer} from './dialog-container';
@@ -141,14 +141,24 @@ export class Dialog implements OnDestroy {
     const dialogRef = new DialogRef(overlayRef, config);
     const dialogContainer = this._attachContainer(overlayRef, dialogRef, config);
 
-    (dialogRef as {containerInstance: BasePortalOutlet}).containerInstance = dialogContainer;
-    this._attachDialogContent(componentOrTemplateRef, dialogRef, dialogContainer, config);
+    (dialogRef as {containerInstance: DialogContainer}).containerInstance = dialogContainer;
 
     // If this is the first dialog that we're opening, hide all the non-overlay content.
     if (!this.openDialogs.length) {
-      this._hideNonDialogContentFromAssistiveTechnology();
+      // Resolve this ahead of time, because some internal apps
+      // mock it out and depend on it being synchronous.
+      const overlayContainer = this._overlayContainer.getContainerElement();
+
+      if (dialogContainer._focusTrapped) {
+        dialogContainer._focusTrapped.pipe(take(1)).subscribe(() => {
+          this._hideNonDialogContentFromAssistiveTechnology(overlayContainer);
+        });
+      } else {
+        this._hideNonDialogContentFromAssistiveTechnology(overlayContainer);
+      }
     }
 
+    this._attachDialogContent(componentOrTemplateRef, dialogRef, dialogContainer, config);
     (this.openDialogs as DialogRef<R, C>[]).push(dialogRef);
     dialogRef.closed.subscribe(() => this._removeOpenDialog(dialogRef, true));
     this.afterOpened.next(dialogRef);
@@ -233,14 +243,14 @@ export class Dialog implements OnDestroy {
     overlay: OverlayRef,
     dialogRef: DialogRef<R, C>,
     config: DialogConfig<D, DialogRef<R, C>>,
-  ): BasePortalOutlet {
+  ): DialogContainer {
     const userInjector = config.injector || config.viewContainerRef?.injector;
     const providers: StaticProvider[] = [
       {provide: DialogConfig, useValue: config},
       {provide: DialogRef, useValue: dialogRef},
       {provide: OverlayRef, useValue: overlay},
     ];
-    let containerType: Type<BasePortalOutlet>;
+    let containerType: Type<DialogContainer>;
 
     if (config.container) {
       if (typeof config.container === 'function') {
@@ -274,7 +284,7 @@ export class Dialog implements OnDestroy {
   private _attachDialogContent<R, D, C>(
     componentOrTemplateRef: ComponentType<C> | TemplateRef<C>,
     dialogRef: DialogRef<R, C>,
-    dialogContainer: BasePortalOutlet,
+    dialogContainer: DialogContainer,
     config: DialogConfig<D, DialogRef<R, C>>,
   ) {
     if (componentOrTemplateRef instanceof TemplateRef) {
@@ -316,7 +326,7 @@ export class Dialog implements OnDestroy {
   private _createInjector<R, D, C>(
     config: DialogConfig<D, DialogRef<R, C>>,
     dialogRef: DialogRef<R, C>,
-    dialogContainer: BasePortalOutlet,
+    dialogContainer: DialogContainer,
     fallbackInjector: Injector | undefined,
   ): Injector {
     const userInjector = config.injector || config.viewContainerRef?.injector;
@@ -379,9 +389,7 @@ export class Dialog implements OnDestroy {
   }
 
   /** Hides all of the content that isn't an overlay from assistive technology. */
-  private _hideNonDialogContentFromAssistiveTechnology() {
-    const overlayContainer = this._overlayContainer.getContainerElement();
-
+  private _hideNonDialogContentFromAssistiveTechnology(overlayContainer: HTMLElement) {
     // Ensure that the overlay container is attached to the DOM.
     if (overlayContainer.parentElement) {
       const siblings = overlayContainer.parentElement.children;


### PR DESCRIPTION
The dialog moves focus in an `afterRender`, because it needs to give the content some time to be rendered. This is problematic with some relatively recent behavior in Chrome where the `aria-hidden` gets blocked and a warning is logged if it contains the focused element.

These changes add a way for the container to indicate when it's done moving focus and use the new API to apply the `aria-hidden`.

Fixes #30187.