### PR TITLE
ci: Use 'replace' rangeStrategy to prevent unintended dependency pinning

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -35,6 +35,10 @@
       "schedule": ["after 10:00pm on monday", "before 04:00am on tuesday"]
     },
     {
+      "groupName": "bazel",
+      "matchDepNames": ["/^@bazel/.*/", "/^build_bazel.*/"]
+    },
+    {
       "matchBaseBranches": ["main"],
       "followTag": "next",
       "groupName": "cross-repo Angular dependencies (next)",
@@ -55,6 +59,20 @@
     {
       "matchCurrentVersion": "0.0.0-PLACEHOLDER",
       "enabled": false
+    },
+    {
+      "separateMinorPatch": true,
+      "matchPackageNames": ["typescript", "rxjs", "tslib"]
+    },
+    {
+      "enabled": false,
+      "matchPackageNames": ["typescript", "rxjs", "tslib"],
+      "matchUpdateTypes": ["major"]
+    },
+    {
+      "enabled": false,
+      "matchPackageNames": ["typescript"],
+      "matchUpdateTypes": ["minor"]
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,7 @@
   "stopUpdatingLabel": "action: merge",
   "labels": ["action: review"],
   "dependencyDashboard": true,
-  "rangeStrategy": "pin",
+  "rangeStrategy": "replace",
   "prHourlyLimit": 3,
   "commitBody": "See associated pull request for more information.",
   "timezone": "America/Tijuana",


### PR DESCRIPTION
The previous 'pin' rangeStrategy caused several issues:
* It unexpectedly pinned exact versions of dependencies in the distributed `package.json` files.
* It also automatically updated the Node.js version and engine ranges to their latest versions, which was not the desired behavior for our CI/CD pipeline.

Switching to the 'replace' strategy resolves these problems, ensuring more predictable and stable dependency management within our CI setup.

See: https://github.com/angular/components/pull/31062