### PR TITLE
fix(cdk-experimental/accordion): creates visually hidden span to improve screen reader accessibility

### DIFF
--- a/src/cdk-experimental/accordion/accordion.ts
+++ b/src/cdk-experimental/accordion/accordion.ts
@@ -147,25 +147,29 @@ export class CdkAccordionTrigger {
   constructor() {
     // We'll use afterRenderEffect to ensure the element is created after the host element.
     afterRenderEffect(() => {
-      // Find the element that holds the label text, or the button itself.
+      // Find the button element and its parent
       const buttonElement = this._elementRef.nativeElement;
+      const parentElement = this._renderer.parentNode(buttonElement);
 
-      // Create a new span element
-      const visuallyHiddenSpan = this._renderer.createElement('span');
+      if (parentElement) {
+        // Create a new visually hidden span element to be referenced by accordionPanel
+        const visuallyHiddenSpan = this._renderer.createElement('span');
+        this._renderer.addClass(visuallyHiddenSpan, 'cdk-visually-hidden');
+        this._renderer.setAttribute(visuallyHiddenSpan, 'id', this.pattern.visuallyHiddenId());
 
-      // Add the cdk-visually-hidden class
-      this._renderer.addClass(visuallyHiddenSpan, 'cdk-visually-hidden');
+        // Get the button's text content and set it on the span
+        let buttonText = '';
+        for (const node of Array.from(buttonElement.childNodes)) {
+          if (node instanceof Node && node.nodeType === Node.TEXT_NODE) {
+            buttonText += node.textContent?.trim() + ' ';
+          }
+        }
+        const textNode = this._renderer.createText(buttonText);
+        this._renderer.appendChild(visuallyHiddenSpan, textNode);
 
-      // Set the ID for aria-labelledby
-      this._renderer.setAttribute(visuallyHiddenSpan, 'id', this.visuallyHiddenId());
-
-      // Get the button's text content and set it on the span
-      const buttonText = buttonElement.textContent?.trim() || '';
-      const textNode = this._renderer.createText(buttonText);
-      this._renderer.appendChild(visuallyHiddenSpan, textNode);
-
-      // Prepend the visually hidden span to the button element
-      this._renderer.insertBefore(buttonElement, visuallyHiddenSpan, buttonElement.firstChild);
+        // Insert the visually hidden span before the button, as its sibling
+        this._renderer.insertBefore(parentElement, visuallyHiddenSpan, buttonElement);
+      }
     });
   }
 }

--- a/src/cdk-experimental/accordion/accordion.ts
+++ b/src/cdk-experimental/accordion/accordion.ts
@@ -156,6 +156,7 @@ export class CdkAccordionTrigger {
         const visuallyHiddenSpan = this._renderer.createElement('span');
         this._renderer.addClass(visuallyHiddenSpan, 'cdk-visually-hidden');
         this._renderer.setAttribute(visuallyHiddenSpan, 'id', this.pattern.visuallyHiddenId());
+        this._renderer.setAttribute(visuallyHiddenSpan, 'tabindex', '-1');
 
         // Get the button's text content and set it on the span
         let buttonText = '';

--- a/src/cdk-experimental/accordion/accordion.ts
+++ b/src/cdk-experimental/accordion/accordion.ts
@@ -72,7 +72,7 @@ export class CdkAccordionPanel {
   });
 
   constructor() {
-    // Connect the panel's hidden state to the DeferredContentAware's visibility.
+    /** Connect the panel's hidden state to the DeferredContentAware's visibility. */
     afterRenderEffect(() => {
       this._deferredContentAware.contentVisible.set(!this.pattern.hidden());
     });
@@ -144,8 +144,9 @@ export class CdkAccordionTrigger {
     accordionPanel: this.accordionPanel,
   });
 
-  /** The computed label value of this Accordion Trigger to be passed to a visually hidden
-   *  span that is accessible to screen readers whether the button is disabled or not.
+  /**
+   * The computed label value of this Accordion Trigger to be passed to a visually hidden
+   * span that is accessible to screen readers whether the button is disabled or not.
    */
   readonly visuallyHiddenLabel = computed(() => {
     let buttonText = '';
@@ -156,11 +157,11 @@ export class CdkAccordionTrigger {
       }
     }
 
-    // Determine the state labels of the Accordion Trigger to pass to the label
+    /** Determine the state labels of the Accordion Trigger to pass to the label. */
     const expansionLabel = this.pattern.expanded() ? '(Expanded)' : '(Collapsed)';
     const disabledLabel = this.pattern.disabled() ? '(Disabled)' : '';
 
-    // Combine all parts into the final label
+    /** Combine all parts into the final label. */
     return `${buttonText.trim()} ${expansionLabel} ${disabledLabel}`.trim();
   });
 
@@ -170,7 +171,7 @@ export class CdkAccordionTrigger {
       const parentElement = this._renderer.parentNode(buttonElement);
 
       if (parentElement) {
-        // Create the span and attach it to the DOM only once.
+        /** Create the span and attach it to the DOM only once. */
         if (!this._visuallyHiddenSpan) {
           this._visuallyHiddenSpan = this._renderer.createElement('span');
           this._renderer.addClass(this._visuallyHiddenSpan, 'cdk-visually-hidden');
@@ -183,7 +184,7 @@ export class CdkAccordionTrigger {
           this._renderer.insertBefore(parentElement, this._visuallyHiddenSpan, buttonElement);
         }
 
-        // Update its text content whenever the signal changes.
+        /** Update its text content whenever the signal changes. */
         this._renderer.setProperty(
           this._visuallyHiddenSpan,
           'textContent',
@@ -193,7 +194,7 @@ export class CdkAccordionTrigger {
     });
   }
 
-  // Add a private property to store a reference to the span
+  /** Add a private property to store a reference to the span. */
   private _visuallyHiddenSpan!: HTMLElement;
 }
 
@@ -239,18 +240,20 @@ export class CdkAccordionGroup {
   /** The UI pattern instance for this accordion group. */
   readonly pattern: AccordionGroupPattern = new AccordionGroupPattern({
     ...this,
-    // TODO(ok7sai): Consider making `activeItem` an internal state in the pattern and call
-    // `setDefaultState` in the CDK.
+    /**
+     * TODO(ok7sai): Consider making `activeItem` an internal state in the pattern and call
+     * `setDefaultState` in the CDK.
+     */
     activeItem: signal(undefined),
     items: computed(() => this._triggers().map(trigger => trigger.pattern)),
     expandedIds: this.value,
-    // TODO(ok7sai): Investigate whether an accordion should support horizontal mode.
+    /** TODO(ok7sai): Investigate whether an accordion should support horizontal mode. */
     orientation: () => 'vertical',
     element: () => this._elementRef.nativeElement,
   });
 
   constructor() {
-    // Effect to link triggers with their corresponding panels and update the group's items.
+    /** Effect to link triggers with their corresponding panels and update the group's items. */
     afterRenderEffect(() => {
       const triggers = this._triggers();
       const panels = this._panels();

--- a/src/cdk-experimental/accordion/accordion.ts
+++ b/src/cdk-experimental/accordion/accordion.ts
@@ -94,7 +94,6 @@ export class CdkAccordionPanel {
     '[attr.aria-expanded]': 'pattern.expanded()',
     '[attr.aria-controls]': 'pattern.controls()',
     '[attr.aria-disabled]': 'pattern.disabled()',
-    '[attr.inert]': 'hardDisabled() ? true : null',
     '[attr.disabled]': 'hardDisabled() ? true : null',
     '[attr.tabindex]': 'pattern.tabindex()',
     '(keydown)': 'pattern.onKeydown($event)',
@@ -157,12 +156,8 @@ export class CdkAccordionTrigger {
       }
     }
 
-    /** Determine the state labels of the Accordion Trigger to pass to the label. */
-    const expansionLabel = this.pattern.expanded() ? '(Expanded)' : '(Collapsed)';
-    const disabledLabel = this.pattern.disabled() ? '(Disabled)' : '';
-
     /** Combine all parts into the final label. */
-    return `${buttonText.trim()} ${expansionLabel} ${disabledLabel}`.trim();
+    return `${buttonText.trim()}`.trim();
   });
 
   constructor() {

--- a/src/cdk-experimental/ui-patterns/accordion/accordion.ts
+++ b/src/cdk-experimental/ui-patterns/accordion/accordion.ts
@@ -80,14 +80,16 @@ export type AccordionTriggerInputs = Omit<ListNavigationItem & ListFocusItem, 'i
 
     /** The accordion panel controlled by this trigger. */
     accordionPanel: SignalLike<AccordionPanelPattern | undefined>;
+
+    /** The id of the visually hidden span associated with the Accordion Trigger to be referenced by
+     * screen readers at all times for consistent accessibility.
+     */
+    visuallyHiddenId: SignalLike<string>;
   };
 
 export interface AccordionTriggerPattern extends AccordionTriggerInputs {}
 /** A pattern controls the expansion state of an accordion. */
 export class AccordionTriggerPattern {
-  /** A unique ID for the visually hidden label. */
-  readonly visuallyHiddenId: SignalLike<string>;
-
   /** Whether this tab has expandable content. */
   expandable: SignalLike<boolean>;
 
@@ -121,7 +123,7 @@ export class AccordionTriggerPattern {
     this.value = inputs.value;
     this.accordionGroup = inputs.accordionGroup;
     this.accordionPanel = inputs.accordionPanel;
-    this.visuallyHiddenId = computed(() => this.id() + '-label');
+    this.visuallyHiddenId = inputs.visuallyHiddenId;
     this.expansionControl = new ExpansionControl({
       ...inputs,
       expansionId: inputs.value,

--- a/src/cdk-experimental/ui-patterns/accordion/accordion.ts
+++ b/src/cdk-experimental/ui-patterns/accordion/accordion.ts
@@ -85,6 +85,9 @@ export type AccordionTriggerInputs = Omit<ListNavigationItem & ListFocusItem, 'i
 export interface AccordionTriggerPattern extends AccordionTriggerInputs {}
 /** A pattern controls the expansion state of an accordion. */
 export class AccordionTriggerPattern {
+  /** A unique ID for the visually hidden label. */
+  readonly visuallyHiddenId: SignalLike<string>;
+
   /** Whether this tab has expandable content. */
   expandable: SignalLike<boolean>;
 
@@ -118,6 +121,7 @@ export class AccordionTriggerPattern {
     this.value = inputs.value;
     this.accordionGroup = inputs.accordionGroup;
     this.accordionPanel = inputs.accordionPanel;
+    this.visuallyHiddenId = computed(() => this.id() + '-label');
     this.expansionControl = new ExpansionControl({
       ...inputs,
       expansionId: inputs.value,

--- a/src/cdk-experimental/ui-patterns/accordion/accordion.ts
+++ b/src/cdk-experimental/ui-patterns/accordion/accordion.ts
@@ -81,8 +81,9 @@ export type AccordionTriggerInputs = Omit<ListNavigationItem & ListFocusItem, 'i
     /** The accordion panel controlled by this trigger. */
     accordionPanel: SignalLike<AccordionPanelPattern | undefined>;
 
-    /** The id of the visually hidden span associated with the Accordion Trigger to be referenced by
-     * screen readers at all times for consistent accessibility.
+    /**
+     * The id of the visually hidden span associated with the Accordion Trigger to be
+     * referenced by screen readers at all times for consistent accessibility.
      */
     visuallyHiddenId: SignalLike<string>;
   };


### PR DESCRIPTION
Adds a visually hidden span as a child of the accordion header/button which has a generated id for the associated accordion content panel to reference if/when the accordion header/button is disabled. This should allow screen readers to have an active reference for aria-labelledby to reference.

* [Before screencast]()
* [After screencast](https://screencast.googleplex.com/cast/NDU5OTIzNzU4NDA5MzE4NHxkNjYzMzhhZi1kZA)

Fixes b/438312273