### PR TITLE
docs(google-maps): add terms of service section to readme

### DIFF
--- a/src/google-maps/README.md
+++ b/src/google-maps/README.md
@@ -86,3 +86,25 @@ zoom = 4;
 
 Not every option has its own input. See the API for each component to see if the option has a
 dedicated input or if it should be set in the options input.
+
+## Terms of Service
+
+`@angular/google-maps` uses Google Maps Platform services. Use of Google
+Maps Platform services through this library is subject to the
+[Google Maps Platform Terms of Service][gmp-tos].
+
+This library is not a Google Maps Platform Core Service.
+Therefore, the Google Maps Platform Terms of Service (e.g., Technical
+Support Services, Service Level Agreements, and Deprecation Policy)
+do not apply to this library.
+
+### European Economic Area (EEA) developers
+
+If your billing address is in the European Economic Area, effective on
+8 July 2025, the [Google Maps Platform EEA Terms of Service][gmp-tos-eea]
+will apply to your use of the Services. Functionality varies by region.
+[Learn more][gmp-tos-eea-faq].
+
+[gmp-tos]: https://cloud.google.com/maps-platform/terms
+[gmp-tos-eea]: https://cloud.google.com/terms/maps-platform/eea
+[gmp-tos-eea-faq]: https://developers.google.com/maps/comms/eea/faq


### PR DESCRIPTION
I'm currently creating PRs for all `@googlemaps` packages on npm to include a Paragraph about the terms of service and especially the changes ToS for the EEA market.

CC @anglarett