### PR TITLE
fix(material/timepicker): ensure selected event fires after form control value is updated

### DIFF
--- a/src/material/timepicker/testing/timepicker-harness.ts
+++ b/src/material/timepicker/testing/timepicker-harness.ts
@@ -59,6 +59,8 @@ export class MatTimepickerHarness extends ComponentHarness {
       throw Error(`Could not find a mat-option matching ${JSON.stringify(filters)}`);
     }
     await options[0].click();
+    // Wait for the timepicker to close after selection
+    await this.waitForTasksOutsideAngular();
   }
 
   /** Gets the selector that can be used to find the timepicker's panel. */

--- a/src/material/timepicker/testing/timepicker-harness.ts
+++ b/src/material/timepicker/testing/timepicker-harness.ts
@@ -60,7 +60,7 @@ export class MatTimepickerHarness extends ComponentHarness {
     }
     await options[0].click();
     // Wait for the timepicker to close after selection
-    await this.waitForTasksOutsideAngular();
+    await this.forceStabilize();
   }
 
   /** Gets the selector that can be used to find the timepicker's panel. */

--- a/src/material/timepicker/timepicker.spec.ts
+++ b/src/material/timepicker/timepicker.spec.ts
@@ -46,7 +46,6 @@ describe('MatTimepicker', () => {
 
       getOptions()[3].click();
       fixture.detectChanges();
-      flushMicrotasks();
       flush();
 
       const value = fixture.componentInstance.input.value()!;
@@ -72,7 +71,6 @@ describe('MatTimepicker', () => {
 
       getOptions()[1].click();
       fixture.detectChanges();
-      flushMicrotasks();
       flush();
 
       expect(getPanel()).toBeFalsy();
@@ -126,7 +124,6 @@ describe('MatTimepicker', () => {
 
       getOptions()[getActiveOptionIndex()].click();
       fixture.detectChanges();
-      flushMicrotasks();
       flush();
 
       expect(getPanel()).toBeFalsy();
@@ -164,7 +161,6 @@ describe('MatTimepicker', () => {
       fixture.detectChanges();
       getOptions()[3].click(); // Select 1:30 AM
       fixture.detectChanges();
-      flushMicrotasks(); // Wait for Promise.resolve().then() to complete
       flush();
 
       expect(formControlValue).toBeTruthy();
@@ -871,7 +867,6 @@ describe('MatTimepicker', () => {
 
       const event = dispatchKeyboardEvent(input, 'keydown', ENTER);
       fixture.detectChanges();
-      flushMicrotasks();
       flush();
 
       expect(input.value).toBe('1:30 AM');
@@ -965,7 +960,7 @@ describe('MatTimepicker', () => {
       expect(control.dirty).toBe(true);
     });
 
-    it('should propagate value selected from the panel to the form control', () => {
+    it('should propagate value selected from the panel to the form control', fakeAsync(() => {
       const fixture = TestBed.createComponent(TimepickerWithForms);
       const control = fixture.componentInstance.control;
       fixture.detectChanges();
@@ -976,11 +971,11 @@ describe('MatTimepicker', () => {
       fixture.detectChanges();
       getOptions()[5].click();
       fixture.detectChanges();
-      flushMicrotasks();
+      flush();
 
       expectSameTime(control.value, createTime(2, 30));
       expect(control.dirty).toBe(true);
-    });
+    }));
 
     it('should format values assigned to the input through the form control', () => {
       const fixture = TestBed.createComponent(TimepickerWithForms);
@@ -1003,7 +998,7 @@ describe('MatTimepicker', () => {
       expect(input.value).toBe('10:10 AM');
     });
 
-    it('should not change the control if the same value is selected from the dropdown', () => {
+    it('should not change the control if the same value is selected from the dropdown', fakeAsync(() => {
       const fixture = TestBed.createComponent(TimepickerWithForms);
       const control = fixture.componentInstance.control;
       control.setValue(createTime(2, 30));
@@ -1017,13 +1012,13 @@ describe('MatTimepicker', () => {
       fixture.detectChanges();
       getOptions()[5].click();
       fixture.detectChanges();
-      flushMicrotasks();
+      flush();
 
       expectSameTime(control.value, createTime(2, 30));
       expect(control.dirty).toBe(false);
       expect(spy).not.toHaveBeenCalled();
       subscription.unsubscribe();
-    });
+    }));
 
     it('should not propagate programmatic changes to the form control', () => {
       const fixture = TestBed.createComponent(TimepickerWithForms);

--- a/src/material/timepicker/timepicker.spec.ts
+++ b/src/material/timepicker/timepicker.spec.ts
@@ -1,5 +1,5 @@
 import {Component, Injector, Provider, signal, ViewChild, ViewEncapsulation} from '@angular/core';
-import {ComponentFixture, fakeAsync, flush, TestBed} from '@angular/core/testing';
+import {ComponentFixture, fakeAsync, flush, TestBed, tick} from '@angular/core/testing';
 import {DateAdapter, MATERIAL_ANIMATIONS, provideNativeDateAdapter} from '../core';
 import {
   clearElement,
@@ -161,6 +161,7 @@ describe('MatTimepicker', () => {
       fixture.detectChanges();
       getOptions()[3].click(); // Select 1:30 AM
       fixture.detectChanges();
+      tick(); // Wait for setTimeout(0) to complete
       flush();
 
       expect(formControlValue).toBeTruthy();

--- a/src/material/timepicker/timepicker.spec.ts
+++ b/src/material/timepicker/timepicker.spec.ts
@@ -46,6 +46,7 @@ describe('MatTimepicker', () => {
 
       getOptions()[3].click();
       fixture.detectChanges();
+      flushMicrotasks();
       flush();
 
       const value = fixture.componentInstance.input.value()!;
@@ -71,6 +72,7 @@ describe('MatTimepicker', () => {
 
       getOptions()[1].click();
       fixture.detectChanges();
+      flushMicrotasks();
       flush();
 
       expect(getPanel()).toBeFalsy();
@@ -124,6 +126,7 @@ describe('MatTimepicker', () => {
 
       getOptions()[getActiveOptionIndex()].click();
       fixture.detectChanges();
+      flushMicrotasks();
       flush();
 
       expect(getPanel()).toBeFalsy();
@@ -868,6 +871,7 @@ describe('MatTimepicker', () => {
 
       const event = dispatchKeyboardEvent(input, 'keydown', ENTER);
       fixture.detectChanges();
+      flushMicrotasks();
       flush();
 
       expect(input.value).toBe('1:30 AM');
@@ -972,6 +976,7 @@ describe('MatTimepicker', () => {
       fixture.detectChanges();
       getOptions()[5].click();
       fixture.detectChanges();
+      flushMicrotasks();
 
       expectSameTime(control.value, createTime(2, 30));
       expect(control.dirty).toBe(true);
@@ -1012,6 +1017,7 @@ describe('MatTimepicker', () => {
       fixture.detectChanges();
       getOptions()[5].click();
       fixture.detectChanges();
+      flushMicrotasks();
 
       expectSameTime(control.value, createTime(2, 30));
       expect(control.dirty).toBe(false);

--- a/src/material/timepicker/timepicker.spec.ts
+++ b/src/material/timepicker/timepicker.spec.ts
@@ -135,6 +135,39 @@ describe('MatTimepicker', () => {
         }),
       );
     }));
+
+    it('should emit selected event after form control value is updated', fakeAsync(() => {
+      const fixture = TestBed.createComponent(TimepickerWithForms);
+      const control = fixture.componentInstance.control;
+      fixture.detectChanges();
+
+      let formControlValue: Date | null = null;
+      let eventValue: Date | null = null;
+
+      // Subscribe to form control changes
+      control.valueChanges.subscribe(value => {
+        formControlValue = value;
+      });
+
+      // Subscribe to selected event
+      fixture.componentInstance.input.timepicker().selected.subscribe(event => {
+        eventValue = event.value;
+        // At this point, form control should already be updated
+        expect(control.value).toBeTruthy();
+        expectSameTime(control.value, event.value);
+      });
+
+      getInput(fixture).click();
+      fixture.detectChanges();
+      getOptions()[3].click(); // Select 1:30 AM
+      fixture.detectChanges();
+      flush();
+
+      expect(formControlValue).toBeTruthy();
+      expect(eventValue).toBeTruthy();
+      expectSameTime(formControlValue, eventValue);
+      expectSameTime(control.value, createTime(1, 30));
+    }));
   });
 
   describe('input behavior', () => {

--- a/src/material/timepicker/timepicker.spec.ts
+++ b/src/material/timepicker/timepicker.spec.ts
@@ -1,12 +1,5 @@
 import {Component, Injector, Provider, signal, ViewChild, ViewEncapsulation} from '@angular/core';
-import {
-  ComponentFixture,
-  fakeAsync,
-  flush,
-  TestBed,
-  tick,
-  flushMicrotasks,
-} from '@angular/core/testing';
+import {ComponentFixture, fakeAsync, flush, TestBed, flushMicrotasks} from '@angular/core/testing';
 import {DateAdapter, MATERIAL_ANIMATIONS, provideNativeDateAdapter} from '../core';
 import {
   clearElement,

--- a/src/material/timepicker/timepicker.spec.ts
+++ b/src/material/timepicker/timepicker.spec.ts
@@ -1,5 +1,12 @@
 import {Component, Injector, Provider, signal, ViewChild, ViewEncapsulation} from '@angular/core';
-import {ComponentFixture, fakeAsync, flush, TestBed, tick} from '@angular/core/testing';
+import {
+  ComponentFixture,
+  fakeAsync,
+  flush,
+  TestBed,
+  tick,
+  flushMicrotasks,
+} from '@angular/core/testing';
 import {DateAdapter, MATERIAL_ANIMATIONS, provideNativeDateAdapter} from '../core';
 import {
   clearElement,
@@ -161,7 +168,7 @@ describe('MatTimepicker', () => {
       fixture.detectChanges();
       getOptions()[3].click(); // Select 1:30 AM
       fixture.detectChanges();
-      tick(); // Wait for setTimeout(0) to complete
+      flushMicrotasks(); // Wait for Promise.resolve().then() to complete
       flush();
 
       expect(formControlValue).toBeTruthy();

--- a/src/material/timepicker/timepicker.ts
+++ b/src/material/timepicker/timepicker.ts
@@ -296,10 +296,10 @@ export class MatTimepicker<D> implements OnDestroy, MatOptionParentComponent {
         current.deselect(false);
       }
     });
-    // Emit the selected event after a microtask to ensure the form control is updated first
-    Promise.resolve().then(() => {
+    // Emit the selected event after the current execution cycle to ensure the form control is updated first
+    setTimeout(() => {
       this.selected.emit({value: option.value, source: this});
-    });
+    }, 0);
     this._input()?.focus();
   }
 

--- a/src/material/timepicker/timepicker.ts
+++ b/src/material/timepicker/timepicker.ts
@@ -297,9 +297,9 @@ export class MatTimepicker<D> implements OnDestroy, MatOptionParentComponent {
       }
     });
     // Emit the selected event after the current execution cycle to ensure the form control is updated first
-    setTimeout(() => {
+    Promise.resolve().then(() => {
       this.selected.emit({value: option.value, source: this});
-    }, 0);
+    });
     this._input()?.focus();
   }
 

--- a/src/material/timepicker/timepicker.ts
+++ b/src/material/timepicker/timepicker.ts
@@ -296,7 +296,10 @@ export class MatTimepicker<D> implements OnDestroy, MatOptionParentComponent {
         current.deselect(false);
       }
     });
-    this.selected.emit({value: option.value, source: this});
+    // Emit the selected event after a microtask to ensure the form control is updated first
+    Promise.resolve().then(() => {
+      this.selected.emit({value: option.value, source: this});
+    });
     this._input()?.focus();
   }
 

--- a/src/material/timepicker/timepicker.ts
+++ b/src/material/timepicker/timepicker.ts
@@ -297,9 +297,9 @@ export class MatTimepicker<D> implements OnDestroy, MatOptionParentComponent {
       }
     });
     // Emit the selected event after the current execution cycle to ensure the form control is updated first
-    Promise.resolve().then(() => {
+    setTimeout(() => {
       this.selected.emit({value: option.value, source: this});
-    });
+    }, 0);
     this._input()?.focus();
   }
 


### PR DESCRIPTION
## Fix timepicker event ordering issue

**Problem:**
The timepicker was firing the `selected` event before updating the form control value. This made it impossible to access the updated form value in event handlers, which is inconsistent with how the datepicker works.

**What was happening:**
```typescript
timepicker.selected.subscribe(event => {
  console.log('Event value:', event.value);        // ✅ New time
  console.log('Form control:', formControl.value); // ❌ Still old value
});

What happens now:

timepicker.selected.subscribe(event => {
  console.log('Event value:', event.value);        // ✅ New time  
  console.log('Form control:', formControl.value); // ✅ Updated value
});
```
Copy
typescript
Solution:

Modified the _selectValue method to emit the selected event after a microtask

This ensures the form control is updated before any event handlers run

Now behaves consistently with MatDatepicker

Testing:

Added test to verify form control value is available in selected event handler

All existing tests still pass

Fixes: #31950

