### PR TITLE
fix(material/datepicker): error due to synchronous change detection

### DIFF
--- a/goldens/material/datepicker/index.api.md
+++ b/goldens/material/datepicker/index.api.md
@@ -667,8 +667,8 @@ export class MatMonthView<D> implements AfterContentInit, OnChanges, OnDestroy {
     // (undocumented)
     readonly _changeDetectorRef: ChangeDetectorRef;
     comparisonEnd: D | null;
-    _comparisonRangeEnd: number | null;
-    _comparisonRangeStart: number | null;
+    _comparisonRangeEnd: i0.WritableSignal<number | null>;
+    _comparisonRangeStart: i0.WritableSignal<number | null>;
     comparisonStart: D | null;
     // (undocumented)
     _dateAdapter: DateAdapter<D, any>;
@@ -679,19 +679,19 @@ export class MatMonthView<D> implements AfterContentInit, OnChanges, OnDestroy {
     protected _dragEnded(event: MatCalendarUserEvent<D | null>): void;
     readonly dragStarted: EventEmitter<MatCalendarUserEvent<D>>;
     endDateAccessibleName: string | null;
-    _firstWeekOffset: number;
+    _firstWeekOffset: i0.WritableSignal<number>;
     _focusActiveCell(movePreview?: boolean): void;
     _focusActiveCellAfterViewChecked(): void;
     _handleCalendarBodyKeydown(event: KeyboardEvent): void;
     _handleCalendarBodyKeyup(event: KeyboardEvent): void;
     _init(): void;
-    _isRange: boolean;
+    _isRange: i0.WritableSignal<boolean>;
     _matCalendarBody: MatCalendarBody;
     get maxDate(): D | null;
     set maxDate(value: D | null);
     get minDate(): D | null;
     set minDate(value: D | null);
-    _monthLabel: string;
+    _monthLabel: i0.WritableSignal<string>;
     // (undocumented)
     ngAfterContentInit(): void;
     // (undocumented)
@@ -699,23 +699,23 @@ export class MatMonthView<D> implements AfterContentInit, OnChanges, OnDestroy {
     // (undocumented)
     ngOnDestroy(): void;
     _previewChanged({ event, value: cell }: MatCalendarUserEvent<MatCalendarCell<D> | null>): void;
-    _previewEnd: number | null;
-    _previewStart: number | null;
-    _rangeEnd: number | null;
-    _rangeStart: number | null;
+    _previewEnd: i0.WritableSignal<number | null>;
+    _previewStart: i0.WritableSignal<number | null>;
+    _rangeEnd: i0.WritableSignal<number | null>;
+    _rangeStart: i0.WritableSignal<number | null>;
     get selected(): DateRange<D> | D | null;
     set selected(value: DateRange<D> | D | null);
     readonly selectedChange: EventEmitter<D | null>;
     startDateAccessibleName: string | null;
-    _todayDate: number | null;
+    _todayDate: i0.WritableSignal<number | null>;
     _updateActiveDate(event: MatCalendarUserEvent<number>): void;
     readonly _userSelection: EventEmitter<MatCalendarUserEvent<D | null>>;
-    _weekdays: {
+    _weekdays: i0.WritableSignal<{
         long: string;
         narrow: string;
         id: number;
-    }[];
-    _weeks: MatCalendarCell[][];
+    }[]>;
+    _weeks: i0.WritableSignal<MatCalendarCell<any>[][]>;
     // (undocumented)
     static ɵcmp: i0.ɵɵComponentDeclaration<MatMonthView<any>, "mat-month-view", ["matMonthView"], { "activeDate": { "alias": "activeDate"; "required": false; }; "selected": { "alias": "selected"; "required": false; }; "minDate": { "alias": "minDate"; "required": false; }; "maxDate": { "alias": "maxDate"; "required": false; }; "dateFilter": { "alias": "dateFilter"; "required": false; }; "dateClass": { "alias": "dateClass"; "required": false; }; "comparisonStart": { "alias": "comparisonStart"; "required": false; }; "comparisonEnd": { "alias": "comparisonEnd"; "required": false; }; "startDateAccessibleName": { "alias": "startDateAccessibleName"; "required": false; }; "endDateAccessibleName": { "alias": "endDateAccessibleName"; "required": false; }; "activeDrag": { "alias": "activeDrag"; "required": false; }; }, { "selectedChange": "selectedChange"; "_userSelection": "_userSelection"; "dragStarted": "dragStarted"; "dragEnded": "dragEnded"; "activeDateChange": "activeDateChange"; }, never, never, true, never>;
     // (undocumented)
@@ -751,10 +751,10 @@ export class MatMultiYearView<D> implements AfterContentInit, OnDestroy {
     get selected(): DateRange<D> | D | null;
     set selected(value: DateRange<D> | D | null);
     readonly selectedChange: EventEmitter<D>;
-    _selectedYear: number | null;
-    _todayYear: number;
+    _selectedYear: i0.WritableSignal<number | null>;
+    _todayYear: i0.WritableSignal<number>;
     _updateActiveDate(event: MatCalendarUserEvent<number>): void;
-    _years: MatCalendarCell[][];
+    _years: i0.WritableSignal<MatCalendarCell<any>[][]>;
     readonly yearSelected: EventEmitter<D>;
     _yearSelected(event: MatCalendarUserEvent<number>): void;
     // (undocumented)
@@ -831,7 +831,7 @@ export class MatYearView<D> implements AfterContentInit, OnDestroy {
     set maxDate(value: D | null);
     get minDate(): D | null;
     set minDate(value: D | null);
-    _months: MatCalendarCell[][];
+    _months: i0.WritableSignal<MatCalendarCell<any>[][]>;
     readonly monthSelected: EventEmitter<D>;
     _monthSelected(event: MatCalendarUserEvent<number>): void;
     // (undocumented)
@@ -841,10 +841,10 @@ export class MatYearView<D> implements AfterContentInit, OnDestroy {
     get selected(): DateRange<D> | D | null;
     set selected(value: DateRange<D> | D | null);
     readonly selectedChange: EventEmitter<D>;
-    _selectedMonth: number | null;
-    _todayMonth: number | null;
+    _selectedMonth: i0.WritableSignal<number | null>;
+    _todayMonth: i0.WritableSignal<number | null>;
     _updateActiveDate(event: MatCalendarUserEvent<number>): void;
-    _yearLabel: string;
+    _yearLabel: i0.WritableSignal<string>;
     // (undocumented)
     static ɵcmp: i0.ɵɵComponentDeclaration<MatYearView<any>, "mat-year-view", ["matYearView"], { "activeDate": { "alias": "activeDate"; "required": false; }; "selected": { "alias": "selected"; "required": false; }; "minDate": { "alias": "minDate"; "required": false; }; "maxDate": { "alias": "maxDate"; "required": false; }; "dateFilter": { "alias": "dateFilter"; "required": false; }; "dateClass": { "alias": "dateClass"; "required": false; }; }, { "selectedChange": "selectedChange"; "monthSelected": "monthSelected"; "activeDateChange": "activeDateChange"; }, never, never, true, never>;
     // (undocumented)

--- a/src/material/datepicker/calendar-body.ts
+++ b/src/material/datepicker/calendar-body.ts
@@ -615,7 +615,9 @@ export class MatCalendarBody<D = any> implements OnChanges, OnDestroy, AfterView
       const col = cell.getAttribute('data-mat-col');
 
       if (row && col) {
-        return this.rows[parseInt(row)][parseInt(col)];
+        // We need the optional read here, because this can
+        // fire too late when the user is navigating quickly.
+        return this.rows[parseInt(row)]?.[parseInt(col)] || null;
       }
     }
 

--- a/src/material/datepicker/month-view.html
+++ b/src/material/datepicker/month-view.html
@@ -1,7 +1,7 @@
 <table class="mat-calendar-table" role="grid">
   <thead class="mat-calendar-table-header">
     <tr>
-      @for (day of _weekdays; track day.id) {
+      @for (day of _weekdays(); track day.id) {
         <th scope="col">
           <span class="cdk-visually-hidden">{{day.long}}</span>
           <span aria-hidden="true">{{day.narrow}}</span>
@@ -11,16 +11,16 @@
     <tr aria-hidden="true"><th class="mat-calendar-table-header-divider" colspan="7"></th></tr>
   </thead>
   <tbody mat-calendar-body
-         [label]="_monthLabel"
-         [rows]="_weeks"
-         [todayValue]="_todayDate!"
-         [startValue]="_rangeStart!"
-         [endValue]="_rangeEnd!"
-         [comparisonStart]="_comparisonRangeStart"
-         [comparisonEnd]="_comparisonRangeEnd"
-         [previewStart]="_previewStart"
-         [previewEnd]="_previewEnd"
-         [isRange]="_isRange"
+         [label]="_monthLabel()"
+         [rows]="_weeks()"
+         [todayValue]="_todayDate()!"
+         [startValue]="_rangeStart()!"
+         [endValue]="_rangeEnd()!"
+         [comparisonStart]="_comparisonRangeStart()"
+         [comparisonEnd]="_comparisonRangeEnd()"
+         [previewStart]="_previewStart()"
+         [previewEnd]="_previewEnd()"
+         [isRange]="_isRange()"
          [labelMinRequiredCells]="3"
          [activeCell]="_dateAdapter.getDate(activeDate) - 1"
          [startDateAccessibleName]="startDateAccessibleName"

--- a/src/material/datepicker/month-view.ts
+++ b/src/material/datepicker/month-view.ts
@@ -462,12 +462,6 @@ export class MatMonthView<D> implements AfterContentInit, OnChanges, OnDestroy {
           this._previewEnd = this._getCellCompareValue(dragRange.end);
         }
       }
-
-      // Note that here we need to use `detectChanges`, rather than `markForCheck`, because
-      // the way `_focusActiveCell` is set up at the moment makes it fire at the wrong time
-      // when navigating one month back using the keyboard which will cause this handler
-      // to throw a "changed after checked" error when updating the preview state.
-      this._changeDetectorRef.detectChanges();
     }
   }
 

--- a/src/material/datepicker/multi-year-view.html
+++ b/src/material/datepicker/multi-year-view.html
@@ -3,10 +3,10 @@
     <tr><th class="mat-calendar-table-header-divider" colspan="4"></th></tr>
   </thead>
   <tbody mat-calendar-body
-         [rows]="_years"
-         [todayValue]="_todayYear"
-         [startValue]="_selectedYear!"
-         [endValue]="_selectedYear!"
+         [rows]="_years()"
+         [todayValue]="_todayYear()"
+         [startValue]="_selectedYear()!"
+         [endValue]="_selectedYear()!"
          [numCols]="4"
          [cellAspectRatio]="4 / 7"
          [activeCell]="_getActiveCell()"

--- a/src/material/datepicker/multi-year-view.ts
+++ b/src/material/datepicker/multi-year-view.ts
@@ -30,6 +30,7 @@ import {
   ViewEncapsulation,
   OnDestroy,
   inject,
+  signal,
 } from '@angular/core';
 import {DateAdapter} from '../core';
 import {Directionality} from '@angular/cdk/bidi';
@@ -150,13 +151,13 @@ export class MatMultiYearView<D> implements AfterContentInit, OnDestroy {
   @ViewChild(MatCalendarBody) _matCalendarBody: MatCalendarBody;
 
   /** Grid of calendar cells representing the currently displayed years. */
-  _years: MatCalendarCell[][];
+  _years = signal<MatCalendarCell[][]>([]);
 
   /** The year that today falls on. */
-  _todayYear: number;
+  _todayYear = signal(0);
 
   /** The year of the selected date. Null if the selected date is null. */
-  _selectedYear: number | null;
+  _selectedYear = signal<number | null>(null);
 
   constructor(...args: unknown[]);
 
@@ -180,7 +181,7 @@ export class MatMultiYearView<D> implements AfterContentInit, OnDestroy {
 
   /** Initializes this multi-year view. */
   _init() {
-    this._todayYear = this._dateAdapter.getYear(this._dateAdapter.today());
+    this._todayYear.set(this._dateAdapter.getYear(this._dateAdapter.today()));
 
     // We want a range years such that we maximize the number of
     // enabled dates visible at once. This prevents issues where the minimum year
@@ -192,14 +193,15 @@ export class MatMultiYearView<D> implements AfterContentInit, OnDestroy {
     const minYearOfPage =
       activeYear - getActiveOffset(this._dateAdapter, this.activeDate, this.minDate, this.maxDate);
 
-    this._years = [];
+    const years: MatCalendarCell[][] = [];
     for (let i = 0, row: number[] = []; i < yearsPerPage; i++) {
       row.push(minYearOfPage + i);
       if (row.length == yearsPerRow) {
-        this._years.push(row.map(year => this._createCellForYear(year)));
+        years.push(row.map(year => this._createCellForYear(year)));
         row = [];
       }
     }
+    this._years.set(years);
     this._changeDetectorRef.markForCheck();
   }
 
@@ -389,16 +391,16 @@ export class MatMultiYearView<D> implements AfterContentInit, OnDestroy {
 
   /** Sets the currently-highlighted year based on a model value. */
   private _setSelectedYear(value: DateRange<D> | D | null) {
-    this._selectedYear = null;
+    this._selectedYear.set(null);
 
     if (value instanceof DateRange) {
       const displayValue = value.start || value.end;
 
       if (displayValue) {
-        this._selectedYear = this._dateAdapter.getYear(displayValue);
+        this._selectedYear.set(this._dateAdapter.getYear(displayValue));
       }
     } else if (value) {
-      this._selectedYear = this._dateAdapter.getYear(value);
+      this._selectedYear.set(this._dateAdapter.getYear(value));
     }
   }
 }

--- a/src/material/datepicker/year-view.html
+++ b/src/material/datepicker/year-view.html
@@ -3,11 +3,11 @@
     <tr><th class="mat-calendar-table-header-divider" colspan="4"></th></tr>
   </thead>
   <tbody mat-calendar-body
-         [label]="_yearLabel"
-         [rows]="_months"
-         [todayValue]="_todayMonth!"
-         [startValue]="_selectedMonth!"
-         [endValue]="_selectedMonth!"
+         [label]="_yearLabel()"
+         [rows]="_months()"
+         [todayValue]="_todayMonth()!"
+         [startValue]="_selectedMonth()!"
+         [endValue]="_selectedMonth()!"
          [labelMinRequiredCells]="2"
          [numCols]="4"
          [cellAspectRatio]="4 / 7"

--- a/src/material/datepicker/year-view.ts
+++ b/src/material/datepicker/year-view.ts
@@ -30,6 +30,7 @@ import {
   ViewEncapsulation,
   OnDestroy,
   inject,
+  signal,
 } from '@angular/core';
 import {DateAdapter, MAT_DATE_FORMATS, MatDateFormats} from '../core';
 import {Directionality} from '@angular/cdk/bidi';
@@ -139,19 +140,19 @@ export class MatYearView<D> implements AfterContentInit, OnDestroy {
   @ViewChild(MatCalendarBody) _matCalendarBody: MatCalendarBody;
 
   /** Grid of calendar cells representing the months of the year. */
-  _months: MatCalendarCell[][];
+  _months = signal<MatCalendarCell[][]>([]);
 
   /** The label for this year (e.g. "2017"). */
-  _yearLabel: string;
+  _yearLabel = signal('');
 
   /** The month in this year that today falls on. Null if today is in a different year. */
-  _todayMonth: number | null;
+  _todayMonth = signal<number | null>(null);
 
   /**
    * The month in this year that the selected Date falls on.
    * Null if the selected Date is in a different year.
    */
-  _selectedMonth: number | null;
+  _selectedMonth = signal<number | null>(null);
 
   constructor(...args: unknown[]);
 
@@ -296,16 +297,18 @@ export class MatYearView<D> implements AfterContentInit, OnDestroy {
   /** Initializes this year view. */
   _init() {
     this._setSelectedMonth(this.selected);
-    this._todayMonth = this._getMonthInCurrentYear(this._dateAdapter.today());
-    this._yearLabel = this._dateAdapter.getYearName(this.activeDate);
+    this._todayMonth.set(this._getMonthInCurrentYear(this._dateAdapter.today()));
+    this._yearLabel.set(this._dateAdapter.getYearName(this.activeDate));
 
     let monthNames = this._dateAdapter.getMonthNames('short');
     // First row of months only contains 5 elements so we can fit the year label on the same row.
-    this._months = [
-      [0, 1, 2, 3],
-      [4, 5, 6, 7],
-      [8, 9, 10, 11],
-    ].map(row => row.map(month => this._createCellForMonth(month, monthNames[month])));
+    this._months.set(
+      [
+        [0, 1, 2, 3],
+        [4, 5, 6, 7],
+        [8, 9, 10, 11],
+      ].map(row => row.map(month => this._createCellForMonth(month, monthNames[month]))),
+    );
     this._changeDetectorRef.markForCheck();
   }
 
@@ -435,10 +438,11 @@ export class MatYearView<D> implements AfterContentInit, OnDestroy {
   /** Sets the currently-selected month based on a model value. */
   private _setSelectedMonth(value: DateRange<D> | D | null) {
     if (value instanceof DateRange) {
-      this._selectedMonth =
-        this._getMonthInCurrentYear(value.start) || this._getMonthInCurrentYear(value.end);
+      this._selectedMonth.set(
+        this._getMonthInCurrentYear(value.start) || this._getMonthInCurrentYear(value.end),
+      );
     } else {
-      this._selectedMonth = this._getMonthInCurrentYear(value);
+      this._selectedMonth.set(this._getMonthInCurrentYear(value));
     }
   }
 }


### PR DESCRIPTION
 The month view had a `detectChanges` call that was happening inside a `blur` event which ended up causing re-entrant change detection and hitting an assertion in the framework. These changes remove it since it doesn't appear to be necessary anymore.

Fixes #31959.

I've also converted the internal calendar state to signals to get a feel for how breaking something like this might be.