### PR TITLE
ci: enable puppeteer debug logging in `main` test runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
       - name: Install node modules
         run: pnpm install --frozen-lockfile
       - name: Run tests
-        run: bazel test --build_tag_filters=-e2e --test_tag_filters=-e2e --build_tests_only -- src/...
+        run: bazel test --build_tag_filters=-e2e --test_tag_filters=-e2e --build_tests_only --test_env="DEBUG=puppeteer:*" -- src/...
 
   build:
     runs-on: ubuntu-latest-16core


### PR DESCRIPTION
This might be useful for figuring out why the Firefox tests often seem to time out.