### PR TITLE
fix(material/menu): fix divider color property

### DIFF
--- a/src/material/menu/menu.scss
+++ b/src/material/menu/menu.scss
@@ -100,7 +100,7 @@ mat-menu {
 
   .mat-divider {
     // Use margin instead of padding since divider uses border-top to render out the line.
-    color: token-utils.slot(menu-divider-color, $fallbacks);
+    border-top-color: token-utils.slot(menu-divider-color, $fallbacks);
     margin-bottom: token-utils.slot(menu-divider-bottom-spacing, $fallbacks);
     margin-top: token-utils.slot(menu-divider-top-spacing, $fallbacks);
   }


### PR DESCRIPTION
The material/divider component sets its color using the `border-top-color` but the material/menu component attempts to override this by setting the `color` property which causes any overrides to not get applied.