### PR TITLE
fix(material/tooltip): remove explicit usePopover

### DIFF
--- a/src/material/tooltip/tooltip.ts
+++ b/src/material/tooltip/tooltip.ts
@@ -538,7 +538,6 @@ export class MatTooltip implements OnDestroy, AfterViewInit {
       panelClass: this._overlayPanelClass ? [...this._overlayPanelClass, panelClass] : panelClass,
       scrollStrategy: this._injector.get(MAT_TOOLTIP_SCROLL_STRATEGY)(),
       disableAnimations: this._animationsDisabled,
-      usePopover: true,
     });
 
     this._updatePosition(this._overlayRef);


### PR DESCRIPTION
The tooltip explicitly sets `usePopover` because we were using it to test out popovers. These changes remove it so that users can change the value.