### PR TITLE
build: update firebase-tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "dgeni": "^0.4.14",
     "dgeni-packages": "^0.30.0",
     "esbuild": "^0.25.0",
-    "firebase-tools": "^14.0.0",
+    "firebase-tools": "14.4.0",
     "fs-extra": "^11.0.0",
     "glob": "^7.2.0",
     "highlight.js": "^11.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,7 +228,7 @@ importers:
         specifier: ^0.25.0
         version: 0.25.4
       firebase-tools:
-        specifier: ^14.0.0
+        specifier: 14.4.0
         version: 14.4.0(@types/node@22.14.1)(encoding@0.1.13)
       fs-extra:
         specifier: ^11.0.0
@@ -3014,11 +3014,6 @@ packages:
 
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
-    peerDependencies:
-      ajv: ^8.0.0
-    peerDependenciesMeta:
-      ajv:
-        optional: true
 
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
@@ -11192,8 +11187,8 @@ snapshots:
       indent-string: 4.0.0
     optional: true
 
-  ajv-formats@2.1.1(ajv@8.17.1):
-    optionalDependencies:
+  ajv-formats@2.1.1:
+    dependencies:
       ajv: 8.17.1
 
   ajv-formats@3.0.1:
@@ -12704,7 +12699,7 @@ snapshots:
     dependencies:
       '@apidevtools/json-schema-ref-parser': 9.1.2
       ajv: 8.17.1
-      ajv-formats: 2.1.1(ajv@8.17.1)
+      ajv-formats: 2.1.1
       body-parser: 1.20.3
       content-type: 1.0.5
       deep-freeze: 0.0.1
@@ -16111,7 +16106,7 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
       ajv: 8.17.1
-      ajv-formats: 2.1.1(ajv@8.17.1)
+      ajv-formats: 2.1.1
       ajv-keywords: 5.1.0(ajv@8.17.1)
 
   select-hose@2.0.0: {}

--- a/scripts/docs-deploy/deploy-to-site.mts
+++ b/scripts/docs-deploy/deploy-to-site.mts
@@ -47,7 +47,7 @@ export async function deployToSite(
   await fs.promises.writeFile(gcpServiceKeyTmpFile, firebaseServiceKey);
   process.env['GOOGLE_APPLICATION_CREDENTIALS'] = gcpServiceKeyTmpFile;
 
-  await firebase('use', info.projectId);
+  await firebase('use', info.projectId, '--debug');
   await firebase('target:clear', 'hosting', 'mat-aio');
   await firebase('target:apply', 'hosting', 'mat-aio', info.site.firebaseSiteId);
 


### PR DESCRIPTION
Apparently there is a bug in the latest firebase CLI version that requires more permissions than actually needed; so our deployment in `main` fails.