### PR TITLE
feat(material/radio): Hovering over label of a radio will show the pointer cursor

### DIFF
--- a/src/material/radio/radio.scss
+++ b/src/material/radio/radio.scss
@@ -11,6 +11,12 @@ $fallbacks: m3-radio.get-tokens();
   @include radio-common.radio-structure(true);
   @include radio-common.radio-noop-animations();
 
+  // Clicking the label toggles the radio, but MDC does not include any styles that inform the
+  // user of this. Therefore we add the pointer cursor on top of MDC's styles.
+  label {
+    cursor: pointer;
+  }
+
   .mdc-radio__background::before {
     background-color: token-utils.slot(radio-ripple-color, $fallbacks);
   }


### PR DESCRIPTION
This is consistent with checkbox behavior.

Radio used to work that way too until Angular Material v14. v15 broke it, and it remained broken until now.

Fixes #26067, at least partially

<img width="234" height="238" alt="image" src="https://github.com/user-attachments/assets/d595958e-6ac3-462e-bd63-d06c20e47bf5" />
