### PR TITLE
fix(material/core): remove deprecated APIs for v21

### DIFF
--- a/goldens/material/core/index.api.md
+++ b/goldens/material/core/index.api.md
@@ -29,28 +29,6 @@ import { Signal } from '@angular/core';
 import { Subject } from 'rxjs';
 import { Version } from '@angular/core';
 
-// @public @deprecated (undocumented)
-export class AnimationCurves {
-    // (undocumented)
-    static ACCELERATION_CURVE: string;
-    // (undocumented)
-    static DECELERATION_CURVE: string;
-    // (undocumented)
-    static SHARP_CURVE: string;
-    // (undocumented)
-    static STANDARD_CURVE: string;
-}
-
-// @public @deprecated (undocumented)
-export class AnimationDurations {
-    // (undocumented)
-    static COMPLEX: string;
-    // (undocumented)
-    static ENTERING: string;
-    // (undocumented)
-    static EXITING: string;
-}
-
 // @public
 export interface AnimationsConfig {
     animationsDisabled?: boolean;
@@ -446,8 +424,6 @@ export class NativeDateAdapter extends DateAdapter<Date> {
     today(): Date;
     // (undocumented)
     toIso8601(date: Date): string;
-    // @deprecated (undocumented)
-    useUtcForDisplay: boolean;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<NativeDateAdapter, never>;
     // (undocumented)

--- a/src/material/core/animation/animation.ts
+++ b/src/material/core/animation/animation.ts
@@ -18,29 +18,6 @@ export interface AnimationsConfig {
 /** Injection token used to configure the animations in Angular Material. */
 export const MATERIAL_ANIMATIONS = new InjectionToken<AnimationsConfig>('MATERIAL_ANIMATIONS');
 
-/**
- * @deprecated No longer used, will be removed.
- * @breaking-change 21.0.0
- * @docs-private
- */
-export class AnimationCurves {
-  static STANDARD_CURVE = 'cubic-bezier(0.4,0.0,0.2,1)';
-  static DECELERATION_CURVE = 'cubic-bezier(0.0,0.0,0.2,1)';
-  static ACCELERATION_CURVE = 'cubic-bezier(0.4,0.0,1,1)';
-  static SHARP_CURVE = 'cubic-bezier(0.4,0.0,0.6,1)';
-}
-
-/**
- * @deprecated No longer used, will be removed.
- * @breaking-change 21.0.0
- * @docs-private
- */
-export class AnimationDurations {
-  static COMPLEX = '375ms';
-  static ENTERING = '225ms';
-  static EXITING = '195ms';
-}
-
 let reducedMotion: boolean | null = null;
 
 /**

--- a/src/material/core/datetime/native-date-adapter.ts
+++ b/src/material/core/datetime/native-date-adapter.ts
@@ -42,12 +42,6 @@ function range<T>(length: number, valueFunction: (index: number) => T): T[] {
 /** Adapts the native JS Date for use with cdk-based components that work with dates. */
 @Injectable()
 export class NativeDateAdapter extends DateAdapter<Date> {
-  /**
-   * @deprecated No longer being used. To be removed.
-   * @breaking-change 14.0.0
-   */
-  useUtcForDisplay: boolean = false;
-
   /** The injected locale. */
   private readonly _matDateLocale = inject(MAT_DATE_LOCALE, {optional: true});
 


### PR DESCRIPTION
Deletes APIs that were marked for removal in v21.

BREAKING CHANGE:
* `AnimationCurves` has been removed.
* `AnimationDurations` has been removed.
* `NativeDateAdapter.useUtcForDisplay` has been removed.