### PR TITLE
fix(material/core): align gm3 colors

### DIFF
--- a/src/material/core/tokens/m3/_md-sys-color.scss
+++ b/src/material/core/tokens/m3/_md-sys-color.scss
@@ -1,8 +1,3 @@
-//
-// Design system display name: Material 3
-// Design system version: v0.161
-//
-
 @use 'sass:map';
 
 // Indicates whether alternative tokens should be used
@@ -63,9 +58,7 @@ $_alternate-tokens: false;
 
   @if ($_alternate-tokens) {
     $values: map.merge($values, (
-      background: map.get($palettes, neutral, 10),
       on-surface-variant: map.get($palettes, neutral-variant, 80),
-      surface: map.get($palettes, neutral, 10),
       surface-bright: #37393b,
       surface-container: #1e1f20,
       surface-container-high: #282a2c,
@@ -136,17 +129,12 @@ $_alternate-tokens: false;
   @if ($_alternate-tokens) {
     $values: map.merge($values, (
       background: map.get($palettes, neutral, 100),
-      on-error-container: map.get($palettes, error, 10),
-      on-primary-container: map.get($palettes, primary, 10),
-      on-secondary-container: map.get($palettes, secondary, 10),
-      on-tertiary-container: map.get($palettes, tertiary, 10),
       surface: map.get($palettes, neutral, 100),
       surface-bright: map.get($palettes, neutral, 100),
       surface-container: #f0f4f9,
       surface-container-high: #e9eef6,
       surface-container-highest: #dde3ea,
       surface-container-low: #f8fafd,
-      surface-container-lowest: map.get($palettes, primary, 100),
       surface-dim: #d3dbe5,
       surface-tint: #6991d6,
     ));


### PR DESCRIPTION
Some internal color tokens have changed - this brings them back into spec. The keys are removed since the defaults for internal and external match and do not need the custom overrides