### PR TITLE
fix(material/form-field): floating label triggering callback inside zone

### DIFF
--- a/src/material/form-field/directives/floating-label.ts
+++ b/src/material/form-field/directives/floating-label.ts
@@ -116,7 +116,7 @@ export class MatFormFieldFloatingLabel implements OnDestroy {
     // This is expected, but If we allow this to all happen within the same macro task it causes an
     // error: `ResizeObserver loop limit exceeded`. Therefore we push the notch resize out until
     // the next macro task.
-    setTimeout(() => this._parent._handleLabelResized());
+    this._ngZone.runOutsideAngular(() => setTimeout(() => this._parent._handleLabelResized()));
   }
 
   /** Subscribes to resize events. */


### PR DESCRIPTION
The floating label has a `setTimeout` inside `_handleResize` which was being called inside the zone from the `floating` setter which can trigger unnecessary change detections.