### PR TITLE
fix(material/core): special-case icon button color token

### DIFF
--- a/src/dev-app/theme.scss
+++ b/src/dev-app/theme.scss
@@ -59,12 +59,12 @@ $candy-app-theme: mat.m2-define-light-theme((
         typography: mat.m2-define-typography-config(),
       )
   );
+  @include mat.m2-theme($dark-colors);
 
   // Include the dark theme color styles.
   @include mat.all-component-colors($dark-colors);
   @include experimental.column-resize-color($dark-colors);
   @include experimental.popover-edit-color($dark-colors);
-  @include mat.m2-theme($dark-colors);
 
   // Include the dark theme colors for focus indicators.
   &.demo-strong-focus {

--- a/src/material/core/tokens/_system.scss
+++ b/src/material/core/tokens/_system.scss
@@ -18,6 +18,7 @@
 @use '../style/elevation';
 @use '../theming/config-validation';
 @use '../theming/definition';
+@use '../theming/inspection';
 @use '../theming/m2-inspection';
 @use '../theming/palettes';
 @use '../style/sass-utils';
@@ -322,6 +323,11 @@
 // Unlike M3's `mat.theme()`, this mixin does not replace the need to call
 // individual component theme mixins for Angular Material components.
 @mixin m2-theme($theme-config, $overrides: ()) {
+  @if inspection.get-theme-version($theme-config) == 1 {
+    @error '`m2-theme` mixin should only be called for M2 theme ' +
+        'configs created with define-light-theme or define-dark-theme';
+  }
+
   $config: m2-inspection.get-m2-config($theme-config);
 
   $color: map.get($config, color);


### PR DESCRIPTION
Normally, an icon button should automatically get its color from whatever container it's placed in. This is important so the icon always has the right contrast to be visible, whether it's on a light, dark, or colored background.

However, when the icon button's M2 color token is `inherit`, the browser will always use the fallback color `on-surface-variant` which is going to now be defined in this mixin.

To fix this, this code directly sets the icon's color and makes sure no fallback is defined. This forces the icon to correctly inherit its color from the container as originally intended.


**Also:** adds the mixin to the dev-app theme 