### PR TITLE
docs(aria): add required `'value'` to `ngMenuItem` jsdocs

### DIFF
--- a/src/aria/menu/menu.ts
+++ b/src/aria/menu/menu.ts
@@ -39,14 +39,14 @@ import {MENU_COMPONENT} from './menu-tokens';
  * <button ngMenuTrigger [menu]="myMenu">Options</button>
  *
  * <div ngMenu #myMenu="ngMenu">
- *   <div ngMenuItem>Star</div>
- *   <div ngMenuItem>Edit</div>
- *   <div ngMenuItem [submenu]="subMenu">More</div>
+ *   <div ngMenuItem value="Star">Star</div>
+ *   <div ngMenuItem value="Edit">Edit</div>
+ *   <div ngMenuItem value="More" [submenu]="subMenu">More</div>
  * </div>
  *
  * <div ngMenu #subMenu="ngMenu">
- *   <div ngMenuItem>Sub Item 1</div>
- *   <div ngMenuItem>Sub Item 2</div>
+ *   <div ngMenuItem value="Sub Item 1">Sub Item 1</div>
+ *   <div ngMenuItem value="Sub Item 2">Sub Item 2</div>
  * </div>
  * ```
  *


### PR DESCRIPTION
The `value` is a required input. Without it, `menu.ts` will throw the error "Required input 'value' from directive MenuItem must be specified."

edit: associated PR for the adev docs which also had this same problem: https://github.com/angular/angular/pull/65721