### PR TITLE
fix(cdk/tree): set index in context

### DIFF
--- a/src/cdk/tree/tree.ts
+++ b/src/cdk/tree/tree.ts
@@ -603,6 +603,7 @@ export class CdkTree<T, K = T>
 
     // Node context that will be provided to created embedded view
     const context = new CdkTreeNodeOutletContext<T>(nodeData);
+    context.index = index;
 
     parentData ??= this._parents.get(key) ?? undefined;
     // If the tree is flat tree, then use the `getLevel` function in flat tree control


### PR DESCRIPTION
We already had the `index` inside `insertNode`, but we weren't passing it along to the context.

Fixes #31578.