### PR TITLE
fix(cdk/menu): picking up items from child menu

### DIFF
--- a/goldens/cdk/menu/index.api.md
+++ b/goldens/cdk/menu/index.api.md
@@ -84,6 +84,7 @@ export class CdkMenuBar extends CdkMenuBase implements AfterContentInit {
 
 // @public
 export abstract class CdkMenuBase extends CdkMenuGroup implements Menu, AfterContentInit, OnDestroy {
+    protected _allItems: QueryList<CdkMenuItem>;
     protected closeOpenMenu(menu: MenuStackItem, options?: {
         focusParentTrigger?: boolean;
     }): void;
@@ -110,7 +111,7 @@ export abstract class CdkMenuBase extends CdkMenuGroup implements Menu, AfterCon
     setActiveMenuItem(item: number | CdkMenuItem): void;
     protected triggerItem?: CdkMenuItem;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkMenuBase, never, never, { "id": { "alias": "id"; "required": false; }; }, {}, ["items"], never, true, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkMenuBase, never, never, { "id": { "alias": "id"; "required": false; }; }, {}, ["_allItems"], never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<CdkMenuBase, never>;
 }
@@ -146,6 +147,7 @@ export class CdkMenuItem implements FocusableOption, FocusableElement, Toggler, 
     // (undocumented)
     protected _ngZone: NgZone;
     _onKeydown(event: KeyboardEvent): void;
+    readonly _parentMenu: Menu | null;
     _resetTabIndex(): void;
     _setTabIndex(event?: MouseEvent): void;
     _tabindex: 0 | -1;

--- a/src/cdk/menu/menu-item.ts
+++ b/src/cdk/menu/menu-item.ts
@@ -63,7 +63,7 @@ export class CdkMenuItem implements FocusableOption, FocusableElement, Toggler, 
   private readonly _menuStack = inject(MENU_STACK);
 
   /** The parent menu in which this menuitem resides. */
-  private readonly _parentMenu = inject(CDK_MENU, {optional: true});
+  readonly _parentMenu = inject(CDK_MENU, {optional: true});
 
   /** Reference to the CdkMenuItemTrigger directive if one is added to the same element */
   private readonly _menuTrigger = inject(CdkMenuTrigger, {optional: true, self: true});

--- a/src/cdk/menu/menu.spec.ts
+++ b/src/cdk/menu/menu.spec.ts
@@ -499,6 +499,16 @@ describe('Menu', () => {
       expect(document.activeElement).toEqual(nativeMenuItems[2]);
     });
   });
+
+  it('should not pick up items from nested menu', () => {
+    const getItemsText = (menu: CdkMenu) =>
+      menu.items.map(i => i._elementRef.nativeElement.textContent?.trim());
+    const fixture = TestBed.createComponent(NestedMenuDefinition);
+    fixture.detectChanges();
+
+    expect(getItemsText(fixture.componentInstance.root)).toEqual(['One', 'Two']);
+    expect(getItemsText(fixture.componentInstance.inner)).toEqual(['Three', 'Four', 'Five']);
+  });
 });
 
 @Component({
@@ -666,4 +676,24 @@ class WithComplexNestedMenusOnBottom {
 })
 class MenuWithActiveItem {
   @ViewChild(CdkMenu) menu: CdkMenu;
+}
+
+@Component({
+  template: `
+    <div cdkMenu #root>
+      <button cdkMenuItem>One</button>
+      <button cdkMenuItem>Two</button>
+
+      <div cdkMenu #inner>
+        <button cdkMenuItem>Three</button>
+        <button cdkMenuItem>Four</button>
+        <button cdkMenuItem>Five</button>
+      </div>
+    </div>
+  `,
+  imports: [CdkMenuModule],
+})
+class NestedMenuDefinition {
+  @ViewChild('root', {read: CdkMenu}) root: CdkMenu;
+  @ViewChild('inner', {read: CdkMenu}) inner: CdkMenu;
 }


### PR DESCRIPTION
Fixes that the CDK menu was picking up items from nested menu instances which in turn were throwing off the keyboard navigation.

Fixes #31678.