### PR TITLE
fix(material/table): fixed layout not working

### DIFF
--- a/src/material/table/table.scss
+++ b/src/material/table/table.scss
@@ -30,6 +30,12 @@ $fallbacks: m3-table.get-tokens();
   background-color: token-utils.slot(table-background-color, $fallbacks);
 }
 
+// These styles already come from a similar class in the CDK,
+// but the `.mat-mdc-table` styles override them.
+.mat-table-fixed-layout {
+  table-layout: fixed;
+}
+
 .mdc-data-table__cell {
   box-sizing: border-box;
   overflow: hidden;

--- a/src/material/table/table.ts
+++ b/src/material/table/table.ts
@@ -66,7 +66,7 @@ export class MatRecycleRows {}
   styleUrl: 'table.css',
   host: {
     'class': 'mat-mdc-table mdc-data-table__table',
-    '[class.mdc-table-fixed-layout]': 'fixedLayout',
+    '[class.mat-table-fixed-layout]': 'fixedLayout',
   },
   providers: [
     {provide: CdkTable, useExisting: MatTable},


### PR DESCRIPTION
Fixes that the `fixedLayout` input wasn't doint anything in the Material table, because:
1. The `cdk-table-fixed-layout` styles were being overridden by the Material table's styling.
2. The style that the Material table was applying didn't have any styles associated with it.