### PR TITLE
refactor(material/button): adjust icon query

### DIFF
--- a/src/material/button/testing/button-harness.ts
+++ b/src/material/button/testing/button-harness.ts
@@ -60,8 +60,9 @@ export class MatButtonHarness extends ContentContainerComponentHarness {
       .addOption('buttonType', options.buttonType, (harness, buttonType) =>
         HarnessPredicate.stringMatches(harness.getType(), buttonType),
       )
-      .addOption('iconName', options.iconName, (harness, iconName) => {
-        return harness.hasHarness(MatIconHarness.with({name: iconName}));
+      .addOption('iconName', options.iconName, async (harness, iconName) => {
+        const result = await harness.locatorForOptional(MatIconHarness.with({name: iconName}))();
+        return result !== null;
       });
   }
 


### PR DESCRIPTION
Updates how we query for the icon to align with #32188. While implementing #32188, I was getting errors in some cases when the icons are missing.