### PR TITLE
fix(cdk/scrolling): prevent subpixel gaps in virtual scroll viewport

### DIFF
--- a/src/cdk/scrolling/fixed-size-virtual-scroll.ts
+++ b/src/cdk/scrolling/fixed-size-virtual-scroll.ts
@@ -174,7 +174,7 @@ export class FixedSizeVirtualScrollStrategy implements VirtualScrollStrategy {
     }
 
     this._viewport.setRenderedRange(newRange);
-    this._viewport.setRenderedContentOffset(this._itemSize * newRange.start);
+    this._viewport.setRenderedContentOffset(Math.round(this._itemSize * newRange.start));
     this._scrolledIndexChange.next(Math.floor(firstVisibleIndex));
   }
 }


### PR DESCRIPTION
This PR fixes the issue where cdk-virtual-scroll-viewport renders visible gaps between items at certain zoom levels or scroll positions.

Problem:
Thin gaps (~0.5px) appear between consecutive rows when using *cdkVirtualFor

Issue occurs due to subpixel rounding in offset calculations

Most noticeable when zooming browser window or at specific scroll positions

Solution:
Added Math.round() to the offset calculation in setRenderedContentOffset()

Ensures all item positions are rounded to whole pixels

Eliminates subpixel gaps while maintaining smooth scrolling

Changes:

Single line change in fixed-size-virtual-scroll.ts

Wraps this._itemSize * newRange.start with Math.round()

Testing
Tested with different zoom levels (300%)

Verified no gaps appear between items during scrolling

Confirmed smooth scrolling behavior is preserved

Fixes #31824

