### PR TITLE
build: some overrides not showing up in docs site

### DIFF
--- a/src/material/button/BUILD.bazel
+++ b/src/material/button/BUILD.bazel
@@ -194,7 +194,11 @@ markdown_to_html(
 
 extract_tokens(
     name = "tokens",
-    srcs = [":theme"],
+    srcs = [
+        ":fab_theme",
+        ":icon_button_theme",
+        ":theme",
+    ],
 )
 
 filegroup(


### PR DESCRIPTION
The `tokens` rule for the button didn't have a dependency on the FAB and icon button themes which meant that they weren't showing up in the docs.

Fixes #31395.