### PR TITLE
refactor(aria/ui-patterns): allow non-selectable items

### DIFF
--- a/src/aria/tree/tree.ts
+++ b/src/aria/tree/tree.ts
@@ -245,6 +245,9 @@ export class TreeItem<V> extends DeferredContentAware implements OnInit, OnDestr
   /** Whether the tree item is disabled. */
   readonly disabled = input(false, {transform: booleanAttribute});
 
+  /** Whether the tree item is selectable. */
+  readonly selectable = input<boolean>(true);
+
   /** Optional label for typeahead. Defaults to the element's textContent. */
   readonly label = input<string>();
 

--- a/src/aria/ui-patterns/behaviors/list-selection/list-selection.ts
+++ b/src/aria/ui-patterns/behaviors/list-selection/list-selection.ts
@@ -14,6 +14,9 @@ import {ListFocus, ListFocusInputs, ListFocusItem} from '../list-focus/list-focu
 export interface ListSelectionItem<V> extends ListFocusItem {
   /** The value of the item. */
   value: SignalLike<V>;
+
+  /** Whether the item is selectable. */
+  selectable: SignalLike<boolean>;
 }
 
 /** Represents the required inputs for a collection that contains selectable items. */
@@ -47,7 +50,12 @@ export class ListSelection<T extends ListSelectionItem<V>, V> {
   select(item?: ListSelectionItem<V>, opts = {anchor: true}) {
     item = item ?? (this.inputs.focusManager.inputs.activeItem() as ListSelectionItem<V>);
 
-    if (!item || item.disabled() || this.inputs.value().includes(item.value())) {
+    if (
+      !item ||
+      item.disabled() ||
+      !item.selectable() ||
+      this.inputs.value().includes(item.value())
+    ) {
       return;
     }
 
@@ -66,7 +74,7 @@ export class ListSelection<T extends ListSelectionItem<V>, V> {
   deselect(item?: T | null) {
     item = item ?? this.inputs.focusManager.inputs.activeItem();
 
-    if (item && !item.disabled()) {
+    if (item && !item.disabled() && item.selectable()) {
       this.inputs.value.update(values => values.filter(value => value !== item.value()));
     }
   }
@@ -131,7 +139,7 @@ export class ListSelection<T extends ListSelectionItem<V>, V> {
   toggleAll() {
     const selectableValues = this.inputs
       .items()
-      .filter(i => !i.disabled())
+      .filter(i => !i.disabled() && i.selectable())
       .map(i => i.value());
 
     selectableValues.every(i => this.inputs.value().includes(i))
@@ -142,7 +150,7 @@ export class ListSelection<T extends ListSelectionItem<V>, V> {
   /** Sets the selection to only the current active item. */
   selectOne() {
     const item = this.inputs.focusManager.inputs.activeItem();
-    if (item && item.disabled()) {
+    if (item && (item.disabled() || !item.selectable())) {
       return;
     }
 

--- a/src/aria/ui-patterns/behaviors/list/list.spec.ts
+++ b/src/aria/ui-patterns/behaviors/list/list.spec.ts
@@ -12,6 +12,7 @@ import {fakeAsync, tick} from '@angular/core/testing';
 
 type TestItem<V> = ListItem<V> & {
   disabled: WritableSignal<boolean>;
+  selectable: WritableSignal<boolean>;
   searchTerm: WritableSignal<string>;
   value: WritableSignal<V>;
 };
@@ -44,6 +45,7 @@ describe('List Behavior', () => {
       id: signal(`item-${index}`),
       element: signal(document.createElement('div')),
       disabled: signal(false),
+      selectable: signal(true),
       searchTerm: signal(String(value)),
       index: signal(index),
     }));
@@ -240,10 +242,22 @@ describe('List Behavior', () => {
         expect(list.inputs.value()).toEqual(['Apricot']);
       });
 
+      it('should not select a non-selectable item when navigating with selectOne:true', () => {
+        items[1].selectable.set(false);
+        list.next({selectOne: true});
+        expect(list.inputs.value()).toEqual([]);
+      });
+
       it('should toggle an item when navigating with toggle:true', () => {
         list.goto(items[1], {selectOne: true});
         expect(list.inputs.value()).toEqual(['Apricot']);
 
+        list.goto(items[1], {toggle: true});
+        expect(list.inputs.value()).toEqual([]);
+      });
+
+      it('should not toggle a non-selectable item when navigating with toggle:true', () => {
+        items[1].selectable.set(false);
         list.goto(items[1], {toggle: true});
         expect(list.inputs.value()).toEqual([]);
       });
@@ -279,6 +293,12 @@ describe('List Behavior', () => {
         expect(list.inputs.value()).toEqual(['Apricot']);
       });
 
+      it('should not select a non-selectable item with toggle:true', () => {
+        items[1].selectable.set(false);
+        list.next({toggle: true});
+        expect(list.inputs.value()).toEqual([]);
+      });
+
       it('should allow multiple selected items', () => {
         list.next({toggle: true});
         list.next({toggle: true});
@@ -306,6 +326,13 @@ describe('List Behavior', () => {
 
       it('should not select disabled items in a range', () => {
         items[1].disabled.set(true);
+        list.anchor(0);
+        list.goto(items[3], {selectRange: true});
+        expect(list.inputs.value()).toEqual(['Apple', 'Banana', 'Blackberry']);
+      });
+
+      it('should not select non-selectable items in a range', () => {
+        items[1].selectable.set(false);
         list.anchor(0);
         list.goto(items[3], {selectRange: true});
         expect(list.inputs.value()).toEqual(['Apple', 'Banana', 'Blackberry']);
@@ -346,6 +373,13 @@ describe('List Behavior', () => {
       const {list} = getDefaultPatterns({multi: signal(false)});
       list.search('b', {selectOne: true});
       expect(list.inputs.value()).toEqual(['Banana']);
+    });
+
+    it('should not select a non-selectable item via typeahead', () => {
+      const {list, items} = getDefaultPatterns({multi: signal(false)});
+      items[2].selectable.set(false); // 'Banana'
+      list.search('b', {selectOne: true});
+      expect(list.inputs.value()).toEqual([]);
     });
   });
 });

--- a/src/aria/ui-patterns/combobox/combobox.spec.ts
+++ b/src/aria/ui-patterns/combobox/combobox.spec.ts
@@ -191,6 +191,7 @@ function getTreePattern(
         value: signal(node.value),
         id: signal('tree-item-' + tree.allItems().length),
         disabled: signal(false),
+        selectable: signal(true),
         searchTerm: signal(node.value),
         tree: signal(tree),
         parent: signal(parent),

--- a/src/aria/ui-patterns/listbox/option.ts
+++ b/src/aria/ui-patterns/listbox/option.ts
@@ -20,7 +20,7 @@ interface ListboxPattern<V> {
 }
 
 /** Represents the required inputs for an option in a listbox. */
-export interface OptionInputs<V> extends Omit<ListItem<V>, 'index'> {
+export interface OptionInputs<V> extends Omit<ListItem<V>, 'index' | 'selectable'> {
   listbox: SignalLike<ListboxPattern<V> | undefined>;
 }
 
@@ -40,6 +40,9 @@ export class OptionPattern<V> {
 
   /** Whether the option is selected. */
   selected = computed(() => this.listbox()?.inputs.value().includes(this.value()));
+
+  /** Whether the option is selectable. */
+  selectable = () => true;
 
   /** Whether the option is disabled. */
   disabled: SignalLike<boolean>;

--- a/src/aria/ui-patterns/radio-group/radio-button.ts
+++ b/src/aria/ui-patterns/radio-group/radio-button.ts
@@ -12,7 +12,8 @@ import {ListItem} from '../behaviors/list/list';
 import type {RadioGroupPattern} from './radio-group';
 
 /** Represents the required inputs for a radio button in a radio group. */
-export interface RadioButtonInputs<V> extends Omit<ListItem<V>, 'searchTerm' | 'index'> {
+export interface RadioButtonInputs<V>
+  extends Omit<ListItem<V>, 'searchTerm' | 'index' | 'selectable'> {
   /** A reference to the parent radio group. */
   group: SignalLike<RadioGroupPattern<V> | undefined>;
 }
@@ -37,6 +38,9 @@ export class RadioButtonPattern<V> {
   readonly selected: SignalLike<boolean> = computed(
     () => !!this.group()?.listBehavior.inputs.value().includes(this.value()),
   );
+
+  /** Whether the radio button is selectable. */
+  readonly selectable = () => true;
 
   /** Whether the radio button is disabled. */
   readonly disabled: SignalLike<boolean>;

--- a/src/aria/ui-patterns/tabs/tabs.ts
+++ b/src/aria/ui-patterns/tabs/tabs.ts
@@ -20,7 +20,7 @@ import {List, ListInputs, ListItem} from '../behaviors/list/list';
 
 /** The required inputs to tabs. */
 export interface TabInputs
-  extends Omit<ListItem<string>, 'searchTerm' | 'index'>,
+  extends Omit<ListItem<string>, 'searchTerm' | 'index' | 'selectable'>,
     Omit<ExpansionItem, 'expansionId' | 'expandable'> {
   /** The parent tablist that controls the tab. */
   tablist: SignalLike<TabListPattern>;
@@ -48,6 +48,9 @@ export class TabPattern {
 
   /** The html element that should receive focus. */
   readonly element: SignalLike<HTMLElement>;
+
+  /** Whether the tab is selectable. */
+  readonly selectable = () => true;
 
   /** The text used by the typeahead search. */
   readonly searchTerm = () => ''; // Unused because tabs do not support typeahead.

--- a/src/aria/ui-patterns/toolbar/toolbar-widget-group.ts
+++ b/src/aria/ui-patterns/toolbar/toolbar-widget-group.ts
@@ -46,7 +46,7 @@ export interface ToolbarWidgetGroupControls {
 
 /** Represents the required inputs for a toolbar widget group. */
 export interface ToolbarWidgetGroupInputs<V>
-  extends Omit<ListItem<V>, 'searchTerm' | 'value' | 'index'> {
+  extends Omit<ListItem<V>, 'searchTerm' | 'value' | 'index' | 'selectable'> {
   /** A reference to the parent toolbar. */
   toolbar: SignalLike<ToolbarPattern<V> | undefined>;
 
@@ -73,6 +73,9 @@ export class ToolbarWidgetGroupPattern<V> implements ListItem<V> {
 
   /** The value associated with the widget. */
   readonly value = () => '' as V; // Unused because toolbar does not support selection.
+
+  /** Whether the widget is selectable. */
+  readonly selectable = () => true; // Unused because toolbar does not support selection.
 
   /** The position of the widget within the toolbar. */
   readonly index = computed(() => this.toolbar()?.inputs.items().indexOf(this) ?? -1);

--- a/src/aria/ui-patterns/toolbar/toolbar-widget.ts
+++ b/src/aria/ui-patterns/toolbar/toolbar-widget.ts
@@ -13,7 +13,7 @@ import type {ToolbarPattern} from './toolbar';
 
 /** Represents the required inputs for a toolbar widget in a toolbar. */
 export interface ToolbarWidgetInputs<V>
-  extends Omit<ListItem<V>, 'searchTerm' | 'value' | 'index'> {
+  extends Omit<ListItem<V>, 'searchTerm' | 'value' | 'index' | 'selectable'> {
   /** A reference to the parent toolbar. */
   toolbar: SignalLike<ToolbarPattern<V>>;
 }
@@ -39,6 +39,9 @@ export class ToolbarWidgetPattern<V> implements ListItem<V> {
 
   /** The value associated with the widget. */
   readonly value = () => '' as V; // Unused because toolbar does not support selection.
+
+  /** Whether the widget is selectable. */
+  readonly selectable = () => true; // Unused because toolbar does not support selection.
 
   /** The position of the widget within the toolbar. */
   readonly index = computed(() => this.toolbar().inputs.items().indexOf(this) ?? -1);

--- a/src/aria/ui-patterns/tree/combobox-tree.ts
+++ b/src/aria/ui-patterns/tree/combobox-tree.ts
@@ -72,6 +72,7 @@ export class ComboboxTreePattern<V>
   /** Unfocuses the currently focused item in the tree. */
   unfocus = () => this.listBehavior.unfocus();
 
+  // TODO: handle non-selectable parent nodes.
   /** Selects the specified item in the tree or the current active item if not provided. */
   select = (item?: TreeItemPattern<V>) => this.listBehavior.select(item);
 

--- a/src/components-examples/aria/tree/tree-configurable/tree-configurable-example.html
+++ b/src/components-examples/aria/tree/tree-configurable/tree-configurable-example.html
@@ -53,6 +53,7 @@
     [value]="node.value"
     [label]="node.name"
     [disabled]="node.disabled"
+    [selectable]="!nav.value || !node.children"
     #treeItem="ngTreeItem"
     class="example-tree-item example-selectable example-stateful"
   >

--- a/src/components-examples/aria/tree/tree-nav/tree-nav-example.html
+++ b/src/components-examples/aria/tree/tree-nav/tree-nav-example.html
@@ -13,6 +13,7 @@
       [value]="node.value"
       [label]="node.name"
       [disabled]="node.disabled"
+      [selectable]="!node.children"
       #treeItem="ngTreeItem"
       class="example-tree-item example-selectable example-stateful"
       href="#{{ node.name }}"


### PR DESCRIPTION
Expandable items can be either selectable or non-selectable. For now only Tree has the use case, so it's arguable whether to only implement this behavior in Tree. I am open to ideas.