### PR TITLE
fix(material/schematics): token migration not replacing all instances

### DIFF
--- a/src/material/schematics/ng-update/index.ts
+++ b/src/material/schematics/ng-update/index.ts
@@ -58,7 +58,7 @@ function renameMdcTokens(): Rule {
     tree.visit(path => {
       if (shouldRenameTokens(path)) {
         const content = tree.readText(path);
-        const updatedContent = content.replace('--mdc-', '--mat-');
+        const updatedContent = content.replaceAll('--mdc-', '--mat-');
         if (content !== updatedContent) {
           tree.overwrite(path, updatedContent);
         }
@@ -100,7 +100,7 @@ function renameComponentTokens(): Rule {
         const content = tree.readText(path);
         let updatedContent = content;
         for (const tokenPrefix of tokenPrefixes) {
-          updatedContent = updatedContent.replace(tokenPrefix.old, tokenPrefix.replacement);
+          updatedContent = updatedContent.replaceAll(tokenPrefix.old, tokenPrefix.replacement);
         }
         if (content !== updatedContent) {
           tree.overwrite(path, updatedContent);

--- a/src/material/schematics/ng-update/test-cases/rename-mdc-tokens.spec.ts
+++ b/src/material/schematics/ng-update/test-cases/rename-mdc-tokens.spec.ts
@@ -48,4 +48,58 @@ describe('v20 rename tokens migration', () => {
     `),
     );
   });
+
+  it('should rename multiple instances of the --mdc prefix', async () => {
+    writeFile(
+      THEME_FILE_PATH,
+      `
+        html {
+          --mdc-foo: 1px;
+          --mdc-bar: 2px;
+          --mdc-baz: 3px;
+        }
+      `,
+    );
+
+    await runMigration();
+
+    expect(stripWhitespace(tree.readText(THEME_FILE_PATH))).toBe(
+      stripWhitespace(`
+        html {
+          --mat-foo: 1px;
+          --mat-bar: 2px;
+          --mat-baz: 3px;
+        }
+    `),
+    );
+  });
+
+  it('should rename multiple instances of a specific component token', async () => {
+    writeFile(
+      THEME_FILE_PATH,
+      `
+        .one {
+          --mat-circular-progress-foo: 1px;
+        }
+
+        .two {
+          --mat-circular-progress-bar: 2px;
+        }
+      `,
+    );
+
+    await runMigration();
+
+    expect(stripWhitespace(tree.readText(THEME_FILE_PATH))).toBe(
+      stripWhitespace(`
+        .one {
+          --mat-progress-spinner-foo: 1px;
+        }
+
+        .two {
+          --mat-progress-spinner-bar: 2px;
+        }
+    `),
+    );
+  });
 });


### PR DESCRIPTION
Fixes that the v20 `ng update` migration was only replacing the first instance of tokens.

Fixes #31276.