### PR TITLE
build: remove git validation from default vscode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,7 +11,6 @@
     "**/bazel-out": true,
     "**/dist": true
   },
-  "git.ignoreLimitWarning": true,
   "[javascript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.formatOnSave": true
@@ -24,8 +23,5 @@
   "editor.rulers": [100],
   "bazel.buildifierExecutable": "node_modules/.bin/buildifier",
   "bazel.buildifierFixOnFormat": true,
-  "bazel.executable": "node_modules/.bin/bazel",
-  "git.inputValidation": true,
-  "git.inputValidationSubjectLength": 100,
-  "git.inputValidationLength": 100
+  "bazel.executable": "node_modules/.bin/bazel"
 }


### PR DESCRIPTION
Removes the validations for git messages that were introduced at some point. It seems like having these in the project overrides the user settings and is annoying for some team members. If somebody wants to run these validations, they can add them to their own vscode settings.