### PR TITLE
fix(material/button): remove concrete icon button theme styles

### DIFF
--- a/src/material/button/_icon-button-theme.scss
+++ b/src/material/button/_icon-button-theme.scss
@@ -1,5 +1,4 @@
 @use 'sass:map';
-@use 'sass:math';
 @use './m2-icon-button';
 @use './m3-icon-button';
 @use '../core/tokens/token-utils';


### PR DESCRIPTION
Removes hardcoded concrete styles that are emitted in M2's icon button density mixin