### PR TITLE
fix(material/menu): prevent child menu reopening while parent is animating away

### DIFF
--- a/src/material/menu/menu-trigger.ts
+++ b/src/material/menu/menu-trigger.ts
@@ -211,7 +211,12 @@ export class MatMenuTrigger extends MatMenuTriggerBase implements AfterContentIn
     // Subscribe to changes in the hovered item in order to toggle the panel.
     if (this.triggersSubmenu() && this._parentMaterialMenu) {
       this._hoverSubscription = this._parentMaterialMenu._hovered().subscribe(active => {
-        if (active === this._menuItemInstance && !active.disabled) {
+        if (
+          active === this._menuItemInstance &&
+          !active.disabled &&
+          // Ignore hover events if the parent menu is in the process of being closed (see #31956).
+          this._parentMaterialMenu?._panelAnimationState !== 'void'
+        ) {
           this._openedBy = 'mouse';
           // Open the menu, but do NOT auto-focus on first item when just hovering.
           // When VoiceOver is enabled, this is particularly confusing as the focus will


### PR DESCRIPTION
Fixes that it was possible for the user to re-open a child menu if they quickly hover back to the parent meny while it's animating away.

Fixes #31956.