### PR TITLE
ci: enable Renovate on non-base branches

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,17 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>angular/dev-infra//renovate-presets/default.json5"],
-  "packageRules": [],
+  "baseBranchPatterns": ["main", "20.2.x"],
   "ignoreDeps": ["stylelint", "selenium-webdriver", "@types/selenium-webdriver", "typescript"],
-  "ignorePaths": ["docs/src/assets/stackblitz/**", "integration/**"]
+  "ignorePaths": ["docs/src/assets/stackblitz/**", "integration/**"],
+  "packageRules": [
+    {
+      "matchBaseBranches": ["main"],
+      "addLabels": ["target: minor"]
+    },
+    {
+      "matchBaseBranches": ["!main"],
+      "addLabels": ["target: patch"]
+    }
+  ]
 }


### PR DESCRIPTION
This change allows Renovate to run on all branches, not just the base branch. Note that it will only update cross-repo, Bazel, and GitHub Actions dependencies on these branches.

This is needed as due to the bazel module lock file changes to the package.json cannot be cherry-picked.