### PR TITLE
build: update renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>angular/dev-infra//renovate-presets/default.json5"],
   "packageRules": [],
-  "ignoreDeps": ["stylelint", "selenium-webdriver"]
+  "ignoreDeps": ["stylelint", "selenium-webdriver", "@types/selenium-webdriver", "typescript"],
+  "ignorePaths": ["docs/src/assets/stackblitz/**", "integration/**"]
 }


### PR DESCRIPTION
Updates the Renovate config to skip more dependencies and to not touch integration tests and the Stackblitz template.