### PR TITLE
fix(aria/menu): focus flicker bug

### DIFF
--- a/src/aria/menu/menu.ts
+++ b/src/aria/menu/menu.ts
@@ -261,7 +261,11 @@ export class Menu<V> {
     });
 
     afterRenderEffect(() => {
-      if (!this._pattern.hasBeenFocused() && this._items().length) {
+      if (
+        !this._pattern.hasBeenFocused() &&
+        !this._pattern.hasBeenHovered() &&
+        this._items().length
+      ) {
         untracked(() => this._pattern.setDefaultState());
       }
     });

--- a/src/aria/private/menu/menu.ts
+++ b/src/aria/private/menu/menu.ts
@@ -91,6 +91,9 @@ export class MenuPattern<V> {
   /** Whether the menu has received focus. */
   hasBeenFocused = signal(false);
 
+  /** Whether the menu trigger has been hovered. */
+  hasBeenHovered = signal(false);
+
   /** Timeout used to open sub-menus on hover. */
   _openTimeout: any;
 
@@ -195,6 +198,7 @@ export class MenuPattern<V> {
       return;
     }
 
+    this.hasBeenHovered.set(true);
     const item = this.inputs.items().find(i => i.element()?.contains(event.target as Node));
 
     if (!item) {


### PR DESCRIPTION
* Fixes an issue in standalone menus and context menus where focus would flicker when opening a menu before focusing the menu.