### PR TITLE
fix(multiple): resolve forward ref errors

### DIFF
--- a/src/aria/combobox/combobox.ts
+++ b/src/aria/combobox/combobox.ts
@@ -13,6 +13,7 @@ import {
   contentChild,
   Directive,
   ElementRef,
+  forwardRef,
   inject,
   input,
   model,
@@ -98,7 +99,12 @@ export class Combobox<V> {
   private readonly _deferredContentAware = inject(DeferredContentAware, {optional: true});
 
   /** The combobox popup. */
-  readonly popup = contentChild<ComboboxPopup<V>>(ComboboxPopup);
+  readonly popup = contentChild<ComboboxPopup<V>>(
+    // We need a `forwardRef` here, because the popup class is declared further down
+    // in the same file. When the reference is written to Angular's metadata this can
+    // cause an attempt to access the class before it's defined.
+    forwardRef(() => ComboboxPopup),
+  );
 
   /**
    * The filter mode for the combobox.

--- a/src/aria/listbox/listbox.ts
+++ b/src/aria/listbox/listbox.ts
@@ -13,6 +13,7 @@ import {
   contentChildren,
   Directive,
   ElementRef,
+  forwardRef,
   inject,
   input,
   model,
@@ -81,7 +82,13 @@ export class Listbox<V> {
   private readonly _directionality = inject(Directionality);
 
   /** The Options nested inside of the Listbox. */
-  private readonly _options = contentChildren(Option, {descendants: true});
+  private readonly _options = contentChildren(
+    // We need a `forwardRef` here, because the option class is declared further down
+    // in the same file. When the reference is written to Angular's metadata this can
+    // cause an attempt to access the class before it's defined.
+    forwardRef(() => Option),
+    {descendants: true},
+  );
 
   /** A signal wrapper for directionality. */
   protected textDirection = toSignal(this._directionality.change, {


### PR DESCRIPTION
The combobox and listbox had some cases where they were referencing classes defined further down in the file in their queries.

When the references are extracted into Angular's metadata, this can cause an error at runtime because the reference becomes eager.

These changes wrap the problematic cases in `forwardRef` to resolve the issues.

Fixes #32408.