### PR TITLE
feat(material/testing): Add icon name filtering to MatButtonHarness

### DIFF
--- a/goldens/material/button/testing/index.api.md
+++ b/goldens/material/button/testing/index.api.md
@@ -17,7 +17,7 @@ export interface ButtonHarnessFilters extends BaseHarnessFilters {
     appearance?: ButtonAppearance;
     buttonType?: ButtonType;
     disabled?: boolean;
-    icon?: string | RegExp;
+    iconName?: string | RegExp;
     text?: string | RegExp;
     variant?: ButtonVariant;
 }

--- a/goldens/material/button/testing/index.api.md
+++ b/goldens/material/button/testing/index.api.md
@@ -17,6 +17,7 @@ export interface ButtonHarnessFilters extends BaseHarnessFilters {
     appearance?: ButtonAppearance;
     buttonType?: ButtonType;
     disabled?: boolean;
+    icon?: string | RegExp;
     text?: string | RegExp;
     variant?: ButtonVariant;
 }

--- a/src/material/button/testing/BUILD.bazel
+++ b/src/material/button/testing/BUILD.bazel
@@ -11,6 +11,7 @@ ts_project(
     deps = [
         "//:node_modules/@angular/core",
         "//src/cdk/testing",
+        "//src/material/icon/testing",
     ],
 )
 

--- a/src/material/button/testing/button-harness-filters.ts
+++ b/src/material/button/testing/button-harness-filters.ts
@@ -33,4 +33,7 @@ export interface ButtonHarnessFilters extends BaseHarnessFilters {
 
   /** Only find instances with the specified type. */
   buttonType?: ButtonType;
+
+  /** Only find instances that contain an icon whose name matches the given value. */
+  icon?: string | RegExp;
 }

--- a/src/material/button/testing/button-harness-filters.ts
+++ b/src/material/button/testing/button-harness-filters.ts
@@ -35,5 +35,5 @@ export interface ButtonHarnessFilters extends BaseHarnessFilters {
   buttonType?: ButtonType;
 
   /** Only find instances that contain an icon whose name matches the given value. */
-  icon?: string | RegExp;
+  iconName?: string | RegExp;
 }

--- a/src/material/button/testing/button-harness.spec.ts
+++ b/src/material/button/testing/button-harness.spec.ts
@@ -116,7 +116,7 @@ describe('MatButtonHarness', () => {
   });
 
   it('should be able to filter buttons containing a named icon', async () => {
-    const favBtn = await loader.getHarness(MatButtonHarness.with({icon: 'favorite'}));
+    const favBtn = await loader.getHarness(MatButtonHarness.with({iconName: 'favorite'}));
 
     expect(await (await favBtn.host()).getAttribute('id')).toBe('favorite-icon');
     expect(await (await favBtn.getHarness(MatIconHarness)).getName()).toBe('favorite');

--- a/src/material/button/testing/button-harness.spec.ts
+++ b/src/material/button/testing/button-harness.spec.ts
@@ -115,6 +115,13 @@ describe('MatButtonHarness', () => {
     expect(await favIcon.getName()).toBe('favorite');
   });
 
+  it('should be able to filter buttons containing a named icon', async () => {
+    const favBtn = await loader.getHarness(MatButtonHarness.with({icon: 'favorite'}));
+
+    expect(await (await favBtn.host()).getAttribute('id')).toBe('favorite-icon');
+    expect(await (await favBtn.getHarness(MatIconHarness)).getName()).toBe('favorite');
+  });
+
   it('should be able to ge the type variant of the button', async () => {
     const buttons = await loader.getAllHarnesses(MatButtonHarness);
     const variants = await parallel(() => buttons.map(button => button.getVariant()));

--- a/src/material/button/testing/button-harness.ts
+++ b/src/material/button/testing/button-harness.ts
@@ -60,8 +60,8 @@ export class MatButtonHarness extends ContentContainerComponentHarness {
       .addOption('buttonType', options.buttonType, (harness, buttonType) =>
         HarnessPredicate.stringMatches(harness.getType(), buttonType),
       )
-      .addOption('icon', options.icon, (harness, icon) => {
-        return harness.hasHarness(MatIconHarness.with({name: icon}));
+      .addOption('iconName', options.iconName, (harness, iconName) => {
+        return harness.hasHarness(MatIconHarness.with({name: iconName}));
       });
   }
 

--- a/src/material/button/testing/button-harness.ts
+++ b/src/material/button/testing/button-harness.ts
@@ -12,6 +12,7 @@ import {
   ContentContainerComponentHarness,
   HarnessPredicate,
 } from '@angular/cdk/testing';
+import {MatIconHarness} from '@angular/material/icon/testing';
 import {
   ButtonAppearance,
   ButtonHarnessFilters,
@@ -58,7 +59,10 @@ export class MatButtonHarness extends ContentContainerComponentHarness {
       })
       .addOption('buttonType', options.buttonType, (harness, buttonType) =>
         HarnessPredicate.stringMatches(harness.getType(), buttonType),
-      );
+      )
+      .addOption('icon', options.icon, (harness, icon) => {
+        return harness.hasHarness(MatIconHarness.with({name: icon}));
+      });
   }
 
   /**


### PR DESCRIPTION
In its current implementation, icon buttons and FABs are more difficult to filter for compared to text-based buttons, which can use their { text} filter property, usually relying on a custom selector (eg: class or id) or ancestor. This change aims to simplify this by allowing a user to filter via a contained icon. The filtering logic is quite simple and reuses the existing logic inside `MatIconHarness` for simplicity and reliability.

Example usage:
```
const iconButton = await getHarness(MatButtonHarness.with({ iconName: "favorite" }));
```