### PR TITLE
Clean up standalone imports in tests

### DIFF
--- a/src/material-experimental/menubar/menubar-item.spec.ts
+++ b/src/material-experimental/menubar/menubar-item.spec.ts
@@ -1,5 +1,5 @@
 import {Component, ElementRef, ViewChild} from '@angular/core';
-import {ComponentFixture, waitForAsync, TestBed} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {CdkMenuItem, CdkMenuModule, CdkMenu} from '@angular/cdk/menu';
 import {MatMenuBarItem} from './menubar-item';
 import {MatMenuBarModule} from './menubar-module';
@@ -7,12 +7,6 @@ import {MatMenuBarModule} from './menubar-module';
 describe('MatMenuBarItem', () => {
   let fixture: ComponentFixture<SimpleMenuBarItem>;
   let nativeMenubarItem: HTMLElement;
-
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [MatMenuBarModule, CdkMenuModule, SimpleMenuBarItem],
-    });
-  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(SimpleMenuBarItem);

--- a/src/material-experimental/menubar/menubar.spec.ts
+++ b/src/material-experimental/menubar/menubar.spec.ts
@@ -1,7 +1,7 @@
 import {Component, ViewChild, ElementRef} from '@angular/core';
 import {RIGHT_ARROW} from '@angular/cdk/keycodes';
 import {CdkMenuBar} from '@angular/cdk/menu';
-import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {dispatchKeyboardEvent} from '../../cdk/testing/private';
 import {MatMenuBarModule} from './menubar-module';
 import {MatMenuBar} from './menubar';
@@ -9,12 +9,6 @@ import {MatMenuBar} from './menubar';
 describe('MatMenuBar', () => {
   let fixture: ComponentFixture<SimpleMatMenuBar>;
   let nativeMatMenubar: HTMLElement;
-
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [MatMenuBarModule, SimpleMatMenuBar],
-    });
-  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(SimpleMatMenuBar);

--- a/src/material/datepicker/calendar-body.spec.ts
+++ b/src/material/datepicker/calendar-body.spec.ts
@@ -4,17 +4,11 @@ import {
   dispatchTouchEvent,
 } from '@angular/cdk/testing/private';
 import {Component} from '@angular/core';
-import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {MatCalendarBody, MatCalendarCell, MatCalendarUserEvent} from './calendar-body';
 
 describe('MatCalendarBody', () => {
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [MatCalendarBody, StandardCalendarBody, RangeCalendarBody],
-    });
-  }));
-
   describe('standard calendar body', () => {
     let fixture: ComponentFixture<StandardCalendarBody>;
     let testComponent: StandardCalendarBody;

--- a/src/material/datepicker/calendar-header.spec.ts
+++ b/src/material/datepicker/calendar-header.spec.ts
@@ -12,13 +12,7 @@ import {yearsPerPage} from './multi-year-view';
 describe('MatCalendarHeader', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [
-        MatNativeDateModule,
-        MatDatepickerModule,
-        // Test components.
-        StandardCalendar,
-        CalendarWithMinMaxDate,
-      ],
+      imports: [MatNativeDateModule, MatDatepickerModule],
       providers: [MatDatepickerIntl, provideFakeDirectionality('ltr')],
     });
   }));

--- a/src/material/datepicker/month-view.spec.ts
+++ b/src/material/datepicker/month-view.spec.ts
@@ -25,7 +25,7 @@ import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {MAT_DATE_FORMATS, MatNativeDateModule} from '../core';
 import {DEC, FEB, JAN, MAR, NOV} from '../testing';
-import {MatCalendarBody, MatCalendarUserEvent} from './calendar-body';
+import {MatCalendarUserEvent} from './calendar-body';
 import {
   DefaultMatCalendarRangeStrategy,
   MAT_DATE_RANGE_SELECTION_STRATEGY,
@@ -41,15 +41,7 @@ describe('MatMonthView', () => {
       dir = signal<Direction>('ltr');
 
       TestBed.configureTestingModule({
-        imports: [
-          MatNativeDateModule,
-          MatCalendarBody,
-          MatMonthView,
-          // Test components.
-          StandardMonthView,
-          MonthViewWithDateFilter,
-          MonthViewWithDateClass,
-        ],
+        imports: [MatNativeDateModule],
         providers: [
           provideFakeDirectionality(dir),
           {provide: MAT_DATE_RANGE_SELECTION_STRATEGY, useClass: DefaultMatCalendarRangeStrategy},
@@ -806,15 +798,7 @@ describe('MatMonthView', () => {
 
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
-        imports: [
-          MatNativeDateModule,
-          MatCalendarBody,
-          MatMonthView,
-          // Test components.
-          StandardMonthView,
-          MonthViewWithDateFilter,
-          MonthViewWithDateClass,
-        ],
+        imports: [MatNativeDateModule],
         providers: [
           provideFakeDirectionality('ltr'),
           {provide: MAT_DATE_RANGE_SELECTION_STRATEGY, useClass: DefaultMatCalendarRangeStrategy},

--- a/src/material/datepicker/multi-year-view.spec.ts
+++ b/src/material/datepicker/multi-year-view.spec.ts
@@ -19,7 +19,6 @@ import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {MatNativeDateModule} from '../core';
 import {JAN, MAR} from '../testing';
-import {MatCalendarBody} from './calendar-body';
 import {MatMultiYearView, yearsPerPage, yearsPerRow} from './multi-year-view';
 
 describe('MatMultiYearView', () => {
@@ -29,16 +28,7 @@ describe('MatMultiYearView', () => {
     dir = signal<Direction>('ltr');
 
     TestBed.configureTestingModule({
-      imports: [
-        MatNativeDateModule,
-        MatCalendarBody,
-        MatMultiYearView,
-        // Test components.
-        StandardMultiYearView,
-        MultiYearViewWithDateFilter,
-        MultiYearViewWithMinMaxDate,
-        MultiYearViewWithDateClass,
-      ],
+      imports: [MatNativeDateModule],
       providers: [provideFakeDirectionality(dir)],
     });
   }));

--- a/src/material/datepicker/testing/calendar-harness.spec.ts
+++ b/src/material/datepicker/testing/calendar-harness.spec.ts
@@ -20,7 +20,7 @@ describe('MatCalendarHarness', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [MatNativeDateModule, MatDatepickerModule, CalendarHarnessTest],
+      imports: [MatNativeDateModule],
       providers: [
         {
           // Usually it's the date range picker that provides the default range selection strategy,

--- a/src/material/datepicker/year-view.spec.ts
+++ b/src/material/datepicker/year-view.spec.ts
@@ -19,7 +19,6 @@ import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {MatNativeDateModule} from '../core';
 import {AUG, DEC, FEB, JAN, JUL, JUN, MAR, MAY, NOV, OCT, SEP} from '../testing';
-import {MatCalendarBody} from './calendar-body';
 import {MatYearView} from './year-view';
 
 describe('MatYearView', () => {
@@ -29,15 +28,7 @@ describe('MatYearView', () => {
     dir = signal<Direction>('ltr');
 
     TestBed.configureTestingModule({
-      imports: [
-        MatNativeDateModule,
-        MatCalendarBody,
-        MatYearView,
-        // Test components.
-        StandardYearView,
-        YearViewWithDateFilter,
-        YearViewWithDateClass,
-      ],
+      imports: [MatNativeDateModule],
       providers: [provideFakeDirectionality(dir)],
     });
   }));

--- a/src/material/divider/divider.spec.ts
+++ b/src/material/divider/divider.spec.ts
@@ -7,10 +7,6 @@ describe('MatDivider', () => {
   let fixture: ComponentFixture<MatDividerTestComponent>;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [MatDividerModule, MatDividerTestComponent],
-    });
-
     fixture = TestBed.createComponent(MatDividerTestComponent);
   });
 

--- a/src/material/divider/testing/divider-harness.spec.ts
+++ b/src/material/divider/testing/divider-harness.spec.ts
@@ -10,10 +10,6 @@ describe('MatLegacyButtonHarness', () => {
   let loader: HarnessLoader;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [MatDividerModule, DividerHarnessTest],
-    });
-
     fixture = TestBed.createComponent(DividerHarnessTest);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.loader(fixture);

--- a/src/material/expansion/expansion.spec.ts
+++ b/src/material/expansion/expansion.spec.ts
@@ -25,17 +25,6 @@ import {MATERIAL_ANIMATIONS} from '../core';
 describe('MatExpansionPanel', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [
-        MatExpansionModule,
-        PanelWithContent,
-        PanelWithContentInNgIf,
-        PanelWithCustomMargin,
-        LazyPanelWithContent,
-        LazyPanelOpenOnLoad,
-        PanelWithTwoWayBinding,
-        PanelWithHeaderTabindex,
-        NestedLazyPanelWithContent,
-      ],
       providers: [
         {
           provide: MATERIAL_ANIMATIONS,

--- a/src/material/list/list.spec.ts
+++ b/src/material/list/list.spec.ts
@@ -1,34 +1,10 @@
 import {dispatchFakeEvent, dispatchMouseEvent} from '@angular/cdk/testing/private';
 import {Component, QueryList, ViewChild, ViewChildren} from '@angular/core';
-import {TestBed, fakeAsync, waitForAsync} from '@angular/core/testing';
+import {TestBed, fakeAsync} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {MatListItem, MatListModule} from './index';
 
 describe('MatList', () => {
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [
-        MatListModule,
-        ListWithOneAnchorItem,
-        ListWithOneItem,
-        ListWithTwoLineItem,
-        ListWithThreeLineItem,
-        ListWithAvatar,
-        ListWithItemWithCssClass,
-        ListWithDynamicNumberOfLines,
-        ListWithMultipleItems,
-        NavListWithOneAnchorItem,
-        NavListWithActivatedItem,
-        ActionListWithoutType,
-        ActionListWithType,
-        ActionListWithDisabledList,
-        ActionListWithDisabledItem,
-        ListWithDisabledItems,
-        StandaloneListItem,
-      ],
-    });
-  }));
-
   it('should apply an additional class to lists without lines', () => {
     const fixture = TestBed.createComponent(ListWithOneItem);
     const listItem = fixture.debugElement.query(By.css('mat-list-item'))!;

--- a/src/material/list/selection-list.spec.ts
+++ b/src/material/list/selection-list.spec.ts
@@ -692,12 +692,6 @@ describe('MatSelectionList without forms', () => {
     let selectionList: DebugElement;
 
     beforeEach(waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [MatListModule, SelectionListWithSelectedOption],
-      });
-    }));
-
-    beforeEach(waitForAsync(() => {
       fixture = TestBed.createComponent(SelectionListWithSelectedOption);
       listOptionElements = fixture.debugElement.queryAll(By.directive(MatListOption))!;
       selectionList = fixture.debugElement.query(By.directive(MatSelectionList))!;
@@ -726,12 +720,6 @@ describe('MatSelectionList without forms', () => {
   describe('single-selection with list option selected', () => {
     let fixture: ComponentFixture<SingleSelectionListWithSelectedOption>;
     let listOptionElements: DebugElement[];
-
-    beforeEach(waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [MatListModule, SingleSelectionListWithSelectedOption],
-      });
-    }));
 
     beforeEach(waitForAsync(() => {
       fixture = TestBed.createComponent(SingleSelectionListWithSelectedOption);
@@ -764,7 +752,6 @@ describe('MatSelectionList without forms', () => {
       const matListConfig: MatListConfig = {hideSingleSelectionIndicator: true};
 
       TestBed.configureTestingModule({
-        imports: [MatListModule, SingleSelectionListWithSelectedOption],
         providers: [{provide: MAT_LIST_CONFIG, useValue: matListConfig}],
       });
     }));
@@ -794,12 +781,6 @@ describe('MatSelectionList without forms', () => {
     let fixture: ComponentFixture<SelectionListWithDisabledOption>;
     let listOptionEl: HTMLElement;
     let listOption: MatListOption;
-
-    beforeEach(waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [MatListModule, SelectionListWithDisabledOption],
-      });
-    }));
 
     beforeEach(waitForAsync(() => {
       fixture = TestBed.createComponent(SelectionListWithDisabledOption);
@@ -841,18 +822,6 @@ describe('MatSelectionList without forms', () => {
     let fixture: ComponentFixture<SelectionListWithListDisabled>;
     let listOption: DebugElement[];
     let selectionList: DebugElement;
-
-    beforeEach(waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [
-          MatListModule,
-          SelectionListWithListOptions,
-          SelectionListWithCheckboxPositionAfter,
-          SelectionListWithListDisabled,
-          SelectionListWithOnlyOneOption,
-        ],
-      });
-    }));
 
     beforeEach(waitForAsync(() => {
       fixture = TestBed.createComponent(SelectionListWithListDisabled);
@@ -942,18 +911,6 @@ describe('MatSelectionList without forms', () => {
     let fixture: ComponentFixture<SelectionListWithCheckboxPositionAfter>;
 
     beforeEach(waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [
-          MatListModule,
-          SelectionListWithListOptions,
-          SelectionListWithCheckboxPositionAfter,
-          SelectionListWithListDisabled,
-          SelectionListWithOnlyOneOption,
-        ],
-      });
-    }));
-
-    beforeEach(waitForAsync(() => {
       fixture = TestBed.createComponent(SelectionListWithCheckboxPositionAfter);
       fixture.detectChanges();
     }));
@@ -969,12 +926,6 @@ describe('MatSelectionList without forms', () => {
   });
 
   describe('with list item elements', () => {
-    beforeEach(waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [MatListModule, SelectionListWithAvatar, SelectionListWithIcon],
-      });
-    }));
-
     function expectCheckboxAtPosition(
       listItemElement: HTMLElement,
       position: MatListOptionTogglePosition,
@@ -1102,10 +1053,6 @@ describe('MatSelectionList without forms', () => {
     let selectionList: DebugElement;
 
     beforeEach(waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [MatListModule, SelectionListWithListOptions],
-      });
-
       fixture = TestBed.createComponent(SelectionListWithListOptions);
       fixture.componentInstance.multiple = false;
       fixture.changeDetectorRef.markForCheck();
@@ -1228,10 +1175,6 @@ describe('MatSelectionList without forms', () => {
     let option: MatListOption;
 
     beforeEach(waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [MatListModule, ListOptionWithTwoWayBinding],
-      });
-
       fixture = TestBed.createComponent(ListOptionWithTwoWayBinding);
       fixture.detectChanges();
       const optionDebug = fixture.debugElement.query(By.directive(MatListOption));
@@ -1856,17 +1799,6 @@ class SingleSelectionListWithSelectedOption {}
 class SelectionListWithSelectedOptionAndValue {
   itemValue = 'item1';
 }
-
-@Component({
-  template: `
-  <mat-selection-list id="selection-list-4">
-    <mat-list-option togglePosition="after" class="test-focus" id="123">
-      Inbox
-    </mat-list-option>
-  </mat-selection-list>`,
-  imports: [MatListModule],
-})
-class SelectionListWithOnlyOneOption {}
 
 @Component({
   template: `

--- a/src/material/list/testing/list-harness.spec.ts
+++ b/src/material/list/testing/list-harness.spec.ts
@@ -45,10 +45,6 @@ function runBaseListFunctionalityTests<
 
     beforeEach(async () => {
       const testComponent = testComponentFn();
-      TestBed.configureTestingModule({
-        imports: [MatListModule, testComponent],
-      });
-
       fixture = TestBed.createComponent(testComponent);
       fixture.detectChanges();
       const loader = TestbedHarnessEnvironment.loader(fixture);
@@ -319,10 +315,6 @@ describe('MatActionListHarness', () => {
     let fixture: ComponentFixture<ActionListHarnessTest>;
 
     beforeEach(async () => {
-      TestBed.configureTestingModule({
-        imports: [MatListModule, ActionListHarnessTest],
-      });
-
       fixture = TestBed.createComponent(ActionListHarnessTest);
       fixture.detectChanges();
       const loader = TestbedHarnessEnvironment.loader(fixture);
@@ -352,10 +344,6 @@ describe('MatNavListHarness', () => {
     let fixture: ComponentFixture<NavListHarnessTest>;
 
     beforeEach(async () => {
-      TestBed.configureTestingModule({
-        imports: [MatListModule, NavListHarnessTest],
-      });
-
       fixture = TestBed.createComponent(NavListHarnessTest);
       fixture.detectChanges();
       const loader = TestbedHarnessEnvironment.loader(fixture);
@@ -421,10 +409,6 @@ describe('MatSelectionListHarness', () => {
     let fixture: ComponentFixture<SelectionListHarnessTest>;
 
     beforeEach(async () => {
-      TestBed.configureTestingModule({
-        imports: [MatListModule, SelectionListHarnessTest],
-      });
-
       fixture = TestBed.createComponent(SelectionListHarnessTest);
       fixture.detectChanges();
       const loader = TestbedHarnessEnvironment.loader(fixture);

--- a/src/material/menu/menu.spec.ts
+++ b/src/material/menu/menu.spec.ts
@@ -43,7 +43,7 @@ import {
   provideFakeDirectionality,
 } from '../../cdk/testing/private';
 import {MATERIAL_ANIMATIONS, MatRipple} from '../core';
-import {MatMenu, MatMenuItem, MatMenuModule} from './index';
+import {MatMenu, MatMenuItem} from './index';
 import {
   MAT_MENU_DEFAULT_OPTIONS,
   MAT_MENU_SCROLL_STRATEGY,
@@ -2555,7 +2555,6 @@ describe('MatMenu', () => {
 describe('MatMenu default overrides', () => {
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
-      imports: [MatMenuModule],
       providers: [
         {
           provide: MAT_MENU_DEFAULT_OPTIONS,

--- a/src/material/progress-bar/progress-bar.spec.ts
+++ b/src/material/progress-bar/progress-bar.spec.ts
@@ -9,7 +9,7 @@ import {
 } from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
-import {MAT_PROGRESS_BAR_DEFAULT_OPTIONS, MatProgressBarModule} from './index';
+import {MAT_PROGRESS_BAR_DEFAULT_OPTIONS} from './index';
 import {MatProgressBar} from './progress-bar';
 
 describe('MatProgressBar', () => {
@@ -17,11 +17,7 @@ describe('MatProgressBar', () => {
     componentType: Type<T>,
     providers: (Provider | EnvironmentProviders)[] = [],
   ): ComponentFixture<T> {
-    TestBed.configureTestingModule({
-      imports: [MatProgressBarModule, componentType],
-      providers,
-    });
-
+    TestBed.configureTestingModule({providers});
     return TestBed.createComponent<T>(componentType);
   }
 

--- a/src/material/progress-bar/testing/progress-bar-harness.spec.ts
+++ b/src/material/progress-bar/testing/progress-bar-harness.spec.ts
@@ -10,10 +10,6 @@ describe('MatProgressBarHarness', () => {
   let loader: HarnessLoader;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [MatProgressBarModule, ProgressBarHarnessTest],
-    });
-
     fixture = TestBed.createComponent(ProgressBarHarnessTest);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.loader(fixture);

--- a/src/material/progress-spinner/progress-spinner.spec.ts
+++ b/src/material/progress-spinner/progress-spinner.spec.ts
@@ -1,29 +1,10 @@
-import {waitForAsync, TestBed} from '@angular/core/testing';
+import {TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
-import {Component, ElementRef, ViewChild, ViewEncapsulation, signal} from '@angular/core';
+import {Component, signal} from '@angular/core';
 import {MatProgressSpinnerModule} from './progress-spinner-module';
 import {MatProgressSpinner, MAT_PROGRESS_SPINNER_DEFAULT_OPTIONS} from './progress-spinner';
 
 describe('MatProgressSpinner', () => {
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [
-        MatProgressSpinnerModule,
-        BasicProgressSpinner,
-        IndeterminateProgressSpinner,
-        ProgressSpinnerWithValueAndBoundMode,
-        ProgressSpinnerWithColor,
-        ProgressSpinnerCustomStrokeWidth,
-        ProgressSpinnerCustomDiameter,
-        SpinnerWithColor,
-        ProgressSpinnerWithStringValues,
-        IndeterminateSpinnerInShadowDom,
-        IndeterminateSpinnerInShadowDomWithNgIf,
-        SpinnerWithMode,
-      ],
-    });
-  }));
-
   it('should apply a mode of "determinate" if no mode is provided.', () => {
     let fixture = TestBed.createComponent(BasicProgressSpinner);
     fixture.detectChanges();
@@ -455,35 +436,6 @@ class ProgressSpinnerWithColor {
   imports: [MatProgressSpinnerModule],
 })
 class ProgressSpinnerWithStringValues {}
-
-@Component({
-  template: `
-    <mat-progress-spinner mode="indeterminate" [diameter]="diameter"></mat-progress-spinner>
-  `,
-  encapsulation: ViewEncapsulation.ShadowDom,
-  imports: [MatProgressSpinnerModule],
-})
-class IndeterminateSpinnerInShadowDom {
-  diameter: number;
-}
-
-@Component({
-  template: `
-    @if (true) {
-      <div>
-        <mat-progress-spinner mode="indeterminate" [diameter]="diameter"></mat-progress-spinner>
-      </div>
-    }
-  `,
-  encapsulation: ViewEncapsulation.ShadowDom,
-  imports: [MatProgressSpinnerModule],
-})
-class IndeterminateSpinnerInShadowDomWithNgIf {
-  @ViewChild(MatProgressSpinner, {read: ElementRef})
-  spinner: ElementRef<HTMLElement>;
-
-  diameter: number;
-}
 
 @Component({
   template: '<mat-spinner mode="determinate"></mat-spinner>',

--- a/src/material/progress-spinner/testing/progress-spinner-harness.spec.ts
+++ b/src/material/progress-spinner/testing/progress-spinner-harness.spec.ts
@@ -10,10 +10,6 @@ describe('MatProgressSpinnerHarness', () => {
   let loader: HarnessLoader;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [MatProgressSpinnerModule, ProgressSpinnerHarnessTest],
-    });
-
     fixture = TestBed.createComponent(ProgressSpinnerHarnessTest);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.loader(fixture);

--- a/src/material/radio/radio.spec.ts
+++ b/src/material/radio/radio.spec.ts
@@ -12,28 +12,6 @@ import {
 } from './index';
 
 describe('MatRadio', () => {
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [
-        MatRadioModule,
-        FormsModule,
-        ReactiveFormsModule,
-        DisableableRadioButton,
-        FocusableRadioButton,
-        RadiosInsideRadioGroup,
-        RadioGroupWithNgModel,
-        RadioGroupWithFormControl,
-        StandaloneRadioButtons,
-        InterleavedRadioGroup,
-        TranscludingWrapper,
-        RadioButtonWithPredefinedTabindex,
-        RadioButtonWithPredefinedAriaAttributes,
-        RadiosInsidePreCheckedRadioGroup,
-        PreselectedRadioWithStaticValueAndNgIf,
-      ],
-    });
-  }));
-
   describe('inside of a group', () => {
     let fixture: ComponentFixture<RadiosInsideRadioGroup>;
     let groupDebugElement: DebugElement;
@@ -1034,7 +1012,6 @@ describe('MatRadioDefaultOverrides', () => {
   describe('when MAT_RADIO_DEFAULT_OPTIONS overridden', () => {
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
-        imports: [MatRadioModule, FormsModule, DefaultRadioButton, RadioButtonWithColorBinding],
         providers: [
           {
             provide: MAT_RADIO_DEFAULT_OPTIONS,

--- a/src/material/radio/testing/radio-harness.spec.ts
+++ b/src/material/radio/testing/radio-harness.spec.ts
@@ -11,10 +11,6 @@ describe('radio harness', () => {
   let loader: HarnessLoader;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [MatRadioModule, ReactiveFormsModule, MultipleRadioButtonsHarnessTest],
-    });
-
     fixture = TestBed.createComponent(MultipleRadioButtonsHarnessTest);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.loader(fixture);

--- a/src/material/sidenav/drawer.spec.ts
+++ b/src/material/sidenav/drawer.spec.ts
@@ -451,7 +451,6 @@ describe('MatDrawer', () => {
       const errorHandler = jasmine.createSpyObj(['handleError']);
 
       TestBed.configureTestingModule({
-        imports: [DrawerDynamicPosition],
         providers: [
           {
             provide: ErrorHandler,

--- a/src/material/slide-toggle/slide-toggle.spec.ts
+++ b/src/material/slide-toggle/slide-toggle.spec.ts
@@ -16,22 +16,6 @@ import {MatSlideToggle, MatSlideToggleChange, MatSlideToggleModule} from './inde
 import {MAT_SLIDE_TOGGLE_DEFAULT_OPTIONS} from './slide-toggle-config';
 
 describe('MatSlideToggle without forms', () => {
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [
-        MatSlideToggleModule,
-        BidiModule,
-        SlideToggleBasic,
-        SlideToggleCheckedAndDisabledAttr,
-        SlideToggleWithTabindexAttr,
-        SlideToggleWithoutLabel,
-        SlideToggleProjectedLabel,
-        TextBindingComponent,
-        SlideToggleWithStaticAriaAttributes,
-      ],
-    });
-  });
-
   describe('basic behavior', () => {
     let fixture: ComponentFixture<any>;
 
@@ -539,20 +523,6 @@ describe('MatSlideToggle without forms', () => {
 });
 
 describe('MatSlideToggle with forms', () => {
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [
-        MatSlideToggleModule,
-        FormsModule,
-        ReactiveFormsModule,
-        SlideToggleWithForm,
-        SlideToggleWithModel,
-        SlideToggleWithFormControl,
-        SlideToggleWithModelAndChangeEvent,
-      ],
-    });
-  });
-
   describe('using ngModel', () => {
     let fixture: ComponentFixture<SlideToggleWithModel>;
 
@@ -959,35 +929,12 @@ class SlideToggleWithTabindexAttr {
 }
 
 @Component({
-  template: `<mat-slide-toggle>{{label}}</mat-slide-toggle>`,
-  imports: [MatSlideToggleModule, BidiModule],
-})
-class SlideToggleWithoutLabel {
-  label: string;
-}
-
-@Component({
   template: `<mat-slide-toggle [(ngModel)]="checked" (change)="onChange()"></mat-slide-toggle>`,
   imports: [MatSlideToggleModule, FormsModule, ReactiveFormsModule],
 })
 class SlideToggleWithModelAndChangeEvent {
   checked: boolean;
   onChange: () => void = () => {};
-}
-
-@Component({
-  template: `<mat-slide-toggle><some-text></some-text></mat-slide-toggle>`,
-  imports: [MatSlideToggleModule, BidiModule],
-})
-class SlideToggleProjectedLabel {}
-
-@Component({
-  selector: 'some-text',
-  template: `<span>{{text}}</span>`,
-  imports: [MatSlideToggleModule, BidiModule],
-})
-class TextBindingComponent {
-  text: string = 'Some text';
 }
 
 @Component({

--- a/src/material/slide-toggle/testing/slide-toggle-harness.spec.ts
+++ b/src/material/slide-toggle/testing/slide-toggle-harness.spec.ts
@@ -11,10 +11,6 @@ describe('MatSlideToggleHarness', () => {
   let loader: HarnessLoader;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [MatSlideToggleModule, ReactiveFormsModule, SlideToggleHarnessTest],
-    });
-
     fixture = TestBed.createComponent(SlideToggleHarnessTest);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.loader(fixture);

--- a/src/material/snack-bar/snack-bar.spec.ts
+++ b/src/material/snack-bar/snack-bar.spec.ts
@@ -16,7 +16,6 @@ import {
   MAT_SNACK_BAR_DATA,
   MatSnackBar,
   MatSnackBarConfig,
-  MatSnackBarModule,
   MatSnackBarRef,
   SimpleSnackBar,
 } from './index';
@@ -39,12 +38,6 @@ describe('MatSnackBar', () => {
 
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
-      imports: [
-        MatSnackBarModule,
-        ComponentWithChildViewContainer,
-        BurritosNotification,
-        DirectiveWithViewContainer,
-      ],
       providers: [{provide: MATERIAL_ANIMATIONS, useValue: {animationsDisabled: true}}],
     });
 
@@ -671,10 +664,6 @@ describe('MatSnackBar with parent MatSnackBar', () => {
   let fixture: ComponentFixture<ComponentThatProvidesMatSnackBar>;
 
   beforeEach(fakeAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [MatSnackBarModule, ComponentThatProvidesMatSnackBar, DirectiveWithViewContainer],
-    });
-
     parentSnackBar = TestBed.inject(MatSnackBar);
     overlayContainerElement = TestBed.inject(OverlayContainer).getContainerElement();
     fixture = TestBed.createComponent(ComponentThatProvidesMatSnackBar);
@@ -741,10 +730,6 @@ describe('MatSnackBar Positioning', () => {
   let simpleActionLabel = 'pickup';
 
   beforeEach(fakeAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [MatSnackBarModule, ComponentWithChildViewContainer, DirectiveWithViewContainer],
-    });
-
     snackBar = TestBed.inject(MatSnackBar);
     overlayContainerEl = TestBed.inject(OverlayContainer).getContainerElement();
     viewContainerFixture = TestBed.createComponent(ComponentWithChildViewContainer);

--- a/src/material/snack-bar/snack-bar.zone.spec.ts
+++ b/src/material/snack-bar/snack-bar.zone.spec.ts
@@ -9,7 +9,6 @@ import {
   inject,
 } from '@angular/core';
 import {ComponentFixture, TestBed, fakeAsync, flush, tick} from '@angular/core/testing';
-import {MatSnackBarModule} from './snack-bar-module';
 import {MatSnackBar} from './snack-bar';
 import {MatSnackBarConfig} from './snack-bar-config';
 import {MATERIAL_ANIMATIONS} from '../core';
@@ -20,7 +19,6 @@ describe('MatSnackBar Zone.js integration', () => {
 
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
-      imports: [MatSnackBarModule, ComponentWithChildViewContainer, DirectiveWithViewContainer],
       providers: [
         provideZoneChangeDetection(),
         {provide: MATERIAL_ANIMATIONS, useValue: {animationsDisabled: true}},

--- a/src/material/sort/sort.spec.ts
+++ b/src/material/sort/sort.spec.ts
@@ -27,25 +27,6 @@ describe('MatSort', () => {
     let fixture: ComponentFixture<SimpleMatSortApp>;
     let component: SimpleMatSortApp;
 
-    beforeEach(waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [
-          MatSortModule,
-          MatTableModule,
-          CdkTableModule,
-          SimpleMatSortApp,
-          CdkTableMatSortApp,
-          MatTableMatSortApp,
-          MatSortHeaderMissingMatSortApp,
-          MatSortDuplicateMatSortableIdsApp,
-          MatSortableMissingIdApp,
-          MatSortableInvalidDirection,
-          MatSortableInvalidDirection,
-          MatSortWithArrowPosition,
-        ],
-      });
-    }));
-
     beforeEach(() => {
       fixture = TestBed.createComponent(SimpleMatSortApp);
       component = fixture.componentInstance;
@@ -357,7 +338,6 @@ describe('MatSort', () => {
 
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
-        imports: [MatSortModule, MatTableModule, CdkTableModule, MatSortWithoutExplicitInputs],
         providers: [
           {
             provide: MAT_SORT_DEFAULT_OPTIONS,
@@ -390,7 +370,6 @@ describe('MatSort', () => {
 
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
-        imports: [MatSortModule, MatTableModule, CdkTableModule, MatSortWithoutInputs],
         providers: [
           {
             provide: MAT_SORT_DEFAULT_OPTIONS,

--- a/src/material/table/table-data-source.spec.ts
+++ b/src/material/table/table-data-source.spec.ts
@@ -1,16 +1,9 @@
 import {MatTableDataSource} from './table-data-source';
-import {waitForAsync, ComponentFixture, TestBed} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatSort, MatSortModule} from '@angular/material/sort';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {Component, ViewChild} from '@angular/core';
 
 describe('MatTableDataSource', () => {
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [MatSortModule, NoopAnimationsModule, MatSortApp],
-    });
-  }));
-
   describe('sort', () => {
     let dataSource: MatTableDataSource<any>;
     let fixture: ComponentFixture<MatSortApp>;

--- a/src/material/table/table.spec.ts
+++ b/src/material/table/table.spec.ts
@@ -1,12 +1,5 @@
 import {AfterViewInit, Component, OnInit, ViewChild} from '@angular/core';
-import {
-  waitForAsync,
-  ComponentFixture,
-  fakeAsync,
-  flushMicrotasks,
-  TestBed,
-  tick,
-} from '@angular/core/testing';
+import {ComponentFixture, fakeAsync, flushMicrotasks, TestBed, tick} from '@angular/core/testing';
 import {MatTable, MatTableDataSource, MatTableModule} from './index';
 import {DataSource} from '@angular/cdk/table';
 import {BehaviorSubject, Observable} from 'rxjs';
@@ -14,26 +7,6 @@ import {MatSort, MatSortHeader, MatSortModule} from '../sort';
 import {MatPaginator, MatPaginatorModule} from '../paginator';
 
 describe('MatTable', () => {
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [
-        MatTableModule,
-        MatPaginatorModule,
-        MatSortModule,
-        MatTableApp,
-        MatTableWithWhenRowApp,
-        ArrayDataSourceMatTableApp,
-        NativeHtmlTableApp,
-        MatTableWithSortApp,
-        MatTableWithPaginatorApp,
-        StickyTableApp,
-        TableWithNgContainerRow,
-        NestedTableApp,
-        MatFlexTableApp,
-      ],
-    });
-  }));
-
   describe('with basic data source', () => {
     it('should be able to create a table with the right content and without when row', () => {
       let fixture = TestBed.createComponent(MatTableApp);

--- a/src/material/table/testing/table-harness.spec.ts
+++ b/src/material/table/testing/table-harness.spec.ts
@@ -10,10 +10,6 @@ describe('MatTableHarness', () => {
   let loader: HarnessLoader;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [MatTableModule, TableHarnessTest],
-    });
-
     fixture = TestBed.createComponent(TableHarnessTest);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.loader(fixture);

--- a/src/material/tabs/tab-body.spec.ts
+++ b/src/material/tabs/tab-body.spec.ts
@@ -15,17 +15,14 @@ import {
 import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {MatRippleModule} from '../core';
-import {MatTabBody, MatTabBodyPortal} from './tab-body';
+import {MatTabBody} from './tab-body';
 
 describe('MatTabBody', () => {
   let dir: WritableSignal<Direction>;
 
   beforeEach(waitForAsync(() => {
     dir = signal('ltr');
-    TestBed.configureTestingModule({
-      imports: [PortalModule, MatRippleModule, MatTabBody, MatTabBodyPortal, SimpleTabBodyApp],
-      providers: [provideFakeDirectionality(dir)],
-    });
+    TestBed.configureTestingModule({providers: [provideFakeDirectionality(dir)]});
   }));
 
   it('should be center position if origin is unchanged', () => {

--- a/src/material/tabs/tab-group.spec.ts
+++ b/src/material/tabs/tab-group.spec.ts
@@ -25,23 +25,6 @@ import {MATERIAL_ANIMATIONS} from '../core';
 describe('MatTabGroup', () => {
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
-      imports: [
-        MatTabsModule,
-        SimpleTabsTestApp,
-        SimpleDynamicTabsTestApp,
-        BindedTabsTestApp,
-        AsyncTabsTestApp,
-        DisabledTabsTestApp,
-        TabGroupWithSimpleApi,
-        TemplateTabs,
-        TabGroupWithAriaInputs,
-        TabGroupWithIsActiveBinding,
-        NestedTabs,
-        TabGroupWithIndirectDescendantTabs,
-        TabGroupWithSpaceAbove,
-        NestedTabGroupWithLabel,
-        TabsWithClassesTestApp,
-      ],
       providers: [{provide: MATERIAL_ANIMATIONS, useValue: {animationsDisabled: true}}],
     });
   }));
@@ -1057,12 +1040,6 @@ describe('MatTabGroup', () => {
 });
 
 describe('nested MatTabGroup with enabled animations', () => {
-  beforeEach(fakeAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [MatTabsModule, NestedTabs, TabsWithCustomAnimationDuration],
-    });
-  }));
-
   it('should not throw when creating a component with nested tab groups', fakeAsync(() => {
     expect(() => {
       let fixture = TestBed.createComponent(NestedTabs);
@@ -1091,12 +1068,6 @@ describe('nested MatTabGroup with enabled animations', () => {
 
 describe('MatTabGroup with ink bar fit to content', () => {
   let fixture: ComponentFixture<TabGroupWithInkBarFitToContent>;
-
-  beforeEach(fakeAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [MatTabsModule, TabGroupWithInkBarFitToContent],
-    });
-  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TabGroupWithInkBarFitToContent);
@@ -1136,7 +1107,6 @@ describe('MatTabNavBar with a default config', () => {
 
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
-      imports: [MatTabsModule, SimpleTabsTestApp],
       providers: [
         {
           provide: MAT_TABS_CONFIG,
@@ -1167,7 +1137,6 @@ describe('MatTabNavBar with a default config', () => {
 describe('MatTabGroup labels aligned with a config', () => {
   it('should work with start align', () => {
     const fixture = TestBed.configureTestingModule({
-      imports: [MatTabsModule, TabsWithAlignConfig],
       providers: [
         {
           provide: MAT_TABS_CONFIG,
@@ -1183,7 +1152,6 @@ describe('MatTabGroup labels aligned with a config', () => {
 
   it('should work with center align', () => {
     const fixture = TestBed.configureTestingModule({
-      imports: [MatTabsModule, TabsWithAlignConfig],
       providers: [
         {
           provide: MAT_TABS_CONFIG,
@@ -1199,7 +1167,6 @@ describe('MatTabGroup labels aligned with a config', () => {
 
   it('should work with end align', () => {
     const fixture = TestBed.configureTestingModule({
-      imports: [MatTabsModule, TabsWithAlignConfig],
       providers: [
         {
           provide: MAT_TABS_CONFIG,
@@ -1214,9 +1181,7 @@ describe('MatTabGroup labels aligned with a config', () => {
   });
 
   it('should not add align if default config doesnt set align', () => {
-    const fixture = TestBed.configureTestingModule({
-      imports: [MatTabsModule, TabsWithAlignConfig],
-    }).createComponent(TabsWithAlignConfig);
+    const fixture = TestBed.createComponent(TabsWithAlignConfig);
     fixture.detectChanges();
 
     let tabElement = fixture.nativeElement.querySelector('[mat-align-tabs="start"]');
@@ -1234,7 +1199,6 @@ describe('MatTabGroup labels aligned with a config', () => {
 
   it('should not break if config sets align on already aligned tabs', () => {
     const fixture = TestBed.configureTestingModule({
-      imports: [MatTabsModule, TabsWithAlignCenter],
       providers: [{provide: MAT_TABS_CONFIG, useValue: {alignTabs: 'end'}}],
     }).createComponent(TabsWithAlignCenter);
     fixture.detectChanges();

--- a/src/material/tabs/tab-header.spec.ts
+++ b/src/material/tabs/tab-header.spec.ts
@@ -1,9 +1,7 @@
 import {Dir, Direction} from '@angular/cdk/bidi';
 import {END, ENTER, HOME, LEFT_ARROW, RIGHT_ARROW, SPACE} from '@angular/cdk/keycodes';
-import {MutationObserverFactory, ObserversModule} from '@angular/cdk/observers';
+import {MutationObserverFactory} from '@angular/cdk/observers';
 import {SharedResizeObserver} from '@angular/cdk/observers/private';
-import {PortalModule} from '@angular/cdk/portal';
-import {ScrollingModule, ViewportRuler} from '@angular/cdk/scrolling';
 import {
   createKeyboardEvent,
   createMouseEvent,
@@ -22,7 +20,6 @@ import {
   tick,
   waitForAsync,
 } from '@angular/core/testing';
-import {MatRippleModule} from '../core';
 import {By} from '@angular/platform-browser';
 import {Subject} from 'rxjs';
 import {MatTabHeader} from './tab-header';
@@ -34,19 +31,6 @@ describe('MatTabHeader', () => {
   let resizeEvents: Subject<ResizeObserverEntry[]>;
 
   beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [
-        PortalModule,
-        MatRippleModule,
-        ScrollingModule,
-        ObserversModule,
-        MatTabHeader,
-        MatTabLabelWrapper,
-        SimpleTabHeaderApp,
-      ],
-      providers: [ViewportRuler],
-    });
-
     resizeEvents = new Subject();
     spyOn(TestBed.inject(SharedResizeObserver), 'observe').and.returnValue(resizeEvents);
   }));

--- a/src/material/tabs/tab-nav-bar/tab-nav-bar.spec.ts
+++ b/src/material/tabs/tab-nav-bar/tab-nav-bar.spec.ts
@@ -26,12 +26,6 @@ describe('MatTabNavBar', () => {
     dir = signal('ltr');
 
     TestBed.configureTestingModule({
-      imports: [
-        MatTabsModule,
-        SimpleTabNavBarTestApp,
-        TabLinkWithNgIf,
-        TabBarWithInactiveTabsOnInit,
-      ],
       providers: [
         {provide: MAT_RIPPLE_GLOBAL_OPTIONS, useFactory: () => globalRippleOptions},
         provideFakeDirectionality(dir),
@@ -503,7 +497,6 @@ describe('MatTabNavBar with a default config', () => {
 
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
-      imports: [MatTabsModule, TabLinkWithNgIf],
       providers: [{provide: MAT_TABS_CONFIG, useValue: {fitInkBarToContent: true}}],
     });
   }));
@@ -523,12 +516,6 @@ describe('MatTabNavBar with a default config', () => {
 });
 
 describe('MatTabNavBar with enabled animations', () => {
-  beforeEach(fakeAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [MatTabsModule, TabsWithCustomAnimationDuration],
-    });
-  }));
-
   it('should not throw when setting an animationDuration without units', fakeAsync(() => {
     expect(() => {
       let fixture = TestBed.createComponent(TabsWithCustomAnimationDuration);

--- a/src/material/toolbar/testing/toolbar-harness.spec.ts
+++ b/src/material/toolbar/testing/toolbar-harness.spec.ts
@@ -10,10 +10,6 @@ describe('MatToolbarHarness', () => {
   let loader: HarnessLoader;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [MatToolbarModule, ToolbarHarnessTest],
-    });
-
     fixture = TestBed.createComponent(ToolbarHarnessTest);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.loader(fixture);

--- a/src/material/toolbar/toolbar.spec.ts
+++ b/src/material/toolbar/toolbar.spec.ts
@@ -1,21 +1,9 @@
 import {Component, signal} from '@angular/core';
-import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {MatToolbarModule} from './index';
 
 describe('MatToolbar', () => {
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [
-        MatToolbarModule,
-        ToolbarSingleRow,
-        ToolbarMultipleRows,
-        ToolbarMixedRowModes,
-        ToolbarMultipleIndirectRows,
-      ],
-    });
-  }));
-
   describe('with single row', () => {
     let fixture: ComponentFixture<ToolbarSingleRow>;
     let testComponent: ToolbarSingleRow;

--- a/src/material/tooltip/tooltip.zone.spec.ts
+++ b/src/material/tooltip/tooltip.zone.spec.ts
@@ -17,7 +17,6 @@ const initialTooltipMessage = 'initial tooltip message';
 describe('MatTooltip Zone.js integration', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [MatTooltipModule, OverlayModule, ScrollableTooltipDemo],
       providers: [provideZoneChangeDetection(), provideFakeDirectionality('rtl')],
     });
   }));

--- a/src/material/tree/testing/tree-harness.spec.ts
+++ b/src/material/tree/testing/tree-harness.spec.ts
@@ -16,10 +16,6 @@ describe('MatTreeHarness', () => {
   let loader: HarnessLoader;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [MatTreeModule, TreeHarnessTest],
-    });
-
     fixture = TestBed.createComponent(TreeHarnessTest);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.loader(fixture);


### PR DESCRIPTION
Most of the `imports` in our tests aren't necessary anymore after we switched everything over to standalone. These changes clean up all the usages.