### PR TITLE
fix(material/button-toggle): density clamping typo forcing it to 0

### DIFF
--- a/src/material/button-toggle/_m3-button-toggle.scss
+++ b/src/material/button-toggle/_m3-button-toggle.scss
@@ -63,7 +63,7 @@
 
 // Tokens that can be configured through Angular Material's density theming API.
 @function get-density-tokens($scale) {
-  $scale: theming.clamp-density(scale, -4);
+  $scale: theming.clamp-density($scale, -4);
   $index: ($scale * -1) + 1;
 
   @return (


### PR DESCRIPTION
I don't if I have something else to say.
Quite simple fix but lost a lot of time because of this in enterprise repo because of this during an upgrade.