### PR TITLE
fix(material/core): separate text/bg colors in utility classes

### DIFF
--- a/src/dev-app/system-classes-demo/system-classes-demo.html
+++ b/src/dev-app/system-classes-demo/system-classes-demo.html
@@ -2,92 +2,147 @@
 
 <section>
   <h2>Color</h2>
-  <div class="demo-grid">
-    <div class="mat-bg-primary demo-box">mat-bg-primary</div>
-    <div class="mat-bg-primary-container demo-box">mat-bg-primary-container</div>
-    <div class="mat-bg-secondary demo-box">mat-bg-secondary</div>
-    <div class="mat-bg-secondary-container demo-box">mat-bg-secondary-container</div>
-    <div class="mat-bg-error demo-box">mat-bg-error</div>
-    <div class="mat-bg-error-container demo-box">mat-bg-error-container</div>
-    <div class="mat-bg-surface demo-box">mat-bg-surface</div>
-    <div class="mat-bg-surface-variant demo-box">mat-bg-surface-variant</div>
-    <div class="mat-bg-surface-container-highest demo-box">mat-bg-surface-container-highest</div>
-    <div class="mat-bg-surface-container-high demo-box">mat-bg-surface-container-high</div>
-    <div class="mat-bg-surface-container demo-box">mat-bg-surface-container</div>
-    <div class="mat-bg-surface-container-low demo-box">mat-bg-surface-container-low</div>
-    <div class="mat-bg-surface-container-lowest demo-box">mat-bg-surface-container-lowest</div>
-    <div class="mat-bg-inverse-surface demo-box">mat-bg-inverse-surface</div>
-    <div class="mat-bg-disabled demo-box">mat-bg-disabled</div>
+  <h3>Primary</h3>
+  <div class="demo-section-container demo-grid">
+    <div class="mat-border mat-corner-sm mat-bg-surface mat-text-primary demo-box">
+      .mat-bg-surface <br/> .mat-text-primary
+    </div>
+    <div class="mat-border mat-corner-sm mat-bg-primary mat-text-on-primary demo-box">
+      .mat-bg-primary <br/> .mat-text-on-primary
+    </div>
+    <div class="mat-border mat-corner-sm mat-bg-primary-container mat-text-on-primary-container demo-box">
+      .mat-bg-primary-container <br/> .mat-text-on-primary-container
+    </div>
   </div>
-</section>
-
-<section>
-  <h2>Text Color</h2>
-  <div class="demo-grid">
-    <div class="mat-text-primary">mat-text-primary</div>
-    <div class="mat-text-secondary">mat-text-secondary</div>
-    <div class="mat-text-error">mat-text-error</div>
-    <div class="mat-text-disabled">mat-text-disabled</div>
+  <h3>Secondary</h3>
+  <div class="demo-section-container demo-grid">
+    <div class="mat-border mat-corner-sm mat-bg-surface mat-text-secondary demo-box">
+      .mat-bg-surface <br/> .mat-text-secondary
+    </div>
+    <div class="mat-border mat-corner-sm mat-bg-secondary mat-text-on-secondary demo-box">
+      .mat-bg-secondary <br/> .mat-text-on-secondary
+    </div>
+    <div class="mat-border mat-corner-sm mat-bg-secondary-container mat-text-on-secondary-container demo-box">
+      .mat-bg-secondary-container <br/> .mat-text-on-secondary-container
+    </div>
   </div>
-</section>
+  <h3>Error</h3>
+  <div class="demo-section-container demo-grid">
+    <div class="mat-border mat-corner-sm mat-bg-surface mat-text-error demo-box">
+      .mat-bg-surface <br/> .mat-text-error
+    </div>
+    <div class="mat-border mat-corner-sm mat-bg-error mat-text-on-error demo-box">
+      .mat-bg-error <br/> .mat-text-on-error
+    </div>
+    <div class="mat-border mat-corner-sm mat-bg-error-container mat-text-on-error-container demo-box">
+      .mat-bg-error-container <br/> .mat-text-on-error-container
+    </div>
+  </div>
+  <h3>Surface</h3>
+  <div class="demo-section-container demo-grid">
+    <div class="mat-border mat-corner-sm mat-bg-surface mat-text-on-surface demo-box">
+      .mat-bg-surface <br/> .mat-text-on-surface
+    </div>
+    <div class="mat-border mat-corner-sm mat-bg-surface mat-text-on-surface-variant demo-box">
+      .mat-bg-surface <br/> .mat-text-on-surface-variant
+    </div>
+    <div class="mat-border mat-corner-sm mat-bg-surface-variant mat-text-on-surface demo-box">
+      .mat-bg-surface-variant <br/> .mat-text-on-surface
+    </div>
+    <div class="mat-border mat-corner-sm mat-bg-surface-container-highest mat-text-on-surface demo-box">
+      .mat-bg-surface-container-highest <br/> .mat-text-on-surface
+    </div>
+    <div class="mat-border mat-corner-sm mat-bg-surface-container-high mat-text-on-surface demo-box">
+      .mat-bg-surface-container-high <br/> .mat-text-on-surface
+    </div>
+    <div class="mat-border mat-corner-sm mat-bg-surface-container mat-text-on-surface demo-box">
+      .mat-bg-surface-container <br/> .mat-text-on-surface
+    </div>
+    <div class="mat-border mat-corner-sm mat-bg-surface-container-low mat-text-on-surface demo-box">
+      .mat-bg-surface-container-low <br/> .mat-text-on-surface
+    </div>
+    <div class="mat-border mat-corner-sm mat-bg-surface-container-lowest mat-text-on-surface demo-box">
+      .mat-bg-surface-container-lowest <br/> .mat-text-on-surface
+    </div>
+    <div class="mat-border mat-corner-sm mat-bg-inverse-surface mat-text-inverse-on-surface demo-box">
+      .mat-bg-inverse-surface <br/> .mat-text-inverse-on-surface
+    </div>
+  </div>
+  <h3>Disabled</h3>
+  <div class="demo-section-container demo-grid">
+    <div class="mat-border mat-corner-sm mat-bg-surface mat-text-disabled demo-box">
+      .mat-bg-surface <br/> .mat-text-disabled
+    </div>
+    <div class="mat-border mat-corner-sm mat-bg-disabled mat-text-disabled demo-box">
+      .mat-bg-disabled <br/> .mat-text-disabled
+    </div>
+  </div>
 
 <section>
   <h2>Typography</h2>
-  <div class="demo-typography">
+  <h3> Display </h3>
+  <div class="demo-section-container demo-typography">
     <div class="mat-font-display-lg">mat-font-display-lg (Display Large)</div>
     <div class="mat-font-display-md">mat-font-display-md (Display Medium)</div>
     <div class="mat-font-display-sm">mat-font-display-sm (Display Small)</div>
+  </div>
+  <h3> Headline </h3>
+  <div class="demo-section-container demo-typography">
     <div class="mat-font-headline-lg">mat-font-headline-lg (Headline Large)</div>
     <div class="mat-font-headline-md">mat-font-headline-md (Headline Medium)</div>
     <div class="mat-font-headline-sm">mat-font-headline-sm (Headline Small)</div>
+  </div>
+  <h3> Title </h3>
+  <div class="demo-section-container demo-typography">
     <div class="mat-font-title-lg">mat-font-title-lg (Title Large)</div>
     <div class="mat-font-title-md">mat-font-title-md (Title Medium)</div>
     <div class="mat-font-title-sm">mat-font-title-sm (Title Small)</div>
+  </div>
+  <h3> Headline </h3>
+  <div class="demo-section-container demo-typography">
     <div class="mat-font-body-lg">mat-font-body-lg (Body Large)</div>
     <div class="mat-font-body-md">mat-font-body-md (Body Medium)</div>
     <div class="mat-font-body-sm">mat-font-body-sm (Body Small)</div>
+  </div>
+  <h3> Label </h3>
+  <div class="demo-section-container demo-typography">
+    <div class="mat-font-label-lg">mat-font-label-lg (Label Large)</div>
+    <div class="mat-font-label-md">mat-font-label-md (Label Medium)</div>
+    <div class="mat-font-label-sm">mat-font-label-sm (Label Small)</div>
   </div>
 </section>
 
 <section>
   <h2>Shape</h2>
-  <div class="demo-grid">
-    <div class="mat-corner-extra-sm demo-box mat-bg-primary-container">
+  <div class="demo-section-container demo-grid">
+    <div class="mat-border mat-corner-extra-sm demo-box mat-bg-primary-container">
       mat-corner-extra-sm
     </div>
-    <div class="mat-corner-sm demo-box mat-bg-primary-container">mat-corner-sm</div>
-    <div class="mat-corner-md demo-box mat-bg-primary-container">mat-corner-md</div>
-    <div class="mat-corner-lg demo-box mat-bg-primary-container">mat-corner-lg</div>
-    <div class="mat-corner-xl demo-box mat-bg-primary-container">
+    <div class="mat-border mat-corner-sm demo-box mat-bg-primary-container">mat-corner-sm</div>
+    <div class="mat-border mat-corner-md demo-box mat-bg-primary-container">mat-corner-md</div>
+    <div class="mat-border mat-corner-lg demo-box mat-bg-primary-container">mat-corner-lg</div>
+    <div class="mat-border mat-corner-xl demo-box mat-bg-primary-container">
       mat-corner-xl
     </div>
-    <div class="mat-corner-full demo-box mat-bg-primary-container">mat-corner-full</div>
+    <div class="mat-border mat-corner-full demo-box mat-bg-primary-container">mat-corner-full</div>
   </div>
 </section>
 
 <section>
   <h2>Elevation</h2>
-  <div class="demo-grid">
-    <div class="mat-shadow-1 demo-box mat-bg-surface">mat-shadow-1</div>
-    <div class="mat-shadow-2 demo-box mat-bg-surface">mat-shadow-2</div>
-    <div class="mat-shadow-3 demo-box mat-bg-surface">mat-shadow-3</div>
-    <div class="mat-shadow-4 demo-box mat-bg-surface">mat-shadow-4</div>
-    <div class="mat-shadow-5 demo-box mat-bg-surface">mat-shadow-5</div>
+  <div class="demo-section-container demo-grid">
+    <div class="mat-border-subtle mat-shadow-1 demo-box mat-bg-surface">mat-shadow-1</div>
+    <div class="mat-border-subtle mat-shadow-2 demo-box mat-bg-surface">mat-shadow-2</div>
+    <div class="mat-border-subtle mat-shadow-3 demo-box mat-bg-surface">mat-shadow-3</div>
+    <div class="mat-border-subtle mat-shadow-4 demo-box mat-bg-surface">mat-shadow-4</div>
+    <div class="mat-border-subtle mat-shadow-5 demo-box mat-bg-surface">mat-shadow-5</div>
   </div>
 </section>
 
 <section>
   <h2>Outline</h2>
-  <div class="demo-grid">
+  <div class="demo-section-container demo-grid">
     <div class="mat-border demo-box">mat-border</div>
     <div class="mat-border-subtle demo-box">mat-border-subtle</div>
-  </div>
-</section>
-
-<section>
-  <h2>Stateful</h2>
-  <div class="demo-grid">
-    <div class="mat-interactive demo-box">mat-interactive</div>
-    <div class="mat-interactive-primary demo-box">mat-interactive-primary</div>
   </div>
 </section>

--- a/src/dev-app/system-classes-demo/system-classes-demo.scss
+++ b/src/dev-app/system-classes-demo/system-classes-demo.scss
@@ -1,6 +1,6 @@
 .demo-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
   gap: 16px;
 }
 
@@ -15,4 +15,12 @@
 
 .demo-typography > div {
   margin-bottom: 16px;
+}
+
+.demo-section-container {
+  padding: 16px;
+}
+
+h3 {
+  padding-left: 16px;
 }

--- a/src/material/core/tokens/_classes.scss
+++ b/src/material/core/tokens/_classes.scss
@@ -3,134 +3,109 @@
 @mixin system-classes() {
 
   // ***********************************************************************************************
-  // Background - Apply background color and a contrastful corresponding text color
-  // See https://m3.material.io/styles/color/roles for guidance.
+  // Background - Applies background colors defined by Material Design.
+  // See https://m3.material.io/styles/color/roles for detailed guidance.
   // ***********************************************************************************************
 
-  // Styles an element with a primary color background and applies an accessible contrasting
-  // color for text and icons. Use for key components across the UI, such as buttons that
-  // have greater importance on the page. In Angular Material, this is used for the selected
-  // date in a datepicker, the handle of a slider, and the background of a checkbox.
+  // Styles an element with a primary color background. Use for key components across the UI, such
+  // as buttons that have greater importance on the page. In Angular Material, this is used for the
+  // selected date in a datepicker, the handle of a slider, and the background of a checkbox.
   .mat-bg-primary {
     background-color: var(--mat-sys-primary);
-    color: var(--mat-sys-on-primary);
   }
 
-  // Styles an element with a primary container color background and applies an accessible
-  // contrasting color for text and icons. Use for filling components that should stand out
-  // on a surface. In Angular Material, this is used for
-  // the container of a floating action button.
+  // Styles an element with a primary container color background. Use for filling components that
+  // should stand out on a surface. In Angular Material, this is used for the container of a
+  // floating action button.
   .mat-bg-primary-container {
     background-color: var(--mat-sys-primary-container);
-    color: var(--mat-sys-on-primary-container);
   }
 
-  // Styles an element with a secondary color background and applies an accessible contrasting
-  // color for text and icons. Use for less prominent components in the UI that have a different
-  // color scheme than the primary.
+  // Styles an element with a secondary color background. Use for less prominent components in the
+  // UI that have a different color scheme than the primary.
   .mat-bg-secondary {
     background-color: var(--mat-sys-secondary);
-    color: var(--mat-sys-on-secondary);
   }
 
-  // Styles an element with a secondary container color background and applies an accessible
-  // contrasting color for text and icons. Use for components that need less emphasis than
-  // secondary, such as filter chips. In Angular Material, this is used for selected items
-  // in a list and the container of a tonal button.
+  // Styles an element with a secondary container color background. Use for components that need
+  // less emphasis than secondary, such as filter chips. In Angular Material, this is used for
+  // selected items in a list and the container of a tonal button.
   .mat-bg-secondary-container {
     background-color: var(--mat-sys-secondary-container);
-    color: var(--mat-sys-on-secondary-container);
   }
 
-  // Styles an element with an error color background and applies an accessible contrasting
-  // color for text and icons. Use for indicating an error state, such as an invalid text field, or
-  // for the background of an important notification. In Angular Material, this is used for the
-  // background of a badge.
+  // Styles an element with an error color background. Use for indicating an error state, such as
+  // an invalid text field, or for the background of an important notification. In Angular
+  // Material, this is used for the background of a badge.
   .mat-bg-error {
     background-color: var(--mat-sys-error);
-    color: var(--mat-sys-on-error);
   }
 
-  // Styles an element with an error container color background and applies an accessible
-  // contrasting color for text and icons. Use for components that need less emphasis than
-  // error, such as a container for error text.
+  // Styles an element with an error container color background. Use for components that need less
+  // emphasis than error, such as a container for error text.
   .mat-bg-error-container {
     background-color: var(--mat-sys-error-container);
-    color: var(--mat-sys-on-error-container);
   }
 
-  // Styles an element with a surface color background and applies an accessible contrasting
-  // color for text and icons. Use for general surfaces of components. In Angular Material, this is
-  // used for the background of many components, like tables, dialogs, menus, and toolbars.
+  // Styles an element with a surface color background. Use for general surfaces of components. In
+  // Angular Material, this is used for the background of many components, like tables, dialogs,
+  // menus, and toolbars.
   .mat-bg-surface {
     background-color: var(--mat-sys-surface);
-    color: var(--mat-sys-on-surface);
   }
 
-  // Styles an element with a surface variant color background and applies an accessible
-  // contrasting color for text and icons. Use for surfaces that need to stand out from the
-  // main surface color. In Angular Material, this is used for the background of a filled
-  // form field and the track of a progress bar.
+  // Styles an element with a surface variant color background. Use for surfaces that need to stand
+  // out from the main surface color. In Angular Material, this is used for the background of a
+  // filled form field and the track of a progress bar.
   .mat-bg-surface-variant {
     background-color: var(--mat-sys-surface-variant);
-    color: var(--mat-sys-on-surface-variant);
   }
 
-  // Styles an element with the "highest" surface container color background and applies an
-  // accessible contrasting color for text and icons. Use for surfaces that need the most
-  // emphasis against the main surface color. In Angular Material, this is used for the
-  // background of a filled card.
+  // Styles an element with the "highest" surface container color background. Use for surfaces that
+  // need the most emphasis against the main surface color. In Angular Material, this is used for
+  // the background of a filled card.
   .mat-bg-surface-container-highest {
     background-color: var(--mat-sys-surface-container-highest);
-    color: var(--mat-sys-on-surface);
   }
 
-  // Styles an element with a "high" surface container color background and applies an accessible
-  // contrasting color for text and icons. Use for surfaces that need more emphasis against
-  // the main surface color. In Angular Material, this is used for the background of a datepicker.
+  // Styles an element with a "high" surface container color background. Use for surfaces that need
+  // more emphasis against the main surface color. In Angular Material, this is used for the
+  // background of a datepicker.
   .mat-bg-surface-container-high {
     background-color: var(--mat-sys-surface-container-high);
-    color: var(--mat-sys-on-surface);
   }
 
-  // Styles an element with a surface container color background and applies an accessible
-  // contrasting color for text and icons. Use for surfaces that need to stand out from the
-  // main surface color. In Angular Material, this is used for the background of a menu.
+  // Styles an element with a surface container color background. Use for surfaces that need to
+  // stand out from the main surface color. In Angular Material, this is used for the background
+  // of a menu.
   .mat-bg-surface-container {
     background-color: var(--mat-sys-surface-container);
-    color: var(--mat-sys-on-surface);
   }
 
-  // Styles an element with a "low" surface container color background and applies an accessible
-  // contrasting color for text and icons. Use for surfaces that need less emphasis against
-  // the main surface color. In Angular Material, this is used for the background of a bottom sheet.
+  // Styles an element with a "low" surface container color background. Use for surfaces that need
+  // less emphasis against the main surface color. In Angular Material, this is used for the
+  // background of a bottom sheet.
   .mat-bg-surface-container-low {
     background-color: var(--mat-sys-surface-container-low);
-    color: var(--mat-sys-on-surface);
   }
 
-  // Styles an element with the "lowest" surface container color background and applies an
-  // accessible contrasting color for text and icons. Use for surfaces that need the least
-  // emphasis against the main surface color.
+  // Styles an element with the "lowest" surface container color background. Use for surfaces that
+  // need the least emphasis against the main surface color.
   .mat-bg-surface-container-lowest {
     background-color: var(--mat-sys-surface-container-lowest);
-    color: var(--mat-sys-on-surface);
   }
 
-  // Styles an element with an inverse surface color background and applies an accessible
-  // contrasting color for text and icons. Use for making elements stand out against the
-  // default color scheme. Good for temporary notifications. In Angular Material, this is used for
-  // the background of a snackbar and a tooltip.
+  // Styles an element with an inverse surface color background. Use for making elements stand out
+  // against the default color scheme. Good for temporary notifications. In Angular Material, this
+  // is used for the background of a snackbar and a tooltip.
   .mat-bg-inverse-surface {
     background-color: var(--mat-sys-inverse-surface);
-    color: var(--mat-sys-inverse-on-surface);
   }
 
-  // Styles an element with a disabled color background and applies an accessible contrasting
-  // color for text and icons. Use for disabled components. In Angular Material, this is used
-  // for components generally filled with the primary color but are currently disabled.
+  // Styles an element with a disabled color background. Use for disabled components. In Angular
+  // Material, this is used for components generally filled with the primary color but are
+  // currently disabled.
   .mat-bg-disabled {
-    color: color-mix(in srgb, var(--mat-sys-on-surface) 38%, transparent);
     background-color: color-mix(in srgb, var(--mat-sys-on-surface) 12%, transparent);
   }
 
@@ -145,8 +120,7 @@
     color: var(--mat-sys-primary);
   }
 
-  // Styles the text of an element with the secondary color. Use for text that needs less emphasis
-  // than primary text.
+  // Styles the text of an element with the secondary color. Use for text that needs to stand out.
   .mat-text-secondary {
     color: var(--mat-sys-secondary);
   }
@@ -158,11 +132,60 @@
   }
 
   // Styles the text of an element with the disabled color. Use for text in disabled components.
-  // In Angular Material this is used to show text is disabled, generally on a "surface" background.
   .mat-text-disabled {
     color: color-mix(in srgb, var(--mat-sys-on-surface) 38%, transparent);
   }
 
+  // Styles the text of an element with the on-surface-variant color. Use for text that should have
+  // a lower emphasis than the surrounding text. This can include subheading, captions, and hint
+  // text.
+  .mat-text-on-surface-variant {
+    color: var(--mat-sys-on-surface-variant);
+  }
+
+  // Styles the text of an element with a color that contrasts well against a primary background.
+  .mat-text-on-primary {
+    color: var(--mat-sys-on-primary);
+  }
+
+  // Styles the text of an element with a color that contrasts well against a primary-container
+  // background.
+  .mat-text-on-primary-container {
+    color: var(--mat-sys-on-primary-container);
+  }
+
+  // Styles the text of an element with a color that contrasts well against a secondary background.
+  .mat-text-on-secondary {
+    color: var(--mat-sys-on-secondary);
+  }
+
+  // Styles the text of an element with a color that contrasts well against a secondary-container
+  // background.
+  .mat-text-on-secondary-container {
+    color: var(--mat-sys-on-secondary-container);
+  }
+
+  // Styles the text of an element with a color that contrasts well against an error background.
+  .mat-text-on-error {
+    color: var(--mat-sys-on-error);
+  }
+
+  // Styles the text of an element with a color that contrasts well against an error-container
+  // background.
+  .mat-text-on-error-container {
+    color: var(--mat-sys-on-error-container);
+  }
+
+  // Styles the text of an element with a color that contrasts well against a surface background.
+  .mat-text-on-surface {
+    color: var(--mat-sys-on-surface);
+  }
+
+  // Styles the text of an element with a color that contrasts well against an inverse-surface
+  // background.
+  .mat-text-inverse-on-surface {
+    color: var(--mat-sys-inverse-on-surface);
+  }
 
   // ***********************************************************************************************
   // Font - Apply typography styles
@@ -230,6 +253,26 @@
   .mat-font-headline-lg {
     font: var(--mat-sys-headline-large);
     letter-spacing: var(--mat-sys-headline-large-tracking);
+  }
+
+  // Sets the font to the label small typeface. Use for small labels, such as text in a badge.
+  .mat-font-label-sm {
+    font: var(--mat-sys-label-small);
+    letter-spacing: var(--mat-sys-label-small-tracking);
+  }
+
+  // Sets the font to the label medium typeface. Use for medium labels. In Angular Material, this
+  // is used for the slider label.
+  .mat-font-label-md {
+    font: var(--mat-sys-label-medium);
+    letter-spacing: var(--mat-sys-label-medium-tracking);
+  }
+
+  // Sets the font to the label large typeface. Use for large labels. In Angular Material, this is
+  // used for buttons, chips, and menu labels.
+  .mat-font-label-lg {
+    font: var(--mat-sys-label-large);
+    letter-spacing: var(--mat-sys-label-large-tracking);
   }
 
   // Sets the font to the title small typeface. Use for small titles, such as a card title. In
@@ -316,68 +359,6 @@
   .mat-border-subtle {
     border: 1px solid var(--mat-sys-outline-variant);
   }
-
-
-  // ***********************************************************************************************
-  // Interactive - Adds interaction colors for hover, active, and focus
-  // ***********************************************************************************************
-
-  // Adds hover, focus, and active states to an element by applying varying shades of the surface
-  // color. Use for interactive components that are not based on a primary color.
-  .mat-interactive {
-    &:hover {
-      background: color-mix(
-        in srgb,
-        var(--mat-sys-on-surface) calc(var(--mat-sys-hover-state-layer-opacity) * 100%),
-        transparent
-      );
-    }
-
-    &:focus {
-      background: color-mix(
-        in srgb,
-        var(--mat-sys-on-surface) calc(var(--mat-sys-focus-state-layer-opacity) * 100%),
-        transparent
-      );
-    }
-
-    &:active {
-      background: color-mix(
-        in srgb,
-        var(--mat-sys-on-surface) calc(var(--mat-sys-pressed-state-layer-opacity) * 100%),
-        transparent
-      );
-    }
-  }
-
-  // Adds hover, focus, and active states to an element by applying varying shades of the primary
-  // color. Use for interactive components that are not based on a primary color.
-  .mat-interactive-primary {
-    &:hover {
-      background: color-mix(
-        in srgb,
-        var(--mat-sys-primary) calc(var(--mat-sys-hover-state-layer-opacity) * 100%),
-        transparent
-      );
-    }
-
-    &:focus {
-      background: color-mix(
-        in srgb,
-        var(--mat-sys-primary) calc(var(--mat-sys-focus-state-layer-opacity) * 100%),
-        transparent
-      );
-    }
-
-    &:active {
-      background: color-mix(
-        in srgb,
-        var(--mat-sys-primary) calc(var(--mat-sys-pressed-state-layer-opacity) * 100%),
-        transparent
-      );
-    }
-  }
-
 
   // ***********************************************************************************************
   // Shadow - Applies elevation levels through box-shadow


### PR DESCRIPTION
Moves `color` out of the `mat-bg` classes. Adds `mat-text` classes for all available text colors

LLMs seemed to get confused about it, and this is more aligned with how Tailwind handles styles