### PR TITLE
fix(material/datepicker): datepicker comparison ranges uses substandard colors

### DIFF
--- a/src/material/core/tokens/m3/_md-sys-color.scss
+++ b/src/material/core/tokens/m3/_md-sys-color.scss
@@ -101,7 +101,7 @@ $_alternate-tokens: false;
     outline: map.get($palettes, neutral-variant, 50),
     outline-variant: map.get($palettes, neutral-variant, 80),
     primary: map.get($palettes, primary, 40),
-    primary-container: map.get($palettes, primary, 90),
+    primary-container: map.get($palettes, primary, 80),
     primary-fixed: map.get($palettes, primary, 90),
     primary-fixed-dim: map.get($palettes, primary, 80),
     scrim: map.get($palettes, neutral, 0),
@@ -121,7 +121,7 @@ $_alternate-tokens: false;
     surface-tint: map.get($palettes, primary, 40),
     surface-variant: map.get($palettes, neutral-variant, 90),
     tertiary: map.get($palettes, tertiary, 40),
-    tertiary-container: map.get($palettes, tertiary, 90),
+    tertiary-container: map.get($palettes, tertiary, 80),
     tertiary-fixed: map.get($palettes, tertiary, 90),
     tertiary-fixed-dim: map.get($palettes, tertiary, 80)
   );


### PR DESCRIPTION
Update color mapping values for primary-container and tertiary-container to improve contrast.

fix issue #31663 

Before the fix:
<img width="264" height="318" alt="31663-Before-Fix" src="https://github.com/user-attachments/assets/c9aa7cf3-d824-472e-a2f9-5657bdb25271" />

After the fix:
<img width="263" height="318" alt="31663-After-Fix" src="https://github.com/user-attachments/assets/292f8274-16cf-4f19-9b81-1c904b329d9a" />

