### PR TITLE
docs(material/button): variants table not rendering

### DIFF
--- a/src/material/button/button.md
+++ b/src/material/button/button.md
@@ -9,6 +9,7 @@ is performed. An `<a>` element should be used whenever the user will _navigate_ 
 
 
 There are several button variants, each applied as an attribute:
+
 | Attribute            | Description                                                              |
 |----------------------|--------------------------------------------------------------------------|
 | `matButton`          | Rectangular button that can contain text and icons                       |


### PR DESCRIPTION
Fixes that the variants that wasn't rendering, because there was no extra new line between it and the preceding paragraph.

Fixes #31262.