### PR TITLE
fix(docs): Automatic scrolling fails on screens smaller than 721px

### DIFF
--- a/docs/src/app/pages/component-sidenav/component-sidenav.scss
+++ b/docs/src/app/pages/component-sidenav/component-sidenav.scss
@@ -116,7 +116,7 @@ div.docs-component-viewer-nav-content .mat-nav-list .mat-mdc-list-item .mat-list
 
 @media (max-width: 720px) {
   .docs-component-viewer-sidenav-container {
-    flex: 1 0 auto;
+    flex: 1 0;
   }
 
   .docs-component-sidenav-body-content {


### PR DESCRIPTION
Fixes a flexbox issue where if a flex item has `flex-basis: auto` and `min-height: auto`, it exceeds the height of its flex parent. Consequently, when `scrollBy` is called by `scrollDetector` in `drop-list-ref.ts`, the container is not scrollable because its height is determined by its content. Removing `min-height: auto` forces the flex item to match the height of its flex parent, allowing `scrollBy` to function correctly.

Fixes #26476