### PR TITLE
fix(cdk-experimental/accordion): removes inert attribute from accordion trigger

### DIFF
--- a/src/cdk-experimental/accordion/accordion.ts
+++ b/src/cdk-experimental/accordion/accordion.ts
@@ -93,7 +93,6 @@ export class CdkAccordionPanel {
     '[attr.aria-expanded]': 'pattern.expanded()',
     '[attr.aria-controls]': 'pattern.controls()',
     '[attr.aria-disabled]': 'pattern.disabled()',
-    '[attr.inert]': 'hardDisabled() ? true : null',
     '[attr.disabled]': 'hardDisabled() ? true : null',
     '[attr.tabindex]': 'pattern.tabindex()',
     '(keydown)': 'pattern.onKeydown($event)',


### PR DESCRIPTION
Updates accordion trigger attributes by removing the inert attribute to allow for screen readers to correctly reference the aria-labelledby id value of a disabled accordion trigger when associating it with a accordion content panel. Additionally, when moving focus to the disabled trigger, removing the inert attribute allows for the button's state to be announced (ie. disabled, collapsed/expanded). 

* [Before screencast](https://screencast.googleplex.com/cast/NDYxMTc4NzM3Nzg2ODgwMHwyNjc5ZThiYS1iNg)
* [After screencast](https://screencast.googleplex.com/cast/NTkwNTI3MzkyMjI1Njg5NnxmMzU1NDE5Yi03Nw)

Fixes b/438312273