### PR TITLE
fix(cdk): add `@angular/platform-browser` to peer dependencies

### DIFF
--- a/src/cdk/package.json
+++ b/src/cdk/package.json
@@ -47,6 +47,7 @@
   "peerDependencies": {
     "@angular/core": "0.0.0-NG",
     "@angular/common": "0.0.0-NG",
+    "@angular/platform-browser": "0.0.0-NG",
     "rxjs": "^6.5.3 || ^7.4.0"
   },
   "dependencies": {


### PR DESCRIPTION
This commit https://github.com/angular/components/pull/32412 introduced a new dependency but it was not listed in the peer dependencies. This causes the build to fail when using PNPM as the package cannot be resolved.