### PR TITLE
fix(material/slider): tick marks not showing dynamically

### DIFF
--- a/goldens/material/slider/index.api.md
+++ b/goldens/material/slider/index.api.md
@@ -103,7 +103,8 @@ export class MatSlider implements AfterViewInit, OnDestroy, _MatSlider {
     }): void;
     // (undocumented)
     _setTransition(withAnimation: boolean): void;
-    showTickMarks: boolean;
+    get showTickMarks(): boolean;
+    set showTickMarks(value: boolean);
     // (undocumented)
     _startThumbTransform: string;
     protected startValueIndicatorText: string;

--- a/src/material/slider/slider.ts
+++ b/src/material/slider/slider.ts
@@ -132,7 +132,18 @@ export class MatSlider implements AfterViewInit, OnDestroy, _MatSlider {
 
   /** Whether the slider displays tick marks along the slider track. */
   @Input({transform: booleanAttribute})
-  showTickMarks: boolean = false;
+  get showTickMarks(): boolean {
+    return this._showTickMarks;
+  }
+  set showTickMarks(value: boolean) {
+    this._showTickMarks = value;
+
+    if (this._hasViewInitialized) {
+      this._updateTickMarkUI();
+      this._updateTickMarkTrackUI();
+    }
+  }
+  private _showTickMarks: boolean = false;
 
   /** The minimum value that the slider can have. */
   @Input({transform: numberAttribute})


### PR DESCRIPTION
Fixes that if `showTickMarks` is `false` initially and then switches to `true`, the slider wasn't updating to show the tick marks.

Fixes #31590.