### PR TITLE
fix(cdk/testing): make setContenteditableValue required

### DIFF
--- a/goldens/cdk/testing/index.api.md
+++ b/goldens/cdk/testing/index.api.md
@@ -230,7 +230,7 @@ export interface TestElement {
     selectOptions(...optionIndexes: number[]): Promise<void>;
     sendKeys(...keys: (string | TestKey)[]): Promise<void>;
     sendKeys(modifiers: ModifierKeys, ...keys: (string | TestKey)[]): Promise<void>;
-    setContenteditableValue?(value: string): Promise<void>;
+    setContenteditableValue(value: string): Promise<void>;
     setInputValue(value: string): Promise<void>;
     text(options?: TextOptions): Promise<string>;
 }

--- a/src/cdk/testing/test-element.ts
+++ b/src/cdk/testing/test-element.ts
@@ -141,9 +141,8 @@ export interface TestElement {
   /**
    * Sets the value of a `contenteditable` element.
    * @param value Value to be set on the element.
-   * @breaking-change 16.0.0 Will become a required method.
    */
-  setContenteditableValue?(value: string): Promise<void>;
+  setContenteditableValue(value: string): Promise<void>;
 
   /** Gets the value for the given attribute from the element. */
   getAttribute(name: string): Promise<string | null>;

--- a/src/cdk/testing/tests/cross-environment.spec.ts
+++ b/src/cdk/testing/tests/cross-environment.spec.ts
@@ -713,9 +713,7 @@ export function crossEnvironmentSpecs(
       const element = await harness.contenteditable();
       expect(await element.text()).not.toBe('hello');
 
-      // @breaking-change 16.0.0 Remove non-null assertion once `setContenteditableValue`
-      // becomes a required method.
-      await element.setContenteditableValue!('hello');
+      await element.setContenteditableValue('hello');
 
       expect(await element.text()).toBe('hello');
     });

--- a/src/material/chips/testing/chip-edit-input-harness.ts
+++ b/src/material/chips/testing/chip-edit-input-harness.ts
@@ -33,16 +33,6 @@ export class MatChipEditInputHarness extends ComponentHarness {
   /** Sets the value of the input. */
   async setValue(value: string): Promise<void> {
     const host = await this.host();
-
-    // @breaking-change 16.0.0 Remove this null check once `setContenteditableValue`
-    // becomes a required method.
-    if (!host.setContenteditableValue) {
-      throw new Error(
-        'Cannot set chip edit input value, because test ' +
-          'element does not implement the `setContenteditableValue` method.',
-      );
-    }
-
     return host.setContenteditableValue(value);
   }
 }


### PR DESCRIPTION
Makes the `TestElement.setContenteditableValue` method required.

BREAKING CHANGE:
* `TestElement` implementations need to provide a `setContenteditableValue`.