### PR TITLE
build: fix lint failure

### DIFF
--- a/docs/src/styles/_markdown.scss
+++ b/docs/src/styles/_markdown.scss
@@ -34,8 +34,7 @@
     }
 
     // stylelint-disable-next-line selector-class-pattern
-    h3 .material-icons,
-    h4 .material-icons {
+    h3 .material-icons, h4 .material-icons {
       color: var(--mat-sys-on-surface);
     }
 


### PR DESCRIPTION
Fixes a lint failure, because a selector moved to the next line.