### PR TITLE
docs(material/cdk/observers):  Documentation supplement due to extended capabilities of the directive

### DIFF
--- a/src/cdk/observers/observers.md
+++ b/src/cdk/observers/observers.md
@@ -12,3 +12,10 @@ mutation to the content is observed.
   <ng-content></ng-content>
 </div>
 ```
+
+Directive also can be used for observing any type of content
+```html
+<div class="content-wrapper" (click)="changeText()" (cdkObserveContent)="textChanged()">
+  {{ text }}
+</div>
+```


### PR DESCRIPTION
When using the **cdkObserveContent** directive, I noticed that it reacts to changes in any content within the element it applies to, not just **ng-content**, or is this a coincidence?

If this is intended, I suggest improving the documentation so that this feature does not seem like a coincidence.
https://material.angular.dev/cdk/observers/overview

_The suggested changes to the code could be edited better to convey the information more simply_

Example:
```html
<div class="content-wrapper" (click)="changeText()" (cdkObserveContent)="textChanged()">
  {{ text }}
</div>
```

```
text = 'text1';

textChanged() {
  console.log(this.text);
}

changeText() {
  this.text = 'text2';
}
```

When I click on the div in the console I see a message:
![image](https://github.com/user-attachments/assets/9284c96a-3d48-45ba-8003-efe2df9ce6bb)