### PR TITLE
build: enable type checking of host bindings in docs

### DIFF
--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -31,6 +31,7 @@
     "fullTemplateTypeCheck": true,
     "strictInjectionParameters": true,
     "strictInputAccessModifiers": true,
-    "strictTemplates": true
+    "strictTemplates": true,
+    "typeCheckHostBindings": true
   }
 }


### PR DESCRIPTION
The docs are on a separate tsconfig so they didn't have the config that enables type checking of their host bindings.