### PR TITLE
build: clean up animations references in build files

### DIFF
--- a/src/cdk/dialog/BUILD.bazel
+++ b/src/cdk/dialog/BUILD.bazel
@@ -17,7 +17,6 @@ ng_project(
     ),
     assets = [":dialog-container.css"] + glob(["**/*.html"]),
     deps = [
-        "//:node_modules/@angular/animations",
         "//:node_modules/@angular/common",
         "//:node_modules/@angular/core",
         "//:node_modules/rxjs",

--- a/src/e2e-app/BUILD.bazel
+++ b/src/e2e-app/BUILD.bazel
@@ -34,7 +34,6 @@ ng_project(
         exclude = ["index.html"],
     ),
     deps = [
-        "//:node_modules/@angular/animations",
         "//:node_modules/@angular/core",
         "//:node_modules/@angular/forms",
         "//:node_modules/@angular/platform-browser",

--- a/src/material/badge/BUILD.bazel
+++ b/src/material/badge/BUILD.bazel
@@ -71,7 +71,6 @@ ng_project(
     ],
     assets = [":badge_css"],
     deps = [
-        "//:node_modules/@angular/animations",
         "//:node_modules/@angular/common",
         "//:node_modules/@angular/core",
         "//:node_modules/@angular/platform-browser",

--- a/src/material/checkbox/BUILD.bazel
+++ b/src/material/checkbox/BUILD.bazel
@@ -87,7 +87,6 @@ ng_project(
         ":css",
     ],
     deps = [
-        "//:node_modules/@angular/animations",
         "//:node_modules/@angular/core",
         "//:node_modules/@angular/forms",
         "//src/material/core",

--- a/src/material/chips/BUILD.bazel
+++ b/src/material/chips/BUILD.bazel
@@ -96,7 +96,6 @@ ng_project(
         ":chip_set_css",
     ],
     deps = [
-        "//:node_modules/@angular/animations",
         "//:node_modules/@angular/common",
         "//:node_modules/@angular/core",
         "//:node_modules/@angular/forms",
@@ -116,7 +115,6 @@ ts_project(
     ),
     deps = [
         ":chips",
-        "//:node_modules/@angular/animations",
         "//:node_modules/@angular/common",
         "//:node_modules/@angular/core",
         "//:node_modules/@angular/forms",

--- a/src/material/slide-toggle/BUILD.bazel
+++ b/src/material/slide-toggle/BUILD.bazel
@@ -77,7 +77,6 @@ ng_project(
         ":css",
     ],
     deps = [
-        "//:node_modules/@angular/animations",
         "//:node_modules/@angular/core",
         "//:node_modules/@angular/forms",
         "//:node_modules/rxjs",


### PR DESCRIPTION
Removes unnecessary references to the animations module from BUILD files.