### PR TITLE
feat(cdk/drag-drop): add opt-in indicator of pick-up position

### DIFF
--- a/goldens/cdk/drag-drop/index.api.md
+++ b/goldens/cdk/drag-drop/index.api.md
@@ -257,12 +257,15 @@ export class CdkDropList<T = any> implements OnDestroy {
     enterPredicate: (drag: CdkDrag, drop: CdkDropList) => boolean;
     readonly exited: EventEmitter<CdkDragExit<T>>;
     getSortedItems(): CdkDrag[];
+    hasAnchor: boolean;
     id: string;
     lockAxis: DragAxis;
     // (undocumented)
     static ngAcceptInputType_autoScrollDisabled: unknown;
     // (undocumented)
     static ngAcceptInputType_disabled: unknown;
+    // (undocumented)
+    static ngAcceptInputType_hasAnchor: unknown;
     // (undocumented)
     static ngAcceptInputType_sortingDisabled: unknown;
     // (undocumented)
@@ -273,7 +276,7 @@ export class CdkDropList<T = any> implements OnDestroy {
     sortingDisabled: boolean;
     sortPredicate: (index: number, drag: CdkDrag, drop: CdkDropList) => boolean;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkDropList<any>, "[cdkDropList], cdk-drop-list", ["cdkDropList"], { "connectedTo": { "alias": "cdkDropListConnectedTo"; "required": false; }; "data": { "alias": "cdkDropListData"; "required": false; }; "orientation": { "alias": "cdkDropListOrientation"; "required": false; }; "id": { "alias": "id"; "required": false; }; "lockAxis": { "alias": "cdkDropListLockAxis"; "required": false; }; "disabled": { "alias": "cdkDropListDisabled"; "required": false; }; "sortingDisabled": { "alias": "cdkDropListSortingDisabled"; "required": false; }; "enterPredicate": { "alias": "cdkDropListEnterPredicate"; "required": false; }; "sortPredicate": { "alias": "cdkDropListSortPredicate"; "required": false; }; "autoScrollDisabled": { "alias": "cdkDropListAutoScrollDisabled"; "required": false; }; "autoScrollStep": { "alias": "cdkDropListAutoScrollStep"; "required": false; }; "elementContainerSelector": { "alias": "cdkDropListElementContainer"; "required": false; }; }, { "dropped": "cdkDropListDropped"; "entered": "cdkDropListEntered"; "exited": "cdkDropListExited"; "sorted": "cdkDropListSorted"; }, never, never, true, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkDropList<any>, "[cdkDropList], cdk-drop-list", ["cdkDropList"], { "connectedTo": { "alias": "cdkDropListConnectedTo"; "required": false; }; "data": { "alias": "cdkDropListData"; "required": false; }; "orientation": { "alias": "cdkDropListOrientation"; "required": false; }; "id": { "alias": "id"; "required": false; }; "lockAxis": { "alias": "cdkDropListLockAxis"; "required": false; }; "disabled": { "alias": "cdkDropListDisabled"; "required": false; }; "sortingDisabled": { "alias": "cdkDropListSortingDisabled"; "required": false; }; "enterPredicate": { "alias": "cdkDropListEnterPredicate"; "required": false; }; "sortPredicate": { "alias": "cdkDropListSortPredicate"; "required": false; }; "autoScrollDisabled": { "alias": "cdkDropListAutoScrollDisabled"; "required": false; }; "autoScrollStep": { "alias": "cdkDropListAutoScrollStep"; "required": false; }; "elementContainerSelector": { "alias": "cdkDropListElementContainer"; "required": false; }; "hasAnchor": { "alias": "cdkDropListHasAnchor"; "required": false; }; }, { "dropped": "cdkDropListDropped"; "entered": "cdkDropListEntered"; "exited": "cdkDropListExited"; "sorted": "cdkDropListSorted"; }, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<CdkDropList<any>, never>;
 }
@@ -512,9 +515,11 @@ export class DropListRef<T = any> {
         item: DragRef;
         container: DropListRef;
     }>;
+    getItemAtIndex(index: number): DragRef | null;
     getItemIndex(item: DragRef): number;
     getScrollableParents(): readonly HTMLElement[];
     _getSiblingContainerFromPosition(item: DragRef, x: number, y: number): DropListRef | undefined;
+    hasAnchor: boolean;
     isDragging(): boolean;
     _isOverContainer(x: number, y: number): boolean;
     isReceiving(): boolean;

--- a/src/cdk/drag-drop/directives/drop-list.ts
+++ b/src/cdk/drag-drop/directives/drop-list.ts
@@ -150,6 +150,20 @@ export class CdkDropList<T = any> implements OnDestroy {
    */
   @Input('cdkDropListElementContainer') elementContainerSelector: string | null;
 
+  /**
+   * By default when an item leaves its initial container, its placeholder will be transferred
+   * to the new container. If that's not desirable for your use case, you can enable this option
+   * which will clone the placeholder and leave it inside the original container. If the item is
+   * returned to the initial container, the anchor element will be removed automatically.
+   *
+   * The cloned placeholder can be styled by targeting the `cdk-drag-anchor` class.
+   *
+   * This option is useful in combination with `cdkDropListSortingDisabled` to implement copying
+   * behavior in a drop list.
+   */
+  @Input({alias: 'cdkDropListHasAnchor', transform: booleanAttribute})
+  hasAnchor: boolean;
+
   /** Emits when the user drops an item inside the container. */
   @Output('cdkDropListDropped')
   readonly dropped: EventEmitter<CdkDragDrop<T, any>> = new EventEmitter<CdkDragDrop<T, any>>();
@@ -339,6 +353,7 @@ export class CdkDropList<T = any> implements OnDestroy {
       ref.sortingDisabled = this.sortingDisabled;
       ref.autoScrollDisabled = this.autoScrollDisabled;
       ref.autoScrollStep = coerceNumberProperty(this.autoScrollStep, 2);
+      ref.hasAnchor = this.hasAnchor;
       ref
         .connectedTo(siblings.filter(drop => drop && drop !== this).map(list => list._dropListRef))
         .withOrientation(this.orientation);

--- a/src/cdk/drag-drop/drag-drop.md
+++ b/src/cdk/drag-drop/drag-drop.md
@@ -82,6 +82,7 @@ by the directives:
 | `.cdk-drag-handle`  | Class that is added to the host element of the cdkDragHandle directive.  |
 | `.cdk-drag-preview` | This is the element that will be rendered next to the user's cursor as they're dragging an item in a sortable list. By default the element looks exactly like the element that is being dragged. |
 | `.cdk-drag-placeholder` | This is element that will be shown instead of the real element as it's being dragged inside a `cdkDropList`. By default this will look exactly like the element that is being sorted. |
+| `.cdk-drag-anchor`  | Only relevant when `cdkDropListHasAnchor` is enabled. Element indicating the position from which the dragged item started the drag sequence. |
 | `.cdk-drop-list-dragging` | A class that is added to `cdkDropList` while the user is dragging an item.  |
 | `.cdk-drop-list-disabled` | A class that is added to `cdkDropList` when it is disabled.  |
 | `.cdk-drop-list-receiving`| A class that is added to `cdkDropList` when it can receive an item that is being dragged inside a connected drop list.  |
@@ -172,6 +173,24 @@ the advantage of allowing the items to wrap to the next line, but it **cannot** 
 sorting action.
 
 <!-- example(cdk-drag-drop-mixed-sorting) -->
+
+### Copying items from one list to another
+When the user starts dragging an item in a sortable list, by default the `cdkDropList` directive
+will render out a placeholder element to show where the item will be dropped. If the item is dragged
+into another list, the placeholder will be moved into the new list together with the item.
+
+If your use case calls for the item to remain in the original list, you can set the
+`cdkDropListHasAnchor` input which will tell the `cdkDropList` to create an "anchor" element. The
+anchor differs from the placeholder in that it will stay in the original container and won't move
+to any subsequent containers that the item is dragged into. If the user moves the item back into
+the original container, the anchor will be removed automatically. It can be styled by targeting
+the `cdk-drag-anchor` CSS class.
+
+Combining `cdkDropListHasAnchor` and `cdkDropListSortingDisabled` makes it possible to construct a
+list that user copies items from, but doesn't necessarily transfer out of (e.g. a product list and
+a shopping cart).
+
+<!-- example(cdk-drag-drop-copy-list) -->
 
 ### Restricting movement within an element
 

--- a/src/cdk/drag-drop/drop-list-ref.ts
+++ b/src/cdk/drag-drop/drop-list-ref.ts
@@ -75,6 +75,11 @@ export class DropListRef<T = any> {
   autoScrollStep: number = 2;
 
   /**
+   * Whether the items in the list should leave an anchor node when leaving the initial container.
+   */
+  hasAnchor: boolean = false;
+
+  /**
    * Function that is used to determine whether an item
    * is allowed to be moved into a drop container.
    */
@@ -438,6 +443,16 @@ export class DropListRef<T = any> {
     return this._isDragging
       ? this._sortStrategy.getItemIndex(item)
       : this._draggables.indexOf(item);
+  }
+
+  /**
+   * Gets the item at a specific index.
+   * @param index Index at which to retrieve the item.
+   */
+  getItemAtIndex(index: number): DragRef | null {
+    return this._isDragging
+      ? this._sortStrategy.getItemAtIndex(index)
+      : this._draggables[index] || null;
   }
 
   /**

--- a/src/cdk/drag-drop/sorting/drop-list-sort-strategy.ts
+++ b/src/cdk/drag-drop/sorting/drop-list-sort-strategy.ts
@@ -33,5 +33,6 @@ export interface DropListSortStrategy {
   reset(): void;
   getActiveItemsSnapshot(): readonly DragRef[];
   getItemIndex(item: DragRef): number;
+  getItemAtIndex(index: number): DragRef | null;
   updateOnScroll(topDifference: number, leftDifference: number): void;
 }

--- a/src/cdk/drag-drop/sorting/mixed-sort-strategy.ts
+++ b/src/cdk/drag-drop/sorting/mixed-sort-strategy.ts
@@ -222,6 +222,11 @@ export class MixedSortStrategy implements DropListSortStrategy {
     return this._activeItems.indexOf(item);
   }
 
+  /** Gets the item at a specific index. */
+  getItemAtIndex(index: number): DragRef | null {
+    return this._activeItems[index] || null;
+  }
+
   /** Used to notify the strategy that the scroll position has changed. */
   updateOnScroll(): void {
     this._activeItems.forEach(item => {

--- a/src/cdk/drag-drop/sorting/single-axis-sort-strategy.ts
+++ b/src/cdk/drag-drop/sorting/single-axis-sort-strategy.ts
@@ -263,15 +263,12 @@ export class SingleAxisSortStrategy implements DropListSortStrategy {
 
   /** Gets the index of a specific item. */
   getItemIndex(item: DragRef): number {
-    // Items are sorted always by top/left in the cache, however they flow differently in RTL.
-    // The rest of the logic still stands no matter what orientation we're in, however
-    // we need to invert the array when determining the index.
-    const items =
-      this.orientation === 'horizontal' && this.direction === 'rtl'
-        ? this._itemPositions.slice().reverse()
-        : this._itemPositions;
+    return this._getVisualItemPositions().findIndex(currentItem => currentItem.drag === item);
+  }
 
-    return items.findIndex(currentItem => currentItem.drag === item);
+  /** Gets the item at a specific index. */
+  getItemAtIndex(index: number): DragRef | null {
+    return this._getVisualItemPositions()[index]?.drag || null;
   }
 
   /** Used to notify the strategy that the scroll position has changed. */
@@ -318,6 +315,15 @@ export class SingleAxisSortStrategy implements DropListSortStrategy {
           ? a.clientRect.left - b.clientRect.left
           : a.clientRect.top - b.clientRect.top;
       });
+  }
+
+  private _getVisualItemPositions() {
+    // Items are sorted always by top/left in the cache, however they flow differently in RTL.
+    // The rest of the logic still stands no matter what orientation we're in, however
+    // we need to invert the array when determining the index.
+    return this.orientation === 'horizontal' && this.direction === 'rtl'
+      ? this._itemPositions.slice().reverse()
+      : this._itemPositions;
   }
 
   /**

--- a/src/components-examples/cdk/drag-drop/cdk-drag-drop-copy-list/cdk-drag-drop-copy-list-example.css
+++ b/src/components-examples/cdk/drag-drop/cdk-drag-drop-copy-list/cdk-drag-drop-copy-list-example.css
@@ -1,0 +1,50 @@
+.example-container {
+  width: 400px;
+  max-width: 100%;
+  margin: 0 25px 25px 0;
+  display: inline-block;
+  vertical-align: top;
+}
+
+.example-list {
+  border: solid 1px #ccc;
+  min-height: 60px;
+  background: white;
+  border-radius: 4px;
+  overflow: hidden;
+  display: block;
+}
+
+.example-box {
+  padding: 20px 10px;
+  border-bottom: solid 1px #ccc;
+  color: rgba(0, 0, 0, 0.87);
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  box-sizing: border-box;
+  cursor: move;
+  background: white;
+  font-size: 14px;
+}
+
+.cdk-drag-preview {
+  box-sizing: border-box;
+  border-radius: 4px;
+  box-shadow: 0 5px 5px -3px rgba(0, 0, 0, 0.2),
+              0 8px 10px 1px rgba(0, 0, 0, 0.14),
+              0 3px 14px 2px rgba(0, 0, 0, 0.12);
+}
+
+.cdk-drag-animating {
+  transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
+}
+
+.example-box:last-child {
+  border: none;
+}
+
+.example-list.cdk-drop-list-dragging .example-box:not(.cdk-drag-placeholder) {
+  transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
+}

--- a/src/components-examples/cdk/drag-drop/cdk-drag-drop-copy-list/cdk-drag-drop-copy-list-example.html
+++ b/src/components-examples/cdk/drag-drop/cdk-drag-drop-copy-list/cdk-drag-drop-copy-list-example.html
@@ -1,0 +1,31 @@
+<div class="example-container">
+  <h2>Products</h2>
+
+  <div
+    cdkDropList
+    [cdkDropListData]="products"
+    [cdkDropListConnectedTo]="[cartList]"
+    cdkDropListSortingDisabled
+    cdkDropListHasAnchor
+    class="example-list">
+    @for (product of products; track $index) {
+      <div class="example-box" cdkDrag [cdkDragData]="product">{{product}}</div>
+    }
+  </div>
+</div>
+
+<div class="example-container">
+  <h2>Shopping cart</h2>
+
+  <div
+    cdkDropList
+    #cartList="cdkDropList"
+    [cdkDropListData]="cart"
+    class="example-list"
+    (cdkDropListDropped)="drop($event)">
+    @for (product of cart; track $index) {
+      <div class="example-box" cdkDrag>{{product}}</div>
+    }
+  </div>
+</div>
+

--- a/src/components-examples/cdk/drag-drop/cdk-drag-drop-copy-list/cdk-drag-drop-copy-list-example.ts
+++ b/src/components-examples/cdk/drag-drop/cdk-drag-drop-copy-list/cdk-drag-drop-copy-list-example.ts
@@ -1,0 +1,35 @@
+import {Component} from '@angular/core';
+import {
+  CdkDragDrop,
+  moveItemInArray,
+  copyArrayItem,
+  CdkDrag,
+  CdkDropList,
+} from '@angular/cdk/drag-drop';
+
+/**
+ * @title Drag&Drop copy between lists
+ */
+@Component({
+  selector: 'cdk-drag-drop-copy-list-example',
+  templateUrl: 'cdk-drag-drop-copy-list-example.html',
+  styleUrl: 'cdk-drag-drop-copy-list-example.css',
+  imports: [CdkDropList, CdkDrag],
+})
+export class CdkDragDropCopyListExample {
+  products = ['Bananas', 'Oranges', 'Bread', 'Butter', 'Soda', 'Eggs'];
+  cart = ['Tomatoes'];
+
+  drop(event: CdkDragDrop<string[]>) {
+    if (event.previousContainer === event.container) {
+      moveItemInArray(event.container.data, event.previousIndex, event.currentIndex);
+    } else {
+      copyArrayItem(
+        event.previousContainer.data,
+        event.container.data,
+        event.previousIndex,
+        event.currentIndex,
+      );
+    }
+  }
+}

--- a/src/components-examples/cdk/drag-drop/index.ts
+++ b/src/components-examples/cdk/drag-drop/index.ts
@@ -18,3 +18,4 @@ export {CdkDragDropSortPredicateExample} from './cdk-drag-drop-sort-predicate/cd
 export {CdkDragDropTableExample} from './cdk-drag-drop-table/cdk-drag-drop-table-example';
 export {CdkDragDropMixedSortingExample} from './cdk-drag-drop-mixed-sorting/cdk-drag-drop-mixed-sorting-example';
 export {CdkDragDropTabsExample} from './cdk-drag-drop-tabs/cdk-drag-drop-tabs-example';
+export {CdkDragDropCopyListExample} from './cdk-drag-drop-copy-list/cdk-drag-drop-copy-list-example';


### PR DESCRIPTION
Currently we create a placeholder element to indicate where an item will be dropped. The placeholder gets moved around between drop containers as the user is dragging. In some cases this might not be desirable, because the data representing the dragged item might be copied, rather than moved.

These changes address this use case by adding the `cdkDropListHasAnchor` input. When enabled, it'll tell the drop list to leave an anchor element, representing the dragged item, inside the original list. The anchor differs from the placeholder in that it will stay in the original container and won't move to any subsequent containers.

Fixes #13906.