### PR TITLE
docs(multiple): remove invalid tags from doc strings

### DIFF
--- a/src/cdk/collections/dispose-view-repeater-strategy.ts
+++ b/src/cdk/collections/dispose-view-repeater-strategy.ts
@@ -23,7 +23,7 @@ import {
 
 /**
  * A repeater that destroys views when they are removed from a
- * {@link ViewContainerRef}. When new items are inserted into the container,
+ * `ViewContainerRef`. When new items are inserted into the container,
  * the repeater will always construct a new embedded view for each item.
  *
  * @template T The type for the embedded view's $implicit property.

--- a/src/cdk/collections/recycle-view-repeater-strategy.ts
+++ b/src/cdk/collections/recycle-view-repeater-strategy.ts
@@ -24,7 +24,7 @@ import {
 
 /**
  * A repeater that caches views when they are removed from a
- * {@link ViewContainerRef}. When new items are inserted into the container,
+ * `ViewContainerRef`. When new items are inserted into the container,
  * the repeater will reuse one of the cached views instead of creating a new
  * embedded view. Recycling cached views reduces the quantity of expensive DOM
  * inserts.

--- a/src/cdk/collections/view-repeater.ts
+++ b/src/cdk/collections/view-repeater.ts
@@ -50,14 +50,14 @@ export type _ViewRepeaterItemContextFactory<T, R, C extends _ViewRepeaterItemCon
 ) => _ViewRepeaterItemInsertArgs<C>;
 
 /**
- * Extracts the value of an item from an {@link IterableChangeRecord}.
+ * Extracts the value of an item from an `IterableChangeRecord`.
  *
  * @template T The type for the embedded view's $implicit property.
  * @template R The type for the item in each IterableDiffer change record.
  */
 export type _ViewRepeaterItemValueResolver<T, R> = (record: IterableChangeRecord<R>) => T;
 
-/** Indicates how a view was changed by a {@link _ViewRepeater}. */
+/** Indicates how a view was changed by a `_ViewRepeater`. */
 export enum _ViewRepeaterOperation {
   /** The content of an existing view was replaced with another item. */
   REPLACED,
@@ -70,8 +70,7 @@ export enum _ViewRepeaterOperation {
 }
 
 /**
- * Meta data describing the state of a view after it was updated by a
- * {@link _ViewRepeater}.
+ * Meta data describing the state of a view after it was updated by a `_ViewRepeater`.
  *
  * @template R The type for the item in each IterableDiffer change record.
  * @template C The type for the context passed to each embedded view.
@@ -94,7 +93,7 @@ export interface _ViewRepeaterItemChange<R, C> {
 export type _ViewRepeaterItemChanged<R, C> = (change: _ViewRepeaterItemChange<R, C>) => void;
 
 /**
- * Describes a strategy for rendering items in a {@link ViewContainerRef}.
+ * Describes a strategy for rendering items in a `ViewContainerRef`.
  *
  * @template T The type for the embedded view's $implicit property.
  * @template R The type for the item in each IterableDiffer change record.
@@ -113,7 +112,7 @@ export interface _ViewRepeater<T, R, C extends _ViewRepeaterItemContext<T>> {
 }
 
 /**
- * Injection token for {@link _ViewRepeater}. This token is for use by Angular Material only.
+ * Injection token for `_ViewRepeater`. This token is for use by Angular Material only.
  * @docs-private
  */
 export const _VIEW_REPEATER_STRATEGY = new InjectionToken<

--- a/src/cdk/scrolling/virtual-scrollable.ts
+++ b/src/cdk/scrolling/virtual-scrollable.ts
@@ -12,7 +12,7 @@ import {CdkScrollable} from './scrollable';
 export const VIRTUAL_SCROLLABLE = new InjectionToken<CdkVirtualScrollable>('VIRTUAL_SCROLLABLE');
 
 /**
- * Extending the {@link CdkScrollable} to be used as scrolling container for virtual scrolling.
+ * Extending the `CdkScrollable` to be used as scrolling container for virtual scrolling.
  */
 @Directive()
 export abstract class CdkVirtualScrollable extends CdkScrollable {

--- a/src/cdk/table/table.ts
+++ b/src/cdk/table/table.ts
@@ -389,7 +389,7 @@ export class CdkTable<T>
   /**
    * Whether the sticky styler should recalculate cell widths when applying sticky styles. If
    * `false`, cached values will be used instead. This is only applicable to tables with
-   * {@link fixedLayout} enabled. For other tables, cell widths will always be recalculated.
+   * `_fixedLayout` enabled. For other tables, cell widths will always be recalculated.
    */
   private _forceRecalculateCellWidths = true;
 

--- a/src/google-maps/map-marker-clusterer/map-marker-clusterer-types.ts
+++ b/src/google-maps/map-marker-clusterer/map-marker-clusterer-types.ts
@@ -68,16 +68,16 @@ export type onClusterClickHandler = (
 export interface MarkerClustererOptions {
   markers?: Marker[];
   /**
-   * An algorithm to cluster markers. Default is {@link SuperClusterAlgorithm}. Must
-   * provide a `calculate` method accepting {@link AlgorithmInput} and returning
-   * an array of {@link Cluster}.
+   * An algorithm to cluster markers. Default is `SuperClusterAlgorithm`. Must
+   * provide a `calculate` method accepting `AlgorithmInput` and returning
+   * an array of `Cluster`.
    */
   algorithm?: Algorithm;
   algorithmOptions?: AlgorithmOptions;
   map?: google.maps.Map | null;
   /**
-   * An object that converts a {@link Cluster} into a `google.maps.Marker`.
-   * Default is {@link DefaultRenderer}.
+   * An object that converts a `Cluster` into a `google.maps.Marker`.
+   * Default is `DefaultRenderer`.
    */
   renderer?: Renderer;
   onClusterClick?: onClusterClickHandler;
@@ -93,7 +93,7 @@ export declare const defaultOnClusterClickHandler: onClusterClickHandler;
 
 export interface Renderer {
   /**
-   * Turn a {@link Cluster} into a `Marker`.
+   * Turn a `Cluster` into a `Marker`.
    *
    * Below is a simple example to create a marker with the number of markers in the cluster as a label.
    *
@@ -125,7 +125,7 @@ export interface ClusterStats {
 
 export interface Algorithm {
   /**
-   * Calculates an array of {@link Cluster}.
+   * Calculates an array of `Cluster`.
    */
   calculate: ({markers, map}: AlgorithmInput) => AlgorithmOutput;
 }
@@ -156,7 +156,7 @@ export interface AlgorithmInput {
 
 export interface AlgorithmOutput {
   /**
-   * The clusters returned based upon the {@link AlgorithmInput}.
+   * The clusters returned based upon the `AlgorithmInput`.
    */
   clusters: Cluster[];
   /**

--- a/src/material/datepicker/datepicker-base.ts
+++ b/src/material/datepicker/datepicker-base.ts
@@ -352,7 +352,7 @@ export interface MatDatepickerControl<D> {
   stateChanges: Observable<void>;
 }
 
-/** A datepicker that can be attached to a {@link MatDatepickerControl}. */
+/** A datepicker that can be attached to a `MatDatepickerControl`. */
 export interface MatDatepickerPanel<
   C extends MatDatepickerControl<D>,
   S,


### PR DESCRIPTION
We had `@link` doc strings in several doc strings, but we don't have any handling for `@link` in the pipeline which was causing it to log some warnings. These changes remove the invalid tags.