### PR TITLE
docs: fix nav tabs overlapping

### DIFF
--- a/docs/src/app/pages/component-viewer/component-viewer.scss
+++ b/docs/src/app/pages/component-viewer/component-viewer.scss
@@ -34,7 +34,7 @@ app-component-viewer {
   &.docs-sticky-top {
     position: sticky;
     top: 0;
-    z-index: 1;
+    z-index: 2;
     background: var(--mat-sys-surface);
   }
 }


### PR DESCRIPTION
Fix issue with nav tabs overlapping over `mat-tab-body`. See:
![overlapping ](https://github.com/user-attachments/assets/6dff2e47-610a-4f28-b0b9-d2fffce8a64a)
Related to #32011 
