### PR TITLE
refactor(aria/toolbar): reorder toolbar examples

### DIFF
--- a/src/dev-app/aria-toolbar/toolbar-demo.html
+++ b/src/dev-app/aria-toolbar/toolbar-demo.html
@@ -5,12 +5,12 @@
       <toolbar-basic-horizontal-example></toolbar-basic-horizontal-example>
     </div>
     <div class="example-toolbar-container">
-      <h2>Toolbar Skip Disabled</h2>
-      <toolbar-skip-disabled-example></toolbar-skip-disabled-example>
-    </div>
-    <div class="example-toolbar-container">
       <h2>Toolbar Basic Vertical</h2>
       <toolbar-basic-vertical-example></toolbar-basic-vertical-example>
+    </div>
+    <div class="example-toolbar-container">
+      <h2>Toolbar Skip Disabled</h2>
+      <toolbar-skip-disabled-example></toolbar-skip-disabled-example>
     </div>
     <div class="example-configurable-radio-container example-toolbar-container">
       <h2>Configurable CDK Toolbar</h2>


### PR DESCRIPTION
Updates toolbar demos to reorder the vertical demo to be after the horizontal demo and before the skip disabled demo.