### PR TITLE
docs(aria/grid): calendar example with arrow key scrolling

### DIFF
--- a/src/components-examples/aria/grid/grid-calendar/grid-calendar-example.html
+++ b/src/components-examples/aria/grid/grid-calendar/grid-calendar-example.html
@@ -18,6 +18,7 @@
     [enableSelection]="true"
     [softDisabled]="false"
     selectionMode="explicit"
+    (keydown)="onKeyDown($event)"
   >
     <thead>
       <tr>
@@ -44,6 +45,7 @@
               ngGridCellWidget
               class="example-calendar-day-button"
               [attr.aria-label]="day.ariaLabel"
+              [attr.data-day]="day.dayNum"
             >
               {{day.displayName}}
             </button>


### PR DESCRIPTION
Simple scrolling without needing to access grid internal states.