### PR TITLE
fix(google-maps): fix update schematic

### DIFF
--- a/src/google-maps/schematics/ng-update/index.ts
+++ b/src/google-maps/schematics/ng-update/index.ts
@@ -6,5 +6,9 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import {Rule} from '@angular-devkit/schematics';
+
 /** Entry point for the migration schematics with target of Angular Material v20 */
-export function updateToV20(): void {}
+export function updateToV20(): Rule {
+  return () => {};
+}


### PR DESCRIPTION
This change fixes the `updateToV20` schematic which should be a factory function not the schematic itself.

Fixes the error:

```
❯ Updates the Angular Google Maps package to v20.                                                                                                      
✖ Migration failed: rule is not a function                                                                                                             
  See "/tmp/ng-1KmdDK/angular-errors.log" for further details.     
```