### PR TITLE
fix(material/icon): go through common innerHTML handler

### DIFF
--- a/src/cdk/private/inner-html.ts
+++ b/src/cdk/private/inner-html.ts
@@ -18,7 +18,7 @@ import {trustedHTMLFromString} from './trusted-types';
 export function _setInnerHtml(element: HTMLElement, html: SafeHtml, sanitizer: DomSanitizer): void {
   const cleanHtml = sanitizer.sanitize(SecurityContext.HTML, html);
 
-  if (cleanHtml === null && (typeof ngDevMode === 'undefined' || ngDevMode)) {
+  if (!cleanHtml && (typeof ngDevMode === 'undefined' || ngDevMode)) {
     throw new Error(`Could not sanitize HTML: ${html}`);
   }
 

--- a/src/material/icon/icon.spec.ts
+++ b/src/material/icon/icon.spec.ts
@@ -854,10 +854,13 @@ describe('MatIcon', () => {
       // Stub out console.warn so we don't pollute our logs with Angular's warnings.
       // Jasmine will tear the spy down at the end of the test.
       spyOn(console, 'warn');
+      iconRegistry.addSvgIconLiteral('circle', '<svg><circle></svg>');
 
       expect(() => {
-        iconRegistry.addSvgIconLiteral('circle', '<svg><circle></svg>');
-      }).toThrowError(/was not trusted as safe HTML/);
+        const fixture = TestBed.createComponent(IconFromSvgName);
+        fixture.componentInstance.iconName = 'circle';
+        fixture.detectChanges();
+      }).toThrowError(/Could not sanitize HTML/);
     });
 
     it('should extract an icon from SVG icon set', () => {


### PR DESCRIPTION
Reworks the icon to use the common function for setting `innerHTML`. This allows us to remove some exemptions internally.