### PR TITLE
feat(material/menu): add support for context menu 

### DIFF
--- a/goldens/material/menu/index.api.md
+++ b/goldens/material/menu/index.api.md
@@ -7,7 +7,9 @@
 import { AfterContentInit } from '@angular/core';
 import { AfterViewInit } from '@angular/core';
 import { Direction } from '@angular/cdk/bidi';
+import { ElementRef } from '@angular/core';
 import { EventEmitter } from '@angular/core';
+import { FlexibleConnectedPositionStrategyOrigin } from '@angular/cdk/overlay';
 import { FocusableOption } from '@angular/cdk/a11y';
 import { FocusOrigin } from '@angular/cdk/a11y';
 import * as i0 from '@angular/core';
@@ -18,7 +20,9 @@ import { InjectionToken } from '@angular/core';
 import { Observable } from 'rxjs';
 import { OnDestroy } from '@angular/core';
 import { OnInit } from '@angular/core';
+import { OverlayRef } from '@angular/cdk/overlay';
 import { QueryList } from '@angular/core';
+import * as rxjs from 'rxjs';
 import { ScrollStrategy } from '@angular/cdk/overlay';
 import { Subject } from 'rxjs';
 import { TemplateRef } from '@angular/core';
@@ -190,7 +194,7 @@ export class MatMenuModule {
     // (undocumented)
     static ɵinj: i0.ɵɵInjectorDeclaration<MatMenuModule>;
     // (undocumented)
-    static ɵmod: i0.ɵɵNgModuleDeclaration<MatMenuModule, never, [typeof MatRippleModule, typeof MatCommonModule, typeof i2.OverlayModule, typeof MatMenu, typeof MatMenuItem, typeof MatMenuContent, typeof MatMenuTrigger], [typeof i5.CdkScrollableModule, typeof MatMenu, typeof MatCommonModule, typeof MatMenuItem, typeof MatMenuContent, typeof MatMenuTrigger]>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<MatMenuModule, never, [typeof MatRippleModule, typeof MatCommonModule, typeof i2.OverlayModule, typeof MatMenu, typeof MatMenuItem, typeof MatMenuContent, typeof MatMenuTrigger, typeof MatContextMenuTrigger], [typeof i5.CdkScrollableModule, typeof MatMenu, typeof MatCommonModule, typeof MatMenuItem, typeof MatMenuContent, typeof MatMenuTrigger, typeof MatContextMenuTrigger]>;
 }
 
 // @public
@@ -234,14 +238,16 @@ export interface MatMenuPanel<T = any> {
 }
 
 // @public
-export class MatMenuTrigger implements AfterContentInit, OnDestroy {
+export class MatMenuTrigger extends MatMenuTriggerBase implements AfterContentInit, OnDestroy {
     constructor(...args: unknown[]);
     closeMenu(): void;
     // @deprecated (undocumented)
     get _deprecatedMatMenuTriggerFor(): MatMenuPanel | null;
     set _deprecatedMatMenuTriggerFor(v: MatMenuPanel | null);
-    get dir(): Direction;
-    focus(origin?: FocusOrigin, options?: FocusOptions): void;
+    // (undocumented)
+    protected _getOutsideClickStream(overlayRef: OverlayRef): rxjs.Observable<MouseEvent>;
+    // (undocumented)
+    protected _getOverlayOrigin(): i0.ElementRef<HTMLElement>;
     _handleClick(event: MouseEvent): void;
     _handleKeydown(event: KeyboardEvent): void;
     _handleMousedown(event: MouseEvent): void;
@@ -249,7 +255,6 @@ export class MatMenuTrigger implements AfterContentInit, OnDestroy {
     set menu(menu: MatMenuPanel | null);
     readonly menuClosed: EventEmitter<void>;
     menuData: any;
-    get menuOpen(): boolean;
     readonly menuOpened: EventEmitter<void>;
     // (undocumented)
     ngAfterContentInit(): void;
@@ -259,8 +264,6 @@ export class MatMenuTrigger implements AfterContentInit, OnDestroy {
     readonly onMenuClose: EventEmitter<void>;
     // @deprecated
     readonly onMenuOpen: EventEmitter<void>;
-    // (undocumented)
-    _openedBy: Exclude<FocusOrigin, 'program' | null> | undefined;
     openMenu(): void;
     restoreFocus: boolean;
     toggleMenu(): void;

--- a/goldens/material/menu/index.api.md
+++ b/goldens/material/menu/index.api.md
@@ -49,6 +49,40 @@ export const MAT_MENU_SCROLL_STRATEGY_FACTORY_PROVIDER: {
     useFactory: typeof MAT_MENU_SCROLL_STRATEGY_FACTORY;
 };
 
+// @public
+export class MatContextMenuTrigger extends MatMenuTriggerBase implements OnDestroy {
+    constructor();
+    // (undocumented)
+    protected _destroyMenu(reason: MenuCloseReason): void;
+    disabled: boolean;
+    // (undocumented)
+    protected _getOutsideClickStream(overlayRef: OverlayRef): rxjs.Observable<MouseEvent>;
+    // (undocumented)
+    protected _getOverlayOrigin(): {
+        x: number;
+        y: number;
+        initialX: number;
+        initialY: number;
+        initialScrollX: number;
+        initialScrollY: number;
+    };
+    protected _handleContextMenuEvent(event: MouseEvent): void;
+    get menu(): MatMenuPanel | null;
+    set menu(menu: MatMenuPanel | null);
+    readonly menuClosed: EventEmitter<void>;
+    menuData: any;
+    readonly menuOpened: EventEmitter<void>;
+    // (undocumented)
+    static ngAcceptInputType_disabled: unknown;
+    // (undocumented)
+    ngOnDestroy(): void;
+    restoreFocus: boolean;
+    // (undocumented)
+    static ɵdir: i0.ɵɵDirectiveDeclaration<MatContextMenuTrigger, "[matContextMenuTriggerFor]", ["matContextMenuTrigger"], { "menu": { "alias": "matContextMenuTriggerFor"; "required": true; }; "menuData": { "alias": "matContextMenuTriggerData"; "required": false; }; "restoreFocus": { "alias": "matContextMenuTriggerRestoreFocus"; "required": false; }; "disabled": { "alias": "matContextMenuTriggerDisabled"; "required": false; }; }, { "menuOpened": "menuOpened"; "menuClosed": "menuClosed"; }, never, never, true, never>;
+    // (undocumented)
+    static ɵfac: i0.ɵɵFactoryDeclaration<MatContextMenuTrigger, never>;
+}
+
 // @public (undocumented)
 export class MatMenu implements AfterContentInit, MatMenuPanel<MatMenuItem>, OnInit, OnDestroy {
     constructor(...args: unknown[]);

--- a/goldens/material/menu/testing/index.api.md
+++ b/goldens/material/menu/testing/index.api.md
@@ -11,6 +11,24 @@ import { HarnessLoader } from '@angular/cdk/testing';
 import { HarnessPredicate } from '@angular/cdk/testing';
 
 // @public
+export interface ContextMenuHarnessFilters extends BaseHarnessFilters {
+}
+
+// @public
+export class MatContextMenuHarness extends ContentContainerComponentHarness<string> {
+    clickItem(itemFilter: Omit<MenuItemHarnessFilters, 'ancestor'>, ...subItemFilters: Omit<MenuItemHarnessFilters, 'ancestor'>[]): Promise<void>;
+    close(): Promise<void>;
+    getItems(filters?: Omit<MenuItemHarnessFilters, 'ancestor'>): Promise<MatMenuItemHarness[]>;
+    // (undocumented)
+    protected getRootHarnessLoader(): Promise<HarnessLoader>;
+    static hostSelector: string;
+    isDisabled(): Promise<boolean>;
+    isOpen(): Promise<boolean>;
+    open(relativeX?: number, relativeY?: number): Promise<void>;
+    static with<T extends MatContextMenuHarness>(this: ComponentHarnessConstructor<T>, options?: ContextMenuHarnessFilters): HarnessPredicate<T>;
+}
+
+// @public
 export class MatMenuHarness extends ContentContainerComponentHarness<string> {
     blur(): Promise<void>;
     clickItem(itemFilter: Omit<MenuItemHarnessFilters, 'ancestor'>, ...subItemFilters: Omit<MenuItemHarnessFilters, 'ancestor'>[]): Promise<void>;

--- a/src/components-examples/material/menu/context-menu/context-menu-example.css
+++ b/src/components-examples/material/menu/context-menu/context-menu-example.css
@@ -1,0 +1,12 @@
+.example-context-menu-area {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 300px;
+  max-width: 300px;
+  border: dashed 1px;
+  text-align: center;
+  padding: 30px;
+  box-sizing: border-box;
+}

--- a/src/components-examples/material/menu/context-menu/context-menu-example.html
+++ b/src/components-examples/material/menu/context-menu/context-menu-example.html
@@ -1,0 +1,22 @@
+<div class="example-context-menu-area" [matContextMenuTriggerFor]="contextMenu">
+  Right click here to trigger a context menu
+</div>
+
+<mat-menu #contextMenu>
+  <button mat-menu-item>
+    <mat-icon>content_cut</mat-icon>
+    Cut
+  </button>
+  <button mat-menu-item>
+    <mat-icon>content_copy</mat-icon>
+    Copy
+  </button>
+  <button mat-menu-item>
+    <mat-icon>content_paste</mat-icon>
+    Paste
+  </button>
+  <button mat-menu-item>
+    <mat-icon>print</mat-icon>
+    Print
+  </button>
+</mat-menu>

--- a/src/components-examples/material/menu/context-menu/context-menu-example.ts
+++ b/src/components-examples/material/menu/context-menu/context-menu-example.ts
@@ -1,0 +1,14 @@
+import {Component} from '@angular/core';
+import {MatMenuModule} from '@angular/material/menu';
+import {MatIconModule} from '@angular/material/icon';
+
+/**
+ * @title Context menu
+ */
+@Component({
+  selector: 'context-menu-example',
+  templateUrl: 'context-menu-example.html',
+  styleUrl: './context-menu-example.css',
+  imports: [MatMenuModule, MatIconModule],
+})
+export class ContextMenuExample {}

--- a/src/components-examples/material/menu/index.ts
+++ b/src/components-examples/material/menu/index.ts
@@ -3,3 +3,4 @@ export {MenuOverviewExample} from './menu-overview/menu-overview-example';
 export {MenuPositionExample} from './menu-position/menu-position-example';
 export {MenuNestedExample} from './menu-nested/menu-nested-example';
 export {MenuHarnessExample} from './menu-harness/menu-harness-example';
+export {ContextMenuExample} from './context-menu/context-menu-example';

--- a/src/dev-app/menu/menu-demo.html
+++ b/src/dev-app/menu/menu-demo.html
@@ -194,4 +194,29 @@
   </div>
 </div>
 
-<div style="height: 500px">This div is for testing scrolled menus.</div>
+<div class="demo-context-menu-area" [matContextMenuTriggerFor]="contextMenu">
+  Right click here to trigger a context menu
+</div>
+
+<mat-menu #contextMenu>
+  <button mat-menu-item>
+    <mat-icon>content_cut</mat-icon>
+    Cut
+  </button>
+  <button mat-menu-item>
+    <mat-icon>content_copy</mat-icon>
+    Copy
+  </button>
+  <button mat-menu-item>
+    <mat-icon>content_paste</mat-icon>
+    Paste
+  </button>
+  <button mat-menu-item>
+    <mat-icon>print</mat-icon>
+    Print
+  </button>
+</mat-menu>
+
+<div style="height: 500px">
+  <!-- Makes the page scrollable for easier testing. -->
+</div>

--- a/src/dev-app/menu/menu-demo.scss
+++ b/src/dev-app/menu/menu-demo.scss
@@ -11,3 +11,13 @@
     justify-content: flex-end;
   }
 }
+
+.demo-context-menu-area {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 500px;
+  max-width: 500px;
+  outline: dashed 1px;
+}

--- a/src/material/menu/BUILD.bazel
+++ b/src/material/menu/BUILD.bazel
@@ -76,6 +76,7 @@ ng_project(
         "menu-panel.ts",
         "menu-positions.ts",
         "menu-trigger.ts",
+        "menu-trigger-base.ts",
         "module.ts",
         "public-api.ts",
     ],

--- a/src/material/menu/BUILD.bazel
+++ b/src/material/menu/BUILD.bazel
@@ -67,6 +67,7 @@ sass_binary(
 ng_project(
     name = "menu",
     srcs = [
+        "context-menu-trigger.ts",
         "index.ts",
         "menu.ts",
         "menu-animations.ts",

--- a/src/material/menu/context-menu-trigger.spec.ts
+++ b/src/material/menu/context-menu-trigger.spec.ts
@@ -1,0 +1,192 @@
+import {Component, signal} from '@angular/core';
+import {ComponentFixture, fakeAsync, flush, TestBed} from '@angular/core/testing';
+import {MatContextMenuTrigger} from './context-menu-trigger';
+import {MatMenu} from './menu';
+import {MatMenuItem} from './menu-item';
+import {dispatchFakeEvent, dispatchMouseEvent} from '@angular/cdk/testing/private';
+
+describe('context menu trigger', () => {
+  let fixture: ComponentFixture<ContextMenuTest>;
+
+  function getTrigger(): HTMLElement {
+    return fixture.nativeElement.querySelector('.area');
+  }
+
+  function getMenu(): HTMLElement | null {
+    return document.querySelector('.mat-mdc-menu-panel');
+  }
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ContextMenuTest);
+    fixture.detectChanges();
+  });
+
+  it('should open the menu on the `contextmenu` event', () => {
+    expect(getMenu()).toBe(null);
+    dispatchMouseEvent(getTrigger(), 'contextmenu', 10, 10);
+    fixture.detectChanges();
+    expect(getMenu()).toBeTruthy();
+  });
+
+  it('should close the menu when clicking outside the trigger', fakeAsync(() => {
+    dispatchMouseEvent(getTrigger(), 'contextmenu', 10, 10);
+    fixture.detectChanges();
+    expect(getMenu()).toBeTruthy();
+
+    document.body.click();
+    fixture.detectChanges();
+    flush();
+    expect(getMenu()).toBe(null);
+  }));
+
+  it('should reposition the menu when right-clicking within the area', () => {
+    dispatchMouseEvent(getTrigger(), 'contextmenu', 10, 10);
+    fixture.detectChanges();
+    let menuRect = getMenu()!.getBoundingClientRect();
+    expect(menuRect.top).toBe(10);
+    expect(menuRect.left).toBe(10);
+
+    dispatchMouseEvent(getTrigger(), 'contextmenu', 50, 75);
+    fixture.detectChanges();
+    menuRect = getMenu()!.getBoundingClientRect();
+    expect(menuRect.top).toBe(75);
+    expect(menuRect.left).toBe(50);
+  });
+
+  it('should ignore the first auxclick after opening', fakeAsync(() => {
+    dispatchMouseEvent(getTrigger(), 'contextmenu', 10, 10);
+    fixture.detectChanges();
+    expect(getMenu()).toBeTruthy();
+
+    dispatchMouseEvent(document.body, 'auxclick');
+    fixture.detectChanges();
+    flush();
+    expect(getMenu()).toBeTruthy();
+
+    dispatchMouseEvent(document.body, 'auxclick');
+    fixture.detectChanges();
+    flush();
+    expect(getMenu()).toBe(null);
+  }));
+
+  it('should close on `contextmenu` events outside the trigger', fakeAsync(() => {
+    dispatchMouseEvent(getTrigger(), 'contextmenu', 10, 10);
+    fixture.detectChanges();
+    expect(getMenu()).toBeTruthy();
+
+    dispatchMouseEvent(document.body, 'contextmenu');
+    fixture.detectChanges();
+    flush();
+    expect(getMenu()).toBe(null);
+  }));
+
+  it('should not close on `contextmenu` events from inside the menu', fakeAsync(() => {
+    dispatchMouseEvent(getTrigger(), 'contextmenu', 10, 10);
+    fixture.detectChanges();
+    expect(getMenu()).toBeTruthy();
+
+    dispatchMouseEvent(getMenu()!, 'contextmenu');
+    fixture.detectChanges();
+    flush();
+    expect(getMenu()).toBeTruthy();
+  }));
+
+  it('should set aria-controls on the trigger while the menu is open', () => {
+    expect(getTrigger().getAttribute('aria-controls')).toBe(null);
+    dispatchMouseEvent(getTrigger(), 'contextmenu', 10, 10);
+    fixture.detectChanges();
+    expect(getTrigger().getAttribute('aria-controls')).toBeTruthy();
+  });
+
+  it('should reposition the menu as the user is scrolling', () => {
+    const scroller = document.createElement('div');
+    scroller.style.height = '1000px';
+    fixture.nativeElement.appendChild(scroller);
+
+    dispatchMouseEvent(getTrigger(), 'contextmenu', 10, 10);
+    fixture.detectChanges();
+    let menuRect = getMenu()!.getBoundingClientRect();
+    expect(menuRect.top).toBe(10);
+    expect(menuRect.left).toBe(10);
+
+    scrollTo(0, 100);
+    dispatchFakeEvent(document, 'scroll');
+    fixture.detectChanges();
+    menuRect = getMenu()!.getBoundingClientRect();
+    expect(menuRect.top).toBe(-90);
+    expect(menuRect.left).toBe(10);
+
+    window.scroll(0, 0);
+    scroller.remove();
+  });
+
+  it('should emit events when the menu is opened and closed', fakeAsync(() => {
+    const {opened, closed} = fixture.componentInstance;
+    expect(opened).toHaveBeenCalledTimes(0);
+    expect(closed).toHaveBeenCalledTimes(0);
+
+    dispatchMouseEvent(getTrigger(), 'contextmenu', 10, 10);
+    fixture.detectChanges();
+    expect(opened).toHaveBeenCalledTimes(1);
+    expect(closed).toHaveBeenCalledTimes(0);
+
+    document.body.click();
+    fixture.detectChanges();
+    flush();
+    expect(opened).toHaveBeenCalledTimes(1);
+    expect(closed).toHaveBeenCalledTimes(1);
+  }));
+
+  it('should close the menu if the trigger is destroyed', fakeAsync(() => {
+    dispatchMouseEvent(getTrigger(), 'contextmenu', 10, 10);
+    fixture.detectChanges();
+    expect(getMenu()).toBeTruthy();
+
+    fixture.componentInstance.showTrigger.set(false);
+    fixture.detectChanges();
+    flush();
+    expect(getMenu()).toBe(null);
+  }));
+
+  it('should not open when clicking on a disabled context menu trigger', () => {
+    fixture.componentInstance.disabled.set(true);
+    fixture.detectChanges();
+    expect(getTrigger().classList).toContain('mat-context-menu-trigger-disabled');
+    expect(getMenu()).toBe(null);
+    dispatchMouseEvent(getTrigger(), 'contextmenu', 10, 10);
+    fixture.detectChanges();
+    expect(getMenu()).toBe(null);
+  });
+});
+
+@Component({
+  template: `
+    @if (showTrigger()) {
+      <div
+        class="area"
+        [matContextMenuTriggerFor]="menu"
+        [matContextMenuTriggerDisabled]="disabled()"
+        (menuOpened)="opened()"
+        (menuClosed)="closed()"></div>
+    }
+    <mat-menu #menu>
+      <button mat-menu-item>One</button>
+      <button mat-menu-item>Two</button>
+      <button mat-menu-item>Three</button>
+    </mat-menu>
+  `,
+  imports: [MatContextMenuTrigger, MatMenu, MatMenuItem],
+  styles: `
+    .area {
+      width: 200px;
+      height: 200px;
+      outline: solid 1px;
+    }
+  `,
+})
+class ContextMenuTest {
+  showTrigger = signal(true);
+  disabled = signal(false);
+  opened = jasmine.createSpy('opened');
+  closed = jasmine.createSpy('closed');
+}

--- a/src/material/menu/context-menu-trigger.ts
+++ b/src/material/menu/context-menu-trigger.ts
@@ -1,0 +1,213 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {
+  booleanAttribute,
+  Directive,
+  DOCUMENT,
+  EventEmitter,
+  inject,
+  Input,
+  OnDestroy,
+  Output,
+} from '@angular/core';
+import {MatMenuTriggerBase} from './menu-trigger-base';
+import {
+  FlexibleConnectedPositionStrategy,
+  OverlayRef,
+  ScrollDispatcher,
+  ViewportRuler,
+} from '@angular/cdk/overlay';
+import {_getEventTarget, _getShadowRoot} from '@angular/cdk/platform';
+import {Subscription} from 'rxjs';
+import {skipWhile} from 'rxjs/operators';
+import {MatMenuPanel} from './menu-panel';
+import {_animationsDisabled} from '../core';
+import {MenuCloseReason} from './menu';
+
+/**
+ * Trigger that opens a menu whenever the user right-clicks within its host element.
+ */
+@Directive({
+  selector: '[matContextMenuTriggerFor]',
+  host: {
+    'class': 'mat-context-menu-trigger',
+    '[class.mat-context-menu-trigger-disabled]': 'disabled',
+    '[attr.aria-controls]': 'menuOpen ? menu?.panelId : null',
+    '(contextmenu)': '_handleContextMenuEvent($event)',
+  },
+  exportAs: 'matContextMenuTrigger',
+})
+export class MatContextMenuTrigger extends MatMenuTriggerBase implements OnDestroy {
+  private _point = {x: 0, y: 0, initialX: 0, initialY: 0, initialScrollX: 0, initialScrollY: 0};
+  private _triggerPressedControl = false;
+  private _rootNode: DocumentOrShadowRoot | undefined;
+  private _document = inject(DOCUMENT);
+  private _viewportRuler = inject(ViewportRuler);
+  private _scrollDispatcher = inject(ScrollDispatcher);
+  private _scrollSubscription: Subscription | undefined;
+
+  /** References the menu instance that the trigger is associated with. */
+  @Input({alias: 'matContextMenuTriggerFor', required: true})
+  get menu(): MatMenuPanel | null {
+    return this._menu;
+  }
+  set menu(menu: MatMenuPanel | null) {
+    this._menu = menu;
+  }
+
+  /** Data to be passed along to any lazily-rendered content. */
+  @Input('matContextMenuTriggerData')
+  override menuData: any;
+
+  /**
+   * Whether focus should be restored when the menu is closed.
+   * Note that disabling this option can have accessibility implications
+   * and it's up to you to manage focus, if you decide to turn it off.
+   */
+  @Input('matContextMenuTriggerRestoreFocus')
+  override restoreFocus: boolean = true;
+
+  /** Whether the context menu is disabled. */
+  @Input({alias: 'matContextMenuTriggerDisabled', transform: booleanAttribute})
+  disabled: boolean = false;
+
+  /** Event emitted when the associated menu is opened. */
+  @Output()
+  readonly menuOpened: EventEmitter<void> = new EventEmitter<void>();
+
+  /** Event emitted when the associated menu is closed. */
+  @Output() readonly menuClosed: EventEmitter<void> = new EventEmitter<void>();
+
+  constructor() {
+    super(false);
+  }
+
+  override ngOnDestroy(): void {
+    super.ngOnDestroy();
+    this._scrollSubscription?.unsubscribe();
+  }
+
+  /** Handler for `contextmenu` events. */
+  protected _handleContextMenuEvent(event: MouseEvent) {
+    if (!this.disabled) {
+      event.preventDefault();
+
+      // If the menu is already open, only update its position.
+      if (this.menuOpen) {
+        this._initializePoint(event.clientX, event.clientY);
+        this._updatePosition();
+      } else {
+        this._openContextMenu(event);
+      }
+    }
+  }
+
+  protected override _destroyMenu(reason: MenuCloseReason): void {
+    super._destroyMenu(reason);
+    this._scrollSubscription?.unsubscribe();
+  }
+
+  protected override _getOverlayOrigin() {
+    return this._point;
+  }
+
+  protected override _getOutsideClickStream(overlayRef: OverlayRef) {
+    return overlayRef.outsidePointerEvents().pipe(
+      skipWhile((event, index) => {
+        if (event.type === 'contextmenu') {
+          // Do not close when attempting to open a context menu within the trigger.
+          return this._isWithinMenuOrTrigger(_getEventTarget(event) as Element);
+        } else if (event.type === 'auxclick') {
+          // Skip the first `auxclick` since it happens at
+          // the same time as the event that opens the menu.
+          if (index === 0) {
+            return true;
+          }
+
+          // Do not close on `auxclick` within the menu since we want to reposition the menu
+          // instead. Note that we have to resolve the clicked element using its position,
+          // rather than `event.target`, because the `target` is set to the `body`.
+          this._rootNode ??= _getShadowRoot(this._element.nativeElement) || this._document;
+          return this._isWithinMenuOrTrigger(
+            this._rootNode.elementFromPoint(event.clientX, event.clientY),
+          );
+        }
+
+        // Using a mouse, the `contextmenu` event can fire either when pressing the right button
+        // or left button + control. Most browsers won't dispatch a `click` event right after
+        // a `contextmenu` event triggered by left button + control, but Safari will (see #27832).
+        // This closes the menu immediately. To work around it, we check that both the triggering
+        // event and the current outside click event both had the control key pressed, and that
+        // that this is the first outside click event.
+        return this._triggerPressedControl && index === 0 && event.ctrlKey;
+      }),
+    );
+  }
+
+  /** Checks whether an element is within the trigger or the opened overlay. */
+  private _isWithinMenuOrTrigger(target: Element | null): boolean {
+    if (!target) {
+      return false;
+    }
+
+    const element = this._element.nativeElement;
+    if (target === element || element.contains(target)) {
+      return true;
+    }
+
+    const overlay = this._overlayRef?.hostElement;
+    return overlay === target || !!overlay?.contains(target);
+  }
+
+  /** Opens the context menu. */
+  private _openContextMenu(event: MouseEvent) {
+    // A context menu can be triggered via a mouse right click or a keyboard shortcut.
+    if (event.button === 2) {
+      this._openedBy = 'mouse';
+    } else {
+      this._openedBy = event.button === 0 ? 'keyboard' : undefined;
+    }
+
+    this._initializePoint(event.clientX, event.clientY);
+    this._triggerPressedControl = event.ctrlKey;
+    super._openMenu(true);
+    this._scrollSubscription?.unsubscribe();
+    this._scrollSubscription = this._scrollDispatcher.scrolled(0).subscribe(() => {
+      // When passing a point to the connected position strategy, the position
+      // won't update as the user is scrolling so we have to do it manually.
+      const position = this._viewportRuler.getViewportScrollPosition();
+      const point = this._point;
+      point.y = point.initialY + (point.initialScrollY - position.top);
+      point.x = point.initialX + (point.initialScrollX - position.left);
+      this._updatePosition();
+    });
+  }
+
+  /** Initializes the point representing the origin relative to which the menu will be rendered. */
+  private _initializePoint(x: number, y: number) {
+    const scrollPosition = this._viewportRuler.getViewportScrollPosition();
+    const point = this._point;
+    point.x = point.initialX = x;
+    point.y = point.initialY = y;
+    point.initialScrollX = scrollPosition.left;
+    point.initialScrollY = scrollPosition.top;
+  }
+
+  /** Refreshes the position of the overlay. */
+  private _updatePosition() {
+    const overlayRef = this._overlayRef;
+
+    if (overlayRef) {
+      const positionStrategy = overlayRef.getConfig()
+        .positionStrategy as FlexibleConnectedPositionStrategy;
+      positionStrategy.setOrigin(this._point);
+      overlayRef.updatePosition();
+    }
+  }
+}

--- a/src/material/menu/menu-trigger-base.ts
+++ b/src/material/menu/menu-trigger-base.ts
@@ -1,0 +1,494 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {FocusMonitor, FocusOrigin} from '@angular/cdk/a11y';
+import {Direction, Directionality} from '@angular/cdk/bidi';
+import {
+  createFlexibleConnectedPositionStrategy,
+  createOverlayRef,
+  createRepositionScrollStrategy,
+  FlexibleConnectedPositionStrategy,
+  FlexibleConnectedPositionStrategyOrigin,
+  HorizontalConnectionPos,
+  OverlayConfig,
+  OverlayRef,
+  ScrollStrategy,
+  VerticalConnectionPos,
+} from '@angular/cdk/overlay';
+import {TemplatePortal} from '@angular/cdk/portal';
+import {
+  ChangeDetectorRef,
+  Directive,
+  ElementRef,
+  EventEmitter,
+  inject,
+  InjectionToken,
+  Injector,
+  NgZone,
+  OnDestroy,
+  ViewContainerRef,
+} from '@angular/core';
+import {merge, Observable, of as observableOf, Subscription} from 'rxjs';
+import {filter, take, takeUntil} from 'rxjs/operators';
+import {MatMenu, MenuCloseReason} from './menu';
+import {throwMatMenuRecursiveError} from './menu-errors';
+import {MatMenuItem} from './menu-item';
+import {MAT_MENU_PANEL, MatMenuPanel} from './menu-panel';
+import {MenuPositionX, MenuPositionY} from './menu-positions';
+import {_animationsDisabled} from '../core';
+
+/** Injection token that determines the scroll handling while the menu is open. */
+export const MAT_MENU_SCROLL_STRATEGY = new InjectionToken<() => ScrollStrategy>(
+  'mat-menu-scroll-strategy',
+  {
+    providedIn: 'root',
+    factory: () => {
+      const injector = inject(Injector);
+      return () => createRepositionScrollStrategy(injector);
+    },
+  },
+);
+
+/**
+ * @docs-private
+ * @deprecated No longer used, will be removed.
+ * @breaking-change 21.0.0
+ */
+export function MAT_MENU_SCROLL_STRATEGY_FACTORY(_overlay: unknown): () => ScrollStrategy {
+  const injector = inject(Injector);
+  return () => createRepositionScrollStrategy(injector);
+}
+
+/**
+ * @docs-private
+ * @deprecated No longer used, will be removed.
+ * @breaking-change 21.0.0
+ */
+export const MAT_MENU_SCROLL_STRATEGY_FACTORY_PROVIDER = {
+  provide: MAT_MENU_SCROLL_STRATEGY,
+  deps: [] as any[],
+  useFactory: MAT_MENU_SCROLL_STRATEGY_FACTORY,
+};
+
+/**
+ * Default top padding of the menu panel.
+ * @deprecated No longer being used. Will be removed.
+ * @breaking-change 15.0.0
+ */
+export const MENU_PANEL_TOP_PADDING = 8;
+
+/** Mapping between menu panels and the last trigger that opened them. */
+const PANELS_TO_TRIGGERS = new WeakMap<MatMenuPanel, MatMenuTriggerBase>();
+
+/** Directive applied to an element that should trigger a `mat-menu`. */
+@Directive()
+export abstract class MatMenuTriggerBase implements OnDestroy {
+  protected _element = inject<ElementRef<HTMLElement>>(ElementRef);
+  private _viewContainerRef = inject(ViewContainerRef);
+  protected _menuItemInstance = inject(MatMenuItem, {optional: true, self: true})!;
+  private _dir = inject(Directionality, {optional: true});
+  private _focusMonitor = inject(FocusMonitor);
+  private _ngZone = inject(NgZone);
+  private _injector = inject(Injector);
+  private _scrollStrategy = inject(MAT_MENU_SCROLL_STRATEGY);
+  private _changeDetectorRef = inject(ChangeDetectorRef);
+  private _animationsDisabled = _animationsDisabled();
+
+  private _portal: TemplatePortal;
+  protected _overlayRef: OverlayRef | null = null;
+  private _menuOpen: boolean = false;
+  private _closingActionsSubscription = Subscription.EMPTY;
+  private _menuCloseSubscription = Subscription.EMPTY;
+  private _pendingRemoval: Subscription | undefined;
+
+  /**
+   * We're specifically looking for a `MatMenu` here since the generic `MatMenuPanel`
+   * interface lacks some functionality around nested menus and animations.
+   */
+  protected _parentMaterialMenu: MatMenu | undefined;
+
+  /**
+   * Cached value of the padding of the parent menu panel.
+   * Used to offset sub-menus to compensate for the padding.
+   */
+  private _parentInnerPadding: number | undefined;
+
+  // Tracking input type is necessary so it's possible to only auto-focus
+  // the first item of the list when the menu is opened via the keyboard
+  protected _openedBy: Exclude<FocusOrigin, 'program' | null> | undefined = undefined;
+
+  /** Data that will be passed to the menu panel. */
+  abstract menuData: any;
+
+  /** Whether focus should be restored when the menu is closed. */
+  abstract restoreFocus: boolean;
+
+  /** Menu currently assigned to the trigger. */
+  protected get _menu(): MatMenuPanel | null {
+    return this._menuInternal;
+  }
+
+  protected set _menu(menu: MatMenuPanel | null) {
+    if (menu === this._menuInternal) {
+      return;
+    }
+
+    this._menuInternal = menu;
+    this._menuCloseSubscription.unsubscribe();
+
+    if (menu) {
+      if (menu === this._parentMaterialMenu && (typeof ngDevMode === 'undefined' || ngDevMode)) {
+        throwMatMenuRecursiveError();
+      }
+
+      this._menuCloseSubscription = menu.close.subscribe((reason: MenuCloseReason) => {
+        this._destroyMenu(reason);
+
+        // If a click closed the menu, we should close the entire chain of nested menus.
+        if ((reason === 'click' || reason === 'tab') && this._parentMaterialMenu) {
+          this._parentMaterialMenu.closed.emit(reason);
+        }
+      });
+    }
+
+    this._menuItemInstance?._setTriggersSubmenu(this._triggersSubmenu());
+  }
+  private _menuInternal: MatMenuPanel | null;
+
+  /** Event emitted when the associated menu is opened. */
+  abstract menuOpened: EventEmitter<void>;
+
+  /** Event emitted when the associated menu is closed. */
+  abstract menuClosed: EventEmitter<void>;
+
+  /** Gets the origin for the overlay. */
+  protected abstract _getOverlayOrigin(): FlexibleConnectedPositionStrategyOrigin;
+
+  protected abstract _getOutsideClickStream(overlayRef: OverlayRef): Observable<unknown>;
+
+  constructor(private readonly _canHaveBackdrop: boolean) {
+    const parentMenu = inject<MatMenuPanel>(MAT_MENU_PANEL, {optional: true});
+    this._parentMaterialMenu = parentMenu instanceof MatMenu ? parentMenu : undefined;
+  }
+
+  ngOnDestroy() {
+    if (this._menu && this._ownsMenu(this._menu)) {
+      PANELS_TO_TRIGGERS.delete(this._menu);
+    }
+
+    this._pendingRemoval?.unsubscribe();
+    this._menuCloseSubscription.unsubscribe();
+    this._closingActionsSubscription.unsubscribe();
+
+    if (this._overlayRef) {
+      this._overlayRef.dispose();
+      this._overlayRef = null;
+    }
+  }
+
+  /** Whether the menu is open. */
+  get menuOpen(): boolean {
+    return this._menuOpen;
+  }
+
+  /** The text direction of the containing app. */
+  get dir(): Direction {
+    return this._dir && this._dir.value === 'rtl' ? 'rtl' : 'ltr';
+  }
+
+  /** Whether the menu triggers a sub-menu or a top-level one. */
+  protected _triggersSubmenu(): boolean {
+    return !!(this._menuItemInstance && this._parentMaterialMenu && this._menu);
+  }
+
+  protected _closeMenu() {
+    this._menu?.close.emit();
+  }
+
+  /** Internal method to open menu providing option to auto focus on first item. */
+  protected _openMenu(autoFocus: boolean): void {
+    const menu = this._menu;
+
+    if (this._menuOpen || !menu) {
+      return;
+    }
+
+    this._pendingRemoval?.unsubscribe();
+    const previousTrigger = PANELS_TO_TRIGGERS.get(menu);
+    PANELS_TO_TRIGGERS.set(menu, this);
+
+    // If the same menu is currently attached to another trigger,
+    // we need to close it so it doesn't end up in a broken state.
+    if (previousTrigger && previousTrigger !== this) {
+      previousTrigger._closeMenu();
+    }
+
+    const overlayRef = this._createOverlay(menu);
+    const overlayConfig = overlayRef.getConfig();
+    const positionStrategy = overlayConfig.positionStrategy as FlexibleConnectedPositionStrategy;
+
+    this._setPosition(menu, positionStrategy);
+
+    if (this._canHaveBackdrop) {
+      overlayConfig.hasBackdrop =
+        menu.hasBackdrop == null ? !this._triggersSubmenu() : menu.hasBackdrop;
+    } else {
+      overlayConfig.hasBackdrop = false;
+    }
+
+    // We need the `hasAttached` check for the case where the user kicked off a removal animation,
+    // but re-entered the menu. Re-attaching the same portal will trigger an error otherwise.
+    if (!overlayRef.hasAttached()) {
+      overlayRef.attach(this._getPortal(menu));
+      menu.lazyContent?.attach(this.menuData);
+    }
+
+    this._closingActionsSubscription = this._menuClosingActions().subscribe(() =>
+      this._closeMenu(),
+    );
+    menu.parentMenu = this._triggersSubmenu() ? this._parentMaterialMenu : undefined;
+    menu.direction = this.dir;
+
+    if (autoFocus) {
+      menu.focusFirstItem(this._openedBy || 'program');
+    }
+
+    this._setIsMenuOpen(true);
+
+    if (menu instanceof MatMenu) {
+      menu._setIsOpen(true);
+      menu._directDescendantItems.changes.pipe(takeUntil(menu.close)).subscribe(() => {
+        // Re-adjust the position without locking when the amount of items
+        // changes so that the overlay is allowed to pick a new optimal position.
+        positionStrategy.withLockedPosition(false).reapplyLastPosition();
+        positionStrategy.withLockedPosition(true);
+      });
+    }
+  }
+
+  /**
+   * Focuses the menu trigger.
+   * @param origin Source of the menu trigger's focus.
+   */
+  focus(origin?: FocusOrigin, options?: FocusOptions) {
+    if (this._focusMonitor && origin) {
+      this._focusMonitor.focusVia(this._element, origin, options);
+    } else {
+      this._element.nativeElement.focus(options);
+    }
+  }
+
+  /** Closes the menu and does the necessary cleanup. */
+  protected _destroyMenu(reason: MenuCloseReason) {
+    const overlayRef = this._overlayRef;
+    const menu = this._menu;
+
+    if (!overlayRef || !this.menuOpen) {
+      return;
+    }
+
+    this._closingActionsSubscription.unsubscribe();
+    this._pendingRemoval?.unsubscribe();
+
+    // Note that we don't wait for the animation to finish if another trigger took
+    // over the menu, because the panel will end up empty which looks glitchy.
+    if (menu instanceof MatMenu && this._ownsMenu(menu)) {
+      this._pendingRemoval = menu._animationDone.pipe(take(1)).subscribe(() => {
+        overlayRef.detach();
+        menu.lazyContent?.detach();
+      });
+      menu._setIsOpen(false);
+    } else {
+      overlayRef.detach();
+      menu?.lazyContent?.detach();
+    }
+
+    if (menu && this._ownsMenu(menu)) {
+      PANELS_TO_TRIGGERS.delete(menu);
+    }
+
+    // Always restore focus if the user is navigating using the keyboard or the menu was opened
+    // programmatically. We don't restore for non-root triggers, because it can prevent focus
+    // from making it back to the root trigger when closing a long chain of menus by clicking
+    // on the backdrop.
+    if (
+      this.restoreFocus &&
+      (reason === 'keydown' || !this._openedBy || !this._triggersSubmenu())
+    ) {
+      this.focus(this._openedBy);
+    }
+
+    this._openedBy = undefined;
+    this._setIsMenuOpen(false);
+  }
+
+  // set state rather than toggle to support triggers sharing a menu
+  private _setIsMenuOpen(isOpen: boolean): void {
+    if (isOpen !== this._menuOpen) {
+      this._menuOpen = isOpen;
+      this._menuOpen ? this.menuOpened.emit() : this.menuClosed.emit();
+
+      if (this._triggersSubmenu()) {
+        this._menuItemInstance._setHighlighted(isOpen);
+      }
+
+      this._changeDetectorRef.markForCheck();
+    }
+  }
+
+  /**
+   * This method creates the overlay from the provided menu's template and saves its
+   * OverlayRef so that it can be attached to the DOM when openMenu is called.
+   */
+  private _createOverlay(menu: MatMenuPanel): OverlayRef {
+    if (!this._overlayRef) {
+      const config = this._getOverlayConfig(menu);
+      this._subscribeToPositions(
+        menu,
+        config.positionStrategy as FlexibleConnectedPositionStrategy,
+      );
+      this._overlayRef = createOverlayRef(this._injector, config);
+      this._overlayRef.keydownEvents().subscribe(event => {
+        if (this._menu instanceof MatMenu) {
+          this._menu._handleKeydown(event);
+        }
+      });
+    }
+
+    return this._overlayRef;
+  }
+
+  /**
+   * This method builds the configuration object needed to create the overlay, the OverlayState.
+   * @returns OverlayConfig
+   */
+  private _getOverlayConfig(menu: MatMenuPanel): OverlayConfig {
+    return new OverlayConfig({
+      positionStrategy: createFlexibleConnectedPositionStrategy(
+        this._injector,
+        this._getOverlayOrigin(),
+      )
+        .withLockedPosition()
+        .withGrowAfterOpen()
+        .withTransformOriginOn('.mat-menu-panel, .mat-mdc-menu-panel'),
+      backdropClass: menu.backdropClass || 'cdk-overlay-transparent-backdrop',
+      panelClass: menu.overlayPanelClass,
+      scrollStrategy: this._scrollStrategy(),
+      direction: this._dir || 'ltr',
+      disableAnimations: this._animationsDisabled,
+    });
+  }
+
+  /**
+   * Listens to changes in the position of the overlay and sets the correct classes
+   * on the menu based on the new position. This ensures the animation origin is always
+   * correct, even if a fallback position is used for the overlay.
+   */
+  private _subscribeToPositions(menu: MatMenuPanel, position: FlexibleConnectedPositionStrategy) {
+    if (menu.setPositionClasses) {
+      position.positionChanges.subscribe(change => {
+        this._ngZone.run(() => {
+          const posX: MenuPositionX =
+            change.connectionPair.overlayX === 'start' ? 'after' : 'before';
+          const posY: MenuPositionY = change.connectionPair.overlayY === 'top' ? 'below' : 'above';
+          menu.setPositionClasses!(posX, posY);
+        });
+      });
+    }
+  }
+
+  /**
+   * Sets the appropriate positions on a position strategy
+   * so the overlay connects with the trigger correctly.
+   * @param positionStrategy Strategy whose position to update.
+   */
+  private _setPosition(menu: MatMenuPanel, positionStrategy: FlexibleConnectedPositionStrategy) {
+    let [originX, originFallbackX]: HorizontalConnectionPos[] =
+      menu.xPosition === 'before' ? ['end', 'start'] : ['start', 'end'];
+
+    let [overlayY, overlayFallbackY]: VerticalConnectionPos[] =
+      menu.yPosition === 'above' ? ['bottom', 'top'] : ['top', 'bottom'];
+
+    let [originY, originFallbackY] = [overlayY, overlayFallbackY];
+    let [overlayX, overlayFallbackX] = [originX, originFallbackX];
+    let offsetY = 0;
+
+    if (this._triggersSubmenu()) {
+      // When the menu is a sub-menu, it should always align itself
+      // to the edges of the trigger, instead of overlapping it.
+      overlayFallbackX = originX = menu.xPosition === 'before' ? 'start' : 'end';
+      originFallbackX = overlayX = originX === 'end' ? 'start' : 'end';
+
+      if (this._parentMaterialMenu) {
+        if (this._parentInnerPadding == null) {
+          const firstItem = this._parentMaterialMenu.items.first;
+          this._parentInnerPadding = firstItem ? firstItem._getHostElement().offsetTop : 0;
+        }
+
+        offsetY = overlayY === 'bottom' ? this._parentInnerPadding : -this._parentInnerPadding;
+      }
+    } else if (!menu.overlapTrigger) {
+      originY = overlayY === 'top' ? 'bottom' : 'top';
+      originFallbackY = overlayFallbackY === 'top' ? 'bottom' : 'top';
+    }
+
+    positionStrategy.withPositions([
+      {originX, originY, overlayX, overlayY, offsetY},
+      {originX: originFallbackX, originY, overlayX: overlayFallbackX, overlayY, offsetY},
+      {
+        originX,
+        originY: originFallbackY,
+        overlayX,
+        overlayY: overlayFallbackY,
+        offsetY: -offsetY,
+      },
+      {
+        originX: originFallbackX,
+        originY: originFallbackY,
+        overlayX: overlayFallbackX,
+        overlayY: overlayFallbackY,
+        offsetY: -offsetY,
+      },
+    ]);
+  }
+
+  /** Returns a stream that emits whenever an action that should close the menu occurs. */
+  private _menuClosingActions() {
+    const outsideClicks = this._getOutsideClickStream(this._overlayRef!);
+    const detachments = this._overlayRef!.detachments();
+    const parentClose = this._parentMaterialMenu ? this._parentMaterialMenu.closed : observableOf();
+    const hover = this._parentMaterialMenu
+      ? this._parentMaterialMenu
+          ._hovered()
+          .pipe(filter(active => this._menuOpen && active !== this._menuItemInstance))
+      : observableOf();
+
+    return merge(outsideClicks, parentClose as Observable<MenuCloseReason>, hover, detachments);
+  }
+
+  /** Gets the portal that should be attached to the overlay. */
+  private _getPortal(menu: MatMenuPanel): TemplatePortal {
+    // Note that we can avoid this check by keeping the portal on the menu panel.
+    // While it would be cleaner, we'd have to introduce another required method on
+    // `MatMenuPanel`, making it harder to consume.
+    if (!this._portal || this._portal.templateRef !== menu.templateRef) {
+      this._portal = new TemplatePortal(menu.templateRef, this._viewContainerRef);
+    }
+
+    return this._portal;
+  }
+
+  /**
+   * Determines whether the trigger owns a specific menu panel, at the current point in time.
+   * This allows us to distinguish the case where the same panel is passed into multiple triggers
+   * and multiple are open at a time.
+   */
+  private _ownsMenu(menu: MatMenuPanel): boolean {
+    return PANELS_TO_TRIGGERS.get(menu) === this;
+  }
+}

--- a/src/material/menu/menu-trigger.ts
+++ b/src/material/menu/menu-trigger.ts
@@ -6,97 +6,27 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {
-  FocusMonitor,
-  FocusOrigin,
-  isFakeMousedownFromScreenReader,
-  isFakeTouchstartFromScreenReader,
-} from '@angular/cdk/a11y';
-import {Direction, Directionality} from '@angular/cdk/bidi';
+import {isFakeMousedownFromScreenReader, isFakeTouchstartFromScreenReader} from '@angular/cdk/a11y';
 import {ENTER, LEFT_ARROW, RIGHT_ARROW, SPACE} from '@angular/cdk/keycodes';
 import {
-  createFlexibleConnectedPositionStrategy,
-  createOverlayRef,
-  createRepositionScrollStrategy,
-  FlexibleConnectedPositionStrategy,
-  HorizontalConnectionPos,
-  OverlayConfig,
-  OverlayRef,
-  ScrollStrategy,
-  VerticalConnectionPos,
-} from '@angular/cdk/overlay';
-import {TemplatePortal} from '@angular/cdk/portal';
-import {
   AfterContentInit,
-  ChangeDetectorRef,
   Directive,
-  ElementRef,
   EventEmitter,
   inject,
-  InjectionToken,
-  Injector,
   Input,
-  NgZone,
   OnDestroy,
   Output,
   Renderer2,
-  ViewContainerRef,
 } from '@angular/core';
-import {merge, Observable, of as observableOf, Subscription} from 'rxjs';
-import {filter, take, takeUntil} from 'rxjs/operators';
-import {MatMenu, MenuCloseReason} from './menu';
-import {throwMatMenuRecursiveError} from './menu-errors';
-import {MatMenuItem} from './menu-item';
-import {MAT_MENU_PANEL, MatMenuPanel} from './menu-panel';
-import {MenuPositionX, MenuPositionY} from './menu-positions';
+import {OverlayRef} from '@angular/cdk/overlay';
+import {Subscription} from 'rxjs';
+import {MatMenuPanel} from './menu-panel';
 import {_animationsDisabled} from '../core';
-
-/** Injection token that determines the scroll handling while the menu is open. */
-export const MAT_MENU_SCROLL_STRATEGY = new InjectionToken<() => ScrollStrategy>(
-  'mat-menu-scroll-strategy',
-  {
-    providedIn: 'root',
-    factory: () => {
-      const injector = inject(Injector);
-      return () => createRepositionScrollStrategy(injector);
-    },
-  },
-);
-
-/**
- * @docs-private
- * @deprecated No longer used, will be removed.
- * @breaking-change 21.0.0
- */
-export function MAT_MENU_SCROLL_STRATEGY_FACTORY(_overlay: unknown): () => ScrollStrategy {
-  const injector = inject(Injector);
-  return () => createRepositionScrollStrategy(injector);
-}
-
-/**
- * @docs-private
- * @deprecated No longer used, will be removed.
- * @breaking-change 21.0.0
- */
-export const MAT_MENU_SCROLL_STRATEGY_FACTORY_PROVIDER = {
-  provide: MAT_MENU_SCROLL_STRATEGY,
-  deps: [] as any[],
-  useFactory: MAT_MENU_SCROLL_STRATEGY_FACTORY,
-};
-
-/**
- * Default top padding of the menu panel.
- * @deprecated No longer being used. Will be removed.
- * @breaking-change 15.0.0
- */
-export const MENU_PANEL_TOP_PADDING = 8;
-
-/** Mapping between menu panels and the last trigger that opened them. */
-const PANELS_TO_TRIGGERS = new WeakMap<MatMenuPanel, MatMenuTrigger>();
+import {MatMenuTriggerBase} from './menu-trigger-base';
 
 /** Directive applied to an element that should trigger a `mat-menu`. */
 @Directive({
-  selector: `[mat-menu-trigger-for], [matMenuTriggerFor]`,
+  selector: '[mat-menu-trigger-for], [matMenuTriggerFor]',
   host: {
     'class': 'mat-mdc-menu-trigger',
     '[attr.aria-haspopup]': 'menu ? "menu" : null',
@@ -108,42 +38,9 @@ const PANELS_TO_TRIGGERS = new WeakMap<MatMenuPanel, MatMenuTrigger>();
   },
   exportAs: 'matMenuTrigger',
 })
-export class MatMenuTrigger implements AfterContentInit, OnDestroy {
-  private _element = inject<ElementRef<HTMLElement>>(ElementRef);
-  private _viewContainerRef = inject(ViewContainerRef);
-  private _menuItemInstance = inject(MatMenuItem, {optional: true, self: true})!;
-  private _dir = inject(Directionality, {optional: true});
-  private _focusMonitor = inject(FocusMonitor);
-  private _ngZone = inject(NgZone);
-  private _injector = inject(Injector);
-  private _scrollStrategy = inject(MAT_MENU_SCROLL_STRATEGY);
-  private _changeDetectorRef = inject(ChangeDetectorRef);
-  private _animationsDisabled = _animationsDisabled();
+export class MatMenuTrigger extends MatMenuTriggerBase implements AfterContentInit, OnDestroy {
   private _cleanupTouchstart: () => void;
-
-  private _portal: TemplatePortal;
-  private _overlayRef: OverlayRef | null = null;
-  private _menuOpen: boolean = false;
-  private _closingActionsSubscription = Subscription.EMPTY;
   private _hoverSubscription = Subscription.EMPTY;
-  private _menuCloseSubscription = Subscription.EMPTY;
-  private _pendingRemoval: Subscription | undefined;
-
-  /**
-   * We're specifically looking for a `MatMenu` here since the generic `MatMenuPanel`
-   * interface lacks some functionality around nested menus and animations.
-   */
-  private _parentMaterialMenu: MatMenu | undefined;
-
-  /**
-   * Cached value of the padding of the parent menu panel.
-   * Used to offset sub-menus to compensate for the padding.
-   */
-  private _parentInnerPadding: number | undefined;
-
-  // Tracking input type is necessary so it's possible to only auto-focus
-  // the first item of the list when the menu is opened via the keyboard
-  _openedBy: Exclude<FocusOrigin, 'program' | null> | undefined = undefined;
 
   /**
    * @deprecated
@@ -163,41 +60,20 @@ export class MatMenuTrigger implements AfterContentInit, OnDestroy {
     return this._menu;
   }
   set menu(menu: MatMenuPanel | null) {
-    if (menu === this._menu) {
-      return;
-    }
-
     this._menu = menu;
-    this._menuCloseSubscription.unsubscribe();
-
-    if (menu) {
-      if (menu === this._parentMaterialMenu && (typeof ngDevMode === 'undefined' || ngDevMode)) {
-        throwMatMenuRecursiveError();
-      }
-
-      this._menuCloseSubscription = menu.close.subscribe((reason: MenuCloseReason) => {
-        this._destroyMenu(reason);
-
-        // If a click closed the menu, we should close the entire chain of nested menus.
-        if ((reason === 'click' || reason === 'tab') && this._parentMaterialMenu) {
-          this._parentMaterialMenu.closed.emit(reason);
-        }
-      });
-    }
-
-    this._menuItemInstance?._setTriggersSubmenu(this.triggersSubmenu());
   }
-  private _menu: MatMenuPanel | null;
 
   /** Data to be passed along to any lazily-rendered content. */
-  @Input('matMenuTriggerData') menuData: any;
+  @Input('matMenuTriggerData')
+  override menuData: any;
 
   /**
    * Whether focus should be restored when the menu is closed.
    * Note that disabling this option can have accessibility implications
    * and it's up to you to manage focus, if you decide to turn it off.
    */
-  @Input('matMenuTriggerRestoreFocus') restoreFocus: boolean = true;
+  @Input('matMenuTriggerRestoreFocus')
+  override restoreFocus: boolean = true;
 
   /** Event emitted when the associated menu is opened. */
   @Output() readonly menuOpened: EventEmitter<void> = new EventEmitter<void>();
@@ -224,10 +100,9 @@ export class MatMenuTrigger implements AfterContentInit, OnDestroy {
   constructor(...args: unknown[]);
 
   constructor() {
-    const parentMenu = inject<MatMenuPanel>(MAT_MENU_PANEL, {optional: true});
-    const renderer = inject(Renderer2);
+    super(true);
 
-    this._parentMaterialMenu = parentMenu instanceof MatMenu ? parentMenu : undefined;
+    const renderer = inject(Renderer2);
     this._cleanupTouchstart = renderer.listen(
       this._element.nativeElement,
       'touchstart',
@@ -240,118 +115,24 @@ export class MatMenuTrigger implements AfterContentInit, OnDestroy {
     );
   }
 
-  ngAfterContentInit() {
-    this._handleHover();
-  }
-
-  ngOnDestroy() {
-    if (this.menu && this._ownsMenu(this.menu)) {
-      PANELS_TO_TRIGGERS.delete(this.menu);
-    }
-
-    this._cleanupTouchstart();
-    this._pendingRemoval?.unsubscribe();
-    this._menuCloseSubscription.unsubscribe();
-    this._closingActionsSubscription.unsubscribe();
-    this._hoverSubscription.unsubscribe();
-
-    if (this._overlayRef) {
-      this._overlayRef.dispose();
-      this._overlayRef = null;
-    }
-  }
-
-  /** Whether the menu is open. */
-  get menuOpen(): boolean {
-    return this._menuOpen;
-  }
-
-  /** The text direction of the containing app. */
-  get dir(): Direction {
-    return this._dir && this._dir.value === 'rtl' ? 'rtl' : 'ltr';
-  }
-
   /** Whether the menu triggers a sub-menu or a top-level one. */
   triggersSubmenu(): boolean {
-    return !!(this._menuItemInstance && this._parentMaterialMenu && this.menu);
+    return super._triggersSubmenu();
   }
 
   /** Toggles the menu between the open and closed states. */
   toggleMenu(): void {
-    return this._menuOpen ? this.closeMenu() : this.openMenu();
+    return this.menuOpen ? this.closeMenu() : this.openMenu();
   }
 
   /** Opens the menu. */
   openMenu(): void {
-    // Auto focus by default
     this._openMenu(true);
-  }
-
-  /** Internal method to open menu providing option to auto focus on first item. */
-  private _openMenu(autoFocus: boolean): void {
-    const menu = this.menu;
-
-    if (this._menuOpen || !menu) {
-      return;
-    }
-
-    this._pendingRemoval?.unsubscribe();
-    const previousTrigger = PANELS_TO_TRIGGERS.get(menu);
-    PANELS_TO_TRIGGERS.set(menu, this);
-
-    // If the same menu is currently attached to another trigger,
-    // we need to close it so it doesn't end up in a broken state.
-    if (previousTrigger && previousTrigger !== this) {
-      previousTrigger.closeMenu();
-    }
-
-    const overlayRef = this._createOverlay(menu);
-    const overlayConfig = overlayRef.getConfig();
-    const positionStrategy = overlayConfig.positionStrategy as FlexibleConnectedPositionStrategy;
-
-    this._setPosition(menu, positionStrategy);
-    overlayConfig.hasBackdrop =
-      menu.hasBackdrop == null ? !this.triggersSubmenu() : menu.hasBackdrop;
-
-    // We need the `hasAttached` check for the case where the user kicked off a removal animation,
-    // but re-entered the menu. Re-attaching the same portal will trigger an error otherwise.
-    if (!overlayRef.hasAttached()) {
-      overlayRef.attach(this._getPortal(menu));
-      menu.lazyContent?.attach(this.menuData);
-    }
-
-    this._closingActionsSubscription = this._menuClosingActions().subscribe(() => this.closeMenu());
-    menu.parentMenu = this.triggersSubmenu() ? this._parentMaterialMenu : undefined;
-    menu.direction = this.dir;
-    if (autoFocus) menu.focusFirstItem(this._openedBy || 'program');
-    this._setIsMenuOpen(true);
-
-    if (menu instanceof MatMenu) {
-      menu._setIsOpen(true);
-      menu._directDescendantItems.changes.pipe(takeUntil(menu.close)).subscribe(() => {
-        // Re-adjust the position without locking when the amount of items
-        // changes so that the overlay is allowed to pick a new optimal position.
-        positionStrategy.withLockedPosition(false).reapplyLastPosition();
-        positionStrategy.withLockedPosition(true);
-      });
-    }
   }
 
   /** Closes the menu. */
   closeMenu(): void {
-    this.menu?.close.emit();
-  }
-
-  /**
-   * Focuses the menu trigger.
-   * @param origin Source of the menu trigger's focus.
-   */
-  focus(origin?: FocusOrigin, options?: FocusOptions) {
-    if (this._focusMonitor && origin) {
-      this._focusMonitor.focusVia(this._element, origin, options);
-    } else {
-      this._element.nativeElement.focus(options);
-    }
+    this._closeMenu();
   }
 
   /**
@@ -361,186 +142,22 @@ export class MatMenuTrigger implements AfterContentInit, OnDestroy {
     this._overlayRef?.updatePosition();
   }
 
-  /** Closes the menu and does the necessary cleanup. */
-  private _destroyMenu(reason: MenuCloseReason) {
-    const overlayRef = this._overlayRef;
-    const menu = this._menu;
-
-    if (!overlayRef || !this.menuOpen) {
-      return;
-    }
-
-    this._closingActionsSubscription.unsubscribe();
-    this._pendingRemoval?.unsubscribe();
-
-    // Note that we don't wait for the animation to finish if another trigger took
-    // over the menu, because the panel will end up empty which looks glitchy.
-    if (menu instanceof MatMenu && this._ownsMenu(menu)) {
-      this._pendingRemoval = menu._animationDone.pipe(take(1)).subscribe(() => {
-        overlayRef.detach();
-        menu.lazyContent?.detach();
-      });
-      menu._setIsOpen(false);
-    } else {
-      overlayRef.detach();
-      menu?.lazyContent?.detach();
-    }
-
-    if (menu && this._ownsMenu(menu)) {
-      PANELS_TO_TRIGGERS.delete(menu);
-    }
-
-    // Always restore focus if the user is navigating using the keyboard or the menu was opened
-    // programmatically. We don't restore for non-root triggers, because it can prevent focus
-    // from making it back to the root trigger when closing a long chain of menus by clicking
-    // on the backdrop.
-    if (this.restoreFocus && (reason === 'keydown' || !this._openedBy || !this.triggersSubmenu())) {
-      this.focus(this._openedBy);
-    }
-
-    this._openedBy = undefined;
-    this._setIsMenuOpen(false);
+  ngAfterContentInit() {
+    this._handleHover();
   }
 
-  // set state rather than toggle to support triggers sharing a menu
-  private _setIsMenuOpen(isOpen: boolean): void {
-    if (isOpen !== this._menuOpen) {
-      this._menuOpen = isOpen;
-      this._menuOpen ? this.menuOpened.emit() : this.menuClosed.emit();
-
-      if (this.triggersSubmenu()) {
-        this._menuItemInstance._setHighlighted(isOpen);
-      }
-
-      this._changeDetectorRef.markForCheck();
-    }
+  override ngOnDestroy() {
+    super.ngOnDestroy();
+    this._cleanupTouchstart();
+    this._hoverSubscription.unsubscribe();
   }
 
-  /**
-   * This method creates the overlay from the provided menu's template and saves its
-   * OverlayRef so that it can be attached to the DOM when openMenu is called.
-   */
-  private _createOverlay(menu: MatMenuPanel): OverlayRef {
-    if (!this._overlayRef) {
-      const config = this._getOverlayConfig(menu);
-      this._subscribeToPositions(
-        menu,
-        config.positionStrategy as FlexibleConnectedPositionStrategy,
-      );
-      this._overlayRef = createOverlayRef(this._injector, config);
-      this._overlayRef.keydownEvents().subscribe(event => {
-        if (this.menu instanceof MatMenu) {
-          this.menu._handleKeydown(event);
-        }
-      });
-    }
-
-    return this._overlayRef;
+  protected override _getOverlayOrigin() {
+    return this._element;
   }
 
-  /**
-   * This method builds the configuration object needed to create the overlay, the OverlayState.
-   * @returns OverlayConfig
-   */
-  private _getOverlayConfig(menu: MatMenuPanel): OverlayConfig {
-    return new OverlayConfig({
-      positionStrategy: createFlexibleConnectedPositionStrategy(this._injector, this._element)
-        .withLockedPosition()
-        .withGrowAfterOpen()
-        .withTransformOriginOn('.mat-menu-panel, .mat-mdc-menu-panel'),
-      backdropClass: menu.backdropClass || 'cdk-overlay-transparent-backdrop',
-      panelClass: menu.overlayPanelClass,
-      scrollStrategy: this._scrollStrategy(),
-      direction: this._dir || 'ltr',
-      disableAnimations: this._animationsDisabled,
-    });
-  }
-
-  /**
-   * Listens to changes in the position of the overlay and sets the correct classes
-   * on the menu based on the new position. This ensures the animation origin is always
-   * correct, even if a fallback position is used for the overlay.
-   */
-  private _subscribeToPositions(menu: MatMenuPanel, position: FlexibleConnectedPositionStrategy) {
-    if (menu.setPositionClasses) {
-      position.positionChanges.subscribe(change => {
-        this._ngZone.run(() => {
-          const posX: MenuPositionX =
-            change.connectionPair.overlayX === 'start' ? 'after' : 'before';
-          const posY: MenuPositionY = change.connectionPair.overlayY === 'top' ? 'below' : 'above';
-          menu.setPositionClasses!(posX, posY);
-        });
-      });
-    }
-  }
-
-  /**
-   * Sets the appropriate positions on a position strategy
-   * so the overlay connects with the trigger correctly.
-   * @param positionStrategy Strategy whose position to update.
-   */
-  private _setPosition(menu: MatMenuPanel, positionStrategy: FlexibleConnectedPositionStrategy) {
-    let [originX, originFallbackX]: HorizontalConnectionPos[] =
-      menu.xPosition === 'before' ? ['end', 'start'] : ['start', 'end'];
-
-    let [overlayY, overlayFallbackY]: VerticalConnectionPos[] =
-      menu.yPosition === 'above' ? ['bottom', 'top'] : ['top', 'bottom'];
-
-    let [originY, originFallbackY] = [overlayY, overlayFallbackY];
-    let [overlayX, overlayFallbackX] = [originX, originFallbackX];
-    let offsetY = 0;
-
-    if (this.triggersSubmenu()) {
-      // When the menu is a sub-menu, it should always align itself
-      // to the edges of the trigger, instead of overlapping it.
-      overlayFallbackX = originX = menu.xPosition === 'before' ? 'start' : 'end';
-      originFallbackX = overlayX = originX === 'end' ? 'start' : 'end';
-
-      if (this._parentMaterialMenu) {
-        if (this._parentInnerPadding == null) {
-          const firstItem = this._parentMaterialMenu.items.first;
-          this._parentInnerPadding = firstItem ? firstItem._getHostElement().offsetTop : 0;
-        }
-
-        offsetY = overlayY === 'bottom' ? this._parentInnerPadding : -this._parentInnerPadding;
-      }
-    } else if (!menu.overlapTrigger) {
-      originY = overlayY === 'top' ? 'bottom' : 'top';
-      originFallbackY = overlayFallbackY === 'top' ? 'bottom' : 'top';
-    }
-
-    positionStrategy.withPositions([
-      {originX, originY, overlayX, overlayY, offsetY},
-      {originX: originFallbackX, originY, overlayX: overlayFallbackX, overlayY, offsetY},
-      {
-        originX,
-        originY: originFallbackY,
-        overlayX,
-        overlayY: overlayFallbackY,
-        offsetY: -offsetY,
-      },
-      {
-        originX: originFallbackX,
-        originY: originFallbackY,
-        overlayX: overlayFallbackX,
-        overlayY: overlayFallbackY,
-        offsetY: -offsetY,
-      },
-    ]);
-  }
-
-  /** Returns a stream that emits whenever an action that should close the menu occurs. */
-  private _menuClosingActions() {
-    const backdrop = this._overlayRef!.backdropClick();
-    const detachments = this._overlayRef!.detachments();
-    const parentClose = this._parentMaterialMenu ? this._parentMaterialMenu.closed : observableOf();
-    const hover = this._parentMaterialMenu
-      ? this._parentMaterialMenu
-          ._hovered()
-          .pipe(filter(active => this._menuOpen && active !== this._menuItemInstance))
-      : observableOf();
-
-    return merge(backdrop, parentClose as Observable<MenuCloseReason>, hover, detachments);
+  protected override _getOutsideClickStream(overlayRef: OverlayRef) {
+    return overlayRef.backdropClick();
   }
 
   /** Handles mouse presses on the trigger. */
@@ -603,26 +220,5 @@ export class MatMenuTrigger implements AfterContentInit, OnDestroy {
         }
       });
     }
-  }
-
-  /** Gets the portal that should be attached to the overlay. */
-  private _getPortal(menu: MatMenuPanel): TemplatePortal {
-    // Note that we can avoid this check by keeping the portal on the menu panel.
-    // While it would be cleaner, we'd have to introduce another required method on
-    // `MatMenuPanel`, making it harder to consume.
-    if (!this._portal || this._portal.templateRef !== menu.templateRef) {
-      this._portal = new TemplatePortal(menu.templateRef, this._viewContainerRef);
-    }
-
-    return this._portal;
-  }
-
-  /**
-   * Determines whether the trigger owns a specific menu panel, at the current point in time.
-   * This allows us to distinguish the case where the same panel is passed into multiple triggers
-   * and multiple are open at a time.
-   */
-  private _ownsMenu(menu: MatMenuPanel): boolean {
-    return PANELS_TO_TRIGGERS.get(menu) === this;
   }
 }

--- a/src/material/menu/menu.md
+++ b/src/material/menu/menu.md
@@ -49,6 +49,16 @@ that should trigger the sub-menu:
               "file": "menu-nested-example.html",
               "region": "sub-menu"}) -->
 
+### Context menu
+A context menu is a menu that is triggered by right-clicking in a specific area, rather than
+clicking on a trigger element. It is re-positioned if the user right-clicks somewhere else in the
+area and will be closed if the user clicks away.
+
+You can set up a `mat-menu` as a context menu by adding the `matContextMenuTriggerFor` directive
+to your container and binding it to a menu instance.
+
+<!-- example(context-menu) -->
+
 ### Lazy rendering
 By default, the menu content will be initialized even when the panel is closed. To defer
 initialization until the menu is open, the content can be provided as an `ng-template`

--- a/src/material/menu/module.ts
+++ b/src/material/menu/module.ts
@@ -15,6 +15,7 @@ import {MatMenuItem} from './menu-item';
 import {MatMenuContent} from './menu-content';
 import {MatMenuTrigger} from './menu-trigger';
 import {MAT_MENU_SCROLL_STRATEGY_FACTORY_PROVIDER} from './menu-trigger-base';
+import {MatContextMenuTrigger} from './context-menu-trigger';
 
 @NgModule({
   imports: [
@@ -25,6 +26,7 @@ import {MAT_MENU_SCROLL_STRATEGY_FACTORY_PROVIDER} from './menu-trigger-base';
     MatMenuItem,
     MatMenuContent,
     MatMenuTrigger,
+    MatContextMenuTrigger,
   ],
   exports: [
     CdkScrollableModule,
@@ -33,6 +35,7 @@ import {MAT_MENU_SCROLL_STRATEGY_FACTORY_PROVIDER} from './menu-trigger-base';
     MatMenuItem,
     MatMenuContent,
     MatMenuTrigger,
+    MatContextMenuTrigger,
   ],
   providers: [MAT_MENU_SCROLL_STRATEGY_FACTORY_PROVIDER],
 })

--- a/src/material/menu/module.ts
+++ b/src/material/menu/module.ts
@@ -13,7 +13,8 @@ import {CdkScrollableModule} from '@angular/cdk/scrolling';
 import {MatMenu} from './menu';
 import {MatMenuItem} from './menu-item';
 import {MatMenuContent} from './menu-content';
-import {MAT_MENU_SCROLL_STRATEGY_FACTORY_PROVIDER, MatMenuTrigger} from './menu-trigger';
+import {MatMenuTrigger} from './menu-trigger';
+import {MAT_MENU_SCROLL_STRATEGY_FACTORY_PROVIDER} from './menu-trigger-base';
 
 @NgModule({
   imports: [

--- a/src/material/menu/public-api.ts
+++ b/src/material/menu/public-api.ts
@@ -9,12 +9,12 @@
 export {MatMenu, MAT_MENU_DEFAULT_OPTIONS, MatMenuDefaultOptions, MenuCloseReason} from './menu';
 export * from './menu-item';
 export * from './menu-content';
+export {MatMenuTrigger} from './menu-trigger';
 export {
-  MatMenuTrigger,
   MAT_MENU_SCROLL_STRATEGY,
   MAT_MENU_SCROLL_STRATEGY_FACTORY_PROVIDER,
   MENU_PANEL_TOP_PADDING,
-} from './menu-trigger';
+} from './menu-trigger-base';
 export * from './module';
 export * from './menu-animations';
 export * from './menu-positions';

--- a/src/material/menu/public-api.ts
+++ b/src/material/menu/public-api.ts
@@ -19,3 +19,4 @@ export * from './module';
 export * from './menu-animations';
 export * from './menu-positions';
 export * from './menu-panel';
+export {MatContextMenuTrigger} from './context-menu-trigger';

--- a/src/material/menu/testing/context-menu-harness.spec.ts
+++ b/src/material/menu/testing/context-menu-harness.spec.ts
@@ -1,0 +1,82 @@
+import {Component, signal} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {HarnessLoader} from '@angular/cdk/testing';
+import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
+import {MatMenuModule} from '../module';
+import {MatContextMenuHarness} from './context-menu-harness';
+
+describe('MatContextMenuHarness', () => {
+  let fixture: ComponentFixture<MenuHarnessTest>;
+  let loader: HarnessLoader;
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(MenuHarnessTest);
+    fixture.detectChanges();
+    loader = TestbedHarnessEnvironment.loader(fixture);
+  });
+
+  it('should load all context menu harnesses', async () => {
+    const menues = await loader.getAllHarnesses(MatContextMenuHarness);
+    expect(menues.length).toBe(1);
+  });
+
+  it('should open and close', async () => {
+    const menu = await loader.getHarness(MatContextMenuHarness);
+    expect(await menu.isOpen()).toBe(false);
+    await menu.open();
+    expect(await menu.isOpen()).toBe(true);
+    await menu.open();
+    expect(await menu.isOpen()).toBe(true);
+    await menu.close();
+    expect(await menu.isOpen()).toBe(false);
+    await menu.close();
+    expect(await menu.isOpen()).toBe(false);
+  });
+
+  it('should get all items', async () => {
+    const menu = await loader.getHarness(MatContextMenuHarness);
+    await menu.open();
+    expect((await menu.getItems()).length).toBe(3);
+  });
+
+  it('should get filtered items', async () => {
+    const menu = await loader.getHarness(MatContextMenuHarness);
+    await menu.open();
+    const items = await menu.getItems({text: 'Copy'});
+    expect(items.length).toBe(1);
+    expect(await items[0].getText()).toBe('Copy');
+  });
+
+  it('should get whether the trigger is disabled', async () => {
+    const menu = await loader.getHarness(MatContextMenuHarness);
+    expect(await menu.isDisabled()).toBe(false);
+    fixture.componentInstance.disabled.set(true);
+    expect(await menu.isDisabled()).toBe(true);
+  });
+});
+
+@Component({
+  template: `
+    <div
+      class="area"
+      [matContextMenuTriggerFor]="contextMenu"
+      [matContextMenuTriggerDisabled]="disabled()"></div>
+
+    <mat-menu #contextMenu>
+      <menu mat-menu-item>Cut</menu>
+      <menu mat-menu-item>Copy</menu>
+      <menu mat-menu-item>Paste</menu>
+    </mat-menu>
+  `,
+  imports: [MatMenuModule],
+  styles: `
+    .area {
+      width: 100px;
+      height: 100px;
+      outline: solid 1px;
+    }
+  `,
+})
+class MenuHarnessTest {
+  disabled = signal(false);
+}

--- a/src/material/menu/testing/context-menu-harness.ts
+++ b/src/material/menu/testing/context-menu-harness.ts
@@ -1,0 +1,120 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {
+  ComponentHarnessConstructor,
+  ContentContainerComponentHarness,
+  HarnessLoader,
+  HarnessPredicate,
+  TestElement,
+} from '@angular/cdk/testing';
+import {ContextMenuHarnessFilters, MenuItemHarnessFilters} from './menu-harness-filters';
+import {clickItemImplementation, MatMenuItemHarness} from './menu-harness';
+
+/** Harness for interacting with context menus in tests. */
+export class MatContextMenuHarness extends ContentContainerComponentHarness<string> {
+  private _documentRootLocator = this.documentRootLocatorFactory();
+
+  /** The selector for the host element of a `MatContextMenu` instance. */
+  static hostSelector = '.mat-context-menu-trigger';
+
+  /**
+   * Gets a `HarnessPredicate` that can be used to search for a context menu with specific
+   * attributes.
+   * @param options Options for filtering which menu instances are considered a match.
+   * @return a `HarnessPredicate` configured with the given options.
+   */
+  static with<T extends MatContextMenuHarness>(
+    this: ComponentHarnessConstructor<T>,
+    options: ContextMenuHarnessFilters = {},
+  ): HarnessPredicate<T> {
+    return new HarnessPredicate(this, options);
+  }
+
+  /** Whether the menu is open. */
+  async isOpen(): Promise<boolean> {
+    return !!(await this._getMenuPanel());
+  }
+
+  /**
+   * Opens the menu.
+   * @param relativeX X coordinate, relative to the element, to dispatch the opening click at.
+   * @param relativeY Y coordinate, relative to the element, to dispatch the opening click at.
+   */
+  async open(relativeX = 0, relativeY = 0): Promise<void> {
+    if (!(await this.isOpen())) {
+      return (await this.host()).rightClick(relativeX, relativeY);
+    }
+  }
+
+  /** Closes the menu. */
+  async close(): Promise<void> {
+    const panel = await this._getMenuPanel();
+    if (panel) {
+      return panel.click();
+    }
+  }
+
+  /** Gets whether the context menu trigger is disabled. */
+  async isDisabled(): Promise<boolean> {
+    const host = await this.host();
+    return host.hasClass('mat-context-menu-trigger-disabled');
+  }
+
+  /**
+   * Gets a list of `MatMenuItemHarness` representing the items in the menu.
+   * @param filters Optionally filters which menu items are included.
+   */
+  async getItems(
+    filters?: Omit<MenuItemHarnessFilters, 'ancestor'>,
+  ): Promise<MatMenuItemHarness[]> {
+    const panelId = await this._getPanelId();
+    if (panelId) {
+      return this._documentRootLocator.locatorForAll(
+        MatMenuItemHarness.with({
+          ...(filters || {}),
+          ancestor: `#${panelId}`,
+        } as MenuItemHarnessFilters),
+      )();
+    }
+    return [];
+  }
+
+  /**
+   * Clicks an item in the menu, and optionally continues clicking items in subsequent sub-menus.
+   * @param itemFilter A filter used to represent which item in the menu should be clicked. The
+   *     first matching menu item will be clicked.
+   * @param subItemFilters A list of filters representing the items to click in any subsequent
+   *     sub-menus. The first item in the sub-menu matching the corresponding filter in
+   *     `subItemFilters` will be clicked.
+   */
+  async clickItem(
+    itemFilter: Omit<MenuItemHarnessFilters, 'ancestor'>,
+    ...subItemFilters: Omit<MenuItemHarnessFilters, 'ancestor'>[]
+  ): Promise<void> {
+    await this.open();
+    return clickItemImplementation(await this.getItems(itemFilter), itemFilter, subItemFilters);
+  }
+
+  protected override async getRootHarnessLoader(): Promise<HarnessLoader> {
+    const panelId = await this._getPanelId();
+    return this.documentRootLocatorFactory().harnessLoaderFor(`#${panelId}`);
+  }
+
+  /** Gets the menu panel associated with this menu. */
+  private async _getMenuPanel(): Promise<TestElement | null> {
+    const panelId = await this._getPanelId();
+    return panelId ? this._documentRootLocator.locatorForOptional(`#${panelId}`)() : null;
+  }
+
+  /** Gets the id of the menu panel associated with this menu. */
+  private async _getPanelId(): Promise<string | null> {
+    const panelId = await (await this.host()).getAttribute('aria-controls');
+    return panelId || null;
+  }
+}

--- a/src/material/menu/testing/menu-harness-filters.ts
+++ b/src/material/menu/testing/menu-harness-filters.ts
@@ -21,3 +21,6 @@ export interface MenuItemHarnessFilters extends BaseHarnessFilters {
   /** Only find instances that have a sub-menu. */
   hasSubmenu?: boolean;
 }
+
+/** A set of criteria that can be used to filter a list of `MatContextMenuHarness` instances. */
+export interface ContextMenuHarnessFilters extends BaseHarnessFilters {}

--- a/src/material/menu/testing/menu-harness.ts
+++ b/src/material/menu/testing/menu-harness.ts
@@ -117,20 +117,7 @@ export class MatMenuHarness extends ContentContainerComponentHarness<string> {
     ...subItemFilters: Omit<MenuItemHarnessFilters, 'ancestor'>[]
   ): Promise<void> {
     await this.open();
-    const items = await this.getItems(itemFilter);
-    if (!items.length) {
-      throw Error(`Could not find item matching ${JSON.stringify(itemFilter)}`);
-    }
-
-    if (!subItemFilters.length) {
-      return await items[0].click();
-    }
-
-    const menu = await items[0].getSubmenu();
-    if (!menu) {
-      throw Error(`Item matching ${JSON.stringify(itemFilter)} does not have a submenu`);
-    }
-    return menu.clickItem(...(subItemFilters as [Omit<MenuItemHarnessFilters, 'ancestor'>]));
+    return clickItemImplementation(await this.getItems(itemFilter), itemFilter, subItemFilters);
   }
 
   protected override async getRootHarnessLoader(): Promise<HarnessLoader> {
@@ -218,4 +205,24 @@ export class MatMenuItemHarness extends ContentContainerComponentHarness<string>
     }
     return null;
   }
+}
+
+export async function clickItemImplementation(
+  items: MatMenuItemHarness[],
+  itemFilter: Omit<MenuItemHarnessFilters, 'ancestor'>,
+  subItemFilters: Omit<MenuItemHarnessFilters, 'ancestor'>[],
+): Promise<void> {
+  if (!items.length) {
+    throw Error(`Could not find item matching ${JSON.stringify(itemFilter)}`);
+  }
+
+  if (!subItemFilters.length) {
+    return await items[0].click();
+  }
+
+  const menu = await items[0].getSubmenu();
+  if (!menu) {
+    throw Error(`Item matching ${JSON.stringify(itemFilter)} does not have a submenu`);
+  }
+  return menu.clickItem(...(subItemFilters as [Omit<MenuItemHarnessFilters, 'ancestor'>]));
 }

--- a/src/material/menu/testing/public-api.ts
+++ b/src/material/menu/testing/public-api.ts
@@ -6,5 +6,6 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-export * from './menu-harness';
+export {MatMenuHarness, MatMenuItemHarness} from './menu-harness';
+export {MatContextMenuHarness} from './context-menu-harness';
 export * from './menu-harness-filters';


### PR DESCRIPTION
Adds the new `MatContextMenuTrigger` directive that allows users to mark an area as a trigger for a menu. When the user right-clicks inside of the area, the menu will be opened next to their pointer.

Fixes #5007.