### PR TITLE
fix(material/tabs): not emitting token in M3

### DIFF
--- a/src/material/tabs/_m3-tabs.scss
+++ b/src/material/tabs/_m3-tabs.scss
@@ -29,6 +29,7 @@ $prefix: (mat, tab);
       active-indicator-color: map.get($system, primary),
       active-label-text-color: map.get($system, on-surface),
       active-ripple-color: map.get($system, on-surface),
+      disabled-ripple-color: map.get($system, on-surface-variant),
       divider-color: map.get($system, surface-variant),
       inactive-focus-label-text-color: map.get($system, on-surface),
       inactive-hover-label-text-color: map.get($system, on-surface),


### PR DESCRIPTION
Fixes that the tabs weren't emitting the `disabled-ripple-color` in M3 which prevented the focus indication from being shown on disabled tabs.

Fixes #31133.