### PR TITLE
docs: remove specific pnpm version reference

### DIFF
--- a/DEV_ENVIRONMENT.md
+++ b/DEV_ENVIRONMENT.md
@@ -1,5 +1,6 @@
 # Developer guide: getting your environment set up
-1. Make sure you have both `node` and `pnpm@9` installed.
+
+1. Make sure you have both `node` and `pnpm` installed.
    We recommend using `nvm` to manage your node versions.
 2. If you are on Windows, see [the extra steps needed for contributing on Windows](#windows)
 3. Fork the `angular/components` repo on GitHub.
@@ -8,13 +9,13 @@
    and `<your-username>` for your fork. Also see the [team git shortcuts](https://github.com/angular/components/wiki/Team-git----bash-shortcuts).
 5. From the root of the project, run `pnpm i` to install the dependencies.
 
-
 To build angular/components in release mode, run `pnpm build`. The output can be found under `dist/releases`.
 
 To bring up a local server, run `pnpm dev-app`. This will automatically watch for changes
 and rebuild. The browser should refresh automatically when changes are made.
 
 ### Running tests
+
 To run unit tests, run `pnpm test <target>`. The `target` can be either a short name (e.g. `pnpm test button`) or an explicit path `pnpm test src/cdk/stepper`.
 To run the e2e tests, run `pnpm e2e`.
 To run lint, run `pnpm lint`.
@@ -23,6 +24,7 @@ You can debug unit tests by running `pnpm test` with the `--debug` option. This 
 manually connect a browser to the Karma server.
 
 ### Getting Packages from Build Artifacts
+
 Each CI run for a Pull Request stores the built Angular packages as
 [build artifacts](https://circleci.com/docs/2.0/artifacts). The artifacts are not guaranteed to be
 available as a long-term distribution mechanism, but they are guaranteed to be available around the
@@ -32,6 +34,7 @@ You can access the artifacts for a specific CI run by going to the workflow page
 `upload_release_packages` job and then switching to the "Artifacts" tab.
 
 #### Archives for each Package
+
 On the "Artifacts" tab, there is a list of links to compressed archives for Angular packages. The
 archive names are of the format `<package-name>-pr<pr-number>-<sha>.tgz` (for example
 `material-pr12345-a1b2c3d.tgz`).
@@ -49,6 +52,7 @@ to point to the artifact URLs and then run `pnpm` to install the packages:
 ```
 
 #### Download all Packages
+
 In addition to the individual package archives, a `.tgz` file including all packages is also
 available (named `all-pr<pr-number>-<sha>.tgz`). This can be used if one prefers to download all
 packages locally and test them by either of the following ways:
@@ -57,14 +61,14 @@ packages locally and test them by either of the following ways:
 2. Directly copy the local uncompressed package directories into the `node_modules/` directory
    of a project.
 
-
 ### Approving public API changes
+
 If you're making changes to a public API, they need to be propagated to our public API golden files.
 To save the changes you can run `pnpm approve-api <target>` and to review the changes, you can look
 at the file under `goldens/<package>/<entry-point>.api.md`.
 
-
 ### Disabling Git hooks
+
 If your development workflow does not intend the commit message validation to run automatically
 when commits are being created, or if you do not want to run the formatter upon `git commit`, you
 can disable any installed Git hooks by setting `HUSKY=0` in your shell environment. e.g.
@@ -85,7 +89,7 @@ without requiring secrets to be committed.
 
 The following variables are currently used in the dev-app:
 
-* `GOOGLE_MAPS_KEY` - Optional key for the Google Maps API.
+- `GOOGLE_MAPS_KEY` - Optional key for the Google Maps API.
 
 For example, you can store a personal development Google Maps API key for the
 dev-app within your `.bashrc` or `.zshrc` file.


### PR DESCRIPTION
Replaces explicit "pnpm 9" mention with a general "pnpm" reference, as version 10 is now current and the docs should remain version-agnostic.

**Markdown has been formatted!** 