### PR TITLE
fix(material/button): fixes mat-icon svg size and visibility issues

### DIFF
--- a/src/material/button/button.scss
+++ b/src/material/button/button.scss
@@ -10,7 +10,8 @@ $fallbacks: m3-button.get-tokens();
 .mat-mdc-button-base {
   text-decoration: none;
   // Makes button icon not cut off/shrink making the icon visible to fix b/411228600
-  & .mat-icon {
+  // Exclude icon button and FABs which have fixed dimensions to fix 32338
+  &:not(.mat-mdc-icon-button):not(.mat-mdc-fab-base) .mat-icon {
     // stylelint-disable material/no-prefixes
     min-height: fit-content;
     flex-shrink: 0;


### PR DESCRIPTION
Updates Angular Components Button component styling for mat-icon-buttons and all mat-fab-button variants. Only includes min-height of min-content for icons in other button variants so that when displaying svg icons such as fontawesome the height fits into the icon and is visible in safari browsers

Fixes #32338 

BEFORE:
<img width="375" height="104" alt="Screenshot 2025-11-13 at 10 14 04 PM" src="https://github.com/user-attachments/assets/3f0eaac1-c7da-416f-b8cd-e2afdb331557" />
AFTER:
<img width="359" height="85" alt="Screenshot 2025-11-13 at 10 14 32 PM" src="https://github.com/user-attachments/assets/96f9ebc9-7095-46a3-a27b-3b99b4bfc886" />

