### PR TITLE
fix(cdk/tree): cdk tree with levelAccessor should only render expended nodes instead of all nodes

### DIFF
--- a/src/cdk/tree/tree-with-tree-control.spec.ts
+++ b/src/cdk/tree/tree-with-tree-control.spec.ts
@@ -133,7 +133,12 @@ describe('CdkTree with TreeControl', () => {
         dataSource.addChild(data[0], true);
         fixture.detectChanges();
 
-        const ariaLevels = getNodes(treeElement).map(n => n.getAttribute('aria-level'));
+        let ariaLevels = getNodes(treeElement).map(n => n.getAttribute('aria-level'));
+        expect(ariaLevels).toEqual(['2', '2', '2']);
+
+        component.treeControl.expandAll();
+        fixture.detectChanges();
+        ariaLevels = getNodes(treeElement).map(n => n.getAttribute('aria-level'));
         expect(ariaLevels).toEqual(['2', '3', '2', '2']);
       });
 
@@ -143,7 +148,7 @@ describe('CdkTree with TreeControl', () => {
         dataSource.addChild(data[2]);
         fixture.detectChanges();
         let ariaExpandedStates = getNodes(treeElement).map(n => n.getAttribute('aria-expanded'));
-        expect(ariaExpandedStates).toEqual([null, null, 'false', null]);
+        expect(ariaExpandedStates).toEqual([null, null, 'false']);
 
         component.treeControl.expandAll();
         fixture.detectChanges();
@@ -393,6 +398,17 @@ describe('CdkTree with TreeControl', () => {
           'px',
           [`[topping_1] - [cheese_1] + [base_1]`],
           [`[topping_2] - [cheese_2] + [base_2]`],
+          [`[topping_3] - [cheese_3] + [base_3]`],
+        );
+        component.treeControl.expandAll();
+        fixture.detectChanges();
+        treeElement = fixture.nativeElement.querySelector('cdk-tree');
+        expectFlatTreeToMatch(
+          treeElement,
+          28,
+          'px',
+          [`[topping_1] - [cheese_1] + [base_1]`],
+          [`[topping_2] - [cheese_2] + [base_2]`],
           [_, `topping_4 - cheese_4 + base_4`],
           [`[topping_3] - [cheese_3] + [base_3]`],
         );
@@ -440,6 +456,18 @@ describe('CdkTree with TreeControl', () => {
           'px',
           [`[topping_1] - [cheese_1] + [base_1]`],
           [`[topping_2] - [cheese_2] + [base_2]`],
+          [`[topping_3] - [cheese_3] + [base_3]`],
+        );
+
+        (getNodes(treeElement)[1] as HTMLElement).click();
+        fixture.detectChanges();
+        treeElement = fixture.nativeElement.querySelector('cdk-tree');
+        expectFlatTreeToMatch(
+          treeElement,
+          28,
+          'px',
+          [`[topping_1] - [cheese_1] + [base_1]`],
+          [`[topping_2] - [cheese_2] + [base_2]`],
           [_, `[topping_4] - [cheese_4] + [base_4]`],
           [`[topping_3] - [cheese_3] + [base_3]`],
         );
@@ -481,6 +509,18 @@ describe('CdkTree with TreeControl', () => {
         treeElement = fixture.nativeElement.querySelector('cdk-tree');
         data = dataSource.data;
         expect(data.length).toBe(4);
+        expectFlatTreeToMatch(
+          treeElement,
+          28,
+          'px',
+          [`[topping_1] - [cheese_1] + [base_1]`],
+          [`[topping_2] - [cheese_2] + [base_2]`],
+          [`[topping_3] - [cheese_3] + [base_3]`],
+        );
+
+        (getNodes(treeElement)[1] as HTMLElement).click();
+        fixture.detectChanges();
+        treeElement = fixture.nativeElement.querySelector('cdk-tree');
         expectFlatTreeToMatch(
           treeElement,
           28,

--- a/src/cdk/tree/tree.spec.ts
+++ b/src/cdk/tree/tree.spec.ts
@@ -139,7 +139,12 @@ describe('CdkTree', () => {
         dataSource.addChild(data[0], true);
         fixture.detectChanges();
 
-        const ariaLevels = getNodes(treeElement).map(n => n.getAttribute('aria-level'));
+        let ariaLevels = getNodes(treeElement).map(n => n.getAttribute('aria-level'));
+        expect(ariaLevels).toEqual(['2', '2', '2']);
+
+        tree.expandAll();
+        fixture.detectChanges();
+        ariaLevels = getNodes(treeElement).map(n => n.getAttribute('aria-level'));
         expect(ariaLevels).toEqual(['2', '3', '2', '2']);
       });
 
@@ -149,7 +154,7 @@ describe('CdkTree', () => {
         dataSource.addChild(data[2]);
         fixture.detectChanges();
         let ariaExpandedStates = getNodes(treeElement).map(n => n.getAttribute('aria-expanded'));
-        expect(ariaExpandedStates).toEqual([null, null, 'false', null]);
+        expect(ariaExpandedStates).toEqual([null, null, 'false']);
 
         component.tree.expandAll();
         fixture.detectChanges();
@@ -334,7 +339,7 @@ describe('CdkTree', () => {
 
         expect(getNodes(treeElement).map(x => x.getAttribute('tabindex')))
           .withContext(`Expecting parent node to be focused since it was collapsed.`)
-          .toEqual(['0', '-1']);
+          .toEqual(['0']);
       });
 
       it('should expand/collapse the node recursively', () => {
@@ -445,6 +450,18 @@ describe('CdkTree', () => {
           'px',
           [`[topping_1] - [cheese_1] + [base_1]`],
           [`[topping_2] - [cheese_2] + [base_2]`],
+          [`[topping_3] - [cheese_3] + [base_3]`],
+        );
+
+        tree.expandAll();
+        fixture.detectChanges();
+        treeElement = fixture.nativeElement.querySelector('cdk-tree');
+        expectFlatTreeToMatch(
+          treeElement,
+          28,
+          'px',
+          [`[topping_1] - [cheese_1] + [base_1]`],
+          [`[topping_2] - [cheese_2] + [base_2]`],
           [_, `topping_4 - cheese_4 + base_4`],
           [`[topping_3] - [cheese_3] + [base_3]`],
         );
@@ -485,6 +502,18 @@ describe('CdkTree', () => {
         treeElement = fixture.nativeElement.querySelector('cdk-tree');
         data = dataSource.data;
         expect(data.length).toBe(4);
+        expectFlatTreeToMatch(
+          treeElement,
+          28,
+          'px',
+          [`[topping_1] - [cheese_1] + [base_1]`],
+          [`[topping_2] - [cheese_2] + [base_2]`],
+          [`[topping_3] - [cheese_3] + [base_3]`],
+        );
+
+        tree.expandAll();
+        fixture.detectChanges();
+        treeElement = fixture.nativeElement.querySelector('cdk-tree');
         expectFlatTreeToMatch(
           treeElement,
           28,
@@ -532,6 +561,18 @@ describe('CdkTree', () => {
         treeElement = fixture.nativeElement.querySelector('cdk-tree');
         data = dataSource.data;
         expect(data.length).toBe(4);
+        expectFlatTreeToMatch(
+          treeElement,
+          28,
+          'px',
+          [`[topping_1] - [cheese_1] + [base_1]`],
+          [`[topping_2] - [cheese_2] + [base_2]`],
+          [`[topping_3] - [cheese_3] + [base_3]`],
+        );
+
+        tree.expandAll();
+        fixture.detectChanges();
+        treeElement = fixture.nativeElement.querySelector('cdk-tree');
         expectFlatTreeToMatch(
           treeElement,
           28,

--- a/src/components-examples/cdk/tree/cdk-tree-flat-children-accessor/cdk-tree-flat-children-accessor-example.html
+++ b/src/components-examples/cdk/tree/cdk-tree-flat-children-accessor/cdk-tree-flat-children-accessor-example.html
@@ -1,8 +1,6 @@
 <cdk-tree #tree [dataSource]="dataSource" [childrenAccessor]="childrenAccessor">
   <!-- This is the tree node template for leaf nodes -->
   <cdk-tree-node *cdkTreeNodeDef="let node" cdkTreeNodePadding
-                 [style.display]="shouldRender(node) ? 'flex' : 'none'"
-                 [isDisabled]="!shouldRender(node)"
                  class="example-tree-node">
     <!-- use a disabled button to provide padding for tree leaf -->
     <button matIconButton disabled></button>
@@ -12,8 +10,6 @@
   <cdk-tree-node *cdkTreeNodeDef="let node; when: hasChild" cdkTreeNodePadding
                  cdkTreeNodeToggle
                  [cdkTreeNodeTypeaheadLabel]="node.name"
-                 [style.display]="shouldRender(node) ? 'flex' : 'none'"
-                 [isDisabled]="!shouldRender(node)"
                  [isExpandable]="true"
                  class="example-tree-node">
     <button matIconButton cdkTreeNodeToggle [attr.aria-label]="'Toggle ' + node.name">

--- a/src/components-examples/cdk/tree/cdk-tree-flat-level-accessor/cdk-tree-flat-level-accessor-example.html
+++ b/src/components-examples/cdk/tree/cdk-tree-flat-level-accessor/cdk-tree-flat-level-accessor-example.html
@@ -1,8 +1,6 @@
 <cdk-tree #tree [dataSource]="dataSource" [levelAccessor]="levelAccessor">
   <!-- This is the tree node template for leaf nodes -->
   <cdk-tree-node *cdkTreeNodeDef="let node" cdkTreeNodePadding
-                 [style.display]="shouldRender(node) ? 'flex' : 'none'"
-                 [isDisabled]="!shouldRender(node)"
                  class="example-tree-node">
     <!-- use a disabled button to provide padding for tree leaf -->
     <button matIconButton disabled></button>
@@ -12,8 +10,6 @@
   <cdk-tree-node *cdkTreeNodeDef="let node; when: hasChild" cdkTreeNodePadding
                  cdkTreeNodeToggle
                  [cdkTreeNodeTypeaheadLabel]="node.name"
-                 [style.display]="shouldRender(node) ? 'flex' : 'none'"
-                 [isDisabled]="!shouldRender(node)"
                  [isExpandable]="node.expandable"
                  class="example-tree-node">
     <button matIconButton cdkTreeNodeToggle

--- a/src/components-examples/cdk/tree/cdk-tree-flat/cdk-tree-flat-example.html
+++ b/src/components-examples/cdk/tree/cdk-tree-flat/cdk-tree-flat-example.html
@@ -1,8 +1,6 @@
 <cdk-tree [dataSource]="dataSource" [treeControl]="treeControl">
   <!-- This is the tree node template for leaf nodes -->
   <cdk-tree-node *cdkTreeNodeDef="let node" cdkTreeNodePadding
-                 [style.display]="shouldRender(node) ? 'flex' : 'none'"
-                 [isDisabled]="!shouldRender(node)"
                  class="example-tree-node">
     <!-- use a disabled button to provide padding for tree leaf -->
     <button matIconButton disabled></button>
@@ -11,8 +9,6 @@
   <!-- This is the tree node template for expandable nodes -->
   <cdk-tree-node *cdkTreeNodeDef="let node; when: hasChild" cdkTreeNodePadding
                  cdkTreeNodeToggle [cdkTreeNodeTypeaheadLabel]="node.name"
-                 [style.display]="shouldRender(node) ? 'flex' : 'none'"
-                 [isDisabled]="!shouldRender(node)"
                  (expandedChange)="node.isExpanded = $event"
                  class="example-tree-node">
     <button matIconButton cdkTreeNodeToggle


### PR DESCRIPTION
to fix #30735 