### PR TITLE
[Cherry pick] refactor(multiple): expose APIs necessary for demos

### DIFF
--- a/src/components-examples/aria/combobox/combobox-readonly/combobox-readonly-example.ts
+++ b/src/components-examples/aria/combobox/combobox-readonly/combobox-readonly-example.ts
@@ -51,10 +51,9 @@ export class ComboboxReadonlyExample {
     afterRenderEffect(() => {
       const popover = this.popover()!;
       const combobox = this.combobox()!;
-      combobox._pattern.expanded() ? this.showPopover() : popover.nativeElement.hidePopover();
+      combobox.expanded() ? this.showPopover() : popover.nativeElement.hidePopover();
 
-      // TODO(wagnermaciel): Make this easier for developers to do.
-      this.listbox()?._pattern.inputs.activeItem()?.element().scrollIntoView({block: 'nearest'});
+      this.listbox()?.scrollActiveItemIntoView();
     });
   }
 
@@ -62,7 +61,7 @@ export class ComboboxReadonlyExample {
     const popover = this.popover()!;
     const combobox = this.combobox()!;
 
-    const comboboxRect = combobox._pattern.inputs.inputEl()?.getBoundingClientRect();
+    const comboboxRect = combobox.inputElement()?.getBoundingClientRect();
     const popoverEl = popover.nativeElement;
 
     if (comboboxRect) {


### PR DESCRIPTION
Exposes some APIs used in the demos instead of accessing the private `_pattern`.

(cherry picked from commit f0e411b56c071f01b506b1412a4fa0fb80381334)