### PR TITLE
docs: fix broken link in theme-color schematic documentation

### DIFF
--- a/src/material/schematics/ng-generate/theme-color/README.md
+++ b/src/material/schematics/ng-generate/theme-color/README.md
@@ -14,7 +14,7 @@ for more information about Material's color design.
 
 For more customization, custom colors can be also be provided for the
 secondary, tertiary, neutral, neutral variant, and error palette colors. It is recommended to choose
-colors that are contrastful. Material has more detailed guidance for [accessible design](https://m3.material.io/foundations/accessible-design/patterns).
+colors that are contrastful. Material has more detailed guidance for [accessible design](https://m3.material.io/foundations/designing/color-contrast).
 
 ## Options
 


### PR DESCRIPTION
The link to Material's accessible design guidance currently leads to a [404 page](https://m3.material.io/foundations/accessible-design/patterns). This link has been updated to point to the latest Material documentation on color and contrast instead, which seems to be the most suitable replacement page.