### PR TITLE
build: remove provideHttpClient

### DIFF
--- a/docs/src/app/pages/guide-viewer/guide-viewer.spec.ts
+++ b/docs/src/app/pages/guide-viewer/guide-viewer.spec.ts
@@ -2,7 +2,6 @@ import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {Observable} from 'rxjs';
 import {ActivatedRoute, provideRouter} from '@angular/router';
 import {GuideViewer} from './guide-viewer';
-import {provideHttpClient} from '@angular/common/http';
 
 const guideItemsId = 'getting-started';
 
@@ -21,11 +20,7 @@ describe('GuideViewer', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [
-        provideRouter([]),
-        {provide: ActivatedRoute, useValue: mockActivatedRoute},
-        provideHttpClient(),
-      ],
+      providers: [provideRouter([]), {provide: ActivatedRoute, useValue: mockActivatedRoute}],
     });
   });
 

--- a/docs/src/app/shared/doc-viewer/doc-viewer.spec.ts
+++ b/docs/src/app/shared/doc-viewer/doc-viewer.spec.ts
@@ -1,5 +1,4 @@
 import {Clipboard} from '@angular/cdk/clipboard';
-import {provideHttpClient} from '@angular/common/http';
 import {HttpTestingController, provideHttpClientTesting} from '@angular/common/http/testing';
 import {Component, provideZoneChangeDetection} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
@@ -20,7 +19,6 @@ describe('DocViewer', () => {
       providers: [
         {provide: Clipboard, useValue: clipboardSpy},
         provideRouter([]),
-        provideHttpClient(),
         provideHttpClientTesting(),
         provideZoneChangeDetection(),
       ],

--- a/docs/src/assets/stackblitz/src/main.ts
+++ b/docs/src/assets/stackblitz/src/main.ts
@@ -7,7 +7,6 @@
  */
 
 import {bootstrapApplication} from '@angular/platform-browser';
-import {provideHttpClient} from '@angular/common/http';
 import {VERSION as CDK_VERSION} from '@angular/cdk';
 import {VERSION as MAT_VERSION} from '@angular/material/core';
 import {MaterialDocsExample} from './example/material-docs-example';
@@ -15,6 +14,4 @@ import {MaterialDocsExample} from './example/material-docs-example';
 console.info('Angular CDK version', CDK_VERSION.full);
 console.info('Angular Material version', MAT_VERSION.full);
 
-bootstrapApplication(MaterialDocsExample, {
-  providers: [provideHttpClient()],
-}).catch(err => console.error(err));
+bootstrapApplication(MaterialDocsExample).catch(err => console.error(err));

--- a/docs/src/main.ts
+++ b/docs/src/main.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {provideHttpClient} from '@angular/common/http';
 import {ErrorHandler, provideZoneChangeDetection} from '@angular/core';
 
 import {LocationStrategy, PathLocationStrategy} from '@angular/common';
@@ -32,7 +31,6 @@ bootstrapApplication(MaterialDocsApp, {
         anchorScrolling: 'enabled',
       }),
     ),
-    provideHttpClient(),
     provideZoneChangeDetection(),
   ],
 }).catch(err => console.error(err));

--- a/src/dev-app/main.ts
+++ b/src/dev-app/main.ts
@@ -9,7 +9,6 @@
 // Load `$localize` for examples using it.
 import '@angular/localize/init';
 
-import {provideHttpClient} from '@angular/common/http';
 import {
   provideZonelessChangeDetection,
   // tslint:disable-next-line:no-zone-dependencies -- Allow manual testing of dev-app with zones
@@ -51,7 +50,6 @@ function bootstrap(): void {
     providers: [
       provideRouter(DEV_APP_ROUTES),
       provideNativeDateAdapter(),
-      provideHttpClient(),
       {
         provide: MATERIAL_ANIMATIONS,
         useValue: {


### PR DESCRIPTION
`provideHttpClient` shouldn't be necessary anymore since the client is `providedIn: 'root'`.