### PR TITLE
test(cdk-experimental/accordion): add examples to dev-app

### DIFF
--- a/src/components-examples/cdk-experimental/accordion/cdk-accordion-configurable/cdk-accordion-configurable-example.html
+++ b/src/components-examples/cdk-experimental/accordion/cdk-accordion-configurable/cdk-accordion-configurable-example.html
@@ -1,0 +1,109 @@
+<div class="example-accordion-controls">
+  <mat-checkbox [formControl]="wrap">Wrap (ArrowKey-only)</mat-checkbox>
+  <mat-checkbox [formControl]="multi">Multi</mat-checkbox>
+  <mat-checkbox [formControl]="disabled">Disabled</mat-checkbox>
+  <mat-checkbox [formControl]="skipDisabled">Skip Disabled</mat-checkbox>
+
+  <mat-form-field subscriptSizing="dynamic" appearance="outline">
+    <mat-label>Expanded Items</mat-label>
+    <mat-select [(value)]="expandedIds" multiple>
+      @for (item of items; track item) {
+        <mat-option [value]="item">{{item}}</mat-option>
+      }
+    </mat-select>
+  </mat-form-field>
+</div>
+
+<div
+  cdkAccordionGroup
+  class="example-accordion-group"
+  [multiExpandable]="multi.value"
+  [disabled]="disabled.value"
+  [skipDisabled]="skipDisabled.value"
+  [wrap]="wrap.value"
+  [(value)]="expandedIds"
+>
+  <div class="example-accordion">
+    <h3 class="example-accordion-header">
+      <button cdkAccordionTrigger value="item1">
+        Item 1 Trigger
+        <mat-icon aria-hidden="true">{{expansionIcon('item1')()}}</mat-icon>
+      </button>
+    </h3>
+    <div cdkAccordionPanel value="item1" class="example-accordion-panel">
+      <ng-template cdkAccordionContent>
+        <p>This is the content for Item 1.</p>
+        <button>Focusable Button</button>
+      </ng-template>
+    </div>
+  </div>
+
+  <div class="example-accordion">
+    <h3 class="example-accordion-header">
+      <button cdkAccordionTrigger value="item2" disabled>
+        Item 2 Trigger (disabled)
+        <mat-icon aria-hidden="true">{{expansionIcon('item2')()}}</mat-icon>
+      </button>
+    </h3>
+    <div cdkAccordionPanel value="item2" class="example-accordion-panel">
+      <ng-template cdkAccordionContent>
+        <p>This is the content for Item 2.</p>
+        <label>Input inside panel: <input type="text"></label>
+      </ng-template>
+    </div>
+  </div>
+
+  <div class="example-accordion">
+    <h3 class="example-accordion-header">
+      <button cdkAccordionTrigger value="item3">
+        Item 3 Trigger
+        <mat-icon aria-hidden="true">{{expansionIcon('item3')()}}</mat-icon>
+      </button>
+    </h3>
+    <div
+      cdkAccordionPanel
+      value="item3"
+      class="example-accordion-panel"
+    >
+      <ng-template cdkAccordionContent>
+        <p>This is the content for Item 3.</p>
+      </ng-template>
+    </div>
+  </div>
+
+  <div class="example-accordion">
+    <h3 class="example-accordion-header">
+      <button cdkAccordionTrigger value="item4">
+        Item 4 Trigger
+        <mat-icon aria-hidden="true">{{expansionIcon('item4')()}}</mat-icon>
+      </button>
+    </h3>
+    <div
+      cdkAccordionPanel
+      value="item4"
+      class="example-accordion-panel"
+    >
+      <ng-template cdkAccordionContent>
+        <p>This is the content for Item 4</p>
+      </ng-template>
+    </div>
+  </div>
+
+  <div class="example-accordion">
+    <h3 class="example-accordion-header">
+      <button cdkAccordionTrigger value="item5">
+        Item 5 Trigger
+        <mat-icon aria-hidden="true">{{expansionIcon('item5')()}}</mat-icon>
+      </button>
+    </h3>
+    <div
+      cdkAccordionPanel
+      value="item5"
+      class="example-accordion-panel"
+    >
+      <ng-template cdkAccordionContent>
+        <p>This is the content for Item 5</p>
+      </ng-template>
+    </div>
+  </div>
+</div>

--- a/src/components-examples/cdk-experimental/accordion/cdk-accordion-configurable/cdk-accordion-configurable-example.ts
+++ b/src/components-examples/cdk-experimental/accordion/cdk-accordion-configurable/cdk-accordion-configurable-example.ts
@@ -12,12 +12,13 @@ import {
   CdkAccordionContent,
 } from '@angular/cdk-experimental/accordion';
 
-/** @title Accordion using UI Patterns. */
+/** @title Configurable Accordion using UI Patterns. */
 @Component({
-  selector: 'cdk-accordion-example',
-  exportAs: 'cdkAccordionExample',
-  templateUrl: 'cdk-accordion-example.html',
-  styleUrl: 'cdk-accordion-example.css',
+  selector: 'cdk-accordion-configurable-example',
+  exportAs: 'cdkAccordionConfigurableExample',
+  templateUrl: 'cdk-accordion-configurable-example.html',
+  styleUrl: '../cdk-accordion-examples.css', // Point to shared CSS
+  standalone: true,
   imports: [
     ReactiveFormsModule,
     MatIconModule,
@@ -31,7 +32,7 @@ import {
     CdkAccordionContent,
   ],
 })
-export class CdkAccordionExample {
+export class CdkAccordionConfigurableExample {
   // Accordion Group Properties
   wrap = new FormControl(true, {nonNullable: true});
   multi = new FormControl(true, {nonNullable: true});
@@ -40,7 +41,7 @@ export class CdkAccordionExample {
   expandedIds = model<string[]>(['item1']);
 
   // Example items
-  items = ['item1', 'item2', 'item3'];
+  items = ['item1', 'item2', 'item3', 'item4', 'item5'];
 
   expansionIcon(item: string): Signal<string> {
     return computed(() => (this.expandedIds().includes(item) ? 'expand_less' : 'expand_more'));

--- a/src/components-examples/cdk-experimental/accordion/cdk-accordion-disabled-focusable/cdk-accordion-disabled-focusable-example.html
+++ b/src/components-examples/cdk-experimental/accordion/cdk-accordion-disabled-focusable/cdk-accordion-disabled-focusable-example.html
@@ -1,29 +1,11 @@
-<div class="example-accordion-controls">
-  <mat-checkbox [formControl]="wrap">Wrap (ArrowKey-only)</mat-checkbox>
-  <mat-checkbox [formControl]="multi">Multi</mat-checkbox>
-  <mat-checkbox [formControl]="disabled">Disabled</mat-checkbox>
-  <mat-checkbox [formControl]="skipDisabled">Skip Disabled</mat-checkbox>
-
-  <mat-form-field subscriptSizing="dynamic" appearance="outline">
-    <mat-label>Expanded Items</mat-label>
-    <mat-select [(value)]="expandedIds" multiple>
-      @for (item of items; track item) {
-        <mat-option [value]="item">{{item}}</mat-option>
-      }
-    </mat-select>
-  </mat-form-field>
-</div>
-
 <div
   cdkAccordionGroup
   class="example-accordion-group"
-  [multiExpandable]="multi.value"
-  [disabled]="disabled.value"
-  [skipDisabled]="skipDisabled.value"
-  [wrap]="wrap.value"
+  [multiExpandable]="true"
+  [skipDisabled]="false"
   [(value)]="expandedIds"
 >
-  <div class="example-accordion-container">
+  <div class="example-accordion">
     <h3 class="example-accordion-header">
       <button cdkAccordionTrigger value="item1">
         Item 1 Trigger
@@ -33,12 +15,11 @@
     <div cdkAccordionPanel value="item1" class="example-accordion-panel">
       <ng-template cdkAccordionContent>
         <p>This is the content for Item 1.</p>
-        <button>Focusable Button</button>
       </ng-template>
     </div>
   </div>
 
-  <div class="example-accordion-container">
+  <div class="example-accordion">
     <h3 class="example-accordion-header">
       <button cdkAccordionTrigger value="item2" disabled>
         Item 2 Trigger (disabled)
@@ -47,26 +28,49 @@
     </h3>
     <div cdkAccordionPanel value="item2" class="example-accordion-panel">
       <ng-template cdkAccordionContent>
-        <p>This is the content for Item 2.</p>
-        <label>Input inside panel: <input type="text"></label>
+        <p>This is the content for Item 2. This should not be expandable if trigger is disabled.</p>
       </ng-template>
     </div>
   </div>
 
-  <div class="example-accordion-container">
+  <div class="example-accordion">
     <h3 class="example-accordion-header">
       <button cdkAccordionTrigger value="item3">
         Item 3 Trigger
         <mat-icon aria-hidden="true">{{expansionIcon('item3')()}}</mat-icon>
       </button>
     </h3>
-    <div
-      cdkAccordionPanel
-      value="item3"
-      class="example-accordion-panel"
-    >
+    <div cdkAccordionPanel value="item3" class="example-accordion-panel">
       <ng-template cdkAccordionContent>
         <p>This is the content for Item 3.</p>
+      </ng-template>
+    </div>
+  </div>
+
+  <div class="example-accordion">
+    <h3 class="example-accordion-header">
+      <button cdkAccordionTrigger value="item4">
+        Item 4 Trigger
+        <mat-icon aria-hidden="true">{{expansionIcon('item4')()}}</mat-icon>
+      </button>
+    </h3>
+    <div cdkAccordionPanel value="item4" class="example-accordion-panel">
+      <ng-template cdkAccordionContent>
+        <p>This is the content for Item 4</p>
+      </ng-template>
+    </div>
+  </div>
+
+  <div class="example-accordion">
+    <h3 class="example-accordion-header">
+      <button cdkAccordionTrigger value="item5">
+        Item 5 Trigger
+        <mat-icon aria-hidden="true">{{expansionIcon('item5')()}}</mat-icon>
+      </button>
+    </h3>
+    <div cdkAccordionPanel value="item5" class="example-accordion-panel">
+      <ng-template cdkAccordionContent>
+        <p>This is the content for Item 5</p>
       </ng-template>
     </div>
   </div>

--- a/src/components-examples/cdk-experimental/accordion/cdk-accordion-disabled-focusable/cdk-accordion-disabled-focusable-example.ts
+++ b/src/components-examples/cdk-experimental/accordion/cdk-accordion-disabled-focusable/cdk-accordion-disabled-focusable-example.ts
@@ -1,0 +1,30 @@
+import {Component, computed, model, Signal} from '@angular/core';
+import {MatIconModule} from '@angular/material/icon';
+import {
+  CdkAccordionGroup,
+  CdkAccordionTrigger,
+  CdkAccordionPanel,
+  CdkAccordionContent,
+} from '@angular/cdk-experimental/accordion';
+
+/** @title Accordion with focusable disabled items. */
+@Component({
+  selector: 'cdk-accordion-disabled-focusable-example',
+  templateUrl: 'cdk-accordion-disabled-focusable-example.html',
+  styleUrl: '../cdk-accordion-examples.css',
+  standalone: true,
+  imports: [
+    MatIconModule,
+    CdkAccordionGroup,
+    CdkAccordionTrigger,
+    CdkAccordionPanel,
+    CdkAccordionContent,
+  ],
+})
+export class CdkAccordionDisabledFocusableExample {
+  expandedIds = model<string[]>([]);
+
+  expansionIcon(item: string): Signal<string> {
+    return computed(() => (this.expandedIds().includes(item) ? 'expand_less' : 'expand_more'));
+  }
+}

--- a/src/components-examples/cdk-experimental/accordion/cdk-accordion-disabled-skipped/cdk-accordion-disabled-skipped-example.html
+++ b/src/components-examples/cdk-experimental/accordion/cdk-accordion-disabled-skipped/cdk-accordion-disabled-skipped-example.html
@@ -1,0 +1,77 @@
+<div
+  cdkAccordionGroup
+  class="example-accordion-group"
+  [multiExpandable]="true"
+  [skipDisabled]="true"
+  [(value)]="expandedIds"
+>
+  <div class="example-accordion">
+    <h3 class="example-accordion-header">
+      <button cdkAccordionTrigger value="item1">
+        Item 1 Trigger
+        <mat-icon aria-hidden="true">{{expansionIcon('item1')()}}</mat-icon>
+      </button>
+    </h3>
+    <div cdkAccordionPanel value="item1" class="example-accordion-panel">
+      <ng-template cdkAccordionContent>
+        <p>This is the content for Item 1.</p>
+      </ng-template>
+    </div>
+  </div>
+
+  <div class="example-accordion">
+    <h3 class="example-accordion-header">
+      <button cdkAccordionTrigger value="item2" disabled>
+        Item 2 Trigger (disabled)
+        <mat-icon aria-hidden="true">{{expansionIcon('item2')()}}</mat-icon>
+      </button>
+    </h3>
+    <div cdkAccordionPanel value="item2" class="example-accordion-panel">
+      <ng-template cdkAccordionContent>
+        <p>This is the content for Item 2. This should not be reachable or expandable.</p>
+      </ng-template>
+    </div>
+  </div>
+
+  <div class="example-accordion">
+    <h3 class="example-accordion-header">
+      <button cdkAccordionTrigger value="item3">
+        Item 3 Trigger
+        <mat-icon aria-hidden="true">{{expansionIcon('item3')()}}</mat-icon>
+      </button>
+    </h3>
+    <div cdkAccordionPanel value="item3" class="example-accordion-panel">
+      <ng-template cdkAccordionContent>
+        <p>This is the content for Item 3.</p>
+      </ng-template>
+    </div>
+  </div>
+
+  <div class="example-accordion">
+    <h3 class="example-accordion-header">
+      <button cdkAccordionTrigger value="item4">
+        Item 4 Trigger
+        <mat-icon aria-hidden="true">{{expansionIcon('item4')()}}</mat-icon>
+      </button>
+    </h3>
+    <div cdkAccordionPanel value="item4" class="example-accordion-panel">
+      <ng-template cdkAccordionContent>
+        <p>This is the content for Item 4</p>
+      </ng-template>
+    </div>
+  </div>
+
+  <div class="example-accordion">
+    <h3 class="example-accordion-header">
+      <button cdkAccordionTrigger value="item5">
+        Item 5 Trigger
+        <mat-icon aria-hidden="true">{{expansionIcon('item5')()}}</mat-icon>
+      </button>
+    </h3>
+    <div cdkAccordionPanel value="item5" class="example-accordion-panel">
+      <ng-template cdkAccordionContent>
+        <p>This is the content for Item 5</p>
+      </ng-template>
+    </div>
+  </div>
+</div>

--- a/src/components-examples/cdk-experimental/accordion/cdk-accordion-disabled-skipped/cdk-accordion-disabled-skipped-example.ts
+++ b/src/components-examples/cdk-experimental/accordion/cdk-accordion-disabled-skipped/cdk-accordion-disabled-skipped-example.ts
@@ -1,0 +1,30 @@
+import {Component, computed, model, Signal} from '@angular/core';
+import {MatIconModule} from '@angular/material/icon';
+import {
+  CdkAccordionGroup,
+  CdkAccordionTrigger,
+  CdkAccordionPanel,
+  CdkAccordionContent,
+} from '@angular/cdk-experimental/accordion';
+
+/** @title Accordion with skipped disabled items. */
+@Component({
+  selector: 'cdk-accordion-disabled-skipped-example',
+  templateUrl: 'cdk-accordion-disabled-skipped-example.html',
+  styleUrl: '../cdk-accordion-examples.css',
+  standalone: true,
+  imports: [
+    MatIconModule,
+    CdkAccordionGroup,
+    CdkAccordionTrigger,
+    CdkAccordionPanel,
+    CdkAccordionContent,
+  ],
+})
+export class CdkAccordionDisabledSkippedExample {
+  expandedIds = model<string[]>([]);
+
+  expansionIcon(item: string): Signal<string> {
+    return computed(() => (this.expandedIds().includes(item) ? 'expand_less' : 'expand_more'));
+  }
+}

--- a/src/components-examples/cdk-experimental/accordion/cdk-accordion-disabled/cdk-accordion-disabled-example.html
+++ b/src/components-examples/cdk-experimental/accordion/cdk-accordion-disabled/cdk-accordion-disabled-example.html
@@ -1,0 +1,73 @@
+<div cdkAccordionGroup class="example-accordion-group" [(value)]="expandedIds" [disabled]="true">
+  <div class="example-accordion">
+    <h3 class="example-accordion-header">
+      <button cdkAccordionTrigger value="item1">
+        Item 1 Trigger
+        <mat-icon aria-hidden="true">{{expansionIcon('item1')()}}</mat-icon>
+      </button>
+    </h3>
+    <div cdkAccordionPanel value="item1" class="example-accordion-panel">
+      <ng-template cdkAccordionContent>
+        <p>This is the content for Item 1.</p>
+        <button>Focusable Button</button>
+      </ng-template>
+    </div>
+  </div>
+
+  <div class="example-accordion">
+    <h3 class="example-accordion-header">
+      <button cdkAccordionTrigger value="item2">
+        Item 2 Trigger
+        <mat-icon aria-hidden="true">{{expansionIcon('item2')()}}</mat-icon>
+      </button>
+    </h3>
+    <div cdkAccordionPanel value="item2" class="example-accordion-panel">
+      <ng-template cdkAccordionContent>
+        <p>This is the content for Item 2.</p>
+        <label>Input inside panel: <input type="text" /></label>
+      </ng-template>
+    </div>
+  </div>
+
+  <div class="example-accordion">
+    <h3 class="example-accordion-header">
+      <button cdkAccordionTrigger value="item3">
+        Item 3 Trigger
+        <mat-icon aria-hidden="true">{{expansionIcon('item3')()}}</mat-icon>
+      </button>
+    </h3>
+    <div cdkAccordionPanel value="item3" class="example-accordion-panel">
+      <ng-template cdkAccordionContent>
+        <p>This is the content for Item 3.</p>
+      </ng-template>
+    </div>
+  </div>
+
+  <div class="example-accordion">
+    <h3 class="example-accordion-header">
+      <button cdkAccordionTrigger value="item4">
+        Item 4 Trigger
+        <mat-icon aria-hidden="true">{{expansionIcon('item4')()}}</mat-icon>
+      </button>
+    </h3>
+    <div cdkAccordionPanel value="item4" class="example-accordion-panel">
+      <ng-template cdkAccordionContent>
+        <p>This is the content for Item 4</p>
+      </ng-template>
+    </div>
+  </div>
+
+  <div class="example-accordion">
+    <h3 class="example-accordion-header">
+      <button cdkAccordionTrigger value="item5">
+        Item 5 Trigger
+        <mat-icon aria-hidden="true">{{expansionIcon('item5')()}}</mat-icon>
+      </button>
+    </h3>
+    <div cdkAccordionPanel value="item5" class="example-accordion-panel">
+      <ng-template cdkAccordionContent>
+        <p>This is the content for Item 5</p>
+      </ng-template>
+    </div>
+  </div>
+</div>

--- a/src/components-examples/cdk-experimental/accordion/cdk-accordion-disabled/cdk-accordion-disabled-example.ts
+++ b/src/components-examples/cdk-experimental/accordion/cdk-accordion-disabled/cdk-accordion-disabled-example.ts
@@ -1,0 +1,30 @@
+import {Component, computed, model, Signal} from '@angular/core';
+import {MatIconModule} from '@angular/material/icon';
+import {
+  CdkAccordionGroup,
+  CdkAccordionTrigger,
+  CdkAccordionPanel,
+  CdkAccordionContent,
+} from '@angular/cdk-experimental/accordion';
+
+/** @title Disabled Accordion. */
+@Component({
+  selector: 'cdk-accordion-disabled-example',
+  templateUrl: 'cdk-accordion-disabled-example.html',
+  styleUrl: '../cdk-accordion-examples.css',
+  standalone: true,
+  imports: [
+    MatIconModule,
+    CdkAccordionGroup,
+    CdkAccordionTrigger,
+    CdkAccordionPanel,
+    CdkAccordionContent,
+  ],
+})
+export class CdkAccordionDisabledExample {
+  expandedIds = model<string[]>(['item1']);
+
+  expansionIcon(item: string): Signal<string> {
+    return computed(() => (this.expandedIds().includes(item) ? 'expand_less' : 'expand_more'));
+  }
+}

--- a/src/components-examples/cdk-experimental/accordion/cdk-accordion-examples.css
+++ b/src/components-examples/cdk-experimental/accordion/cdk-accordion-examples.css
@@ -1,3 +1,4 @@
+/* Common styles for CDK Accordion examples */
 .example-accordion-controls {
   display: flex;
   flex-wrap: wrap;

--- a/src/components-examples/cdk-experimental/accordion/cdk-accordion-multi-expansion/cdk-accordion-multi-expansion-example.html
+++ b/src/components-examples/cdk-experimental/accordion/cdk-accordion-multi-expansion/cdk-accordion-multi-expansion-example.html
@@ -1,0 +1,90 @@
+<div
+  cdkAccordionGroup
+  class="example-accordion-group"
+  [multiExpandable]="true"
+  [(value)]="expandedIds"
+>
+  <div class="example-accordion">
+    <h3 class="example-accordion-header">
+      <button cdkAccordionTrigger value="item1">
+        Item 1 Trigger
+        <mat-icon aria-hidden="true">{{expansionIcon('item1')()}}</mat-icon>
+      </button>
+    </h3>
+    <div cdkAccordionPanel value="item1" class="example-accordion-panel">
+      <ng-template cdkAccordionContent>
+        <p>This is the content for Item 1. Multiple items can be expanded.</p>
+        <button>Focusable Button</button>
+      </ng-template>
+    </div>
+  </div>
+
+  <div class="example-accordion">
+    <h3 class="example-accordion-header">
+      <button cdkAccordionTrigger value="item2">
+        Item 2 Trigger
+        <mat-icon aria-hidden="true">{{expansionIcon('item2')()}}</mat-icon>
+      </button>
+    </h3>
+    <div cdkAccordionPanel value="item2" class="example-accordion-panel">
+      <ng-template cdkAccordionContent>
+        <p>This is the content for Item 2.</p>
+        <label>Input inside panel: <input type="text"></label>
+      </ng-template>
+    </div>
+  </div>
+
+  <div class="example-accordion">
+    <h3 class="example-accordion-header">
+      <button cdkAccordionTrigger value="item3">
+        Item 3 Trigger
+        <mat-icon aria-hidden="true">{{expansionIcon('item3')()}}</mat-icon>
+      </button>
+    </h3>
+    <div
+      cdkAccordionPanel
+      value="item3"
+      class="example-accordion-panel"
+    >
+      <ng-template cdkAccordionContent>
+        <p>This is the content for Item 3.</p>
+      </ng-template>
+    </div>
+  </div>
+
+  <div class="example-accordion">
+    <h3 class="example-accordion-header">
+      <button cdkAccordionTrigger value="item4">
+        Item 4 Trigger
+        <mat-icon aria-hidden="true">{{expansionIcon('item4')()}}</mat-icon>
+      </button>
+    </h3>
+    <div
+      cdkAccordionPanel
+      value="item4"
+      class="example-accordion-panel"
+    >
+      <ng-template cdkAccordionContent>
+        <p>This is the content for Item 4</p>
+      </ng-template>
+    </div>
+  </div>
+
+  <div class="example-accordion">
+    <h3 class="example-accordion-header">
+      <button cdkAccordionTrigger value="item5">
+        Item 5 Trigger
+        <mat-icon aria-hidden="true">{{expansionIcon('item5')()}}</mat-icon>
+      </button>
+    </h3>
+    <div
+      cdkAccordionPanel
+      value="item5"
+      class="example-accordion-panel"
+    >
+      <ng-template cdkAccordionContent>
+        <p>This is the content for Item 5</p>
+      </ng-template>
+    </div>
+  </div>
+</div>

--- a/src/components-examples/cdk-experimental/accordion/cdk-accordion-multi-expansion/cdk-accordion-multi-expansion-example.ts
+++ b/src/components-examples/cdk-experimental/accordion/cdk-accordion-multi-expansion/cdk-accordion-multi-expansion-example.ts
@@ -1,0 +1,30 @@
+import {Component, computed, model, Signal} from '@angular/core';
+import {MatIconModule} from '@angular/material/icon';
+import {
+  CdkAccordionGroup,
+  CdkAccordionTrigger,
+  CdkAccordionPanel,
+  CdkAccordionContent,
+} from '@angular/cdk-experimental/accordion';
+
+/** @title Accordion with multi-expansion. */
+@Component({
+  selector: 'cdk-accordion-multi-expansion-example',
+  templateUrl: 'cdk-accordion-multi-expansion-example.html',
+  styleUrl: '../cdk-accordion-examples.css',
+  standalone: true,
+  imports: [
+    MatIconModule,
+    CdkAccordionGroup,
+    CdkAccordionTrigger,
+    CdkAccordionPanel,
+    CdkAccordionContent,
+  ],
+})
+export class CdkAccordionMultiExpansionExample {
+  expandedIds = model<string[]>([]);
+
+  expansionIcon(item: string): Signal<string> {
+    return computed(() => (this.expandedIds().includes(item) ? 'expand_less' : 'expand_more'));
+  }
+}

--- a/src/components-examples/cdk-experimental/accordion/cdk-accordion-single-expansion/cdk-accordion-single-expansion-example.html
+++ b/src/components-examples/cdk-experimental/accordion/cdk-accordion-single-expansion/cdk-accordion-single-expansion-example.html
@@ -1,0 +1,90 @@
+<div
+  cdkAccordionGroup
+  class="example-accordion-group"
+  [multiExpandable]="false"
+  [(value)]="expandedIds"
+>
+  <div class="example-accordion">
+    <h3 class="example-accordion-header">
+      <button cdkAccordionTrigger value="item1">
+        Item 1 Trigger
+        <mat-icon aria-hidden="true">{{expansionIcon('item1')()}}</mat-icon>
+      </button>
+    </h3>
+    <div cdkAccordionPanel value="item1" class="example-accordion-panel">
+      <ng-template cdkAccordionContent>
+        <p>This is the content for Item 1.</p>
+        <button>Focusable Button</button>
+      </ng-template>
+    </div>
+  </div>
+
+  <div class="example-accordion">
+    <h3 class="example-accordion-header">
+      <button cdkAccordionTrigger value="item2">
+        Item 2 Trigger
+        <mat-icon aria-hidden="true">{{expansionIcon('item2')()}}</mat-icon>
+      </button>
+    </h3>
+    <div cdkAccordionPanel value="item2" class="example-accordion-panel">
+      <ng-template cdkAccordionContent>
+        <p>This is the content for Item 2.</p>
+        <label>Input inside panel: <input type="text"></label>
+      </ng-template>
+    </div>
+  </div>
+
+  <div class="example-accordion">
+    <h3 class="example-accordion-header">
+      <button cdkAccordionTrigger value="item3">
+        Item 3 Trigger
+        <mat-icon aria-hidden="true">{{expansionIcon('item3')()}}</mat-icon>
+      </button>
+    </h3>
+    <div
+      cdkAccordionPanel
+      value="item3"
+      class="example-accordion-panel"
+    >
+      <ng-template cdkAccordionContent>
+        <p>This is the content for Item 3.</p>
+      </ng-template>
+    </div>
+  </div>
+
+  <div class="example-accordion">
+    <h3 class="example-accordion-header">
+      <button cdkAccordionTrigger value="item4">
+        Item 4 Trigger
+        <mat-icon aria-hidden="true">{{expansionIcon('item4')()}}</mat-icon>
+      </button>
+    </h3>
+    <div
+      cdkAccordionPanel
+      value="item4"
+      class="example-accordion-panel"
+    >
+      <ng-template cdkAccordionContent>
+        <p>This is the content for Item 4</p>
+      </ng-template>
+    </div>
+  </div>
+
+  <div class="example-accordion">
+    <h3 class="example-accordion-header">
+      <button cdkAccordionTrigger value="item5">
+        Item 5 Trigger
+        <mat-icon aria-hidden="true">{{expansionIcon('item5')()}}</mat-icon>
+      </button>
+    </h3>
+    <div
+      cdkAccordionPanel
+      value="item5"
+      class="example-accordion-panel"
+    >
+      <ng-template cdkAccordionContent>
+        <p>This is the content for Item 5</p>
+      </ng-template>
+    </div>
+  </div>
+</div>

--- a/src/components-examples/cdk-experimental/accordion/cdk-accordion-single-expansion/cdk-accordion-single-expansion-example.ts
+++ b/src/components-examples/cdk-experimental/accordion/cdk-accordion-single-expansion/cdk-accordion-single-expansion-example.ts
@@ -1,0 +1,30 @@
+import {Component, computed, model, Signal} from '@angular/core';
+import {MatIconModule} from '@angular/material/icon';
+import {
+  CdkAccordionGroup,
+  CdkAccordionTrigger,
+  CdkAccordionPanel,
+  CdkAccordionContent,
+} from '@angular/cdk-experimental/accordion';
+
+/** @title Accordion with single expansion. */
+@Component({
+  selector: 'cdk-accordion-single-expansion-example',
+  templateUrl: 'cdk-accordion-single-expansion-example.html',
+  styleUrl: '../cdk-accordion-examples.css',
+  standalone: true,
+  imports: [
+    MatIconModule,
+    CdkAccordionGroup,
+    CdkAccordionTrigger,
+    CdkAccordionPanel,
+    CdkAccordionContent,
+  ],
+})
+export class CdkAccordionSingleExpansionExample {
+  expandedIds = model<string[]>([]);
+
+  expansionIcon(item: string): Signal<string> {
+    return computed(() => (this.expandedIds().includes(item) ? 'expand_less' : 'expand_more'));
+  }
+}

--- a/src/components-examples/cdk-experimental/accordion/index.ts
+++ b/src/components-examples/cdk-experimental/accordion/index.ts
@@ -1,1 +1,6 @@
-export {CdkAccordionExample} from './cdk-accordion/cdk-accordion-example';
+export {CdkAccordionConfigurableExample} from './cdk-accordion-configurable/cdk-accordion-configurable-example';
+export {CdkAccordionSingleExpansionExample} from './cdk-accordion-single-expansion/cdk-accordion-single-expansion-example';
+export {CdkAccordionMultiExpansionExample} from './cdk-accordion-multi-expansion/cdk-accordion-multi-expansion-example';
+export {CdkAccordionDisabledFocusableExample} from './cdk-accordion-disabled-focusable/cdk-accordion-disabled-focusable-example';
+export {CdkAccordionDisabledSkippedExample} from './cdk-accordion-disabled-skipped/cdk-accordion-disabled-skipped-example';
+export {CdkAccordionDisabledExample} from './cdk-accordion-disabled/cdk-accordion-disabled-example';

--- a/src/dev-app/cdk-experimental-accordion/BUILD.bazel
+++ b/src/dev-app/cdk-experimental-accordion/BUILD.bazel
@@ -5,6 +5,9 @@ package(default_visibility = ["//visibility:public"])
 ng_project(
     name = "cdk-experimental-accordion",
     srcs = glob(["**/*.ts"]),
-    assets = ["cdk-accordion-demo.html"],
+    assets = [
+        "cdk-accordion-demo.html",
+        "cdk-accordion-demo.css",
+    ],
     deps = ["//src/components-examples/cdk-experimental/accordion"],
 )

--- a/src/dev-app/cdk-experimental-accordion/cdk-accordion-demo.css
+++ b/src/dev-app/cdk-experimental-accordion/cdk-accordion-demo.css
@@ -1,0 +1,27 @@
+.example-accordion-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(500px, 1fr));
+  gap: 20px;
+}
+
+.example-accordion-container {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+}
+
+.example-accordion-container,
+.example-configurable-accordion-container {
+  border: 1px solid #555;
+  border-radius: 5px;
+  padding: 20px;
+}
+
+.example-configurable-accordion-container {
+  margin-top: 40px;
+}
+
+h4 {
+  height: 36px;
+  margin-top: 0;
+}

--- a/src/dev-app/cdk-experimental-accordion/cdk-accordion-demo.html
+++ b/src/dev-app/cdk-experimental-accordion/cdk-accordion-demo.html
@@ -1,4 +1,38 @@
 <div>
-  <h4>Accordion using UI Patterns</h4>
-  <cdk-accordion-example></cdk-accordion-example>
+  <div class="example-accordion-grid">
+    <div class="example-accordion-container">
+      <h4>Single expansion - Able to expand and collapse accordion panels.</h4>
+      <cdk-accordion-single-expansion-example></cdk-accordion-single-expansion-example>
+    </div>
+
+    <div class="example-accordion-container">
+      <h4>Multi expansion - Able to expand and collapse multiple accordion panels</h4>
+      <cdk-accordion-multi-expansion-example></cdk-accordion-multi-expansion-example>
+    </div>
+
+    <div class="example-accordion-container">
+      <h4>
+        Disabled Accordions are Focusable - Able to navigate to a disabled accordion. Disabled
+        accordions are not expandable.
+      </h4>
+      <cdk-accordion-disabled-focusable-example></cdk-accordion-disabled-focusable-example>
+    </div>
+
+    <div class="example-accordion-container">
+      <h4>
+        Disabled Accordions are Skipped - Disabled accordions are skipped over and not expandable.
+      </h4>
+      <cdk-accordion-disabled-skipped-example></cdk-accordion-disabled-skipped-example>
+    </div>
+
+    <div class="example-accordion-container">
+      <h4>Disabled - Focus should land on the accordion group instead of an accordion trigger.</h4>
+      <cdk-accordion-disabled-example></cdk-accordion-disabled-example>
+    </div>
+  </div>
+
+  <div class="example-configurable-accordion-container">
+    <h4>Configurable Accordion</h4>
+    <cdk-accordion-configurable-example></cdk-accordion-configurable-example>
+  </div>
 </div>

--- a/src/dev-app/cdk-experimental-accordion/cdk-accordion-demo.ts
+++ b/src/dev-app/cdk-experimental-accordion/cdk-accordion-demo.ts
@@ -6,12 +6,28 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ChangeDetectionStrategy, Component} from '@angular/core';
-import {CdkAccordionExample} from '@angular/components-examples/cdk-experimental/accordion';
+import {ChangeDetectionStrategy, Component, ViewEncapsulation} from '@angular/core';
+import {
+  CdkAccordionConfigurableExample,
+  CdkAccordionDisabledExample,
+  CdkAccordionDisabledFocusableExample,
+  CdkAccordionDisabledSkippedExample,
+  CdkAccordionMultiExpansionExample,
+  CdkAccordionSingleExpansionExample,
+} from '@angular/components-examples/cdk-experimental/accordion';
 
 @Component({
   templateUrl: 'cdk-accordion-demo.html',
-  imports: [CdkAccordionExample],
+  styleUrl: 'cdk-accordion-demo.css',
+  imports: [
+    CdkAccordionConfigurableExample,
+    CdkAccordionSingleExpansionExample,
+    CdkAccordionMultiExpansionExample,
+    CdkAccordionDisabledFocusableExample,
+    CdkAccordionDisabledSkippedExample,
+    CdkAccordionDisabledExample,
+  ],
+  encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class CdkExperimentalAccordionDemo {}


### PR DESCRIPTION
Adds several new examples for the cdk-experimental accordion component:
- Single expansion
- Multi expansion
- Disabled items that are focusable
- Disabled items that are skipped