### PR TITLE
fix(material/form-field): outline being thrown off by Tailwind

### DIFF
--- a/src/material/form-field/_mdc-text-field-structure.scss
+++ b/src/material/form-field/_mdc-text-field-structure.scss
@@ -369,6 +369,8 @@ $fallbacks: m3-form-field.get-tokens();
     box-sizing: border-box;
     height: 100%;
     pointer-events: none;
+    // Reset border coming from something like Tailwind (see #32511).
+    border: none;
     border-top: 1px solid;
     border-bottom: 1px solid;
 


### PR DESCRIPTION
In some setups, it seems like Tailwind adds a `border: solid 0` to all elements which ends up breaking the outline for the form field. These changes add an explicit reset to avoid it.

Fixes #32511.