### PR TITLE
docs: Update ARIA Tabs design pattern link in documentation

### DIFF
--- a/src/material/tabs/tabs.md
+++ b/src/material/tabs/tabs.md
@@ -96,7 +96,7 @@ off-screen tabs in the DOM, you can set the `preserveContent` input to `true`.
 
 ### Accessibility
 `MatTabGroup` and `MatTabNavBar` both implement the
-[ARIA Tabs design pattern](https://www.w3.org/TR/wai-aria-practices-1.1/#tabpanel). Both components
+[ARIA Tabs design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/). Both components
 compose `tablist`, `tab`, and `tabpanel` elements with handling for keyboard inputs and focus
 management.
 


### PR DESCRIPTION
The previous link no longer links to a real webpage. It gets automatically redirected to 
https://www.w3.org/WAI/ARIA/apg/#tabpanel
Which does not have an element with id #tabpanel .