### PR TITLE
feat(material/sort): header icon customization

### DIFF
--- a/goldens/material/sort/index.api.md
+++ b/goldens/material/sort/index.api.md
@@ -14,6 +14,7 @@ import { OnChanges } from '@angular/core';
 import { OnDestroy } from '@angular/core';
 import { OnInit } from '@angular/core';
 import { Subject } from 'rxjs';
+import { TemplateRef } from '@angular/core';
 
 // @public @deprecated
 export type ArrowViewState = SortDirection | 'hint' | 'active';
@@ -73,6 +74,7 @@ export interface MatSortable {
 export interface MatSortDefaultOptions {
     arrowPosition?: SortHeaderArrowPosition;
     disableClear?: boolean;
+    icons?: SortHeaderIcons;
 }
 
 // @public
@@ -83,6 +85,7 @@ export class MatSortHeader implements MatSortable, OnDestroy, OnInit, AfterViewI
     arrowPosition: SortHeaderArrowPosition;
     // (undocumented)
     _columnDef: MatSortHeaderColumnDef | null;
+    get defaultIcons(): SortHeaderIcons | undefined;
     disableClear: boolean;
     disabled: boolean;
     _getAriaSortAttribute(): "none" | "ascending" | "descending";
@@ -110,10 +113,11 @@ export class MatSortHeader implements MatSortable, OnDestroy, OnInit, AfterViewI
     _sort: MatSort;
     get sortActionDescription(): string;
     set sortActionDescription(value: string);
+    readonly sortIconsTemplate: i0.InputSignal<TemplateRef<any> | null>;
     start: SortDirection;
     _toggleOnInteraction(): void;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<MatSortHeader, "[mat-sort-header]", ["matSortHeader"], { "id": { "alias": "mat-sort-header"; "required": false; }; "arrowPosition": { "alias": "arrowPosition"; "required": false; }; "start": { "alias": "start"; "required": false; }; "disabled": { "alias": "disabled"; "required": false; }; "sortActionDescription": { "alias": "sortActionDescription"; "required": false; }; "disableClear": { "alias": "disableClear"; "required": false; }; }, {}, never, ["*"], true, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MatSortHeader, "[mat-sort-header]", ["matSortHeader"], { "id": { "alias": "mat-sort-header"; "required": false; }; "arrowPosition": { "alias": "arrowPosition"; "required": false; }; "start": { "alias": "start"; "required": false; }; "disabled": { "alias": "disabled"; "required": false; }; "sortActionDescription": { "alias": "sortActionDescription"; "required": false; }; "disableClear": { "alias": "disableClear"; "required": false; }; "sortIconsTemplate": { "alias": "matSortIconsTemplate"; "required": false; "isSignal": true; }; }, {}, never, ["*"], true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatSortHeader, never>;
 }
@@ -148,6 +152,13 @@ export type SortDirection = 'asc' | 'desc' | '';
 
 // @public
 export type SortHeaderArrowPosition = 'before' | 'after';
+
+// @public
+export interface SortHeaderIcons {
+    ascending: string;
+    default?: string;
+    descending: string;
+}
 
 // (No @packageDocumentation comment for this package)
 

--- a/src/components-examples/material/sort/BUILD.bazel
+++ b/src/components-examples/material/sort/BUILD.bazel
@@ -18,6 +18,7 @@ ng_project(
         "//:node_modules/@types/jasmine",
         "//src/cdk/testing",
         "//src/cdk/testing/testbed",
+        "//src/material/icon",
         "//src/material/sort",
         "//src/material/sort/testing",
     ],

--- a/src/components-examples/material/sort/index.ts
+++ b/src/components-examples/material/sort/index.ts
@@ -1,2 +1,6 @@
 export {SortOverviewExample} from './sort-overview/sort-overview-example';
+export {SortHeaderIconsExample} from './sort-header-icons/sort-header-icons-example';
+export {SortHeaderIconsWithDefaultExample} from './sort-header-icons-with-default/sort-header-icons-with-default-example';
+export {SortHeaderCustomExample} from './sort-header-custom/sort-header-custom-example';
+export {SortHeaderCustomWithDefaultExample} from './sort-header-custom-with-default/sort-header-custom-with-default-example';
 export {SortHarnessExample} from './sort-harness/sort-harness-example';

--- a/src/components-examples/material/sort/sort-header-custom-with-default/sort-header-custom-with-default-example.css
+++ b/src/components-examples/material/sort/sort-header-custom-with-default/sort-header-custom-with-default-example.css
@@ -1,0 +1,3 @@
+.mat-sort-header-container {
+  align-items: center;
+}

--- a/src/components-examples/material/sort/sort-header-custom-with-default/sort-header-custom-with-default-example.html
+++ b/src/components-examples/material/sort/sort-header-custom-with-default/sort-header-custom-with-default-example.html
@@ -1,0 +1,33 @@
+<ng-template #sortIconsTemplate let-sortHeader>
+  @if (!sortHeader.isDisabled && sortHeader.isSorted) {
+    @if (sortHeader.direction === 'desc') {
+      <mat-icon focusable="false" aria-hidden="true" style="color: red;">keyboard_arrow_down</mat-icon>
+    }
+    @else {
+      <mat-icon focusable="false" aria-hidden="true" style="color: green;">keyboard_arrow_up</mat-icon>
+    }
+  }
+  @else {
+    <mat-icon focusable="false" aria-hidden="true">unfold_more</mat-icon>
+  }
+</ng-template>
+
+<table matSort (matSortChange)="sortData($event)">
+  <tr>
+    <th mat-sort-header="name" [matSortIconsTemplate]="sortIconsTemplate">Dessert (100g)</th>
+    <th mat-sort-header="calories" [matSortIconsTemplate]="sortIconsTemplate">Calories</th>
+    <th mat-sort-header="fat" [matSortIconsTemplate]="sortIconsTemplate">Fat (g)</th>
+    <th mat-sort-header="carbs" [matSortIconsTemplate]="sortIconsTemplate">Carbs (g)</th>
+    <th mat-sort-header="protein" [matSortIconsTemplate]="sortIconsTemplate">Protein (g)</th>
+  </tr>
+
+  @for (dessert of sortedData; track dessert) {
+    <tr>
+      <td>{{dessert.name}}</td>
+      <td>{{dessert.calories}}</td>
+      <td>{{dessert.fat}}</td>
+      <td>{{dessert.carbs}}</td>
+      <td>{{dessert.protein}}</td>
+    </tr>
+  }
+</table>

--- a/src/components-examples/material/sort/sort-header-custom-with-default/sort-header-custom-with-default-example.ts
+++ b/src/components-examples/material/sort/sort-header-custom-with-default/sort-header-custom-with-default-example.ts
@@ -1,0 +1,66 @@
+import {Component} from '@angular/core';
+import {MatIcon} from '@angular/material/icon';
+import {Sort, MatSortModule} from '@angular/material/sort';
+
+export interface Dessert {
+  calories: number;
+  carbs: number;
+  fat: number;
+  name: string;
+  protein: number;
+}
+
+/**
+ * @title Sorting header with custom template (including default).
+ */
+@Component({
+  selector: 'sort-header-custom-with-default-example',
+  templateUrl: 'sort-header-custom-with-default-example.html',
+  styleUrl: 'sort-header-custom-with-default-example.css',
+  imports: [MatSortModule, MatIcon],
+})
+export class SortHeaderCustomWithDefaultExample {
+  desserts: Dessert[] = [
+    {name: 'Frozen yogurt', calories: 159, fat: 6, carbs: 24, protein: 4},
+    {name: 'Ice cream sandwich', calories: 237, fat: 9, carbs: 37, protein: 4},
+    {name: 'Eclair', calories: 262, fat: 16, carbs: 24, protein: 6},
+    {name: 'Cupcake', calories: 305, fat: 4, carbs: 67, protein: 4},
+    {name: 'Gingerbread', calories: 356, fat: 16, carbs: 49, protein: 4},
+  ];
+
+  sortedData: Dessert[];
+
+  constructor() {
+    this.sortedData = this.desserts.slice();
+  }
+
+  sortData(sort: Sort) {
+    const data = this.desserts.slice();
+    if (!sort.active || sort.direction === '') {
+      this.sortedData = data;
+      return;
+    }
+
+    this.sortedData = data.sort((a, b) => {
+      const isAsc = sort.direction === 'asc';
+      switch (sort.active) {
+        case 'name':
+          return compare(a.name, b.name, isAsc);
+        case 'calories':
+          return compare(a.calories, b.calories, isAsc);
+        case 'fat':
+          return compare(a.fat, b.fat, isAsc);
+        case 'carbs':
+          return compare(a.carbs, b.carbs, isAsc);
+        case 'protein':
+          return compare(a.protein, b.protein, isAsc);
+        default:
+          return 0;
+      }
+    });
+  }
+}
+
+function compare(a: number | string, b: number | string, isAsc: boolean) {
+  return (a < b ? -1 : 1) * (isAsc ? 1 : -1);
+}

--- a/src/components-examples/material/sort/sort-header-custom/sort-header-custom-example.css
+++ b/src/components-examples/material/sort/sort-header-custom/sort-header-custom-example.css
@@ -1,0 +1,10 @@
+.mat-sort-header-container {
+  align-items: center;
+}
+
+sup {
+  font-size: 7px;
+  top: -3px;
+  position: absolute;
+  display: block;
+}

--- a/src/components-examples/material/sort/sort-header-custom/sort-header-custom-example.html
+++ b/src/components-examples/material/sort/sort-header-custom/sort-header-custom-example.html
@@ -1,0 +1,25 @@
+<ng-template #sortIconsTemplate let-sortHeader>
+  @if (!sortHeader.isDisabled && sortHeader.isSorted) {
+    <sup>{{ sortHeader.direction === 'desc' ? 'Z-A' : 'A-Z' }}</sup>
+  }
+</ng-template>
+
+<table matSort (matSortChange)="sortData($event)">
+  <tr>
+    <th mat-sort-header="name" [matSortIconsTemplate]="sortIconsTemplate">Dessert (100g)</th>
+    <th mat-sort-header="calories" [matSortIconsTemplate]="sortIconsTemplate">Calories</th>
+    <th mat-sort-header="fat" [matSortIconsTemplate]="sortIconsTemplate">Fat (g)</th>
+    <th mat-sort-header="carbs" [matSortIconsTemplate]="sortIconsTemplate">Carbs (g)</th>
+    <th mat-sort-header="protein" [matSortIconsTemplate]="sortIconsTemplate">Protein (g)</th>
+  </tr>
+
+  @for (dessert of sortedData; track dessert) {
+    <tr>
+      <td>{{dessert.name}}</td>
+      <td>{{dessert.calories}}</td>
+      <td>{{dessert.fat}}</td>
+      <td>{{dessert.carbs}}</td>
+      <td>{{dessert.protein}}</td>
+    </tr>
+  }
+</table>

--- a/src/components-examples/material/sort/sort-header-custom/sort-header-custom-example.ts
+++ b/src/components-examples/material/sort/sort-header-custom/sort-header-custom-example.ts
@@ -1,0 +1,65 @@
+import {Component} from '@angular/core';
+import {Sort, MatSortModule} from '@angular/material/sort';
+
+export interface Dessert {
+  calories: number;
+  carbs: number;
+  fat: number;
+  name: string;
+  protein: number;
+}
+
+/**
+ * @title Sorting header with custom template.
+ */
+@Component({
+  selector: 'sort-header-custom-example',
+  templateUrl: 'sort-header-custom-example.html',
+  styleUrl: 'sort-header-custom-example.css',
+  imports: [MatSortModule],
+})
+export class SortHeaderCustomExample {
+  desserts: Dessert[] = [
+    {name: 'Frozen yogurt', calories: 159, fat: 6, carbs: 24, protein: 4},
+    {name: 'Ice cream sandwich', calories: 237, fat: 9, carbs: 37, protein: 4},
+    {name: 'Eclair', calories: 262, fat: 16, carbs: 24, protein: 6},
+    {name: 'Cupcake', calories: 305, fat: 4, carbs: 67, protein: 4},
+    {name: 'Gingerbread', calories: 356, fat: 16, carbs: 49, protein: 4},
+  ];
+
+  sortedData: Dessert[];
+
+  constructor() {
+    this.sortedData = this.desserts.slice();
+  }
+
+  sortData(sort: Sort) {
+    const data = this.desserts.slice();
+    if (!sort.active || sort.direction === '') {
+      this.sortedData = data;
+      return;
+    }
+
+    this.sortedData = data.sort((a, b) => {
+      const isAsc = sort.direction === 'asc';
+      switch (sort.active) {
+        case 'name':
+          return compare(a.name, b.name, isAsc);
+        case 'calories':
+          return compare(a.calories, b.calories, isAsc);
+        case 'fat':
+          return compare(a.fat, b.fat, isAsc);
+        case 'carbs':
+          return compare(a.carbs, b.carbs, isAsc);
+        case 'protein':
+          return compare(a.protein, b.protein, isAsc);
+        default:
+          return 0;
+      }
+    });
+  }
+}
+
+function compare(a: number | string, b: number | string, isAsc: boolean) {
+  return (a < b ? -1 : 1) * (isAsc ? 1 : -1);
+}

--- a/src/components-examples/material/sort/sort-header-icons-with-default/sort-header-icons-with-default-example.css
+++ b/src/components-examples/material/sort/sort-header-icons-with-default/sort-header-icons-with-default-example.css
@@ -1,0 +1,3 @@
+.mat-sort-header-container {
+  align-items: center;
+}

--- a/src/components-examples/material/sort/sort-header-icons-with-default/sort-header-icons-with-default-example.html
+++ b/src/components-examples/material/sort/sort-header-icons-with-default/sort-header-icons-with-default-example.html
@@ -1,0 +1,19 @@
+<table matSort (matSortChange)="sortData($event)">
+  <tr>
+    <th mat-sort-header="name">Dessert (100g)</th>
+    <th mat-sort-header="calories">Calories</th>
+    <th mat-sort-header="fat">Fat (g)</th>
+    <th mat-sort-header="carbs">Carbs (g)</th>
+    <th mat-sort-header="protein">Protein (g)</th>
+  </tr>
+
+  @for (dessert of sortedData; track dessert) {
+    <tr>
+      <td>{{dessert.name}}</td>
+      <td>{{dessert.calories}}</td>
+      <td>{{dessert.fat}}</td>
+      <td>{{dessert.carbs}}</td>
+      <td>{{dessert.protein}}</td>
+    </tr>
+  }
+</table>

--- a/src/components-examples/material/sort/sort-header-icons-with-default/sort-header-icons-with-default-example.ts
+++ b/src/components-examples/material/sort/sort-header-icons-with-default/sort-header-icons-with-default-example.ts
@@ -1,0 +1,77 @@
+import {Component} from '@angular/core';
+import {Sort, MatSortModule, MAT_SORT_DEFAULT_OPTIONS} from '@angular/material/sort';
+
+export interface Dessert {
+  calories: number;
+  carbs: number;
+  fat: number;
+  name: string;
+  protein: number;
+}
+
+/**
+ * @title Sorting header with configured default icons.
+ */
+@Component({
+  selector: 'sort-header-icons-with-default-example',
+  templateUrl: 'sort-header-icons-with-default-example.html',
+  styleUrl: 'sort-header-icons-with-default-example.css',
+  imports: [MatSortModule],
+  providers: [
+    {
+      provide: MAT_SORT_DEFAULT_OPTIONS,
+      useValue: {
+        icons: {
+          ascending: 'keyboard_arrow_up',
+          descending: 'keyboard_arrow_down',
+          default: 'unfold_more', // if you'd like to have always visible default sorting icon
+        },
+      },
+    },
+  ],
+})
+export class SortHeaderIconsWithDefaultExample {
+  desserts: Dessert[] = [
+    {name: 'Frozen yogurt', calories: 159, fat: 6, carbs: 24, protein: 4},
+    {name: 'Ice cream sandwich', calories: 237, fat: 9, carbs: 37, protein: 4},
+    {name: 'Eclair', calories: 262, fat: 16, carbs: 24, protein: 6},
+    {name: 'Cupcake', calories: 305, fat: 4, carbs: 67, protein: 4},
+    {name: 'Gingerbread', calories: 356, fat: 16, carbs: 49, protein: 4},
+  ];
+
+  sortedData: Dessert[];
+
+  constructor() {
+    this.sortedData = this.desserts.slice();
+  }
+
+  sortData(sort: Sort) {
+    const data = this.desserts.slice();
+    if (!sort.active || sort.direction === '') {
+      this.sortedData = data;
+      return;
+    }
+
+    this.sortedData = data.sort((a, b) => {
+      const isAsc = sort.direction === 'asc';
+      switch (sort.active) {
+        case 'name':
+          return compare(a.name, b.name, isAsc);
+        case 'calories':
+          return compare(a.calories, b.calories, isAsc);
+        case 'fat':
+          return compare(a.fat, b.fat, isAsc);
+        case 'carbs':
+          return compare(a.carbs, b.carbs, isAsc);
+        case 'protein':
+          return compare(a.protein, b.protein, isAsc);
+        default:
+          return 0;
+      }
+    });
+  }
+}
+
+function compare(a: number | string, b: number | string, isAsc: boolean) {
+  return (a < b ? -1 : 1) * (isAsc ? 1 : -1);
+}

--- a/src/components-examples/material/sort/sort-header-icons/sort-header-icons-example.css
+++ b/src/components-examples/material/sort/sort-header-icons/sort-header-icons-example.css
@@ -1,0 +1,3 @@
+.mat-sort-header-container {
+  align-items: center;
+}

--- a/src/components-examples/material/sort/sort-header-icons/sort-header-icons-example.html
+++ b/src/components-examples/material/sort/sort-header-icons/sort-header-icons-example.html
@@ -1,0 +1,19 @@
+<table matSort (matSortChange)="sortData($event)">
+  <tr>
+    <th mat-sort-header="name">Dessert (100g)</th>
+    <th mat-sort-header="calories">Calories</th>
+    <th mat-sort-header="fat">Fat (g)</th>
+    <th mat-sort-header="carbs">Carbs (g)</th>
+    <th mat-sort-header="protein">Protein (g)</th>
+  </tr>
+
+  @for (dessert of sortedData; track dessert) {
+    <tr>
+      <td>{{dessert.name}}</td>
+      <td>{{dessert.calories}}</td>
+      <td>{{dessert.fat}}</td>
+      <td>{{dessert.carbs}}</td>
+      <td>{{dessert.protein}}</td>
+    </tr>
+  }
+</table>

--- a/src/components-examples/material/sort/sort-header-icons/sort-header-icons-example.ts
+++ b/src/components-examples/material/sort/sort-header-icons/sort-header-icons-example.ts
@@ -1,0 +1,76 @@
+import {Component} from '@angular/core';
+import {Sort, MatSortModule, MAT_SORT_DEFAULT_OPTIONS} from '@angular/material/sort';
+
+export interface Dessert {
+  calories: number;
+  carbs: number;
+  fat: number;
+  name: string;
+  protein: number;
+}
+
+/**
+ * @title Sorting header with configured icons.
+ */
+@Component({
+  selector: 'sort-header-icons-example',
+  templateUrl: 'sort-header-icons-example.html',
+  styleUrl: 'sort-header-icons-example.css',
+  imports: [MatSortModule],
+  providers: [
+    {
+      provide: MAT_SORT_DEFAULT_OPTIONS,
+      useValue: {
+        icons: {
+          ascending: 'keyboard_arrow_up',
+          descending: 'keyboard_arrow_down',
+        },
+      },
+    },
+  ],
+})
+export class SortHeaderIconsExample {
+  desserts: Dessert[] = [
+    {name: 'Frozen yogurt', calories: 159, fat: 6, carbs: 24, protein: 4},
+    {name: 'Ice cream sandwich', calories: 237, fat: 9, carbs: 37, protein: 4},
+    {name: 'Eclair', calories: 262, fat: 16, carbs: 24, protein: 6},
+    {name: 'Cupcake', calories: 305, fat: 4, carbs: 67, protein: 4},
+    {name: 'Gingerbread', calories: 356, fat: 16, carbs: 49, protein: 4},
+  ];
+
+  sortedData: Dessert[];
+
+  constructor() {
+    this.sortedData = this.desserts.slice();
+  }
+
+  sortData(sort: Sort) {
+    const data = this.desserts.slice();
+    if (!sort.active || sort.direction === '') {
+      this.sortedData = data;
+      return;
+    }
+
+    this.sortedData = data.sort((a, b) => {
+      const isAsc = sort.direction === 'asc';
+      switch (sort.active) {
+        case 'name':
+          return compare(a.name, b.name, isAsc);
+        case 'calories':
+          return compare(a.calories, b.calories, isAsc);
+        case 'fat':
+          return compare(a.fat, b.fat, isAsc);
+        case 'carbs':
+          return compare(a.carbs, b.carbs, isAsc);
+        case 'protein':
+          return compare(a.protein, b.protein, isAsc);
+        default:
+          return 0;
+      }
+    });
+  }
+}
+
+function compare(a: number | string, b: number | string, isAsc: boolean) {
+  return (a < b ? -1 : 1) * (isAsc ? 1 : -1);
+}

--- a/src/material/sort/BUILD.bazel
+++ b/src/material/sort/BUILD.bazel
@@ -69,6 +69,7 @@ ng_project(
         "sort-direction.ts",
         "sort-errors.ts",
         "sort-header.ts",
+        "sort-header-icons.ts",
         "sort-header-intl.ts",
         "sort-module.ts",
     ],
@@ -77,12 +78,14 @@ ng_project(
         ":css",
     ],
     deps = [
+        "//:node_modules/@angular/common",
         "//:node_modules/@angular/core",
         "//:node_modules/rxjs",
         "//src:dev_mode_types",
         "//src/cdk/a11y",
         "//src/cdk/keycodes",
         "//src/material/core",
+        "//src/material/icon",
     ],
 )
 

--- a/src/material/sort/public-api.ts
+++ b/src/material/sort/public-api.ts
@@ -9,5 +9,6 @@
 export * from './sort-module';
 export * from './sort-direction';
 export * from './sort-header';
+export * from './sort-header-icons';
 export * from './sort-header-intl';
 export * from './sort';

--- a/src/material/sort/sort-header-icons.ts
+++ b/src/material/sort/sort-header-icons.ts
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+/** Configuration object for customizing the icons used by `mat-sort-header`. */
+export interface SortHeaderIcons {
+  /** Icon shown when the column is not sorted (idle state). */
+  default?: string;
+  /** Icon shown when the column is sorted ascending. */
+  ascending: string;
+  /** Icon shown when the column is sorted descending. */
+  descending: string;
+}

--- a/src/material/sort/sort-header.html
+++ b/src/material/sort/sort-header.html
@@ -11,8 +11,9 @@
 <div class="mat-sort-header-container mat-focus-indicator"
      [class.mat-sort-header-sorted]="_isSorted()"
      [class.mat-sort-header-position-before]="arrowPosition === 'before'"
-     [class.mat-sort-header-descending]="this._sort.direction === 'desc'"
-     [class.mat-sort-header-ascending]="this._sort.direction === 'asc'"
+     [class.mat-sort-header-descending]="_sort.direction === 'desc'"
+     [class.mat-sort-header-ascending]="_sort.direction === 'asc'"
+     [class.mat-sort-header-has-idle-icon]="defaultIcons?.default"
      [class.mat-sort-header-recently-cleared-ascending]="_recentlyCleared() === 'asc'"
      [class.mat-sort-header-recently-cleared-descending]="_recentlyCleared() === 'desc'"
      [class.mat-sort-header-animations-disabled]="_animationsDisabled"
@@ -29,12 +30,32 @@
     <ng-content></ng-content>
   </div>
 
-  <!-- Disable animations while a current animation is running -->
-  @if (_renderArrow()) {
-    <div class="mat-sort-header-arrow">
-      <svg viewBox="0 -960 960 960" focusable="false" aria-hidden="true">
-        <path d="M440-240v-368L296-464l-56-56 240-240 240 240-56 56-144-144v368h-80Z"/>
-      </svg>
+  <ng-template #defaultTemplate let-sortHeader>
+    @if ((!_isDisabled() && !defaultIcons?.default) || _isSorted()) {
+      <mat-icon focusable="false" aria-hidden="true">
+        {{ _sort.direction === 'desc' ? defaultIcons?.descending : defaultIcons?.ascending }}
+      </mat-icon>
+    }
+    @else if (!_isSorted() && defaultIcons?.default) {
+      <mat-icon focusable="false" aria-hidden="true">{{ defaultIcons?.default }}</mat-icon>
+    }
+  </ng-template>
+
+  @if (sortIconsTemplate() || defaultIcons) {
+    <div class="mat-sort-header-icon-slot">
+      <ng-container [ngTemplateOutlet]="sortIconsTemplate() || defaultTemplate"
+                    [ngTemplateOutletContext]="{ $implicit: { isDisabled: _isDisabled(), direction: _sort.direction, isSorted: _isSorted() } }">
+      </ng-container>
     </div>
+  }
+  @else {
+    <!-- Disable animations while a current animation is running -->
+    @if (_renderArrow()) {
+      <div class="mat-sort-header-arrow">
+        <svg viewBox="0 -960 960 960" focusable="false" aria-hidden="true">
+          <path d="M440-240v-368L296-464l-56-56 240-240 240 240-56 56-144-144v368h-80Z"/>
+        </svg>
+      </div>
+    }
   }
 </div>

--- a/src/material/sort/sort-header.scss
+++ b/src/material/sort/sort-header.scss
@@ -70,6 +70,54 @@ $fallbacks: m3-sort.get-tokens();
   }
 }
 
+.mat-sort-header-icon-slot {
+  $timing: 225ms cubic-bezier(0.4, 0, 0.2, 1);
+  width: 12px;
+  height: 12px;
+  position: relative;
+  transition: opacity $timing;
+  opacity: 0;
+  overflow: visible;
+  color: token-utils.slot(sort-arrow-color, $fallbacks);
+
+  // stylelint-disable max-line-length
+  .mat-sort-header.cdk-keyboard-focused .mat-sort-header-container:not(.mat-sort-header-has-idle-icon) &,
+  .mat-sort-header.cdk-program-focused .mat-sort-header-container:not(.mat-sort-header-has-idle-icon) &,
+  .mat-sort-header:hover .mat-sort-header-container:not(.mat-sort-header-has-idle-icon):not(.mat-sort-header-sorted) & {
+    opacity: 0.54;
+  }
+  // stylelint-enable max-line-length
+
+  .mat-sort-header-container.mat-sort-header-has-idle-icon &,
+  .mat-sort-header:not(.mat-sort-header-has-idle-icon) .mat-sort-header-sorted & {
+    opacity: 1;
+  }
+
+  .mat-sort-header-animations-disabled & {
+    transition-duration: 0ms;
+  }
+
+  & > mat-icon {
+    width: 24px;
+    height: 24px;
+    fill: currentColor;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    margin: -12px 0 0 -12px;
+  }
+
+  &,
+  [dir='rtl'] .mat-sort-header-position-before & {
+    margin: 0 0 0 6px;
+  }
+
+  .mat-sort-header-position-before &,
+  [dir='rtl'] & {
+    margin: 0 6px 0 0;
+  }
+}
+
 .mat-sort-header-arrow {
   $timing: 225ms cubic-bezier(0.4, 0, 0.2, 1);
   height: 12px;

--- a/src/material/sort/sort-header.ts
+++ b/src/material/sort/sort-header.ts
@@ -21,7 +21,10 @@ import {
   inject,
   signal,
   ChangeDetectorRef,
+  TemplateRef,
+  input,
 } from '@angular/core';
+import {CommonModule} from '@angular/common';
 import {merge, Subscription} from 'rxjs';
 import {
   MAT_SORT_DEFAULT_OPTIONS,
@@ -35,6 +38,7 @@ import {getSortHeaderNotContainedWithinSortError} from './sort-errors';
 import {MatSortHeaderIntl} from './sort-header-intl';
 import {_CdkPrivateStyleLoader} from '@angular/cdk/private';
 import {_animationsDisabled, _StructuralStylesLoader} from '../core';
+import {MatIcon} from '../icon';
 
 /**
  * Valid positions for the arrow to be in for its opacity and translation. If the state is a
@@ -89,6 +93,7 @@ interface MatSortHeaderColumnDef {
   },
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [CommonModule, MatIcon],
 })
 export class MatSortHeader implements MatSortable, OnDestroy, OnInit, AfterViewInit {
   _intl = inject(MatSortHeaderIntl);
@@ -96,10 +101,11 @@ export class MatSortHeader implements MatSortable, OnDestroy, OnInit, AfterViewI
   _columnDef = inject<MatSortHeaderColumnDef>('MAT_SORT_HEADER_COLUMN_DEF' as any, {
     optional: true,
   });
-  private _changeDetectorRef = inject(ChangeDetectorRef);
-  private _focusMonitor = inject(FocusMonitor);
-  private _elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
-  private _ariaDescriber = inject(AriaDescriber, {optional: true});
+  private readonly _changeDetectorRef = inject(ChangeDetectorRef);
+  private readonly _focusMonitor = inject(FocusMonitor);
+  private readonly _elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
+  private readonly _ariaDescriber = inject(AriaDescriber, {optional: true});
+  private readonly _defaultOptions = inject(MAT_SORT_DEFAULT_OPTIONS, {optional: true});
   private _renderChanges: Subscription | undefined;
   protected _animationsDisabled = _animationsDisabled();
 
@@ -150,6 +156,19 @@ export class MatSortHeader implements MatSortable, OnDestroy, OnInit, AfterViewI
   /** Overrides the disable clear value of the containing MatSort for this MatSortable. */
   @Input({transform: booleanAttribute})
   disableClear: boolean;
+
+  /**
+   * Template for the sort icons.
+   * `{ isDisabled: boolean; direction: 'asc' | 'desc' | ''; isSorted: boolean }` passed as context.
+   */
+  readonly sortIconsTemplate = input<TemplateRef<any> | null>(null, {
+    alias: 'matSortIconsTemplate',
+  });
+
+  /** Icons used by `mat-sort-header`. */
+  get defaultIcons() {
+    return this._defaultOptions?.icons;
+  }
 
   constructor(...args: unknown[]);
 

--- a/src/material/sort/sort.ts
+++ b/src/material/sort/sort.ts
@@ -26,6 +26,7 @@ import {
   getSortHeaderMissingIdError,
   getSortInvalidDirectionError,
 } from './sort-errors';
+import {SortHeaderIcons} from './sort-header-icons';
 
 /** Position of the arrow that displays when sorted. */
 export type SortHeaderArrowPosition = 'before' | 'after';
@@ -57,6 +58,11 @@ export interface MatSortDefaultOptions {
   disableClear?: boolean;
   /** Position of the arrow that displays when sorted. */
   arrowPosition?: SortHeaderArrowPosition;
+  /**
+   * Icons used for the sort indicator.
+   * Optional - unspecified ones fall back to the framework default arrow.
+   */
+  icons?: SortHeaderIcons;
 }
 
 /** Injection token to be used to override the default options for `mat-sort`. */


### PR DESCRIPTION
- Add optional `icons` (`SortHeaderIcons`) configuration object to `MAT_SORT_DEFAULT_OPTIONS` for customizing the icons used by `mat-sort-header`
- Add `matSortIconsTemplate` template for the sort icons to `[mat-sort-header]`. `{ isDisabled: boolean; direction: 'asc' | 'desc' | ''; isSorted: boolean }` passed as context.

Close #32002, #30563