### PR TITLE
fix(material/form-field): redundant focus on Android WebView

### DIFF
--- a/src/material/form-field/form-field.html
+++ b/src/material/form-field/form-field.html
@@ -44,6 +44,7 @@
   [class.mdc-text-field--disabled]="_control.disabled"
   [class.mdc-text-field--invalid]="_control.errorState"
   (click)="_control.onContainerClick($event)"
+  tabindex="-1"
 >
   @if (!_hasOutline() && !_control.disabled) {
     <div class="mat-mdc-form-field-focus-overlay"></div>


### PR DESCRIPTION
fix(material/form-field): redundant focus on Android WebView

Fixes a bug in the Angular Material form-field where div '.mat-mdc-text-field-wrapper' incorrectly receives keyboard focus on Android WebView

Fixes #31669