### PR TITLE
refactor: move trusted types logic into CDK

### DIFF
--- a/goldens/cdk/private/index.api.md
+++ b/goldens/cdk/private/index.api.md
@@ -16,6 +16,15 @@ export class _CdkPrivateStyleLoader {
     static ɵprov: i0.ɵɵInjectableDeclaration<_CdkPrivateStyleLoader>;
 }
 
+// @public (undocumented)
+export interface TrustedHTML {
+    // (undocumented)
+    __brand__: 'TrustedHTML';
+}
+
+// @public
+export function trustedHTMLFromString(html: string): TrustedHTML;
+
 // @public
 export class _VisuallyHiddenLoader {
     // (undocumented)

--- a/src/cdk/private/public-api.ts
+++ b/src/cdk/private/public-api.ts
@@ -8,3 +8,4 @@
 
 export * from './style-loader';
 export * from './visually-hidden/visually-hidden';
+export {TrustedHTML, trustedHTMLFromString} from './trusted-types';

--- a/src/cdk/private/trusted-types.ts
+++ b/src/cdk/private/trusted-types.ts
@@ -6,21 +6,17 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-/**
- * @fileoverview
- * A module to facilitate use of a Trusted Types policy internally within
- * Angular Material. It lazily constructs the Trusted Types policy, providing
- * helper utilities for promoting strings to Trusted Types. When Trusted Types
- * are not available, strings are used as a fallback.
- * @security All use of this module is security-sensitive and should go through
- * security review.
- */
+// A module to facilitate use of a Trusted Types policy internally within
+// Angular Material. It lazily constructs the Trusted Types policy, providing
+// helper utilities for promoting strings to Trusted Types. When Trusted Types
+// are not available, strings are used as a fallback.
+// All use of this module is security-sensitive and should go through security review.
 
-export declare interface TrustedHTML {
+export interface TrustedHTML {
   __brand__: 'TrustedHTML';
 }
 
-export declare interface TrustedTypePolicyFactory {
+interface TrustedTypePolicyFactory {
   createPolicy(
     policyName: string,
     policyOptions: {
@@ -29,7 +25,7 @@ export declare interface TrustedTypePolicyFactory {
   ): TrustedTypePolicy;
 }
 
-export declare interface TrustedTypePolicy {
+interface TrustedTypePolicy {
   createHTML(input: string): TrustedHTML;
 }
 
@@ -61,7 +57,8 @@ function getPolicy(): TrustedTypePolicy | null {
 /**
  * Unsafely promote a string to a TrustedHTML, falling back to strings when
  * Trusted Types are not available.
- * @security This is a security-sensitive function; any use of this function
+ *
+ * Important!!! This is a security-sensitive function; any use of this function
  * must go through security review. In particular, it must be assured that the
  * provided string will never cause an XSS vulnerability if used in a context
  * that will be interpreted as HTML by a browser, e.g. when assigning to

--- a/src/material/icon/BUILD.bazel
+++ b/src/material/icon/BUILD.bazel
@@ -68,7 +68,6 @@ ng_project(
         "icon-registry.ts",
         "index.ts",
         "public-api.ts",
-        "trusted-types.ts",
     ],
     assets = [
         ":css",
@@ -79,6 +78,7 @@ ng_project(
         "//:node_modules/@angular/platform-browser",
         "//:node_modules/rxjs",
         "//src:dev_mode_types",
+        "//src/cdk/private",
         "//src/material/core",
     ],
 )

--- a/src/material/icon/icon-registry.ts
+++ b/src/material/icon/icon-registry.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import {TrustedHTML, trustedHTMLFromString} from '@angular/cdk/private';
 import {HttpClient, HttpErrorResponse} from '@angular/common/http';
 import {
   ErrorHandler,
@@ -19,7 +20,6 @@ import {
 import {DomSanitizer, SafeHtml, SafeResourceUrl} from '@angular/platform-browser';
 import {forkJoin, Observable, of as observableOf, throwError as observableThrow} from 'rxjs';
 import {catchError, finalize, map, share, tap} from 'rxjs/operators';
-import {TrustedHTML, trustedHTMLFromString} from './trusted-types';
 
 /**
  * Returns an exception to be thrown in the case when attempting to


### PR DESCRIPTION
Moves the logic around trusted types into the CDK so it can be reused.

This is a pre-requisite change for #32386.