### PR TITLE
fix(cdk/portal): remove deprecated directives

### DIFF
--- a/goldens/cdk/portal/index.api.md
+++ b/goldens/cdk/portal/index.api.md
@@ -111,14 +111,6 @@ export abstract class Portal<T> {
     setAttachedHost(host: PortalOutlet | null): void;
 }
 
-// @public @deprecated (undocumented)
-export class PortalHostDirective extends CdkPortalOutlet {
-    // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<PortalHostDirective, "[cdkPortalHost], [portalHost]", ["cdkPortalHost"], { "portal": { "alias": "cdkPortalHost"; "required": false; }; }, {}, never, never, true, never>;
-    // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<PortalHostDirective, never>;
-}
-
 // @public (undocumented)
 export class PortalModule {
     // (undocumented)
@@ -126,7 +118,7 @@ export class PortalModule {
     // (undocumented)
     static ɵinj: i0.ɵɵInjectorDeclaration<PortalModule>;
     // (undocumented)
-    static ɵmod: i0.ɵɵNgModuleDeclaration<PortalModule, never, [typeof CdkPortal, typeof CdkPortalOutlet, typeof TemplatePortalDirective, typeof PortalHostDirective], [typeof CdkPortal, typeof CdkPortalOutlet, typeof TemplatePortalDirective, typeof PortalHostDirective]>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<PortalModule, never, [typeof CdkPortal, typeof CdkPortalOutlet], [typeof CdkPortal, typeof CdkPortalOutlet]>;
 }
 
 // @public
@@ -153,14 +145,6 @@ export class TemplatePortal<C = any> extends Portal<EmbeddedViewRef<C>> {
     get origin(): ElementRef;
     templateRef: TemplateRef<C>;
     viewContainerRef: ViewContainerRef;
-}
-
-// @public @deprecated (undocumented)
-export class TemplatePortalDirective extends CdkPortal {
-    // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<TemplatePortalDirective, "[cdk-portal], [portal]", ["cdkPortal"], {}, {}, never, never, true, never>;
-    // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<TemplatePortalDirective, never>;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/src/cdk/dialog/dialog-module.ts
+++ b/src/cdk/dialog/dialog-module.ts
@@ -29,9 +29,4 @@ export class DialogModule {}
 // See: https://github.com/angular/components/issues/30663.
 // Note: These exports need to be stable and shouldn't be renamed unnecessarily because
 // consuming libraries might have references to them in their own partial compilation output.
-export {
-  CdkPortal as ɵɵCdkPortal,
-  CdkPortalOutlet as ɵɵCdkPortalOutlet,
-  TemplatePortalDirective as ɵɵTemplatePortalDirective,
-  PortalHostDirective as ɵɵPortalHostDirective,
-} from '../portal';
+export {CdkPortal as ɵɵCdkPortal, CdkPortalOutlet as ɵɵCdkPortalOutlet} from '../portal';

--- a/src/cdk/overlay/fullscreen-overlay-container.spec.ts
+++ b/src/cdk/overlay/fullscreen-overlay-container.spec.ts
@@ -2,7 +2,6 @@ import {waitForAsync, TestBed} from '@angular/core/testing';
 import {Component, ViewChild, ViewContainerRef, inject, DOCUMENT, Injector} from '@angular/core';
 import {CdkPortal} from '../portal';
 import {OverlayContainer, FullscreenOverlayContainer, createOverlayRef} from './index';
-import {TemplatePortalDirective} from '../portal/portal-directives';
 
 describe('FullscreenOverlayContainer', () => {
   let injector: Injector;
@@ -106,8 +105,8 @@ describe('FullscreenOverlayContainer', () => {
 
 /** Test-bed component that contains a TempatePortal and an ElementRef. */
 @Component({
-  template: `<ng-template cdk-portal>Cake</ng-template>`,
-  imports: [TemplatePortalDirective],
+  template: `<ng-template cdkPortal>Cake</ng-template>`,
+  imports: [CdkPortal],
 })
 class TestComponentWithTemplatePortals {
   viewContainerRef = inject(ViewContainerRef);

--- a/src/cdk/portal/portal-directives.ts
+++ b/src/cdk/portal/portal-directives.ts
@@ -45,22 +45,6 @@ export class CdkPortal extends TemplatePortal {
 }
 
 /**
- * @deprecated Use `CdkPortal` instead.
- * @breaking-change 9.0.0
- */
-@Directive({
-  selector: '[cdk-portal], [portal]',
-  exportAs: 'cdkPortal',
-  providers: [
-    {
-      provide: CdkPortal,
-      useExisting: TemplatePortalDirective,
-    },
-  ],
-})
-export class TemplatePortalDirective extends CdkPortal {}
-
-/**
  * Possible attached references to the CdkPortalOutlet.
  */
 export type CdkPortalOutletAttachedRef = ComponentRef<any> | EmbeddedViewRef<any> | null;
@@ -234,25 +218,8 @@ export class CdkPortalOutlet extends BasePortalOutlet implements OnInit, OnDestr
   }
 }
 
-/**
- * @deprecated Use `CdkPortalOutlet` instead.
- * @breaking-change 9.0.0
- */
-@Directive({
-  selector: '[cdkPortalHost], [portalHost]',
-  exportAs: 'cdkPortalHost',
-  inputs: [{name: 'portal', alias: 'cdkPortalHost'}],
-  providers: [
-    {
-      provide: CdkPortalOutlet,
-      useExisting: PortalHostDirective,
-    },
-  ],
-})
-export class PortalHostDirective extends CdkPortalOutlet {}
-
 @NgModule({
-  imports: [CdkPortal, CdkPortalOutlet, TemplatePortalDirective, PortalHostDirective],
-  exports: [CdkPortal, CdkPortalOutlet, TemplatePortalDirective, PortalHostDirective],
+  imports: [CdkPortal, CdkPortalOutlet],
+  exports: [CdkPortal, CdkPortalOutlet],
 })
 export class PortalModule {}

--- a/src/dev-app/portal/portal-demo.html
+++ b/src/dev-app/portal/portal-demo.html
@@ -24,12 +24,12 @@
     referring to something *in* the template (such as #item in @for). As such, the component
     has to use @ViewChild / @ViewChildren to get these references.
     See https://github.com/angular/angular/issues/7158 -->
-<ng-template cdk-portal>
+<ng-template cdkPortal>
   <p> - Why don't jokes work in octal?</p>
   <p> - Because 7 10 11.</p>
 </ng-template>
 
-<div *cdk-portal>
+<div *cdkPortal>
  <p> - Did you hear about this year's Fibonacci Conference? </p>
  <p> - It's going to be as big as the last two put together. </p>
 </div>


### PR DESCRIPTION
Removes a couple of directives that have been deprecated for a long time.

BREAKING CHANGE:
* `TemplatePortalDirective` has been removed. Use `CdkPortal` instead.
* `PortalHostDirective` has been removed. Use `CdkPortalOutlet` instead.