### PR TITLE
build: run tests against Safari 26

### DIFF
--- a/src/aria/toolbar/toolbar.spec.ts
+++ b/src/aria/toolbar/toolbar.spec.ts
@@ -545,7 +545,6 @@ describe('Toolbar', () => {
         const widgets = fixture.debugElement
           .queryAll(By.css('[toolbar-button]'))
           .map((debugEl: DebugElement) => debugEl.nativeElement as HTMLElement);
-        console.log('clicking:', widgets[0]);
         click(widgets[0]);
         expect(document.activeElement).toBe(widgets[0]);
       });

--- a/test/browser-providers.js
+++ b/test/browser-providers.js
@@ -4,7 +4,7 @@
  *   - `browserstack`: Launches the browser within BrowserStack
  */
 const browserConfig = {
-  'Safari16': {unitTest: {target: 'browserstack'}},
+  'Safari26': {unitTest: {target: 'browserstack'}},
 };
 
 /** Exports all available custom Karma browsers. */

--- a/test/karma-browsers.json
+++ b/test/karma-browsers.json
@@ -1,9 +1,9 @@
 {
-  "BROWSERSTACK_SAFARI16": {
+  "BROWSERSTACK_SAFARI26": {
     "base": "BrowserStack",
     "browser": "Safari",
-    "browser_version": "16.0",
+    "browser_version": "26.0",
     "os": "OS X",
-    "os_version": "Ventura"
+    "os_version": "Tahoe"
   }
 }


### PR DESCRIPTION
Switches to running our unit tests against a newer version of Safari.