### PR TITLE
fix(material/radio): updating required value should mark for check

### DIFF
--- a/src/material/radio/radio.spec.ts
+++ b/src/material/radio/radio.spec.ts
@@ -1,5 +1,5 @@
 import {dispatchFakeEvent} from '@angular/cdk/testing/private';
-import {Component, DebugElement, provideCheckNoChangesConfig, ViewChild} from '@angular/core';
+import {Component, DebugElement, ViewChild} from '@angular/core';
 import {ComponentFixture, TestBed, fakeAsync, tick, waitForAsync} from '@angular/core/testing';
 import {FormControl, FormsModule, NgModel, ReactiveFormsModule} from '@angular/forms';
 import {By} from '@angular/platform-browser';
@@ -14,7 +14,6 @@ import {
 describe('MatRadio', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      providers: [provideCheckNoChangesConfig({exhaustive: false})],
       imports: [
         MatRadioModule,
         FormsModule,

--- a/src/material/radio/radio.ts
+++ b/src/material/radio/radio.ts
@@ -523,6 +523,9 @@ export class MatRadioButton implements OnInit, AfterViewInit, DoCheck, OnDestroy
     return this._required || (this.radioGroup && this.radioGroup.required);
   }
   set required(value: boolean) {
+    if (value !== this._required) {
+      this._changeDetector.markForCheck();
+    }
     this._required = value;
   }
 


### PR DESCRIPTION
This change ensures that updates to the required value of the radio button also mark the component for check, ensuring OnPush compatibility.