### PR TITLE
feat(cdk/a11y): allow safe HTML to be passed to live announcer

### DIFF
--- a/goldens/cdk/a11y/index.api.md
+++ b/goldens/cdk/a11y/index.api.md
@@ -18,6 +18,7 @@ import { OnChanges } from '@angular/core';
 import { OnDestroy } from '@angular/core';
 import { Provider } from '@angular/core';
 import { QueryList } from '@angular/core';
+import { SafeHtml } from '@angular/platform-browser';
 import { Signal } from '@angular/core';
 import { SimpleChanges } from '@angular/core';
 import { Subject } from 'rxjs';
@@ -404,10 +405,10 @@ export const LIVE_ANNOUNCER_ELEMENT_TOKEN: InjectionToken<HTMLElement | null>;
 // @public (undocumented)
 export class LiveAnnouncer implements OnDestroy {
     constructor(...args: unknown[]);
-    announce(message: string): Promise<void>;
-    announce(message: string, politeness?: AriaLivePoliteness): Promise<void>;
-    announce(message: string, duration?: number): Promise<void>;
-    announce(message: string, politeness?: AriaLivePoliteness, duration?: number): Promise<void>;
+    announce(message: LiveAnnouncerMessage): Promise<void>;
+    announce(message: LiveAnnouncerMessage, politeness?: AriaLivePoliteness): Promise<void>;
+    announce(message: LiveAnnouncerMessage, duration?: number): Promise<void>;
+    announce(message: LiveAnnouncerMessage, politeness?: AriaLivePoliteness, duration?: number): Promise<void>;
     clear(): void;
     // (undocumented)
     ngOnDestroy(): void;
@@ -422,6 +423,9 @@ export interface LiveAnnouncerDefaultOptions {
     duration?: number;
     politeness?: AriaLivePoliteness;
 }
+
+// @public
+export type LiveAnnouncerMessage = string | SafeHtml;
 
 // @public @deprecated
 export const MESSAGES_CONTAINER_ID = "cdk-describedby-message-container";

--- a/goldens/cdk/private/index.api.md
+++ b/goldens/cdk/private/index.api.md
@@ -4,7 +4,9 @@
 
 ```ts
 
+import { DomSanitizer } from '@angular/platform-browser';
 import * as i0 from '@angular/core';
+import { SafeHtml } from '@angular/platform-browser';
 import { Type } from '@angular/core';
 
 // @public
@@ -15,6 +17,9 @@ export class _CdkPrivateStyleLoader {
     // (undocumented)
     static ɵprov: i0.ɵɵInjectableDeclaration<_CdkPrivateStyleLoader>;
 }
+
+// @public
+export function _setInnerHtml(element: HTMLElement, html: SafeHtml, sanitizer: DomSanitizer): void;
 
 // @public (undocumented)
 export interface TrustedHTML {

--- a/src/cdk/a11y/BUILD.bazel
+++ b/src/cdk/a11y/BUILD.bazel
@@ -18,6 +18,7 @@ ng_project(
     deps = [
         "//:node_modules/@angular/common",
         "//:node_modules/@angular/core",
+        "//:node_modules/@angular/platform-browser",
         "//:node_modules/rxjs",
         "//src:dev_mode_types",
         "//src/cdk/coercion",

--- a/src/cdk/private/public-api.ts
+++ b/src/cdk/private/public-api.ts
@@ -9,3 +9,4 @@
 export * from './style-loader';
 export * from './visually-hidden/visually-hidden';
 export {TrustedHTML, trustedHTMLFromString} from './trusted-types';
+export {_setInnerHtml} from './inner-html';


### PR DESCRIPTION
This is a second stab at landing #32386.

Adds support for passing safe HTML into the `LiveAnnouncer`. This can be necessary when announcing content in a different language from the rest of the page.

Fixes #31835.