### PR TITLE
fix(material/core): brand family not set for plain value

### DIFF
--- a/src/material/core/tokens/_m3-system.scss
+++ b/src/material/core/tokens/_m3-system.scss
@@ -115,6 +115,7 @@
       $regular: map.get($typography, regular-weight) or $regular;
     } @else {
       $plain: $typography;
+      $brand: $typography;
     }
     $typography-config: (
       definition.$internals: (


### PR DESCRIPTION
If a non-map value is set for the `typography`, we were only setting the plain font family while the brand one was falling back to Roboto.

Fixes #31254.