### PR TITLE
refactor(aria/tree): remove tree group wrapper

### DIFF
--- a/src/aria/combobox/combobox.spec.ts
+++ b/src/aria/combobox/combobox.spec.ts
@@ -4,7 +4,7 @@ import {By} from '@angular/platform-browser';
 import {Combobox, ComboboxInput, ComboboxPopup, ComboboxPopupContainer} from '../combobox';
 import {Listbox, Option} from '../listbox';
 import {runAccessibilityChecks} from '@angular/cdk/testing/private';
-import {Tree, TreeItem, TreeItemGroup, TreeItemGroupContent} from '../tree';
+import {Tree, TreeItem, TreeItemGroup} from '../tree';
 import {NgTemplateOutlet} from '@angular/common';
 
 describe('Combobox', () => {
@@ -1083,8 +1083,8 @@ class ComboboxListboxExample {
     </li>
 
     @if (node.children) {
-      <ul ngTreeItemGroup [ownedBy]="treeItem" #group="ngTreeItemGroup">
-        <ng-template ngTreeItemGroupContent>
+      <ul role="group">
+        <ng-template ngTreeItemGroup [ownedBy]="treeItem" #group="ngTreeItemGroup">
           <ng-template
             [ngTemplateOutlet]="treeNodes"
             [ngTemplateOutletContext]="{nodes: node.children, parent: group}"
@@ -1102,7 +1102,6 @@ class ComboboxListboxExample {
     Tree,
     TreeItem,
     TreeItemGroup,
-    TreeItemGroupContent,
     NgTemplateOutlet,
   ],
 })

--- a/src/aria/deferred-content/deferred-content.ts
+++ b/src/aria/deferred-content/deferred-content.ts
@@ -42,19 +42,21 @@ export class DeferredContentAware {
  */
 @Directive()
 export class DeferredContent {
-  private readonly _deferredContentAware = inject(DeferredContentAware);
+  private readonly _deferredContentAware = inject(DeferredContentAware, {optional: true});
   private readonly _templateRef = inject(TemplateRef);
   private readonly _viewContainerRef = inject(ViewContainerRef);
   private _isRendered = false;
 
+  readonly deferredContentAware = signal(this._deferredContentAware);
+
   constructor() {
     afterRenderEffect(() => {
-      if (this._deferredContentAware.contentVisible()) {
+      if (this.deferredContentAware()?.contentVisible()) {
         if (this._isRendered) return;
         this._viewContainerRef.clear();
         this._viewContainerRef.createEmbeddedView(this._templateRef);
         this._isRendered = true;
-      } else if (!this._deferredContentAware.preserveContent()) {
+      } else if (!this.deferredContentAware()?.preserveContent()) {
         this._viewContainerRef.clear();
         this._isRendered = false;
       }

--- a/src/aria/tree/index.ts
+++ b/src/aria/tree/index.ts
@@ -6,4 +6,4 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-export {TreeItemGroup, TreeItemGroupContent, Tree, TreeItem} from './tree';
+export {TreeItemGroup, Tree, TreeItem} from './tree';

--- a/src/components-examples/aria/combobox/combobox-tree-auto-select/combobox-tree-auto-select-example.html
+++ b/src/components-examples/aria/combobox/combobox-tree-auto-select/combobox-tree-auto-select-example.html
@@ -49,8 +49,8 @@
     </li>
 
     @if (node.children) {
-      <ul ngTreeItemGroup [ownedBy]="treeItem" #group="ngTreeItemGroup">
-        <ng-template ngTreeItemGroupContent>
+      <ul role="group">
+        <ng-template  ngTreeItemGroup [ownedBy]="treeItem" #group="ngTreeItemGroup">
           <ng-template
             [ngTemplateOutlet]="treeNodes"
             [ngTemplateOutletContext]="{nodes: node.children, parent: group}"

--- a/src/components-examples/aria/combobox/combobox-tree-auto-select/combobox-tree-auto-select-example.ts
+++ b/src/components-examples/aria/combobox/combobox-tree-auto-select/combobox-tree-auto-select-example.ts
@@ -12,7 +12,7 @@ import {
   ComboboxPopup,
   ComboboxPopupContainer,
 } from '@angular/aria/combobox';
-import {Tree, TreeItem, TreeItemGroup, TreeItemGroupContent} from '@angular/aria/tree';
+import {Tree, TreeItem, TreeItemGroup} from '@angular/aria/tree';
 import {
   afterRenderEffect,
   ChangeDetectionStrategy,
@@ -38,7 +38,6 @@ import {NgTemplateOutlet} from '@angular/common';
     Tree,
     TreeItem,
     TreeItemGroup,
-    TreeItemGroupContent,
     NgTemplateOutlet,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/components-examples/aria/combobox/combobox-tree-highlight/combobox-tree-highlight-example.html
+++ b/src/components-examples/aria/combobox/combobox-tree-highlight/combobox-tree-highlight-example.html
@@ -49,8 +49,8 @@
     </li>
 
     @if (node.children) {
-      <ul ngTreeItemGroup [ownedBy]="treeItem" #group="ngTreeItemGroup">
-        <ng-template ngTreeItemGroupContent>
+      <ul role="group">
+        <ng-template ngTreeItemGroup [ownedBy]="treeItem" #group="ngTreeItemGroup">
           <ng-template
             [ngTemplateOutlet]="treeNodes"
             [ngTemplateOutletContext]="{nodes: node.children, parent: group}"

--- a/src/components-examples/aria/combobox/combobox-tree-highlight/combobox-tree-highlight-example.ts
+++ b/src/components-examples/aria/combobox/combobox-tree-highlight/combobox-tree-highlight-example.ts
@@ -12,7 +12,7 @@ import {
   ComboboxPopup,
   ComboboxPopupContainer,
 } from '@angular/aria/combobox';
-import {Tree, TreeItem, TreeItemGroup, TreeItemGroupContent} from '@angular/aria/tree';
+import {Tree, TreeItem, TreeItemGroup} from '@angular/aria/tree';
 import {
   afterRenderEffect,
   ChangeDetectionStrategy,
@@ -38,7 +38,6 @@ import {NgTemplateOutlet} from '@angular/common';
     Tree,
     TreeItem,
     TreeItemGroup,
-    TreeItemGroupContent,
     NgTemplateOutlet,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/components-examples/aria/combobox/combobox-tree-manual/combobox-tree-manual-example.html
+++ b/src/components-examples/aria/combobox/combobox-tree-manual/combobox-tree-manual-example.html
@@ -49,8 +49,8 @@
     </li>
 
     @if (node.children) {
-      <ul ngTreeItemGroup [ownedBy]="treeItem" #group="ngTreeItemGroup">
-        <ng-template ngTreeItemGroupContent>
+      <ul role="group">
+        <ng-template ngTreeItemGroup [ownedBy]="treeItem" #group="ngTreeItemGroup">
           <ng-template
             [ngTemplateOutlet]="treeNodes"
             [ngTemplateOutletContext]="{nodes: node.children, parent: group}"

--- a/src/components-examples/aria/combobox/combobox-tree-manual/combobox-tree-manual-example.ts
+++ b/src/components-examples/aria/combobox/combobox-tree-manual/combobox-tree-manual-example.ts
@@ -12,7 +12,7 @@ import {
   ComboboxPopup,
   ComboboxPopupContainer,
 } from '@angular/aria/combobox';
-import {Tree, TreeItem, TreeItemGroup, TreeItemGroupContent} from '@angular/aria/tree';
+import {Tree, TreeItem, TreeItemGroup} from '@angular/aria/tree';
 import {
   afterRenderEffect,
   ChangeDetectionStrategy,
@@ -38,7 +38,6 @@ import {NgTemplateOutlet} from '@angular/common';
     Tree,
     TreeItem,
     TreeItemGroup,
-    TreeItemGroupContent,
     NgTemplateOutlet,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/components-examples/aria/tree/tree-active-descendant/tree-active-descendant-example.html
+++ b/src/components-examples/aria/tree/tree-active-descendant/tree-active-descendant-example.html
@@ -23,8 +23,8 @@
   </li>
 
   @if (node.children) {
-  <ul ngTreeItemGroup [ownedBy]="treeItem" #group="ngTreeItemGroup">
-    <ng-template ngTreeItemGroupContent>
+  <ul role="group">
+    <ng-template ngTreeItemGroup [ownedBy]="treeItem" #group="ngTreeItemGroup">
       <ng-template
         [ngTemplateOutlet]="treeNodes"
         [ngTemplateOutletContext]="{nodes: node.children, parent: group}"

--- a/src/components-examples/aria/tree/tree-active-descendant/tree-active-descendant-example.ts
+++ b/src/components-examples/aria/tree/tree-active-descendant/tree-active-descendant-example.ts
@@ -8,7 +8,7 @@
 
 import {Component} from '@angular/core';
 import {NgTemplateOutlet} from '@angular/common';
-import {Tree, TreeItem, TreeItemGroup, TreeItemGroupContent} from '@angular/aria/tree';
+import {Tree, TreeItem, TreeItemGroup} from '@angular/aria/tree';
 import {TreeNode, NODES} from '../tree-data';
 
 /**
@@ -20,7 +20,7 @@ import {TreeNode, NODES} from '../tree-data';
   templateUrl: 'tree-active-descendant-example.html',
   styleUrl: '../tree-common.css',
   standalone: true,
-  imports: [Tree, TreeItem, TreeItemGroup, TreeItemGroupContent, NgTemplateOutlet],
+  imports: [Tree, TreeItem, TreeItemGroup, NgTemplateOutlet],
 })
 export class TreeActiveDescendantExample {
   nodes: TreeNode[] = NODES;

--- a/src/components-examples/aria/tree/tree-configurable/tree-configurable-example.html
+++ b/src/components-examples/aria/tree/tree-configurable/tree-configurable-example.html
@@ -63,8 +63,8 @@
   </li>
 
   @if (node.children) {
-  <ul ngTreeItemGroup [ownedBy]="treeItem" #group="ngTreeItemGroup">
-    <ng-template ngTreeItemGroupContent>
+  <ul role="group">
+    <ng-template ngTreeItemGroup [ownedBy]="treeItem" #group="ngTreeItemGroup">
       <ng-template
         [ngTemplateOutlet]="treeNodes"
         [ngTemplateOutletContext]="{nodes: node.children, parent: group}"

--- a/src/components-examples/aria/tree/tree-configurable/tree-configurable-example.ts
+++ b/src/components-examples/aria/tree/tree-configurable/tree-configurable-example.ts
@@ -11,7 +11,7 @@ import {FormControl, FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {MatCheckboxModule} from '@angular/material/checkbox';
 import {MatFormFieldModule} from '@angular/material/form-field';
 import {MatSelectModule} from '@angular/material/select';
-import {Tree, TreeItem, TreeItemGroup, TreeItemGroupContent} from '@angular/aria/tree';
+import {Tree, TreeItem, TreeItemGroup} from '@angular/aria/tree';
 import {NODES, TreeNode} from '../tree-data';
 
 /** @title Configurable Tree. */
@@ -31,7 +31,6 @@ import {NODES, TreeNode} from '../tree-data';
     Tree,
     TreeItem,
     TreeItemGroup,
-    TreeItemGroupContent,
   ],
 })
 export class TreeConfigurableExample {

--- a/src/components-examples/aria/tree/tree-disabled-focusable/tree-disabled-focusable-example.html
+++ b/src/components-examples/aria/tree/tree-disabled-focusable/tree-disabled-focusable-example.html
@@ -23,8 +23,8 @@
   </li>
 
   @if (node.children) {
-  <ul ngTreeItemGroup [ownedBy]="treeItem" #group="ngTreeItemGroup">
-    <ng-template ngTreeItemGroupContent>
+  <ul role="group">
+    <ng-template ngTreeItemGroup [ownedBy]="treeItem" #group="ngTreeItemGroup">
       <ng-template
         [ngTemplateOutlet]="treeNodes"
         [ngTemplateOutletContext]="{nodes: node.children, parent: group}"

--- a/src/components-examples/aria/tree/tree-disabled-focusable/tree-disabled-focusable-example.ts
+++ b/src/components-examples/aria/tree/tree-disabled-focusable/tree-disabled-focusable-example.ts
@@ -8,7 +8,7 @@
 
 import {Component} from '@angular/core';
 import {NgTemplateOutlet} from '@angular/common';
-import {Tree, TreeItem, TreeItemGroup, TreeItemGroupContent} from '@angular/aria/tree';
+import {Tree, TreeItem, TreeItemGroup} from '@angular/aria/tree';
 import {TreeNode, NODES} from '../tree-data';
 
 /**
@@ -20,7 +20,7 @@ import {TreeNode, NODES} from '../tree-data';
   templateUrl: 'tree-disabled-focusable-example.html',
   styleUrl: '../tree-common.css',
   standalone: true,
-  imports: [Tree, TreeItem, TreeItemGroup, TreeItemGroupContent, NgTemplateOutlet],
+  imports: [Tree, TreeItem, TreeItemGroup, NgTemplateOutlet],
 })
 export class TreeDisabledFocusableExample {
   nodes: TreeNode[] = NODES;

--- a/src/components-examples/aria/tree/tree-disabled-skipped/tree-disabled-skipped-example.html
+++ b/src/components-examples/aria/tree/tree-disabled-skipped/tree-disabled-skipped-example.html
@@ -23,8 +23,8 @@
   </li>
 
   @if (node.children) {
-  <ul ngTreeItemGroup [ownedBy]="treeItem" #group="ngTreeItemGroup">
-    <ng-template ngTreeItemGroupContent>
+  <ul role="group">
+    <ng-template ngTreeItemGroup [ownedBy]="treeItem" #group="ngTreeItemGroup">
       <ng-template
         [ngTemplateOutlet]="treeNodes"
         [ngTemplateOutletContext]="{nodes: node.children, parent: group}"

--- a/src/components-examples/aria/tree/tree-disabled-skipped/tree-disabled-skipped-example.ts
+++ b/src/components-examples/aria/tree/tree-disabled-skipped/tree-disabled-skipped-example.ts
@@ -8,7 +8,7 @@
 
 import {Component} from '@angular/core';
 import {NgTemplateOutlet} from '@angular/common';
-import {Tree, TreeItem, TreeItemGroup, TreeItemGroupContent} from '@angular/aria/tree';
+import {Tree, TreeItem, TreeItemGroup} from '@angular/aria/tree';
 import {TreeNode, NODES} from '../tree-data';
 
 /**
@@ -20,7 +20,7 @@ import {TreeNode, NODES} from '../tree-data';
   templateUrl: 'tree-disabled-skipped-example.html',
   styleUrl: '../tree-common.css',
   standalone: true,
-  imports: [Tree, TreeItem, TreeItemGroup, TreeItemGroupContent, NgTemplateOutlet],
+  imports: [Tree, TreeItem, TreeItemGroup, NgTemplateOutlet],
 })
 export class TreeDisabledSkippedExample {
   nodes: TreeNode[] = NODES;

--- a/src/components-examples/aria/tree/tree-disabled/tree-disabled-example.html
+++ b/src/components-examples/aria/tree/tree-disabled/tree-disabled-example.html
@@ -23,8 +23,8 @@
   </li>
 
   @if (node.children) {
-  <ul ngTreeItemGroup [ownedBy]="treeItem" #group="ngTreeItemGroup">
-    <ng-template ngTreeItemGroupContent>
+  <ul role="group">
+    <ng-template ngTreeItemGroup [ownedBy]="treeItem" #group="ngTreeItemGroup">
       <ng-template
         [ngTemplateOutlet]="treeNodes"
         [ngTemplateOutletContext]="{nodes: node.children, parent: group}"

--- a/src/components-examples/aria/tree/tree-disabled/tree-disabled-example.ts
+++ b/src/components-examples/aria/tree/tree-disabled/tree-disabled-example.ts
@@ -8,7 +8,7 @@
 
 import {Component} from '@angular/core';
 import {NgTemplateOutlet} from '@angular/common';
-import {Tree, TreeItem, TreeItemGroup, TreeItemGroupContent} from '@angular/aria/tree';
+import {Tree, TreeItem, TreeItemGroup} from '@angular/aria/tree';
 import {TreeNode, NODES} from '../tree-data';
 
 /**
@@ -20,7 +20,7 @@ import {TreeNode, NODES} from '../tree-data';
   templateUrl: 'tree-disabled-example.html',
   styleUrl: '../tree-common.css',
   standalone: true,
-  imports: [Tree, TreeItem, TreeItemGroup, TreeItemGroupContent, NgTemplateOutlet],
+  imports: [Tree, TreeItem, TreeItemGroup, NgTemplateOutlet],
 })
 export class TreeDisabledExample {
   nodes: TreeNode[] = NODES;

--- a/src/components-examples/aria/tree/tree-multi-select-follow-focus/tree-multi-select-follow-focus-example.html
+++ b/src/components-examples/aria/tree/tree-multi-select-follow-focus/tree-multi-select-follow-focus-example.html
@@ -23,8 +23,8 @@
   </li>
 
   @if (node.children) {
-  <ul ngTreeItemGroup [ownedBy]="treeItem" #group="ngTreeItemGroup">
-    <ng-template ngTreeItemGroupContent>
+  <ul role="group">
+    <ng-template ngTreeItemGroup [ownedBy]="treeItem" #group="ngTreeItemGroup">
       <ng-template
         [ngTemplateOutlet]="treeNodes"
         [ngTemplateOutletContext]="{nodes: node.children, parent: group}"

--- a/src/components-examples/aria/tree/tree-multi-select-follow-focus/tree-multi-select-follow-focus-example.ts
+++ b/src/components-examples/aria/tree/tree-multi-select-follow-focus/tree-multi-select-follow-focus-example.ts
@@ -8,7 +8,7 @@
 
 import {Component} from '@angular/core';
 import {NgTemplateOutlet} from '@angular/common';
-import {Tree, TreeItem, TreeItemGroup, TreeItemGroupContent} from '@angular/aria/tree';
+import {Tree, TreeItem, TreeItemGroup} from '@angular/aria/tree';
 import {TreeNode, NODES} from '../tree-data';
 
 /**
@@ -20,7 +20,7 @@ import {TreeNode, NODES} from '../tree-data';
   templateUrl: 'tree-multi-select-follow-focus-example.html',
   styleUrl: '../tree-common.css',
   standalone: true,
-  imports: [Tree, TreeItem, TreeItemGroup, TreeItemGroupContent, NgTemplateOutlet],
+  imports: [Tree, TreeItem, TreeItemGroup, NgTemplateOutlet],
 })
 export class TreeMultiSelectFollowFocusExample {
   nodes: TreeNode[] = NODES;

--- a/src/components-examples/aria/tree/tree-multi-select/tree-multi-select-example.html
+++ b/src/components-examples/aria/tree/tree-multi-select/tree-multi-select-example.html
@@ -23,8 +23,8 @@
   </li>
 
   @if (node.children) {
-  <ul ngTreeItemGroup [ownedBy]="treeItem" #group="ngTreeItemGroup">
-    <ng-template ngTreeItemGroupContent>
+  <ul role="group">
+    <ng-template ngTreeItemGroup [ownedBy]="treeItem" #group="ngTreeItemGroup">
       <ng-template
         [ngTemplateOutlet]="treeNodes"
         [ngTemplateOutletContext]="{nodes: node.children, parent: group}"

--- a/src/components-examples/aria/tree/tree-multi-select/tree-multi-select-example.ts
+++ b/src/components-examples/aria/tree/tree-multi-select/tree-multi-select-example.ts
@@ -8,7 +8,7 @@
 
 import {Component} from '@angular/core';
 import {NgTemplateOutlet} from '@angular/common';
-import {Tree, TreeItem, TreeItemGroup, TreeItemGroupContent} from '@angular/aria/tree';
+import {Tree, TreeItem, TreeItemGroup} from '@angular/aria/tree';
 import {TreeNode, NODES} from '../tree-data';
 
 /**
@@ -20,7 +20,7 @@ import {TreeNode, NODES} from '../tree-data';
   templateUrl: 'tree-multi-select-example.html',
   styleUrl: '../tree-common.css',
   standalone: true,
-  imports: [Tree, TreeItem, TreeItemGroup, TreeItemGroupContent, NgTemplateOutlet],
+  imports: [Tree, TreeItem, TreeItemGroup, NgTemplateOutlet],
 })
 export class TreeMultiSelectExample {
   nodes: TreeNode[] = NODES;

--- a/src/components-examples/aria/tree/tree-nav/tree-nav-example.html
+++ b/src/components-examples/aria/tree/tree-nav/tree-nav-example.html
@@ -35,8 +35,8 @@
     </a>
 
     @if (node.children) {
-      <ul ngTreeItemGroup [ownedBy]="treeItem" #group="ngTreeItemGroup">
-        <ng-template ngTreeItemGroupContent>
+      <ul role="group">
+        <ng-template ngTreeItemGroup [ownedBy]="treeItem" #group="ngTreeItemGroup">
           <ng-template
             [ngTemplateOutlet]="treeNodes"
             [ngTemplateOutletContext]="{nodes: node.children, parent: group}"

--- a/src/components-examples/aria/tree/tree-nav/tree-nav-example.ts
+++ b/src/components-examples/aria/tree/tree-nav/tree-nav-example.ts
@@ -8,7 +8,7 @@
 
 import {Component} from '@angular/core';
 import {NgTemplateOutlet} from '@angular/common';
-import {Tree, TreeItem, TreeItemGroup, TreeItemGroupContent} from '@angular/aria/tree';
+import {Tree, TreeItem, TreeItemGroup} from '@angular/aria/tree';
 import {TreeNode, NODES} from '../tree-data';
 
 /**
@@ -20,7 +20,7 @@ import {TreeNode, NODES} from '../tree-data';
   templateUrl: 'tree-nav-example.html',
   styleUrl: '../tree-common.css',
   standalone: true,
-  imports: [Tree, TreeItem, TreeItemGroup, TreeItemGroupContent, NgTemplateOutlet],
+  imports: [Tree, TreeItem, TreeItemGroup, NgTemplateOutlet],
 })
 export class TreeNavExample {
   nodes: TreeNode[] = NODES;

--- a/src/components-examples/aria/tree/tree-single-select-follow-focus/tree-single-select-follow-focus-example.html
+++ b/src/components-examples/aria/tree/tree-single-select-follow-focus/tree-single-select-follow-focus-example.html
@@ -23,8 +23,8 @@
   </li>
 
   @if (node.children) {
-  <ul ngTreeItemGroup [ownedBy]="treeItem" #group="ngTreeItemGroup">
-    <ng-template ngTreeItemGroupContent>
+  <ul role=group>
+    <ng-template ngTreeItemGroup [ownedBy]="treeItem" #group="ngTreeItemGroup">
       <ng-template
         [ngTemplateOutlet]="treeNodes"
         [ngTemplateOutletContext]="{nodes: node.children, parent: group}"

--- a/src/components-examples/aria/tree/tree-single-select-follow-focus/tree-single-select-follow-focus-example.ts
+++ b/src/components-examples/aria/tree/tree-single-select-follow-focus/tree-single-select-follow-focus-example.ts
@@ -8,7 +8,7 @@
 
 import {Component} from '@angular/core';
 import {NgTemplateOutlet} from '@angular/common';
-import {Tree, TreeItem, TreeItemGroup, TreeItemGroupContent} from '@angular/aria/tree';
+import {Tree, TreeItem, TreeItemGroup} from '@angular/aria/tree';
 import {TreeNode, NODES} from '../tree-data';
 
 /**
@@ -20,7 +20,7 @@ import {TreeNode, NODES} from '../tree-data';
   templateUrl: 'tree-single-select-follow-focus-example.html',
   styleUrl: '../tree-common.css',
   standalone: true,
-  imports: [Tree, TreeItem, TreeItemGroup, TreeItemGroupContent, NgTemplateOutlet],
+  imports: [Tree, TreeItem, TreeItemGroup, NgTemplateOutlet],
 })
 export class TreeSingleSelectFollowFocusExample {
   nodes: TreeNode[] = NODES;

--- a/src/components-examples/aria/tree/tree-single-select/tree-single-select-example.html
+++ b/src/components-examples/aria/tree/tree-single-select/tree-single-select-example.html
@@ -23,8 +23,8 @@
   </li>
 
   @if (node.children) {
-  <ul ngTreeItemGroup [ownedBy]="treeItem" #group="ngTreeItemGroup">
-    <ng-template ngTreeItemGroupContent>
+  <ul role="group">
+    <ng-template ngTreeItemGroup [ownedBy]="treeItem" #group="ngTreeItemGroup">
       <ng-template
         [ngTemplateOutlet]="treeNodes"
         [ngTemplateOutletContext]="{nodes: node.children, parent: group}"

--- a/src/components-examples/aria/tree/tree-single-select/tree-single-select-example.ts
+++ b/src/components-examples/aria/tree/tree-single-select/tree-single-select-example.ts
@@ -8,7 +8,7 @@
 
 import {Component} from '@angular/core';
 import {NgTemplateOutlet} from '@angular/common';
-import {Tree, TreeItem, TreeItemGroup, TreeItemGroupContent} from '@angular/aria/tree';
+import {Tree, TreeItem, TreeItemGroup} from '@angular/aria/tree';
 import {TreeNode, NODES} from '../tree-data';
 
 /**
@@ -20,7 +20,7 @@ import {TreeNode, NODES} from '../tree-data';
   templateUrl: 'tree-single-select-example.html',
   styleUrl: '../tree-common.css',
   standalone: true,
-  imports: [Tree, TreeItem, TreeItemGroup, TreeItemGroupContent, NgTemplateOutlet],
+  imports: [Tree, TreeItem, TreeItemGroup, NgTemplateOutlet],
 })
 export class TreeSingleSelectExample {
   nodes: TreeNode[] = NODES;


### PR DESCRIPTION
### This change comes with trade-offs

**Pro:** This enables a truly flatten tree structure, no wrapper required
```
<tree>
  <treeitem aria-level="1"></treeitem>
  <treeitem aria-level="2"></treeitem>
  <treeitem aria-level="3"></treeitem>
  <treeitem aria-level="2"></treeitem>
  <treeitem aria-level="1"></treeitem>
</tree>
```
instead of
```
<tree>
  <treeitem aria-level="1"></treeitem>
  <treegroup>
    <treeitem aria-level="2"></treeitem>
    <treegroup>
      <treeitem aria-level="3"></treeitem>
    </treegroup>
    <treeitem aria-level="2"></treeitem>
  </treegroup>
  <treeitem aria-level="1"></treeitem>
</tree>
```

**Con:** For a nested tree, developers must manually put a `role="group"` parent to avoid `aria-required-parent` violation. (`treeitem` needs a `tree` or `group` parent, a `treeitem` inside a `treeitem` directly without a `group` wrapper causes a violation)
```
<tree>
  <treeitem aria-level="1">
    <treeitem aria-level="2">
      <treeitem aria-level="3"></treeitem>
    </treeitem>
    <treeitem aria-level="2"></treeitem>
  </treeitem>
  <treeitem aria-level="1"></treeitem>
</tree>
```
above causes violation as group wrappers are required
```
<tree>
  <treeitem aria-level="1">
    <div role="group">
      <treeitem aria-level="2">
        <div role="group">
          <treeitem aria-level="3"></treeitem>
        </div>
      </treeitem>
      <treeitem aria-level="2"></treeitem>
    </div>
  </treeitem>
  <treeitem aria-level="1"></treeitem>
</tree>
```
