### PR TITLE
fix(material/radio): color tokens excluded when passing in variant

### DIFF
--- a/src/material/radio/_m3-radio.scss
+++ b/src/material/radio/_m3-radio.scss
@@ -47,7 +47,7 @@
   // Temporary removal where color variants previously did not include the
   // unselected icon color. Remove this and approve internal screenshot changes.
   @if $color-variant {
-    $tokens: map.remove($tokens, color, radio-unselected-icon-color);
+    $tokens: map.deep-remove($tokens, color, radio-unselected-icon-color);
   }
 
   @return $tokens;


### PR DESCRIPTION
Fixes that when passing in a variant into the radio button's `get-tokens` function, we were removing the color tokens altogether, because passing in multiple arguments into `map.remove` removes all those keys, rather than removing a nested value.

Fixes #31319.