### PR TITLE
fix(material/chips): fix stretched chip avatar image

### DIFF
--- a/src/material/chips/chip.scss
+++ b/src/material/chips/chip.scss
@@ -740,10 +740,3 @@ $fallbacks: m3-chip.get-tokens();
 .mat-mdc-chip-action:focus .mat-focus-indicator::before {
   content: '';
 }
-
-// Prevents icon from being cut off when text spacing is increased.
-// .mat-mdc-chip-remove selector necessary for remove button with icon.
-// Fixes b/250063405.
-.mdc-evolution-chip__icon, .mat-mdc-chip-edit .mat-icon, .mat-mdc-chip-remove .mat-icon {
-  min-height: fit-content;
-}


### PR DESCRIPTION
This PR fixes a bug in the Material chip component where avatar images were significantly vertically stretched on many browsers. After some investigation, it appears this bug was introduced with #30867 - reverting the CSS rule here fixes the issue on both Safari (where it was most prominent) and on Chrome.

### Before (Vertical Stretching Issue)

In both Safari and Chrome, chip images were stretched (though Safari to a much greater extent).

Safari             |  Chrome
:-------------------------:|:-------------------------:
![](https://github.com/user-attachments/assets/4f86762b-8cd4-44dd-9da7-dea74907f2e0)  |  ![](https://github.com/user-attachments/assets/2bf59247-1777-4a48-8c8e-48c1e70b9799)

### After

Images appear correctly when testing in the dev environment in both Safari and Chrome:

<img width="351" height="200" alt="image" src="https://github.com/user-attachments/assets/a573b16c-57d1-446c-9f3a-2750b90f3da6" />

*All chip component tests pass after this change is made.* 

### Consequences

Since this PR reverts #30867, the previously mentioned bug with text spacing may be re-introduced. I was unable to replicate it in the dev environment, though it might be something to look into. Still wanted to open this PR since this issue seems widespread for all uses of the avatar on the chip component and is currently affecting applications in production using the new version.

Fixes #32251.