### PR TITLE
docs: update link to Angular security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,3 @@
 Angular is part of Google [Open Source Software Vulnerability Reward Program](https://bughunters.google.com/about/rules/6521337925468160/google-open-source-software-vulnerability-reward-program-rules). For vulnerabilities in Angular, please submit your report [here](https://bughunters.google.com/report).
 
-For more information, check out [Angular's security policy](https://angular.dev/guide/security).
+For more information, check out [Angular's security policy](https://angular.dev/best-practices/security).


### PR DESCRIPTION
The security policy link in `SECURITY.md` leads to a nonexistent page. This change updates that link so that it correctly points to Angular's current security documentation.