### PR TITLE
fix(material/schematics): add schematic to rename tokens

### DIFF
--- a/src/material/schematics/ng-update/BUILD.bazel
+++ b/src/material/schematics/ng-update/BUILD.bazel
@@ -68,6 +68,7 @@ ts_project(
 jasmine_test(
     name = "test",
     data = [
+        ":ng_update_index",
         ":schematics_test_cases",
         ":test_lib",
         "//src/material/schematics:collection_assets",

--- a/src/material/schematics/ng-update/index.ts
+++ b/src/material/schematics/ng-update/index.ts
@@ -52,36 +52,36 @@ function renameMdcTokens(): Rule {
 // Renames Angular Material component token CSS variables that were renamed so that the base
 // component's name came first or otherwise renamed to match our terminology instead of MDC's.
 function renameComponentTokens(): Rule {
-  const replacements = [
-    {oldStr: '--mat-circular-progress', newStr: '--mat-progress-spinner'},
-    {oldStr: '--mat-elevated-card', newStr: '--mat-card-elevated'},
-    {oldStr: '--mat-extended-fab', newStr: '--mat-fab-extended'},
-    {oldStr: '--mat-filled-button', newStr: '--mat-button-filled'},
-    {oldStr: '--mat-filled-text-field', newStr: '--mat-form-field-filled'},
-    {oldStr: '--mat-full-pseudo-checkbox', newStr: '--mat-pseudo-checkbox-full'},
-    {oldStr: '--mat-legacy-button-toggle', newStr: '--mat-button-toggle-legacy'},
-    {oldStr: '--mat-linear-progress', newStr: '--mat-progress-bar'},
-    {oldStr: '--mat-minimal-pseudo-checkbox', newStr: '--mat-pseudo-checkbox-minimal'},
-    {oldStr: '--mat-outlined-button', newStr: '--mat-button-outlined'},
-    {oldStr: '--mat-outlined-card', newStr: '--mat-card-outlined'},
-    {oldStr: '--mat-outlined-text-field', newStr: '--mat-form-field-outlined'},
-    {oldStr: '--mat-plain-tooltip', newStr: '--mat-tooltip'},
-    {oldStr: '--mat-protected-button', newStr: '--mat-button-protected'},
-    {oldStr: '--mat-secondary-navigation-tab', newStr: '--mat-tab'},
-    {oldStr: '--mat-standard-button-toggle', newStr: '--mat-button-toggle'},
-    {oldStr: '--mat-switch', newStr: '--mat-slide-toggle'},
-    {oldStr: '--mat-tab-header', newStr: '--mat-tab'},
-    {oldStr: '--mat-tab-header-with-background', newStr: '--mat-tab'},
-    {oldStr: '--mat-tab-indicator', newStr: '--mat-tab'},
-    {oldStr: '--mat-text-button', newStr: '--mat-button-text'},
-    {oldStr: '--mat-tonal-button', newStr: '--mat-button-tonal'},
+  const tokenPrefixes = [
+    {old: '--mat-circular-progress', replacement: '--mat-progress-spinner'},
+    {old: '--mat-elevated-card', replacement: '--mat-card-elevated'},
+    {old: '--mat-extended-fab', replacement: '--mat-fab-extended'},
+    {old: '--mat-filled-button', replacement: '--mat-button-filled'},
+    {old: '--mat-filled-text-field', replacement: '--mat-form-field-filled'},
+    {old: '--mat-full-pseudo-checkbox', replacement: '--mat-pseudo-checkbox-full'},
+    {old: '--mat-legacy-button-toggle', replacement: '--mat-button-toggle-legacy'},
+    {old: '--mat-linear-progress', replacement: '--mat-progress-bar'},
+    {old: '--mat-minimal-pseudo-checkbox', replacement: '--mat-pseudo-checkbox-minimal'},
+    {old: '--mat-outlined-button', replacement: '--mat-button-outlined'},
+    {old: '--mat-outlined-card', replacement: '--mat-card-outlined'},
+    {old: '--mat-outlined-text-field', replacement: '--mat-form-field-outlined'},
+    {old: '--mat-plain-tooltip', replacement: '--mat-tooltip'},
+    {old: '--mat-protected-button', replacement: '--mat-button-protected'},
+    {old: '--mat-secondary-navigation-tab', replacement: '--mat-tab'},
+    {old: '--mat-standard-button-toggle', replacement: '--mat-button-toggle'},
+    {old: '--mat-switch', replacement: '--mat-slide-toggle'},
+    {old: '--mat-tab-header', replacement: '--mat-tab'},
+    {old: '--mat-tab-header-with-background', replacement: '--mat-tab'},
+    {old: '--mat-tab-indicator', replacement: '--mat-tab'},
+    {old: '--mat-text-button', replacement: '--mat-button-text'},
+    {old: '--mat-tonal-button', replacement: '--mat-button-tonal'},
   ];
   return tree => {
     tree.visit(path => {
       const content = tree.readText(path);
       let updatedContent = content;
-      for (const replacement of replacements) {
-        updatedContent = updatedContent.replace(replacement.oldStr, replacement.newStr);
+      for (const tokenPrefix of tokenPrefixes) {
+        updatedContent = updatedContent.replace(tokenPrefix.old, tokenPrefix.replacement);
       }
       if (content !== updatedContent) {
         tree.overwrite(path, updatedContent);

--- a/src/material/schematics/ng-update/index.ts
+++ b/src/material/schematics/ng-update/index.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Rule, SchematicContext} from '@angular-devkit/schematics';
+import {chain, Rule, SchematicContext} from '@angular-devkit/schematics';
 import {
   createMigrationSchematicRule,
   NullableDevkitMigration,
@@ -22,14 +22,72 @@ const materialMigrations: NullableDevkitMigration[] = [
   ExplicitSystemVariablePrefixMigration,
 ];
 
-/** Entry point for the migration schematics with target of Angular Material v19 */
+/** Entry point for the migration schematics with target of Angular Material v20 */
 export function updateToV20(): Rule {
-  return createMigrationSchematicRule(
-    TargetVersion.V20,
-    materialMigrations,
-    materialUpgradeData,
-    onMigrationComplete,
-  );
+  return chain([
+    createMigrationSchematicRule(
+      TargetVersion.V20,
+      materialMigrations,
+      materialUpgradeData,
+      onMigrationComplete,
+    ),
+    renameMdcTokens(),
+    renameComponentTokens(),
+  ]);
+}
+
+// Renames any CSS variables beginning with "--mdc-" to be "--mat-". These CSS variables
+// refer to tokens that used to be derived from a mix of MDC and Angular. Now all the tokens
+// are converged on being prefixed "--mat-".
+function renameMdcTokens(): Rule {
+  return tree => {
+    tree.visit(path => {
+      const content = tree.readText(path);
+      const updatedContent = content.replace('--mdc-', '--mat-');
+      tree.overwrite(path, updatedContent);
+    });
+  };
+}
+
+// Renames Angular Material component token CSS variables that were renamed so that the base
+// component's name came first or otherwise renamed to match our terminology instead of MDC's.
+function renameComponentTokens(): Rule {
+  const replacements = [
+    {oldStr: '--mat-circular-progress', newStr: '--mat-progress-spinner'},
+    {oldStr: '--mat-elevated-card', newStr: '--mat-card-elevated'},
+    {oldStr: '--mat-extended-fab', newStr: '--mat-fab-extended'},
+    {oldStr: '--mat-filled-button', newStr: '--mat-button-filled'},
+    {oldStr: '--mat-filled-text-field', newStr: '--mat-form-field-filled'},
+    {oldStr: '--mat-full-pseudo-checkbox', newStr: '--mat-pseudo-checkbox-full'},
+    {oldStr: '--mat-legacy-button-toggle', newStr: '--mat-button-toggle-legacy'},
+    {oldStr: '--mat-linear-progress', newStr: '--mat-progress-bar'},
+    {oldStr: '--mat-minimal-pseudo-checkbox', newStr: '--mat-pseudo-checkbox-minimal'},
+    {oldStr: '--mat-outlined-button', newStr: '--mat-button-outlined'},
+    {oldStr: '--mat-outlined-card', newStr: '--mat-card-outlined'},
+    {oldStr: '--mat-outlined-text-field', newStr: '--mat-form-field-outlined'},
+    {oldStr: '--mat-plain-tooltip', newStr: '--mat-tooltip'},
+    {oldStr: '--mat-protected-button', newStr: '--mat-button-protected'},
+    {oldStr: '--mat-secondary-navigation-tab', newStr: '--mat-tab'},
+    {oldStr: '--mat-standard-button-toggle', newStr: '--mat-button-toggle'},
+    {oldStr: '--mat-switch', newStr: '--mat-slide-toggle'},
+    {oldStr: '--mat-tab-header', newStr: '--mat-tab'},
+    {oldStr: '--mat-tab-header-with-background', newStr: '--mat-tab'},
+    {oldStr: '--mat-tab-indicator', newStr: '--mat-tab'},
+    {oldStr: '--mat-text-button', newStr: '--mat-button-text'},
+    {oldStr: '--mat-tonal-button', newStr: '--mat-button-tonal'},
+  ];
+  return tree => {
+    tree.visit(path => {
+      const content = tree.readText(path);
+      let updatedContent = content;
+      for (const replacement of replacements) {
+        updatedContent = updatedContent.replace(replacement.oldStr, replacement.newStr);
+      }
+      if (content !== updatedContent) {
+        tree.overwrite(path, updatedContent);
+      }
+    });
+  };
 }
 
 /** Function that will be called when the migration completed. */

--- a/src/material/schematics/ng-update/test-cases/rename-mdc-tokens.spec.ts
+++ b/src/material/schematics/ng-update/test-cases/rename-mdc-tokens.spec.ts
@@ -1,5 +1,5 @@
 import {UnitTestTree} from '@angular-devkit/schematics/testing';
-import {createTestCaseSetup} from '@angular/cdk/schematics/testing';
+import {createTestCaseSetup} from '../../../../cdk/schematics/testing';
 import {MIGRATION_PATH} from '../../paths';
 
 const THEME_FILE_PATH = '/projects/cdk-testing/src/theme.scss';
@@ -20,12 +20,16 @@ describe('v20 rename tokens migration', () => {
     runMigration = testSetup.runFixers;
   });
 
-  it('should rename mdc tokens to mat', async () => {
+  it('should rename mdc tokens to mat and change component ordering', async () => {
     writeFile(
       THEME_FILE_PATH,
       `
         html {
           --mdc-icon-button-icon-size: 24px;
+          --mat-filled-button-color: red;
+          --mat-filled-text-field-color: red;
+          --mat-full-pseudo-checkbox-color: red;
+          --mat-legacy-button-toggle-color: red;
         }
       `,
     );
@@ -36,6 +40,10 @@ describe('v20 rename tokens migration', () => {
       stripWhitespace(`
         html {
           --mat-icon-button-icon-size: 24px;
+          --mat-button-filled-color: red;
+          --mat-form-field-filled-color: red;
+          --mat-pseudo-checkbox-full-color: red;
+          --mat-button-toggle-legacy-color: red;
         }
     `),
     );

--- a/src/material/schematics/ng-update/test-cases/rename-mdc-tokens.spec.ts
+++ b/src/material/schematics/ng-update/test-cases/rename-mdc-tokens.spec.ts
@@ -1,0 +1,43 @@
+import {UnitTestTree} from '@angular-devkit/schematics/testing';
+import {createTestCaseSetup} from '@angular/cdk/schematics/testing';
+import {MIGRATION_PATH} from '../../paths';
+
+const THEME_FILE_PATH = '/projects/cdk-testing/src/theme.scss';
+
+describe('v20 rename tokens migration', () => {
+  let tree: UnitTestTree;
+  let writeFile: (filename: string, content: string) => void;
+  let runMigration: () => Promise<unknown>;
+
+  function stripWhitespace(content: string): string {
+    return content.replace(/\s/g, '');
+  }
+
+  beforeEach(async () => {
+    const testSetup = await createTestCaseSetup('migration-v20', MIGRATION_PATH, []);
+    tree = testSetup.appTree;
+    writeFile = testSetup.writeFile;
+    runMigration = testSetup.runFixers;
+  });
+
+  it('should rename mdc tokens to mat', async () => {
+    writeFile(
+      THEME_FILE_PATH,
+      `
+        html {
+          --mdc-icon-button-icon-size: 24px;
+        }
+      `,
+    );
+
+    await runMigration();
+
+    expect(stripWhitespace(tree.readText(THEME_FILE_PATH))).toBe(
+      stripWhitespace(`
+        html {
+          --mat-icon-button-icon-size: 24px;
+        }
+    `),
+    );
+  });
+});


### PR DESCRIPTION
Adds a migration to rename tokens:
1. Switches from `--mdc-` prefixes to `--mat-`
2. Switches around some component prefixes, like from `--mat-tonal-button-` to `--mat-button-tonal` (component goes first, then variant)
3. Renames component names to match our terms, like from `text-field` to `form-field`