### PR TITLE
ci: use static target: automation label in renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,15 +3,5 @@
   "extends": ["github>angular/dev-infra//renovate-presets/default.json5"],
   "baseBranchPatterns": ["main", "20.2.x"],
   "ignoreDeps": ["stylelint", "selenium-webdriver", "@types/selenium-webdriver", "typescript"],
-  "ignorePaths": ["docs/src/assets/stackblitz/**", "integration/**"],
-  "packageRules": [
-    {
-      "matchBaseBranches": ["main"],
-      "addLabels": ["target: minor"]
-    },
-    {
-      "matchBaseBranches": ["!main"],
-      "addLabels": ["target: patch"]
-    }
-  ]
+  "ignorePaths": ["docs/src/assets/stackblitz/**", "integration/**"]
 }


### PR DESCRIPTION
The `target: automation` label is used by the Angular team to identify PRs that are created by automation. This is used to skip some checks that are not required for automated PRs.