### PR TITLE
feat(material/table): accept undefined sort and paginator

### DIFF
--- a/goldens/material/table/index.api.md
+++ b/goldens/material/table/index.api.md
@@ -187,10 +187,10 @@ export class MatTableDataSource<T, P extends MatPaginator = MatPaginator> extend
     _orderData(data: T[]): T[];
     _pageData(data: T[]): T[];
     get paginator(): P | null;
-    set paginator(paginator: P | null);
+    set paginator(paginator: P | null | undefined);
     _renderChangesSubscription: Subscription | null;
     get sort(): MatSort | null;
-    set sort(sort: MatSort | null);
+    set sort(sort: MatSort | null | undefined);
     sortData: (data: T[], sort: MatSort) => T[];
     sortingDataAccessor: (data: T, sortHeaderId: string) => string | number;
     _updateChangeSubscription(): void;

--- a/src/material/table/table-data-source.ts
+++ b/src/material/table/table-data-source.ts
@@ -107,8 +107,10 @@ export class MatTableDataSource<T, P extends MatPaginator = MatPaginator> extend
     return this._sort;
   }
 
-  set sort(sort: MatSort | null) {
-    this._sort = sort;
+  set sort(sort: MatSort | null | undefined) {
+    // Treat undefined like the initial this._sort value.
+    // Note that the API can be changed in a breaking change to fix the cast.
+    this._sort = sort as MatSort | null;
     this._updateChangeSubscription();
   }
 
@@ -128,8 +130,10 @@ export class MatTableDataSource<T, P extends MatPaginator = MatPaginator> extend
     return this._paginator;
   }
 
-  set paginator(paginator: P | null) {
-    this._paginator = paginator;
+  set paginator(paginator: P | null | undefined) {
+    // Treat undefined like the initial this._paginator value.
+    // Note that the API can be changed in a breaking change to fix the cast.
+    this._paginator = paginator as P | null;
     this._updateChangeSubscription();
   }
 


### PR DESCRIPTION
Extend types of the sort and paginator setter to include undefined to avoid `?? null` when using singals (e.g. `viewChild`).