### PR TITLE
fix(material/button-toggle): use smaller border radius

### DIFF
--- a/src/material/button-toggle/_m3-button-toggle.scss
+++ b/src/material/button-toggle/_m3-button-toggle.scss
@@ -17,7 +17,7 @@ $prefix: (mat, button-toggle);
   $tokens: sass-utils.merge-all(
     m3-utils.generate-typography-tokens($systems, label-text, label-large),
   (
-    shape: map.get($systems, md-sys-shape, corner-full),
+    shape: map.get($systems, md-sys-shape, corner-extra-large),
     hover-state-layer-opacity: map.get($systems, md-sys-state, hover-state-layer-opacity),
     focus-state-layer-opacity: map.get($systems, md-sys-state, focus-state-layer-opacity),
     text-color: map.get($systems, md-sys-color, on-surface),


### PR DESCRIPTION
Currently the button toggle uses the `corner-full` value for its broder radius which starts too look weird for a vertical group with text inside the toggles.

These changes switch to using the `corner-extra-large` value instead.

Fixes #31010.