### PR TITLE
docs: add reference links to ARIA

### DIFF
--- a/src/aria/accordion/accordion-content.ts
+++ b/src/aria/accordion/accordion-content.ts
@@ -26,6 +26,7 @@ import {DeferredContent} from '../private';
  * ```
  *
  * @developerPreview 21.0
+ * @see [Accordion](guide/aria/accordion)
  */
 @Directive({
   selector: 'ng-template[ngAccordionContent]',

--- a/src/aria/accordion/accordion-group.ts
+++ b/src/aria/accordion/accordion-group.ts
@@ -57,6 +57,7 @@ import {ACCORDION_GROUP} from './accordion-tokens';
  * ```
  *
  * @developerPreview 21.0
+ * @see [Accordion](guide/aria/accordion)
  */
 @Directive({
   selector: '[ngAccordionGroup]',

--- a/src/aria/accordion/accordion-panel.ts
+++ b/src/aria/accordion/accordion-panel.ts
@@ -37,6 +37,7 @@ import {DeferredContentAware, AccordionPanelPattern, AccordionTriggerPattern} fr
  * ```
  *
  * @developerPreview 21.0
+ * @see [Accordion](guide/aria/accordion)
  */
 @Directive({
   selector: '[ngAccordionPanel]',

--- a/src/aria/accordion/accordion-trigger.ts
+++ b/src/aria/accordion/accordion-trigger.ts
@@ -37,6 +37,7 @@ import {ACCORDION_GROUP} from './accordion-tokens';
  * ```
  *
  * @developerPreview 21.0
+ * @see [Accordion](guide/aria/accordion)
  */
 @Directive({
   selector: '[ngAccordionTrigger]',

--- a/src/aria/combobox/combobox-dialog.ts
+++ b/src/aria/combobox/combobox-dialog.ts
@@ -25,6 +25,11 @@ import {ComboboxPopup} from './combobox-popup';
  * ```
  *
  * @developerPreview 21.0
+ *
+ * @see [Combobox](guide/aria/combobox)
+ * @see [Select](guide/aria/select)
+ * @see [Multiselect](guide/aria/multiselect)
+ * @see [Autocomplete](guide/aria/autocomplete)
  */
 @Directive({
   selector: 'dialog[ngComboboxDialog]',

--- a/src/aria/combobox/combobox-input.ts
+++ b/src/aria/combobox/combobox-input.ts
@@ -35,6 +35,11 @@ import {Combobox} from './combobox';
  * ```
  *
  * @developerPreview 21.0
+ *
+ * @see [Combobox](guide/aria/combobox)
+ * @see [Select](guide/aria/select)
+ * @see [Multiselect](guide/aria/multiselect)
+ * @see [Autocomplete](guide/aria/autocomplete)
  */
 @Directive({
   selector: 'input[ngComboboxInput]',

--- a/src/aria/combobox/combobox-popup-container.ts
+++ b/src/aria/combobox/combobox-popup-container.ts
@@ -38,6 +38,11 @@ import {DeferredContent} from '../private';
  * ```
  *
  * @developerPreview 21.0
+ *
+ * @see [Combobox](guide/aria/combobox)
+ * @see [Select](guide/aria/select)
+ * @see [Multiselect](guide/aria/multiselect)
+ * @see [Autocomplete](guide/aria/autocomplete)
  */
 @Directive({
   selector: 'ng-template[ngComboboxPopupContainer]',

--- a/src/aria/combobox/combobox-popup.ts
+++ b/src/aria/combobox/combobox-popup.ts
@@ -20,6 +20,11 @@ import {COMBOBOX} from './combobox-tokens';
  * exposing the popup's control pattern to the parent combobox.
  *
  * @developerPreview 21.0
+ *
+ * @see [Combobox](guide/aria/combobox)
+ * @see [Select](guide/aria/select)
+ * @see [Multiselect](guide/aria/multiselect)
+ * @see [Autocomplete](guide/aria/autocomplete)
  */
 @Directive({
   selector: '[ngComboboxPopup]',

--- a/src/aria/combobox/combobox.ts
+++ b/src/aria/combobox/combobox.ts
@@ -52,6 +52,11 @@ import {COMBOBOX} from './combobox-tokens';
  * ```
  *
  * @developerPreview 21.0
+ *
+ * @see [Combobox](guide/aria/combobox)
+ * @see [Select](guide/aria/select)
+ * @see [Multiselect](guide/aria/multiselect)
+ * @see [Autocomplete](guide/aria/autocomplete)
  */
 @Directive({
   selector: '[ngCombobox]',

--- a/src/aria/grid/grid-cell-widget.ts
+++ b/src/aria/grid/grid-cell-widget.ts
@@ -36,6 +36,8 @@ import {GRID_CELL} from './grid-tokens';
  * ```
  *
  * @developerPreview 21.0
+ *
+ * @see [Grid](guide/aria/grid)
  */
 @Directive({
   selector: '[ngGridCellWidget]',

--- a/src/aria/grid/grid-cell.ts
+++ b/src/aria/grid/grid-cell.ts
@@ -35,6 +35,8 @@ import {GRID_CELL, GRID_ROW} from './grid-tokens';
  * ```
  *
  * @developerPreview 21.0
+ *
+ * @see [Grid](guide/aria/grid)
  */
 @Directive({
   selector: '[ngGridCell]',

--- a/src/aria/grid/grid-row.ts
+++ b/src/aria/grid/grid-row.ts
@@ -29,6 +29,8 @@ import {GRID_CELL, GRID_ROW} from './grid-tokens';
  * ```
  *
  * @developerPreview 21.0
+ *
+ * @see [Grid](guide/aria/grid)
  */
 @Directive({
   selector: '[ngGridRow]',

--- a/src/aria/grid/grid.ts
+++ b/src/aria/grid/grid.ts
@@ -41,6 +41,8 @@ import {GRID_ROW} from './grid-tokens';
  * ```
  *
  * @developerPreview 21.0
+ *
+ * @see [Grid](guide/aria/grid)
  */
 @Directive({
   selector: '[ngGrid]',

--- a/src/aria/listbox/listbox.ts
+++ b/src/aria/listbox/listbox.ts
@@ -45,6 +45,11 @@ import {LISTBOX} from './tokens';
  * ```
  *
  * @developerPreview 21.0
+ *
+ * @see [Listbox](guide/aria/listbox)
+ * @see [Autocomplete](guide/aria/autocomplete)
+ * @see [Select](guide/aria/select)
+ * @see [Multiselect](guide/aria/multiselect)
  */
 @Directive({
   selector: '[ngListbox]',

--- a/src/aria/listbox/option.ts
+++ b/src/aria/listbox/option.ts
@@ -25,6 +25,11 @@ import {LISTBOX} from './tokens';
  * ```
  *
  * @developerPreview 21.0
+ *
+ * @see [Listbox](guide/aria/listbox)
+ * @see [Autocomplete](guide/aria/autocomplete)
+ * @see [Select](guide/aria/select)
+ * @see [Multiselect](guide/aria/multiselect)
  */
 @Directive({
   selector: '[ngOption]',

--- a/src/aria/menu/menu-bar.ts
+++ b/src/aria/menu/menu-bar.ts
@@ -49,6 +49,9 @@ import {MENU_COMPONENT} from './menu-tokens';
  * ```
  *
  * @developerPreview 21.0
+ *
+ * @see [Menu](guide/aria/menu)
+ * @see [MenuBar](guide/aria/menubar)
  */
 @Directive({
   selector: '[ngMenuBar]',

--- a/src/aria/menu/menu-content.ts
+++ b/src/aria/menu/menu-content.ts
@@ -25,6 +25,9 @@ import {DeferredContent} from '../private';
  * ```
  *
  * @developerPreview 21.0
+ *
+ * @see [Menu](guide/aria/menu)
+ * @see [MenuBar](guide/aria/menubar)
  */
 @Directive({
   selector: 'ng-template[ngMenuContent]',

--- a/src/aria/menu/menu-item.ts
+++ b/src/aria/menu/menu-item.ts
@@ -26,6 +26,9 @@ import type {MenuBar} from './menu-bar';
  * ```
  *
  * @developerPreview 21.0
+ *
+ * @see [Menu](guide/aria/menu)
+ * @see [MenuBar](guide/aria/menubar)
  */
 @Directive({
   selector: '[ngMenuItem]',

--- a/src/aria/menu/menu-trigger.ts
+++ b/src/aria/menu/menu-trigger.ts
@@ -36,6 +36,9 @@ import type {Menu} from './menu';
  * ```
  *
  * @developerPreview 21.0
+ *
+ * @see [Menu](guide/aria/menu)
+ * @see [MenuBar](guide/aria/menubar)
  */
 @Directive({
   selector: 'button[ngMenuTrigger]',

--- a/src/aria/menu/menu.ts
+++ b/src/aria/menu/menu.ts
@@ -51,6 +51,9 @@ import {MENU_COMPONENT} from './menu-tokens';
  * ```
  *
  * @developerPreview 21.0
+ *
+ * @see [Menu](guide/aria/menu)
+ * @see [MenuBar](guide/aria/menubar)
  */
 @Directive({
   selector: '[ngMenu]',

--- a/src/aria/tabs/tab-content.ts
+++ b/src/aria/tabs/tab-content.ts
@@ -25,6 +25,8 @@ import {DeferredContent} from '../private';
  * ```
  *
  * @developerPreview 21.0
+ *
+ * @see [Tabs](guide/aria/tabs)
  */
 @Directive({
   selector: 'ng-template[ngTabContent]',

--- a/src/aria/tabs/tab-list.ts
+++ b/src/aria/tabs/tab-list.ts
@@ -39,6 +39,8 @@ import type {Tab} from './tab';
  * ```
  *
  * @developerPreview 21.0
+ *
+ * @see [Tabs](guide/aria/tabs)
  */
 @Directive({
   selector: '[ngTabList]',

--- a/src/aria/tabs/tab-panel.ts
+++ b/src/aria/tabs/tab-panel.ts
@@ -36,6 +36,8 @@ import {TABS} from './utils';
  * ```
  *
  * @developerPreview 21.0
+ *
+ * @see [Tabs](guide/aria/tabs)
  */
 @Directive({
   selector: '[ngTabPanel]',

--- a/src/aria/tabs/tab.ts
+++ b/src/aria/tabs/tab.ts
@@ -35,6 +35,8 @@ import {HasElement, TABS} from './utils';
  * ```
  *
  * @developerPreview 21.0
+ *
+ * @see [Tabs](guide/aria/tabs)
  */
 @Directive({
   selector: '[ngTab]',

--- a/src/aria/tabs/tabs.ts
+++ b/src/aria/tabs/tabs.ts
@@ -39,6 +39,8 @@ import {TABS} from './utils';
  * ```
  *
  * @developerPreview 21.0
+ *
+ * @see [Tabs](guide/aria/tabs)
  */
 @Directive({
   selector: '[ngTabs]',

--- a/src/aria/toolbar/toolbar-widget-group.ts
+++ b/src/aria/toolbar/toolbar-widget-group.ts
@@ -25,6 +25,8 @@ import {TOOLBAR_WIDGET_GROUP} from './utils';
  * that have their own internal navigation.
  *
  * @developerPreview 21.0
+ *
+ * @see [Toolbar](guide/aria/toolbar)
  */
 @Directive({
   selector: '[ngToolbarWidgetGroup]',

--- a/src/aria/toolbar/toolbar-widget.ts
+++ b/src/aria/toolbar/toolbar-widget.ts
@@ -36,6 +36,8 @@ import type {ToolbarWidgetGroup} from './toolbar-widget-group';
  * ```
  *
  * @developerPreview 21.0
+ *
+ * @see [Toolbar](guide/aria/toolbar)
  */
 @Directive({
   selector: '[ngToolbarWidget]',

--- a/src/aria/toolbar/toolbar.ts
+++ b/src/aria/toolbar/toolbar.ts
@@ -41,6 +41,8 @@ import {sortDirectives} from './utils';
  * ```
  *
  * @developerPreview 21.0
+ *
+ * @see [Toolbar](guide/aria/toolbar)
  */
 @Directive({
   selector: '[ngToolbar]',

--- a/src/aria/tree/tree-item-group.ts
+++ b/src/aria/tree/tree-item-group.ts
@@ -39,6 +39,8 @@ import {sortDirectives} from './utils';
  * ```
  *
  * @developerPreview 21.0
+ *
+ * @see [Tree](guide/aria/tree)
  */
 @Directive({
   selector: 'ng-template[ngTreeItemGroup]',

--- a/src/aria/tree/tree.ts
+++ b/src/aria/tree/tree.ts
@@ -58,6 +58,8 @@ import {sortDirectives} from './utils';
  * ```
  *
  * @developerPreview 21.0
+ *
+ * @see [Tree](guide/aria/tree)
  */
 @Directive({
   selector: '[ngTree]',


### PR DESCRIPTION
Adds see links in the ARIA components documentation to improve discoverability of related documentation and usage guides