### PR TITLE
refactor(cdk/overlay): insert point-connected overlays in container

### DIFF
--- a/src/cdk/overlay/position/flexible-connected-position-strategy.ts
+++ b/src/cdk/overlay/position/flexible-connected-position-strategy.ts
@@ -542,7 +542,7 @@ export class FlexibleConnectedPositionStrategy implements PositionStrategy {
     } else if (origin instanceof Element) {
       return origin;
     }
-    return document.body.lastChild as Element;
+    return null;
   }
 
   /**


### PR DESCRIPTION
Uses the overlay container to insert overlays connected to a point, rather than putting them at the end of the `body`.