### PR TITLE
build: define typescript version via string in module.bazel file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
       - name: Install node modules
         run: pnpm install --frozen-lockfile
       - name: Run tests
-        run: bazel test --build_tag_filters=-e2e --test_tag_filters=-e2e --build_tests_only --test_env="DEBUG=puppeteer:*" -- src/...
+        run: bazel test --build_tests_only --test_tag_filters=-linker-integration-test --test_tag_filters=-e2e -- //... -//goldens/... -//integration/...
 
   build:
     runs-on: ubuntu-latest-16core

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -113,7 +113,7 @@ jobs:
       - name: Install node modules
         run: pnpm install --frozen-lockfile
       - name: Run tests
-        run: bazel test --build_tag_filters=-e2e --test_tag_filters=-e2e --build_tests_only -- src/...
+        run: bazel test --build_tests_only --test_tag_filters=-linker-integration-test --test_tag_filters=-e2e -- //... -//goldens/... -//integration/...
 
   build:
     runs-on: ubuntu-latest-16core

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,9 +1,10 @@
+load("@devinfra//bazel/validation:defs.bzl", "validate_ts_version_matching")
+load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//:pkg-externals.bzl", "PKG_EXTERNALS")
 load("//src/cdk:config.bzl", "CDK_ENTRYPOINTS")
 load("//src/cdk-experimental:config.bzl", "CDK_EXPERIMENTAL_ENTRYPOINTS")
 load("//src/material:config.bzl", "MATERIAL_ENTRYPOINTS", "MATERIAL_TESTING_ENTRYPOINTS")
 load("//src/material-experimental:config.bzl", "MATERIAL_EXPERIMENTAL_ENTRYPOINTS", "MATERIAL_EXPERIMENTAL_TESTING_ENTRYPOINTS")
-load("@npm//:defs.bzl", "npm_link_all_packages")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -34,4 +35,9 @@ genrule(
     name = "entry_points_manifest",
     outs = ["entry_points_manifest.json"],
     cmd = "echo '%s' > $@" % entryPoints,
+)
+
+validate_ts_version_matching(
+    module_lock_file = "MODULE.bazel.lock",
+    package_json = "package.json",
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -39,7 +39,7 @@ git_override(
 bazel_dep(name = "devinfra")
 git_override(
     module_name = "devinfra",
-    commit = "80db036355181684ed07021a175e9f039190d3d6",
+    commit = "7e2eefa1375195fa7616f78a76f538a188852067",
     remote = "https://github.com/angular/dev-infra.git",
 )
 
@@ -51,7 +51,7 @@ rules_ts_ext.deps(
     name = "components_npm_typescript",
     # Obtained by: curl --silent https://registry.npmjs.org/typescript/5.9.2 | jq -r '.dist.integrity'
     ts_integrity = "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-    ts_version_from = "//:package.json",
+    ts_version = "5.9.2",
 )
 use_repo(rules_ts_ext, **{"npm_typescript": "components_npm_typescript"})
 

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -542,10 +542,8 @@
     "@@aspect_rules_ts~//ts:extensions.bzl%ext": {
       "general": {
         "bzlTransitiveDigest": "9IJp6IlB/FMHFBJe4MX/DQM4zi3oArC8yqYE/+NyPwk=",
-        "usagesDigest": "Sz9Bt4IU6oJPfWwcpEB3Uz+IShADwq16bU/Mk+/8uzE=",
+        "usagesDigest": "FN1SAx4DpL2FgDt82a58jz0UTyLqjp7ZhcUaVdApZz8=",
         "recordedFileInputs": {
-          "@@//package.json": "94d93025c2a6bb176bedd0f622fdb6d372bc6543921242273de83d6055e3f3f7",
-          "@@devinfra~//bazel/package.json": "960bcecf963a211f96a3967c7cfb5d3e1cea08d94b27056a3e8dbf2fad1e2dd3",
           "@@rules_browsers~//package.json": "0d8cc69cc2c9ecf0eff677fa86843ad9146eca22462aace022a09c3adcb979f8"
         },
         "recordedDirentsInputs": {},
@@ -555,8 +553,7 @@
             "bzlFile": "@@aspect_rules_ts~//ts/private:npm_repositories.bzl",
             "ruleClassName": "http_archive_version",
             "attributes": {
-              "version": "",
-              "version_from": "@@//:package.json",
+              "version": "5.9.2",
               "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
               "urls": [
                 "https://registry.npmjs.org/typescript/-/typescript-{}.tgz"
@@ -590,8 +587,7 @@
             "bzlFile": "@@aspect_rules_ts~//ts/private:npm_repositories.bzl",
             "ruleClassName": "http_archive_version",
             "attributes": {
-              "version": "",
-              "version_from": "@@devinfra~//bazel:package.json",
+              "version": "5.9.2",
               "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
               "urls": [
                 "https://registry.npmjs.org/typescript/-/typescript-{}.tgz"


### PR DESCRIPTION
Within our module.bazel file when describing the version of typescript to use for rules_ts, we use ts_version instead of ts_version_from to prevent our package.json file from being part of the set of files used to calculate the sha for the lock file.  Any unrelated change to the version of the typescript file would end up causing our lockfile to be out of date. This amount of churn has proven to be too much for our current setup. We instead now test to validate the versions defined in the package.json and MODULE.bazel files match.

Backport of https://github.com/angular/angular/pull/63431/commits