### PR TITLE
fix(material-experimental/column-resize): add null checks for overlay

### DIFF
--- a/src/dev-app/theme-m3.scss
+++ b/src/dev-app/theme-m3.scss
@@ -1,4 +1,5 @@
 @use '@angular/material' as mat;
+@use '@angular/material-experimental' as matx;
 
 // Plus imports for other components in your app.
 
@@ -38,7 +39,7 @@ html {
     @include mat.system-level-colors($light-theme);
     @include mat.system-level-typography($light-theme);
     // TODO(mmalerba): Support M3 for experimental components.
-    // @include matx.column-resize-theme($light-theme);
+    @include matx.column-resize-theme($light-theme);
     // @include matx.popover-edit-theme($light-theme);
   }
 

--- a/src/material-experimental/column-resize/_column-resize-theme.scss
+++ b/src/material-experimental/column-resize/_column-resize-theme.scss
@@ -2,8 +2,8 @@
 @use 'sass:map';
 
 @mixin color($theme) {
-  $resizable-hover-divider: mat.get-theme-color($theme, primary, 600);
-  $resizable-active-divider: mat.get-theme-color($theme, primary, 600);
+  $resizable-hover-divider: mat.get-theme-color($theme, primary, 60);
+  $resizable-active-divider: mat.get-theme-color($theme, primary, 60);
 
   // TODO: these styles don't really belong in the `color` part of the theme.
   // We should figure out a better place for them.


### PR DESCRIPTION
Fixes some null pointer errors that show up in the logs for some internal apps.