### PR TITLE
fix(material/input): remove native clear button

### DIFF
--- a/src/material/form-field/_mdc-text-field-structure.scss
+++ b/src/material/form-field/_mdc-text-field-structure.scss
@@ -44,7 +44,8 @@ $fallbacks: m3-form-field.get-tokens();
 
     // Note that while this style and the `-ms-clear` are identical, we can't combine
     // them because if one of them isn't supported, it'll invalidate the whole rule.
-    &::-webkit-calendar-picker-indicator {
+    &::-webkit-calendar-picker-indicator,
+    &::-webkit-search-cancel-button {
       display: none;
     }
 


### PR DESCRIPTION
Updates our CSS resets to remove the native clear button on `type="search"`. This is similar to what we do for other input types.

Fixes #31298.