### PR TITLE
docs: remove inaccurate note from focus monitor docs

### DIFF
--- a/src/cdk/a11y/a11y.md
+++ b/src/cdk/a11y/a11y.md
@@ -170,13 +170,6 @@ to the element when focused. It will add `.cdk-focused` if the element is focuse
 add `.cdk-${origin}-focused` (with `${origin}` being `mouse`, `keyboard`, `touch`, or `program`) to
 indicate how the element was focused.
 
-Note: currently the `FocusMonitor` emits on the observable _outside_ of the Angular zone. Therefore,
-if you `markForCheck` in the subscription you must put yourself back in the Angular zone.
-
-```ts
-focusMonitor.monitor(el).subscribe(origin => this.ngZone.run(() => /* ... */ ));
-```
-
 Any element that is monitored by calling `monitor` should eventually be unmonitored by calling
 `stopMonitoring` with the same element.
 


### PR DESCRIPTION
Removes a note from the focus monitor docs that is no longer valid.

Fixes #30529.