### PR TITLE
refactor(multiple): remove unnecessary fields from examples

### DIFF
--- a/src/components-examples/aria/accordion/accordion-configurable/accordion-configurable-example.ts
+++ b/src/components-examples/aria/accordion/accordion-configurable/accordion-configurable-example.ts
@@ -15,10 +15,8 @@ import {
 /** @title Configurable Accordion using UI Patterns. */
 @Component({
   selector: 'accordion-configurable-example',
-  exportAs: 'AccordionConfigurableExample',
   templateUrl: 'accordion-configurable-example.html',
-  styleUrl: '../accordion-examples.css', // Point to shared CSS
-  standalone: true,
+  styleUrl: '../accordion-examples.css',
   imports: [
     ReactiveFormsModule,
     MatIconModule,

--- a/src/components-examples/aria/accordion/accordion-disabled-focusable/accordion-disabled-focusable-example.ts
+++ b/src/components-examples/aria/accordion/accordion-disabled-focusable/accordion-disabled-focusable-example.ts
@@ -12,7 +12,6 @@ import {
   selector: 'accordion-disabled-focusable-example',
   templateUrl: 'accordion-disabled-focusable-example.html',
   styleUrl: '../accordion-examples.css',
-  standalone: true,
   imports: [MatIconModule, AccordionGroup, AccordionTrigger, AccordionPanel, AccordionContent],
 })
 export class AccordionDisabledFocusableExample {

--- a/src/components-examples/aria/accordion/accordion-disabled-skipped/accordion-disabled-skipped-example.ts
+++ b/src/components-examples/aria/accordion/accordion-disabled-skipped/accordion-disabled-skipped-example.ts
@@ -12,7 +12,6 @@ import {
   selector: 'accordion-disabled-skipped-example',
   templateUrl: 'accordion-disabled-skipped-example.html',
   styleUrl: '../accordion-examples.css',
-  standalone: true,
   imports: [MatIconModule, AccordionGroup, AccordionTrigger, AccordionPanel, AccordionContent],
 })
 export class AccordionDisabledSkippedExample {

--- a/src/components-examples/aria/accordion/accordion-disabled/accordion-disabled-example.ts
+++ b/src/components-examples/aria/accordion/accordion-disabled/accordion-disabled-example.ts
@@ -12,7 +12,6 @@ import {
   selector: 'accordion-disabled-example',
   templateUrl: 'accordion-disabled-example.html',
   styleUrl: '../accordion-examples.css',
-  standalone: true,
   imports: [MatIconModule, AccordionGroup, AccordionTrigger, AccordionPanel, AccordionContent],
 })
 export class AccordionDisabledExample {

--- a/src/components-examples/aria/accordion/accordion-multi-expansion/accordion-multi-expansion-example.ts
+++ b/src/components-examples/aria/accordion/accordion-multi-expansion/accordion-multi-expansion-example.ts
@@ -12,7 +12,6 @@ import {
   selector: 'accordion-multi-expansion-example',
   templateUrl: 'accordion-multi-expansion-example.html',
   styleUrl: '../accordion-examples.css',
-  standalone: true,
   imports: [MatIconModule, AccordionGroup, AccordionTrigger, AccordionPanel, AccordionContent],
 })
 export class AccordionMultiExpansionExample {

--- a/src/components-examples/aria/accordion/accordion-single-expansion/accordion-single-expansion-example.ts
+++ b/src/components-examples/aria/accordion/accordion-single-expansion/accordion-single-expansion-example.ts
@@ -12,7 +12,6 @@ import {
   selector: 'accordion-single-expansion-example',
   templateUrl: 'accordion-single-expansion-example.html',
   styleUrl: '../accordion-examples.css',
-  standalone: true,
   imports: [MatIconModule, AccordionGroup, AccordionTrigger, AccordionPanel, AccordionContent],
 })
 export class AccordionSingleExpansionExample {

--- a/src/components-examples/aria/listbox/listbox-active-descendant/listbox-active-descendant-example.ts
+++ b/src/components-examples/aria/listbox/listbox-active-descendant/listbox-active-descendant-example.ts
@@ -7,10 +7,8 @@ import {MatPseudoCheckbox} from '@angular/material/core';
  */
 @Component({
   selector: 'listbox-active-descendant-example',
-  exportAs: 'ListboxActiveDescendantExample',
   templateUrl: 'listbox-active-descendant-example.html',
   styleUrl: '../listbox-configurable/listbox-configurable-example.css',
-  standalone: true,
   imports: [Listbox, Option, MatPseudoCheckbox],
 })
 export class ListboxActiveDescendantExample {

--- a/src/components-examples/aria/listbox/listbox-configurable/listbox-configurable-example.ts
+++ b/src/components-examples/aria/listbox/listbox-configurable/listbox-configurable-example.ts
@@ -9,10 +9,8 @@ import {MatPseudoCheckbox} from '@angular/material/core';
 /** @title Configurable Listbox. */
 @Component({
   selector: 'listbox-configurable-example',
-  exportAs: 'ListboxConfigurableExample',
   templateUrl: 'listbox-configurable-example.html',
   styleUrl: 'listbox-configurable-example.css',
-  standalone: true,
   imports: [
     Listbox,
     Option,

--- a/src/components-examples/aria/listbox/listbox-disabled-focusable/listbox-disabled-focusable-example.ts
+++ b/src/components-examples/aria/listbox/listbox-disabled-focusable/listbox-disabled-focusable-example.ts
@@ -7,10 +7,8 @@ import {MatPseudoCheckbox} from '@angular/material/core';
  */
 @Component({
   selector: 'listbox-disabled-focusable-example',
-  exportAs: 'ListboxDisabledFocusableExample',
   templateUrl: 'listbox-disabled-focusable-example.html',
   styleUrl: '../listbox-configurable/listbox-configurable-example.css',
-  standalone: true,
   imports: [Listbox, Option, MatPseudoCheckbox],
 })
 export class ListboxDisabledFocusableExample {

--- a/src/components-examples/aria/listbox/listbox-disabled-skipped/listbox-disabled-skipped-example.ts
+++ b/src/components-examples/aria/listbox/listbox-disabled-skipped/listbox-disabled-skipped-example.ts
@@ -7,10 +7,8 @@ import {MatPseudoCheckbox} from '@angular/material/core';
  */
 @Component({
   selector: 'listbox-disabled-skipped-example',
-  exportAs: 'ListboxDisabledSkippedExample',
   templateUrl: 'listbox-disabled-skipped-example.html',
   styleUrl: '../listbox-configurable/listbox-configurable-example.css',
-  standalone: true,
   imports: [Listbox, Option, MatPseudoCheckbox],
 })
 export class ListboxDisabledSkippedExample {

--- a/src/components-examples/aria/listbox/listbox-disabled/listbox-disabled-example.ts
+++ b/src/components-examples/aria/listbox/listbox-disabled/listbox-disabled-example.ts
@@ -7,10 +7,8 @@ import {MatPseudoCheckbox} from '@angular/material/core';
  */
 @Component({
   selector: 'listbox-disabled-example',
-  exportAs: 'ListboxDisabledExample',
   templateUrl: 'listbox-disabled-example.html',
   styleUrl: '../listbox-configurable/listbox-configurable-example.css',
-  standalone: true,
   imports: [Listbox, Option, MatPseudoCheckbox],
 })
 export class ListboxDisabledExample {

--- a/src/components-examples/aria/listbox/listbox-horizontal/listbox-horizontal-example.ts
+++ b/src/components-examples/aria/listbox/listbox-horizontal/listbox-horizontal-example.ts
@@ -7,10 +7,8 @@ import {MatPseudoCheckbox} from '@angular/material/core';
  */
 @Component({
   selector: 'listbox-horizontal-example',
-  exportAs: 'ListboxHorizontalExample',
   templateUrl: 'listbox-horizontal-example.html',
   styleUrl: '../listbox-configurable/listbox-configurable-example.css',
-  standalone: true,
   imports: [Listbox, Option, MatPseudoCheckbox],
 })
 export class ListboxHorizontalExample {

--- a/src/components-examples/aria/listbox/listbox-multi-select-follow-focus/listbox-multi-select-follow-focus-example.ts
+++ b/src/components-examples/aria/listbox/listbox-multi-select-follow-focus/listbox-multi-select-follow-focus-example.ts
@@ -7,10 +7,8 @@ import {MatPseudoCheckbox} from '@angular/material/core';
  */
 @Component({
   selector: 'listbox-multi-select-follow-focus-example',
-  exportAs: 'ListboxMultiSelectFollowFocusExample',
   templateUrl: 'listbox-multi-select-follow-focus-example.html',
   styleUrl: '../listbox-configurable/listbox-configurable-example.css',
-  standalone: true,
   imports: [Listbox, Option, MatPseudoCheckbox],
 })
 export class ListboxMultiSelectFollowFocusExample {

--- a/src/components-examples/aria/listbox/listbox-multi-select/listbox-multi-select-example.ts
+++ b/src/components-examples/aria/listbox/listbox-multi-select/listbox-multi-select-example.ts
@@ -9,7 +9,6 @@ import {MatPseudoCheckbox} from '@angular/material/core';
   selector: 'listbox-multi-select-example',
   templateUrl: './listbox-multi-select-example.html',
   styleUrl: '../listbox-configurable/listbox-configurable-example.css',
-  standalone: true,
   imports: [Listbox, Option, MatPseudoCheckbox],
 })
 export class ListboxMultiSelectExample {

--- a/src/components-examples/aria/listbox/listbox-readonly/listbox-readonly-example.ts
+++ b/src/components-examples/aria/listbox/listbox-readonly/listbox-readonly-example.ts
@@ -7,10 +7,8 @@ import {MatPseudoCheckbox} from '@angular/material/core';
  */
 @Component({
   selector: 'listbox-readonly-example',
-  exportAs: 'ListboxReadonlyExample',
   templateUrl: 'listbox-readonly-example.html',
   styleUrl: '../listbox-configurable/listbox-configurable-example.css',
-  standalone: true,
   imports: [Listbox, Option, MatPseudoCheckbox],
 })
 export class ListboxReadonlyExample {

--- a/src/components-examples/aria/listbox/listbox-rtl-horizontal/listbox-rtl-horizontal-example.ts
+++ b/src/components-examples/aria/listbox/listbox-rtl-horizontal/listbox-rtl-horizontal-example.ts
@@ -8,10 +8,8 @@ import {MatPseudoCheckbox} from '@angular/material/core';
  */
 @Component({
   selector: 'listbox-rtl-horizontal-example',
-  exportAs: 'ListboxRtlHorizontalExample',
   templateUrl: 'listbox-rtl-horizontal-example.html',
   styleUrl: '../listbox-configurable/listbox-configurable-example.css',
-  standalone: true,
   imports: [Listbox, Option, Dir, MatPseudoCheckbox],
 })
 export class ListboxRtlHorizontalExample {

--- a/src/components-examples/aria/listbox/listbox-single-select-follow-focus/listbox-single-select-follow-focus-example.ts
+++ b/src/components-examples/aria/listbox/listbox-single-select-follow-focus/listbox-single-select-follow-focus-example.ts
@@ -5,10 +5,8 @@ import {MatPseudoCheckbox} from '@angular/material/core';
 /** @title Listbox with single selection and selection follows focus. */
 @Component({
   selector: 'listbox-single-select-follow-focus-example',
-  exportAs: 'ListboxSingleSelectFollowFocusExample',
   templateUrl: 'listbox-single-select-follow-focus-example.html',
-  styleUrl: '../listbox-configurable/listbox-configurable-example.css', // Reuse common styles
-  standalone: true,
+  styleUrl: '../listbox-configurable/listbox-configurable-example.css',
   imports: [Listbox, Option, MatPseudoCheckbox],
 })
 export class ListboxSingleSelectFollowFocusExample {

--- a/src/components-examples/aria/listbox/listbox-single-select/listbox-single-select-example.ts
+++ b/src/components-examples/aria/listbox/listbox-single-select/listbox-single-select-example.ts
@@ -5,10 +5,8 @@ import {MatPseudoCheckbox} from '@angular/material/core';
 /** @title Listbox with single selection. */
 @Component({
   selector: 'listbox-single-select-example',
-  exportAs: 'ListboxSingleSelectExample',
   templateUrl: 'listbox-single-select-example.html',
-  styleUrl: '../listbox-configurable/listbox-configurable-example.css', // Reuse common styles
-  standalone: true,
+  styleUrl: '../listbox-configurable/listbox-configurable-example.css',
   imports: [Listbox, Option, MatPseudoCheckbox],
 })
 export class ListboxSingleSelectExample {

--- a/src/components-examples/aria/radio-group/radio-group-active-descendant/radio-group-active-descendant-example.ts
+++ b/src/components-examples/aria/radio-group/radio-group-active-descendant/radio-group-active-descendant-example.ts
@@ -5,9 +5,7 @@ import {RadioGroup, RadioButton} from '@angular/aria/radio-group';
 /** @title Active descendant radio group. */
 @Component({
   selector: 'radio-group-active-descendant-example',
-  exportAs: 'RadioActiveDescendantExample',
   templateUrl: 'radio-group-active-descendant-example.html',
-  standalone: true,
   styleUrl: '../radio-common.css',
   imports: [RadioGroup, RadioButton, FormsModule],
 })

--- a/src/components-examples/aria/radio-group/radio-group-configurable/radio-group-configurable-example.ts
+++ b/src/components-examples/aria/radio-group/radio-group-configurable/radio-group-configurable-example.ts
@@ -8,10 +8,8 @@ import {FormControl, FormsModule, ReactiveFormsModule} from '@angular/forms';
 /** @title Configurable CDK Radio Group */
 @Component({
   selector: 'radio-group-configurable-example',
-  exportAs: 'RadioConfigurableExample',
   templateUrl: 'radio-group-configurable-example.html',
   styleUrl: '../radio-common.css',
-  standalone: true,
   imports: [
     RadioGroup,
     RadioButton,

--- a/src/components-examples/aria/radio-group/radio-group-disabled-focusable/radio-group-disabled-focusable-example.ts
+++ b/src/components-examples/aria/radio-group/radio-group-disabled-focusable/radio-group-disabled-focusable-example.ts
@@ -5,10 +5,8 @@ import {RadioGroup, RadioButton} from '@angular/aria/radio-group';
 /** @title Radio group with disabled options that are focusable. */
 @Component({
   selector: 'radio-group-disabled-focusable-example',
-  exportAs: 'RadioDisabledFocusableExample',
   templateUrl: 'radio-group-disabled-focusable-example.html',
   styleUrl: '../radio-common.css',
-  standalone: true,
   imports: [RadioGroup, RadioButton, FormsModule],
 })
 export class RadioGroupDisabledFocusableExample {

--- a/src/components-examples/aria/radio-group/radio-group-disabled-skipped/radio-group-disabled-skipped-example.ts
+++ b/src/components-examples/aria/radio-group/radio-group-disabled-skipped/radio-group-disabled-skipped-example.ts
@@ -5,10 +5,8 @@ import {RadioGroup, RadioButton} from '@angular/aria/radio-group';
 /** @title Radio group with disabled options that are skipped. */
 @Component({
   selector: 'radio-group-disabled-skipped-example',
-  exportAs: 'RadioDisabledSkippedExample',
   templateUrl: 'radio-group-disabled-skipped-example.html',
   styleUrl: '../radio-common.css',
-  standalone: true,
   imports: [RadioGroup, RadioButton, FormsModule],
 })
 export class RadioGroupDisabledSkippedExample {

--- a/src/components-examples/aria/radio-group/radio-group-disabled/radio-group-disabled-example.ts
+++ b/src/components-examples/aria/radio-group/radio-group-disabled/radio-group-disabled-example.ts
@@ -5,10 +5,8 @@ import {RadioGroup, RadioButton} from '@angular/aria/radio-group';
 /** @title Disabled radio group. */
 @Component({
   selector: 'radio-group-disabled-example',
-  exportAs: 'RadioDisabledExample',
   templateUrl: 'radio-group-disabled-example.html',
   styleUrl: '../radio-common.css',
-  standalone: true,
   imports: [RadioGroup, RadioButton, FormsModule],
 })
 export class RadioGroupDisabledExample {

--- a/src/components-examples/aria/radio-group/radio-group-horizontal/radio-group-horizontal-example.ts
+++ b/src/components-examples/aria/radio-group/radio-group-horizontal/radio-group-horizontal-example.ts
@@ -5,10 +5,8 @@ import {RadioGroup, RadioButton} from '@angular/aria/radio-group';
 /** @title Horizontal radio group. */
 @Component({
   selector: 'radio-group-horizontal-example',
-  exportAs: 'RadioHorizontalExample',
   templateUrl: 'radio-group-horizontal-example.html',
   styleUrl: '../radio-common.css',
-  standalone: true,
   imports: [RadioGroup, RadioButton, FormsModule],
 })
 export class RadioGroupHorizontalExample {

--- a/src/components-examples/aria/radio-group/radio-group-readonly/radio-group-readonly-example.ts
+++ b/src/components-examples/aria/radio-group/radio-group-readonly/radio-group-readonly-example.ts
@@ -5,10 +5,8 @@ import {RadioGroup, RadioButton} from '@angular/aria/radio-group';
 /** @title Readonly radio group. */
 @Component({
   selector: 'radio-group-readonly-example',
-  exportAs: 'RadioReadonlyExample',
   templateUrl: 'radio-group-readonly-example.html',
   styleUrl: '../radio-common.css',
-  standalone: true,
   imports: [RadioGroup, RadioButton, FormsModule],
 })
 export class RadioGroupReadonlyExample {

--- a/src/components-examples/aria/radio-group/radio-group-rtl-horizontal/radio-group-rtl-horizontal-example.ts
+++ b/src/components-examples/aria/radio-group/radio-group-rtl-horizontal/radio-group-rtl-horizontal-example.ts
@@ -6,10 +6,8 @@ import {RadioGroup, RadioButton} from '@angular/aria/radio-group';
 /** @title RTL horizontal radio group. */
 @Component({
   selector: 'radio-group-rtl-horizontal-example',
-  exportAs: 'RadioRtlHorizontalExample',
   templateUrl: 'radio-group-rtl-horizontal-example.html',
   styleUrl: '../radio-common.css',
-  standalone: true,
   imports: [RadioGroup, RadioButton, Dir, FormsModule],
 })
 export class RadioGroupRtlHorizontalExample {

--- a/src/components-examples/aria/radio-group/radio-group-standard/radio-group-standard-example.ts
+++ b/src/components-examples/aria/radio-group/radio-group-standard/radio-group-standard-example.ts
@@ -5,10 +5,8 @@ import {RadioGroup, RadioButton} from '@angular/aria/radio-group';
 /** @title Basic radio group. */
 @Component({
   selector: 'radio-group-standard-example',
-  exportAs: 'RadioStandardExample',
   templateUrl: 'radio-group-standard-example.html',
   styleUrl: '../radio-common.css',
-  standalone: true,
   imports: [RadioGroup, RadioButton, FormsModule],
 })
 export class RadioGroupStandardExample {

--- a/src/components-examples/aria/tabs/active-descendant/tabs-active-descendant-example.ts
+++ b/src/components-examples/aria/tabs/active-descendant/tabs-active-descendant-example.ts
@@ -4,10 +4,8 @@ import {Tab, Tabs, TabList, TabPanel, TabContent} from '@angular/aria/tabs';
 /** @title Active Descendant */
 @Component({
   selector: 'tabs-active-descendant-example',
-  exportAs: 'TabsActiveDescendantExample',
   templateUrl: 'tabs-active-descendant-example.html',
   styleUrls: ['../tabs-common.css'],
-  standalone: true,
   imports: [TabList, Tab, Tabs, TabPanel, TabContent],
 })
 export class TabsActiveDescendantExample {}

--- a/src/components-examples/aria/tabs/disabled-focusable/tabs-disabled-focusable-example.ts
+++ b/src/components-examples/aria/tabs/disabled-focusable/tabs-disabled-focusable-example.ts
@@ -4,10 +4,8 @@ import {Tab, Tabs, TabList, TabPanel, TabContent} from '@angular/aria/tabs';
 /** @title Disabled Tabs are Focusable */
 @Component({
   selector: 'tabs-disabled-focusable-example',
-  exportAs: 'TabsDisabledFocusableExample',
   templateUrl: 'tabs-disabled-focusable-example.html',
   styleUrls: ['../tabs-common.css'],
-  standalone: true,
   imports: [TabList, Tab, Tabs, TabPanel, TabContent],
 })
 export class TabsDisabledFocusableExample {}

--- a/src/components-examples/aria/tabs/disabled-skipped/tabs-disabled-skipped-example.ts
+++ b/src/components-examples/aria/tabs/disabled-skipped/tabs-disabled-skipped-example.ts
@@ -4,10 +4,8 @@ import {Tab, Tabs, TabList, TabPanel, TabContent} from '@angular/aria/tabs';
 /** @title Disabled Tabs are Skipped */
 @Component({
   selector: 'tabs-disabled-skipped-example',
-  exportAs: 'TabsDisabledSkippedExample',
   templateUrl: 'tabs-disabled-skipped-example.html',
   styleUrls: ['../tabs-common.css'],
-  standalone: true,
   imports: [TabList, Tab, Tabs, TabPanel, TabContent],
 })
 export class TabsDisabledSkippedExample {}

--- a/src/components-examples/aria/tabs/disabled/tabs-disabled-example.ts
+++ b/src/components-examples/aria/tabs/disabled/tabs-disabled-example.ts
@@ -4,10 +4,8 @@ import {Tab, Tabs, TabList, TabPanel, TabContent} from '@angular/aria/tabs';
 /** @title Disabled */
 @Component({
   selector: 'tabs-disabled-example',
-  exportAs: 'TabsDisabledExample',
   templateUrl: 'tabs-disabled-example.html',
   styleUrls: ['../tabs-common.css'],
-  standalone: true,
   imports: [TabList, Tab, Tabs, TabPanel, TabContent],
 })
 export class TabsDisabledExample {}

--- a/src/components-examples/aria/tabs/explicit-selection/tabs-explicit-selection-example.ts
+++ b/src/components-examples/aria/tabs/explicit-selection/tabs-explicit-selection-example.ts
@@ -4,10 +4,8 @@ import {Tab, Tabs, TabList, TabPanel, TabContent} from '@angular/aria/tabs';
 /** @title Explicit selection */
 @Component({
   selector: 'tabs-explicit-selection-example',
-  exportAs: 'TabsExplicitSelectionExample',
   templateUrl: 'tabs-explicit-selection-example.html',
   styleUrls: ['../tabs-common.css'],
-  standalone: true,
   imports: [TabList, Tab, Tabs, TabPanel, TabContent],
 })
 export class TabsExplicitSelectionExample {}

--- a/src/components-examples/aria/tabs/rtl/tabs-rtl-example.ts
+++ b/src/components-examples/aria/tabs/rtl/tabs-rtl-example.ts
@@ -5,10 +5,8 @@ import {Tab, Tabs, TabList, TabPanel, TabContent} from '@angular/aria/tabs';
 /** * @title RTL */
 @Component({
   selector: 'tabs-rtl-example',
-  exportAs: 'TabsRtlExample',
   templateUrl: 'tabs-rtl-example.html',
   styleUrls: ['../tabs-common.css'],
-  standalone: true,
   imports: [TabList, Tab, Tabs, TabPanel, TabContent, Dir],
 })
 export class TabsRtlExample {

--- a/src/components-examples/aria/tabs/selection-follows-focus/tabs-selection-follows-focus-example.ts
+++ b/src/components-examples/aria/tabs/selection-follows-focus/tabs-selection-follows-focus-example.ts
@@ -4,10 +4,8 @@ import {Tab, Tabs, TabList, TabPanel, TabContent} from '@angular/aria/tabs';
 /** @title Selection Follows Focus */
 @Component({
   selector: 'tabs-selection-follows-focus-example',
-  exportAs: 'TabsSelectionFollowsFocusExample',
   templateUrl: 'tabs-selection-follows-focus-example.html',
   styleUrls: ['../tabs-common.css'],
-  standalone: true,
   imports: [TabList, Tab, Tabs, TabPanel, TabContent],
 })
 export class TabsSelectionFollowsFocusExample {}

--- a/src/components-examples/aria/tabs/tabs-configurable/tabs-configurable-example.ts
+++ b/src/components-examples/aria/tabs/tabs-configurable/tabs-configurable-example.ts
@@ -8,10 +8,8 @@ import {FormControl, ReactiveFormsModule} from '@angular/forms';
 /** @title Configurable Tabs. */
 @Component({
   selector: 'tabs-configurable-example',
-  exportAs: 'TabsConfigurableExample',
   templateUrl: 'tabs-configurable-example.html',
   styleUrls: ['../tabs-common.css'],
-  standalone: true,
   imports: [
     Tabs,
     TabList,

--- a/src/components-examples/aria/tabs/vertical-orientation/tabs-vertical-example.ts
+++ b/src/components-examples/aria/tabs/vertical-orientation/tabs-vertical-example.ts
@@ -4,10 +4,8 @@ import {Tab, Tabs, TabList, TabPanel, TabContent} from '@angular/aria/tabs';
 /** @title Vertical */
 @Component({
   selector: 'tabs-vertical-example',
-  exportAs: 'TabsVerticalExample',
   templateUrl: 'tabs-vertical-example.html',
   styleUrls: ['../tabs-common.css'],
-  standalone: true,
   imports: [TabList, Tab, Tabs, TabPanel, TabContent],
 })
 export class TabsVerticalExample {}

--- a/src/components-examples/aria/toolbar/toolbar-configurable/toolbar-configurable-example.ts
+++ b/src/components-examples/aria/toolbar/toolbar-configurable/toolbar-configurable-example.ts
@@ -9,10 +9,8 @@ import {Toolbar, ToolbarWidget} from '@angular/aria/toolbar';
 /** @title Configurable CDK Radio Group */
 @Component({
   selector: 'toolbar-configurable-example',
-  exportAs: 'ToolbarConfigurableExample',
   templateUrl: 'toolbar-configurable-example.html',
   styleUrl: '../toolbar-common.css',
-  standalone: true,
   imports: [
     RadioGroup,
     RadioButton,

--- a/src/components-examples/aria/tree/tree-active-descendant/tree-active-descendant-example.ts
+++ b/src/components-examples/aria/tree/tree-active-descendant/tree-active-descendant-example.ts
@@ -16,10 +16,8 @@ import {TreeNode, NODES} from '../tree-data';
  */
 @Component({
   selector: 'tree-active-descendant-example',
-  exportAs: 'TreeActiveDescendantExample',
   templateUrl: 'tree-active-descendant-example.html',
   styleUrl: '../tree-common.css',
-  standalone: true,
   imports: [Tree, TreeItem, TreeItemGroup, NgTemplateOutlet],
 })
 export class TreeActiveDescendantExample {

--- a/src/components-examples/aria/tree/tree-configurable/tree-configurable-example.ts
+++ b/src/components-examples/aria/tree/tree-configurable/tree-configurable-example.ts
@@ -17,10 +17,8 @@ import {NODES, TreeNode} from '../tree-data';
 /** @title Configurable Tree. */
 @Component({
   selector: 'tree-configurable-example',
-  exportAs: 'TreeConfigurableExample',
   templateUrl: 'tree-configurable-example.html',
   styleUrl: '../tree-common.css',
-  standalone: true,
   imports: [
     FormsModule,
     ReactiveFormsModule,

--- a/src/components-examples/aria/tree/tree-disabled-focusable/tree-disabled-focusable-example.ts
+++ b/src/components-examples/aria/tree/tree-disabled-focusable/tree-disabled-focusable-example.ts
@@ -16,10 +16,8 @@ import {TreeNode, NODES} from '../tree-data';
  */
 @Component({
   selector: 'tree-disabled-focusable-example',
-  exportAs: 'TreeDisabledFocusableExample',
   templateUrl: 'tree-disabled-focusable-example.html',
   styleUrl: '../tree-common.css',
-  standalone: true,
   imports: [Tree, TreeItem, TreeItemGroup, NgTemplateOutlet],
 })
 export class TreeDisabledFocusableExample {

--- a/src/components-examples/aria/tree/tree-disabled-skipped/tree-disabled-skipped-example.ts
+++ b/src/components-examples/aria/tree/tree-disabled-skipped/tree-disabled-skipped-example.ts
@@ -16,10 +16,8 @@ import {TreeNode, NODES} from '../tree-data';
  */
 @Component({
   selector: 'tree-disabled-skipped-example',
-  exportAs: 'TreeDisabledSkippedExample',
   templateUrl: 'tree-disabled-skipped-example.html',
   styleUrl: '../tree-common.css',
-  standalone: true,
   imports: [Tree, TreeItem, TreeItemGroup, NgTemplateOutlet],
 })
 export class TreeDisabledSkippedExample {

--- a/src/components-examples/aria/tree/tree-disabled/tree-disabled-example.ts
+++ b/src/components-examples/aria/tree/tree-disabled/tree-disabled-example.ts
@@ -16,10 +16,8 @@ import {TreeNode, NODES} from '../tree-data';
  */
 @Component({
   selector: 'tree-disabled-example',
-  exportAs: 'TreeDisabledExample',
   templateUrl: 'tree-disabled-example.html',
   styleUrl: '../tree-common.css',
-  standalone: true,
   imports: [Tree, TreeItem, TreeItemGroup, NgTemplateOutlet],
 })
 export class TreeDisabledExample {

--- a/src/components-examples/aria/tree/tree-multi-select-follow-focus/tree-multi-select-follow-focus-example.ts
+++ b/src/components-examples/aria/tree/tree-multi-select-follow-focus/tree-multi-select-follow-focus-example.ts
@@ -16,10 +16,8 @@ import {TreeNode, NODES} from '../tree-data';
  */
 @Component({
   selector: 'tree-multi-select-follow-focus-example',
-  exportAs: 'TreeMultiSelectFollowFocusExample',
   templateUrl: 'tree-multi-select-follow-focus-example.html',
   styleUrl: '../tree-common.css',
-  standalone: true,
   imports: [Tree, TreeItem, TreeItemGroup, NgTemplateOutlet],
 })
 export class TreeMultiSelectFollowFocusExample {

--- a/src/components-examples/aria/tree/tree-multi-select/tree-multi-select-example.ts
+++ b/src/components-examples/aria/tree/tree-multi-select/tree-multi-select-example.ts
@@ -16,10 +16,8 @@ import {TreeNode, NODES} from '../tree-data';
  */
 @Component({
   selector: 'tree-multi-select-example',
-  exportAs: 'TreeMultiSelectExample',
   templateUrl: 'tree-multi-select-example.html',
   styleUrl: '../tree-common.css',
-  standalone: true,
   imports: [Tree, TreeItem, TreeItemGroup, NgTemplateOutlet],
 })
 export class TreeMultiSelectExample {

--- a/src/components-examples/aria/tree/tree-nav/tree-nav-example.ts
+++ b/src/components-examples/aria/tree/tree-nav/tree-nav-example.ts
@@ -16,10 +16,8 @@ import {TreeNode, NODES} from '../tree-data';
  */
 @Component({
   selector: 'tree-nav-example',
-  exportAs: 'TreeNavExample',
   templateUrl: 'tree-nav-example.html',
   styleUrl: '../tree-common.css',
-  standalone: true,
   imports: [Tree, TreeItem, TreeItemGroup, NgTemplateOutlet],
 })
 export class TreeNavExample {

--- a/src/components-examples/aria/tree/tree-single-select-follow-focus/tree-single-select-follow-focus-example.ts
+++ b/src/components-examples/aria/tree/tree-single-select-follow-focus/tree-single-select-follow-focus-example.ts
@@ -16,10 +16,8 @@ import {TreeNode, NODES} from '../tree-data';
  */
 @Component({
   selector: 'tree-single-select-follow-focus-example',
-  exportAs: 'TreeSingleSelectFollowFocusExample',
   templateUrl: 'tree-single-select-follow-focus-example.html',
   styleUrl: '../tree-common.css',
-  standalone: true,
   imports: [Tree, TreeItem, TreeItemGroup, NgTemplateOutlet],
 })
 export class TreeSingleSelectFollowFocusExample {

--- a/src/components-examples/aria/tree/tree-single-select/tree-single-select-example.ts
+++ b/src/components-examples/aria/tree/tree-single-select/tree-single-select-example.ts
@@ -16,10 +16,8 @@ import {TreeNode, NODES} from '../tree-data';
  */
 @Component({
   selector: 'tree-single-select-example',
-  exportAs: 'TreeSingleSelectExample',
   templateUrl: 'tree-single-select-example.html',
   styleUrl: '../tree-common.css',
-  standalone: true,
   imports: [Tree, TreeItem, TreeItemGroup, NgTemplateOutlet],
 })
 export class TreeSingleSelectExample {

--- a/src/components-examples/cdk/listbox/cdk-listbox-activedescendant/cdk-listbox-activedescendant-example.ts
+++ b/src/components-examples/cdk/listbox/cdk-listbox-activedescendant/cdk-listbox-activedescendant-example.ts
@@ -4,7 +4,6 @@ import {CdkListbox, CdkOption} from '@angular/cdk/listbox';
 /** @title Listbox with aria-activedescendant. */
 @Component({
   selector: 'cdk-listbox-activedescendant-example',
-  exportAs: 'cdkListboxActivedescendantExample',
   templateUrl: 'cdk-listbox-activedescendant-example.html',
   styleUrl: 'cdk-listbox-activedescendant-example.css',
   imports: [CdkListbox, CdkOption],

--- a/src/components-examples/cdk/listbox/cdk-listbox-compare-with/cdk-listbox-compare-with-example.ts
+++ b/src/components-examples/cdk/listbox/cdk-listbox-compare-with/cdk-listbox-compare-with-example.ts
@@ -15,7 +15,6 @@ const formatter = new Intl.DateTimeFormat(undefined, {
 /** @title Listbox with complex object as values. */
 @Component({
   selector: 'cdk-listbox-compare-with-example',
-  exportAs: 'cdkListboxCompareWithExample',
   templateUrl: 'cdk-listbox-compare-with-example.html',
   styleUrl: 'cdk-listbox-compare-with-example.css',
   imports: [CdkListbox, CdkOption, JsonPipe],

--- a/src/components-examples/cdk/listbox/cdk-listbox-custom-navigation/cdk-listbox-custom-navigation-example.ts
+++ b/src/components-examples/cdk/listbox/cdk-listbox-custom-navigation/cdk-listbox-custom-navigation-example.ts
@@ -4,7 +4,6 @@ import {CdkListbox, CdkOption} from '@angular/cdk/listbox';
 /** @title Listbox with custom keyboard navigation options. */
 @Component({
   selector: 'cdk-listbox-custom-navigation-example',
-  exportAs: 'cdkListboxCustomNavigationExample',
   templateUrl: 'cdk-listbox-custom-navigation-example.html',
   styleUrl: 'cdk-listbox-custom-navigation-example.css',
   imports: [CdkListbox, CdkOption],

--- a/src/components-examples/cdk/listbox/cdk-listbox-custom-typeahead/cdk-listbox-custom-typeahead-example.ts
+++ b/src/components-examples/cdk/listbox/cdk-listbox-custom-typeahead/cdk-listbox-custom-typeahead-example.ts
@@ -4,7 +4,6 @@ import {CdkListbox, CdkOption} from '@angular/cdk/listbox';
 /** @title Listbox with custom typeahead. */
 @Component({
   selector: 'cdk-listbox-custom-typeahead-example',
-  exportAs: 'cdkListboxCustomTypeaheadExample',
   templateUrl: 'cdk-listbox-custom-typeahead-example.html',
   styleUrl: 'cdk-listbox-custom-typeahead-example.css',
   imports: [CdkListbox, CdkOption],

--- a/src/components-examples/cdk/listbox/cdk-listbox-disabled/cdk-listbox-disabled-example.ts
+++ b/src/components-examples/cdk/listbox/cdk-listbox-disabled/cdk-listbox-disabled-example.ts
@@ -5,7 +5,6 @@ import {CdkListbox, CdkOption} from '@angular/cdk/listbox';
 /** @title Listbox with disabled options. */
 @Component({
   selector: 'cdk-listbox-disabled-example',
-  exportAs: 'cdkListboxDisabledExample',
   templateUrl: 'cdk-listbox-disabled-example.html',
   styleUrl: 'cdk-listbox-disabled-example.css',
   imports: [FormsModule, ReactiveFormsModule, CdkListbox, CdkOption],

--- a/src/components-examples/cdk/listbox/cdk-listbox-forms-validation/cdk-listbox-forms-validation-example.ts
+++ b/src/components-examples/cdk/listbox/cdk-listbox-forms-validation/cdk-listbox-forms-validation-example.ts
@@ -8,7 +8,6 @@ import {CdkListbox, CdkOption} from '@angular/cdk/listbox';
 /** @title Listbox with forms validation. */
 @Component({
   selector: 'cdk-listbox-forms-validation-example',
-  exportAs: 'cdkListboxFormsValidationExample',
   templateUrl: 'cdk-listbox-forms-validation-example.html',
   styleUrl: 'cdk-listbox-forms-validation-example.css',
   imports: [CdkListbox, FormsModule, ReactiveFormsModule, CdkOption, AsyncPipe, JsonPipe],

--- a/src/components-examples/cdk/listbox/cdk-listbox-horizontal/cdk-listbox-horizontal-example.ts
+++ b/src/components-examples/cdk/listbox/cdk-listbox-horizontal/cdk-listbox-horizontal-example.ts
@@ -4,7 +4,6 @@ import {CdkListbox, CdkOption} from '@angular/cdk/listbox';
 /** @title Horizontal listbox */
 @Component({
   selector: 'cdk-listbox-horizontal-example',
-  exportAs: 'cdkListboxhorizontalExample',
   templateUrl: 'cdk-listbox-horizontal-example.html',
   styleUrl: 'cdk-listbox-horizontal-example.css',
   imports: [CdkListbox, CdkOption],

--- a/src/components-examples/cdk/listbox/cdk-listbox-multiple/cdk-listbox-multiple-example.ts
+++ b/src/components-examples/cdk/listbox/cdk-listbox-multiple/cdk-listbox-multiple-example.ts
@@ -4,7 +4,6 @@ import {CdkListbox, CdkOption} from '@angular/cdk/listbox';
 /** @title Listbox with multiple selection. */
 @Component({
   selector: 'cdk-listbox-multiple-example',
-  exportAs: 'cdkListboxMultipleExample',
   templateUrl: 'cdk-listbox-multiple-example.html',
   styleUrl: 'cdk-listbox-multiple-example.css',
   imports: [CdkListbox, CdkOption],

--- a/src/components-examples/cdk/listbox/cdk-listbox-overview/cdk-listbox-overview-example.ts
+++ b/src/components-examples/cdk/listbox/cdk-listbox-overview/cdk-listbox-overview-example.ts
@@ -4,7 +4,6 @@ import {CdkListbox, CdkOption} from '@angular/cdk/listbox';
 /** @title Basic listbox. */
 @Component({
   selector: 'cdk-listbox-overview-example',
-  exportAs: 'cdkListboxOverviewExample',
   templateUrl: 'cdk-listbox-overview-example.html',
   styleUrl: 'cdk-listbox-overview-example.css',
   imports: [CdkListbox, CdkOption],

--- a/src/components-examples/cdk/listbox/cdk-listbox-reactive-forms/cdk-listbox-reactive-forms-example.ts
+++ b/src/components-examples/cdk/listbox/cdk-listbox-reactive-forms/cdk-listbox-reactive-forms-example.ts
@@ -6,7 +6,6 @@ import {CdkListbox, CdkOption} from '@angular/cdk/listbox';
 /** @title Listbox with reactive forms. */
 @Component({
   selector: 'cdk-listbox-reactive-forms-example',
-  exportAs: 'cdkListboxReactiveFormsExample',
   templateUrl: 'cdk-listbox-reactive-forms-example.html',
   styleUrl: 'cdk-listbox-reactive-forms-example.css',
   imports: [CdkListbox, FormsModule, ReactiveFormsModule, CdkOption, JsonPipe],

--- a/src/components-examples/cdk/listbox/cdk-listbox-template-forms/cdk-listbox-template-forms-example.ts
+++ b/src/components-examples/cdk/listbox/cdk-listbox-template-forms/cdk-listbox-template-forms-example.ts
@@ -6,7 +6,6 @@ import {CdkListbox, CdkOption} from '@angular/cdk/listbox';
 /** @title Listbox with template-driven forms. */
 @Component({
   selector: 'cdk-listbox-template-forms-example',
-  exportAs: 'cdkListboxTemplateFormsExample',
   templateUrl: 'cdk-listbox-template-forms-example.html',
   styleUrl: 'cdk-listbox-template-forms-example.css',
   imports: [CdkListbox, FormsModule, CdkOption, JsonPipe],

--- a/src/components-examples/cdk/listbox/cdk-listbox-value-binding/cdk-listbox-value-binding-example.ts
+++ b/src/components-examples/cdk/listbox/cdk-listbox-value-binding/cdk-listbox-value-binding-example.ts
@@ -5,7 +5,6 @@ import {CdkListbox, CdkOption} from '@angular/cdk/listbox';
 /** @title Listbox with value binding. */
 @Component({
   selector: 'cdk-listbox-value-binding-example',
-  exportAs: 'cdkListboxValueBindingExample',
   templateUrl: 'cdk-listbox-value-binding-example.html',
   styleUrl: 'cdk-listbox-value-binding-example.css',
   imports: [CdkListbox, CdkOption, JsonPipe],

--- a/src/components-examples/cdk/menu/cdk-menu-context/cdk-menu-context-example.ts
+++ b/src/components-examples/cdk/menu/cdk-menu-context/cdk-menu-context-example.ts
@@ -4,7 +4,6 @@ import {CdkContextMenuTrigger, CdkMenuItem, CdkMenu} from '@angular/cdk/menu';
 /** @title Context menu. */
 @Component({
   selector: 'cdk-menu-context-example',
-  exportAs: 'cdkMenuContextExample',
   styleUrl: 'cdk-menu-context-example.css',
   templateUrl: 'cdk-menu-context-example.html',
   imports: [CdkContextMenuTrigger, CdkMenu, CdkMenuItem],

--- a/src/components-examples/cdk/menu/cdk-menu-inline/cdk-menu-inline-example.ts
+++ b/src/components-examples/cdk/menu/cdk-menu-inline/cdk-menu-inline-example.ts
@@ -4,7 +4,6 @@ import {CdkMenu, CdkMenuItem} from '@angular/cdk/menu';
 /** @title Gmail inline menu. */
 @Component({
   selector: 'cdk-menu-inline-example',
-  exportAs: 'cdkMenuInlineExample',
   styleUrl: 'cdk-menu-inline-example.css',
   templateUrl: 'cdk-menu-inline-example.html',
   imports: [CdkMenu, CdkMenuItem],

--- a/src/components-examples/cdk/menu/cdk-menu-menubar/cdk-menu-menubar-example.ts
+++ b/src/components-examples/cdk/menu/cdk-menu-menubar/cdk-menu-menubar-example.ts
@@ -12,7 +12,6 @@ import {
 /** @title Google Docs Menu Bar. */
 @Component({
   selector: 'cdk-menu-menubar-example',
-  exportAs: 'cdkMenuMenubarExample',
   styleUrl: 'cdk-menu-menubar-example.css',
   templateUrl: 'cdk-menu-menubar-example.html',
   imports: [

--- a/src/components-examples/cdk/menu/cdk-menu-nested-context/cdk-menu-nested-context-example.ts
+++ b/src/components-examples/cdk/menu/cdk-menu-nested-context/cdk-menu-nested-context-example.ts
@@ -4,7 +4,6 @@ import {CdkMenu, CdkMenuItem, CdkContextMenuTrigger} from '@angular/cdk/menu';
 /** @title Nested context menus. */
 @Component({
   selector: 'cdk-menu-nested-context-example',
-  exportAs: 'cdkMenuNestedContextExample',
   styleUrl: 'cdk-menu-nested-context-example.css',
   templateUrl: 'cdk-menu-nested-context-example.html',
   imports: [CdkContextMenuTrigger, CdkMenu, CdkMenuItem],


### PR DESCRIPTION
Removes the `standalone` and `exportAs` fields from all live examples since they aren't necessary.