### PR TITLE
build: reformat files after dependency update

### DIFF
--- a/integration/module-tests/BUILD.bazel
+++ b/integration/module-tests/BUILD.bazel
@@ -1,5 +1,5 @@
-load("//tools:defaults.bzl", "ts_project")
 load("//integration/module-tests:index.bzl", "module_test")
+load("//tools:defaults.bzl", "ts_project")
 
 ts_project(
     name = "test_lib",

--- a/integration/ts-compat/BUILD.bazel
+++ b/integration/ts-compat/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("@aspect_rules_js//js:defs.bzl", "js_test")
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("//integration/ts-compat:import-all-entry-points.bzl", "generate_import_all_entry_points_file")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/aria/private/accordion/accordion.ts
+++ b/src/aria/private/accordion/accordion.ts
@@ -18,13 +18,12 @@ import {
 import {SignalLike, WritableSignalLike} from '../behaviors/signal-like/signal-like';
 
 /** Inputs of the AccordionGroupPattern. */
-export interface AccordionGroupInputs
-  extends Omit<
-    ListNavigationInputs<AccordionTriggerPattern> &
-      ListFocusInputs<AccordionTriggerPattern> &
-      Omit<ListExpansionInputs, 'items'>,
-    'focusMode'
-  > {
+export interface AccordionGroupInputs extends Omit<
+  ListNavigationInputs<AccordionTriggerPattern> &
+    ListFocusInputs<AccordionTriggerPattern> &
+    Omit<ListExpansionInputs, 'items'>,
+  'focusMode'
+> {
   /** A function that returns the trigger associated with a given element. */
   getItem: (e: Element | null | undefined) => AccordionTriggerPattern | undefined;
 }
@@ -124,8 +123,7 @@ export class AccordionGroupPattern {
 
 /** Inputs for the AccordionTriggerPattern. */
 export interface AccordionTriggerInputs
-  extends Omit<ListNavigationItem & ListFocusItem, 'index'>,
-    Omit<ExpansionItem, 'expandable'> {
+  extends Omit<ListNavigationItem & ListFocusItem, 'index'>, Omit<ExpansionItem, 'expandable'> {
   /** A local unique identifier for the trigger's corresponding panel. */
   panelId: SignalLike<string>;
 

--- a/src/aria/private/combobox/combobox.ts
+++ b/src/aria/private/combobox/combobox.ts
@@ -105,8 +105,10 @@ export interface ComboboxListboxControls<T extends ListItem<V>, V> {
   setValue: (value: V | undefined) => void; // For re-setting the value if the popup was destroyed.
 }
 
-export interface ComboboxTreeControls<T extends ListItem<V>, V>
-  extends ComboboxListboxControls<T, V> {
+export interface ComboboxTreeControls<T extends ListItem<V>, V> extends ComboboxListboxControls<
+  T,
+  V
+> {
   /** Whether the currently active item in the popup is collapsible. */
   isItemCollapsible: () => boolean;
 

--- a/src/aria/private/grid/cell.ts
+++ b/src/aria/private/grid/cell.ts
@@ -18,7 +18,8 @@ import {GridCellWidgetPattern} from './widget';
 
 /** The inputs for the `GridCellPattern`. */
 export interface GridCellInputs
-  extends GridCell,
+  extends
+    GridCell,
     Omit<
       ListNavigationInputs<GridCellWidgetPattern>,
       'focusMode' | 'items' | 'activeItem' | 'softDisabled' | 'element'

--- a/src/aria/private/tabs/tabs.ts
+++ b/src/aria/private/tabs/tabs.ts
@@ -20,8 +20,7 @@ import {
 
 /** The required inputs to tabs. */
 export interface TabInputs
-  extends Omit<ListNavigationItem, 'index'>,
-    Omit<ExpansionItem, 'expandable'> {
+  extends Omit<ListNavigationItem, 'index'>, Omit<ExpansionItem, 'expandable'> {
   /** The parent tablist that controls the tab. */
   tablist: SignalLike<TabListPattern>;
 
@@ -123,7 +122,8 @@ export class TabPanelPattern {
 
 /** The required inputs for the tablist. */
 export interface TabListInputs
-  extends Omit<ListNavigationInputs<TabPattern>, 'multi'>,
+  extends
+    Omit<ListNavigationInputs<TabPattern>, 'multi'>,
     Omit<ListExpansionInputs, 'multiExpandable' | 'items'> {
   /** The selection strategy used by the tablist. */
   selectionMode: SignalLike<'follow' | 'explicit'>;

--- a/src/aria/private/toolbar/toolbar-widget.ts
+++ b/src/aria/private/toolbar/toolbar-widget.ts
@@ -13,8 +13,10 @@ import type {ToolbarPattern} from './toolbar';
 import {ToolbarWidgetGroupPattern} from './toolbar-widget-group';
 
 /** Represents the required inputs for a toolbar widget in a toolbar. */
-export interface ToolbarWidgetInputs<V>
-  extends Omit<ListItem<V>, 'searchTerm' | 'index' | 'selectable'> {
+export interface ToolbarWidgetInputs<V> extends Omit<
+  ListItem<V>,
+  'searchTerm' | 'index' | 'selectable'
+> {
   /** A reference to the parent toolbar. */
   toolbar: SignalLike<ToolbarPattern<V>>;
 

--- a/src/aria/private/tree/tree.ts
+++ b/src/aria/private/tree/tree.ts
@@ -14,8 +14,7 @@ import {KeyboardEventManager, PointerEventManager, Modifier} from '../behaviors/
 
 /** Represents the required inputs for a tree item. */
 export interface TreeItemInputs<V>
-  extends Omit<ListItem<V>, 'index'>,
-    Omit<ExpansionItem, 'expandable'> {
+  extends Omit<ListItem<V>, 'index'>, Omit<ExpansionItem, 'expandable'> {
   /** The parent item. */
   parent: SignalLike<TreeItemPattern<V> | TreePattern<V>>;
 

--- a/src/cdk/collections/dispose-view-repeater-strategy.ts
+++ b/src/cdk/collections/dispose-view-repeater-strategy.ts
@@ -30,9 +30,11 @@ import {
  * @template R The type for the item in each IterableDiffer change record.
  * @template C The type for the context passed to each embedded view.
  */
-export class _DisposeViewRepeaterStrategy<T, R, C extends _ViewRepeaterItemContext<T>>
-  implements _ViewRepeater<T, R, C>
-{
+export class _DisposeViewRepeaterStrategy<
+  T,
+  R,
+  C extends _ViewRepeaterItemContext<T>,
+> implements _ViewRepeater<T, R, C> {
   applyChanges(
     changes: IterableChanges<R>,
     viewContainerRef: ViewContainerRef,

--- a/src/cdk/collections/recycle-view-repeater-strategy.ts
+++ b/src/cdk/collections/recycle-view-repeater-strategy.ts
@@ -33,9 +33,11 @@ import {
  * @template R The type for the item in each IterableDiffer change record.
  * @template C The type for the context passed to each embedded view.
  */
-export class _RecycleViewRepeaterStrategy<T, R, C extends _ViewRepeaterItemContext<T>>
-  implements _ViewRepeater<T, R, C>
-{
+export class _RecycleViewRepeaterStrategy<
+  T,
+  R,
+  C extends _ViewRepeaterItemContext<T>,
+> implements _ViewRepeater<T, R, C> {
   /**
    * The size of the cache used to store unused views.
    * Setting the cache size to `0` will disable caching. Defaults to 20 views.

--- a/src/cdk/table/table-errors.ts
+++ b/src/cdk/table/table-errors.ts
@@ -30,7 +30,7 @@ export function getTableDuplicateColumnNameError(name: string) {
 export function getTableMultipleDefaultRowDefsError() {
   return Error(
     `There can only be one default row without a when predicate function. ` +
-      'Or set `multiTemplateDataRows`.'
+      'Or set `multiTemplateDataRows`.',
   );
 }
 

--- a/src/cdk/table/table.ts
+++ b/src/cdk/table/table.ts
@@ -187,8 +187,7 @@ export class NoDataRowOutlet implements RowOutlet {
  * @docs-private
  */
 export interface RowContext<T>
-  extends CdkCellOutletMultiRowContext<T>,
-    CdkCellOutletRowContext<T> {}
+  extends CdkCellOutletMultiRowContext<T>, CdkCellOutletRowContext<T> {}
 
 /**
  * Class used to conveniently type the embedded view ref for rows with a context.

--- a/src/cdk/testing/BUILD.bazel
+++ b/src/cdk/testing/BUILD.bazel
@@ -1,6 +1,6 @@
+load("//src/cdk/testing/tests:webdriver-test.bzl", "webdriver_test")
 load("//src/e2e-app:test_suite.bzl", "e2e_test_suite")
 load("//tools:defaults.bzl", "markdown_to_html", "ng_web_test_suite", "ts_project")
-load("//src/cdk/testing/tests:webdriver-test.bzl", "webdriver_test")
 load("//tools/adev-api-extraction:extract_api_to_json.bzl", "extract_api_to_json")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/google-maps/schematics/BUILD.bazel
+++ b/src/google-maps/schematics/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
-load("//tools:defaults.bzl", "npm_package", "ts_project")
 load("@aspect_rules_ts//ts:defs.bzl", rules_js_tsconfig = "ts_config")
+load("//tools:defaults.bzl", "npm_package", "ts_project")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/src/material/datepicker/date-selection-model.ts
+++ b/src/material/datepicker/date-selection-model.ts
@@ -53,9 +53,10 @@ export interface DateSelectionModelChange<S> {
  * @docs-private
  */
 @Injectable()
-export abstract class MatDateSelectionModel<S, D = ExtractDateTypeFromSelection<S>>
-  implements OnDestroy
-{
+export abstract class MatDateSelectionModel<
+  S,
+  D = ExtractDateTypeFromSelection<S>,
+> implements OnDestroy {
   private readonly _selectionChanged = new Subject<DateSelectionModelChange<S>>();
 
   /** Emits when the selection has changed. */

--- a/src/material/datepicker/datepicker-base.ts
+++ b/src/material/datepicker/datepicker-base.ts
@@ -368,10 +368,10 @@ export interface MatDatepickerPanel<
 /** Base class for a datepicker. */
 @Directive()
 export abstract class MatDatepickerBase<
-    C extends MatDatepickerControl<D>,
-    S,
-    D = ExtractDateTypeFromSelection<S>,
-  >
+  C extends MatDatepickerControl<D>,
+  S,
+  D = ExtractDateTypeFromSelection<S>,
+>
   implements MatDatepickerPanel<C, S, D>, OnDestroy, OnChanges
 {
   private _injector = inject(Injector);

--- a/tools/adev-api-extraction/BUILD.bazel
+++ b/tools/adev-api-extraction/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@aspect_rules_js//js:defs.bzl", "js_binary")
-load("//tools:defaults.bzl", "ts_project")
 load("@aspect_rules_ts//ts:defs.bzl", "ts_config")
+load("//tools:defaults.bzl", "ts_project")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/tools/bazel/ng_package_interop.bzl
+++ b/tools/bazel/ng_package_interop.bzl
@@ -1,5 +1,5 @@
-load("@aspect_rules_js//npm:providers.bzl", "NpmPackageInfo")
 load("@aspect_rules_js//js:libs.bzl", "js_lib_helpers")
+load("@aspect_rules_js//npm:providers.bzl", "NpmPackageInfo")
 
 def _ng_package_interop_impl(ctx):
     # forward all npm_package_store_infos

--- a/tools/dgeni/common/dgeni-definitions.ts
+++ b/tools/dgeni/common/dgeni-definitions.ts
@@ -51,15 +51,11 @@ export interface CategorizedPropertyMemberDoc extends PropertyMemberDoc, Depreca
 
 /** Extended Dgeni method-member document that simplifies logic for the Dgeni template. */
 export interface CategorizedMethodMemberDoc
-  extends NormalizedFunctionParameters,
-    MethodMemberDoc,
-    DeprecationInfo {}
+  extends NormalizedFunctionParameters, MethodMemberDoc, DeprecationInfo {}
 
 /** Extended Dgeni function export document that simplifies logic for the Dgeni template. */
 export interface CategorizedFunctionExportDoc
-  extends NormalizedFunctionParameters,
-    FunctionExportDoc,
-    DeprecationInfo {}
+  extends NormalizedFunctionParameters, FunctionExportDoc, DeprecationInfo {}
 
 /** Extended Dgeni const export document that simplifies logic for the Dgeni template. */
 export interface CategorizedConstExportDoc extends ConstExportDoc, DeprecationInfo {}

--- a/tools/tslint-rules/memberNamingRule.ts
+++ b/tools/tslint-rules/memberNamingRule.ts
@@ -28,10 +28,13 @@ class Walker extends Lint.RuleWalker {
 
     const args = options.ruleArguments[0] || {};
 
-    this._config = Object.keys(args).reduce((config, key) => {
-      config[key] = new RegExp(args[key]);
-      return config;
-    }, {} as {[key: string]: RegExp});
+    this._config = Object.keys(args).reduce(
+      (config, key) => {
+        config[key] = new RegExp(args[key]);
+        return config;
+      },
+      {} as {[key: string]: RegExp},
+    );
   }
 
   override visitClassDeclaration(node: ts.ClassDeclaration) {


### PR DESCRIPTION
The Prettier dependency was recently updated which changed the formatting of some of the files. These changes update it to ensure that all files pass the lint checks.