### PR TITLE
fix(material/sort): error if signal is bound to disabled input

### DIFF
--- a/src/material/sort/sort-header.ts
+++ b/src/material/sort/sort-header.ts
@@ -188,9 +188,11 @@ export class MatSortHeader implements MatSortable, OnDestroy, OnInit, AfterViewI
   ngAfterViewInit() {
     // We use the focus monitor because we also want to style
     // things differently based on the focus origin.
-    this._focusMonitor
-      .monitor(this._elementRef, true)
-      .subscribe(() => this._recentlyCleared.set(null));
+    this._focusMonitor.monitor(this._elementRef, true).subscribe(() => {
+      // We need the delay here, because we can trigger a signal write error if the header
+      // has a signal bound to `disabled` which causes it to be blurred (see #31723.)
+      Promise.resolve().then(() => this._recentlyCleared.set(null));
+    });
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
The sort header clears a signal when the focused state of its descendants changes. This was causing a signal write error if a signal is bound to its `disabled` input, because changing the disabled state also ends up blurring the focused descendant.

Fixes #31723.