### PR TITLE
build: add import maps `extract_api_to_json`

### DIFF
--- a/src/aria/accordion/BUILD.bazel
+++ b/src/aria/accordion/BUILD.bazel
@@ -1,5 +1,4 @@
-load("//tools:defaults.bzl", "ng_project", "ng_web_test_suite")
-load("//tools/adev-api-extraction:extract_api_to_json.bzl", "extract_api_to_json")
+load("//tools:defaults.bzl", "extract_api_to_json", "ng_project", "ng_web_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/src/aria/combobox/BUILD.bazel
+++ b/src/aria/combobox/BUILD.bazel
@@ -1,5 +1,4 @@
-load("//tools:defaults.bzl", "ng_project", "ng_web_test_suite", "ts_project")
-load("//tools/adev-api-extraction:extract_api_to_json.bzl", "extract_api_to_json")
+load("//tools:defaults.bzl", "extract_api_to_json", "ng_project", "ng_web_test_suite", "ts_project")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/src/aria/grid/BUILD.bazel
+++ b/src/aria/grid/BUILD.bazel
@@ -1,5 +1,4 @@
-load("//tools:defaults.bzl", "ng_project")
-load("//tools/adev-api-extraction:extract_api_to_json.bzl", "extract_api_to_json")
+load("//tools:defaults.bzl", "extract_api_to_json", "ng_project")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/src/aria/listbox/BUILD.bazel
+++ b/src/aria/listbox/BUILD.bazel
@@ -1,5 +1,4 @@
-load("//tools:defaults.bzl", "ng_project", "ng_web_test_suite")
-load("//tools/adev-api-extraction:extract_api_to_json.bzl", "extract_api_to_json")
+load("//tools:defaults.bzl", "extract_api_to_json", "ng_project", "ng_web_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/src/aria/menu/BUILD.bazel
+++ b/src/aria/menu/BUILD.bazel
@@ -1,5 +1,4 @@
-load("//tools:defaults.bzl", "ng_project", "ng_web_test_suite")
-load("//tools/adev-api-extraction:extract_api_to_json.bzl", "extract_api_to_json")
+load("//tools:defaults.bzl", "extract_api_to_json", "ng_project", "ng_web_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/src/aria/tabs/BUILD.bazel
+++ b/src/aria/tabs/BUILD.bazel
@@ -1,5 +1,4 @@
-load("//tools:defaults.bzl", "ng_project", "ng_web_test_suite")
-load("//tools/adev-api-extraction:extract_api_to_json.bzl", "extract_api_to_json")
+load("//tools:defaults.bzl", "extract_api_to_json", "ng_project", "ng_web_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/src/aria/toolbar/BUILD.bazel
+++ b/src/aria/toolbar/BUILD.bazel
@@ -1,5 +1,4 @@
-load("//tools:defaults.bzl", "ng_project", "ng_web_test_suite", "ts_project")
-load("//tools/adev-api-extraction:extract_api_to_json.bzl", "extract_api_to_json")
+load("//tools:defaults.bzl", "extract_api_to_json", "ng_project", "ng_web_test_suite", "ts_project")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/src/aria/tree/BUILD.bazel
+++ b/src/aria/tree/BUILD.bazel
@@ -1,5 +1,4 @@
-load("//tools:defaults.bzl", "ng_project", "ng_web_test_suite")
-load("//tools/adev-api-extraction:extract_api_to_json.bzl", "extract_api_to_json")
+load("//tools:defaults.bzl", "extract_api_to_json", "ng_project", "ng_web_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -14,6 +14,7 @@ load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("@rules_sass//src:index.bzl", _sass_binary = "sass_binary", _sass_library = "sass_library")
 load("//:packages.bzl", "NO_STAMP_NPM_PACKAGE_SUBSTITUTIONS", "NPM_PACKAGE_SUBSTITUTIONS")
 load("//:pkg-externals.bzl", "PKG_EXTERNALS")
+load("//tools/adev-api-extraction:extract_api_to_json.bzl", _extract_api_to_json = "extract_api_to_json")
 load("//tools/bazel:ng_package_interop.bzl", "ng_package_interop")
 load("//tools/bazel:web_test_suite.bzl", _ng_web_test_suite = "ng_web_test_suite")
 load("//tools/extract-tokens:index.bzl", _extract_tokens = "extract_tokens")
@@ -245,5 +246,16 @@ def protractor_web_test_suite(name, deps, **kwargs):
             "//:node_modules/protractor",
             "//:node_modules/selenium-webdriver",
         ],
+        **kwargs
+    )
+
+def extract_api_to_json(**kwargs):
+    _extract_api_to_json(
+        import_map = {
+            "@angular/core": "//:node_modules/@angular/core",
+            "@angular/core/*": "//:node_modules/@angular/core",
+            "@angular/cdk/bidi": "//src/cdk/bidi",
+            "@angular/aria/private": "//src/aria/private",
+        },
         **kwargs
     )


### PR DESCRIPTION
In order to get the correct types for the aria entries in the API json, we need to map external packages.

fixes #angular/angular#65566