### PR TITLE
build: add package_deps to aria package

### DIFF
--- a/src/aria/BUILD.bazel
+++ b/src/aria/BUILD.bazel
@@ -19,6 +19,9 @@ ng_package(
     name = "npm_package",
     package_name = "@angular/aria",
     srcs = ["package.json"],
+    package_deps = [
+        ":node_modules/@angular/cdk",
+    ],
     tags = ["release-package"],
     visibility = [
         "//:__pkg__",


### PR DESCRIPTION
Adds the CDK to the `package_deps` of the `@angular/aria` package so that they're installed from source.