### PR TITLE
docs: remove references to animations package

### DIFF
--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -14,10 +14,7 @@ Add Angular Material to your application by running the following command:
 ng add @angular/material
 ```
 
-The `ng add` command will install Angular Material, the
-[Component Dev Kit (CDK)](https://material.angular.dev/cdk/categories),
-[Angular Animations](https://angular.dev/guide/animations) and ask you the following questions to
-determine which features to include:
+The `ng add` command will install Angular Material, the [Component Dev Kit (CDK)](https://material.angular.dev/cdk/categories), and will ask you the following questions to determine which features to include:
 
 1. Choose a prebuilt theme name, or "custom" for a custom theme:
 

--- a/guides/schematics.md
+++ b/guides/schematics.md
@@ -8,9 +8,7 @@ creating Material applications easier.
 Schematics are included with both `@angular/cdk` and `@angular/material`. Once you install the npm
 packages, they will be available through the Angular CLI.
 
-Using the command below will install Angular Material, the [Component Dev Kit](https://material.angular.dev/cdk) (CDK),
-and [Angular Animations](https://angular.dev/guide/animations) in your project. Then it will run the
-installation schematic.
+Using the command below will install Angular Material and the [Component Dev Kit](https://material.angular.dev/cdk) (CDK) in your project. Then it will run the installation schematic.
 
 ```bash
 ng add @angular/material


### PR DESCRIPTION
Angular Material no longer depends on the `@angular/animations` package and it's no longer installed in the `ng add` schematic (#30446).