### PR TITLE
fix(cdk/tree): remove leaking subscription

### DIFF
--- a/src/cdk/tree/tree.ts
+++ b/src/cdk/tree/tree.ts
@@ -1400,6 +1400,7 @@ export class CdkTreeNode<T, K = T> implements OnDestroy, OnInit, TreeKeyManagerI
       .changed.pipe(
         map(() => this.isExpanded),
         distinctUntilChanged(),
+        takeUntil(this._destroyed),
       )
       .subscribe(() => this._changeDetectorRef.markForCheck());
     this._tree._setNodeTypeIfUnset(this._type);


### PR DESCRIPTION
Fixes that we weren't unsubscribing from one observable in the tree.

Fixes #31454.