### PR TITLE
feat(aria/combobox): adds disabled binding to aria combobox.ts

### DIFF
--- a/src/aria/combobox/combobox.ts
+++ b/src/aria/combobox/combobox.ts
@@ -37,6 +37,7 @@ import {toSignal} from '@angular/core/rxjs-interop';
     },
   ],
   host: {
+    '[attr.aria-disabled]': 'disabled()',
     '[attr.data-expanded]': 'pattern.expanded()',
     '(input)': 'pattern.onInput($event)',
     '(keydown)': 'pattern.onKeydown($event)',
@@ -119,6 +120,7 @@ export class Combobox<V> {
     '[attr.aria-controls]': 'combobox.pattern.popupId()',
     '[attr.aria-haspopup]': 'combobox.pattern.hasPopup()',
     '[attr.aria-autocomplete]': 'combobox.pattern.autocomplete()',
+    '[disabled]': 'combobox.disabled()',
   },
 })
 export class ComboboxInput {


### PR DESCRIPTION
Adds disabled binding to aria combobox.ts to have disabled attribute be automatically added as aria-disabled on the parent div and disabled on the input of combobox.

[Screencast](https://screencast.googleplex.com/cast/NjY1MjA3NTA4NDYxMTU4NHwxOGIxMmUzYS03MA) of my attempt at making a disabled demo using this attribute.