### PR TITLE
fix(cdk/drag-drop): ensure container is registered in addItem

### DIFF
--- a/src/cdk/drag-drop/directives/drag.ts
+++ b/src/cdk/drag-drop/directives/drag.ts
@@ -248,7 +248,6 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
     // is too late since the two modes save different kinds of information. We work around it by
     // assigning the drop container both from here and the list.
     if (dropContainer) {
-      this._dragRef._withDropContainer(dropContainer._dropListRef);
       dropContainer.addItem(this);
 
       // The drop container reads this so we need to sync it here.

--- a/src/cdk/drag-drop/directives/drop-list.ts
+++ b/src/cdk/drag-drop/directives/drop-list.ts
@@ -235,6 +235,7 @@ export class CdkDropList<T = any> implements OnDestroy {
   /** Registers an items with the drop list. */
   addItem(item: CdkDrag): void {
     this._unsortedItems.add(item);
+    item._dragRef._withDropContainer(this._dropListRef);
 
     // Only sync the items while dragging since this method is
     // called when items are being initialized one-by-one.


### PR DESCRIPTION
Currently we only sync drop container in the `CdkDrag` container. These changes move the logic into `addItem` to ensure that it always happens.

Fixes #31514.