### PR TITLE
build: remove reflect-metadata dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,6 @@
     "postcss-scss": "^4.0.4",
     "prettier": "^3.5.3",
     "protractor": "^7.0.0",
-    "reflect-metadata": "^0.2.0",
     "requirejs": "^2.3.6",
     "rollup": "^4.0.0",
     "rollup-plugin-dts": "6.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -299,9 +299,6 @@ importers:
       protractor:
         specifier: ^7.0.0
         version: 7.0.0
-      reflect-metadata:
-        specifier: ^0.2.0
-        version: 0.2.2
       requirejs:
         specifier: ^2.3.6
         version: 2.3.7

--- a/src/universal-app/BUILD.bazel
+++ b/src/universal-app/BUILD.bazel
@@ -1,13 +1,13 @@
-load("@bazel_skylib//rules:build_test.bzl", "build_test")
-load("@aspect_rules_js//js:defs.bzl", "js_binary", "js_run_binary")
-load("//tools:defaults.bzl", "http_server", "ng_project", "protractor_web_test_suite", "sass_binary", "ts_project")
-load("@aspect_rules_ts//ts:defs.bzl", rules_js_tsconfig = "ts_config")
 load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
+load("@aspect_rules_js//js:defs.bzl", "js_binary", "js_run_binary")
+load("@aspect_rules_ts//ts:defs.bzl", rules_js_tsconfig = "ts_config")
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("//src/cdk:config.bzl", "CDK_TARGETS")
 load("//src/cdk-experimental:config.bzl", "CDK_EXPERIMENTAL_TARGETS")
 load("//src/components-examples:config.bzl", "ALL_EXAMPLES")
 load("//src/material:config.bzl", "MATERIAL_TARGETS")
 load("//src/material-experimental:config.bzl", "MATERIAL_EXPERIMENTAL_TARGETS")
+load("//tools:defaults.bzl", "http_server", "ng_project", "protractor_web_test_suite", "sass_binary", "ts_project")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -64,7 +64,6 @@ ts_project(
         "//:node_modules/@angular/platform-server",
         "//:node_modules/@bazel/runfiles",
         "//:node_modules/@types/node",
-        "//:node_modules/reflect-metadata",
         "//:node_modules/zone.js",
     ],
 )

--- a/src/universal-app/prerender.ts
+++ b/src/universal-app/prerender.ts
@@ -1,4 +1,3 @@
-import 'reflect-metadata';
 import 'zone.js';
 
 import {ErrorHandler} from '@angular/core';

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -1,5 +1,5 @@
-load("//tools:defaults.bzl", "ts_project")
 load("@aspect_rules_ts//ts:defs.bzl", rules_js_tsconfig = "ts_config")
+load("//tools:defaults.bzl", "ts_project")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -21,7 +21,6 @@ ts_project(
     deps = [
         "//:node_modules/@angular/core",
         "//:node_modules/@angular/platform-browser",
-        "//:node_modules/reflect-metadata",
         "//:node_modules/zone.js",
     ],
 )

--- a/test/angular-test.init.ts
+++ b/test/angular-test.init.ts
@@ -8,7 +8,6 @@
 
 import 'zone.js';
 import 'zone.js/testing';
-import 'reflect-metadata';
 
 import {NgModule, provideCheckNoChangesConfig, provideZonelessChangeDetection} from '@angular/core';
 import {TestBed} from '@angular/core/testing';


### PR DESCRIPTION
We no longer need to include `reflect-metadata` so we can drop it from our test dependencies.