### PR TITLE
fix(material/button): inherit button shape in focus indicator

### DIFF
--- a/src/material/button/_button-base.scss
+++ b/src/material/button/_button-base.scss
@@ -6,7 +6,7 @@
 // color and opacity for states like hover, active, and focus. Additionally, adds styles to the
 // ripple and state container so that they fill the button, match the border radius, and avoid
 // pointer events.
-@mixin mat-private-button-interactive() {
+@mixin mat-private-button-interactive($focus-indicator-inherits-shape: true) {
   -webkit-tap-highlight-color: transparent;
 
   // The ripple container should match the bounds of the entire button.
@@ -50,6 +50,16 @@
   // The focus indicator should match the bounds of the entire button.
   .mat-focus-indicator {
     @include layout-common.fill();
+
+    @if ($focus-indicator-inherits-shape) {
+      border-radius: inherit;
+    }
+  }
+
+  @if ($focus-indicator-inherits-shape) {
+    .mat-focus-indicator::before {
+      border-radius: inherit;
+    }
   }
 
   &:focus > .mat-focus-indicator::before {

--- a/src/material/button/fab.scss
+++ b/src/material/button/fab.scss
@@ -26,7 +26,8 @@
     transform 270ms 0ms cubic-bezier(0, 0, 0.2, 1);
   flex-shrink: 0; // Prevent the button from shrinking since it's always supposed to be a circle.
 
-  @include button-base.mat-private-button-interactive();
+  // Due to the shape of the FAB, inheriting the shape looks off. Disable it explicitly.
+  @include button-base.mat-private-button-interactive($focus-indicator-inherits-shape: false);
   @include style-private.private-animation-noop();
 
   &::before {


### PR DESCRIPTION
Updates the button's focus indicator to inherit the shape of its button which looks better than the current approach.

Before:
<img width="850" alt="image" src="https://github.com/user-attachments/assets/be661960-78da-486f-80fd-96fc90d1637a" />

After:
<img width="850" alt="image" src="https://github.com/user-attachments/assets/7aa7c0a1-f1c0-4b72-af05-9a7e7cb1dee9" />
