### PR TITLE
fix(multiple): use inline m2 token definitions

### DIFF
--- a/src/material/autocomplete/_autocomplete-theme.scss
+++ b/src/material/autocomplete/_autocomplete-theme.scss
@@ -2,50 +2,44 @@
 @use '../core/theming/theming';
 @use '../core/theming/inspection';
 @use '../core/typography/typography';
-@use '../core/style/sass-utils';
 @use '../core/tokens/token-utils';
 @use 'm2-autocomplete';
 @use 'm3-autocomplete';
 
 @mixin base($theme) {
+  $tokens: m2-autocomplete.get-unthemable-tokens();
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-autocomplete.get-tokens($theme), base));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-autocomplete.get-unthemable-tokens());
-    }
+    $tokens: map.get(m3-autocomplete.get-tokens($theme), base);
   }
+
+  @include token-utils.values($tokens);
 }
 
 @mixin color($theme) {
+  $tokens: m2-autocomplete.get-color-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-autocomplete.get-tokens($theme), color));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-autocomplete.get-color-tokens($theme));
-    }
+    $tokens: map.get(m3-autocomplete.get-tokens($theme), color);
   }
+
+  @include token-utils.values($tokens);
 }
 
 @mixin typography($theme) {
+  $tokens: m2-autocomplete.get-typography-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(
-        map.get(m3-autocomplete.get-tokens($theme), typography));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-autocomplete.get-typography-tokens($theme));
-    }
+    $tokens: map.get(m3-autocomplete.get-tokens($theme), typography);
   }
+
+  @include token-utils.values($tokens);
 }
 
 @mixin density($theme) {
+  $tokens: m2-autocomplete.get-density-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-autocomplete.get-tokens($theme), density));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-autocomplete.get-density-tokens($theme));
-    }
+    $tokens: map.get(m3-autocomplete.get-tokens($theme), density);
   }
+
+  @include token-utils.values($tokens);
 }
 
 /// Defines the tokens that will be available in the `overrides` mixin and for docs extraction.

--- a/src/material/badge/_badge-theme.scss
+++ b/src/material/badge/_badge-theme.scss
@@ -1,4 +1,3 @@
-@use '../core/style/sass-utils';
 @use '../core/theming/inspection';
 @use '../core/theming/theming';
 @use '../core/tokens/token-utils';
@@ -12,14 +11,12 @@
 /// for the mat-badge.
 /// @param {Map} $theme The theme to generate base styles for.
 @mixin base($theme) {
+  $tokens: m2-badge.get-unthemable-tokens();
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-badge.get-tokens($theme), base));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-badge.get-unthemable-tokens()
-      );
-    }
+    $tokens: map.get(m3-badge.get-tokens($theme), base);
   }
+
+  @include token-utils.values($tokens);
 }
 
 /// Outputs color theme styles for the mat-badge.
@@ -28,24 +25,22 @@
 ///     the badge: primary, secondary, tertiary, or error (If not specified,
 ///     default error color will be used).
 @mixin color($theme, $color-variant: null) {
+  $tokens: m2-badge.get-color-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(
-        map.get(m3-badge.get-tokens($theme, $color-variant), color));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-badge.get-color-tokens($theme));
-    }
+    $tokens: map.get(m3-badge.get-tokens($theme, $color-variant), color);
+  }
 
+  @include token-utils.values($tokens);
+
+  @if inspection.get-theme-version($theme) != 1 {
     .mat-badge-accent {
-      @include token-utils.create-token-values-mixed(
-        m2-badge.private-get-color-palette-color-tokens($theme, secondary)
-      );
+      $tokens: m2-badge.private-get-color-palette-color-tokens($theme, secondary);
+      @include token-utils.values($tokens);
     }
 
     .mat-badge-warn {
-      @include token-utils.create-token-values-mixed(
-        m2-badge.private-get-color-palette-color-tokens($theme, error)
-      );
+      $tokens: m2-badge.private-get-color-palette-color-tokens($theme, error);
+      @include token-utils.values($tokens);
     }
   }
 }
@@ -53,24 +48,23 @@
 /// Outputs typography theme styles for the mat-badge.
 /// @param {Map} $theme The theme to generate typography styles for.
 @mixin typography($theme) {
+  $tokens: m2-badge.get-typography-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-badge.get-tokens($theme), typography));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(
-        m2-badge.get-typography-tokens($theme)
-      );
-    }
+    $tokens: map.get(m3-badge.get-tokens($theme), typography);
   }
+
+  @include token-utils.values($tokens);
 }
 
 /// Outputs density theme styles for the mat-badge.
 /// @param {Map} $theme The theme to generate density styles for.
 @mixin density($theme) {
+  $tokens: m2-badge.get-density-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-badge.get-tokens($theme), density));
-  } @else {
+    $tokens: map.get(m3-badge.get-tokens($theme), density);
   }
+
+  @include token-utils.values($tokens);
 }
 
 /// Defines the tokens that will be available in the `overrides` mixin and for docs extraction.

--- a/src/material/bottom-sheet/_bottom-sheet-theme.scss
+++ b/src/material/bottom-sheet/_bottom-sheet-theme.scss
@@ -2,53 +2,44 @@
 @use '../core/typography/typography';
 @use '../core/theming/theming';
 @use '../core/theming/inspection';
-@use '../core/style/sass-utils';
 @use '../core/tokens/token-utils';
 @use './m2-bottom-sheet';
 @use './m3-bottom-sheet';
 
 @mixin base($theme) {
+  $tokens: m2-bottom-sheet.get-unthemable-tokens();
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-bottom-sheet.get-tokens($theme), base));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-bottom-sheet.get-unthemable-tokens());
-    }
+    $tokens: map.get(m3-bottom-sheet.get-tokens($theme), base);
   }
+
+  @include token-utils.values($tokens);
 }
 
 @mixin color($theme) {
+  $tokens: m2-bottom-sheet.get-color-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(
-        map.get(m3-bottom-sheet.get-tokens($theme), color));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(
-        m2-bottom-sheet.get-color-tokens($theme)
-      );
-    }
+    $tokens: map.get(m3-bottom-sheet.get-tokens($theme), color);
   }
+
+  @include token-utils.values($tokens);
 }
 
 @mixin typography($theme) {
+  $tokens: m2-bottom-sheet.get-typography-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(
-        map.get(m3-bottom-sheet.get-tokens($theme), typography));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(
-        m2-bottom-sheet.get-typography-tokens($theme)
-      );
-    }
+    $tokens: map.get(m3-bottom-sheet.get-tokens($theme), typography);
   }
+
+  @include token-utils.values($tokens);
 }
 
 @mixin density($theme) {
+  $tokens: m2-bottom-sheet.get-density-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(
-        map.get(m3-bottom-sheet.get-tokens($theme), density));
-  } @else {
+    $tokens: map.get(m3-bottom-sheet.get-tokens($theme), density);
   }
+
+  @include token-utils.values($tokens);
 }
 
 /// Defines the tokens that will be available in the `overrides` mixin and for docs extraction.

--- a/src/material/button-toggle/_button-toggle-theme.scss
+++ b/src/material/button-toggle/_button-toggle-theme.scss
@@ -1,4 +1,3 @@
-@use '../core/style/sass-utils';
 @use '../core/theming/inspection';
 @use '../core/theming/theming';
 @use '../core/tokens/token-utils';
@@ -11,14 +10,12 @@
 /// for the mat-button-toggle.
 /// @param {Map} $theme The theme to generate base styles for.
 @mixin base($theme) {
+  $tokens: m2-button-toggle.get-unthemable-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-button-toggle.get-tokens($theme), base));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(
-          m2-button-toggle.get-unthemable-tokens($theme));
-    }
+    $tokens: map.get(m3-button-toggle.get-tokens($theme), base);
   }
+
+  @include token-utils.values($tokens);
 }
 
 /// Outputs color theme styles for the mat-button-toggle.
@@ -26,43 +23,34 @@
 /// @param {String} $color-variant: The color variant to use for the button toggle: primary,
 ///        secondary, tertiary, or error (If not specified, default secondary color will be used).
 @mixin color($theme, $color-variant: null) {
+  $tokens: m2-button-toggle.get-color-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(
-        map.get(m3-button-toggle.get-tokens($theme, $color-variant), color));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(
-        m2-button-toggle.get-color-tokens($theme)
-      );
-    }
+    $tokens: map.get(m3-button-toggle.get-tokens($theme, $color-variant), color);
   }
+
+  @include token-utils.values($tokens);
 }
 
 /// Outputs typography theme styles for the mat-button-toggle.
 /// @param {Map} $theme The theme to generate typography styles for.
 @mixin typography($theme) {
+  $tokens: m2-button-toggle.get-typography-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(
-        map.get(m3-button-toggle.get-tokens($theme), typography));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(
-          m2-button-toggle.get-typography-tokens($theme));
-    }
+    $tokens: map.get(m3-button-toggle.get-tokens($theme), typography);
   }
+
+  @include token-utils.values($tokens);
 }
 
 /// Outputs density theme styles for the mat-button-toggle.
 /// @param {Map} $theme The theme to generate density styles for.
 @mixin density($theme) {
+  $tokens: m2-button-toggle.get-density-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(
-        map.get(m3-button-toggle.get-tokens($theme), density));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-button-toggle.get-density-tokens($theme));
-    }
+    $tokens: map.get(m3-button-toggle.get-tokens($theme), density);
   }
+
+  @include token-utils.values($tokens);
 }
 
 /// Defines the tokens that will be available in the `overrides` mixin and for docs extraction.

--- a/src/material/button/_button-theme.scss
+++ b/src/material/button/_button-theme.scss
@@ -1,4 +1,3 @@
-@use '../core/style/sass-utils';
 @use '../core/theming/inspection';
 @use '../core/theming/theming';
 @use '../core/tokens/token-utils';
@@ -7,27 +6,16 @@
 @use './m3-button';
 @use 'sass:map';
 
-@mixin _m2-button-variant($theme, $palette) {
-  $mat-tokens: if(
-    $palette,
-    m2-button.private-get-color-palette-color-tokens($theme, $palette),
-    m2-button.get-color-tokens($theme)
-  );
-
-  @include token-utils.create-token-values-mixed($mat-tokens);
-}
-
 /// Outputs base theme styles (styles not dependent on the color, typography, or density settings)
 /// for the mat-button.
 /// @param {Map} $theme The theme to generate base styles for.
 @mixin base($theme) {
+  $tokens: m2-button.get-unthemable-tokens();
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-button.get-tokens($theme), base));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-button.get-unthemable-tokens());
-    }
+    $tokens: map.get(m3-button.get-tokens($theme), base);
   }
+
+  @include token-utils.values($tokens);
 }
 
 /// Outputs color theme styles for the mat-button.
@@ -36,56 +24,53 @@
 ///     the badge: primary, secondary, tertiary, or error (If not specified,
 ///     default primary color will be used).
 @mixin color($theme, $color-variant: null) {
+  $tokens: m2-button.get-color-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(
-        map.get(m3-button.get-tokens($theme, $color-variant), color));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include _m2-button-variant($theme, null);
-    }
+    $tokens: map.get(m3-button.get-tokens($theme, $color-variant), color);
+  }
 
+  @include token-utils.values($tokens);
+
+  @if inspection.get-theme-version($theme) != 1 {
     .mat-mdc-button,
     .mat-mdc-unelevated-button,
     .mat-mdc-raised-button,
     .mat-mdc-outlined-button,
     .mat-tonal-button {
       &.mat-primary {
-        @include _m2-button-variant($theme, primary);
+        $tokens: m2-button.private-get-color-palette-color-tokens($theme, primary);
+        @include token-utils.values($tokens);
       }
 
       &.mat-accent {
-        @include _m2-button-variant($theme, secondary);
+        $tokens: m2-button.private-get-color-palette-color-tokens($theme, secondary);
+        @include token-utils.values($tokens);
       }
 
       &.mat-warn {
-        @include _m2-button-variant($theme, error);
+        $tokens: m2-button.private-get-color-palette-color-tokens($theme, error);
+        @include token-utils.values($tokens);
       }
     }
   }
 }
 
-/// Outputs typography theme styles for the mat-button.
-/// @param {Map} $theme The theme to generate typography styles for.
 @mixin typography($theme) {
+  $tokens: m2-button.get-typography-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-button.get-tokens($theme), typography));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-button.get-typography-tokens($theme));
-    }
+    $tokens: map.get(m3-button.get-tokens($theme), typography);
   }
+
+  @include token-utils.values($tokens);
 }
 
-/// Outputs density theme styles for the mat-button.
-/// @param {Map} $theme The theme to generate density styles for.
 @mixin density($theme) {
+  $tokens: m2-button.get-density-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-button.get-tokens($theme), density));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-button.get-density-tokens($theme));
-    }
+    $tokens: map.get(m3-button.get-tokens($theme), density);
   }
+
+  @include token-utils.values($tokens);
 }
 
 /// Defines the tokens that will be available in the `overrides` mixin and for docs extraction.

--- a/src/material/button/_fab-theme.scss
+++ b/src/material/button/_fab-theme.scss
@@ -1,4 +1,3 @@
-@use '../core/style/sass-utils';
 @use '../core/theming/theming';
 @use '../core/theming/inspection';
 @use './m2-fab';
@@ -11,23 +10,12 @@
 /// for the mat-fab.
 /// @param {Map} $theme The theme to generate base styles for.
 @mixin base($theme) {
+  $tokens: m2-fab.get-unthemable-tokens();
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-fab.get-tokens($theme), base));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-fab.get-unthemable-tokens());
-    }
+    $tokens: map.get(m3-fab.get-tokens($theme), base);
   }
-}
 
-@mixin _fab-variant($theme, $palette) {
-  $mat-tokens: if(
-    $palette,
-    m2-fab.private-get-color-palette-color-tokens($theme, $palette),
-    m2-fab.get-color-tokens($theme)
-  );
-
-  @include token-utils.create-token-values-mixed($mat-tokens);
+  @include token-utils.values($tokens);
 }
 
 /// Outputs color theme styles for the mat-fab.
@@ -35,25 +23,28 @@
 /// @param {ArgList} $color-variant: The color variant to use for the fab: primary, secondary,
 //          or tertiary. (If not specified, default primary color will be used).
 @mixin color($theme, $color-variant: null) {
+  $tokens: m2-fab.get-color-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(
-        map.get(m3-fab.get-tokens($theme, $color-variant), color));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include _fab-variant($theme, null);
+    $tokens: map.get(m3-fab.get-tokens($theme, $color-variant), color);
+  }
 
-      .mat-mdc-fab, .mat-mdc-mini-fab {
-        &.mat-primary {
-          @include _fab-variant($theme, primary);
-        }
+  @include token-utils.values($tokens);
 
-        &.mat-accent {
-          @include _fab-variant($theme, secondary);
-        }
+  @if inspection.get-theme-version($theme) != 1 {
+    .mat-mdc-fab, .mat-mdc-mini-fab {
+      &.mat-primary {
+        $tokens: m2-fab.private-get-color-palette-color-tokens($theme, primary);
+        @include token-utils.values($tokens);
+      }
 
-        &.mat-warn {
-          @include _fab-variant($theme, error);
-        }
+      &.mat-accent {
+        $tokens: m2-fab.private-get-color-palette-color-tokens($theme, secondary);
+        @include token-utils.values($tokens);
+      }
+
+      &.mat-warn {
+        $tokens: m2-fab.private-get-color-palette-color-tokens($theme, error);
+        @include token-utils.values($tokens);
       }
     }
   }
@@ -62,25 +53,23 @@
 /// Outputs typography theme styles for the mat-fab.
 /// @param {Map} $theme The theme to generate typography styles for.
 @mixin typography($theme) {
+  $tokens: m2-fab.get-typography-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-fab.get-tokens($theme), typography));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-fab.get-typography-tokens($theme));
-    }
+    $tokens: map.get(m3-fab.get-tokens($theme), typography);
   }
+
+  @include token-utils.values($tokens);
 }
 
 /// Outputs density theme styles for the mat-fab.
 /// @param {Map} $theme The theme to generate density styles for.
 @mixin density($theme) {
+  $tokens: m2-fab.get-density-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-fab.get-tokens($theme), density));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-fab.get-density-tokens($theme));
-    }
+    $tokens: map.get(m3-fab.get-tokens($theme), density);
   }
+
+  @include token-utils.values($tokens);
 }
 
 /// Defines the tokens that will be available in the `overrides` mixin and for docs extraction.

--- a/src/material/button/_icon-button-theme.scss
+++ b/src/material/button/_icon-button-theme.scss
@@ -8,14 +8,12 @@
 @use '../core/theming/inspection';
 
 @mixin base($theme) {
+  $tokens: m2-icon-button.get-unthemable-tokens();
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-icon-button.get-tokens($theme), base));
-  } @else {
-    // Add default values for tokens not related to color, typography, or density.
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-icon-button.get-unthemable-tokens());
-    }
+    $tokens: map.get(m3-icon-button.get-tokens($theme), base);
   }
+
+  @include token-utils.values($tokens);
 }
 
 @mixin _m2-icon-button-variant($theme, $palette) {
@@ -33,45 +31,45 @@
 /// @param {String} $color-variant: The color variant to use for the
 //         button: primary, secondary, tertiary, or error.
 @mixin color($theme, $color-variant: null) {
+  $tokens: m2-icon-button.get-color-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(
-        map.get(m3-icon-button.get-tokens($theme, $color-variant), color));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include _m2-icon-button-variant($theme, null);
+    $tokens: map.get(m3-icon-button.get-tokens($theme, $color-variant), color);
+  }
 
-      .mat-mdc-icon-button {
-        &.mat-primary {
-          @include _m2-icon-button-variant($theme, primary);
-        }
+  @include token-utils.values($tokens);
 
-        &.mat-accent {
-          @include _m2-icon-button-variant($theme, secondary);
-        }
+  @if inspection.get-theme-version($theme) != 1 {
+    .mat-mdc-icon-button {
+      &.mat-primary {
+        $tokens: m2-icon-button.private-get-color-palette-color-tokens($theme, primary);
+        @include token-utils.values($tokens);
+      }
 
-        &.mat-warn {
-          @include _m2-icon-button-variant($theme, error);
-        }
+      &.mat-accent {
+        $tokens: m2-icon-button.private-get-color-palette-color-tokens($theme, secondary);
+        @include token-utils.values($tokens);
+      }
+
+      &.mat-warn {
+        $tokens: m2-icon-button.private-get-color-palette-color-tokens($theme, error);
+        @include token-utils.values($tokens);
       }
     }
   }
 }
 
 @mixin typography($theme) {
+  $tokens: m2-icon-button.get-typography-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(
-        map.get(m3-icon-button.get-tokens($theme), typography));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-icon-button.get-typography-tokens($theme)
-      );
-    }
+    $tokens: map.get(m3-icon-button.get-tokens($theme), typography);
   }
+
+  @include token-utils.values($tokens);
 }
 
 @mixin density($theme) {
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-icon-button.get-tokens($theme), density));
+    @include token-utils.values(map.get(m3-icon-button.get-tokens($theme), density));
   } @else {
     $icon-size: 24px;
     $density-scale: inspection.get-theme-density($theme);
@@ -86,7 +84,7 @@
     $calculated-size: map.get($size-map, $density-scale);
 
     @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(
+      @include token-utils.values(
           m2-icon-button.get-density-tokens(
               $theme, $exclude: (icon-button-state-layer-size))
       );

--- a/src/material/card/_card-theme.scss
+++ b/src/material/card/_card-theme.scss
@@ -1,5 +1,4 @@
 @use 'sass:map';
-@use '../core/style/sass-utils';
 @use '../core/theming/theming';
 @use '../core/theming/inspection';
 @use '../core/typography/typography';
@@ -8,43 +7,39 @@
 @use './m3-card';
 
 @mixin base($theme) {
+  $tokens: m2-card.get-unthemable-tokens();
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-card.get-tokens($theme), base));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-card.get-unthemable-tokens());
-    }
+    $tokens: map.get(m3-card.get-tokens($theme), base);
   }
+
+  @include token-utils.values($tokens);
 }
 
 @mixin color($theme) {
+  $tokens: m2-card.get-color-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-card.get-tokens($theme), color));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-card.get-color-tokens($theme));
-    }
+    $tokens: map.get(m3-card.get-tokens($theme), color);
   }
+
+  @include token-utils.values($tokens);
 }
 
 @mixin typography($theme) {
+  $tokens: m2-card.get-typography-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-card.get-tokens($theme), typography));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-card.get-typography-tokens($theme));
-    }
+    $tokens: map.get(m3-card.get-tokens($theme), typography);
   }
+
+  @include token-utils.values($tokens);
 }
 
 @mixin density($theme) {
+  $tokens: m2-card.get-density-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-card.get-tokens($theme), density));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-card.get-density-tokens($theme));
-    }
+    $tokens: map.get(m3-card.get-tokens($theme), density);
   }
+
+  @include token-utils.values($tokens);
 }
 
 /// Defines the tokens that will be available in the `overrides` mixin and for docs extraction.

--- a/src/material/checkbox/_checkbox-theme.scss
+++ b/src/material/checkbox/_checkbox-theme.scss
@@ -1,4 +1,3 @@
-@use '../core/style/sass-utils';
 @use '../core/theming/theming';
 @use '../core/theming/inspection';
 @use '../core/tokens/token-utils';
@@ -11,28 +10,26 @@
 /// for the mat-checkbox.
 /// @param {Map} $theme The theme to generate base styles for.
 @mixin base($theme) {
+  $tokens: m2-checkbox.get-unthemable-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-checkbox.get-tokens($theme), base));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-checkbox.get-unthemable-tokens($theme));
-    }
+    $tokens: map.get(m3-checkbox.get-tokens($theme), base);
   }
+
+  @include token-utils.values($tokens);
 }
 
 /// Outputs color theme styles for the mat-checkbox.
 /// @param {Map} $theme The theme to generate color styles for.
 /// @param {String} $color-variant The color variant to use for the component
 @mixin color($theme, $color-variant: null) {
+  $tokens: m2-checkbox.get-color-tokens($theme, secondary);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(
-        map.get(m3-checkbox.get-tokens($theme, $color-variant), color));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(
-          m2-checkbox.get-color-tokens($theme, secondary));
-    }
+    $tokens: map.get(m3-checkbox.get-tokens($theme, $color-variant), color);
+  }
 
+  @include token-utils.values($tokens);
+
+  @if inspection.get-theme-version($theme) != 1 {
     .mat-mdc-checkbox {
       &.mat-primary {
         @include token-utils.create-token-values-mixed(
@@ -51,29 +48,22 @@
   }
 }
 
-/// Outputs typography theme styles for the mat-checkbox.
-/// @param {Map} $theme The theme to generate typography styles for.
 @mixin typography($theme) {
+  $tokens: m2-checkbox.get-typography-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(
-        map.get(m3-checkbox.get-tokens($theme), typography));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-checkbox.get-typography-tokens($theme));
-    }
+    $tokens: map.get(m3-checkbox.get-tokens($theme), typography);
   }
+
+  @include token-utils.values($tokens);
 }
 
-/// Outputs density theme styles for the mat-checkbox.
-/// @param {Map} $theme The theme to generate density styles for.
 @mixin density($theme) {
+  $tokens: m2-checkbox.get-density-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-checkbox.get-tokens($theme), density));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-checkbox.get-density-tokens($theme));
-    }
+    $tokens: map.get(m3-checkbox.get-tokens($theme), density);
   }
+
+  @include token-utils.values($tokens);
 }
 
 /// Defines the tokens that will be available in the `overrides` mixin and for docs extraction.

--- a/src/material/core/_core-theme.scss
+++ b/src/material/core/_core-theme.scss
@@ -4,7 +4,6 @@
 @use './option/option-theme';
 @use './option/optgroup-theme';
 @use './selection/pseudo-checkbox/pseudo-checkbox-theme';
-@use './style/sass-utils';
 @use './typography/typography';
 @use './tokens/token-utils';
 @use './m2-app';
@@ -16,71 +15,59 @@
 @use 'sass:map';
 
 @mixin base($theme) {
+  $tokens: m2-app.get-unthemable-tokens();
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-app.get-tokens($theme), base));
-    @include token-utils.create-token-values(map.get(m3-ripple.get-tokens($theme), base));
-    @include token-utils.create-token-values(map.get(m3-option.get-tokens($theme), base));
-    @include token-utils.create-token-values(map.get(m3-optgroup.get-tokens($theme), base));
-    @include token-utils.create-token-values(map.get(m3-pseudo-checkbox.get-tokens($theme), base));
-  } @else {
-    @include ripple-theme.base($theme);
-    @include option-theme.base($theme);
-    @include optgroup-theme.base($theme);
-    @include pseudo-checkbox-theme.base($theme);
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-app.get-unthemable-tokens());
-    }
+    $tokens: map.get(m3-app.get-tokens($theme), base);
   }
+
+  @include token-utils.values($tokens);
+
+  @include ripple-theme.base($theme);
+  @include option-theme.base($theme);
+  @include optgroup-theme.base($theme);
+  @include pseudo-checkbox-theme.base($theme);
 }
 
 @mixin color($theme) {
+  $tokens: m2-app.get-color-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-app.get-tokens($theme), color));
-    @include token-utils.create-token-values(map.get(m3-ripple.get-tokens($theme), color));
-    @include token-utils.create-token-values(map.get(m3-option.get-tokens($theme), color));
-    @include token-utils.create-token-values(map.get(m3-optgroup.get-tokens($theme), color));
-    @include token-utils.create-token-values(map.get(m3-pseudo-checkbox.get-tokens($theme), color));
-  } @else {
-    @include ripple-theme.color($theme);
-    @include option-theme.color($theme);
-    @include optgroup-theme.color($theme);
-    @include pseudo-checkbox-theme.color($theme);
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-app.get-color-tokens($theme));
-    }
+    $tokens: map.get(m3-app.get-tokens($theme), color);
   }
+
+  @include token-utils.values($tokens);
+
+  @include ripple-theme.color($theme);
+  @include option-theme.color($theme);
+  @include optgroup-theme.color($theme);
+  @include pseudo-checkbox-theme.color($theme);
 }
 
 @mixin typography($theme) {
+  $tokens: m2-app.get-typography-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-app.get-tokens($theme), typography));
-    @include token-utils.create-token-values(map.get(m3-ripple.get-tokens($theme), typography));
-    @include token-utils.create-token-values(map.get(m3-option.get-tokens($theme), typography));
-    @include token-utils.create-token-values(map.get(m3-optgroup.get-tokens($theme), typography));
-    @include token-utils.create-token-values(
-        map.get(m3-pseudo-checkbox.get-tokens($theme), typography));
-  } @else {
-    @include option-theme.typography($theme);
-    @include optgroup-theme.typography($theme);
-    @include pseudo-checkbox-theme.typography($theme);
-    @include ripple-theme.typography($theme);
+    $tokens: map.get(m3-app.get-tokens($theme), typography);
   }
+
+  @include token-utils.values($tokens);
+
+  @include ripple-theme.typography($theme);
+  @include option-theme.typography($theme);
+  @include optgroup-theme.typography($theme);
+  @include pseudo-checkbox-theme.typography($theme);
 }
 
 @mixin density($theme) {
+  $tokens: m2-app.get-density-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-app.get-tokens($theme), density));
-    @include token-utils.create-token-values(map.get(m3-ripple.get-tokens($theme), density));
-    @include token-utils.create-token-values(map.get(m3-option.get-tokens($theme), density));
-    @include token-utils.create-token-values(map.get(m3-optgroup.get-tokens($theme), density));
-    @include token-utils.create-token-values(
-        map.get(m3-pseudo-checkbox.get-tokens($theme), density));
-  } @else {
-    @include option-theme.density($theme);
-    @include optgroup-theme.density($theme);
-    @include pseudo-checkbox-theme.density($theme);
-    @include ripple-theme.density($theme);
+    $tokens: map.get(m3-app.get-tokens($theme), density);
   }
+
+  @include token-utils.values($tokens);
+
+  @include ripple-theme.density($theme);
+  @include option-theme.density($theme);
+  @include optgroup-theme.density($theme);
+  @include pseudo-checkbox-theme.density($theme);
 }
 
 @function _define-overrides() {

--- a/src/material/core/option/_optgroup-theme.scss
+++ b/src/material/core/option/_optgroup-theme.scss
@@ -2,43 +2,44 @@
 @use './m2-optgroup';
 @use './m3-optgroup';
 @use '../tokens/token-utils';
-@use '../style/sass-utils';
 @use '../theming/theming';
 @use '../theming/inspection';
 @use '../typography/typography';
 
 @mixin base($theme) {
+  $tokens: m2-optgroup.get-unthemable-tokens();
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-optgroup.get-tokens($theme), base));
-  } @else {
+    $tokens: map.get(m3-optgroup.get-tokens($theme), base);
   }
+
+  @include token-utils.values($tokens);
 }
 
 @mixin color($theme) {
+  $tokens: m2-optgroup.get-color-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-optgroup.get-tokens($theme), color));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-optgroup.get-color-tokens($theme));
-    }
+    $tokens: map.get(m3-optgroup.get-tokens($theme), color);
   }
+
+  @include token-utils.values($tokens);
 }
 
 @mixin typography($theme) {
+  $tokens: m2-optgroup.get-typography-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-optgroup.get-tokens($theme), typography));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-optgroup.get-typography-tokens($theme));
-    }
+    $tokens: map.get(m3-optgroup.get-tokens($theme), typography);
   }
+
+  @include token-utils.values($tokens);
 }
 
 @mixin density($theme) {
+  $tokens: m2-optgroup.get-density-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-optgroup.get-tokens($theme), base));
-  } @else {
+    $tokens: map.get(m3-optgroup.get-tokens($theme), density);
   }
+
+  @include token-utils.values($tokens);
 }
 
 /// Defines the tokens that will be available in the `overrides` mixin and for docs extraction.

--- a/src/material/core/option/_option-theme.scss
+++ b/src/material/core/option/_option-theme.scss
@@ -1,7 +1,6 @@
 @use './m2-option';
 @use './m3-option';
 @use '../tokens/token-utils';
-@use '../style/sass-utils';
 @use '../theming/theming';
 @use '../theming/inspection';
 @use '../typography/typography';
@@ -11,30 +10,34 @@
 /// for the mat-option.
 /// @param {Map} $theme The theme to generate base styles for.
 @mixin base($theme) {
+  $tokens: m2-option.get-unthemable-tokens();
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-option.get-tokens($theme), base));
-  } @else {
+    $tokens: map.get(m3-option.get-tokens($theme), base);
   }
+
+  @include token-utils.values($tokens);
 }
 
 /// Outputs color theme styles for the mat-option.
 /// @param {Map} $theme The theme to generate color styles for.
 /// @param {String} $color-variant The color variant to use for the component (M3 only)
 @mixin color($theme, $color-variant: null) {
+  $tokens: m2-option.get-color-tokens($theme, primary);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(
-        map.get(m3-option.get-tokens($theme, $color-variant), color));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-option.get-color-tokens($theme, primary));
-    }
+    $tokens: map.get(m3-option.get-tokens($theme, $color-variant), color);
+  }
 
+  @include token-utils.values($tokens);
+
+  @if inspection.get-theme-version($theme) != 1 {
     .mat-accent {
-      @include token-utils.create-token-values-mixed(m2-option.get-color-tokens($theme, secondary));
+      $tokens: m2-option.get-color-tokens($theme, secondary);
+      @include token-utils.values($tokens);
     }
 
     .mat-warn {
-      @include token-utils.create-token-values-mixed(m2-option.get-color-tokens($theme, error));
+      $tokens: m2-option.get-color-tokens($theme, error);
+      @include token-utils.values($tokens);
     }
   }
 }
@@ -42,22 +45,23 @@
 /// Outputs typography theme styles for the mat-option.
 /// @param {Map} $theme The theme to generate typography styles for.
 @mixin typography($theme) {
+  $tokens: m2-option.get-typography-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-option.get-tokens($theme), typography));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-option.get-typography-tokens($theme));
-    }
+    $tokens: map.get(m3-option.get-tokens($theme), typography);
   }
+
+  @include token-utils.values($tokens);
 }
 
 /// Outputs density theme styles for the mat-option.
 /// @param {Map} $theme The theme to generate density styles for.
 @mixin density($theme) {
+  $tokens: m2-option.get-density-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-option.get-tokens($theme), density));
-  } @else {
+    $tokens: map.get(m3-option.get-tokens($theme), density);
   }
+
+  @include token-utils.values($tokens);
 }
 
 /// Defines the tokens that will be available in the `overrides` mixin and for docs extraction.

--- a/src/material/core/ripple/_ripple-theme.scss
+++ b/src/material/core/ripple/_ripple-theme.scss
@@ -2,45 +2,43 @@
 @use './m2-ripple';
 @use './m3-ripple';
 @use '../tokens/token-utils';
-@use '../style/sass-utils';
 @use '../theming/theming';
 @use '../theming/inspection';
 
 @mixin base($theme) {
+  $tokens: m2-ripple.get-unthemable-tokens();
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-ripple.get-tokens($theme), base));
-  } @else {
+    $tokens: map.get(m3-ripple.get-tokens($theme), base);
   }
+
+  @include token-utils.values($tokens);
 }
 
 @mixin color($theme) {
+  $tokens: m2-ripple.get-color-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-ripple.get-tokens($theme), color));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-ripple.get-color-tokens($theme));
-    }
+    $tokens: map.get(m3-ripple.get-tokens($theme), color);
   }
+
+  @include token-utils.values($tokens);
 }
 
 @mixin typography($theme) {
+  $tokens: m2-ripple.get-typography-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-ripple.get-tokens($theme), typography));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-ripple.get-typography-tokens($theme));
-    }
+    $tokens: map.get(m3-ripple.get-tokens($theme), typography);
   }
+
+  @include token-utils.values($tokens);
 }
 
 @mixin density($theme) {
+  $tokens: m2-ripple.get-density-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-ripple.get-tokens($theme), density));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-ripple.get-density-tokens($theme));
-    }
+    $tokens: map.get(m3-ripple.get-tokens($theme), density);
   }
+
+  @include token-utils.values($tokens);
 }
 
 /// Defines the tokens that will be available in the `overrides` mixin and for docs extraction.

--- a/src/material/core/selection/pseudo-checkbox/_pseudo-checkbox-theme.scss
+++ b/src/material/core/selection/pseudo-checkbox/_pseudo-checkbox-theme.scss
@@ -1,32 +1,22 @@
 @use '../../theming/theming';
 @use '../../theming/inspection';
-@use '../../style/sass-utils';
 @use '../../tokens/token-utils';
 @use './m2-pseudo-checkbox';
 @use './m3-pseudo-checkbox';
 @use 'sass:map';
 
 @mixin _palette-styles($theme, $palette-name) {
-  @include sass-utils.current-selector-or-root() {
-    @include token-utils.create-token-values-mixed(
-        m2-pseudo-checkbox.get-color-tokens($theme, $palette-name));
-  }
+  $tokens: m2-pseudo-checkbox.get-color-tokens($theme, $palette-name);
+  @include token-utils.values($tokens);
 }
 
-/// Outputs base theme styles (styles not dependent on the color, typography, or density settings)
-/// for the mat-pseudo-checkbox.
-/// @param {Map} $theme The theme to generate base styles for.
 @mixin base($theme) {
-}
+  $tokens: m2-pseudo-checkbox.get-unthemable-tokens();
+  @if inspection.get-theme-version($theme) == 1 {
+    $tokens: map.get(m3-pseudo-checkbox.get-tokens($theme), base);
+  }
 
-/// Defines the tokens that will be available in the `overrides` mixin and for docs extraction.
-@function _define-overrides() {
-  @return (
-    (
-      namespace: pseudo-checkbox,
-      tokens: token-utils.get-overrides(m3-pseudo-checkbox.get-tokens(), pseudo-checkbox)
-    ),
-  );
+  @include token-utils.values($tokens);
 }
 
 /// Outputs the CSS variable values for the given tokens.
@@ -39,39 +29,62 @@
 /// @param {Map} $theme The theme to generate color styles for.
 /// @param {String} $color-variant The color variant to use for the component (M3 only)
 @mixin color($theme, $color-variant: null) {
+  $tokens: m2-pseudo-checkbox.get-color-tokens($theme, secondary);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(
-        map.get(m3-pseudo-checkbox.get-tokens($theme, $color-variant), color));
-  } @else {
+    $tokens: map.get(m3-pseudo-checkbox.get-tokens($theme, $color-variant), color);
+  }
+
+  @include token-utils.values($tokens);
+
+  @if inspection.get-theme-version($theme) != 1 {
     // Default to the accent color. Note that the pseudo checkboxes are meant to inherit the
     // theme from their parent, rather than implementing their own theming, which is why we
     // don't attach to the `mat-*` classes. Also note that this needs to be below `.mat-primary`
     // in order to allow for the color to be overwritten if the checkbox is inside a parent that
     // has `mat-accent` and is placed inside another parent that has `mat-primary`.
-    @include _palette-styles($theme, secondary);
-
     .mat-primary {
-      @include _palette-styles($theme, primary);
+      $tokens: m2-pseudo-checkbox.get-color-tokens($theme, primary);
+      @include token-utils.values($tokens);
     }
 
     .mat-accent {
-      @include _palette-styles($theme, secondary);
+      $tokens: m2-pseudo-checkbox.get-color-tokens($theme, secondary);
+      @include token-utils.values($tokens);
     }
 
     .mat-warn {
-      @include _palette-styles($theme, error);
+      $tokens: m2-pseudo-checkbox.get-color-tokens($theme, error);
+      @include token-utils.values($tokens);
     }
   }
 }
 
-/// Outputs typography theme styles for the mat-pseudo-checkbox.
-/// @param {Map} $theme The theme to generate typography styles for.
 @mixin typography($theme) {
+  $tokens: m2-pseudo-checkbox.get-typography-tokens($theme);
+  @if inspection.get-theme-version($theme) == 1 {
+    $tokens: map.get(m3-pseudo-checkbox.get-tokens($theme), typography);
+  }
+
+  @include token-utils.values($tokens);
 }
 
-/// Outputs density theme styles for the mat-pseudo-checkbox.
-/// @param {Map} $theme The theme to generate density styles for.
 @mixin density($theme) {
+  $tokens: m2-pseudo-checkbox.get-density-tokens($theme);
+  @if inspection.get-theme-version($theme) == 1 {
+    $tokens: map.get(m3-pseudo-checkbox.get-tokens($theme), density);
+  }
+
+  @include token-utils.values($tokens);
+}
+
+/// Defines the tokens that will be available in the `overrides` mixin and for docs extraction.
+@function _define-overrides() {
+  @return (
+    (
+      namespace: pseudo-checkbox,
+      tokens: token-utils.get-overrides(m3-pseudo-checkbox.get-tokens(), pseudo-checkbox)
+    ),
+  );
 }
 
 /// Outputs all (base, color, typography, and density) theme styles for the mat-pseudo-checkbox.

--- a/src/material/core/tokens/_token-utils.scss
+++ b/src/material/core/tokens/_token-utils.scss
@@ -69,6 +69,17 @@
   @return _create-var(--mat-#{$token}, $sys-fallback);
 }
 
+// Outputs a map of token values as CSS variable definitions.
+@mixin values($tokens) {
+  @include sass-utils.current-selector-or-root() {
+    @each $key, $value in $tokens {
+      @if $value != null {
+        --mat-#{$key}: #{$value};
+      }
+    }
+  }
+}
+
 // Outputs a map of tokens.
 @mixin create-token-values($tokens) {
   @include _create-token-values-internal($tokens, false);

--- a/src/material/datepicker/_datepicker-theme.scss
+++ b/src/material/datepicker/_datepicker-theme.scss
@@ -5,7 +5,6 @@
 @use '../core/theming/theming';
 @use '../core/theming/inspection';
 @use '../core/tokens/token-utils';
-@use '../core/style/sass-utils';
 @use '../core/typography/typography';
 @use '../button/icon-button-theme';
 
@@ -13,37 +12,35 @@
 /// for the mat-datepicker.
 /// @param {Map} $theme The theme to generate base styles for.
 @mixin base($theme) {
+  $tokens: m2-datepicker.get-unthemable-tokens();
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-datepicker.get-tokens($theme), base));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-datepicker.get-unthemable-tokens());
-    }
+    $tokens: map.get(m3-datepicker.get-tokens($theme), base);
   }
+
+  @include token-utils.values($tokens);
 }
 
 /// Outputs color theme styles for the mat-datepicker.
 /// @param {Map} $theme The theme to generate color styles for.
 /// @param {String} $color-variant The color variant to use for the component (M3 only)
 @mixin color($theme, $color-variant: null) {
+  $tokens: m2-datepicker.get-color-tokens($theme, primary);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(
-        map.get(m3-datepicker.get-tokens($theme, $color-variant), color));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(
-          m2-datepicker.get-color-tokens($theme, primary));
-    }
+    $tokens: map.get(m3-datepicker.get-tokens($theme, $color-variant), color);
+  }
 
+  @include token-utils.values($tokens);
+
+  @if inspection.get-theme-version($theme) != 1 {
     .mat-datepicker-content, .mat-datepicker-toggle-active {
       &.mat-accent {
-        @include token-utils.create-token-values-mixed(
-            m2-datepicker.get-color-tokens($theme, secondary));
+        $tokens: m2-datepicker.get-color-tokens($theme, secondary);
+        @include token-utils.values($tokens);
       }
 
       &.mat-warn {
-        @include token-utils.create-token-values-mixed(
-            m2-datepicker.get-color-tokens($theme, error));
+        $tokens: m2-datepicker.get-color-tokens($theme, error);
+        @include token-utils.values($tokens);
       }
     }
   }
@@ -52,13 +49,12 @@
 /// Outputs typography theme styles for the mat-datepicker.
 /// @param {Map} $theme The theme to generate typography styles for.
 @mixin typography($theme) {
+  $tokens: m2-datepicker.get-typography-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-datepicker.get-tokens($theme), typography));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-datepicker.get-typography-tokens($theme));
-    }
+    $tokens: map.get(m3-datepicker.get-tokens($theme), typography);
   }
+
+  @include token-utils.values($tokens);
 }
 
 @mixin date-range-colors(
@@ -78,9 +74,14 @@
 /// Outputs density theme styles for the mat-datepicker.
 /// @param {Map} $theme The theme to generate density styles for.
 @mixin density($theme) {
+  $tokens: m2-datepicker.get-density-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-datepicker.get-tokens($theme), density));
-  } @else {
+    $tokens: map.get(m3-datepicker.get-tokens($theme), density);
+  }
+
+  @include token-utils.values($tokens);
+
+  @if inspection.get-theme-version($theme) != 1 {
     // TODO(crisbeto): move this into the structural styles
     // once the icon button density is switched to tokens.
 

--- a/src/material/dialog/_dialog-theme.scss
+++ b/src/material/dialog/_dialog-theme.scss
@@ -1,5 +1,4 @@
 @use 'sass:map';
-@use '../core/style/sass-utils';
 @use './m2-dialog';
 @use './m3-dialog';
 @use '../core/tokens/token-utils';
@@ -8,41 +7,39 @@
 @use '../core/typography/typography';
 
 @mixin base($theme) {
+  $tokens: m2-dialog.get-unthemable-tokens();
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-dialog.get-tokens($theme), base));
-  } @else {
-    // Add default values for tokens not related to color, typography, or density.
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-dialog.get-unthemable-tokens());
-    }
+    $tokens: map.get(m3-dialog.get-tokens($theme), base);
   }
+
+  @include token-utils.values($tokens);
 }
 
 @mixin color($theme) {
+  $tokens: m2-dialog.get-color-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-dialog.get-tokens($theme), color));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-dialog.get-color-tokens($theme));
-    }
+    $tokens: map.get(m3-dialog.get-tokens($theme), color);
   }
+
+  @include token-utils.values($tokens);
 }
 
 @mixin typography($theme) {
+  $tokens: m2-dialog.get-typography-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-dialog.get-tokens($theme), typography));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-dialog.get-typography-tokens($theme));
-    }
+    $tokens: map.get(m3-dialog.get-tokens($theme), typography);
   }
+
+  @include token-utils.values($tokens);
 }
 
 @mixin density($theme) {
+  $tokens: m2-dialog.get-density-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-dialog.get-tokens($theme), density));
-  } @else {
+    $tokens: map.get(m3-dialog.get-tokens($theme), density);
   }
+
+  @include token-utils.values($tokens);
 }
 
 /// Defines the tokens that will be available in the `overrides` mixin and for docs extraction.

--- a/src/material/divider/_divider-theme.scss
+++ b/src/material/divider/_divider-theme.scss
@@ -1,5 +1,4 @@
 @use 'sass:map';
-@use '../core/style/sass-utils';
 @use '../core/theming/theming';
 @use '../core/theming/inspection';
 @use '../core/tokens/token-utils';
@@ -7,37 +6,39 @@
 @use './m3-divider';
 
 @mixin base($theme) {
+  $tokens: m2-divider.get-unthemable-tokens();
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-divider.get-tokens($theme), base));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-divider.get-unthemable-tokens());
-    }
+    $tokens: map.get(m3-divider.get-tokens($theme), base);
   }
+
+  @include token-utils.values($tokens);
 }
 
 @mixin color($theme) {
+  $tokens: m2-divider.get-color-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-divider.get-tokens($theme), color));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-divider.get-color-tokens($theme));
-    }
+    $tokens: map.get(m3-divider.get-tokens($theme), color);
   }
+
+  @include token-utils.values($tokens);
 }
 
 @mixin typography($theme) {
+  $tokens: m2-divider.get-typography-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-divider.get-tokens($theme), typography));
-  } @else {
+    $tokens: map.get(m3-divider.get-tokens($theme), typography);
   }
+
+  @include token-utils.values($tokens);
 }
 
 @mixin density($theme) {
+  $tokens: m2-divider.get-density-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-divider.get-tokens($theme), density));
-  } @else {
+    $tokens: map.get(m3-divider.get-tokens($theme), density);
   }
+
+  @include token-utils.values($tokens);
 }
 
 /// Defines the tokens that will be available in the `overrides` mixin and for docs extraction.

--- a/src/material/expansion/_expansion-theme.scss
+++ b/src/material/expansion/_expansion-theme.scss
@@ -2,49 +2,44 @@
 @use '../core/theming/theming';
 @use '../core/theming/inspection';
 @use '../core/typography/typography';
-@use '../core/style/sass-utils';
 @use '../core/tokens/token-utils';
 @use './m2-expansion';
 @use './m3-expansion';
 
 @mixin base($theme) {
+  $tokens: m2-expansion.get-unthemable-tokens();
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-expansion.get-tokens($theme), base));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-expansion.get-unthemable-tokens());
-    }
+    $tokens: map.get(m3-expansion.get-tokens($theme), base);
   }
+
+  @include token-utils.values($tokens);
 }
 
 @mixin color($theme) {
+  $tokens: m2-expansion.get-color-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-expansion.get-tokens($theme), color));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-expansion.get-color-tokens($theme));
-    }
+    $tokens: map.get(m3-expansion.get-tokens($theme), color);
   }
+
+  @include token-utils.values($tokens);
 }
 
 @mixin typography($theme) {
+  $tokens: m2-expansion.get-typography-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-expansion.get-tokens($theme), typography));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-expansion.get-typography-tokens($theme));
-    }
+    $tokens: map.get(m3-expansion.get-tokens($theme), typography);
   }
+
+  @include token-utils.values($tokens);
 }
 
 @mixin density($theme) {
+  $tokens: m2-expansion.get-density-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-expansion.get-tokens($theme), density));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-expansion.get-density-tokens($theme));
-    }
+    $tokens: map.get(m3-expansion.get-tokens($theme), density);
   }
+
+  @include token-utils.values($tokens);
 }
 
 /// Defines the tokens that will be available in the `overrides` mixin and for docs extraction.

--- a/src/material/form-field/_form-field-theme.scss
+++ b/src/material/form-field/_form-field-theme.scss
@@ -3,71 +3,58 @@
 @use '../core/theming/theming';
 @use '../core/theming/inspection';
 @use '../core/typography/typography';
-@use '../core/style/sass-utils';
 @use '../core/tokens/token-utils';
 @use 'sass:map';
 
-/// Outputs base theme styles (styles not dependent on the color, typography, or density settings)
-/// for the mat-form-field.
-/// @param {Map} $theme The theme to generate base styles for.
 @mixin base($theme) {
+  $tokens: m2-form-field.get-unthemable-tokens();
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-form-field.get-tokens($theme), base));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-form-field.get-unthemable-tokens());
-    }
+    $tokens: map.get(m3-form-field.get-tokens($theme), base);
   }
+
+  @include token-utils.values($tokens);
 }
 
 /// Outputs color theme styles for the mat-form-field.
 /// @param {Map} $theme The theme to generate color styles for.
 /// @param {String} $color-variant The color variant to use for the component (M3 only)
 @mixin color($theme, $color-variant: null) {
+  $tokens: m2-form-field.get-color-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(
-        map.get(m3-form-field.get-tokens($theme, $color-variant), color));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-form-field.get-color-tokens($theme));
-    }
+    $tokens: map.get(m3-form-field.get-tokens($theme, $color-variant), color);
+  }
 
+  @include token-utils.values($tokens);
+
+  @if inspection.get-theme-version($theme) != 1 {
     .mat-mdc-form-field.mat-accent {
-      @include token-utils.create-token-values-mixed(
-          m2-form-field.private-get-color-palette-color-tokens($theme, secondary)
-      );
+      $tokens: m2-form-field.private-get-color-palette-color-tokens($theme, secondary);
+      @include token-utils.values($tokens);
     }
 
     .mat-mdc-form-field.mat-warn {
-      @include token-utils.create-token-values-mixed(
-          m2-form-field.private-get-color-palette-color-tokens($theme, error)
-      );
+      $tokens: m2-form-field.private-get-color-palette-color-tokens($theme, error);
+      @include token-utils.values($tokens);
     }
   }
 }
 
-/// Outputs typography theme styles for the mat-form-field.
-/// @param {Map} $theme The theme to generate typography styles for.
 @mixin typography($theme) {
+  $tokens: m2-form-field.get-typography-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-form-field.get-tokens($theme), typography));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-form-field.get-typography-tokens($theme));
-    }
+    $tokens: map.get(m3-form-field.get-tokens($theme), typography);
   }
+
+  @include token-utils.values($tokens);
 }
 
-/// Outputs density theme styles for the mat-form-field.
-/// @param {Map} $theme The theme to generate density styles for.
 @mixin density($theme) {
+  $tokens: m2-form-field.get-density-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-form-field.get-tokens($theme), density));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-form-field.get-density-tokens($theme));
-    }
+    $tokens: map.get(m3-form-field.get-tokens($theme), density);
   }
+
+  @include token-utils.values($tokens);
 }
 
 /// Defines the tokens that will be available in the `overrides` mixin and for docs extraction.

--- a/src/material/grid-list/_grid-list-theme.scss
+++ b/src/material/grid-list/_grid-list-theme.scss
@@ -4,39 +4,42 @@
 @use '../core/typography/typography';
 @use './m2-grid-list';
 @use './m3-grid-list';
-@use '../core/style/sass-utils';
 @use '../core/tokens/token-utils';
 
 @mixin base($theme) {
+  $tokens: m2-grid-list.get-unthemable-tokens();
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-grid-list.get-tokens($theme), base));
-  } @else {
+    $tokens: map.get(m3-grid-list.get-tokens($theme), base);
   }
+
+  @include token-utils.values($tokens);
 }
 
-// Include this empty mixin for consistency with the other components.
 @mixin color($theme) {
+  $tokens: m2-grid-list.get-color-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-grid-list.get-tokens($theme), color));
-  } @else {
+    $tokens: map.get(m3-grid-list.get-tokens($theme), color);
   }
+
+  @include token-utils.values($tokens);
 }
 
 @mixin typography($theme) {
+  $tokens: m2-grid-list.get-typography-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-grid-list.get-tokens($theme), typography));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-grid-list.get-typography-tokens($theme));
-    }
+    $tokens: map.get(m3-grid-list.get-tokens($theme), typography);
   }
+
+  @include token-utils.values($tokens);
 }
 
 @mixin density($theme) {
+  $tokens: m2-grid-list.get-density-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-grid-list.get-tokens($theme), density));
-  } @else {
+    $tokens: map.get(m3-grid-list.get-tokens($theme), density);
   }
+
+  @include token-utils.values($tokens);
 }
 
 /// Defines the tokens that will be available in the `overrides` mixin and for docs extraction.

--- a/src/material/icon/_icon-theme.scss
+++ b/src/material/icon/_icon-theme.scss
@@ -1,4 +1,3 @@
-@use '../core/style/sass-utils';
 @use '../core/theming/inspection';
 @use '../core/theming/theming';
 @use '../core/tokens/token-utils';
@@ -12,39 +11,44 @@
   @include token-utils.create-token-values-mixed($tokens);
 }
 
-/// Outputs base theme styles (styles not dependent on the color, typography, or density settings)
-/// for the mat-icon.
-/// @param {Map} $theme The theme to generate base styles for.
 @mixin base($theme) {
+  $tokens: m2-icon.get-unthemable-tokens();
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-icon.get-tokens($theme), base));
-  } @else {
+    $tokens: map.get(m3-icon.get-tokens($theme), base);
   }
+
+  @include token-utils.values($tokens);
 }
 
 /// Outputs color theme styles for the mat-icon.
 /// @param {Map} $theme The theme to generate color styles for.
 /// @param {String} $color-variant The color variant to use for the component (M3 only)
 @mixin color($theme, $color-variant: null) {
+  $tokens: m2-icon.get-color-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(
-        map.get(m3-icon.get-tokens($theme, $color-variant), color));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-icon.get-color-tokens($theme));
-    }
+    $tokens: map.get(m3-icon.get-tokens($theme, $color-variant), color);
+  }
 
+  @include token-utils.values($tokens);
+
+  @if inspection.get-theme-version($theme) != 1 {
     .mat-icon {
       &.mat-primary {
-        @include _palette-colors($theme, primary);
+        $color: inspection.get-theme-color($theme, primary, text);
+        $tokens: m2-icon.private-get-icon-color-tokens($color);
+        @include token-utils.values($tokens);
       }
 
       &.mat-accent {
-        @include _palette-colors($theme, accent);
+        $color: inspection.get-theme-color($theme, accent, text);
+        $tokens: m2-icon.private-get-icon-color-tokens($color);
+        @include token-utils.values($tokens);
       }
 
       &.mat-warn {
-        @include _palette-colors($theme, warn);
+        $color: inspection.get-theme-color($theme, warn, text);
+        $tokens: m2-icon.private-get-icon-color-tokens($color);
+        @include token-utils.values($tokens);
       }
     }
   }

--- a/src/material/list/_list-theme.scss
+++ b/src/material/list/_list-theme.scss
@@ -1,7 +1,6 @@
 @use 'sass:map';
 
 @use '../checkbox/m2-checkbox';
-@use '../core/style/sass-utils';
 @use '../core/theming/inspection';
 @use '../core/theming/theming';
 @use '../core/tokens/token-utils';
@@ -12,56 +11,58 @@
 @use '../core/tokens/m2-utils';
 
 @mixin base($theme) {
-  // Add default values for tokens not related to color, typography, or density.
+  $tokens: m2-list.get-unthemable-tokens();
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-list.get-tokens($theme), base));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-list.get-unthemable-tokens());
-    }
+    $tokens: map.get(m3-list.get-tokens($theme), base);
   }
+
+  @include token-utils.values($tokens);
 }
 
 @mixin color($theme) {
+  $tokens: m2-list.get-color-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-list.get-tokens($theme), color));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-list.get-color-tokens($theme));
-    }
+    $tokens: map.get(m3-list.get-tokens($theme), color);
+  }
 
+  @include token-utils.values($tokens);
+
+  @if inspection.get-theme-version($theme) != 1 {
     .mdc-list-item__start,
     .mdc-list-item__end {
-      @include token-utils.create-token-values-mixed(m2-radio.get-color-tokens($theme, primary));
+      $tokens: m2-radio.get-color-tokens($theme, primary);
+      @include token-utils.values($tokens);
     }
 
     .mat-accent {
       .mdc-list-item__start,
       .mdc-list-item__end {
-        @include token-utils.create-token-values-mixed(
-            m2-radio.get-color-tokens($theme, secondary));
+        $tokens: m2-radio.get-color-tokens($theme, secondary);
+        @include token-utils.values($tokens);
       }
     }
 
     .mat-warn {
       .mdc-list-item__start,
       .mdc-list-item__end {
-        @include token-utils.create-token-values-mixed(
-            m2-radio.get-color-tokens($theme, error));
+        $tokens: m2-radio.get-color-tokens($theme, error);
+        @include token-utils.values($tokens);
       }
     }
 
     .mat-mdc-list-option {
-      @include token-utils.create-token-values-mixed(
-          m2-checkbox.get-color-tokens($theme, primary));
+      $tokens: m2-checkbox.get-color-tokens($theme, primary);
+      @include token-utils.values($tokens);
     }
+
     .mat-mdc-list-option.mat-accent {
-      @include token-utils.create-token-values-mixed(
-          m2-checkbox.get-color-tokens($theme, secondary));
+      $tokens: m2-checkbox.get-color-tokens($theme, secondary);
+      @include token-utils.values($tokens);
     }
+
     .mat-mdc-list-option.mat-warn {
-      @include token-utils.create-token-values-mixed(
-          m2-checkbox.get-color-tokens($theme, error));
+      $tokens: m2-checkbox.get-color-tokens($theme, error);
+      @include token-utils.values($tokens);
     }
 
     // There is no token for activated color on nav list.
@@ -90,19 +91,20 @@
 }
 
 @mixin density($theme) {
+  $tokens: m2-list.get-density-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-list.get-tokens($theme), density));
-  } @else {
-    $density-scale: inspection.get-theme-density($theme);
+    $tokens: map.get(m3-list.get-tokens($theme), density);
+  }
 
-    @include sass-utils.current-selector-or-root() {
-      // TODO: See if this can be removed
-      @include token-utils.create-token-values-mixed(m2-list.get-density-tokens($theme));
-    }
+  @include token-utils.values($tokens);
+
+  @if inspection.get-theme-version($theme) != 1 {
+    $density-scale: inspection.get-theme-density($theme);
 
     .mdc-list-item__start,
     .mdc-list-item__end {
-      @include token-utils.create-token-values-mixed(m2-radio.get-density-tokens($theme));
+      $tokens: m2-radio.get-density-tokens($theme);
+      @include token-utils.values($tokens);
     }
 
     // TODO(mmalerba): This is added to maintain the same style MDC used prior to the token-based
@@ -145,13 +147,14 @@
 }
 
 @mixin typography($theme) {
+  $tokens: m2-list.get-typography-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-list.get-tokens($theme), typography));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-list.get-typography-tokens($theme));
-    }
+    $tokens: map.get(m3-list.get-tokens($theme), typography);
+  }
 
+  @include token-utils.values($tokens);
+
+  @if inspection.get-theme-version($theme) != 1 {
     // MDC does not have tokens for the subheader.
     // TODO(mmalerba): Discuss with MDC about adding them, or create custom tokens.
     .mdc-list-group__subheader {

--- a/src/material/menu/_menu-theme.scss
+++ b/src/material/menu/_menu-theme.scss
@@ -1,47 +1,45 @@
 @use 'sass:map';
 @use './m2-menu';
 @use './m3-menu';
-@use '../core/style/sass-utils';
 @use '../core/tokens/token-utils';
 @use '../core/theming/theming';
 @use '../core/theming/inspection';
 @use '../core/typography/typography';
 
 @mixin base($theme) {
+  $tokens: m2-menu.get-unthemable-tokens();
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-menu.get-tokens($theme), base));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-menu.get-unthemable-tokens());
-    }
+    $tokens: map.get(m3-menu.get-tokens($theme), base);
   }
+
+  @include token-utils.values($tokens);
 }
 
 @mixin color($theme) {
+  $tokens: m2-menu.get-color-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-menu.get-tokens($theme), color));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-menu.get-color-tokens($theme));
-    }
+    $tokens: map.get(m3-menu.get-tokens($theme), color);
   }
+
+  @include token-utils.values($tokens);
 }
 
 @mixin typography($theme) {
+  $tokens: m2-menu.get-typography-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-menu.get-tokens($theme), typography));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-menu.get-typography-tokens($theme));
-    }
+    $tokens: map.get(m3-menu.get-tokens($theme), typography);
   }
+
+  @include token-utils.values($tokens);
 }
 
 @mixin density($theme) {
+  $tokens: m2-menu.get-density-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-menu.get-tokens($theme), density));
-  } @else {
+    $tokens: map.get(m3-menu.get-tokens($theme), density);
   }
+
+  @include token-utils.values($tokens);
 }
 
 /// Defines the tokens that will be available in the `overrides` mixin and for docs extraction.

--- a/src/material/paginator/_paginator-theme.scss
+++ b/src/material/paginator/_paginator-theme.scss
@@ -1,47 +1,45 @@
 @use 'sass:map';
 @use './m2-paginator';
 @use './m3-paginator';
-@use '../core/style/sass-utils';
 @use '../core/typography/typography';
 @use '../core/theming/theming';
 @use '../core/theming/inspection';
 @use '../core/tokens/token-utils';
 
 @mixin base($theme) {
+  $tokens: m2-paginator.get-unthemable-tokens();
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-paginator.get-tokens($theme), base));
-  } @else {
+    $tokens: map.get(m3-paginator.get-tokens($theme), base);
   }
+
+  @include token-utils.values($tokens);
 }
 
 @mixin color($theme) {
+  $tokens: m2-paginator.get-color-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-paginator.get-tokens($theme), color));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-paginator.get-color-tokens($theme));
-    }
+    $tokens: map.get(m3-paginator.get-tokens($theme), color);
   }
+
+  @include token-utils.values($tokens);
 }
 
 @mixin typography($theme) {
+  $tokens: m2-paginator.get-typography-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-paginator.get-tokens($theme), typography));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-paginator.get-typography-tokens($theme));
-    }
+    $tokens: map.get(m3-paginator.get-tokens($theme), typography);
   }
+
+  @include token-utils.values($tokens);
 }
 
 @mixin density($theme) {
+  $tokens: m2-paginator.get-density-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-paginator.get-tokens($theme), density));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-paginator.get-density-tokens($theme));
-    }
+    $tokens: map.get(m3-paginator.get-tokens($theme), density);
   }
+
+  @include token-utils.values($tokens);
 }
 
 /// Defines the tokens that will be available in the `overrides` mixin and for docs extraction.

--- a/src/material/progress-bar/_progress-bar-theme.scss
+++ b/src/material/progress-bar/_progress-bar-theme.scss
@@ -1,4 +1,3 @@
-@use '../core/style/sass-utils';
 @use '../core/theming/theming';
 @use '../core/theming/inspection';
 @use '../core/tokens/token-utils';
@@ -6,57 +5,54 @@
 @use './m3-progress-bar';
 @use 'sass:map';
 
-/// Outputs base theme styles (styles not dependent on the color, typography, or density settings)
-/// for the mat-progress-bar.
-/// @param {Map} $theme The theme to generate base styles for.
 @mixin base($theme) {
+  $tokens: m2-progress-bar.get-unthemable-tokens();
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-progress-bar.get-tokens($theme), base));
-  } @else {
-    // Add default values for tokens not related to color, typography, or density.
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-progress-bar.get-unthemable-tokens());
-    }
+    $tokens: map.get(m3-progress-bar.get-tokens($theme), base);
   }
+
+  @include token-utils.values($tokens);
 }
 
-@mixin _palette-styles($theme, $palette-name) {
-  @include token-utils.create-token-values-mixed(
-      m2-progress-bar.get-color-tokens($theme, $palette-name));
-}
-
-/// Outputs color theme styles for the mat-progress-bar.
-/// @param {Map} $theme The theme to generate color styles for.
-/// @param {ArgList} Additional optional arguments (only supported for M3 themes):
-///   $color-variant: The color variant to use for the progress bar: primary, secondary, tertiary,
-///      or error (If not specified, default primary color will be used).
 @mixin color($theme, $color-variant: null) {
+  $tokens: m2-progress-bar.get-color-tokens($theme, primary);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(
-        map.get(m3-progress-bar.get-tokens($theme, $color-variant), color));
-  } @else {
-    .mat-mdc-progress-bar {
-      @include _palette-styles($theme, primary);
+    $tokens: map.get(m3-progress-bar.get-tokens($theme, $color-variant), color);
+  }
 
+  @include token-utils.values($tokens);
+
+  @if inspection.get-theme-version($theme) != 1 {
+    .mat-mdc-progress-bar {
       &.mat-accent {
-        @include _palette-styles($theme, secondary);
+        $tokens: m2-progress-bar.get-color-tokens($theme, secondary);
+        @include token-utils.values($tokens);
       }
 
       &.mat-warn {
-        @include _palette-styles($theme, error);
+        $tokens: m2-progress-bar.get-color-tokens($theme, error);
+        @include token-utils.values($tokens);
       }
     }
   }
 }
 
-/// Outputs typography theme styles for the mat-progress-bar.
-/// @param {Map} $theme The theme to generate typography styles for.
 @mixin typography($theme) {
+  $tokens: m2-progress-bar.get-typography-tokens($theme);
+  @if inspection.get-theme-version($theme) == 1 {
+    $tokens: map.get(m3-progress-bar.get-tokens($theme), typography);
+  }
+
+  @include token-utils.values($tokens);
 }
 
-/// Outputs density theme styles for the mat-progress-bar.
-/// @param {Map} $theme The theme to generate density styles for.
 @mixin density($theme) {
+  $tokens: m2-progress-bar.get-density-tokens($theme);
+  @if inspection.get-theme-version($theme) == 1 {
+    $tokens: map.get(m3-progress-bar.get-tokens($theme), density);
+  }
+
+  @include token-utils.values($tokens);
 }
 
 /// Defines the tokens that will be available in the `overrides` mixin and for docs extraction.

--- a/src/material/progress-spinner/_progress-spinner-theme.scss
+++ b/src/material/progress-spinner/_progress-spinner-theme.scss
@@ -1,4 +1,3 @@
-@use '../core/style/sass-utils';
 @use '../core/theming/theming';
 @use '../core/theming/inspection';
 @use '../core/tokens/token-utils';
@@ -6,52 +5,55 @@
 @use './m3-progress-spinner';
 @use 'sass:map';
 
-/// Outputs base theme styles (styles not dependent on the color, typography, or density settings)
-/// for the mat-progress-spinner.
-/// @param {Map} $theme The theme to generate base styles for.
 @mixin base($theme) {
+  $tokens: m2-progress-spinner.get-unthemable-tokens();
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-progress-spinner.get-tokens($theme), base));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-progress-spinner.get-unthemable-tokens());
-    }
+    $tokens: map.get(m3-progress-spinner.get-tokens($theme), base);
   }
+
+  @include token-utils.values($tokens);
 }
 
 /// Outputs color theme styles for the mat-progress-spinner.
 /// @param {Map} $theme The theme to generate color styles for.
 /// @param {String} $color-variant The color variant to use for the component (M3 only)
 @mixin color($theme, $color-variant: null) {
+  $tokens: m2-progress-spinner.get-color-tokens($theme, primary);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(
-        map.get(m3-progress-spinner.get-tokens($theme, $color-variant), color));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(
-          m2-progress-spinner.get-color-tokens($theme, primary));
+    $tokens: map.get(m3-progress-spinner.get-tokens($theme, $color-variant), color);
+  }
 
-      .mat-accent {
-        @include token-utils.create-token-values-mixed(
-            m2-progress-spinner.get-color-tokens($theme, secondary));
-      }
+  @include token-utils.values($tokens);
 
-      .mat-warn {
-        @include token-utils.create-token-values-mixed(
-            m2-progress-spinner.get-color-tokens($theme, error));
-      }
+  @if inspection.get-theme-version($theme) != 1 {
+    .mat-accent {
+      $tokens: m2-progress-spinner.get-color-tokens($theme, secondary);
+      @include token-utils.values($tokens);
+    }
+
+    .mat-warn {
+      $tokens: m2-progress-spinner.get-color-tokens($theme, error);
+      @include token-utils.values($tokens);
     }
   }
 }
 
-/// Outputs typography theme styles for the mat-progress-spinner.
-/// @param {Map} $theme The theme to generate typography styles for.
 @mixin typography($theme) {
+  $tokens: m2-progress-spinner.get-typography-tokens($theme);
+  @if inspection.get-theme-version($theme) == 1 {
+    $tokens: map.get(m3-progress-spinner.get-tokens($theme), typography);
+  }
+
+  @include token-utils.values($tokens);
 }
 
-/// Outputs density theme styles for the mat-progress-spinner.
-/// @param {Map} $theme The theme to generate density styles for.
 @mixin density($theme) {
+  $tokens: m2-progress-spinner.get-density-tokens($theme);
+  @if inspection.get-theme-version($theme) == 1 {
+    $tokens: map.get(m3-progress-spinner.get-tokens($theme), density);
+  }
+
+  @include token-utils.values($tokens);
 }
 
 /// Defines the tokens that will be available in the `overrides` mixin and for docs extraction.

--- a/src/material/radio/_radio-theme.scss
+++ b/src/material/radio/_radio-theme.scss
@@ -1,4 +1,3 @@
-@use '../core/style/sass-utils';
 @use '../core/theming/theming';
 @use '../core/theming/inspection';
 @use '../core/tokens/token-utils';
@@ -11,13 +10,12 @@
 /// for the mat-radio.
 /// @param {Map} $theme The theme to generate base styles for.
 @mixin base($theme) {
+  $tokens: m2-radio.get-unthemable-tokens();
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-radio.get-tokens($theme), base));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-radio.get-unthemable-tokens());
-    }
+    $tokens: map.get(m3-radio.get-tokens($theme), base);
   }
+
+  @include token-utils.values($tokens);
 }
 
 /// Outputs color theme styles for the mat-radio.
@@ -25,52 +23,44 @@
 /// @param {String} $color-variant The color variant to use for the component (M3 only)
 @mixin color($theme, $color-variant: null) {
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(
-        map.get(m3-radio.get-tokens($theme, $color-variant), color));
+    $tokens: map.get(m3-radio.get-tokens($theme, $color-variant), color);
+    @include token-utils.values($tokens);
   } @else {
     .mat-mdc-radio-button {
       &.mat-primary {
-        @include token-utils.create-token-values-mixed(
-            m2-radio.get-color-tokens($theme, primary));
+        $tokens: m2-radio.get-color-tokens($theme, primary);
+        @include token-utils.values($tokens);
       }
 
       &.mat-accent {
-        @include token-utils.create-token-values-mixed(
-            m2-radio.get-color-tokens($theme, secondary));
+        $tokens: m2-radio.get-color-tokens($theme, secondary);
+        @include token-utils.values($tokens);
       }
 
       &.mat-warn {
-        @include token-utils.create-token-values-mixed(
-            m2-radio.get-color-tokens($theme, error));
+        $tokens: m2-radio.get-color-tokens($theme, error);
+        @include token-utils.values($tokens);
       }
     }
   }
 }
 
-/// Outputs typography theme styles for the mat-radio.
-/// @param {Map} $theme The theme to generate typography styles for.
 @mixin typography($theme) {
+  $tokens: m2-radio.get-typography-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-radio.get-tokens($theme), typography));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-radio.get-typography-tokens($theme));
-    }
+    $tokens: map.get(m3-radio.get-tokens($theme), typography);
   }
+
+  @include token-utils.values($tokens);
 }
 
-/// Outputs typography theme styles for the mat-radio.
-/// @param {Map} $theme The theme to generate density styles for.
 @mixin density($theme) {
+  $tokens: m2-radio.get-density-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-radio.get-tokens($theme), density));
-  } @else {
-    $density-scale: inspection.get-theme-density($theme);
-
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-radio.get-density-tokens($theme));
-    }
+    $tokens: map.get(m3-radio.get-tokens($theme), density);
   }
+
+  @include token-utils.values($tokens);
 }
 
 /// Defines the tokens that will be available in the `overrides` mixin and for docs extraction.

--- a/src/material/select/_select-theme.scss
+++ b/src/material/select/_select-theme.scss
@@ -1,4 +1,3 @@
-@use '../core/style/sass-utils';
 @use '../core/theming/inspection';
 @use '../core/theming/theming';
 @use '../core/tokens/token-utils';
@@ -11,63 +10,54 @@
 /// for the mat-select.
 /// @param {Map} $theme The theme to generate base styles for.
 @mixin base($theme) {
+  $tokens: m2-select.get-unthemable-tokens();
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-select.get-tokens($theme), base));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      $mat-tokens: m2-select.get-unthemable-tokens();
-      @include token-utils.create-token-values-mixed($mat-tokens);
-    }
+    $tokens: map.get(m3-select.get-tokens($theme), base);
   }
+
+  @include token-utils.values($tokens);
 }
 
 /// Outputs color theme styles for the mat-select.
 /// @param {Map} $theme The theme to generate color styles for.
 /// @param {String} $color-variant The color variant to use for the component (M3 only)
 @mixin color($theme, $color-variant: null) {
+  $tokens: m2-select.get-color-tokens($theme, primary);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(
-        map.get(m3-select.get-tokens($theme, $color-variant), color));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(
-          m2-select.get-color-tokens($theme, primary));
+    $tokens: map.get(m3-select.get-tokens($theme, $color-variant), color);
+  }
 
-      .mat-mdc-form-field.mat-accent {
-        @include token-utils.create-token-values-mixed(
-            m2-select.get-color-tokens($theme, secondary));
-      }
+  @include token-utils.values($tokens);
 
-      .mat-mdc-form-field.mat-warn {
-        @include token-utils.create-token-values-mixed(
-            m2-select.get-color-tokens($theme, error));
-      }
+  @if inspection.get-theme-version($theme) != 1 {
+    .mat-mdc-form-field.mat-accent {
+      $tokens: m2-select.get-color-tokens($theme, secondary);
+      @include token-utils.values($tokens);
+    }
+
+    .mat-mdc-form-field.mat-warn {
+      $tokens: m2-select.get-color-tokens($theme, error);
+      @include token-utils.values($tokens);
     }
   }
 }
 
-/// Outputs typography theme styles for the mat-select.
-/// @param {Map} $theme The theme to generate typography styles for.
 @mixin typography($theme) {
+  $tokens: m2-select.get-typography-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-select.get-tokens($theme), typography));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-select.get-typography-tokens($theme));
-    }
+    $tokens: map.get(m3-select.get-tokens($theme), typography);
   }
+
+  @include token-utils.values($tokens);
 }
 
-/// Outputs typography theme styles for the mat-select.
-/// @param {Map} $theme The theme to generate density styles for.
 @mixin density($theme) {
+  $tokens: m2-select.get-density-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-select.get-tokens($theme), density));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-select.get-density-tokens($theme));
-    }
+    $tokens: map.get(m3-select.get-tokens($theme), density);
   }
+
+  @include token-utils.values($tokens);
 }
 
 /// Defines the tokens that will be available in the `overrides` mixin and for docs extraction.

--- a/src/material/sidenav/_sidenav-theme.scss
+++ b/src/material/sidenav/_sidenav-theme.scss
@@ -1,5 +1,4 @@
 @use 'sass:map';
-@use '../core/style/sass-utils';
 @use '../core/theming/inspection';
 @use '../core/theming/theming';
 @use '../core/tokens/token-utils';
@@ -7,37 +6,39 @@
 @use './m3-sidenav';
 
 @mixin base($theme) {
+  $tokens: m2-sidenav.get-unthemable-tokens();
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-sidenav.get-tokens($theme), base));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-sidenav.get-unthemable-tokens());
-    }
+    $tokens: map.get(m3-sidenav.get-tokens($theme), base);
   }
+
+  @include token-utils.values($tokens);
 }
 
 @mixin color($theme) {
+  $tokens: m2-sidenav.get-color-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-sidenav.get-tokens($theme), color));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-sidenav.get-color-tokens($theme));
-    }
+    $tokens: map.get(m3-sidenav.get-tokens($theme), color);
   }
+
+  @include token-utils.values($tokens);
 }
 
 @mixin typography($theme) {
+  $tokens: m2-sidenav.get-typography-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-sidenav.get-tokens($theme), typography));
-  } @else {
+    $tokens: map.get(m3-sidenav.get-tokens($theme), typography);
   }
+
+  @include token-utils.values($tokens);
 }
 
 @mixin density($theme) {
+  $tokens: m2-sidenav.get-density-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-sidenav.get-tokens($theme), base));
-  } @else {
+    $tokens: map.get(m3-sidenav.get-tokens($theme), density);
   }
+
+  @include token-utils.values($tokens);
 }
 
 /// Defines the tokens that will be available in the `overrides` mixin and for docs extraction.

--- a/src/material/slide-toggle/_slide-toggle-theme.scss
+++ b/src/material/slide-toggle/_slide-toggle-theme.scss
@@ -13,60 +13,52 @@
 /// for the mat-slide-toggle.
 /// @param {Map} $theme The theme to generate base styles for.
 @mixin base($theme) {
+  $tokens: m2-slide-toggle.get-unthemable-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-slide-toggle.get-tokens($theme), base));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      // TODO: See if this can be removed
-      @include token-utils.create-token-values-mixed(m2-slide-toggle.get-unthemable-tokens($theme));
-
-      .mat-mdc-slide-toggle {
-        @include token-utils.create-token-values-mixed(
-            m2-slide-toggle.get-unthemable-tokens($theme));
-      }
-    }
+    $tokens: map.get(m3-slide-toggle.get-tokens($theme), base);
   }
+
+  @include token-utils.values($tokens);
 }
 
 /// Outputs color theme styles for the mat-slide-toggle.
 /// @param {Map} $theme The theme to generate color styles for.
 /// @param {String} $color-variant The color variant to use for the component (M3 only)
 @mixin color($theme, $color-variant: null) {
+  $tokens: m2-slide-toggle.get-color-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(
-        map.get(m3-slide-toggle.get-tokens($theme, $color-variant), color));
-  } @else {
+    $tokens: map.get(m3-slide-toggle.get-tokens($theme, $color-variant), color);
+  }
+
+  @include token-utils.values($tokens);
+
+  @if inspection.get-theme-version($theme) != 1 {
     $mat-tokens: m2-slide-toggle.get-color-tokens($theme);
+    $system: m2-utils.get-system($theme);
 
-    // Add values for MDC slide toggles tokens
     @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-slide-toggle.get-color-tokens($theme));
-      $system: m2-utils.get-system($theme);
+      // TODO(andrewjs): Remove this once all tokens are migrated to
+      // mat internally.
+      --mdc-slide-toggle-disabled-label-text-color: #{
+          m3-utils.color-with-opacity(map.get($system, on-surface), 38%)};
+      // TODO(wagnermaciel): Use our token system to define this css variable.
+      --mat-slide-toggle-disabled-label-text-color: #{
+          m3-utils.color-with-opacity(map.get($system, on-surface), 38%)};
+    }
 
-      & {
-        // TODO(andrewjs): Remove this once all tokens are migrated to
-        // mat internally.
-        --mdc-slide-toggle-disabled-label-text-color: #{
-            m3-utils.color-with-opacity(map.get($system, on-surface), 38%)};
-        // TODO(wagnermaciel): Use our token system to define this css variable.
-        --mat-slide-toggle-disabled-label-text-color: #{
-            m3-utils.color-with-opacity(map.get($system, on-surface), 38%)};
+    .mat-mdc-slide-toggle {
+      // TODO(wagnermaciel): Use our token system to define this css variable.
+      --mat-slide-toggle-label-text-color: #{map.get($system, on-surface)};
+
+      // Change the color palette related tokens to accent or warn if applicable
+      &.mat-accent {
+        $tokens: m2-slide-toggle.private-get-color-palette-color-tokens($theme, secondary);
+        @include token-utils.values($tokens);
       }
 
-      .mat-mdc-slide-toggle {
-        // TODO(wagnermaciel): Use our token system to define this css variable.
-        --mat-slide-toggle-label-text-color: #{map.get($system, on-surface)};
-
-        // Change the color palette related tokens to accent or warn if applicable
-        &.mat-accent {
-          @include token-utils.create-token-values-mixed(
-              m2-slide-toggle.private-get-color-palette-color-tokens($theme, secondary));
-        }
-
-        &.mat-warn {
-          @include token-utils.create-token-values-mixed(
-              m2-slide-toggle.private-get-color-palette-color-tokens($theme, error));
-        }
+      &.mat-warn {
+        $tokens: m2-slide-toggle.private-get-color-palette-color-tokens($theme, error);
+        @include token-utils.values($tokens);
       }
     }
   }
@@ -75,37 +67,23 @@
 /// Outputs typography theme styles for the mat-slide-toggle.
 /// @param {Map} $theme The theme to generate typography styles for.
 @mixin typography($theme) {
+  $tokens: m2-slide-toggle.get-typography-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(
-        map.get(m3-slide-toggle.get-tokens($theme), typography));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      // TODO: See if this can be removed
-      @include token-utils.create-token-values-mixed(m2-slide-toggle.get-typography-tokens($theme));
-
-      .mat-mdc-slide-toggle {
-        @include token-utils.create-token-values-mixed(
-            m2-slide-toggle.get-typography-tokens($theme));
-      }
-    }
+    $tokens: map.get(m3-slide-toggle.get-tokens($theme), typography);
   }
+
+  @include token-utils.values($tokens);
 }
 
 /// Outputs density theme styles for the mat-slide-toggle.
 /// @param {Map} $theme The theme to generate density styles for.
 @mixin density($theme) {
+  $tokens: m2-slide-toggle.get-density-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    // There are no M3 density tokens for this component
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      // TODO: See if this can be removed
-      @include token-utils.create-token-values-mixed(m2-slide-toggle.get-density-tokens($theme));
-
-      .mat-mdc-slide-toggle {
-        @include token-utils.create-token-values-mixed(m2-slide-toggle.get-density-tokens($theme));
-      }
-    }
+    $tokens: map.get(m3-slide-toggle.get-tokens($theme), density);
   }
+
+  @include token-utils.values($tokens);
 }
 
 /// Defines the tokens that will be available in the `overrides` mixin and for docs extraction.

--- a/src/material/slider/_slider-theme.scss
+++ b/src/material/slider/_slider-theme.scss
@@ -1,7 +1,6 @@
 @use '../core/theming/theming';
 @use '../core/theming/inspection';
 @use '../core/typography/typography';
-@use '../core/style/sass-utils';
 @use '../core/tokens/token-utils';
 @use './m2-slider';
 @use './m3-slider';
@@ -11,35 +10,34 @@
 /// for the mat-slider.
 /// @param {Map} $theme The theme to generate base styles for.
 @mixin base($theme) {
+  $tokens: m2-slider.get-unthemable-tokens();
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-slider.get-tokens($theme), base));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-slider.get-unthemable-tokens());
-    }
+    $tokens: map.get(m3-slider.get-tokens($theme), base);
   }
+
+  @include token-utils.values($tokens);
 }
 
 /// Outputs color theme styles for the mat-slider.
 /// @param {Map} $theme The theme to generate color styles for.
 /// @param {String} $color-variant The color variant to use for the component (M3 only)
 @mixin color($theme, $color-variant: null) {
+  $tokens: m2-slider.get-color-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(
-        map.get(m3-slider.get-tokens($theme, $color-variant), color));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-slider.get-color-tokens($theme));
+    $tokens: map.get(m3-slider.get-tokens($theme, $color-variant), color);
+  }
 
-      .mat-accent {
-        @include token-utils.create-token-values-mixed(
-          m2-slider.private-get-color-palette-color-tokens($theme, secondary));
-      }
+  @include token-utils.values($tokens);
 
-      .mat-warn {
-        @include token-utils.create-token-values-mixed(
-          m2-slider.private-get-color-palette-color-tokens($theme, error));
-      }
+  @if inspection.get-theme-version($theme) != 1 {
+    .mat-accent {
+      $tokens: m2-slider.private-get-color-palette-color-tokens($theme, secondary);
+      @include token-utils.values($tokens);
+    }
+
+    .mat-warn {
+      $tokens: m2-slider.private-get-color-palette-color-tokens($theme, error);
+      @include token-utils.values($tokens);
     }
   }
 }
@@ -47,25 +45,23 @@
 /// Outputs typography theme styles for the mat-slider.
 /// @param {Map} $theme The theme to generate typography styles for.
 @mixin typography($theme) {
+  $tokens: m2-slider.get-typography-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-slider.get-tokens($theme), typography));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-slider.get-typography-tokens($theme));
-    }
+    $tokens: map.get(m3-slider.get-tokens($theme), typography);
   }
+
+  @include token-utils.values($tokens);
 }
 
 /// Outputs density theme styles for the mat-slider.
 /// @param {Map} $theme The theme to generate density styles for.
 @mixin density($theme) {
+  $tokens: m2-slider.get-density-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    // There are no M3 density tokens for this component
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-slider.get-density-tokens($theme));
-    }
+    $tokens: map.get(m3-slider.get-tokens($theme), density);
   }
+
+  @include token-utils.values($tokens);
 }
 
 /// Defines the tokens that will be available in the `overrides` mixin and for docs extraction.

--- a/src/material/snack-bar/_snack-bar-theme.scss
+++ b/src/material/snack-bar/_snack-bar-theme.scss
@@ -1,44 +1,44 @@
 @use 'sass:map';
 @use '../core/theming/theming';
 @use '../core/theming/inspection';
-@use '../core/style/sass-utils';
 @use '../core/typography/typography';
 @use '../core/tokens/token-utils';
 @use './m2-snack-bar';
 @use './m3-snack-bar';
 
 @mixin base($theme) {
+  $tokens: m2-snack-bar.get-unthemable-tokens();
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-snack-bar.get-tokens($theme), base));
-  } @else {
-    // Add default values for tokens not related to color, typography, or density.
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-snack-bar.get-unthemable-tokens());
-    }
+    $tokens: map.get(m3-snack-bar.get-tokens($theme), base);
   }
+
+  @include token-utils.values($tokens);
 }
 
 @mixin color($theme) {
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-snack-bar.get-tokens($theme), color));
+    @include token-utils.values(map.get(m3-snack-bar.get-tokens($theme), color));
   } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-snack-bar.get-color-tokens($theme));
-    }
+    @include token-utils.values(m2-snack-bar.get-color-tokens($theme));
   }
 }
 
 @mixin typography($theme) {
+  $tokens: m2-snack-bar.get-typography-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-snack-bar.get-tokens($theme), typography));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-snack-bar.get-typography-tokens($theme));
-    }
+    $tokens: map.get(m3-snack-bar.get-tokens($theme), typography);
   }
+
+  @include token-utils.values($tokens);
 }
 
 @mixin density($theme) {
+  $tokens: m2-snack-bar.get-density-tokens($theme);
+  @if inspection.get-theme-version($theme) == 1 {
+    $tokens: map.get(m3-snack-bar.get-tokens($theme), density);
+  }
+
+  @include token-utils.values($tokens);
 }
 
 /// Defines the tokens that will be available in the `overrides` mixin and for docs extraction.

--- a/src/material/sort/_sort-theme.scss
+++ b/src/material/sort/_sort-theme.scss
@@ -1,47 +1,45 @@
 @use 'sass:map';
 @use './m2-sort';
 @use './m3-sort';
-@use '../core/style/sass-utils';
 @use '../core/typography/typography';
 @use '../core/theming/theming';
 @use '../core/theming/inspection';
 @use '../core/tokens/token-utils';
 
 @mixin base($theme) {
+  $tokens: m2-sort.get-unthemable-tokens();
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-sort.get-tokens($theme), base));
-  } @else {
+    $tokens: map.get(m3-sort.get-tokens($theme), base);
   }
+
+  @include token-utils.values($tokens);
 }
 
 @mixin color($theme) {
+  $tokens: m2-sort.get-color-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-sort.get-tokens($theme), color));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-sort.get-color-tokens($theme));
-    }
+    $tokens: map.get(m3-sort.get-tokens($theme), color);
   }
+
+  @include token-utils.values($tokens);
 }
 
 @mixin typography($theme) {
+  $tokens: m2-sort.get-typography-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-sort.get-tokens($theme), typography));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-sort.get-typography-tokens($theme));
-    }
+    $tokens: map.get(m3-sort.get-tokens($theme), typography);
   }
+
+  @include token-utils.values($tokens);
 }
 
 @mixin density($theme) {
+  $tokens: m2-sort.get-density-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-sort.get-tokens($theme), density));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-sort.get-density-tokens($theme));
-    }
+    $tokens: map.get(m3-sort.get-tokens($theme), density);
   }
+
+  @include token-utils.values($tokens);
 }
 
 /// Defines the tokens that will be available in the `overrides` mixin and for docs extraction.

--- a/src/material/stepper/_stepper-theme.scss
+++ b/src/material/stepper/_stepper-theme.scss
@@ -1,7 +1,6 @@
 @use '../core/theming/theming';
 @use '../core/theming/inspection';
 @use '../core/typography/typography';
-@use '../core/style/sass-utils';
 @use '../core/tokens/token-utils';
 @use './m2-stepper';
 @use './m3-stepper';
@@ -11,58 +10,54 @@
 /// for mat-stepper.
 /// @param {Map} $theme The theme to generate base styles for.
 @mixin base($theme) {
+  $tokens: m2-stepper.get-unthemable-tokens();
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-stepper.get-tokens($theme), base));
-  } @else {
+    $tokens: map.get(m3-stepper.get-tokens($theme), base);
   }
+
+  @include token-utils.values($tokens);
 }
 
 /// Outputs color theme styles for mat-stepper.
 /// @param {Map} $theme The theme to generate color styles for.
 /// @param {String} $color-variant The color variant to use for the component (M3 only)
 @mixin color($theme, $color-variant: null) {
+  $tokens: m2-stepper.get-color-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(
-        map.get(m3-stepper.get-tokens($theme, $color-variant), color));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-stepper.get-color-tokens($theme));
+    $tokens: map.get(m3-stepper.get-tokens($theme, $color-variant), color);
+  }
 
-      .mat-step-header.mat-accent {
-        @include token-utils.create-token-values-mixed(
-          m2-stepper.private-get-color-palette-color-tokens($theme, secondary));
-      }
+  @include token-utils.values($tokens);
 
-      .mat-step-header.mat-warn {
-        @include token-utils.create-token-values-mixed(
-          m2-stepper.private-get-color-palette-color-tokens($theme, error));
-      }
+  @if inspection.get-theme-version($theme) != 1 {
+    .mat-step-header.mat-accent {
+      @include token-utils.create-token-values-mixed(
+        m2-stepper.private-get-color-palette-color-tokens($theme, secondary));
+    }
+
+    .mat-step-header.mat-warn {
+      @include token-utils.create-token-values-mixed(
+        m2-stepper.private-get-color-palette-color-tokens($theme, error));
     }
   }
 }
 
-/// Outputs typography theme styles for mat-stepper.
-/// @param {Map} $theme The theme to generate typography styles for.
 @mixin typography($theme) {
+  $tokens: m2-stepper.get-typography-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-stepper.get-tokens($theme), typography));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-stepper.get-typography-tokens($theme));
-    }
+    $tokens: map.get(m3-stepper.get-tokens($theme), typography);
   }
+
+  @include token-utils.values($tokens);
 }
 
-/// Outputs density theme styles for mat-stepper.
-/// @param {Map} $theme The theme to generate density styles for.
 @mixin density($theme) {
+  $tokens: m2-stepper.get-density-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-stepper.get-tokens($theme), density));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-stepper.get-density-tokens($theme));
-    }
+    $tokens: map.get(m3-stepper.get-tokens($theme), density);
   }
+
+  @include token-utils.values($tokens);
 }
 
 /// Defines the tokens that will be available in the `overrides` mixin and for docs extraction.

--- a/src/material/table/_table-theme.scss
+++ b/src/material/table/_table-theme.scss
@@ -5,46 +5,41 @@
 @use '../core/theming/inspection';
 @use '../core/typography/typography';
 @use '../core/tokens/token-utils';
-@use '../core/style/sass-utils';
 
 @mixin base($theme) {
+  $tokens: m2-table.get-unthemable-tokens();
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-table.get-tokens($theme), base));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-table.get-unthemable-tokens());
-    }
+    $tokens: map.get(m3-table.get-tokens($theme), base);
   }
+
+  @include token-utils.values($tokens);
 }
 
 @mixin color($theme) {
+  $tokens: m2-table.get-color-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-table.get-tokens($theme), color));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-table.get-color-tokens($theme));
-    }
+    $tokens: map.get(m3-table.get-tokens($theme), color);
   }
+
+  @include token-utils.values($tokens);
 }
 
 @mixin typography($theme) {
+  $tokens: m2-table.get-typography-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-table.get-tokens($theme), typography));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-table.get-typography-tokens($theme));
-    }
+    $tokens: map.get(m3-table.get-tokens($theme), typography);
   }
+
+  @include token-utils.values($tokens);
 }
 
 @mixin density($theme) {
+  $tokens: m2-table.get-density-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-table.get-tokens($theme), density));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-table.get-density-tokens($theme));
-    }
+    $tokens: map.get(m3-table.get-tokens($theme), density);
   }
+
+  @include token-utils.values($tokens);
 }
 
 /// Defines the tokens that will be available in the `overrides` mixin and for docs extraction.

--- a/src/material/tabs/_tabs-theme.scss
+++ b/src/material/tabs/_tabs-theme.scss
@@ -1,4 +1,3 @@
-@use '../core/style/sass-utils';
 @use './m2-tabs';
 @use './m3-tabs';
 @use '../core/theming/theming';
@@ -7,17 +6,13 @@
 @use '../core/tokens/token-utils';
 @use 'sass:map';
 
-/// Outputs base theme styles (styles not dependent on the color, typography, or density settings)
-/// for the mat-tab.
-/// @param {Map} $theme The theme to generate base styles for.
 @mixin base($theme) {
+  $tokens: m2-tabs.get-unthemable-tokens();
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-tabs.get-tokens($theme), base));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-tabs.get-unthemable-tokens());
-    }
+    $tokens: map.get(m3-tabs.get-tokens($theme), base);
   }
+
+  @include token-utils.values($tokens);
 }
 
 /// Outputs color theme styles for the mat-tab.
@@ -25,30 +20,30 @@
 /// @param {String} $color-variant The color variant to use for the component (M3 only)
 @mixin color($theme, $color-variant: null) {
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(
-        map.get(m3-tabs.get-tokens($theme, $color-variant), color));
+    $tokens: map.get(m3-tabs.get-tokens($theme, $color-variant), color);
+    @include token-utils.values($tokens);
   } @else {
     .mat-mdc-tab-group,
     .mat-mdc-tab-nav-bar {
-      @include token-utils.create-token-values-mixed(
+      @include token-utils.values(
           m2-tabs.get-color-tokens($theme, primary,
             $exclude: (tab-background-color, tab-foreground-color)));
 
       &.mat-accent {
-        @include token-utils.create-token-values-mixed(
+        @include token-utils.values(
           m2-tabs.get-color-tokens($theme, secondary,
             $exclude: (tab-background-color, tab-foreground-color)));
       }
 
       &.mat-warn {
-        @include token-utils.create-token-values-mixed(
+        @include token-utils.values(
           m2-tabs.get-color-tokens($theme, error,
             $exclude: (tab-background-color, tab-foreground-color)));
       }
 
       &.mat-background-primary {
         $tokens: m2-tabs.get-color-tokens($theme, primary);
-        @include token-utils.create-token-values-mixed((
+        @include token-utils.values((
           tab-background-color: map.get($tokens, tab-background-color),
           tab-foreground-color: map.get($tokens, tab-foreground-color)
         ));
@@ -56,7 +51,7 @@
 
       &.mat-background-accent {
         $tokens: m2-tabs.get-color-tokens($theme, secondary);
-        @include token-utils.create-token-values-mixed((
+        @include token-utils.values((
           tab-background-color: map.get($tokens, tab-background-color),
           tab-foreground-color: map.get($tokens, tab-foreground-color),
         ));
@@ -64,7 +59,7 @@
 
       &.mat-background-warn {
         $tokens: m2-tabs.get-color-tokens($theme, error);
-        @include token-utils.create-token-values-mixed((
+        @include token-utils.values((
           tab-background-color: map.get($tokens, tab-background-color),
           tab-foreground-color: map.get($tokens, tab-foreground-color),
         ));
@@ -77,10 +72,10 @@
 /// @param {Map} $theme The theme to generate typography styles for.
 @mixin typography($theme) {
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-tabs.get-tokens($theme), typography));
+    @include token-utils.values(map.get(m3-tabs.get-tokens($theme), typography));
   } @else {
     .mat-mdc-tab-header {
-      @include token-utils.create-token-values-mixed(m2-tabs.get-typography-tokens($theme));
+      @include token-utils.values(m2-tabs.get-typography-tokens($theme));
     }
   }
 }
@@ -89,10 +84,10 @@
 /// @param {Map} $theme The theme to generate density styles for.
 @mixin density($theme) {
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-tabs.get-tokens($theme), density));
+    @include token-utils.values(map.get(m3-tabs.get-tokens($theme), density));
   } @else {
     .mat-mdc-tab-header {
-      @include token-utils.create-token-values-mixed(m2-tabs.get-density-tokens($theme));
+      @include token-utils.values(m2-tabs.get-density-tokens($theme));
     }
   }
 }

--- a/src/material/timepicker/_timepicker-theme.scss
+++ b/src/material/timepicker/_timepicker-theme.scss
@@ -2,59 +2,44 @@
 @use '../core/theming/theming';
 @use '../core/theming/inspection';
 @use '../core/typography/typography';
-@use '../core/style/sass-utils';
 @use './m2-timepicker';
 @use './m3-timepicker';
 @use '../core/tokens/token-utils';
 
-/// Outputs base theme styles (styles not dependent on the color, typography, or density settings)
-/// for the mat-timepicker.
-/// @param {Map} $theme The theme to generate base styles for.
 @mixin base($theme) {
+  $tokens: m2-timepicker.get-unthemable-tokens();
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-timepicker.get-tokens($theme), base));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-timepicker.get-unthemable-tokens());
-    }
+    $tokens: map.get(m3-timepicker.get-tokens($theme), base);
   }
+
+  @include token-utils.values($tokens);
 }
 
-/// Outputs color theme styles for the mat-timepicker.
-/// @param {Map} $theme The theme to generate color styles for.
 @mixin color($theme) {
+  $tokens: m2-timepicker.get-color-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(
-        map.get(m3-timepicker.get-tokens($theme), color));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-timepicker.get-color-tokens($theme));
-    }
+    $tokens: map.get(m3-timepicker.get-tokens($theme), color);
   }
+
+  @include token-utils.values($tokens);
 }
 
-/// Outputs typography theme styles for the mat-timepicker.
-/// @param {Map} $theme The theme to generate typography styles for.
 @mixin typography($theme) {
+  $tokens: m2-timepicker.get-typography-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-timepicker.get-tokens($theme), typography));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-timepicker.get-typography-tokens($theme));
-    }
+    $tokens: map.get(m3-timepicker.get-tokens($theme), typography);
   }
+
+  @include token-utils.values($tokens);
 }
 
-/// Outputs density theme styles for the mat-timepicker.
-/// @param {Map} $theme The theme to generate density styles for.
 @mixin density($theme) {
+  $tokens: m2-timepicker.get-density-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-timepicker.get-tokens($theme), density));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-timepicker.get-density-tokens($theme));
-    }
+    $tokens: map.get(m3-timepicker.get-tokens($theme), density);
   }
+
+  @include token-utils.values($tokens);
 }
 
 /// Defines the tokens that will be available in the `overrides` mixin and for docs extraction.

--- a/src/material/toolbar/_toolbar-theme.scss
+++ b/src/material/toolbar/_toolbar-theme.scss
@@ -1,5 +1,4 @@
 @use 'sass:map';
-@use '../core/style/sass-utils';
 @use '../core/theming/inspection';
 @use '../core/theming/theming';
 @use '../core/tokens/token-utils';
@@ -8,60 +7,76 @@
 @use './m3-toolbar';
 
 @mixin _palette-styles($theme, $palette-name) {
-  @include token-utils.create-token-values-mixed(
-    m2-toolbar.private-get-color-palette-color-tokens(
-      $background-color: inspection.get-theme-color($theme, $palette-name),
-      $text-color: inspection.get-theme-color($theme, $palette-name, default-contrast)
-    )
+  $tokens: m2-toolbar.private-get-color-palette-color-tokens(
+    $background-color: inspection.get-theme-color($theme, $palette-name),
+    $text-color: inspection.get-theme-color($theme, $palette-name, default-contrast)
   );
+  @include token-utils.values($tokens);
 }
 
 @mixin base($theme) {
+  $tokens: m2-toolbar.get-unthemable-tokens();
+  @if inspection.get-theme-version($theme) == 1 {
+    $tokens: map.get(m3-toolbar.get-tokens($theme), base);
+  }
+
+  @include token-utils.values($tokens);
 }
 
 @mixin color($theme) {
+  $tokens: m2-toolbar.get-color-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-toolbar.get-tokens($theme), color));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-toolbar.get-color-tokens($theme));
-    }
+    $tokens: map.get(m3-toolbar.get-tokens($theme), color);
+  }
 
+  @include token-utils.values($tokens);
+
+  @if inspection.get-theme-version($theme) != 1 {
     .mat-toolbar {
       &.mat-primary {
-        @include _palette-styles($theme, primary);
+        $tokens: m2-toolbar.private-get-color-palette-color-tokens(
+          $background-color: inspection.get-theme-color($theme, primary),
+          $text-color: inspection.get-theme-color($theme, primary, default-contrast)
+        );
+        @include token-utils.values($tokens);
       }
 
       &.mat-accent {
-        @include _palette-styles($theme, accent);
+        $tokens: m2-toolbar.private-get-color-palette-color-tokens(
+          $background-color: inspection.get-theme-color($theme, accent),
+          $text-color: inspection.get-theme-color($theme, accent, default-contrast)
+        );
+        @include token-utils.values($tokens);
       }
 
       &.mat-warn {
-        @include _palette-styles($theme, warn);
+        $tokens: m2-toolbar.private-get-color-palette-color-tokens(
+          $background-color: inspection.get-theme-color($theme, warn),
+          $text-color: inspection.get-theme-color($theme, warn, default-contrast)
+        );
+        @include token-utils.values($tokens);
       }
     }
   }
 }
 
-@mixin typography($theme) {
-  @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-toolbar.get-tokens($theme), typography));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-toolbar.get-typography-tokens($theme));
+  @mixin typography($theme) {
+    $tokens: m2-toolbar.get-typography-tokens($theme);
+    @if inspection.get-theme-version($theme) == 1 {
+      $tokens: map.get(m3-toolbar.get-tokens($theme), typography);
     }
-  }
-}
 
-@mixin density($theme) {
-  @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-toolbar.get-tokens($theme), density));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-toolbar.get-density-tokens($theme));
-    }
+    @include token-utils.values($tokens);
   }
-}
+
+  @mixin density($theme) {
+    $tokens: m2-toolbar.get-density-tokens($theme);
+    @if inspection.get-theme-version($theme) == 1 {
+      $tokens: map.get(m3-toolbar.get-tokens($theme), density);
+    }
+
+    @include token-utils.values($tokens);
+  }
 
 /// Defines the tokens that will be available in the `overrides` mixin and for docs extraction.
 @function _define-overrides() {

--- a/src/material/tooltip/_tooltip-theme.scss
+++ b/src/material/tooltip/_tooltip-theme.scss
@@ -1,4 +1,3 @@
-@use '../core/style/sass-utils';
 @use '../core/theming/theming';
 @use '../core/theming/inspection';
 @use '../core/tokens/token-utils';
@@ -8,44 +7,39 @@
 @use 'sass:map';
 
 @mixin base($theme) {
+  $tokens: m2-tooltip.get-unthemable-tokens();
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-tooltip.get-tokens($theme), base));
-  } @else {
-    // Add default values for tokens not related to color, typography, or density.
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-tooltip.get-unthemable-tokens());
-    }
+    $tokens: map.get(m3-tooltip.get-tokens($theme), base);
   }
+
+  @include token-utils.values($tokens);
 }
 
 @mixin color($theme) {
+  $tokens: m2-tooltip.get-color-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-tooltip.get-tokens($theme), color));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-tooltip.get-color-tokens($theme));
-    }
+    $tokens: map.get(m3-tooltip.get-tokens($theme), color);
   }
+
+  @include token-utils.values($tokens);
 }
 
 @mixin typography($theme) {
+  $tokens: m2-tooltip.get-typography-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-tooltip.get-tokens($theme), typography));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-tooltip.get-typography-tokens($theme));
-    }
+    $tokens: map.get(m3-tooltip.get-tokens($theme), typography);
   }
+
+  @include token-utils.values($tokens);
 }
 
 @mixin density($theme) {
+  $tokens: m2-tooltip.get-density-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-tooltip.get-tokens($theme), density));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-tooltip.get-density-tokens($theme));
-    }
+    $tokens: map.get(m3-tooltip.get-tokens($theme), density);
   }
+
+  @include token-utils.values($tokens);
 }
 
 /// Defines the tokens that will be available in the `overrides` mixin and for docs extraction.

--- a/src/material/tree/_tree-theme.scss
+++ b/src/material/tree/_tree-theme.scss
@@ -2,48 +2,44 @@
 @use '../core/theming/theming';
 @use '../core/theming/inspection';
 @use '../core/typography/typography';
-@use '../core/style/sass-utils';
 @use '../core/tokens/token-utils';
 @use './m2-tree';
 @use './m3-tree';
 
 @mixin base($theme) {
+  $tokens: m2-tree.get-unthemable-tokens();
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-tree.get-tokens($theme), base));
-  } @else {
+    $tokens: map.get(m3-tree.get-tokens($theme), base);
   }
+
+  @include token-utils.values($tokens);
 }
 
 @mixin color($theme) {
+  $tokens: m2-tree.get-color-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-tree.get-tokens($theme), color));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-tree.get-color-tokens($theme));
-    }
+    $tokens: map.get(m3-tree.get-tokens($theme), color);
   }
+
+  @include token-utils.values($tokens);
 }
 
 @mixin typography($theme) {
+  $tokens: m2-tree.get-typography-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-tree.get-tokens($theme), typography));
-  } @else {
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-tree.get-typography-tokens($theme));
-    }
+    $tokens: map.get(m3-tree.get-tokens($theme), typography);
   }
+
+  @include token-utils.values($tokens);
 }
 
 @mixin density($theme) {
+  $tokens: m2-tree.get-density-tokens($theme);
   @if inspection.get-theme-version($theme) == 1 {
-    @include token-utils.create-token-values(map.get(m3-tree.get-tokens($theme), density));
-  } @else {
-    $density-scale: inspection.get-theme-density($theme);
-
-    @include sass-utils.current-selector-or-root() {
-      @include token-utils.create-token-values-mixed(m2-tree.get-density-tokens($theme));
-    }
+    $tokens: map.get(m3-tree.get-tokens($theme), density);
   }
+
+  @include token-utils.values($tokens);
 }
 
 /// Defines the tokens that will be available in the `overrides` mixin and for docs extraction.


### PR DESCRIPTION
Defines M2 theme tokens (CSS vars) inline instead of creating a new selector block

```
// Theme file:
html {
  @include mat.button-theme($theme);
  @include mat.card-theme($theme);
  @include mat.checkbox-theme($theme);
}
```

Before, this would have split each component into its own html block:
```
html {
  // button token CSS variable definitions
}

html {
  // card token CSS variable definitions
}

html {
  // checkbox token CSS variable definitions
}
```

With this change, these will be grouped together:
```
html {
  // button token CSS variable definitions
  // card token CSS variable definitions
  // checkbox token CSS variable definitions
}
```

For some users, this will surface a Sass warning about [mixed-decls](https://sass-lang.com/documentation/breaking-changes/mixed-decls/). This was previously being avoided because the CSS created the variables in subsequent selector blocks, but are now inline.
