### PR TITLE
fix(material/chips): focus not moved on destroy

### DIFF
--- a/goldens/material/chips/index.api.md
+++ b/goldens/material/chips/index.api.md
@@ -79,6 +79,7 @@ export class MatChip implements OnInit, AfterViewInit, AfterContentInit, DoCheck
     focus(): void;
     _getActions(): MatChipAction[];
     _getSourceAction(target: Node): MatChipAction | undefined;
+    _hadFocusOnRemove: boolean;
     _handleKeydown(event: KeyboardEvent): void;
     _handlePrimaryActionInteraction(): void;
     // (undocumented)

--- a/src/material/chips/chip.ts
+++ b/src/material/chips/chip.ts
@@ -172,6 +172,9 @@ export class MatChip implements OnInit, AfterViewInit, AfterContentInit, DoCheck
   /** Whether the chip list is disabled. */
   _chipListDisabled: boolean = false;
 
+  /** Whether the chip was focused when it was removed. */
+  _hadFocusOnRemove = false;
+
   private _textElement!: HTMLElement;
 
   /**
@@ -316,6 +319,7 @@ export class MatChip implements OnInit, AfterViewInit, AfterContentInit, DoCheck
    */
   remove(): void {
     if (this.removable) {
+      this._hadFocusOnRemove = this._hasFocus();
       this.removed.emit({chip: this});
     }
   }


### PR DESCRIPTION
We have some logic that moves focus if a chip is destroyed so that it doesn't go back to the `body`. The removal timing seems to have changed at some point which broke the focus restoration, because the element is blurred before it is destroyed.

These changes make the logic a bit more robust by checking the key manager for the removed chip.