### PR TITLE
fix(material/dialog): dialog's container-color does not follow Material 3 design specs

### DIFF
--- a/src/material/dialog/_m3-dialog.scss
+++ b/src/material/dialog/_m3-dialog.scss
@@ -26,7 +26,7 @@
       dialog-with-actions-content-padding: 20px 24px 0,
     ),
     color: (
-      dialog-container-color: map.get($system, surface),
+      dialog-container-color: map.get($system, surface-container-high),
       dialog-subhead-color: map.get($system, on-surface),
       dialog-supporting-text-color: map.get($system, on-surface-variant),
     ),


### PR DESCRIPTION
Fixes a bug in the Angular Material dialog component where dialog uses `surface` container-color instead of `surface-container-high` as per Material 3 guidelines.

Fixes #30536