### PR TITLE
build: only include adev_assets in snapshot builds

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -63,11 +63,7 @@ build:release --stamp
 
 build:snapshot-build --workspace_status_command="pnpm -s ng-dev:stamp --mode=snapshot"
 build:snapshot-build --stamp
-
-##################################
-# Always enable Ivy compilation  #
-##################################
-build --define=angular_ivy_enabled=True
+build:snapshot-build --//:enable_snapshot_adev_assets
 
 ################################
 # Remote Execution Setup       #

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 load("@devinfra//bazel/validation:defs.bzl", "validate_ts_version_matching")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//:pkg-externals.bzl", "PKG_EXTERNALS")
@@ -42,4 +43,16 @@ genrule(
 validate_ts_version_matching(
     module_lock_file = "MODULE.bazel.lock",
     package_json = "package.json",
+)
+
+bool_flag(
+    name = "enable_snapshot_adev_assets",
+    build_setting_default = False,
+)
+
+config_setting(
+    name = "snapshot_adev_assets",
+    flag_values = {
+        ":enable_snapshot_adev_assets": "true",
+    },
 )

--- a/src/aria/BUILD.bazel
+++ b/src/aria/BUILD.bazel
@@ -20,9 +20,10 @@ ng_package(
     name = "npm_package",
     package_name = "@angular/aria",
     srcs = ["package.json"],
-    nested_packages = [
-        ":adev_assets",
-    ],
+    nested_packages = select({
+        "//:snapshot_adev_assets": [":adev_assets"],
+        "//conditions:default": [],
+    }),
     package_deps = [
         ":node_modules/@angular/cdk",
     ],

--- a/src/cdk/BUILD.bazel
+++ b/src/cdk/BUILD.bazel
@@ -60,8 +60,10 @@ ng_package(
     ] + prebuiltStyleTargets + CDK_SCSS_LIBS,
     nested_packages = [
         "//src/cdk/schematics:npm_package",
-        ":adev_assets",
-    ],
+    ] + select({
+        "//:snapshot_adev_assets": [":adev_assets"],
+        "//conditions:default": [],
+    }),
     replace_prefixes = {
         "adev_assets/": "_adev_assets/",
     },


### PR DESCRIPTION
This change ensures that `adev_assets` are only included in the release output when the build is configured with `snapshot-build`. This prevents these assets from being included in standard NPM releases.