### PR TITLE
fix(progress-bar): avoid ExpressionChangedAfterItHasBeenCheckedError …

### DIFF
--- a/src/components-examples/material/progress-bar/index.ts
+++ b/src/components-examples/material/progress-bar/index.ts
@@ -4,3 +4,4 @@ export {ProgressBarDeterminateExample} from './progress-bar-determinate/progress
 export {ProgressBarIndeterminateExample} from './progress-bar-indeterminate/progress-bar-indeterminate-example';
 export {ProgressBarQueryExample} from './progress-bar-query/progress-bar-query-example';
 export {ProgressBarHarnessExample} from './progress-bar-harness/progress-bar-harness-example';
+export {ProgressBarExpressionFixExample} from './progress-bar-expression-fix/progress-bar-expression-fix-example'

--- a/src/components-examples/material/progress-bar/progress-bar-expression-fix/progress-bar-expression-fix-example.html
+++ b/src/components-examples/material/progress-bar/progress-bar-expression-fix/progress-bar-expression-fix-example.html
@@ -1,0 +1,1 @@
+<mat-progress-bar [mode]="mode" [value]="value"></mat-progress-bar>

--- a/src/components-examples/material/progress-bar/progress-bar-expression-fix/progress-bar-expression-fix-example.ts
+++ b/src/components-examples/material/progress-bar/progress-bar-expression-fix/progress-bar-expression-fix-example.ts
@@ -1,0 +1,19 @@
+import { Component, AfterViewInit, ChangeDetectorRef } from '@angular/core';
+
+@Component({
+  selector: 'progress-bar-expression-fix-example',
+  templateUrl: './progress-bar-expression-fix-example.html',
+})
+export class ProgressBarExpressionFixExample implements AfterViewInit {
+  mode: 'determinate' | 'indeterminate' = 'determinate';
+  value = 50;
+
+  constructor(private cdr: ChangeDetectorRef) {}
+
+  ngAfterViewInit(): void {
+    setTimeout(() => {
+      this.mode = 'indeterminate';
+      this.cdr.detectChanges(); // Fix Bug ExpressionChangedAfterItHasBeenCheckedError
+    });
+  }
+}


### PR DESCRIPTION
### Problem:
When changing `mode` of mat-progress-bar inside `ngAfterViewInit`, Angular throws ExpressionChangedAfterItHasBeenCheckedError.

### Solution:
Wrapped the mode change in a `setTimeout` and used `ChangeDetectorRef.detectChanges()` to notify Angular properly.

