### PR TITLE
build: dependency management updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,7 +148,6 @@
     "tsutils": "^3.21.0",
     "typescript": "5.8.3",
     "vrsource-tslint-rules": "6.0.0",
-    "yaml": "^1.10.2",
     "yargs": "^17.3.1",
     "zx": "^6.2.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -347,9 +347,6 @@ importers:
       vrsource-tslint-rules:
         specifier: 6.0.0
         version: 6.0.0(tslint@6.1.3(typescript@5.8.3))(typescript@5.8.3)
-      yaml:
-        specifier: ^1.10.2
-        version: 1.10.2
       yargs:
         specifier: ^17.3.1
         version: 17.7.2

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>angular/dev-infra//renovate-presets/default.json5"],
-  "packageRules": []
+  "packageRules": [],
+  "ignoreDeps": ["stylelint", "selenium-webdriver"]
 }


### PR DESCRIPTION
Makes the following changes to our dependency management:
1. Removes `yaml` since we don't use it anywhere.
2. Disables updates for `stylelint` and `selenium-webdriver`, because their latest versions have breaking changes that will take some effort to get around.