### PR TITLE
refactor(multiple): use relative imports within aria package

### DIFF
--- a/goldens/aria/accordion/index.api.md
+++ b/goldens/aria/accordion/index.api.md
@@ -4,18 +4,15 @@
 
 ```ts
 
-import { AccordionGroupPattern } from '@angular/aria/private';
-import { AccordionPanelPattern } from '@angular/aria/private';
-import { AccordionTriggerPattern } from '@angular/aria/private';
 import * as _angular_cdk_bidi from '@angular/cdk/bidi';
 import * as _angular_core from '@angular/core';
-import * as i1 from '@angular/aria/private';
+import { OnDestroy } from '@angular/core';
 import { WritableSignal } from '@angular/core';
 
 // @public
 export class AccordionContent {
     // (undocumented)
-    static ɵdir: _angular_core.ɵɵDirectiveDeclaration<AccordionContent, "ng-template[ngAccordionContent]", never, {}, {}, never, never, true, [{ directive: typeof i1.DeferredContent; inputs: {}; outputs: {}; }]>;
+    static ɵdir: _angular_core.ɵɵDirectiveDeclaration<AccordionContent, "ng-template[ngAccordionContent]", never, {}, {}, never, never, true, [{ directive: typeof DeferredContent; inputs: {}; outputs: {}; }]>;
     // (undocumented)
     static ɵfac: _angular_core.ɵɵFactoryDeclaration<AccordionContent, never>;
 }
@@ -50,7 +47,7 @@ export class AccordionPanel {
     toggle(): void;
     readonly visible: _angular_core.Signal<boolean>;
     // (undocumented)
-    static ɵdir: _angular_core.ɵɵDirectiveDeclaration<AccordionPanel, "[ngAccordionPanel]", ["ngAccordionPanel"], { "id": { "alias": "id"; "required": false; "isSignal": true; }; "panelId": { "alias": "panelId"; "required": true; "isSignal": true; }; }, {}, never, never, true, [{ directive: typeof i1.DeferredContentAware; inputs: { "preserveContent": "preserveContent"; }; outputs: {}; }]>;
+    static ɵdir: _angular_core.ɵɵDirectiveDeclaration<AccordionPanel, "[ngAccordionPanel]", ["ngAccordionPanel"], { "id": { "alias": "id"; "required": false; "isSignal": true; }; "panelId": { "alias": "panelId"; "required": true; "isSignal": true; }; }, {}, never, never, true, [{ directive: typeof DeferredContentAware; inputs: { "preserveContent": "preserveContent"; }; outputs: {}; }]>;
     // (undocumented)
     static ɵfac: _angular_core.ɵɵFactoryDeclaration<AccordionPanel, never>;
 }

--- a/goldens/aria/combobox/index.api.md
+++ b/goldens/aria/combobox/index.api.md
@@ -6,11 +6,7 @@
 
 import * as _angular_cdk_bidi from '@angular/cdk/bidi';
 import * as _angular_core from '@angular/core';
-import { ComboboxDialogPattern } from '@angular/aria/private';
-import { ComboboxListboxControls } from '@angular/aria/private';
-import { ComboboxPattern } from '@angular/aria/private';
-import { ComboboxTreeControls } from '@angular/aria/private';
-import * as i1 from '@angular/aria/private';
+import { OnDestroy } from '@angular/core';
 
 // @public
 export class Combobox<V> {
@@ -29,7 +25,7 @@ export class Combobox<V> {
     readonly readonly: _angular_core.InputSignalWithTransform<boolean, unknown>;
     protected textDirection: _angular_core.Signal<_angular_cdk_bidi.Direction>;
     // (undocumented)
-    static ɵdir: _angular_core.ɵɵDirectiveDeclaration<Combobox<any>, "[ngCombobox]", ["ngCombobox"], { "filterMode": { "alias": "filterMode"; "required": false; "isSignal": true; }; "disabled": { "alias": "disabled"; "required": false; "isSignal": true; }; "readonly": { "alias": "readonly"; "required": false; "isSignal": true; }; "firstMatch": { "alias": "firstMatch"; "required": false; "isSignal": true; }; "alwaysExpanded": { "alias": "alwaysExpanded"; "required": false; "isSignal": true; }; }, {}, ["popup"], never, true, [{ directive: typeof i1.DeferredContentAware; inputs: { "preserveContent": "preserveContent"; }; outputs: {}; }]>;
+    static ɵdir: _angular_core.ɵɵDirectiveDeclaration<Combobox<any>, "[ngCombobox]", ["ngCombobox"], { "filterMode": { "alias": "filterMode"; "required": false; "isSignal": true; }; "disabled": { "alias": "disabled"; "required": false; "isSignal": true; }; "readonly": { "alias": "readonly"; "required": false; "isSignal": true; }; "firstMatch": { "alias": "firstMatch"; "required": false; "isSignal": true; }; "alwaysExpanded": { "alias": "alwaysExpanded"; "required": false; "isSignal": true; }; }, {}, ["popup"], never, true, [{ directive: typeof DeferredContentAware; inputs: { "preserveContent": "preserveContent"; }; outputs: {}; }]>;
     // (undocumented)
     static ɵfac: _angular_core.ɵɵFactoryDeclaration<Combobox<any>, never>;
 }
@@ -42,7 +38,7 @@ export class ComboboxDialog {
     readonly combobox: Combobox<any>;
     readonly element: HTMLElement;
     // (undocumented)
-    _pattern: ComboboxDialogPattern_2;
+    _pattern: ComboboxDialogPattern;
     // (undocumented)
     static ɵdir: _angular_core.ɵɵDirectiveDeclaration<ComboboxDialog, "dialog[ngComboboxDialog]", ["ngComboboxDialog"], {}, {}, never, never, true, [{ directive: typeof ComboboxPopup; inputs: {}; outputs: {}; }]>;
     // (undocumented)
@@ -74,7 +70,7 @@ export class ComboboxPopup<V> {
 // @public
 export class ComboboxPopupContainer {
     // (undocumented)
-    static ɵdir: _angular_core.ɵɵDirectiveDeclaration<ComboboxPopupContainer, "ng-template[ngComboboxPopupContainer]", ["ngComboboxPopupContainer"], {}, {}, never, never, true, [{ directive: typeof i1.DeferredContent; inputs: {}; outputs: {}; }]>;
+    static ɵdir: _angular_core.ɵɵDirectiveDeclaration<ComboboxPopupContainer, "ng-template[ngComboboxPopupContainer]", ["ngComboboxPopupContainer"], {}, {}, never, never, true, [{ directive: typeof DeferredContent; inputs: {}; outputs: {}; }]>;
     // (undocumented)
     static ɵfac: _angular_core.ɵɵFactoryDeclaration<ComboboxPopupContainer, never>;
 }

--- a/goldens/aria/listbox/index.api.md
+++ b/goldens/aria/listbox/index.api.md
@@ -7,11 +7,6 @@
 import * as _angular_aria_private_public_api from '@angular/aria/private/public-api';
 import * as _angular_cdk_bidi from '@angular/cdk/bidi';
 import * as _angular_core from '@angular/core';
-import { ComboboxDialogPattern } from '@angular/aria/private';
-import { ComboboxListboxControls } from '@angular/aria/private';
-import { ComboboxPattern } from '@angular/aria/private';
-import { ComboboxTreeControls } from '@angular/aria/private';
-import * as i1 from '@angular/aria/private';
 
 // @public
 export class Listbox<V> {

--- a/goldens/aria/menu/index.api.md
+++ b/goldens/aria/menu/index.api.md
@@ -6,13 +6,8 @@
 
 import * as _angular_cdk_bidi from '@angular/cdk/bidi';
 import * as _angular_core from '@angular/core';
-import * as i1 from '@angular/aria/private';
-import { MenuBarPattern } from '@angular/aria/private';
-import { MenuItemPattern } from '@angular/aria/private';
-import { MenuPattern } from '@angular/aria/private';
-import { MenuTriggerPattern } from '@angular/aria/private';
+import { OnDestroy } from '@angular/core';
 import { Signal } from '@angular/core';
-import { SignalLike } from '@angular/aria/private';
 
 // @public
 export class Menu<V> {
@@ -33,7 +28,7 @@ export class Menu<V> {
     readonly visible: Signal<boolean>;
     readonly wrap: _angular_core.InputSignalWithTransform<boolean, unknown>;
     // (undocumented)
-    static ɵdir: _angular_core.ɵɵDirectiveDeclaration<Menu<any>, "[ngMenu]", ["ngMenu"], { "id": { "alias": "id"; "required": false; "isSignal": true; }; "wrap": { "alias": "wrap"; "required": false; "isSignal": true; }; "typeaheadDelay": { "alias": "typeaheadDelay"; "required": false; "isSignal": true; }; "disabled": { "alias": "disabled"; "required": false; "isSignal": true; }; "expansionDelay": { "alias": "expansionDelay"; "required": false; "isSignal": true; }; }, { "onSelect": "onSelect"; }, ["_allItems"], never, true, [{ directive: typeof i1.DeferredContentAware; inputs: { "preserveContent": "preserveContent"; }; outputs: {}; }]>;
+    static ɵdir: _angular_core.ɵɵDirectiveDeclaration<Menu<any>, "[ngMenu]", ["ngMenu"], { "id": { "alias": "id"; "required": false; "isSignal": true; }; "wrap": { "alias": "wrap"; "required": false; "isSignal": true; }; "typeaheadDelay": { "alias": "typeaheadDelay"; "required": false; "isSignal": true; }; "disabled": { "alias": "disabled"; "required": false; "isSignal": true; }; "expansionDelay": { "alias": "expansionDelay"; "required": false; "isSignal": true; }; }, { "onSelect": "onSelect"; }, ["_allItems"], never, true, [{ directive: typeof DeferredContentAware; inputs: { "preserveContent": "preserveContent"; }; outputs: {}; }]>;
     // (undocumented)
     static ɵfac: _angular_core.ɵɵFactoryDeclaration<Menu<any>, never>;
 }
@@ -63,7 +58,7 @@ export class MenuBar<V> {
 // @public
 export class MenuContent {
     // (undocumented)
-    static ɵdir: _angular_core.ɵɵDirectiveDeclaration<MenuContent, "ng-template[ngMenuContent]", ["ngMenuContent"], {}, {}, never, never, true, [{ directive: typeof i1.DeferredContent; inputs: {}; outputs: {}; }]>;
+    static ɵdir: _angular_core.ɵɵDirectiveDeclaration<MenuContent, "ng-template[ngMenuContent]", ["ngMenuContent"], {}, {}, never, never, true, [{ directive: typeof DeferredContent; inputs: {}; outputs: {}; }]>;
     // (undocumented)
     static ɵfac: _angular_core.ɵɵFactoryDeclaration<MenuContent, never>;
 }

--- a/goldens/aria/tabs/index.api.md
+++ b/goldens/aria/tabs/index.api.md
@@ -4,14 +4,13 @@
 
 ```ts
 
+import * as _angular_aria_private from '@angular/aria/private';
+import * as _angular_aria_private_public_api from '@angular/aria/private/public-api';
 import * as _angular_cdk_bidi from '@angular/cdk/bidi';
 import * as _angular_core from '@angular/core';
-import * as i1 from '@angular/aria/private';
 import { OnDestroy } from '@angular/core';
 import { OnInit } from '@angular/core';
-import { TabListPattern } from '@angular/aria/private';
-import { TabPanelPattern } from '@angular/aria/private';
-import { TabPattern } from '@angular/aria/private';
+import { WritableSignal } from '@angular/core';
 
 // @public
 export class Tab implements HasElement, OnInit, OnDestroy {
@@ -36,7 +35,7 @@ export class Tab implements HasElement, OnInit, OnDestroy {
 // @public
 export class TabContent {
     // (undocumented)
-    static ɵdir: _angular_core.ɵɵDirectiveDeclaration<TabContent, "ng-template[ngTabContent]", ["ngTabContent"], {}, {}, never, never, true, [{ directive: typeof i1.DeferredContent; inputs: {}; outputs: {}; }]>;
+    static ɵdir: _angular_core.ɵɵDirectiveDeclaration<TabContent, "ng-template[ngTabContent]", ["ngTabContent"], {}, {}, never, never, true, [{ directive: typeof DeferredContent; inputs: {}; outputs: {}; }]>;
     // (undocumented)
     static ɵfac: _angular_core.ɵɵFactoryDeclaration<TabContent, never>;
 }
@@ -61,7 +60,7 @@ export class TabList implements OnInit, OnDestroy {
     readonly selectedTab: _angular_core.ModelSignal<string | undefined>;
     readonly selectionMode: _angular_core.InputSignal<"follow" | "explicit">;
     readonly softDisabled: _angular_core.InputSignalWithTransform<boolean, unknown>;
-    readonly _tabPatterns: _angular_core.Signal<i1.TabPattern[]>;
+    readonly _tabPatterns: _angular_core.Signal<_angular_aria_private_public_api.TabPattern[]>;
     readonly textDirection: _angular_core.WritableSignal<_angular_cdk_bidi.Direction>;
     // (undocumented)
     _unregister(child: Tab): void;
@@ -85,7 +84,7 @@ export class TabPanel implements OnInit, OnDestroy {
     readonly value: _angular_core.InputSignal<string>;
     readonly visible: _angular_core.Signal<boolean>;
     // (undocumented)
-    static ɵdir: _angular_core.ɵɵDirectiveDeclaration<TabPanel, "[ngTabPanel]", ["ngTabPanel"], { "id": { "alias": "id"; "required": false; "isSignal": true; }; "value": { "alias": "value"; "required": true; "isSignal": true; }; }, {}, never, never, true, [{ directive: typeof i1.DeferredContentAware; inputs: { "preserveContent": "preserveContent"; }; outputs: {}; }]>;
+    static ɵdir: _angular_core.ɵɵDirectiveDeclaration<TabPanel, "[ngTabPanel]", ["ngTabPanel"], { "id": { "alias": "id"; "required": false; "isSignal": true; }; "value": { "alias": "value"; "required": true; "isSignal": true; }; }, {}, never, never, true, [{ directive: typeof DeferredContentAware; inputs: { "preserveContent": "preserveContent"; }; outputs: {}; }]>;
     // (undocumented)
     static ɵfac: _angular_core.ɵɵFactoryDeclaration<TabPanel, never>;
 }
@@ -95,8 +94,8 @@ export class Tabs {
     readonly element: HTMLElement;
     // (undocumented)
     _register(child: TabList | TabPanel): void;
-    readonly _tabPatterns: _angular_core.Signal<i1.TabPattern[] | undefined>;
-    readonly _unorderedTabpanelPatterns: _angular_core.Signal<i1.TabPanelPattern[]>;
+    readonly _tabPatterns: _angular_core.Signal<_angular_aria_private.TabPattern[] | undefined>;
+    readonly _unorderedTabpanelPatterns: _angular_core.Signal<_angular_aria_private.TabPanelPattern[]>;
     // (undocumented)
     _unregister(child: TabList | TabPanel): void;
     // (undocumented)

--- a/goldens/aria/toolbar/index.api.md
+++ b/goldens/aria/toolbar/index.api.md
@@ -4,21 +4,18 @@
 
 ```ts
 
+import * as _angular_aria_private_public_api from '@angular/aria/private/public-api';
 import * as _angular_cdk_bidi from '@angular/cdk/bidi';
 import * as _angular_core from '@angular/core';
-import * as i1 from '@angular/aria/private';
 import { OnDestroy } from '@angular/core';
 import { OnInit } from '@angular/core';
-import { ToolbarPattern } from '@angular/aria/private';
-import { ToolbarWidgetGroupPattern } from '@angular/aria/private';
-import { ToolbarWidgetPattern } from '@angular/aria/private';
 
 // @public
 export class Toolbar<V> {
     constructor();
     readonly disabled: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly element: HTMLElement;
-    readonly _itemPatterns: _angular_core.Signal<i1.ToolbarWidgetPattern<V>[]>;
+    readonly _itemPatterns: _angular_core.Signal<_angular_aria_private_public_api.ToolbarWidgetPattern<V>[]>;
     // (undocumented)
     _onFocus(): void;
     readonly orientation: _angular_core.InputSignal<"vertical" | "horizontal">;
@@ -51,7 +48,7 @@ export class ToolbarWidget<V> implements OnInit, OnDestroy {
     ngOnInit(): void;
     readonly _pattern: ToolbarWidgetPattern<V>;
     readonly selected: () => boolean;
-    readonly _toolbarPattern: _angular_core.Signal<i1.ToolbarPattern<V>>;
+    readonly _toolbarPattern: _angular_core.Signal<_angular_aria_private_public_api.ToolbarPattern<V>>;
     readonly value: _angular_core.InputSignal<V>;
     // (undocumented)
     static ɵdir: _angular_core.ɵɵDirectiveDeclaration<ToolbarWidget<any>, "[ngToolbarWidget]", ["ngToolbarWidget"], { "id": { "alias": "id"; "required": false; "isSignal": true; }; "disabled": { "alias": "disabled"; "required": false; "isSignal": true; }; "value": { "alias": "value"; "required": true; "isSignal": true; }; }, {}, never, never, true, never>;

--- a/goldens/aria/tree/index.api.md
+++ b/goldens/aria/tree/index.api.md
@@ -6,17 +6,9 @@
 
 import * as _angular_cdk_bidi from '@angular/cdk/bidi';
 import * as _angular_core from '@angular/core';
-import { ComboboxDialogPattern } from '@angular/aria/private';
-import { ComboboxListboxControls } from '@angular/aria/private';
-import { ComboboxPattern } from '@angular/aria/private';
-import { ComboboxTreeControls } from '@angular/aria/private';
-import { DeferredContentAware } from '@angular/aria/private';
-import * as i1 from '@angular/aria/private';
 import { OnDestroy } from '@angular/core';
 import { OnInit } from '@angular/core';
 import { Signal } from '@angular/core';
-import { TreeItemPattern } from '@angular/aria/private';
-import { TreePattern } from '@angular/aria/private';
 
 // @public
 export class Tree<V> {
@@ -97,7 +89,7 @@ export class TreeItemGroup<V> implements OnInit, OnDestroy {
     // (undocumented)
     _unregister(child: TreeItem<V>): void;
     // (undocumented)
-    static ɵdir: _angular_core.ɵɵDirectiveDeclaration<TreeItemGroup<any>, "ng-template[ngTreeItemGroup]", ["ngTreeItemGroup"], { "ownedBy": { "alias": "ownedBy"; "required": true; "isSignal": true; }; }, {}, never, never, true, [{ directive: typeof i1.DeferredContent; inputs: {}; outputs: {}; }]>;
+    static ɵdir: _angular_core.ɵɵDirectiveDeclaration<TreeItemGroup<any>, "ng-template[ngTreeItemGroup]", ["ngTreeItemGroup"], { "ownedBy": { "alias": "ownedBy"; "required": true; "isSignal": true; }; }, {}, never, never, true, [{ directive: typeof DeferredContent; inputs: {}; outputs: {}; }]>;
     // (undocumented)
     static ɵfac: _angular_core.ɵɵFactoryDeclaration<TreeItemGroup<any>, never>;
 }

--- a/src/aria/accordion/accordion-content.ts
+++ b/src/aria/accordion/accordion-content.ts
@@ -7,7 +7,7 @@
  */
 
 import {Directive} from '@angular/core';
-import {DeferredContent} from '@angular/aria/private';
+import {DeferredContent} from '../private';
 
 /**
  * A structural directive that provides a mechanism for lazily rendering the content for an

--- a/src/aria/accordion/accordion-group.ts
+++ b/src/aria/accordion/accordion-group.ts
@@ -18,7 +18,7 @@ import {
   computed,
 } from '@angular/core';
 import {Directionality} from '@angular/cdk/bidi';
-import {AccordionGroupPattern, AccordionTriggerPattern} from '@angular/aria/private';
+import {AccordionGroupPattern, AccordionTriggerPattern} from '../private';
 import {AccordionTrigger} from './accordion-trigger';
 import {AccordionPanel} from './accordion-panel';
 import {ACCORDION_GROUP} from './accordion-tokens';

--- a/src/aria/accordion/accordion-panel.ts
+++ b/src/aria/accordion/accordion-panel.ts
@@ -16,11 +16,7 @@ import {
   WritableSignal,
 } from '@angular/core';
 import {_IdGenerator} from '@angular/cdk/a11y';
-import {
-  DeferredContentAware,
-  AccordionPanelPattern,
-  AccordionTriggerPattern,
-} from '@angular/aria/private';
+import {DeferredContentAware, AccordionPanelPattern, AccordionTriggerPattern} from '../private';
 
 /**
  * The content panel of an accordion item that is conditionally visible.

--- a/src/aria/accordion/accordion-trigger.ts
+++ b/src/aria/accordion/accordion-trigger.ts
@@ -18,7 +18,7 @@ import {
   WritableSignal,
 } from '@angular/core';
 import {_IdGenerator} from '@angular/cdk/a11y';
-import {AccordionPanelPattern, AccordionTriggerPattern} from '@angular/aria/private';
+import {AccordionPanelPattern, AccordionTriggerPattern} from '../private';
 import {ACCORDION_GROUP} from './accordion-tokens';
 
 /**

--- a/src/aria/accordion/index.ts
+++ b/src/aria/accordion/index.ts
@@ -10,3 +10,7 @@ export {AccordionPanel} from './accordion-panel';
 export {AccordionGroup} from './accordion-group';
 export {AccordionTrigger} from './accordion-trigger';
 export {AccordionContent} from './accordion-content';
+
+// This needs to be re-exported, because it's used by the accordion components.
+// See: https://github.com/angular/components/issues/30663.
+export {DeferredContent as ɵɵDeferredContent} from '../private';

--- a/src/aria/combobox/combobox-popup-container.ts
+++ b/src/aria/combobox/combobox-popup-container.ts
@@ -7,7 +7,7 @@
  */
 
 import {Directive} from '@angular/core';
-import {DeferredContent} from '@angular/aria/private';
+import {DeferredContent} from '../private';
 
 /**
  * A structural directive that marks the `ng-template` to be used as the popup

--- a/src/aria/combobox/combobox-popup.ts
+++ b/src/aria/combobox/combobox-popup.ts
@@ -7,11 +7,7 @@
  */
 
 import {Directive, inject, signal} from '@angular/core';
-import {
-  ComboboxListboxControls,
-  ComboboxTreeControls,
-  ComboboxDialogPattern,
-} from '@angular/aria/private';
+import {ComboboxListboxControls, ComboboxTreeControls, ComboboxDialogPattern} from '../private';
 import type {Combobox} from './combobox';
 import {COMBOBOX} from './combobox-tokens';
 

--- a/src/aria/combobox/combobox.ts
+++ b/src/aria/combobox/combobox.ts
@@ -17,7 +17,7 @@ import {
   input,
   signal,
 } from '@angular/core';
-import {DeferredContentAware, ComboboxPattern} from '@angular/aria/private';
+import {DeferredContentAware, ComboboxPattern} from '../private';
 import {Directionality} from '@angular/cdk/bidi';
 import {toSignal} from '@angular/core/rxjs-interop';
 import {ComboboxPopup} from './combobox-popup';

--- a/src/aria/combobox/index.ts
+++ b/src/aria/combobox/index.ts
@@ -11,3 +11,7 @@ export {ComboboxDialog} from './combobox-dialog';
 export {ComboboxInput} from './combobox-input';
 export {ComboboxPopup} from './combobox-popup';
 export {ComboboxPopupContainer} from './combobox-popup-container';
+
+// This needs to be re-exported, because it's used by the combobox components.
+// See: https://github.com/angular/components/issues/30663.
+export {DeferredContent as ɵɵDeferredContent} from '../private';

--- a/src/aria/menu/index.ts
+++ b/src/aria/menu/index.ts
@@ -11,3 +11,7 @@ export {Menu} from './menu';
 export {MenuBar} from './menu-bar';
 export {MenuItem} from './menu-item';
 export {MenuContent} from './menu-content';
+
+// This needs to be re-exported, because it's used by the menu components.
+// See: https://github.com/angular/components/issues/30663.
+export {DeferredContent as ɵɵDeferredContent} from '../private';

--- a/src/aria/menu/menu-bar.ts
+++ b/src/aria/menu/menu-bar.ts
@@ -19,7 +19,7 @@ import {
   output,
   signal,
 } from '@angular/core';
-import {SignalLike, MenuBarPattern} from '@angular/aria/private';
+import {SignalLike, MenuBarPattern} from '../private';
 import {Directionality} from '@angular/cdk/bidi';
 import {MenuItem} from './menu-item';
 import {MENU_COMPONENT} from './menu-tokens';

--- a/src/aria/menu/menu-content.ts
+++ b/src/aria/menu/menu-content.ts
@@ -7,7 +7,7 @@
  */
 
 import {Directive} from '@angular/core';
-import {DeferredContent} from '@angular/aria/private';
+import {DeferredContent} from '../private';
 
 /**
  * Defers the rendering of the menu content.

--- a/src/aria/menu/menu-item.ts
+++ b/src/aria/menu/menu-item.ts
@@ -7,7 +7,7 @@
  */
 
 import {computed, Directive, effect, ElementRef, inject, input, model} from '@angular/core';
-import {MenuItemPattern} from '@angular/aria/private';
+import {MenuItemPattern} from '../private';
 import {_IdGenerator} from '@angular/cdk/a11y';
 import {MENU_COMPONENT} from './menu-tokens';
 import type {Menu} from './menu';

--- a/src/aria/menu/menu-trigger.ts
+++ b/src/aria/menu/menu-trigger.ts
@@ -15,7 +15,7 @@ import {
   inject,
   input,
 } from '@angular/core';
-import {MenuTriggerPattern} from '@angular/aria/private';
+import {MenuTriggerPattern} from '../private';
 import {Directionality} from '@angular/cdk/bidi';
 import type {Menu} from './menu';
 

--- a/src/aria/menu/menu.ts
+++ b/src/aria/menu/menu.ts
@@ -20,7 +20,7 @@ import {
   signal,
   untracked,
 } from '@angular/core';
-import {MenuPattern, DeferredContentAware} from '@angular/aria/private';
+import {MenuPattern, DeferredContentAware} from '../private';
 import {_IdGenerator} from '@angular/cdk/a11y';
 import {Directionality} from '@angular/cdk/bidi';
 import {MenuTrigger} from './menu-trigger';

--- a/src/aria/tabs/index.ts
+++ b/src/aria/tabs/index.ts
@@ -11,3 +11,7 @@ export {TabList} from './tab-list';
 export {Tab} from './tab';
 export {TabPanel} from './tab-panel';
 export {TabContent} from './tab-content';
+
+// This needs to be re-exported, because it's used by the tab components.
+// See: https://github.com/angular/components/issues/30663.
+export {DeferredContent as ɵɵDeferredContent} from '../private';

--- a/src/aria/tabs/tab-content.ts
+++ b/src/aria/tabs/tab-content.ts
@@ -7,7 +7,7 @@
  */
 
 import {Directive} from '@angular/core';
-import {DeferredContent} from '@angular/aria/private';
+import {DeferredContent} from '../private';
 
 /**
  * A TabContent container for the lazy-loaded content.

--- a/src/aria/tabs/tab-list.ts
+++ b/src/aria/tabs/tab-list.ts
@@ -20,7 +20,7 @@ import {
   OnInit,
   OnDestroy,
 } from '@angular/core';
-import {TabListPattern} from '@angular/aria/private';
+import {TabListPattern} from '../private';
 import {sortDirectives, TABS} from './utils';
 import type {Tab} from './tab';
 

--- a/src/aria/tabs/tab-panel.ts
+++ b/src/aria/tabs/tab-panel.ts
@@ -17,7 +17,7 @@ import {
   OnInit,
   OnDestroy,
 } from '@angular/core';
-import {TabPanelPattern, DeferredContentAware} from '@angular/aria/private';
+import {TabPanelPattern, DeferredContentAware} from '../private';
 import {TABS} from './utils';
 
 /**

--- a/src/aria/tabs/tab.ts
+++ b/src/aria/tabs/tab.ts
@@ -18,7 +18,7 @@ import {
   OnInit,
   OnDestroy,
 } from '@angular/core';
-import {TabPattern} from '@angular/aria/private';
+import {TabPattern} from '../private';
 import {TabList} from './tab-list';
 import {HasElement, TABS} from './utils';
 

--- a/src/aria/toolbar/toolbar-widget-group.ts
+++ b/src/aria/toolbar/toolbar-widget-group.ts
@@ -15,7 +15,7 @@ import {
   booleanAttribute,
   contentChildren,
 } from '@angular/core';
-import {ToolbarWidgetPattern, ToolbarWidgetGroupPattern} from '@angular/aria/private';
+import {ToolbarWidgetPattern, ToolbarWidgetGroupPattern} from '../private';
 import {Toolbar} from './toolbar';
 import {ToolbarWidget} from './toolbar-widget';
 import {TOOLBAR_WIDGET_GROUP} from './utils';

--- a/src/aria/toolbar/toolbar-widget.ts
+++ b/src/aria/toolbar/toolbar-widget.ts
@@ -16,7 +16,7 @@ import {
   OnInit,
   OnDestroy,
 } from '@angular/core';
-import {ToolbarWidgetPattern, ToolbarWidgetGroupPattern, SignalLike} from '@angular/aria/private';
+import {ToolbarWidgetPattern, ToolbarWidgetGroupPattern, SignalLike} from '../private';
 import {_IdGenerator} from '@angular/cdk/a11y';
 import {Toolbar} from './toolbar';
 import {TOOLBAR_WIDGET_GROUP} from './utils';

--- a/src/aria/toolbar/toolbar.ts
+++ b/src/aria/toolbar/toolbar.ts
@@ -17,7 +17,7 @@ import {
   signal,
   model,
 } from '@angular/core';
-import {ToolbarPattern} from '@angular/aria/private';
+import {ToolbarPattern} from '../private';
 import {Directionality} from '@angular/cdk/bidi';
 import type {ToolbarWidget} from './toolbar-widget';
 import {sortDirectives} from './utils';

--- a/src/aria/tree/index.ts
+++ b/src/aria/tree/index.ts
@@ -9,3 +9,7 @@
 export {Tree} from './tree';
 export {TreeItem} from './tree-item';
 export {TreeItemGroup} from './tree-item-group';
+
+// This needs to be re-exported, because it's used by the tree components.
+// See: https://github.com/angular/components/issues/30663.
+export {DeferredContent as ɵɵDeferredContent} from '../private';

--- a/src/aria/tree/tree-item-group.ts
+++ b/src/aria/tree/tree-item-group.ts
@@ -16,7 +16,7 @@ import {
   OnInit,
   OnDestroy,
 } from '@angular/core';
-import {TreeItemPattern, DeferredContent} from '@angular/aria/private';
+import {TreeItemPattern, DeferredContent} from '../private';
 import type {TreeItem} from './tree-item';
 import {sortDirectives} from './utils';
 

--- a/src/aria/tree/tree-item.ts
+++ b/src/aria/tree/tree-item.ts
@@ -22,7 +22,7 @@ import {
   afterNextRender,
 } from '@angular/core';
 import {_IdGenerator} from '@angular/cdk/a11y';
-import {ComboboxTreePattern, TreeItemPattern, DeferredContentAware} from '@angular/aria/private';
+import {ComboboxTreePattern, TreeItemPattern, DeferredContentAware} from '../private';
 import {Tree} from './tree';
 import {TreeItemGroup} from './tree-item-group';
 import {HasElement} from './utils';

--- a/src/aria/tree/tree.ts
+++ b/src/aria/tree/tree.ts
@@ -20,7 +20,7 @@ import {
 } from '@angular/core';
 import {_IdGenerator} from '@angular/cdk/a11y';
 import {Directionality} from '@angular/cdk/bidi';
-import {ComboboxTreePattern, TreeItemPattern, TreePattern} from '@angular/aria/private';
+import {ComboboxTreePattern, TreeItemPattern, TreePattern} from '../private';
 import {ComboboxPopup} from '../combobox';
 import type {TreeItem} from './tree-item';
 import {sortDirectives} from './utils';


### PR DESCRIPTION
After the recent infra changes we should use relative imports within the same package (e.g. one `aria` symbol importing another one), whereas absolute imports should only be between packages (e.g. `aria` importing from `cdk`).

These changes update all the imports and add private re-exports for `DeferredContent`. This is necessary to work around a compiler issue.