### PR TITLE
fix(cdk/overlay): error when attempting to attach disposed overlay

### DIFF
--- a/src/cdk/overlay/overlay-ref.ts
+++ b/src/cdk/overlay/overlay-ref.ts
@@ -51,6 +51,7 @@ export class OverlayRef implements PortalOutlet {
   private _backdropRef: BackdropRef | null = null;
   private _detachContentMutationObserver: MutationObserver | undefined;
   private _detachContentAfterRenderRef: AfterRenderRef | undefined;
+  private _disposed: boolean;
 
   /**
    * Reference to the parent of the `_host` at the time it was detached. Used to restore
@@ -120,6 +121,10 @@ export class OverlayRef implements PortalOutlet {
    * @returns The portal attachment result.
    */
   attach(portal: Portal<any>): any {
+    if (this._disposed) {
+      return null;
+    }
+
     // Insert the host into the DOM before attaching the portal, otherwise
     // the animations module will skip animations on repeat attachments.
     this._attachHost();
@@ -240,6 +245,10 @@ export class OverlayRef implements PortalOutlet {
 
   /** Cleans up the overlay from the DOM. */
   dispose(): void {
+    if (this._disposed) {
+      return;
+    }
+
     const isAttached = this.hasAttached();
 
     if (this._positionStrategy) {
@@ -266,6 +275,7 @@ export class OverlayRef implements PortalOutlet {
 
     this._detachments.complete();
     this._completeDetachContent();
+    this._disposed = true;
   }
 
   /** Whether the overlay has attached content. */

--- a/src/cdk/overlay/overlay.spec.ts
+++ b/src/cdk/overlay/overlay.spec.ts
@@ -495,6 +495,13 @@ describe('Overlay', () => {
     expect(paneElement.childNodes.length).toBe(0);
   }));
 
+  it('should do nothing when trying to attach a disposed overlay', () => {
+    const overlayRef = createOverlayRef(injector);
+    overlayRef.dispose();
+    overlayRef.attach(componentPortal);
+    expect(document.querySelector('.cdk-overlay-pane')).toBeFalsy();
+  });
+
   describe('positioning', () => {
     let config: OverlayConfig;
 


### PR DESCRIPTION
Fixes an error that was being thrown when calling `attach` on an overlay that was disposed already.