### PR TITLE
fix(cdk-experimental/accordion): fix disabled trigger button can't be focused when skipDisabled=false

### DIFF
--- a/src/cdk-experimental/accordion/accordion.ts
+++ b/src/cdk-experimental/accordion/accordion.ts
@@ -93,6 +93,8 @@ export class CdkAccordionPanel {
     '[attr.aria-expanded]': 'pattern.expanded()',
     '[attr.aria-controls]': 'pattern.controls()',
     '[attr.aria-disabled]': 'pattern.disabled()',
+    '[attr.inert]': 'hardDisabled() ? true : null',
+    '[attr.disabled]': 'hardDisabled() ? true : null',
     '[attr.tabindex]': 'pattern.tabindex()',
     '(keydown)': 'pattern.onKeydown($event)',
     '(pointerdown)': 'pattern.onPointerdown($event)',
@@ -114,6 +116,13 @@ export class CdkAccordionTrigger {
 
   /** Whether the trigger is disabled. */
   disabled = input(false, {transform: booleanAttribute});
+
+  /**
+   * Whether this trigger is completely inaccessible.
+   *
+   * TODO(ok7sai): Consider move this to UI patterns.
+   */
+  readonly hardDisabled = computed(() => this.pattern.disabled() && this.pattern.tabindex() < 0);
 
   /** The accordion panel pattern controlled by this trigger. This is set by CdkAccordionGroup. */
   readonly accordionPanel: WritableSignal<AccordionPanelPattern | undefined> = signal(undefined);


### PR DESCRIPTION
In short, in the demo page
```
<button cdkAccordionTrigger disabled>
```
Makes the button natively disabled and not focusable, so even with `skipDisabled=false` it can't be focused by the focus manager.

Change it to
```
<button cdkAccordionTrigger [disabled]="true">
```
Makes the `cdkAccordionTrigger` to be disabled without changing the button state.

Also added the `inert` attribute to the button when it's completely disabled(disabled and skip disabled), so it can't be focused by a pointer.