### PR TITLE
fix(material/snack-bar): add max height for snack bar

### DIFF
--- a/src/material/snack-bar/simple-snack-bar.scss
+++ b/src/material/snack-bar/simple-snack-bar.scss
@@ -2,4 +2,9 @@
 // wrapping layer to the mdc-snackbar__surface, it should also include flex display.
 .mat-mdc-simple-snack-bar {
   display: flex;
+
+  .mat-mdc-snack-bar-label {
+    max-height: 50vh;
+    overflow: auto;
+  }
 }


### PR DESCRIPTION
Adds a max height for the snack bar in case users pass huge strings into it.

Fixes #31996.