### PR TITLE
fix(material/autocomplete): empty autocomplete obscuring content

### DIFF
--- a/src/material/autocomplete/autocomplete.scss
+++ b/src/material/autocomplete/autocomplete.scss
@@ -43,11 +43,12 @@ div.mat-mdc-autocomplete-panel {
   &.mat-mdc-autocomplete-visible {
     visibility: visible;
   }
+}
 
-  &.mat-mdc-autocomplete-hidden {
-    visibility: hidden;
-    pointer-events: none;
-  }
+div.mat-mdc-autocomplete-panel.mat-mdc-autocomplete-hidden,
+.cdk-overlay-pane:has(> .mat-mdc-autocomplete-hidden) {
+  visibility: hidden;
+  pointer-events: none;
 }
 
 @keyframes _mat-autocomplete-enter {


### PR DESCRIPTION
When the select doesn't have any content, it becomes hidden however the overlay is still attached which can obscure content right under the input.