### PR TITLE
docs: release notes for the v20.2.12 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+<a name="20.2.12"></a>
+# 20.2.12 "patch-main" (2025-11-06)
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="21.0.0-rc.0"></a>
 # 21.0.0-rc.0 "leather shoes" (2025-10-31)
 ### cdk


### PR DESCRIPTION
Cherry-picks the changelog from the "20.2.x" branch to the next branch (main).