### PR TITLE
feat(material/radio): Hovering over label of a radio will show the pointer cursor

### DIFF
--- a/src/material/radio/radio.scss
+++ b/src/material/radio/radio.scss
@@ -11,6 +11,12 @@ $fallbacks: m3-radio.get-tokens();
   @include radio-common.radio-structure(true);
   @include radio-common.radio-noop-animations();
 
+  // Clicking the label toggles the radio, but MDC does not include any styles that inform the
+  // user of this. Therefore we add the pointer cursor on top of MDC's styles.
+  label {
+    cursor: pointer;
+  }
+
   .mdc-radio__background::before {
     background-color: token-utils.slot(radio-ripple-color, $fallbacks);
   }


### PR DESCRIPTION
This is a backport for 20.2 branch of the already merged #31894. So it might get released in the future 20.2.8.