### PR TITLE
docs: migrate to signals and takeUntilDestroyed

### DIFF
--- a/docs/src/app/pages/component-category-list/component-category-list.html
+++ b/docs/src/app/pages/component-category-list/component-category-list.html
@@ -1,21 +1,27 @@
-<div class="docs-component-category-list-summary docs-markdown"
-     id="category-summary"
-     focusOnNavigation>
-  <div [innerHTML]="_categoryListSummary"></div>
+<div
+  class="docs-component-category-list-summary docs-markdown"
+  id="category-summary"
+  focusOnNavigation
+>
+  <div [innerHTML]="_categoryListSummary()"></div>
 </div>
-@if (items.length > 0) {
+@if (items().length > 0) {
   <div class="docs-component-category-list">
-    @for (component of items; track component) {
-      <a class="docs-component-category-list-item"
-         [routerLink]="'/' + section + '/' + component.id">
+    @for (component of items(); track component.id) {
+      <a
+        class="docs-component-category-list-item"
+        [routerLink]="'/' + section() + '/' + component.id"
+      >
         <div class="docs-component-category-list-card" matRipple>
-          @if (section === 'components') {
-            <img class="docs-component-category-list-card-image-wrapper"
-                [src]="'../../../assets/screenshots/' + component.id + '.scene.png'"
-                loading="lazy"
-                alt=""
-                role="presentation"
-                aria-hidden="true">
+          @if (section() === 'components') {
+            <img
+              class="docs-component-category-list-card-image-wrapper"
+              [src]="'../../../assets/screenshots/' + component.id + '.scene.png'"
+              loading="lazy"
+              alt=""
+              role="presentation"
+              aria-hidden="true"
+            />
           }
           <div class="docs-component-category-list-card-title">{{component.name}}</div>
           <div class="docs-component-category-list-card-summary">{{component.summary}}</div>


### PR DESCRIPTION
- Replace lifecycle hooks with constructor initialization
- Convert properties to signals (items, section, _categoryListSummary)
- Use takeUntilDestroyed() for automatic cleanup
- Replace async/await with switchMap to prevent race conditions
- Remove manual subscription management

Benefits: Better performance, automatic cleanup, safer async handling