### PR TITLE
fix(material-date-fns-adapter): parse time string containing only hours

### DIFF
--- a/src/material-date-fns-adapter/adapter/date-fns-adapter.spec.ts
+++ b/src/material-date-fns-adapter/adapter/date-fns-adapter.spec.ts
@@ -535,6 +535,15 @@ describe('DateFnsAdapter', () => {
     expect(adapter.getSeconds(result)).toBe(0);
   });
 
+  it('should parse a time string containing only hours', () => {
+    const result = adapter.parseTime('11', 'HH')!;
+    expect(result).toBeTruthy();
+    expect(adapter.isValid(result)).toBe(true);
+    expect(adapter.getHours(result)).toBe(11);
+    expect(adapter.getMinutes(result)).toBe(0);
+    expect(adapter.getSeconds(result)).toBe(0);
+  });
+
   it('should return an invalid date when parsing invalid time string', () => {
     expect(adapter.isValid(adapter.parseTime('abc', 'p')!)).toBe(false);
     expect(adapter.isValid(adapter.parseTime('123', 'p')!)).toBe(false);

--- a/src/material-luxon-adapter/adapter/luxon-date-adapter.spec.ts
+++ b/src/material-luxon-adapter/adapter/luxon-date-adapter.spec.ts
@@ -633,6 +633,15 @@ describe('LuxonDateAdapter', () => {
     expect(adapter.getSeconds(result)).toBe(0);
   });
 
+  it('should parse a time string containing only hours', () => {
+    const result = adapter.parseTime('11', 'HH')!;
+    expect(result).toBeTruthy();
+    expect(adapter.isValid(result)).toBe(true);
+    expect(adapter.getHours(result)).toBe(11);
+    expect(adapter.getMinutes(result)).toBe(0);
+    expect(adapter.getSeconds(result)).toBe(0);
+  });
+
   it('should parse a time string with characters around the time', () => {
     adapter.setLocale('bg-BG');
     const result = adapter.parseTime('14:52 ч.', 't')!;

--- a/src/material-moment-adapter/adapter/moment-date-adapter.spec.ts
+++ b/src/material-moment-adapter/adapter/moment-date-adapter.spec.ts
@@ -614,6 +614,15 @@ describe('MomentDateAdapter', () => {
     expect(adapter.getSeconds(result)).toBe(0);
   });
 
+  it('should parse a time string containing only hours', () => {
+    const result = adapter.parseTime('11', 'HH')!;
+    expect(result).toBeTruthy();
+    expect(adapter.isValid(result)).toBe(true);
+    expect(adapter.getHours(result)).toBe(11);
+    expect(adapter.getMinutes(result)).toBe(0);
+    expect(adapter.getSeconds(result)).toBe(0);
+  });
+
   it('should parse a time string with characters around the time', () => {
     adapter.setLocale('bg-BG');
     const result = adapter.parseTime('14:52 ч.', 'LT')!;


### PR DESCRIPTION
Add test cases for parse time string containing only hours to:
* `material-date-fns-adapter`
* `material-luxon-adapter`
* `material-moment-adapter`

Fixe `material-date-fns-adapter` `parseTime()` method and refactor a bit to be able to reuse the code (`_parse()`).