### PR TITLE
fix(material/schematics): incorrect on-tertiary color being generated

### DIFF
--- a/src/material/schematics/ng-generate/theme-color/index.spec.ts
+++ b/src/material/schematics/ng-generate/theme-color/index.spec.ts
@@ -1091,7 +1091,7 @@ html {
 
     /* Tertiary palette variables */
     --mat-sys-tertiary: light-dark(#4d1f00, #ffece4);
-    --mat-sys-on-tertiary: light-dark(#4d1f00, #ffece4);
+    --mat-sys-on-tertiary: light-dark(#ffffff, #000000);
     --mat-sys-tertiary-container: light-dark(#7a3500, #ffb184);
     --mat-sys-on-tertiary-container: light-dark(#ffffff, #190600);
     --mat-sys-tertiary-fixed: light-dark(#7a3500, #ffdbc9);

--- a/src/material/schematics/ng-generate/theme-color/index.ts
+++ b/src/material/schematics/ng-generate/theme-color/index.ts
@@ -531,8 +531,8 @@ function getColorSysVariablesCSS(
   css += createLightDarkVar(
     leftSpacing,
     'on-tertiary',
-    isHighContrast ? lightScheme.tertiary : lightScheme.tertiaryPalette.tone(100),
-    isHighContrast ? darkScheme.tertiary : darkScheme.tertiaryPalette.tone(20),
+    isHighContrast ? lightScheme.onTertiary : lightScheme.tertiaryPalette.tone(100),
+    isHighContrast ? darkScheme.onTertiary : darkScheme.tertiaryPalette.tone(20),
   );
   css += createLightDarkVar(
     leftSpacing,


### PR DESCRIPTION
Fixes that the `theme-color` schematic was generating the wrong color for `on-tertiary`.

Fixes #30603.