### PR TITLE
fix(material/menu): switch internal state to signals

### DIFF
--- a/goldens/material/menu/index.api.md
+++ b/goldens/material/menu/index.api.md
@@ -100,7 +100,7 @@ export class MatMenu implements AfterContentInit, MatMenuPanel<MatMenuItem>, OnI
     _handleKeydown(event: KeyboardEvent): void;
     hasBackdrop?: boolean;
     _hovered(): Observable<MatMenuItem>;
-    _isAnimating: boolean;
+    _isAnimating: i0.WritableSignal<boolean>;
     // @deprecated
     items: QueryList<MatMenuItem>;
     lazyContent: MatMenuContent;

--- a/src/material/menu/menu.html
+++ b/src/material/menu/menu.html
@@ -5,7 +5,7 @@
     [class]="_classList"
     [class.mat-menu-panel-animations-disabled]="_animationsDisabled"
     [class.mat-menu-panel-exit-animation]="_panelAnimationState === 'void'"
-    [class.mat-menu-panel-animating]="_isAnimating"
+    [class.mat-menu-panel-animating]="_isAnimating()"
     (click)="closed.emit('click')"
     tabindex="-1"
     role="menu"

--- a/src/material/menu/menu.ts
+++ b/src/material/menu/menu.ts
@@ -29,6 +29,7 @@ import {
   AfterRenderRef,
   inject,
   Injector,
+  signal,
 } from '@angular/core';
 import {_IdGenerator, FocusKeyManager, FocusOrigin} from '@angular/cdk/a11y';
 import {Direction} from '@angular/cdk/bidi';
@@ -137,7 +138,7 @@ export class MatMenu implements AfterContentInit, MatMenuPanel<MatMenuItem>, OnI
   readonly _animationDone = new Subject<'void' | 'enter'>();
 
   /** Whether the menu is animating. */
-  _isAnimating = false;
+  _isAnimating = signal(false);
 
   /** Parent menu of the current menu panel. */
   parentMenu: MatMenuPanel | undefined;
@@ -461,13 +462,13 @@ export class MatMenu implements AfterContentInit, MatMenuPanel<MatMenuItem>, OnI
         this._exitFallbackTimeout = undefined;
       }
       this._animationDone.next(isExit ? 'void' : 'enter');
-      this._isAnimating = false;
+      this._isAnimating.set(false);
     }
   }
 
   protected _onAnimationStart(state: string) {
     if (state === ENTER_ANIMATION || state === EXIT_ANIMATION) {
-      this._isAnimating = true;
+      this._isAnimating.set(true);
     }
   }
 


### PR DESCRIPTION
Switches the `_isAnimating` state to a signal in order to avoid "changed after checked" errors.

Fixes #31933.