### PR TITLE
fix(material/autocomplete): default to transparent backdrop

### DIFF
--- a/src/material/autocomplete/autocomplete-trigger.ts
+++ b/src/material/autocomplete/autocomplete-trigger.ts
@@ -912,7 +912,7 @@ export class MatAutocompleteTrigger
       width: this._getPanelWidth(),
       direction: this._dir ?? undefined,
       hasBackdrop: this._defaults?.hasBackdrop,
-      backdropClass: this._defaults?.backdropClass,
+      backdropClass: this._defaults?.backdropClass || 'cdk-overlay-transparent-backdrop',
       panelClass: this._overlayPanelClass,
       disableAnimations: this._animationsDisabled,
     });


### PR DESCRIPTION
The autocomplete was leaving the `backdropClass` as undefined which meant that it would default to a dark one, if the user opted into it having a backdrop.

Fixes #31614.