### PR TITLE
refactor: remove last references of CommonModule

### DIFF
--- a/src/components-examples/cdk/tree/cdk-tree-complex/cdk-tree-complex-example.ts
+++ b/src/components-examples/cdk/tree/cdk-tree-complex/cdk-tree-complex-example.ts
@@ -1,5 +1,5 @@
 import {CdkTreeModule} from '@angular/cdk/tree';
-import {CommonModule} from '@angular/common';
+import {AsyncPipe} from '@angular/common';
 import {ChangeDetectionStrategy, Component, OnInit} from '@angular/core';
 import {MatButtonModule} from '@angular/material/button';
 import {MatIconModule} from '@angular/material/icon';
@@ -247,7 +247,7 @@ class ComplexDataStore {
   selector: 'cdk-tree-complex-example',
   templateUrl: 'cdk-tree-complex-example.html',
   styleUrls: ['cdk-tree-complex-example.css'],
-  imports: [CdkTreeModule, MatButtonModule, MatIconModule, CommonModule, MatProgressSpinnerModule],
+  imports: [CdkTreeModule, MatButtonModule, MatIconModule, MatProgressSpinnerModule, AsyncPipe],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class CdkTreeComplexExample implements OnInit {

--- a/src/dev-app/system/system-demo.ts
+++ b/src/dev-app/system/system-demo.ts
@@ -1,4 +1,3 @@
-import {CommonModule} from '@angular/common';
 import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {MatCardModule} from '@angular/material/card';
 
@@ -30,7 +29,7 @@ interface ColorGroup {
   selector: 'system-demo',
   templateUrl: 'system-demo.html',
   styleUrls: ['system-demo.css'],
-  imports: [CommonModule, MatCardModule],
+  imports: [MatCardModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SystemDemo {

--- a/tslint.json
+++ b/tslint.json
@@ -40,6 +40,7 @@
       {"name": ["Object", "assign"], "message": "Use the spread operator instead."},
       {"name": ["*", "asObservable"], "message": "Cast to Observable type instead."},
       {"name": ["*", "removeChild"], "message": "Use `remove` instead instead."},
+      {"name": ["CommonModule"], "message": "Import the necessary symbols directly instead."},
       {"name": ["*", "compileComponents"], "message": "`compileComponents` is not necessary."},
       {
         "name": ["isDevMode"],


### PR DESCRIPTION
Removes the last remaining references of the `CommonModule`. All of its dependencies should be imported directly instead.