### PR TITLE
Use exhaustive checkNoChanges by default

### DIFF
--- a/src/cdk-experimental/scrolling/virtual-scroll-viewport.spec.ts
+++ b/src/cdk-experimental/scrolling/virtual-scroll-viewport.spec.ts
@@ -1,5 +1,11 @@
 import {CdkVirtualScrollViewport, ScrollingModule} from '@angular/cdk/scrolling';
-import {Component, Input, ViewChild, ViewEncapsulation} from '@angular/core';
+import {
+  Component,
+  Input,
+  provideCheckNoChangesConfig,
+  ViewChild,
+  ViewEncapsulation,
+} from '@angular/core';
 import {ComponentFixture, TestBed, fakeAsync, flush, waitForAsync} from '@angular/core/testing';
 import {ScrollingModule as ExperimentalScrollingModule} from './scrolling-module';
 
@@ -11,6 +17,7 @@ describe('CdkVirtualScrollViewport', () => {
 
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
+        providers: [provideCheckNoChangesConfig({exhaustive: false})],
         imports: [ScrollingModule, ExperimentalScrollingModule, AutoSizeVirtualScroll],
       });
     }));

--- a/src/components-examples/material/checkbox/checkbox-harness/checkbox-harness-example.spec.ts
+++ b/src/components-examples/material/checkbox/checkbox-harness/checkbox-harness-example.spec.ts
@@ -3,12 +3,14 @@ import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatCheckboxHarness} from '@angular/material/checkbox/testing';
 import {CheckboxHarnessExample} from './checkbox-harness-example';
+import {provideCheckNoChangesConfig} from '@angular/core';
 
 describe('CheckboxHarnessExample', () => {
   let fixture: ComponentFixture<CheckboxHarnessExample>;
   let loader: HarnessLoader;
 
   beforeEach(() => {
+    TestBed.configureTestingModule({providers: [provideCheckNoChangesConfig({exhaustive: false})]});
     fixture = TestBed.createComponent(CheckboxHarnessExample);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.loader(fixture);

--- a/src/material/button-toggle/button-toggle.spec.ts
+++ b/src/material/button-toggle/button-toggle.spec.ts
@@ -1,5 +1,12 @@
 import {dispatchMouseEvent} from '@angular/cdk/testing/private';
-import {Component, DebugElement, QueryList, ViewChild, ViewChildren} from '@angular/core';
+import {
+  Component,
+  DebugElement,
+  provideCheckNoChangesConfig,
+  QueryList,
+  ViewChild,
+  ViewChildren,
+} from '@angular/core';
 import {ComponentFixture, TestBed, fakeAsync, flush, tick} from '@angular/core/testing';
 import {FormControl, FormsModule, NgModel, ReactiveFormsModule} from '@angular/forms';
 import {By} from '@angular/platform-browser';
@@ -14,6 +21,7 @@ import {
 describe('MatButtonToggle with forms', () => {
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
+      providers: [provideCheckNoChangesConfig({exhaustive: false})],
       imports: [
         MatButtonToggleModule,
         FormsModule,
@@ -327,6 +335,7 @@ describe('MatButtonToggle with forms', () => {
 describe('MatButtonToggle without forms', () => {
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
+      providers: [provideCheckNoChangesConfig({exhaustive: false})],
       imports: [
         MatButtonToggleModule,
         ButtonTogglesInsideButtonToggleGroup,

--- a/src/material/checkbox/testing/checkbox-harness.spec.ts
+++ b/src/material/checkbox/testing/checkbox-harness.spec.ts
@@ -1,4 +1,4 @@
-import {Component, signal} from '@angular/core';
+import {Component, provideCheckNoChangesConfig, signal} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
@@ -12,6 +12,7 @@ describe('MatCheckboxHarness', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
+      providers: [provideCheckNoChangesConfig({exhaustive: false})],
       imports: [MatCheckboxModule, ReactiveFormsModule, CheckboxHarnessTest],
     });
 

--- a/src/material/datepicker/calendar.spec.ts
+++ b/src/material/datepicker/calendar.spec.ts
@@ -5,7 +5,7 @@ import {
   dispatchKeyboardEvent,
   dispatchMouseEvent,
 } from '@angular/cdk/testing/private';
-import {Component} from '@angular/core';
+import {Component, provideCheckNoChangesConfig} from '@angular/core';
 import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 import {DateAdapter, MatNativeDateModule} from '../core';
 import {By} from '@angular/platform-browser';
@@ -21,7 +21,11 @@ describe('MatCalendar', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [MatNativeDateModule, MatDatepickerModule],
-      providers: [MatDatepickerIntl, {provide: Directionality, useFactory: () => ({value: 'ltr'})}],
+      providers: [
+        MatDatepickerIntl,
+        {provide: Directionality, useFactory: () => ({value: 'ltr'})},
+        provideCheckNoChangesConfig({exhaustive: false}),
+      ],
       declarations: [
         // Test components.
         StandardCalendar,

--- a/src/material/datepicker/date-range-input.spec.ts
+++ b/src/material/datepicker/date-range-input.spec.ts
@@ -3,7 +3,16 @@ import {Direction, Directionality} from '@angular/cdk/bidi';
 import {BACKSPACE, LEFT_ARROW, RIGHT_ARROW} from '@angular/cdk/keycodes';
 import {OverlayContainer} from '@angular/cdk/overlay';
 import {dispatchFakeEvent, dispatchKeyboardEvent} from '@angular/cdk/testing/private';
-import {Component, Directive, ElementRef, Provider, signal, Type, ViewChild} from '@angular/core';
+import {
+  Component,
+  Directive,
+  ElementRef,
+  provideCheckNoChangesConfig,
+  Provider,
+  signal,
+  Type,
+  ViewChild,
+} from '@angular/core';
 import {ComponentFixture, fakeAsync, flush, TestBed, tick} from '@angular/core/testing';
 import {
   FormControl,
@@ -37,6 +46,7 @@ describe('MatDateRangeInput', () => {
         component,
       ],
       providers: [
+        provideCheckNoChangesConfig({exhaustive: false}),
         ...providers,
         {provide: MATERIAL_ANIMATIONS, useValue: {animationsDisabled: true}},
       ],

--- a/src/material/expansion/accordion.spec.ts
+++ b/src/material/expansion/accordion.spec.ts
@@ -5,7 +5,13 @@ import {
   dispatchEvent,
   dispatchKeyboardEvent,
 } from '@angular/cdk/testing/private';
-import {Component, QueryList, ViewChild, ViewChildren} from '@angular/core';
+import {
+  Component,
+  provideCheckNoChangesConfig,
+  QueryList,
+  ViewChild,
+  ViewChildren,
+} from '@angular/core';
 import {TestBed, waitForAsync} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {
@@ -20,6 +26,7 @@ describe('MatAccordion', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
+      providers: [provideCheckNoChangesConfig({exhaustive: false})],
       imports: [
         MatExpansionModule,
         AccordionWithHideToggle,

--- a/src/material/list/selection-list.spec.ts
+++ b/src/material/list/selection-list.spec.ts
@@ -10,6 +10,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   DebugElement,
+  provideCheckNoChangesConfig,
   QueryList,
   ViewChildren,
 } from '@angular/core';
@@ -44,6 +45,7 @@ describe('MatSelectionList without forms', () => {
 
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
+        providers: [provideCheckNoChangesConfig({exhaustive: false})],
         imports: [
           MatListModule,
           SelectionListWithListOptions,
@@ -1277,6 +1279,7 @@ describe('MatSelectionList without forms', () => {
 describe('MatSelectionList with forms', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
+      providers: [provideCheckNoChangesConfig({exhaustive: false})],
       imports: [
         MatListModule,
         FormsModule,

--- a/src/material/menu/menu.spec.ts
+++ b/src/material/menu/menu.spec.ts
@@ -22,6 +22,7 @@ import {
   Input,
   OnDestroy,
   Output,
+  provideCheckNoChangesConfig,
   Provider,
   QueryList,
   TemplateRef,
@@ -68,6 +69,7 @@ describe('MatMenu', () => {
   ): ComponentFixture<T> {
     TestBed.configureTestingModule({
       providers: [
+        provideCheckNoChangesConfig({exhaustive: false}),
         ...providers,
         {provide: MATERIAL_ANIMATIONS, useValue: {animationsDisabled: true}},
       ],

--- a/src/material/radio/radio.spec.ts
+++ b/src/material/radio/radio.spec.ts
@@ -1,5 +1,5 @@
 import {dispatchFakeEvent} from '@angular/cdk/testing/private';
-import {Component, DebugElement, ViewChild} from '@angular/core';
+import {Component, DebugElement, provideCheckNoChangesConfig, ViewChild} from '@angular/core';
 import {ComponentFixture, TestBed, fakeAsync, tick, waitForAsync} from '@angular/core/testing';
 import {FormControl, FormsModule, NgModel, ReactiveFormsModule} from '@angular/forms';
 import {By} from '@angular/platform-browser';
@@ -14,6 +14,7 @@ import {
 describe('MatRadio', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
+      providers: [provideCheckNoChangesConfig({exhaustive: false})],
       imports: [
         MatRadioModule,
         FormsModule,

--- a/src/material/select/select.spec.ts
+++ b/src/material/select/select.spec.ts
@@ -37,6 +37,7 @@ import {
   ViewChild,
   ViewChildren,
   inject,
+  provideCheckNoChangesConfig,
 } from '@angular/core';
 import {
   ComponentFixture,
@@ -96,6 +97,7 @@ describe('MatSelect', () => {
         OverlayModule,
       ],
       providers: [
+        provideCheckNoChangesConfig({exhaustive: false}),
         {provide: MATERIAL_ANIMATIONS, useValue: {animationsDisabled: true}},
         {provide: Directionality, useFactory: () => (dir = {value: 'ltr', change: EMPTY})},
         {

--- a/src/material/sidenav/drawer.spec.ts
+++ b/src/material/sidenav/drawer.spec.ts
@@ -7,7 +7,13 @@ import {
   dispatchEvent,
   dispatchKeyboardEvent,
 } from '@angular/cdk/testing/private';
-import {Component, ElementRef, ErrorHandler, ViewChild} from '@angular/core';
+import {
+  Component,
+  ElementRef,
+  ErrorHandler,
+  provideCheckNoChangesConfig,
+  ViewChild,
+} from '@angular/core';
 import {
   ComponentFixture,
   TestBed,
@@ -24,7 +30,10 @@ import {MATERIAL_ANIMATIONS} from '../core';
 describe('MatDrawer', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      providers: [{provide: MATERIAL_ANIMATIONS, useValue: {animationsDisabled: true}}],
+      providers: [
+        {provide: MATERIAL_ANIMATIONS, useValue: {animationsDisabled: true}},
+        provideCheckNoChangesConfig({exhaustive: false}),
+      ],
       imports: [
         MatSidenavModule,
         A11yModule,
@@ -891,6 +900,7 @@ describe('MatDrawer', () => {
 describe('MatDrawerContainer', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
+      providers: [provideCheckNoChangesConfig({exhaustive: false})],
       imports: [
         MatSidenavModule,
         A11yModule,

--- a/src/material/sidenav/sidenav.spec.ts
+++ b/src/material/sidenav/sidenav.spec.ts
@@ -1,4 +1,4 @@
-import {Component, ViewChild} from '@angular/core';
+import {Component, provideCheckNoChangesConfig, ViewChild} from '@angular/core';
 import {TestBed, fakeAsync, tick, waitForAsync} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {MatSidenav, MatSidenavContainer, MatSidenavModule} from './index';
@@ -6,6 +6,7 @@ import {MatSidenav, MatSidenavContainer, MatSidenavModule} from './index';
 describe('MatSidenav', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
+      providers: [provideCheckNoChangesConfig({exhaustive: false})],
       imports: [
         MatSidenavModule,
         SidenavWithFixedPosition,

--- a/src/material/sidenav/testing/sidenav-harness.spec.ts
+++ b/src/material/sidenav/testing/sidenav-harness.spec.ts
@@ -1,4 +1,4 @@
-import {Component, signal} from '@angular/core';
+import {Component, provideCheckNoChangesConfig, signal} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {HarnessLoader, parallel} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
@@ -16,6 +16,9 @@ describe('MatSidenavHarness', () => {
     let loader: HarnessLoader;
 
     beforeEach(() => {
+      TestBed.configureTestingModule({
+        providers: [provideCheckNoChangesConfig({exhaustive: false})],
+      });
       fixture = TestBed.createComponent(DrawerHarnessTest);
       fixture.detectChanges();
       loader = TestbedHarnessEnvironment.loader(fixture);

--- a/src/material/stepper/stepper.spec.ts
+++ b/src/material/stepper/stepper.spec.ts
@@ -32,6 +32,7 @@ import {
   ViewChildren,
   ViewEncapsulation,
   inject,
+  provideCheckNoChangesConfig,
   signal,
 } from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
@@ -1829,6 +1830,7 @@ function createComponent<T>(
   TestBed.configureTestingModule({
     imports: [MatStepperModule, ReactiveFormsModule, ...imports],
     providers: [
+      provideCheckNoChangesConfig({exhaustive: false}),
       {provide: Directionality, useFactory: () => dir},
       {provide: MATERIAL_ANIMATIONS, useValue: {animationsDisabled: true}},
       ...providers,

--- a/src/material/tabs/tab-nav-bar/tab-nav-bar.spec.ts
+++ b/src/material/tabs/tab-nav-bar/tab-nav-bar.spec.ts
@@ -6,7 +6,13 @@ import {
   dispatchKeyboardEvent,
   dispatchMouseEvent,
 } from '@angular/cdk/testing/private';
-import {Component, QueryList, ViewChild, ViewChildren} from '@angular/core';
+import {
+  Component,
+  provideCheckNoChangesConfig,
+  QueryList,
+  ViewChild,
+  ViewChildren,
+} from '@angular/core';
 import {ComponentFixture, TestBed, fakeAsync, tick, waitForAsync} from '@angular/core/testing';
 import {MAT_RIPPLE_GLOBAL_OPTIONS, RippleGlobalOptions} from '../../core';
 import {By} from '@angular/platform-browser';
@@ -32,6 +38,7 @@ describe('MatTabNavBar', () => {
         TabBarWithInactiveTabsOnInit,
       ],
       providers: [
+        provideCheckNoChangesConfig({exhaustive: false}),
         {provide: MAT_RIPPLE_GLOBAL_OPTIONS, useFactory: () => globalRippleOptions},
         {provide: Directionality, useFactory: () => ({value: dir, change: dirChange})},
       ],

--- a/test/angular-test.init.ts
+++ b/test/angular-test.init.ts
@@ -10,22 +10,12 @@ import 'zone.js';
 import 'zone.js/testing';
 import 'reflect-metadata';
 
-import {ErrorHandler, NgModule, provideZonelessChangeDetection} from '@angular/core';
+import {NgModule, provideCheckNoChangesConfig, provideZonelessChangeDetection} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {BrowserTestingModule, platformBrowserTesting} from '@angular/platform-browser/testing';
 
 @NgModule({
-  providers: [
-    provideZonelessChangeDetection(),
-    {
-      provide: ErrorHandler,
-      useValue: {
-        handleError: (e: any) => {
-          throw e;
-        },
-      },
-    },
-  ],
+  providers: [provideZonelessChangeDetection(), provideCheckNoChangesConfig({exhaustive: true})],
 })
 export class TestModule {}
 


### PR DESCRIPTION
When components use `OnPush`, they prevent `ExpressionHasChanged...`
from being thrown when it should (https://github.com/angular/angular/issues/45612).
The exhaustive option ignores dirty
flags and traverses the entire view tree checking for changes. This
commit configures component tests to do this by default and opts out any
tests with existing issues.

This also includes a commit to show one of the issues that surfaced along with the fix