### PR TITLE
fix(aria/tree): adds rtl keyboard functionality for tree

### DIFF
--- a/src/aria/private/tree/tree.ts
+++ b/src/aria/private/tree/tree.ts
@@ -168,9 +168,6 @@ export interface TreeInputs<V> extends Omit<ListInputs<TreeItemPattern<V>, V>, '
 
   /** The aria-current type. */
   currentType: SignalLike<'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'>;
-
-  /** The text direction of the tree. */
-  textDirection: SignalLike<'ltr' | 'rtl'>;
 }
 
 export interface TreePattern<V> extends TreeInputs<V> {}


### PR DESCRIPTION
Updates aria tree keyboard functionality to have RightArrow collapse and LeftArrow expand for rtl.

* [Screencast of RTL nav](https://screencast.googleplex.com/cast/NTczMjI4NjM2MzMzNjcwNHxlZDMzYTY1ZS04YQ): RightArrow key collapses and LeftArrow key expands.
* **Note:** styles were not adjusted, just the keyboard functionality.