### PR TITLE
fix(material/paginator): trim extraneous announcements

### DIFF
--- a/src/material/paginator/paginator.html
+++ b/src/material/paginator/paginator.html
@@ -2,7 +2,7 @@
   <div class="mat-mdc-paginator-container">
     @if (!hidePageSize) {
       <div class="mat-mdc-paginator-page-size">
-        <div class="mat-mdc-paginator-page-size-label" [attr.id]="_pageSizeLabelId">
+        <div class="mat-mdc-paginator-page-size-label" [attr.id]="_pageSizeLabelId" aria-hidden="true">
           {{_intl.itemsPerPageLabel}}
         </div>
 
@@ -37,7 +37,7 @@
     }
 
     <div class="mat-mdc-paginator-range-actions">
-      <div class="mat-mdc-paginator-range-label" aria-live="polite">
+      <div class="mat-mdc-paginator-range-label" aria-atomic="true" aria-live="polite" role="status">
         {{_intl.getRangeLabel(pageIndex, pageSize, length)}}
       </div>
 


### PR DESCRIPTION
Fixes b/447648716 by tweaking html and aria attributes to remove on extra announcement with voice over, and amend other one.

Hide the select label from aria as already used for the labelel-by so it does not read off as two annoucements (one with group appended)

Add role of status to the live annouce of the page count, so it will still read a second time but at least will announce correctly as a status message instead of just generic group.

There are a lot of similar issues with divs causing extra announcements with VO. This at least mitigates a little and makes it make more sense.