### PR TITLE
ci: update snapshots CI workflow to use the new `build-snapshots` script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,8 +135,8 @@ jobs:
         uses: angular/dev-infra/github-actions/bazel/configure-remote@95e3a0ede6dfa1aedd34b03918ad72b18f87e5ae
       - name: Install node modules
         run: pnpm install --frozen-lockfile
-      - name: Build and Verify Release Output
-        run: pnpm build-and-check-release-output
+      - name: Build Snapshots
+        run: pnpm build-snapshots
       - name: Verify tooling setup
         run: pnpm check-tooling-setup
       - name: Build Docs Content

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "build": "node --no-warnings=ExperimentalWarning --loader ts-node/esm/transpile-only ./scripts/build-packages-dist-main.mts",
     "build-docs-content": "node --no-warnings=ExperimentalWarning --loader ts-node/esm/transpile-only ./scripts/build-docs-content-main.mts",
     "build-and-check-release-output": "node --no-warnings=ExperimentalWarning --loader ts-node/esm/transpile-only scripts/build-and-check-release-output.mts",
+    "build-snapshots": "node --no-warnings=ExperimentalWarning --loader ts-node/esm/transpile-only scripts/build-packages-dist-main.mts",
     "dev-app": "ibazel run //src/dev-app:devserver",
     "docs-app": "ibazel run //docs:serve",
     "universal-app": "bazel run //src/universal-app:server",


### PR DESCRIPTION
Previously, in snapshots the release config was used. See: https://github.com/angular/cdk-builds/blob/8ff0017b73614e4a80bd0c3d4a7fa0fe5ef10954/package.json#L3