### PR TITLE
docs: correct color-scheme syntax in theming guide

### DIFF
--- a/guides/theming.md
+++ b/guides/theming.md
@@ -266,7 +266,7 @@ define a value for `color-scheme`, then the light colors will always be applied.
 
 You can define `color-scheme: light` or `color-scheme: dark` to explicitly
 define your application’s mode. To set the mode depending on the user’s system
-preferences, use `color-scheme: light-dark` as shown in the following example:
+preferences, use `color-scheme: light dark` as shown in the following example:
 
 ```scss
 @use '@angular/material' as mat;


### PR DESCRIPTION
This fixes a typo in the "Supporting Light and Dark Mode" section of the theming guide.

The paragraph text incorrectly describes the value for the `color-scheme` property as `light-dark` (with a hyphen), when the correct CSS syntax is `light dark` (with a space).

The code example in the guide is already correct; this change simply aligns the descriptive text with the example and the CSS specification.