### PR TITLE
docs: remove unnecessary fields from examples

### DIFF
--- a/src/components-examples/aria/grid/grid-calendar/grid-calendar-example.ts
+++ b/src/components-examples/aria/grid/grid-calendar/grid-calendar-example.ts
@@ -30,7 +30,6 @@ interface CalendarCell<D = any> {
 /** @title Grid Calendar. */
 @Component({
   selector: 'grid-calendar-example',
-  exportAs: 'GridCalendarExample',
   templateUrl: 'grid-calendar-example.html',
   styleUrls: ['../grid-common.css', 'grid-calendar-example.css'],
   imports: [Grid, GridRow, GridCell, GridCellWidget],

--- a/src/components-examples/aria/grid/grid-configurable/grid-configurable-example.ts
+++ b/src/components-examples/aria/grid/grid-configurable/grid-configurable-example.ts
@@ -75,10 +75,8 @@ function generateValidGrid(
 /** @title Configurable Grid. */
 @Component({
   selector: 'grid-configurable-example',
-  exportAs: 'GridConfigurableExample',
   templateUrl: 'grid-configurable-example.html',
   styleUrls: ['../grid-common.css', 'grid-configurable-example.css'],
-  standalone: true,
   imports: [
     FormsModule,
     ReactiveFormsModule,

--- a/src/components-examples/aria/grid/grid-pill-list/grid-pill-list-example.ts
+++ b/src/components-examples/aria/grid/grid-pill-list/grid-pill-list-example.ts
@@ -16,10 +16,8 @@ import {toSignal} from '@angular/core/rxjs-interop';
 /** @title Grid Pill List. */
 @Component({
   selector: 'grid-pill-list-example',
-  exportAs: 'GridPillListExample',
   templateUrl: 'grid-pill-list-example.html',
   styleUrls: ['../grid-common.css', 'grid-pill-list-example.css'],
-  standalone: true,
   imports: [
     Grid,
     GridRow,

--- a/src/components-examples/aria/menu/menu-bar-rtl/menu-bar-rtl-example.ts
+++ b/src/components-examples/aria/menu/menu-bar-rtl/menu-bar-rtl-example.ts
@@ -14,10 +14,8 @@ import {MenuContent} from '@angular/aria/menu';
 /** @title Menu bar RTL example. */
 @Component({
   selector: 'menu-bar-rtl-example',
-  exportAs: 'MenuBarRTLExample',
   templateUrl: 'menu-bar-rtl-example.html',
   styleUrl: '../menu-example.css',
-  standalone: true,
   imports: [
     Dir,
     SimpleMenu,

--- a/src/components-examples/aria/menu/menu-bar/menu-bar-example.ts
+++ b/src/components-examples/aria/menu/menu-bar/menu-bar-example.ts
@@ -13,10 +13,8 @@ import {MenuContent} from '@angular/aria/menu';
 /** @title Menu bar example. */
 @Component({
   selector: 'menu-bar-example',
-  exportAs: 'MenuBarExample',
   templateUrl: 'menu-bar-example.html',
   styleUrl: '../menu-example.css',
-  standalone: true,
   imports: [
     SimpleMenu,
     SimpleMenuBar,

--- a/src/components-examples/aria/menu/menu-context/menu-context-example.ts
+++ b/src/components-examples/aria/menu/menu-context/menu-context-example.ts
@@ -11,10 +11,8 @@ import {
 /** @title Context menu example. */
 @Component({
   selector: 'menu-context-example',
-  exportAs: 'MenuContextExample',
   templateUrl: 'menu-context-example.html',
   styleUrl: '../menu-example.css',
-  standalone: true,
   imports: [
     SimpleMenu,
     SimpleMenuItem,

--- a/src/components-examples/aria/menu/menu-standalone/menu-standalone-example.ts
+++ b/src/components-examples/aria/menu/menu-standalone/menu-standalone-example.ts
@@ -7,10 +7,8 @@ import {SimpleMenu, SimpleMenuItem, SimpleMenuItemIcon, SimpleMenuItemText} from
  */
 @Component({
   selector: 'menu-standalone-example',
-  exportAs: 'MenuStandaloneExample',
   templateUrl: 'menu-standalone-example.html',
   styleUrl: '../menu-example.css',
-  standalone: true,
   imports: [Menu, MenuContent, SimpleMenu, SimpleMenuItem, SimpleMenuItemIcon, SimpleMenuItemText],
 })
 export class MenuStandaloneExample {}

--- a/src/components-examples/aria/menu/menu-trigger/menu-trigger-example.ts
+++ b/src/components-examples/aria/menu/menu-trigger/menu-trigger-example.ts
@@ -5,10 +5,8 @@ import {SimpleMenu, SimpleMenuItem, SimpleMenuItemIcon, SimpleMenuItemText} from
 /** @title Menu trigger example. */
 @Component({
   selector: 'menu-trigger-example',
-  exportAs: 'MenuTriggerExample',
   templateUrl: 'menu-trigger-example.html',
   styleUrl: '../menu-example.css',
-  standalone: true,
   imports: [
     MenuContent,
     MenuTrigger,


### PR DESCRIPTION
The `standalone: true` and `exportAs` fields aren't necessary inside of our live examples.