### PR TITLE
docs: fix undefined variable in custom stepper guide

### DIFF
--- a/guides/creating-a-custom-stepper-using-the-cdk-stepper.md
+++ b/guides/creating-a-custom-stepper-using-the-cdk-stepper.md
@@ -45,8 +45,8 @@ This is the HTML template of our custom stepper component:
 
   <footer class="step-navigation-bar">
     <button class="nav-button" cdkStepperPrevious>&larr;</button>
-    @for (step of steps; track step) {
-      <button class="step" [class.active]="selectedIndex === $index" (click)="onClick(i)">
+    @for (step of steps; track step; let i = $index) {
+      <button class="step" [class.active]="selectedIndex === i" (click)="onClick(i)">
         Step {{i + 1}}
       </button>
     }


### PR DESCRIPTION
In the `@for` loop of the `custom-stepper.component.html` template, the code references an undefined variable `i`. To fix this, the loop should declare `i` using the built-in `$index` variable provided by Angular's `@for` block.

This matches the approach used in the embedded StackBlitz example for this page.