### PR TITLE
fix(material/sidenav): removes -1 tabindex from sidenav 

### DIFF
--- a/src/material/sidenav/drawer.ts
+++ b/src/material/sidenav/drawer.ts
@@ -165,7 +165,7 @@ export class MatDrawerContent extends CdkScrollable implements AfterContentInit 
     // this was also done by the animations module which some internal tests seem to depend on.
     // Simulate it by toggling the `hidden` attribute instead.
     '[style.visibility]': '(!_container && !opened) ? "hidden" : null',
-    'tabIndex': '(mode !== "side") ? "-1" : null',
+    '[attr.tabIndex]': '(mode !== "side") ? "-1" : null',
   },
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,

--- a/src/material/sidenav/drawer.ts
+++ b/src/material/sidenav/drawer.ts
@@ -165,6 +165,8 @@ export class MatDrawerContent extends CdkScrollable implements AfterContentInit 
     // this was also done by the animations module which some internal tests seem to depend on.
     // Simulate it by toggling the `hidden` attribute instead.
     '[style.visibility]': '(!_container && !opened) ? "hidden" : null',
+    // The sidenav container should not be focused on when used in side mode. See b/286459024 for
+    // reference. Updates tabIndex of drawer/container to default to null if in side mode.
     '[attr.tabIndex]': '(mode !== "side") ? "-1" : null',
   },
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/material/sidenav/drawer.ts
+++ b/src/material/sidenav/drawer.ts
@@ -165,7 +165,7 @@ export class MatDrawerContent extends CdkScrollable implements AfterContentInit 
     // this was also done by the animations module which some internal tests seem to depend on.
     // Simulate it by toggling the `hidden` attribute instead.
     '[style.visibility]': '(!_container && !opened) ? "hidden" : null',
-    'tabIndex': '-1',
+    'tabIndex': '(mode !== "side") ? "-1" : null',
   },
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,

--- a/src/material/sidenav/sidenav.ts
+++ b/src/material/sidenav/sidenav.ts
@@ -47,6 +47,8 @@ export class MatSidenavContent extends MatDrawerContent {}
   templateUrl: 'drawer.html',
   host: {
     'class': 'mat-drawer mat-sidenav',
+    // The sidenav container should not be focused on when used in side mode. See b/286459024 for
+    // reference. Updates tabIndex of drawer/container to default to null if in side mode.
     '[attr.tabIndex]': '(mode !== "side") ? "-1" : null',
     // must prevent the browser from aligning text based on value
     '[attr.align]': 'null',

--- a/src/material/sidenav/sidenav.ts
+++ b/src/material/sidenav/sidenav.ts
@@ -47,7 +47,7 @@ export class MatSidenavContent extends MatDrawerContent {}
   templateUrl: 'drawer.html',
   host: {
     'class': 'mat-drawer mat-sidenav',
-    'tabIndex': '-1',
+    '[attr.tabIndex]': '(mode !== "side") ? "-1" : null',
     // must prevent the browser from aligning text based on value
     '[attr.align]': 'null',
     '[class.mat-drawer-end]': 'position === "end"',


### PR DESCRIPTION
Updates Angular Components SideNav component so that when
the mode is not equalt to side the tabIndex value is -1.
Otherwise provide a null value.

[Before fix screenshot](https://screenshot.googleplex.com/65vh5qPmjsDBphi)
[After fix screenshot](https://screenshot.googleplex.com/3pLLsoTDcKQH9a2)
[After fix screenshot of mat-drawer-end comparison](https://screenshot.googleplex.com/62DCitRjqkCzB75)

Fixes b/286459024