### PR TITLE
feat(material/chips): allow for modifiers to be specified on separator keys

### DIFF
--- a/goldens/material/chips/index.api.md
+++ b/goldens/material/chips/index.api.md
@@ -19,6 +19,7 @@ import * as i0 from '@angular/core';
 import * as i2 from '@angular/cdk/bidi';
 import { InjectionToken } from '@angular/core';
 import { Injector } from '@angular/core';
+import { ModifierKey } from '@angular/cdk/keycodes';
 import { NgControl } from '@angular/forms';
 import { NgForm } from '@angular/forms';
 import { NgZone } from '@angular/core';
@@ -304,7 +305,7 @@ export class MatChipInput implements MatChipTextControl, OnChanges, OnDestroy {
     _onInput(): void;
     placeholder: string;
     readonly: boolean;
-    separatorKeyCodes: readonly number[] | ReadonlySet<number>;
+    separatorKeyCodes: readonly (number | SeparatorKey)[] | ReadonlySet<number | SeparatorKey>;
     // (undocumented)
     setDescribedByIds(ids: string[]): void;
     // (undocumented)
@@ -472,7 +473,7 @@ export class MatChipRow extends MatChip implements AfterViewInit {
 export interface MatChipsDefaultOptions {
     hideSingleSelectionIndicator?: boolean;
     inputDisabledInteractive?: boolean;
-    separatorKeyCodes: readonly number[] | ReadonlySet<number>;
+    separatorKeyCodes: readonly (number | SeparatorKey)[] | ReadonlySet<number | SeparatorKey>;
 }
 
 // @public
@@ -562,6 +563,14 @@ export class MatChipTrailingIcon extends MatChipContent {
     static ɵdir: i0.ɵɵDirectiveDeclaration<MatChipTrailingIcon, "mat-chip-trailing-icon, [matChipTrailingIcon]", never, {}, {}, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatChipTrailingIcon, never>;
+}
+
+// @public
+export interface SeparatorKey {
+    // (undocumented)
+    keyCode: number;
+    // (undocumented)
+    modifiers: readonly ModifierKey[];
 }
 
 // (No @packageDocumentation comment for this package)

--- a/src/material/chips/chip-input.spec.ts
+++ b/src/material/chips/chip-input.spec.ts
@@ -303,6 +303,40 @@ describe('MatChipInput', () => {
 
       expect(testChipInput.add).not.toHaveBeenCalled();
     });
+
+    it('should ignore modifier keys when `SeparatorKey.modifiers` is empty', () => {
+      spyOn(testChipInput, 'add');
+
+      chipInputDirective.separatorKeyCodes = [{keyCode: COMMA, modifiers: []}];
+      fixture.detectChanges();
+
+      // With a modifier.
+      dispatchKeyboardEvent(inputNativeElement, 'keydown', COMMA, undefined, {shift: true});
+      expect(testChipInput.add).not.toHaveBeenCalled();
+
+      // Without a modifier.
+      dispatchKeyboardEvent(inputNativeElement, 'keydown', COMMA);
+      expect(testChipInput.add).toHaveBeenCalledTimes(1);
+    });
+
+    it('should only allow modifiers from the `SeparatorKey.modifiers` array', () => {
+      spyOn(testChipInput, 'add');
+
+      chipInputDirective.separatorKeyCodes = [{keyCode: COMMA, modifiers: ['ctrlKey']}];
+      fixture.detectChanges();
+
+      // Without a modifier.
+      dispatchKeyboardEvent(inputNativeElement, 'keydown', COMMA);
+      expect(testChipInput.add).not.toHaveBeenCalled();
+
+      // With a different modifier.
+      dispatchKeyboardEvent(inputNativeElement, 'keydown', COMMA, undefined, {shift: true});
+      expect(testChipInput.add).not.toHaveBeenCalled();
+
+      // With the correct modifier.
+      dispatchKeyboardEvent(inputNativeElement, 'keydown', COMMA, undefined, {control: true});
+      expect(testChipInput.add).toHaveBeenCalledTimes(1);
+    });
   });
 });
 

--- a/src/material/chips/tokens.ts
+++ b/src/material/chips/tokens.ts
@@ -6,13 +6,19 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ENTER} from '@angular/cdk/keycodes';
+import {ENTER, ModifierKey} from '@angular/cdk/keycodes';
 import {InjectionToken} from '@angular/core';
+
+/** Key that can be used as a separator between chips. */
+export interface SeparatorKey {
+  keyCode: number;
+  modifiers: readonly ModifierKey[];
+}
 
 /** Default options, for the chips module, that can be overridden. */
 export interface MatChipsDefaultOptions {
   /** The list of key codes that will trigger a chipEnd event. */
-  separatorKeyCodes: readonly number[] | ReadonlySet<number>;
+  separatorKeyCodes: readonly (number | SeparatorKey)[] | ReadonlySet<number | SeparatorKey>;
 
   /** Whether icon indicators should be hidden for single-selection. */
   hideSingleSelectionIndicator?: boolean;


### PR DESCRIPTION
Currently we ignore separator keys if any modifier is pressed, but in some cases that might not be desirable. These changes add an option to specify a separator key with modifiers so that users can customize the behavior.