### PR TITLE
fix(material/radio): add missing disabled styles

### DIFF
--- a/src/material/checkbox/_checkbox-common.scss
+++ b/src/material/checkbox/_checkbox-common.scss
@@ -63,6 +63,10 @@ $_fallback-size: 40px;
   .mdc-checkbox--disabled {
     cursor: default;
     pointer-events: none;
+
+    @include cdk.high-contrast {
+      color: GrayText;
+    }
   }
 
   .mdc-checkbox__background {

--- a/src/material/list/_list-item-hcm-indicator.scss
+++ b/src/material/list/_list-item-hcm-indicator.scss
@@ -1,6 +1,6 @@
 @use '@angular/cdk';
 
-// Renders a circle indicator when Windows Hich Constrast mode (HCM) is enabled. In some
+// Renders a circle indicator when Windows High Contrast mode (HCM) is enabled. In some
 // situations, such as a selected option, the list item communicates the selected state by changing
 // its background color. Since that doesn't work in HCM, this mixin provides an alternative by
 // rendering a circle.

--- a/src/material/radio/_radio-common.scss
+++ b/src/material/radio/_radio-common.scss
@@ -77,6 +77,15 @@ $fallbacks: m3-radio.get-tokens();
         }
       }
     }
+
+    .mdc-radio--disabled {
+      cursor: default;
+      pointer-events: none;
+
+      @include cdk.high-contrast {
+        color: GrayText;
+      }
+    }
   }
 
   .mdc-radio__background {
@@ -149,7 +158,8 @@ $fallbacks: m3-radio.get-tokens();
     width: token-utils.slot(radio-state-layer-size, $fallbacks);
     height: token-utils.slot(radio-state-layer-size, $fallbacks);
 
-    &:checked, &:disabled {
+    &:checked,
+    &:disabled {
       + .mdc-radio__background {
         transition: _enter-transition(opacity), _enter-transition(transform);
 
@@ -236,13 +246,10 @@ $fallbacks: m3-radio.get-tokens();
     &.mat-mdc-radio-disabled-interactive .mdc-radio--disabled {
       pointer-events: auto;
 
-      // stylelint-disable selector-combinator-space-before
-      .mdc-radio__native-control:not(:checked) + .mdc-radio__background
-          > .mdc-radio__outer-circle {
+      .mdc-radio__native-control:not(:checked) + .mdc-radio__background > .mdc-radio__outer-circle {
         border-color: token-utils.slot(radio-disabled-unselected-icon-color, $fallbacks);
         opacity: token-utils.slot(radio-disabled-unselected-icon-opacity, $fallbacks);
       }
-      // stylelint-enable selector-combinator-space-before
 
       &:hover .mdc-radio__native-control:checked + .mdc-radio__background,
       .mdc-radio__native-control:checked:focus + .mdc-radio__background,


### PR DESCRIPTION
Adds proper cursor, pointer-events, and high-contrast opacity for `.mdc-radio--disabled`.

Fixes #31937