### PR TITLE
fix(material/select): ensure proper highlighting on selection

### DIFF
--- a/src/material/core/option/option.scss
+++ b/src/material/core/option/option.scss
@@ -41,9 +41,10 @@ $_side-padding: 16px;
   }
 
   &.mdc-list-item--selected:not(.mdc-list-item--disabled) {
-    // We don't change the background & text color in multiple mode since
-    // it has the checkbox to show the selected state.
-    &:not(.mat-mdc-option-multiple) {
+    // Overide selected colors for non disabled list items except:
+    // - when active, focused, or hovered so still indicates that state to the user.
+    // - multiple mode since it already has the checkbox to show the selected state.
+    &:not(.mat-mdc-option-active,.mat-mdc-option-multiple,:focus,:hover) {
       background-color: token-utils.slot(option-selected-state-layer-color, $fallbacks);
       .mdc-list-item__primary-text {
         color: token-utils.slot(option-selected-state-label-text-color, $fallbacks);


### PR DESCRIPTION
Fixes b/259542956 by excluding selected state color overrides when the option item is focused or hovered on, so user can see the focus/hover state even when item has been selected.