### PR TITLE
docs: sync border-radius with by replacing --mat-sys-corner-large to …

### DIFF
--- a/docs/src/app/pages/system-variables/system-variables.scss
+++ b/docs/src/app/pages/system-variables/system-variables.scss
@@ -162,7 +162,7 @@ mat-expansion-panel {
 .demo-elevation {
   height: 40px;
   width: 300px;
-  margin: 32px;
+  margin: 32px 0;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -182,7 +182,7 @@ mat-expansion-panel {
   background-color: var(--mat-sys-primary);
   color: var(--mat-sys-on-primary);
   font: var(--mat-sys-body-medium);
-  border-radius: var(--mat-sys-corner-large);
+  border-radius: var(--mat-sys-corner-small);
   box-shadow: var(--mat-sys-level3);
   padding: 16px;
 


### PR DESCRIPTION
Before:
<img width="740" height="691" alt="image" src="https://github.com/user-attachments/assets/c6acca1d-53c3-4236-93fa-72623423f214" />

After:
<img width="740" height="691" alt="image" src="https://github.com/user-attachments/assets/c9feb891-4b14-4e6a-8e50-0fc7f660bc4f" />
