### PR TITLE
refactor: set up function for setting innerHTML

### DIFF
--- a/.ng-dev/google-sync-config.json
+++ b/.ng-dev/google-sync-config.json
@@ -28,6 +28,7 @@
     "src/**/*spec.ts",
     "src/cdk/schematics/**/*",
     "src/cdk/testing/private/**/*",
+    "src/cdk/private/inner-html.ts",
     "src/material/schematics/**/*",
     "src/material/schematics/ng-generate/theme-color/**/*.bazel",
     "src/material/schematics/ng-generate/theme-color/index_bundled.d.ts",

--- a/src/cdk/private/BUILD.bazel
+++ b/src/cdk/private/BUILD.bazel
@@ -11,6 +11,7 @@ ng_project(
     assets = [":visually-hidden-styles"],
     deps = [
         "//:node_modules/@angular/core",
+        "//:node_modules/@angular/platform-browser",
     ],
 )
 

--- a/src/cdk/private/inner-html.ts
+++ b/src/cdk/private/inner-html.ts
@@ -1,0 +1,26 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {SecurityContext} from '@angular/core';
+import {DomSanitizer, SafeHtml} from '@angular/platform-browser';
+import {trustedHTMLFromString} from './trusted-types';
+
+// !!!Note!!! this file isn't synced into g3, but is replaced with a version that uses
+// internal-specific APIs. The internal version may have to be updated if the signature of
+// the function changes.
+
+/** Sanitizes and sets the `innerHTML` of an element. */
+export function _setInnerHtml(element: HTMLElement, html: SafeHtml, sanitizer: DomSanitizer): void {
+  const cleanHtml = sanitizer.sanitize(SecurityContext.HTML, html);
+
+  if (cleanHtml === null && (typeof ngDevMode === 'undefined' || ngDevMode)) {
+    throw new Error(`Could not sanitize HTML: ${html}`);
+  }
+
+  element.innerHTML = trustedHTMLFromString(cleanHtml || '') as unknown as string;
+}


### PR DESCRIPTION
When setting `innerHTML`, we have to go through a different API internally. These changes add a file that we can replace during the sync process.