### PR TITLE
Fix bootstrapApplication to use the main-component

### DIFF
--- a/docs/src/app/shared/stackblitz/stackblitz-writer.ts
+++ b/docs/src/app/shared/stackblitz/stackblitz-writer.ts
@@ -215,8 +215,8 @@ export class StackBlitzWriter {
       // Replace `bootstrapApplication(MaterialDocsExample,`
       // will be replaced as `bootstrapApplication(ButtonDemo,`
       fileContent = fileContent.replace(
-        /bootstrapApplication\(MaterialDocsExample,/g,
-        `bootstrapApplication(${mainComponentName},`,
+        /bootstrapApplication\(MaterialDocsExample/g,
+        `bootstrapApplication(${mainComponentName}`,
       );
 
       const dotIndex = data.indexFilename.lastIndexOf('.');


### PR DESCRIPTION
There seems to be a trailing comma here that doesn't exist in the template and causes this replacement to be a no-op.

<img width="645" height="377" alt="image" src="https://github.com/user-attachments/assets/cb984aa6-fe7a-49c4-9e28-a127b5f48265" />
