### PR TITLE
refactor(multiple): remove unnecessary dependency arrays

### DIFF
--- a/goldens/cdk/menu/index.api.md
+++ b/goldens/cdk/menu/index.api.md
@@ -21,7 +21,6 @@ import { Observable } from 'rxjs';
 import { OnChanges } from '@angular/core';
 import { OnDestroy } from '@angular/core';
 import { OnInit } from '@angular/core';
-import { Optional } from '@angular/core';
 import { QueryList } from '@angular/core';
 import { Renderer2 } from '@angular/core';
 import * as rxjs from 'rxjs';
@@ -368,15 +367,13 @@ export { MenuTracker }
 // @public
 export const PARENT_OR_NEW_INLINE_MENU_STACK_PROVIDER: (orientation: "vertical" | "horizontal") => {
     provide: InjectionToken<MenuStack>;
-    deps: Optional[][];
-    useFactory: (parentMenuStack?: MenuStack) => MenuStack;
+    useFactory: () => MenuStack;
 };
 
 // @public
 export const PARENT_OR_NEW_MENU_STACK_PROVIDER: {
     provide: InjectionToken<MenuStack>;
-    deps: Optional[][];
-    useFactory: (parentMenuStack?: MenuStack) => MenuStack;
+    useFactory: () => MenuStack;
 };
 
 // @public

--- a/src/cdk/menu/menu-stack.ts
+++ b/src/cdk/menu/menu-stack.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {inject, Inject, Injectable, InjectionToken, Optional, SkipSelf} from '@angular/core';
+import {inject, Injectable, InjectionToken} from '@angular/core';
 import {_IdGenerator} from '../a11y';
 import {Observable, Subject} from 'rxjs';
 import {debounceTime, distinctUntilChanged, startWith} from 'rxjs/operators';
@@ -30,8 +30,7 @@ export const MENU_STACK = new InjectionToken<MenuStack>('cdk-menu-stack');
 /** Provider that provides the parent menu stack, or a new menu stack if there is no parent one. */
 export const PARENT_OR_NEW_MENU_STACK_PROVIDER = {
   provide: MENU_STACK,
-  deps: [[new Optional(), new SkipSelf(), new Inject(MENU_STACK)]],
-  useFactory: (parentMenuStack?: MenuStack) => parentMenuStack || new MenuStack(),
+  useFactory: () => inject(MENU_STACK, {optional: true, skipSelf: true}) || new MenuStack(),
 };
 
 /** Provider that provides the parent menu stack, or a new inline menu stack if there is no parent one. */
@@ -39,8 +38,8 @@ export const PARENT_OR_NEW_INLINE_MENU_STACK_PROVIDER = (
   orientation: 'vertical' | 'horizontal',
 ) => ({
   provide: MENU_STACK,
-  deps: [[new Optional(), new SkipSelf(), new Inject(MENU_STACK)]],
-  useFactory: (parentMenuStack?: MenuStack) => parentMenuStack || MenuStack.inline(orientation),
+  useFactory: () =>
+    inject(MENU_STACK, {optional: true, skipSelf: true}) || MenuStack.inline(orientation),
 });
 
 /** Options that can be provided to the close or closeAll methods. */

--- a/src/cdk/observers/observe-content.spec.ts
+++ b/src/cdk/observers/observe-content.spec.ts
@@ -46,7 +46,6 @@ describe('Observe content directive', () => {
       // test this scenario reliably without risking flaky tests, which is why we supply a mock
       // MutationObserver and check that the methods are called at the right time.
       TestBed.overrideProvider(MutationObserverFactory, {
-        deps: [],
         useFactory: () => ({
           create: () => ({observe: observeSpy, disconnect: disconnectSpy}),
         }),

--- a/src/cdk/scrolling/virtual-scroll-viewport.ts
+++ b/src/cdk/scrolling/virtual-scroll-viewport.ts
@@ -19,12 +19,10 @@ import {
   effect,
   ElementRef,
   inject,
-  Inject,
   Injector,
   Input,
   OnDestroy,
   OnInit,
-  Optional,
   Output,
   signal,
   untracked,
@@ -74,11 +72,8 @@ const SCROLL_SCHEDULER =
   providers: [
     {
       provide: CdkScrollable,
-      useFactory: (
-        virtualScrollable: CdkVirtualScrollable | null,
-        viewport: CdkVirtualScrollViewport,
-      ) => virtualScrollable || viewport,
-      deps: [[new Optional(), new Inject(VIRTUAL_SCROLLABLE)], CdkVirtualScrollViewport],
+      useFactory: () =>
+        inject(VIRTUAL_SCROLLABLE, {optional: true}) || inject(CdkVirtualScrollViewport),
     },
   ],
 })

--- a/src/cdk/testing/private/fake-directionality.ts
+++ b/src/cdk/testing/private/fake-directionality.ts
@@ -33,6 +33,5 @@ export function provideFakeDirectionality(direction: Direction | WritableSignal<
     provide: Directionality,
     useFactory: () =>
       new FakeDirectionality(typeof direction === 'string' ? signal(direction) : direction),
-    deps: [],
   };
 }

--- a/src/material-date-fns-adapter/adapter/index.ts
+++ b/src/material-date-fns-adapter/adapter/index.ts
@@ -7,12 +7,7 @@
  */
 
 import {NgModule, Provider} from '@angular/core';
-import {
-  DateAdapter,
-  MAT_DATE_FORMATS,
-  MAT_DATE_LOCALE,
-  MatDateFormats,
-} from '@angular/material/core';
+import {DateAdapter, MAT_DATE_FORMATS, MatDateFormats} from '@angular/material/core';
 import {DateFnsAdapter} from './date-fns-adapter';
 import {MAT_DATE_FNS_FORMATS} from './date-fns-formats';
 
@@ -24,7 +19,6 @@ export * from './date-fns-formats';
     {
       provide: DateAdapter,
       useClass: DateFnsAdapter,
-      deps: [MAT_DATE_LOCALE],
     },
   ],
 })
@@ -40,7 +34,6 @@ export function provideDateFnsAdapter(formats: MatDateFormats = MAT_DATE_FNS_FOR
     {
       provide: DateAdapter,
       useClass: DateFnsAdapter,
-      deps: [MAT_DATE_LOCALE],
     },
     {provide: MAT_DATE_FORMATS, useValue: formats},
   ];

--- a/src/material-luxon-adapter/adapter/index.ts
+++ b/src/material-luxon-adapter/adapter/index.ts
@@ -7,13 +7,8 @@
  */
 
 import {NgModule, Provider} from '@angular/core';
-import {
-  DateAdapter,
-  MAT_DATE_FORMATS,
-  MAT_DATE_LOCALE,
-  MatDateFormats,
-} from '@angular/material/core';
-import {MAT_LUXON_DATE_ADAPTER_OPTIONS, LuxonDateAdapter} from './luxon-date-adapter';
+import {DateAdapter, MAT_DATE_FORMATS, MatDateFormats} from '@angular/material/core';
+import {LuxonDateAdapter} from './luxon-date-adapter';
 import {MAT_LUXON_DATE_FORMATS} from './luxon-date-formats';
 
 export * from './luxon-date-adapter';
@@ -24,7 +19,6 @@ export * from './luxon-date-formats';
     {
       provide: DateAdapter,
       useClass: LuxonDateAdapter,
-      deps: [MAT_DATE_LOCALE, MAT_LUXON_DATE_ADAPTER_OPTIONS],
     },
   ],
 })
@@ -42,7 +36,6 @@ export function provideLuxonDateAdapter(
     {
       provide: DateAdapter,
       useClass: LuxonDateAdapter,
-      deps: [MAT_DATE_LOCALE, MAT_LUXON_DATE_ADAPTER_OPTIONS],
     },
     {provide: MAT_DATE_FORMATS, useValue: formats},
   ];

--- a/src/material-moment-adapter/adapter/index.ts
+++ b/src/material-moment-adapter/adapter/index.ts
@@ -7,12 +7,7 @@
  */
 
 import {NgModule, Provider} from '@angular/core';
-import {
-  DateAdapter,
-  MAT_DATE_FORMATS,
-  MAT_DATE_LOCALE,
-  MatDateFormats,
-} from '@angular/material/core';
+import {DateAdapter, MAT_DATE_FORMATS, MatDateFormats} from '@angular/material/core';
 import {
   MAT_MOMENT_DATE_ADAPTER_OPTIONS,
   MatMomentDateAdapterOptions,
@@ -28,7 +23,6 @@ export * from './moment-date-formats';
     {
       provide: DateAdapter,
       useClass: MomentDateAdapter,
-      deps: [MAT_DATE_LOCALE, MAT_MOMENT_DATE_ADAPTER_OPTIONS],
     },
   ],
 })
@@ -47,7 +41,6 @@ export function provideMomentDateAdapter(
     {
       provide: DateAdapter,
       useClass: MomentDateAdapter,
-      deps: [MAT_DATE_LOCALE, MAT_MOMENT_DATE_ADAPTER_OPTIONS],
     },
     {provide: MAT_DATE_FORMATS, useValue: formats},
   ];

--- a/src/material/snack-bar/snack-bar.spec.ts
+++ b/src/material/snack-bar/snack-bar.spec.ts
@@ -509,7 +509,6 @@ describe('MatSnackBar', () => {
     viewContainerFixture.destroy();
 
     TestBed.resetTestingModule().overrideProvider(MAT_SNACK_BAR_DEFAULT_OPTIONS, {
-      deps: [],
       useFactory: () => ({panelClass: 'custom-class'}),
     });
 


### PR DESCRIPTION
We don't really need to use the `deps` arrays anymore since we've fully switched over to `inject`. These changes remove the leftovers.