### PR TITLE
refactor(multiple): use takeUntilDestroyed() for automatic cleanup

### DIFF
--- a/src/material/bottom-sheet/bottom-sheet-container.ts
+++ b/src/material/bottom-sheet/bottom-sheet-container.ts
@@ -16,9 +16,9 @@ import {
   ViewEncapsulation,
   inject,
 } from '@angular/core';
-import {Subscription} from 'rxjs';
 import {CdkPortalOutlet} from '@angular/cdk/portal';
 import {_animationsDisabled} from '../core';
+import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 
 const ENTER_ANIMATION = '_mat-bottom-sheet-enter';
 const EXIT_ANIMATION = '_mat-bottom-sheet-exit';
@@ -53,7 +53,6 @@ const EXIT_ANIMATION = '_mat-bottom-sheet-exit';
   imports: [CdkPortalOutlet],
 })
 export class MatBottomSheetContainer extends CdkDialogContainer implements OnDestroy {
-  private _breakpointSubscription: Subscription;
   protected _animationsDisabled = _animationsDisabled();
 
   /** The state of the bottom sheet animations. */
@@ -75,8 +74,9 @@ export class MatBottomSheetContainer extends CdkDialogContainer implements OnDes
 
     const breakpointObserver = inject(BreakpointObserver);
 
-    this._breakpointSubscription = breakpointObserver
+    breakpointObserver
       .observe([Breakpoints.Medium, Breakpoints.Large, Breakpoints.XLarge])
+      .pipe(takeUntilDestroyed())
       .subscribe(() => {
         const classList = (this._elementRef.nativeElement as HTMLElement).classList;
 
@@ -121,7 +121,6 @@ export class MatBottomSheetContainer extends CdkDialogContainer implements OnDes
 
   override ngOnDestroy() {
     super.ngOnDestroy();
-    this._breakpointSubscription.unsubscribe();
     this._destroyed = true;
   }
 

--- a/src/material/chips/chip-grid.ts
+++ b/src/material/chips/chip-grid.ts
@@ -34,11 +34,11 @@ import {
 import {_ErrorStateTracker, ErrorStateMatcher} from '../core';
 import {MatFormFieldControl} from '../form-field';
 import {merge, Observable, Subject} from 'rxjs';
-import {takeUntil} from 'rxjs/operators';
 import {MatChipEvent} from './chip';
 import {MatChipRow} from './chip-row';
 import {MatChipSet} from './chip-set';
 import {MatChipTextControl} from './chip-text-control';
+import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 
 /** Change event object that is emitted when the chip grid value has changed. */
 export class MatChipGridChange {
@@ -277,13 +277,13 @@ export class MatChipGrid
   }
 
   ngAfterContentInit() {
-    this.chipBlurChanges.pipe(takeUntil(this._destroyed)).subscribe(() => {
+    this.chipBlurChanges.pipe(takeUntilDestroyed(this._destroyRef)).subscribe(() => {
       this._blur();
       this.stateChanges.next();
     });
 
     merge(this.chipFocusChanges, this._chips.changes)
-      .pipe(takeUntil(this._destroyed))
+      .pipe(takeUntilDestroyed(this._destroyRef))
       .subscribe(() => this.stateChanges.next());
   }
 

--- a/src/material/menu/menu-content.ts
+++ b/src/material/menu/menu-content.ts
@@ -20,7 +20,6 @@ import {
   inject,
   DOCUMENT,
 } from '@angular/core';
-import {Subject} from 'rxjs';
 
 /**
  * Injection token that can be used to reference instances of `MatMenuContent`. It serves
@@ -44,9 +43,6 @@ export class MatMenuContent implements OnDestroy {
 
   private _portal: TemplatePortal<any> | undefined;
   private _outlet: DomPortalOutlet | undefined;
-
-  /** Emits when the menu content has been attached. */
-  readonly _attached = new Subject<void>();
 
   constructor(...args: unknown[]);
 
@@ -85,7 +81,6 @@ export class MatMenuContent implements OnDestroy {
     // it needs to check for new menu items and update the `@ContentChild` in `MatMenu`.
     this._changeDetectorRef.markForCheck();
     this._portal.attach(this._outlet, context);
-    this._attached.next();
   }
 
   /**

--- a/src/material/paginator/paginator.ts
+++ b/src/material/paginator/paginator.ts
@@ -27,8 +27,9 @@ import {MatSelect} from '../select';
 import {MatIconButton} from '../button';
 import {MatTooltip} from '../tooltip';
 import {MatFormField, MatFormFieldAppearance} from '../form-field';
-import {Observable, ReplaySubject, Subscription} from 'rxjs';
+import {Observable, ReplaySubject} from 'rxjs';
 import {MatPaginatorIntl} from './paginator-intl';
+import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 
 /** The default page size if there is no page size and there are no provided page size options. */
 const DEFAULT_PAGE_SIZE = 50;
@@ -118,7 +119,6 @@ export class MatPaginator implements OnInit, OnDestroy {
   /** ID for the DOM node containing the paginator's items per page label. */
   readonly _pageSizeLabelId = inject(_IdGenerator).getId('mat-paginator-page-size-label-');
 
-  private _intlChanges: Subscription;
   private _isInitialized = false;
   private _initializedStream = new ReplaySubject<void>(1);
 
@@ -203,12 +203,13 @@ export class MatPaginator implements OnInit, OnDestroy {
   constructor(...args: unknown[]);
 
   constructor() {
-    const _intl = this._intl;
     const defaults = inject<MatPaginatorDefaultOptions>(MAT_PAGINATOR_DEFAULT_OPTIONS, {
       optional: true,
     });
 
-    this._intlChanges = _intl.changes.subscribe(() => this._changeDetectorRef.markForCheck());
+    this._intl.changes
+      .pipe(takeUntilDestroyed())
+      .subscribe(() => this._changeDetectorRef.markForCheck());
 
     if (defaults) {
       const {pageSize, pageSizeOptions, hidePageSize, showFirstLastButtons} = defaults;
@@ -241,7 +242,6 @@ export class MatPaginator implements OnInit, OnDestroy {
 
   ngOnDestroy() {
     this._initializedStream.complete();
-    this._intlChanges.unsubscribe();
   }
 
   /** Advances to the next page if it exists. */

--- a/src/material/slider/slider-input.ts
+++ b/src/material/slider/slider-input.ts
@@ -23,7 +23,6 @@ import {
   signal,
 } from '@angular/core';
 import {ControlValueAccessor, FormControl, NG_VALUE_ACCESSOR} from '@angular/forms';
-import {Subject} from 'rxjs';
 import {
   _MatThumb,
   MatSliderDragEvent,
@@ -254,9 +253,6 @@ export class MatSliderThumb implements _MatSliderThumb, OnDestroy, ControlValueA
   /** Defined when a user is using a form control to manage slider value & validation. */
   private _formControl: FormControl | undefined;
 
-  /** Emits when the component is destroyed. */
-  protected readonly _destroyed = new Subject<void>();
-
   /**
    * Indicates whether UI updates should be skipped.
    *
@@ -297,8 +293,6 @@ export class MatSliderThumb implements _MatSliderThumb, OnDestroy, ControlValueA
 
   ngOnDestroy(): void {
     this._listenerCleanups.forEach(cleanup => cleanup());
-    this._destroyed.next();
-    this._destroyed.complete();
     this.dragStart.complete();
     this.dragEnd.complete();
   }

--- a/src/material/slider/slider.ts
+++ b/src/material/slider/slider.ts
@@ -34,7 +34,7 @@ import {
   RippleGlobalOptions,
   ThemePalette,
 } from '../core';
-import {Subscription} from 'rxjs';
+
 import {
   _MatThumb,
   _MatTickMark,
@@ -49,6 +49,7 @@ import {
 } from './slider-interface';
 import {MatSliderVisualThumb} from './slider-thumb';
 import {_CdkPrivateStyleLoader} from '@angular/cdk/private';
+import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 
 // TODO(wagnermaciel): maybe handle the following edge case:
 // 1. start dragging discrete slider
@@ -372,9 +373,6 @@ export class MatSlider implements AfterViewInit, OnDestroy, _MatSlider {
   /** Whether animations have been disabled. */
   _noopAnimations = _animationsDisabled();
 
-  /** Subscription to changes to the directionality (LTR / RTL) context for the application. */
-  private _dirChangeSubscription: Subscription;
-
   /** Observer used to monitor size changes in the slider. */
   private _resizeObserver: ResizeObserver | null;
 
@@ -423,7 +421,7 @@ export class MatSlider implements AfterViewInit, OnDestroy, _MatSlider {
     inject(_CdkPrivateStyleLoader).load(_StructuralStylesLoader);
 
     if (this._dir) {
-      this._dirChangeSubscription = this._dir.change.subscribe(() => this._onDirChange());
+      this._dir.change.pipe(takeUntilDestroyed()).subscribe(() => this._onDirChange());
       this._isRtl = this._dir.value === 'rtl';
     }
   }
@@ -499,7 +497,6 @@ export class MatSlider implements AfterViewInit, OnDestroy, _MatSlider {
   }
 
   ngOnDestroy(): void {
-    this._dirChangeSubscription.unsubscribe();
     this._resizeObserver?.disconnect();
     this._resizeObserver = null;
   }

--- a/src/material/stepper/step-header.ts
+++ b/src/material/stepper/step-header.ts
@@ -18,7 +18,6 @@ import {
   AfterViewInit,
   inject,
 } from '@angular/core';
-import {Subscription} from 'rxjs';
 import {MatStepLabel} from './step-label';
 import {MatStepperIntl} from './stepper-intl';
 import {MatStepperIconContext} from './stepper-icon';
@@ -27,6 +26,7 @@ import {_StructuralStylesLoader, MatRipple, ThemePalette} from '../core';
 import {MatIcon} from '../icon';
 import {NgTemplateOutlet} from '@angular/common';
 import {_CdkPrivateStyleLoader, _VisuallyHiddenLoader} from '@angular/cdk/private';
+import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 
 @Component({
   selector: 'mat-step-header',
@@ -45,8 +45,6 @@ import {_CdkPrivateStyleLoader, _VisuallyHiddenLoader} from '@angular/cdk/privat
 export class MatStepHeader extends CdkStepHeader implements AfterViewInit, OnDestroy {
   _intl = inject(MatStepperIntl);
   private _focusMonitor = inject(FocusMonitor);
-
-  private _intlSubscription: Subscription;
 
   /** State of the given step. */
   @Input() state: StepState;
@@ -93,7 +91,7 @@ export class MatStepHeader extends CdkStepHeader implements AfterViewInit, OnDes
     styleLoader.load(_StructuralStylesLoader);
     styleLoader.load(_VisuallyHiddenLoader);
     const changeDetectorRef = inject(ChangeDetectorRef);
-    this._intlSubscription = this._intl.changes.subscribe(() => changeDetectorRef.markForCheck());
+    this._intl.changes.pipe(takeUntilDestroyed()).subscribe(() => changeDetectorRef.markForCheck());
   }
 
   ngAfterViewInit() {
@@ -101,7 +99,6 @@ export class MatStepHeader extends CdkStepHeader implements AfterViewInit, OnDes
   }
 
   ngOnDestroy() {
-    this._intlSubscription.unsubscribe();
     this._focusMonitor.stopMonitoring(this._elementRef);
   }
 

--- a/src/material/tree/node.ts
+++ b/src/material/tree/node.ts
@@ -26,7 +26,7 @@ import {
 import {NoopTreeKeyManager, TreeKeyManagerItem, TreeKeyManagerStrategy} from '@angular/cdk/a11y';
 
 /**
- * Determinte if argument TreeKeyManager is the NoopTreeKeyManager. This function is safe to use with SSR.
+ * Determine if argument TreeKeyManager is the NoopTreeKeyManager. This function is safe to use with SSR.
  */
 function isNoopTreeKeyManager<T extends TreeKeyManagerItem>(
   keyManager: TreeKeyManagerStrategy<T>,


### PR DESCRIPTION
Replaces manual subscription tracking with `takeUntilDestroyed()` to ensure subscriptions are cleaned up automatically and simplify the code.