### PR TITLE
Revert "feat(cdk/a11y): allow safe HTML to be passed to live announcer"

### DIFF
--- a/goldens/cdk/a11y/index.api.md
+++ b/goldens/cdk/a11y/index.api.md
@@ -18,7 +18,6 @@ import { OnChanges } from '@angular/core';
 import { OnDestroy } from '@angular/core';
 import { Provider } from '@angular/core';
 import { QueryList } from '@angular/core';
-import { SafeHtml } from '@angular/platform-browser';
 import { Signal } from '@angular/core';
 import { SimpleChanges } from '@angular/core';
 import { Subject } from 'rxjs';
@@ -405,10 +404,10 @@ export const LIVE_ANNOUNCER_ELEMENT_TOKEN: InjectionToken<HTMLElement | null>;
 // @public (undocumented)
 export class LiveAnnouncer implements OnDestroy {
     constructor(...args: unknown[]);
-    announce(message: LiveAnnouncerMessage): Promise<void>;
-    announce(message: LiveAnnouncerMessage, politeness?: AriaLivePoliteness): Promise<void>;
-    announce(message: LiveAnnouncerMessage, duration?: number): Promise<void>;
-    announce(message: LiveAnnouncerMessage, politeness?: AriaLivePoliteness, duration?: number): Promise<void>;
+    announce(message: string): Promise<void>;
+    announce(message: string, politeness?: AriaLivePoliteness): Promise<void>;
+    announce(message: string, duration?: number): Promise<void>;
+    announce(message: string, politeness?: AriaLivePoliteness, duration?: number): Promise<void>;
     clear(): void;
     // (undocumented)
     ngOnDestroy(): void;
@@ -423,9 +422,6 @@ export interface LiveAnnouncerDefaultOptions {
     duration?: number;
     politeness?: AriaLivePoliteness;
 }
-
-// @public
-export type LiveAnnouncerMessage = string | SafeHtml;
 
 // @public @deprecated
 export const MESSAGES_CONTAINER_ID = "cdk-describedby-message-container";

--- a/src/cdk/a11y/BUILD.bazel
+++ b/src/cdk/a11y/BUILD.bazel
@@ -18,7 +18,6 @@ ng_project(
     deps = [
         "//:node_modules/@angular/common",
         "//:node_modules/@angular/core",
-        "//:node_modules/@angular/platform-browser",
         "//:node_modules/rxjs",
         "//src:dev_mode_types",
         "//src/cdk/coercion",

--- a/src/cdk/a11y/live-announcer/live-announcer.spec.ts
+++ b/src/cdk/a11y/live-announcer/live-announcer.spec.ts
@@ -2,9 +2,9 @@ import {MutationObserverFactory} from '../../observers';
 import {ComponentPortal} from '../../portal';
 import {Component, inject, Injector} from '@angular/core';
 import {ComponentFixture, TestBed, fakeAsync, flush, tick} from '@angular/core/testing';
-import {By, DomSanitizer} from '@angular/platform-browser';
+import {By} from '@angular/platform-browser';
 import {A11yModule} from '../index';
-import {LiveAnnouncer, LiveAnnouncerMessage} from './live-announcer';
+import {LiveAnnouncer} from './live-announcer';
 import {
   AriaLivePoliteness,
   LIVE_ANNOUNCER_DEFAULT_OPTIONS,
@@ -202,19 +202,6 @@ describe('LiveAnnouncer', () => {
       tick(100);
       expect(modal.getAttribute('aria-owns')).toBe(`foo bar ${ariaLiveElement.id}`);
     }));
-
-    it('should be able to announce safe HTML', fakeAsync(() => {
-      const sanitizer = TestBed.inject(DomSanitizer);
-      const message = sanitizer.bypassSecurityTrustHtml(
-        '<span class="message" lang="fr">Bonjour</span>',
-      );
-      fixture.componentInstance.announce(message);
-
-      // This flushes our 100ms timeout for the screenreaders.
-      tick(100);
-
-      expect(ariaLiveElement.querySelector('.message')?.textContent).toBe('Bonjour');
-    }));
   });
 
   describe('with a custom element', () => {
@@ -391,13 +378,13 @@ function getLiveElement(): Element {
 }
 
 @Component({
-  template: `<button (click)="announce('Test')">Announce</button>`,
+  template: `<button (click)="announceText('Test')">Announce</button>`,
   imports: [A11yModule],
 })
 class TestApp {
   live = inject(LiveAnnouncer);
 
-  announce(message: LiveAnnouncerMessage) {
+  announceText(message: string) {
     this.live.announce(message);
   }
 }


### PR DESCRIPTION
This reverts commit 3b80628eca7c49edebfd489557e1edea91b45bd7.