### PR TITLE
perf(tooltip): do not create timeout on delay 0

### DIFF
--- a/src/material/tooltip/tooltip.ts
+++ b/src/material/tooltip/tooltip.ts
@@ -1044,11 +1044,15 @@ export class TooltipComponent implements OnDestroy {
     if (this._hideTimeoutId != null) {
       clearTimeout(this._hideTimeoutId);
     }
-
-    this._showTimeoutId = setTimeout(() => {
+    if( delay > 0 ){
+      this._showTimeoutId = setTimeout(() => {
+        this._toggleVisibility(true);
+        this._showTimeoutId = undefined;
+      }, delay);
+    } else {
       this._toggleVisibility(true);
       this._showTimeoutId = undefined;
-    }, delay);
+    }
   }
 
   /**


### PR DESCRIPTION
Currently the tooltip always create a setTimeout even if the delay is 0. This has a little performance impact of the page has many tooltip.
