### PR TITLE
fix(material/core): use different prefix for m2-theme

### DIFF
--- a/src/material/core/tokens/_system.scss
+++ b/src/material/core/tokens/_system.scss
@@ -355,7 +355,7 @@
 @mixin _define-m2-system-vars($vars, $overrides) {
   @include sass-utils.current-selector-or-root {
     @each $name, $value in $vars {
-      --#{definition.$system-level-prefix}-#{$name}: #{map.get($overrides, $name) or $value};
+      --#{definition.$system-fallback-prefix}-#{$name}: #{map.get($overrides, $name) or $value};
     }
   }
 }


### PR DESCRIPTION
These two Sass vars are the same in the code, but internally its transformed due to legacy uses. Switch to the fallback definition