### PR TITLE
fix(material/paginator): Paginator default appearance is `fill`, like  `<mat-form-field>`

### DIFF
--- a/src/material/paginator/paginator.ts
+++ b/src/material/paginator/paginator.ts
@@ -230,7 +230,7 @@ export class MatPaginator implements OnInit, OnDestroy {
       }
     }
 
-    this._formFieldAppearance = defaults?.formFieldAppearance || 'outline';
+    this._formFieldAppearance = defaults?.formFieldAppearance || 'fill';
   }
 
   ngOnInit() {


### PR DESCRIPTION
You can restore `outline` appearance by providing `MAT_PAGINATOR_DEFAULT_OPTIONS` like so:

```ts
{
    provide: MAT_PAGINATOR_DEFAULT_OPTIONS,
    useValue: {
        formFieldAppearance: 'outline',
    } satisfies MatPaginatorDefaultOptions,
}
```

Fixes #26580

BREAKING CHANGE:
* Paginator default appearance is `fill`.