### PR TITLE
build: add explicit dependency to yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
     "tsutils": "^3.21.0",
     "typescript": "5.9.2",
     "vrsource-tslint-rules": "6.0.0",
+    "yaml": "^2.8.1",
     "yargs": "^18.0.0",
     "zx": "^8.0.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -338,6 +338,9 @@ importers:
       vrsource-tslint-rules:
         specifier: 6.0.0
         version: 6.0.0(tslint@6.1.3(typescript@5.9.2))(typescript@5.9.2)
+      yaml:
+        specifier: ^2.8.1
+        version: 2.8.1
       yargs:
         specifier: ^18.0.0
         version: 18.0.0


### PR DESCRIPTION
The docs site deployment seems to indirectly depend on `yaml`. These changes add it as a dependency.