### PR TITLE
#26584: Remove css rule

### DIFF
--- a/src/material/chips/chip.scss
+++ b/src/material/chips/chip.scss
@@ -547,15 +547,6 @@ $fallbacks: m3-chip.get-tokens();
 .mat-mdc-standard-chip {
   -webkit-tap-highlight-color: transparent;
 
-  // MDC sets `overflow: hidden` on these elements in order to truncate the text. This is
-  // unnecessary since our chips don't truncate their text and it makes it difficult to style
-  // the strong focus indicators so we need to override it.
-  .mdc-evolution-chip__cell--primary,
-  .mdc-evolution-chip__action--primary,
-  .mat-mdc-chip-action-label {
-    overflow: visible;
-  }
-
   // MDC sizes and positions this element using `width`, `height` and `padding`.
   // This usually works, but it's common for apps to add `box-sizing: border-box`
   // to all elements on the page which can cause the graphic to be clipped.


### PR DESCRIPTION
Fixes the bug brought up in #26584 by removing the css rule, causing chips to once again truncate text correctly as intended, rather than overflowing.