### PR TITLE
fix(cdk/listbox): coerce tabindex value

### DIFF
--- a/goldens/cdk/listbox/index.api.md
+++ b/goldens/cdk/listbox/index.api.md
@@ -122,6 +122,8 @@ export class CdkOption<T = unknown> implements ListKeyManagerOption, Highlightab
     // (undocumented)
     static ngAcceptInputType_disabled: unknown;
     // (undocumented)
+    static ngAcceptInputType_enabledTabIndex: unknown;
+    // (undocumented)
     ngOnDestroy(): void;
     select(): void;
     setActiveStyles(): void;

--- a/src/cdk/listbox/listbox.ts
+++ b/src/cdk/listbox/listbox.ts
@@ -39,6 +39,7 @@ import {
   inject,
   Input,
   NgZone,
+  numberAttribute,
   OnDestroy,
   Output,
   QueryList,
@@ -130,7 +131,10 @@ export class CdkOption<T = unknown> implements ListKeyManagerOption, Highlightab
   private _disabled = signal(false);
 
   /** The tabindex of the option when it is enabled. */
-  @Input('tabindex')
+  @Input({
+    alias: 'tabindex',
+    transform: (value: unknown) => (value == null ? undefined : numberAttribute(value)),
+  })
   get enabledTabIndex() {
     return this._enabledTabIndex() === undefined
       ? this.listbox.enabledTabIndex


### PR DESCRIPTION
Fixes that the CDK listbox option wasn't coercing its `tabindex` value.

Fixes #31595.