### PR TITLE
[Cherry pick] fix(cdk/dialog): avoid setting aria-hidden before focus has moved

### DIFF
--- a/goldens/cdk/dialog/index.api.md
+++ b/goldens/cdk/dialog/index.api.md
@@ -38,7 +38,7 @@ import { ViewContainerRef } from '@angular/core';
 export type AutoFocusTarget = 'dialog' | 'first-tabbable' | 'first-heading';
 
 // @public
-export class CdkDialogContainer<C extends DialogConfig = DialogConfig> extends BasePortalOutlet implements OnDestroy {
+export class CdkDialogContainer<C extends DialogConfig = DialogConfig> extends BasePortalOutlet implements DialogContainer, OnDestroy {
     constructor(...args: unknown[]);
     // (undocumented)
     _addAriaLabelledBy(id: string): void;
@@ -61,6 +61,8 @@ export class CdkDialogContainer<C extends DialogConfig = DialogConfig> extends B
     protected _elementRef: ElementRef<HTMLElement>;
     // (undocumented)
     protected _focusTrapFactory: FocusTrapFactory;
+    // (undocumented)
+    _focusTrapped: Observable<void>;
     // (undocumented)
     ngOnDestroy(): void;
     // (undocumented)
@@ -121,7 +123,7 @@ export interface DialogCloseOptions {
 }
 
 // @public
-export class DialogConfig<D = unknown, R = unknown, C extends BasePortalOutlet = BasePortalOutlet> {
+export class DialogConfig<D = unknown, R = unknown, C extends DialogContainer = BasePortalOutlet> {
     ariaDescribedBy?: string | null;
     ariaLabel?: string | null;
     ariaLabelledBy?: string | null;
@@ -159,6 +161,13 @@ export class DialogConfig<D = unknown, R = unknown, C extends BasePortalOutlet =
     width?: string;
 }
 
+// @public
+export type DialogContainer = BasePortalOutlet & {
+    _focusTrapped?: Observable<void>;
+    _closeInteractionType?: FocusOrigin;
+    _recaptureFocus?: () => void;
+};
+
 // @public (undocumented)
 export class DialogModule {
     // (undocumented)
@@ -171,7 +180,7 @@ export class DialogModule {
 
 // @public
 export class DialogRef<R = unknown, C = unknown> {
-    constructor(overlayRef: OverlayRef, config: DialogConfig<any, DialogRef<R, C>, BasePortalOutlet>);
+    constructor(overlayRef: OverlayRef, config: DialogConfig<any, DialogRef<R, C>, DialogContainer>);
     addPanelClass(classes: string | string[]): this;
     readonly backdropClick: Observable<MouseEvent>;
     close(result?: R, options?: DialogCloseOptions): void;
@@ -179,10 +188,8 @@ export class DialogRef<R = unknown, C = unknown> {
     readonly componentInstance: C | null;
     readonly componentRef: ComponentRef<C> | null;
     // (undocumented)
-    readonly config: DialogConfig<any, DialogRef<R, C>, BasePortalOutlet>;
-    readonly containerInstance: BasePortalOutlet & {
-        _closeInteractionType?: FocusOrigin;
-    };
+    readonly config: DialogConfig<any, DialogRef<R, C>, DialogContainer>;
+    readonly containerInstance: DialogContainer;
     disableClose: boolean | undefined;
     readonly id: string;
     readonly keydownEvents: Observable<KeyboardEvent>;

--- a/src/cdk/dialog/dialog-config.ts
+++ b/src/cdk/dialog/dialog-config.ts
@@ -9,7 +9,9 @@
 import {ViewContainerRef, Injector, StaticProvider, Type} from '@angular/core';
 import {Direction} from '../bidi';
 import {PositionStrategy, ScrollStrategy} from '../overlay';
+import {Observable} from 'rxjs';
 import {BasePortalOutlet} from '../portal';
+import {FocusOrigin} from '../a11y';
 
 /** Options for where to set focus to automatically on dialog open */
 export type AutoFocusTarget = 'dialog' | 'first-tabbable' | 'first-heading';
@@ -17,8 +19,15 @@ export type AutoFocusTarget = 'dialog' | 'first-tabbable' | 'first-heading';
 /** Valid ARIA roles for a dialog. */
 export type DialogRole = 'dialog' | 'alertdialog';
 
+/** Component that can be used as the container for the dialog. */
+export type DialogContainer = BasePortalOutlet & {
+  _focusTrapped?: Observable<void>;
+  _closeInteractionType?: FocusOrigin;
+  _recaptureFocus?: () => void;
+};
+
 /** Configuration for opening a modal dialog. */
-export class DialogConfig<D = unknown, R = unknown, C extends BasePortalOutlet = BasePortalOutlet> {
+export class DialogConfig<D = unknown, R = unknown, C extends DialogContainer = BasePortalOutlet> {
   /**
    * Where the attached component should live in Angular's *logical* component tree.
    * This affects what is available for injection and the change detection order for the

--- a/src/cdk/dialog/dialog-container.ts
+++ b/src/cdk/dialog/dialog-container.ts
@@ -39,7 +39,8 @@ import {
   afterNextRender,
   inject,
 } from '@angular/core';
-import {DialogConfig} from './dialog-config';
+import {DialogConfig, DialogContainer} from './dialog-config';
+import {Observable, Subject} from 'rxjs';
 
 export function throwDialogContentAlreadyAttachedError() {
   throw Error('Attempting to attach dialog content after content is already attached');
@@ -71,7 +72,7 @@ export function throwDialogContentAlreadyAttachedError() {
 })
 export class CdkDialogContainer<C extends DialogConfig = DialogConfig>
   extends BasePortalOutlet
-  implements OnDestroy
+  implements DialogContainer, OnDestroy
 {
   protected _elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
   protected _focusTrapFactory = inject(FocusTrapFactory);
@@ -81,12 +82,15 @@ export class CdkDialogContainer<C extends DialogConfig = DialogConfig>
   private _overlayRef = inject(OverlayRef);
   private _focusMonitor = inject(FocusMonitor);
   private _renderer = inject(Renderer2);
-
+  protected readonly _changeDetectorRef = inject(ChangeDetectorRef);
+  private _injector = inject(Injector);
   private _platform = inject(Platform);
   protected _document = inject(DOCUMENT, {optional: true})!;
 
   /** The portal outlet inside of this container into which the dialog content will be loaded. */
   @ViewChild(CdkPortalOutlet, {static: true}) _portalOutlet: CdkPortalOutlet;
+
+  _focusTrapped: Observable<void> = new Subject<void>();
 
   /** The class that traps and manages focus within the dialog. */
   private _focusTrap: FocusTrap | null = null;
@@ -108,10 +112,6 @@ export class CdkDialogContainer<C extends DialogConfig = DialogConfig>
    * the rest are present.
    */
   _ariaLabelledByQueue: string[] = [];
-
-  protected readonly _changeDetectorRef = inject(ChangeDetectorRef);
-
-  private _injector = inject(Injector);
 
   private _isDestroyed = false;
 
@@ -158,6 +158,7 @@ export class CdkDialogContainer<C extends DialogConfig = DialogConfig>
   }
 
   ngOnDestroy() {
+    (this._focusTrapped as Subject<void>).complete();
     this._isDestroyed = true;
     this._restoreFocus();
   }
@@ -293,6 +294,7 @@ export class CdkDialogContainer<C extends DialogConfig = DialogConfig>
             this._focusByCssSelector(this._config.autoFocus!, options);
             break;
         }
+        (this._focusTrapped as Subject<void>).next();
       },
       {injector: this._injector},
     );

--- a/src/cdk/dialog/dialog-ref.ts
+++ b/src/cdk/dialog/dialog-ref.ts
@@ -9,9 +9,8 @@
 import {OverlayRef} from '../overlay';
 import {ESCAPE, hasModifierKey} from '../keycodes';
 import {Observable, Subject, Subscription} from 'rxjs';
-import {DialogConfig} from './dialog-config';
+import {DialogConfig, DialogContainer} from './dialog-config';
 import {FocusOrigin} from '../a11y';
-import {BasePortalOutlet} from '../portal';
 import {ComponentRef} from '@angular/core';
 
 /** Additional options that can be passed in when closing a dialog. */
@@ -37,7 +36,7 @@ export class DialogRef<R = unknown, C = unknown> {
   readonly componentRef: ComponentRef<C> | null;
 
   /** Instance of the container that is rendering out the dialog content. */
-  readonly containerInstance: BasePortalOutlet & {_closeInteractionType?: FocusOrigin};
+  readonly containerInstance: DialogContainer;
 
   /** Whether the user is allowed to close the dialog. */
   disableClose: boolean | undefined;
@@ -62,7 +61,7 @@ export class DialogRef<R = unknown, C = unknown> {
 
   constructor(
     readonly overlayRef: OverlayRef,
-    readonly config: DialogConfig<any, DialogRef<R, C>, BasePortalOutlet>,
+    readonly config: DialogConfig<any, DialogRef<R, C>, DialogContainer>,
   ) {
     this.disableClose = config.disableClose;
     this.backdropClick = overlayRef.backdropClick();
@@ -107,7 +106,7 @@ export class DialogRef<R = unknown, C = unknown> {
       closedSubject.next(result);
       closedSubject.complete();
       (this as {componentInstance: C}).componentInstance = (
-        this as {containerInstance: BasePortalOutlet}
+        this as {containerInstance: DialogContainer}
       ).containerInstance = null!;
     }
   }


### PR DESCRIPTION
Cherry-picks #31030 into the patch branch.

The dialog moves focus in an `afterRender`, because it needs to give the content some time to be rendered. This is problematic with some relatively recent behavior in Chrome where the `aria-hidden` gets blocked and a warning is logged if it contains the focused element.

These changes add a way for the container to indicate when it's done moving focus and use the new API to apply the `aria-hidden`.

Fixes #30187.