### PR TITLE
fix(cdk/scrolling): Fix undefined error when documentElement.style is undefined

### DIFF
--- a/src/cdk/platform/features/scrolling.ts
+++ b/src/cdk/platform/features/scrolling.ts
@@ -42,7 +42,7 @@ export function supportsScrollBehavior(): boolean {
     }
 
     // If the element can have a `scrollBehavior` style, we can be sure that it's supported.
-    if ('scrollBehavior' in document.documentElement!.style) {
+    if (document.documentElement?.style && 'scrollBehavior' in document.documentElement!.style) {
       scrollBehaviorSupported = true;
     } else {
       // At this point we have 3 possibilities: `scrollTo` isn't supported at all, it's


### PR DESCRIPTION
Currently angular has a side effect which checks for scrollbehavior on module load. This is throwing an exception in our chrome extension content script when running on an xml page when style are undefined

Added a null check to make sure undefined exception is not thrown
<img width="1670" height="382" alt="image" src="https://github.com/user-attachments/assets/67ffbd21-1dc8-4658-bcbc-891b484cfdc2" />
