### PR TITLE
fix(material/schematics): avoid overwriting files that didn't change

### DIFF
--- a/src/material/schematics/ng-update/index.ts
+++ b/src/material/schematics/ng-update/index.ts
@@ -59,7 +59,9 @@ function renameMdcTokens(): Rule {
       if (shouldRenameTokens(path)) {
         const content = tree.readText(path);
         const updatedContent = content.replace('--mdc-', '--mat-');
-        tree.overwrite(path, updatedContent);
+        if (content !== updatedContent) {
+          tree.overwrite(path, updatedContent);
+        }
       }
     });
   };


### PR DESCRIPTION
Fixes that the v20 update migration was overwriting all files, even if they didn't change.

Fixes #31259.