### PR TITLE
fix(material/datepicker): export MatDatepickerBase in public-api.ts

### DIFF
--- a/src/material/datepicker/public-api.ts
+++ b/src/material/datepicker/public-api.ts
@@ -20,6 +20,7 @@ export {
   MAT_DATEPICKER_SCROLL_STRATEGY,
   MAT_DATEPICKER_SCROLL_STRATEGY_FACTORY,
   MAT_DATEPICKER_SCROLL_STRATEGY_FACTORY_PROVIDER,
+  MatDatepickerBase,
   MatDatepickerContent,
   DatepickerDropdownPositionX,
   DatepickerDropdownPositionY,


### PR DESCRIPTION
Export the MatDatepickerBase abstract class to allow extends of MatDatepicker.