### PR TITLE
fix(material/schematics): always add a custom theme with ng add

### DIFF
--- a/src/material/schematics/ng-add/schema.json
+++ b/src/material/schematics/ng-add/schema.json
@@ -16,7 +16,7 @@
       "type": "string",
       "default": "azure-blue",
       "x-prompt": {
-        "message": "Choose a prebuilt theme name, or \"custom\" for a custom theme:",
+        "message": "Select a pair of starter prebuilt color palettes for your Angular Material theme",
         "type": "list",
         "items": [
           {
@@ -34,16 +34,9 @@
           {
             "value": "cyan-orange",
             "label": "Cyan/Orange        [Preview: https://material.angular.dev?theme=cyan-orange]"
-          },
-          {"value": "custom", "label": "Custom"}
+          }
         ]
       }
-    },
-    "typography": {
-      "type": "boolean",
-      "default": false,
-      "description": "Whether to set up global typography styles.",
-      "x-prompt": "Set up global Angular Material typography styles?"
     }
   },
   "required": []

--- a/src/material/schematics/ng-add/setup-project.ts
+++ b/src/material/schematics/ng-add/setup-project.ts
@@ -6,13 +6,13 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {chain, noop, Rule, SchematicContext, Tree} from '@angular-devkit/schematics';
+import {chain, Rule, SchematicContext, Tree} from '@angular-devkit/schematics';
 import {getProjectFromWorkspace, getProjectStyleFile} from '@angular/cdk/schematics';
 import {readWorkspace} from '@schematics/angular/utility';
 import {ProjectType} from '@schematics/angular/utility/workspace-models';
 import {addFontsToIndex} from './fonts/material-fonts';
 import {Schema} from './schema';
-import {addThemeToAppStyles, addTypographyClass} from './theming/theming';
+import {addThemeToAppStyles} from './theming/theming';
 
 /**
  * Scaffolds the basics of a Angular Material application, this includes:
@@ -29,7 +29,6 @@ export default function (options: Schema): Rule {
         addThemeToAppStyles(options),
         addFontsToIndex(options),
         addMaterialAppStyles(options),
-        options.typography ? addTypographyClass(options) : noop(),
       ]);
     }
     context.logger.warn(

--- a/src/material/schematics/ng-add/theming/create-custom-theme.ts
+++ b/src/material/schematics/ng-add/theming/create-custom-theme.ts
@@ -7,21 +7,40 @@
  */
 
 /** Create custom theme for the given application configuration. */
-export function createCustomTheme(name: string = 'app') {
+export function createCustomTheme(userPaletteChoice: string) {
+  const colorPalettes = new Map<string, {primary: string; tertiary: string}>([
+    ['azure-blue', {primary: 'azure', tertiary: 'blue'}],
+    ['rose-red', {primary: 'rose', tertiary: 'red'}],
+    ['magenta-violet', {primary: 'magenta', tertiary: 'violet'}],
+    ['cyan-orange', {primary: 'cyan', tertiary: 'orange'}],
+  ]);
   return `
-// Custom Theming for Angular Material
-// For more information: https://material.angular.dev/guide/theming
+// Include theming for Angular Material with \`mat.theme()\`.
+// This Sass mixin will define CSS variables that are used for styling Angular Material
+// components according to the Material 3 design spec.
+// Learn more about theming and how to use it for your application's
+// custom components at https://material.angular.dev/guide/theming
 @use '@angular/material' as mat;
 
 html {
   @include mat.theme((
     color: (
-      theme-type: light,
-      primary: mat.$azure-palette,
-      tertiary: mat.$blue-palette,
+      primary: mat.$${colorPalettes.get(userPaletteChoice)!.primary}-palette,
+      tertiary: mat.$${colorPalettes.get(userPaletteChoice)!.tertiary}-palette,
     ),
     typography: Roboto,
     density: 0,
   ));
+
+  // Default the application to a light color theme. This can be changed to
+  // \`dark\` to enable the dark color theme, or to \`light dark\` to defer to the
+  // user's system settings.
+  color-scheme: light;
+
+  // Set a default background, font and text colors for the application using
+  // Angular Material's system-level CSS variables.
+  background-color: var(--mat-sys-surface);
+  color: var(--mat-sys-on-surface);
+  font: var(--mat-sys-body-medium);
 }`;
 }


### PR DESCRIPTION
`ng add` no longer provides options to include the prebuilt themes. Instead, always add a custom theme with user-specified palettes: 

```scss
// Include theming for Angular Material with `mat.theme()`.
// This Sass mixin will define CSS variables that are used for styling Angular Material
// components according to the Material 3 design spec.
// Learn more about theming and how to use it for your application's
// custom components at https://material.angular.dev/guide/theming
@use '@angular/material' as mat;

html {
  @include mat.theme((
    color: (
      primary: mat.$azure-palette,
      tertiary: mat.$blue-palette,
    ),
    typography: Roboto,
    density: 0,
  ));

  // Default the application to a light color theme. This can be changed to
  // `dark` to enable the dark color theme, or to `light dark` to defer to the
  // user's system settings.
  color-scheme: light;

  // Set a default background, font and text colors for the application using
  // Angular Material's system-level CSS variables. Learn more about these
  // variables at https://material.angular.dev/guide/system-variables
  background-color: var(--mat-sys-surface);
  color: var(--mat-sys-on-surface);
  font: var(--mat-sys-body-medium);
}
```

Also, remove the option to insert typography styles. Users should just use the system variables defined in the theming docs