### PR TITLE
refactor(multiple): use signal primitives

### DIFF
--- a/goldens/aria/private/index.api.md
+++ b/goldens/aria/private/index.api.md
@@ -6,7 +6,7 @@
 
 import * as _angular_core from '@angular/core';
 import { OnDestroy } from '@angular/core';
-import { Signal } from '@angular/core';
+import { untracked } from '@angular/core/primitives/signals';
 import { WritableSignal } from '@angular/core';
 
 // @public
@@ -21,14 +21,14 @@ export class AccordionGroupPattern {
     readonly focusBehavior: ListFocus<AccordionTriggerPattern>;
     // (undocumented)
     readonly inputs: AccordionGroupInputs;
-    keydown: _angular_core.Signal<KeyboardEventManager<KeyboardEvent>>;
+    keydown: SignalLike<KeyboardEventManager<KeyboardEvent>>;
     readonly navigationBehavior: ListNavigation<AccordionTriggerPattern>;
-    nextKey: _angular_core.Signal<"ArrowRight" | "ArrowLeft" | "ArrowDown">;
+    nextKey: SignalLike<"ArrowRight" | "ArrowLeft" | "ArrowDown">;
     onFocus(event: FocusEvent): void;
     onKeydown(event: KeyboardEvent): void;
     onPointerdown(event: PointerEvent): void;
-    pointerdown: _angular_core.Signal<PointerEventManager<PointerEvent>>;
-    prevKey: _angular_core.Signal<"ArrowUp" | "ArrowRight" | "ArrowLeft">;
+    pointerdown: SignalLike<PointerEventManager<PointerEvent>>;
+    prevKey: SignalLike<"ArrowUp" | "ArrowRight" | "ArrowLeft">;
     toggle(): void;
 }
 
@@ -59,20 +59,20 @@ export interface AccordionTriggerInputs extends Omit<ListNavigationItem & ListFo
 // @public
 export class AccordionTriggerPattern implements ListNavigationItem, ListFocusItem, ExpansionItem {
     constructor(inputs: AccordionTriggerInputs);
-    readonly active: _angular_core.Signal<boolean>;
+    readonly active: SignalLike<boolean>;
     close(): void;
-    readonly controls: _angular_core.Signal<string | undefined>;
-    readonly disabled: _angular_core.Signal<boolean>;
+    readonly controls: SignalLike<string | undefined>;
+    readonly disabled: SignalLike<boolean>;
     readonly element: SignalLike<HTMLElement>;
     readonly expandable: SignalLike<boolean>;
     readonly expanded: WritableSignalLike<boolean>;
-    readonly hardDisabled: _angular_core.Signal<boolean>;
+    readonly hardDisabled: SignalLike<boolean>;
     readonly id: SignalLike<string>;
-    readonly index: _angular_core.Signal<number>;
+    readonly index: SignalLike<number>;
     // (undocumented)
     readonly inputs: AccordionTriggerInputs;
     open(): void;
-    readonly tabIndex: _angular_core.Signal<-1 | 0>;
+    readonly tabIndex: SignalLike<-1 | 0>;
     toggle(): void;
 }
 
@@ -92,7 +92,7 @@ export class ComboboxDialogPattern {
         id: SignalLike<string>;
     };
     // (undocumented)
-    keydown: _angular_core.Signal<KeyboardEventManager<KeyboardEvent>>;
+    keydown: SignalLike<KeyboardEventManager<KeyboardEvent>>;
     // (undocumented)
     onClick(event: MouseEvent): void;
     // (undocumented)
@@ -147,7 +147,7 @@ export type ComboboxListboxInputs<V> = ListboxInputs<V> & {
 // @public (undocumented)
 export class ComboboxListboxPattern<V> extends ListboxPattern<V> implements ComboboxListboxControls<OptionPattern<V>, V> {
     constructor(inputs: ComboboxListboxInputs<V>);
-    activeId: _angular_core.Signal<string | undefined>;
+    activeId: SignalLike<string | undefined>;
     clearSelection: () => void;
     first: () => void;
     focus: (item: OptionPattern<V>, opts?: {
@@ -156,17 +156,17 @@ export class ComboboxListboxPattern<V> extends ListboxPattern<V> implements Comb
     getActiveItem: () => OptionPattern<V> | undefined;
     getItem: (e: PointerEvent) => OptionPattern<V> | undefined;
     getSelectedItems: () => OptionPattern<V>[];
-    id: _angular_core.Signal<string>;
+    id: SignalLike<string>;
     // (undocumented)
     readonly inputs: ComboboxListboxInputs<V>;
     items: SignalLike<OptionPattern<V>[]>;
     last: () => void;
-    multi: _angular_core.Signal<boolean>;
+    multi: SignalLike<boolean>;
     next: () => void;
     onKeydown(_: KeyboardEvent): void;
     onPointerdown(_: PointerEvent): void;
     prev: () => void;
-    role: _angular_core.Signal<"listbox">;
+    role: SignalLike<"listbox">;
     select: (item?: OptionPattern<V>) => void;
     setDefaultState(): void;
     setValue: (value: V | undefined) => void;
@@ -178,30 +178,30 @@ export class ComboboxListboxPattern<V> extends ListboxPattern<V> implements Comb
 // @public
 export class ComboboxPattern<T extends ListItem<V>, V> {
     constructor(inputs: ComboboxInputs<T, V>);
-    activeDescendant: _angular_core.Signal<string | null>;
-    autocomplete: _angular_core.Signal<"both" | "list">;
-    click: _angular_core.Signal<PointerEventManager<PointerEvent>>;
+    activeDescendant: SignalLike<string | null>;
+    autocomplete: SignalLike<"both" | "list">;
+    click: SignalLike<PointerEventManager<PointerEvent>>;
     close(opts?: {
         reset: boolean;
     }): void;
     collapseItem(): void;
-    collapseKey: _angular_core.Signal<"ArrowLeft" | "ArrowRight">;
+    collapseKey: SignalLike<"ArrowLeft" | "ArrowRight">;
     commit(): void;
     disabled: () => boolean;
-    expanded: _angular_core.WritableSignal<boolean>;
+    expanded: WritableSignalLike<boolean>;
     expandItem(): void;
-    expandKey: _angular_core.Signal<"ArrowLeft" | "ArrowRight">;
+    expandKey: SignalLike<"ArrowLeft" | "ArrowRight">;
     first(): void;
-    firstMatch: _angular_core.Signal<T | undefined>;
-    hasBeenFocused: _angular_core.WritableSignal<boolean>;
-    hasPopup: _angular_core.Signal<"listbox" | "tree" | "grid" | "dialog" | null>;
+    firstMatch: SignalLike<T | undefined>;
+    hasBeenFocused: WritableSignalLike<boolean>;
+    hasPopup: SignalLike<"listbox" | "tree" | "grid" | "dialog" | null>;
     highlight(): void;
-    highlightedItem: _angular_core.WritableSignal<T | undefined>;
+    highlightedItem: WritableSignalLike<T | undefined>;
     // (undocumented)
     readonly inputs: ComboboxInputs<T, V>;
     isDeleting: boolean;
-    isFocused: _angular_core.WritableSignal<boolean>;
-    keydown: _angular_core.Signal<KeyboardEventManager<KeyboardEvent>>;
+    isFocused: WritableSignalLike<boolean>;
+    keydown: SignalLike<KeyboardEventManager<KeyboardEvent>>;
     last(): void;
     listControls: () => ComboboxListboxControls<T, V> | null | undefined;
     next(): void;
@@ -216,9 +216,9 @@ export class ComboboxPattern<T extends ListItem<V>, V> {
         last?: boolean;
         selected?: boolean;
     }): void;
-    popupId: _angular_core.Signal<string | null>;
+    popupId: SignalLike<string | null>;
     prev(): void;
-    readonly: _angular_core.Signal<true | null>;
+    readonly: SignalLike<true | null>;
     select(opts?: {
         item?: T;
         commit?: boolean;
@@ -248,7 +248,7 @@ export type ComboboxTreeInputs<V> = TreeInputs<V> & {
 export class ComboboxTreePattern<V> extends TreePattern<V> implements ComboboxTreeControls<TreeItemPattern<V>, V> {
     constructor(inputs: ComboboxTreeInputs<V>);
     // (undocumented)
-    activeId: _angular_core.Signal<string | undefined>;
+    activeId: SignalLike<string | undefined>;
     clearSelection: () => void;
     collapseAll: () => void;
     collapseItem: () => void;
@@ -264,7 +264,7 @@ export class ComboboxTreePattern<V> extends TreePattern<V> implements ComboboxTr
     isItemCollapsible: () => boolean;
     isItemExpandable(item?: TreeItemPattern<V> | undefined): boolean;
     isItemSelectable: (item?: TreeItemPattern<V> | undefined) => boolean;
-    items: _angular_core.Signal<TreeItemPattern<V>[]>;
+    items: SignalLike<TreeItemPattern<V>[]>;
     last: () => void;
     next: () => void;
     onKeydown(_: KeyboardEvent): void;
@@ -278,6 +278,9 @@ export class ComboboxTreePattern<V> extends TreePattern<V> implements ComboboxTr
     toggle: (item?: TreeItemPattern<V>) => void;
     unfocus: () => void;
 }
+
+// @public (undocumented)
+export function computed<T>(computation: () => T): SignalLike<T>;
 
 // @public
 export function convertGetterSetterToWritableSignalLike<T>(getter: () => T, setter: (v: T) => void): WritableSignalLike<T>;
@@ -369,24 +372,24 @@ export interface GridCellWidgetInputs extends Omit<ListNavigationItem, 'index'> 
 export class GridCellWidgetPattern implements ListNavigationItem {
     constructor(inputs: GridCellWidgetInputs);
     activate(event?: KeyboardEvent | FocusEvent): void;
-    readonly active: Signal<boolean>;
+    readonly active: SignalLike<boolean>;
     deactivate(event?: KeyboardEvent | FocusEvent): void;
-    readonly disabled: Signal<boolean>;
+    readonly disabled: SignalLike<boolean>;
     readonly element: SignalLike<HTMLElement>;
     focus(): void;
     readonly id: SignalLike<string>;
-    readonly index: Signal<number>;
+    readonly index: SignalLike<number>;
     // (undocumented)
     readonly inputs: GridCellWidgetInputs;
-    readonly isActivated: WritableSignal<boolean>;
-    readonly keydown: Signal<KeyboardEventManager<KeyboardEvent>>;
-    readonly lastActivateEvent: WritableSignal<KeyboardEvent | FocusEvent | undefined>;
-    readonly lastDeactivateEvent: WritableSignal<KeyboardEvent | FocusEvent | undefined>;
+    readonly isActivated: WritableSignalLike<boolean>;
+    readonly keydown: SignalLike<KeyboardEventManager<KeyboardEvent>>;
+    readonly lastActivateEvent: WritableSignalLike<KeyboardEvent | FocusEvent | undefined>;
+    readonly lastDeactivateEvent: WritableSignalLike<KeyboardEvent | FocusEvent | undefined>;
     onFocusIn(event: FocusEvent): void;
     onFocusOut(event: FocusEvent): void;
     onKeydown(event: KeyboardEvent): void;
-    readonly tabIndex: Signal<-1 | 0>;
-    readonly widgetHost: Signal<HTMLElement>;
+    readonly tabIndex: SignalLike<-1 | 0>;
+    readonly widgetHost: SignalLike<HTMLElement>;
 }
 
 // @public
@@ -404,20 +407,20 @@ export interface GridInputs extends Omit<GridInputs$1<GridCellPattern>, 'cells'>
 // @public
 export class GridPattern {
     constructor(inputs: GridInputs);
-    readonly activeCell: _angular_core.Signal<GridCellPattern | undefined>;
-    readonly activeDescendant: _angular_core.Signal<string | undefined>;
+    readonly activeCell: SignalLike<GridCellPattern | undefined>;
+    readonly activeDescendant: SignalLike<string | undefined>;
     readonly anchorCell: SignalLike<GridCellPattern | undefined>;
-    readonly cells: _angular_core.Signal<GridCellPattern[][]>;
-    readonly disabled: _angular_core.Signal<boolean>;
-    readonly dragging: _angular_core.WritableSignal<boolean>;
+    readonly cells: SignalLike<GridCellPattern[][]>;
+    readonly disabled: SignalLike<boolean>;
+    readonly dragging: WritableSignalLike<boolean>;
     focusEffect(): void;
     readonly gridBehavior: Grid<GridCellPattern>;
-    readonly hasBeenFocused: _angular_core.WritableSignal<boolean>;
+    readonly hasBeenFocused: WritableSignalLike<boolean>;
     // (undocumented)
     readonly inputs: GridInputs;
-    readonly isFocused: _angular_core.WritableSignal<boolean>;
-    readonly keydown: _angular_core.Signal<KeyboardEventManager<KeyboardEvent>>;
-    readonly nextColKey: _angular_core.Signal<"ArrowRight" | "ArrowLeft">;
+    readonly isFocused: WritableSignalLike<boolean>;
+    readonly keydown: SignalLike<KeyboardEventManager<KeyboardEvent>>;
+    readonly nextColKey: SignalLike<"ArrowRight" | "ArrowLeft">;
     onFocusIn(event: FocusEvent): void;
     onFocusOut(event: FocusEvent): void;
     onKeydown(event: KeyboardEvent): void;
@@ -425,14 +428,14 @@ export class GridPattern {
     onPointermove(event: PointerEvent): void;
     onPointerup(event: PointerEvent): void;
     readonly pauseNavigation: SignalLike<boolean>;
-    readonly pointerdown: _angular_core.Signal<PointerEventManager<PointerEvent>>;
-    readonly pointerup: _angular_core.Signal<PointerEventManager<PointerEvent>>;
-    readonly prevColKey: _angular_core.Signal<"ArrowRight" | "ArrowLeft">;
+    readonly pointerdown: SignalLike<PointerEventManager<PointerEvent>>;
+    readonly pointerup: SignalLike<PointerEventManager<PointerEvent>>;
+    readonly prevColKey: SignalLike<"ArrowRight" | "ArrowLeft">;
     resetFocusEffect(): void;
     resetStateEffect(): void;
     restoreFocusEffect(): void;
     setDefaultStateEffect(): void;
-    readonly tabIndex: _angular_core.Signal<0 | -1>;
+    readonly tabIndex: SignalLike<0 | -1>;
 }
 
 // @public
@@ -450,6 +453,9 @@ export class GridRowPattern {
     rowIndex: SignalLike<number | undefined>;
 }
 
+// @public (undocumented)
+export function linkedSignal<T>(sourceFn: () => T): WritableSignalLike<T>;
+
 // @public
 export type ListboxInputs<V> = ListInputs<OptionPattern<V>, V> & {
     id: SignalLike<string>;
@@ -459,32 +465,32 @@ export type ListboxInputs<V> = ListInputs<OptionPattern<V>, V> & {
 // @public
 export class ListboxPattern<V> {
     constructor(inputs: ListboxInputs<V>);
-    activeDescendant: _angular_core.Signal<string | undefined>;
-    disabled: _angular_core.Signal<boolean>;
-    dynamicSpaceKey: _angular_core.Signal<"" | " ">;
-    followFocus: _angular_core.Signal<boolean>;
+    activeDescendant: SignalLike<string | undefined>;
+    disabled: SignalLike<boolean>;
+    dynamicSpaceKey: SignalLike<"" | " ">;
+    followFocus: SignalLike<boolean>;
     // (undocumented)
     protected _getItem(e: PointerEvent): OptionPattern<V> | undefined;
     // (undocumented)
     readonly inputs: ListboxInputs<V>;
-    keydown: _angular_core.Signal<KeyboardEventManager<KeyboardEvent>>;
+    keydown: SignalLike<KeyboardEventManager<KeyboardEvent>>;
     // (undocumented)
     listBehavior: List<OptionPattern<V>, V>;
     multi: SignalLike<boolean>;
-    nextKey: _angular_core.Signal<"ArrowRight" | "ArrowLeft" | "ArrowDown">;
+    nextKey: SignalLike<"ArrowRight" | "ArrowLeft" | "ArrowDown">;
     onKeydown(event: KeyboardEvent): void;
     // (undocumented)
     onPointerdown(event: PointerEvent): void;
     orientation: SignalLike<'vertical' | 'horizontal'>;
-    pointerdown: _angular_core.Signal<PointerEventManager<PointerEvent>>;
-    prevKey: _angular_core.Signal<"ArrowUp" | "ArrowRight" | "ArrowLeft">;
+    pointerdown: SignalLike<PointerEventManager<PointerEvent>>;
+    prevKey: SignalLike<"ArrowUp" | "ArrowRight" | "ArrowLeft">;
     readonly: SignalLike<boolean>;
     setDefaultState(): void;
-    setsize: _angular_core.Signal<number>;
+    setsize: SignalLike<number>;
     tabIndex: SignalLike<-1 | 0>;
     typeaheadRegexp: RegExp;
     validate(): string[];
-    wrap: _angular_core.WritableSignal<boolean>;
+    wrap: WritableSignalLike<boolean>;
 }
 
 // @public
@@ -499,15 +505,15 @@ export class MenuBarPattern<V> {
     constructor(inputs: MenuBarInputs<V>);
     close(): void;
     disabled: () => boolean;
-    dynamicSpaceKey: Signal<"" | " ">;
+    dynamicSpaceKey: SignalLike<"" | " ">;
     goto(item: MenuItemPattern<V>, opts?: {
         focusElement?: boolean;
     }): void;
-    hasBeenFocused: _angular_core.WritableSignal<boolean>;
+    hasBeenFocused: WritableSignalLike<boolean>;
     // (undocumented)
     readonly inputs: MenuBarInputs<V>;
-    isFocused: _angular_core.WritableSignal<boolean>;
-    keydownManager: Signal<KeyboardEventManager<KeyboardEvent>>;
+    isFocused: WritableSignalLike<boolean>;
+    keydownManager: SignalLike<KeyboardEventManager<KeyboardEvent>>;
     listBehavior: List<MenuItemPattern<V>, V>;
     next(): void;
     onClick(event: MouseEvent): void;
@@ -540,19 +546,19 @@ export interface MenuItemInputs<V> extends Omit<ListItem<V>, 'index' | 'selectab
 // @public
 export class MenuItemPattern<V> implements ListItem<V> {
     constructor(inputs: MenuItemInputs<V>);
-    active: Signal<boolean>;
+    active: SignalLike<boolean>;
     close(opts?: {
         refocus?: boolean;
     }): void;
-    controls: _angular_core.WritableSignal<string | undefined>;
+    controls: WritableSignalLike<string | undefined>;
     disabled: () => boolean;
     element: SignalLike<HTMLElement | undefined>;
-    expanded: Signal<boolean | null>;
-    _expanded: _angular_core.WritableSignal<boolean>;
-    hasBeenFocused: _angular_core.WritableSignal<boolean>;
-    hasPopup: Signal<boolean>;
+    expanded: SignalLike<boolean | null>;
+    _expanded: WritableSignalLike<boolean>;
+    hasBeenFocused: WritableSignalLike<boolean>;
+    hasPopup: SignalLike<boolean>;
     id: SignalLike<string>;
-    index: Signal<number>;
+    index: SignalLike<number>;
     // (undocumented)
     readonly inputs: MenuItemInputs<V>;
     onFocusIn(): void;
@@ -564,7 +570,7 @@ export class MenuItemPattern<V> implements ListItem<V> {
     searchTerm: SignalLike<string>;
     selectable: SignalLike<boolean>;
     submenu: SignalLike<MenuPattern<V> | undefined>;
-    tabIndex: Signal<0 | -1>;
+    tabIndex: SignalLike<0 | -1>;
     value: SignalLike<V>;
 }
 
@@ -579,16 +585,16 @@ export class MenuPattern<V> {
     _closeTimeout: any;
     collapse(): void;
     disabled: () => boolean;
-    dynamicSpaceKey: Signal<"" | " ">;
+    dynamicSpaceKey: SignalLike<"" | " ">;
     expand(): void;
     first(): void;
-    hasBeenFocused: _angular_core.WritableSignal<boolean>;
-    hasBeenHovered: _angular_core.WritableSignal<boolean>;
+    hasBeenFocused: WritableSignalLike<boolean>;
+    hasBeenHovered: WritableSignalLike<boolean>;
     id: SignalLike<string>;
     // (undocumented)
     readonly inputs: MenuInputs<V>;
-    isFocused: _angular_core.WritableSignal<boolean>;
-    keydownManager: Signal<KeyboardEventManager<KeyboardEvent>>;
+    isFocused: WritableSignalLike<boolean>;
+    keydownManager: SignalLike<KeyboardEventManager<KeyboardEvent>>;
     last(): void;
     listBehavior: List<MenuItemPattern<V>, V>;
     next(): void;
@@ -601,14 +607,14 @@ export class MenuPattern<V> {
     _openTimeout: any;
     prev(): void;
     role: () => string;
-    root: Signal<MenuTriggerPattern<V> | MenuBarPattern<V> | MenuPattern<V> | undefined>;
+    root: SignalLike<MenuTriggerPattern<V> | MenuBarPattern<V> | MenuPattern<V> | undefined>;
     setDefaultState(): void;
-    shouldFocus: Signal<boolean>;
+    shouldFocus: SignalLike<boolean>;
     submit(item?: MenuItemPattern<V> | undefined): void;
     tabIndex: () => 0 | -1;
     trigger(): void;
     typeaheadRegexp: RegExp;
-    visible: Signal<boolean>;
+    visible: SignalLike<boolean>;
 }
 
 // @public
@@ -626,12 +632,12 @@ export class MenuTriggerPattern<V> {
         refocus?: boolean;
     }): void;
     disabled: () => boolean;
-    expanded: _angular_core.WritableSignal<boolean>;
-    hasBeenFocused: _angular_core.WritableSignal<boolean>;
+    expanded: WritableSignalLike<boolean>;
+    hasBeenFocused: WritableSignalLike<boolean>;
     hasPopup: () => boolean;
     // (undocumented)
     readonly inputs: MenuTriggerInputs<V>;
-    keydownManager: Signal<KeyboardEventManager<KeyboardEvent>>;
+    keydownManager: SignalLike<KeyboardEventManager<KeyboardEvent>>;
     menu: SignalLike<MenuPattern<V> | undefined>;
     onClick(): void;
     onFocusIn(): void;
@@ -642,7 +648,7 @@ export class MenuTriggerPattern<V> {
         last?: boolean;
     }): void;
     role: () => string;
-    tabIndex: Signal<-1 | 0>;
+    tabIndex: SignalLike<-1 | 0>;
 }
 
 // @public
@@ -668,6 +674,9 @@ export class OptionPattern<V> {
 }
 
 // @public (undocumented)
+export function signal<T>(initialValue: T): WritableSignalLike<T>;
+
+// @public (undocumented)
 export type SignalLike<T> = () => T;
 
 // @public
@@ -685,27 +694,27 @@ export interface TabListInputs extends Omit<ListNavigationInputs<TabPattern>, 'm
 // @public
 export class TabListPattern {
     constructor(inputs: TabListInputs);
-    readonly activeDescendant: _angular_core.Signal<string | undefined>;
+    readonly activeDescendant: SignalLike<string | undefined>;
     readonly activeTab: SignalLike<TabPattern | undefined>;
     readonly disabled: SignalLike<boolean>;
     readonly expansionBehavior: ListExpansion;
     readonly focusBehavior: ListFocus<TabPattern>;
-    readonly followFocus: _angular_core.Signal<boolean>;
+    readonly followFocus: SignalLike<boolean>;
     // (undocumented)
     readonly inputs: TabListInputs;
-    readonly keydown: _angular_core.Signal<KeyboardEventManager<KeyboardEvent>>;
+    readonly keydown: SignalLike<KeyboardEventManager<KeyboardEvent>>;
     readonly navigationBehavior: ListNavigation<TabPattern>;
-    readonly nextKey: _angular_core.Signal<"ArrowRight" | "ArrowLeft" | "ArrowDown">;
+    readonly nextKey: SignalLike<"ArrowRight" | "ArrowLeft" | "ArrowDown">;
     onKeydown(event: KeyboardEvent): void;
     onPointerdown(event: PointerEvent): void;
     open(value: string): boolean;
     open(tab?: TabPattern): boolean;
     readonly orientation: SignalLike<'vertical' | 'horizontal'>;
-    readonly pointerdown: _angular_core.Signal<PointerEventManager<PointerEvent>>;
-    readonly prevKey: _angular_core.Signal<"ArrowUp" | "ArrowRight" | "ArrowLeft">;
-    readonly selectedTab: WritableSignal<TabPattern | undefined>;
+    readonly pointerdown: SignalLike<PointerEventManager<PointerEvent>>;
+    readonly prevKey: SignalLike<"ArrowUp" | "ArrowRight" | "ArrowLeft">;
+    readonly selectedTab: WritableSignalLike<TabPattern | undefined>;
     setDefaultState(): void;
-    readonly tabIndex: _angular_core.Signal<0 | -1>;
+    readonly tabIndex: SignalLike<0 | -1>;
 }
 
 // @public
@@ -718,32 +727,32 @@ export interface TabPanelInputs extends LabelControlOptionalInputs {
 // @public
 export class TabPanelPattern {
     constructor(inputs: TabPanelInputs);
-    readonly hidden: _angular_core.Signal<boolean>;
+    readonly hidden: SignalLike<boolean>;
     readonly id: SignalLike<string>;
     // (undocumented)
     readonly inputs: TabPanelInputs;
-    readonly labelledBy: _angular_core.Signal<string | undefined>;
+    readonly labelledBy: SignalLike<string | undefined>;
     readonly labelManager: LabelControl;
-    readonly tabIndex: _angular_core.Signal<-1 | 0>;
+    readonly tabIndex: SignalLike<-1 | 0>;
     readonly value: SignalLike<string>;
 }
 
 // @public
 export class TabPattern {
     constructor(inputs: TabInputs);
-    readonly active: _angular_core.Signal<boolean>;
-    readonly controls: _angular_core.Signal<string | undefined>;
+    readonly active: SignalLike<boolean>;
+    readonly controls: SignalLike<string | undefined>;
     readonly disabled: SignalLike<boolean>;
     readonly element: SignalLike<HTMLElement>;
     readonly expandable: SignalLike<boolean>;
     readonly expanded: WritableSignalLike<boolean>;
     readonly id: SignalLike<string>;
-    readonly index: _angular_core.Signal<number>;
+    readonly index: SignalLike<number>;
     // (undocumented)
     readonly inputs: TabInputs;
     open(): boolean;
-    readonly selected: _angular_core.Signal<boolean>;
-    readonly tabIndex: _angular_core.Signal<0 | -1>;
+    readonly selected: SignalLike<boolean>;
+    readonly tabIndex: SignalLike<0 | -1>;
     readonly value: SignalLike<string>;
 }
 
@@ -755,9 +764,9 @@ export type ToolbarInputs<V> = Omit<ListInputs<ToolbarWidgetPattern<V>, V>, 'mul
 // @public
 export class ToolbarPattern<V> {
     constructor(inputs: ToolbarInputs<V>);
-    readonly activeDescendant: _angular_core.Signal<string | undefined>;
+    readonly activeDescendant: SignalLike<string | undefined>;
     readonly activeItem: () => ToolbarWidgetPattern<V> | undefined;
-    readonly disabled: _angular_core.Signal<boolean>;
+    readonly disabled: SignalLike<boolean>;
     // (undocumented)
     readonly inputs: ToolbarInputs<V>;
     readonly listBehavior: List<ToolbarWidgetPattern<V>, V>;
@@ -770,7 +779,7 @@ export class ToolbarPattern<V> {
     select(): void;
     setDefaultState(): void;
     readonly softDisabled: SignalLike<boolean>;
-    readonly tabIndex: _angular_core.Signal<0 | -1>;
+    readonly tabIndex: SignalLike<0 | -1>;
     validate(): string[];
 }
 
@@ -814,13 +823,13 @@ export class ToolbarWidgetPattern<V> implements ListItem<V> {
     readonly element: () => HTMLElement | undefined;
     readonly group: () => ToolbarWidgetGroupPattern<ToolbarWidgetPattern<V>, V> | undefined;
     readonly id: () => string;
-    readonly index: _angular_core.Signal<number>;
+    readonly index: SignalLike<number>;
     // (undocumented)
     readonly inputs: ToolbarWidgetInputs<V>;
     readonly searchTerm: () => string;
     readonly selectable: () => boolean;
-    readonly selected: _angular_core.Signal<boolean>;
-    readonly tabIndex: _angular_core.Signal<0 | -1>;
+    readonly selected: SignalLike<boolean>;
+    readonly tabIndex: SignalLike<0 | -1>;
     readonly toolbar: () => ToolbarPattern<V>;
     readonly value: () => V;
 }
@@ -844,7 +853,7 @@ export interface TreeItemInputs<V> extends Omit<ListItem<V>, 'index'>, Omit<Expa
 // @public
 export class TreeItemPattern<V> implements ListItem<V>, ExpansionItem {
     constructor(inputs: TreeItemInputs<V>);
-    readonly active: _angular_core.Signal<boolean>;
+    readonly active: SignalLike<boolean>;
     readonly children: SignalLike<TreeItemPattern<V>[]>;
     readonly current: SignalLike<string | undefined>;
     readonly disabled: SignalLike<boolean>;
@@ -853,17 +862,17 @@ export class TreeItemPattern<V> implements ListItem<V>, ExpansionItem {
     readonly expanded: WritableSignalLike<boolean>;
     readonly expansionBehavior: ListExpansion;
     readonly id: SignalLike<string>;
-    readonly index: _angular_core.Signal<number>;
+    readonly index: SignalLike<number>;
     // (undocumented)
     readonly inputs: TreeItemInputs<V>;
     readonly level: SignalLike<number>;
     readonly parent: SignalLike<TreeItemPattern<V> | TreePattern<V>>;
-    readonly posinset: _angular_core.Signal<number>;
+    readonly posinset: SignalLike<number>;
     readonly searchTerm: SignalLike<string>;
     readonly selectable: SignalLike<boolean>;
     readonly selected: SignalLike<boolean | undefined>;
-    readonly setsize: _angular_core.Signal<number>;
-    readonly tabIndex: _angular_core.Signal<0 | -1>;
+    readonly setsize: SignalLike<number>;
+    readonly tabIndex: SignalLike<0 | -1>;
     readonly tree: SignalLike<TreePattern<V>>;
     readonly value: SignalLike<V>;
     readonly visible: SignalLike<boolean>;
@@ -872,40 +881,40 @@ export class TreeItemPattern<V> implements ListItem<V>, ExpansionItem {
 // @public
 export class TreePattern<V> implements TreeInputs<V> {
     constructor(inputs: TreeInputs<V>);
-    readonly activeDescendant: _angular_core.Signal<string | undefined>;
+    readonly activeDescendant: SignalLike<string | undefined>;
     readonly activeItem: WritableSignalLike<TreeItemPattern<V> | undefined>;
     readonly allItems: SignalLike<TreeItemPattern<V>[]>;
-    readonly children: _angular_core.Signal<TreeItemPattern<V>[]>;
+    readonly children: SignalLike<TreeItemPattern<V>[]>;
     collapse(opts?: SelectOptions): void;
-    readonly collapseKey: _angular_core.Signal<"ArrowUp" | "ArrowRight" | "ArrowLeft">;
+    readonly collapseKey: SignalLike<"ArrowUp" | "ArrowRight" | "ArrowLeft">;
     readonly currentType: SignalLike<'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'>;
     readonly disabled: SignalLike<boolean>;
-    readonly dynamicSpaceKey: _angular_core.Signal<"" | " ">;
+    readonly dynamicSpaceKey: SignalLike<"" | " ">;
     readonly element: SignalLike<HTMLElement>;
     expand(opts?: SelectOptions): void;
     readonly expanded: () => boolean;
-    readonly expandKey: _angular_core.Signal<"ArrowRight" | "ArrowLeft" | "ArrowDown">;
+    readonly expandKey: SignalLike<"ArrowRight" | "ArrowLeft" | "ArrowDown">;
     expandSiblings(item?: TreeItemPattern<V>): void;
     readonly expansionBehavior: ListExpansion;
     readonly focusMode: SignalLike<'roving' | 'activedescendant'>;
-    readonly followFocus: _angular_core.Signal<boolean>;
+    readonly followFocus: SignalLike<boolean>;
     protected _getItem(event: Event): TreeItemPattern<V> | undefined;
     goto(e: PointerEvent, opts?: SelectOptions): void;
     readonly id: SignalLike<string>;
     // (undocumented)
     readonly inputs: TreeInputs<V>;
-    readonly isRtl: _angular_core.Signal<boolean>;
-    readonly keydown: _angular_core.Signal<KeyboardEventManager<KeyboardEvent>>;
+    readonly isRtl: SignalLike<boolean>;
+    readonly keydown: SignalLike<KeyboardEventManager<KeyboardEvent>>;
     readonly level: () => number;
     readonly listBehavior: List<TreeItemPattern<V>, V>;
     readonly multi: SignalLike<boolean>;
     readonly nav: SignalLike<boolean>;
-    readonly nextKey: _angular_core.Signal<"ArrowRight" | "ArrowLeft" | "ArrowDown">;
+    readonly nextKey: SignalLike<"ArrowRight" | "ArrowLeft" | "ArrowDown">;
     onKeydown(event: KeyboardEvent): void;
     onPointerdown(event: PointerEvent): void;
     readonly orientation: SignalLike<'vertical' | 'horizontal'>;
-    pointerdown: _angular_core.Signal<PointerEventManager<PointerEvent>>;
-    readonly prevKey: _angular_core.Signal<"ArrowUp" | "ArrowRight" | "ArrowLeft">;
+    pointerdown: SignalLike<PointerEventManager<PointerEvent>>;
+    readonly prevKey: SignalLike<"ArrowUp" | "ArrowRight" | "ArrowLeft">;
     readonly selectionMode: SignalLike<'follow' | 'explicit'>;
     setDefaultState(): void;
     readonly softDisabled: SignalLike<boolean>;
@@ -916,12 +925,16 @@ export class TreePattern<V> implements TreeInputs<V> {
     readonly typeaheadRegexp: RegExp;
     readonly values: WritableSignalLike<V[]>;
     readonly visible: () => boolean;
-    readonly visibleItems: _angular_core.Signal<TreeItemPattern<V>[]>;
+    readonly visibleItems: SignalLike<TreeItemPattern<V>[]>;
     readonly wrap: SignalLike<boolean>;
 }
 
+export { untracked }
+
 // @public (undocumented)
 export interface WritableSignalLike<T> extends SignalLike<T> {
+    // (undocumented)
+    asReadonly(): SignalLike<T>;
     // (undocumented)
     set(value: T): void;
     // (undocumented)

--- a/goldens/aria/tabs/index.api.md
+++ b/goldens/aria/tabs/index.api.md
@@ -10,7 +10,6 @@ import * as _angular_cdk_bidi from '@angular/cdk/bidi';
 import * as _angular_core from '@angular/core';
 import { OnDestroy } from '@angular/core';
 import { OnInit } from '@angular/core';
-import { WritableSignal } from '@angular/core';
 
 // @public
 export class Tab implements HasElement, OnInit, OnDestroy {

--- a/pkg-externals.bzl
+++ b/pkg-externals.bzl
@@ -20,6 +20,7 @@ PKG_EXTERNALS = [
     "@angular/common/testing",
     "@angular/localize/init",
     "@angular/core",
+    "@angular/core/primitives/signals",
     "@angular/core/rxjs-interop",
     "@angular/core/testing",
     "@angular/forms",

--- a/src/aria/grid/grid-cell-widget.ts
+++ b/src/aria/grid/grid-cell-widget.ts
@@ -105,7 +105,7 @@ export class GridCellWidget {
 
   /** Whether the widget is activated. */
   get isActivated(): Signal<boolean> {
-    return this._pattern.isActivated.asReadonly();
+    return computed(() => this._pattern.isActivated());
   }
 
   constructor() {

--- a/src/aria/private/accordion/BUILD.bazel
+++ b/src/aria/private/accordion/BUILD.bazel
@@ -8,7 +8,6 @@ ts_project(
         "accordion.ts",
     ],
     deps = [
-        "//:node_modules/@angular/core",
         "//src/aria/private/behaviors/event-manager",
         "//src/aria/private/behaviors/expansion",
         "//src/aria/private/behaviors/list-focus",
@@ -26,7 +25,6 @@ ng_project(
     ],
     deps = [
         ":accordion",
-        "//:node_modules/@angular/core",
         "//src/aria/private/behaviors/signal-like",
         "//src/cdk/keycodes",
         "//src/cdk/testing/private",

--- a/src/aria/private/accordion/accordion.spec.ts
+++ b/src/aria/private/accordion/accordion.spec.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {signal} from '@angular/core';
 import {
   AccordionGroupInputs,
   AccordionGroupPattern,
@@ -15,7 +14,7 @@ import {
   AccordionTriggerInputs,
   AccordionTriggerPattern,
 } from './accordion';
-import {SignalLike, WritableSignalLike} from '../behaviors/signal-like/signal-like';
+import {signal, SignalLike, WritableSignalLike} from '../behaviors/signal-like/signal-like';
 import {createKeyboardEvent} from '@angular/cdk/testing/private';
 import {ModifierKeys} from '@angular/cdk/testing';
 

--- a/src/aria/private/accordion/accordion.ts
+++ b/src/aria/private/accordion/accordion.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {computed} from '@angular/core';
 import {KeyboardEventManager, PointerEventManager} from '../behaviors/event-manager';
 import {ExpansionItem, ListExpansion, ListExpansionInputs} from '../behaviors/expansion/expansion';
 import {ListFocus, ListFocusInputs, ListFocusItem} from '../behaviors/list-focus/list-focus';
@@ -15,7 +14,7 @@ import {
   ListNavigationInputs,
   ListNavigationItem,
 } from '../behaviors/list-navigation/list-navigation';
-import {SignalLike, WritableSignalLike} from '../behaviors/signal-like/signal-like';
+import {computed, SignalLike, WritableSignalLike} from '../behaviors/signal-like/signal-like';
 
 /** Inputs of the AccordionGroupPattern. */
 export interface AccordionGroupInputs extends Omit<

--- a/src/aria/private/behaviors/expansion/BUILD.bazel
+++ b/src/aria/private/behaviors/expansion/BUILD.bazel
@@ -24,6 +24,7 @@ ng_project(
         ":expansion",
         "//:node_modules/@angular/core",
         "//src/aria/private/behaviors/list-focus:unit_test_sources",
+        "//src/aria/private/behaviors/signal-like",
     ],
 )
 

--- a/src/aria/private/behaviors/expansion/expansion.spec.ts
+++ b/src/aria/private/behaviors/expansion/expansion.spec.ts
@@ -6,14 +6,14 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {WritableSignal, signal} from '@angular/core';
+import {WritableSignalLike, signal} from '../signal-like/signal-like';
 import {ListExpansion, ListExpansionInputs, ExpansionItem} from './expansion';
 
 type TestItem = ExpansionItem & {
-  id: WritableSignal<string>;
-  disabled: WritableSignal<boolean>;
-  expanded: WritableSignal<boolean>;
-  expandable: WritableSignal<boolean>;
+  id: WritableSignalLike<string>;
+  disabled: WritableSignalLike<boolean>;
+  expanded: WritableSignalLike<boolean>;
+  expandable: WritableSignalLike<boolean>;
 };
 
 type TestInputs = Partial<Omit<ListExpansionInputs, 'items'>> & {
@@ -22,7 +22,7 @@ type TestInputs = Partial<Omit<ListExpansionInputs, 'items'>> & {
   expansionDisabled?: boolean;
 };
 
-function createItems(length: number): WritableSignal<TestItem[]> {
+function createItems(length: number): WritableSignalLike<TestItem[]> {
   return signal(
     Array.from({length}).map((_, i) => {
       const itemId = `item-${i}`;

--- a/src/aria/private/behaviors/grid-focus/BUILD.bazel
+++ b/src/aria/private/behaviors/grid-focus/BUILD.bazel
@@ -18,6 +18,7 @@ ng_project(
     deps = [
         ":grid-focus",
         "//:node_modules/@angular/core",
+        "//src/aria/private/behaviors/signal-like",
     ],
 )
 

--- a/src/aria/private/behaviors/grid-focus/grid-focus.spec.ts
+++ b/src/aria/private/behaviors/grid-focus/grid-focus.spec.ts
@@ -6,30 +6,30 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {computed, Signal, signal, WritableSignal} from '@angular/core';
+import {computed, SignalLike, signal, WritableSignalLike} from '../signal-like/signal-like';
 import {GridFocus, GridFocusInputs, GridFocusCell, RowCol} from './grid-focus';
 
 // Helper type for test cells, extending GridFocusCell
 interface TestGridCell extends GridFocusCell {
-  id: WritableSignal<string>;
-  element: WritableSignal<HTMLElement>;
-  disabled: WritableSignal<boolean>;
+  id: WritableSignalLike<string>;
+  element: WritableSignalLike<HTMLElement>;
+  disabled: WritableSignalLike<boolean>;
 }
 
 // Helper type for configuring GridFocus inputs in tests
 type TestSetupInputs = Partial<GridFocusInputs<TestGridCell>> & {
   numRows?: number;
   numCols?: number;
-  gridFocus?: WritableSignal<GridFocus<TestGridCell> | undefined>;
+  gridFocus?: WritableSignalLike<GridFocus<TestGridCell> | undefined>;
 };
 
 export function createTestCell(
-  gridFocus: Signal<GridFocus<TestGridCell> | undefined>,
+  gridFocus: SignalLike<GridFocus<TestGridCell> | undefined>,
   opts: {id: string; rowspan?: number; colspan?: number},
 ): TestGridCell {
   const el = document.createElement('div');
   spyOn(el, 'focus').and.callThrough();
-  let coordinates: Signal<RowCol> = signal({row: -1, col: -1});
+  let coordinates: SignalLike<RowCol> = signal({row: -1, col: -1});
   const cell: TestGridCell = {
     id: signal(opts.id),
     element: signal(el as HTMLElement),
@@ -46,10 +46,10 @@ export function createTestCell(
 }
 
 export function createTestCells(
-  gridFocus: Signal<GridFocus<TestGridCell> | undefined>,
+  gridFocus: SignalLike<GridFocus<TestGridCell> | undefined>,
   numRows: number,
   numCols: number,
-): WritableSignal<TestGridCell[][]> {
+): WritableSignalLike<TestGridCell[][]> {
   return signal(
     Array.from({length: numRows}).map((_, r) =>
       Array.from({length: numCols}).map((_, c) => {

--- a/src/aria/private/behaviors/grid-navigation/BUILD.bazel
+++ b/src/aria/private/behaviors/grid-navigation/BUILD.bazel
@@ -20,6 +20,7 @@ ng_project(
         ":grid-navigation",
         "//:node_modules/@angular/core",
         "//src/aria/private/behaviors/grid-focus",
+        "//src/aria/private/behaviors/signal-like",
     ],
 )
 

--- a/src/aria/private/behaviors/grid-navigation/grid-navigation.spec.ts
+++ b/src/aria/private/behaviors/grid-navigation/grid-navigation.spec.ts
@@ -6,14 +6,14 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {computed, signal, WritableSignal} from '@angular/core';
+import {computed, signal, WritableSignalLike} from '../../behaviors/signal-like/signal-like';
 import {GridFocus} from '../grid-focus/grid-focus';
 import {GridNavigation, GridNavigationCell, GridNavigationInputs} from './grid-navigation';
 
 type TestGridNav = GridNavigation<TestCell>;
 
 interface TestCell extends GridNavigationCell {
-  disabled: WritableSignal<boolean>;
+  disabled: WritableSignalLike<boolean>;
 }
 
 interface TestCellInputs {

--- a/src/aria/private/behaviors/grid/BUILD.bazel
+++ b/src/aria/private/behaviors/grid/BUILD.bazel
@@ -21,6 +21,7 @@ ts_project(
     deps = [
         ":grid",
         "//:node_modules/@angular/core",
+        "//src/aria/private/behaviors/signal-like",
     ],
 )
 

--- a/src/aria/private/behaviors/grid/grid-data.spec.ts
+++ b/src/aria/private/behaviors/grid/grid-data.spec.ts
@@ -6,13 +6,13 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {signal, Signal, WritableSignal} from '@angular/core';
+import {signal, SignalLike, WritableSignalLike} from '../signal-like/signal-like';
 import {BaseGridCell, GridData} from './grid-data';
 
 export interface TestBaseGridCell extends BaseGridCell {
-  rowSpan: WritableSignal<number>;
-  colSpan: WritableSignal<number>;
-  id: Signal<string>;
+  rowSpan: WritableSignalLike<number>;
+  colSpan: WritableSignalLike<number>;
+  id: SignalLike<string>;
 }
 
 /**

--- a/src/aria/private/behaviors/grid/grid-data.ts
+++ b/src/aria/private/behaviors/grid/grid-data.ts
@@ -6,8 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {computed} from '@angular/core';
-import {SignalLike} from '../signal-like/signal-like';
+import {computed, SignalLike} from '../signal-like/signal-like';
 
 /** Represents coordinates in a grid. */
 export interface RowCol {

--- a/src/aria/private/behaviors/grid/grid-focus.spec.ts
+++ b/src/aria/private/behaviors/grid/grid-focus.spec.ts
@@ -6,14 +6,14 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {signal, Signal, WritableSignal} from '@angular/core';
+import {signal, SignalLike, WritableSignalLike} from '../signal-like/signal-like';
 import {GridData} from './grid-data';
 import {createGridA, createGridB, createGridD, TestBaseGridCell} from './grid-data.spec';
 import {GridFocus, GridFocusInputs} from './grid-focus';
 
 export interface TestGridFocusCell extends TestBaseGridCell {
-  element: WritableSignal<HTMLElement>;
-  disabled: WritableSignal<boolean>;
+  element: WritableSignalLike<HTMLElement>;
+  disabled: WritableSignalLike<boolean>;
 }
 
 function createTestCell(): Omit<TestGridFocusCell, keyof TestBaseGridCell> {
@@ -32,7 +32,7 @@ function createTestGrid(createGridFn: () => TestBaseGridCell[][]): TestGridFocus
 }
 
 function setupGridFocus(
-  cells: Signal<TestGridFocusCell[][]>,
+  cells: SignalLike<TestGridFocusCell[][]>,
   gridFocusInputs: Partial<GridFocusInputs> = {},
 ): GridFocus<TestGridFocusCell> {
   const gridData = new GridData({cells});

--- a/src/aria/private/behaviors/grid/grid-focus.ts
+++ b/src/aria/private/behaviors/grid/grid-focus.ts
@@ -6,8 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {computed, signal, WritableSignal} from '@angular/core';
-import {SignalLike} from '../signal-like/signal-like';
+import {computed, signal, WritableSignalLike, SignalLike} from '../signal-like/signal-like';
 import type {GridData, BaseGridCell, RowCol} from './grid-data';
 
 /** Represents an cell in a grid, such as a grid cell, that may receive focus. */
@@ -43,7 +42,7 @@ interface GridFocusDeps<T extends GridFocusCell> {
 /** Controls focus for a 2D grid of cells. */
 export class GridFocus<T extends GridFocusCell> {
   /** The current active cell. */
-  readonly activeCell: WritableSignal<T | undefined> = signal(undefined);
+  readonly activeCell: WritableSignalLike<T | undefined> = signal(undefined);
 
   /** The current active cell coordinates. */
   readonly activeCoords = signal<RowCol>({row: -1, col: -1});

--- a/src/aria/private/behaviors/grid/grid-navigation.spec.ts
+++ b/src/aria/private/behaviors/grid/grid-navigation.spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {signal, Signal, WritableSignal} from '@angular/core';
+import {signal, SignalLike, WritableSignalLike} from '../signal-like/signal-like';
 import {GridData} from './grid-data';
 import {
   createGridA,
@@ -21,8 +21,8 @@ import {GridFocus, GridFocusInputs} from './grid-focus';
 import {direction, GridNavigation, GridNavigationInputs, WrapStrategy} from './grid-navigation';
 
 export interface TestGridNavigationCell extends TestBaseGridCell {
-  element: WritableSignal<HTMLElement>;
-  disabled: WritableSignal<boolean>;
+  element: WritableSignalLike<HTMLElement>;
+  disabled: WritableSignalLike<boolean>;
 }
 
 function createTestCell(): Omit<TestGridNavigationCell, keyof TestBaseGridCell> {
@@ -41,7 +41,7 @@ function createTestGrid(createGridFn: () => TestBaseGridCell[][]): TestGridNavig
 }
 
 function setupGridNavigation(
-  cells: Signal<TestGridNavigationCell[][]>,
+  cells: SignalLike<TestGridNavigationCell[][]>,
   inputs: Partial<GridNavigationInputs & GridFocusInputs> = {},
 ): {
   gridNav: GridNavigation<TestGridNavigationCell>;

--- a/src/aria/private/behaviors/grid/grid-selection.spec.ts
+++ b/src/aria/private/behaviors/grid/grid-selection.spec.ts
@@ -6,17 +6,17 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {signal, Signal, WritableSignal} from '@angular/core';
+import {signal, SignalLike, WritableSignalLike} from '../signal-like/signal-like';
 import {GridData} from './grid-data';
 import {createGridA, createGridB, createGridD, TestBaseGridCell} from './grid-data.spec';
 import {GridFocus, GridFocusInputs} from './grid-focus';
 import {GridSelection, GridSelectionInputs} from './grid-selection';
 
 export interface TestGridSelectionCell extends TestBaseGridCell {
-  element: WritableSignal<HTMLElement>;
-  disabled: WritableSignal<boolean>;
-  selected: WritableSignal<boolean>;
-  selectable: WritableSignal<boolean>;
+  element: WritableSignalLike<HTMLElement>;
+  disabled: WritableSignalLike<boolean>;
+  selected: WritableSignalLike<boolean>;
+  selectable: WritableSignalLike<boolean>;
 }
 
 function createTestCell(): Omit<TestGridSelectionCell, keyof TestBaseGridCell> {
@@ -37,7 +37,7 @@ function createTestGrid(createGridFn: () => TestBaseGridCell[][]): TestGridSelec
 }
 
 function setupGridSelection(
-  cells: Signal<TestGridSelectionCell[][]>,
+  cells: SignalLike<TestGridSelectionCell[][]>,
   inputs: Partial<GridSelectionInputs & GridFocusInputs> = {},
 ): {
   gridSelection: GridSelection<TestGridSelectionCell>;

--- a/src/aria/private/behaviors/grid/grid-selection.ts
+++ b/src/aria/private/behaviors/grid/grid-selection.ts
@@ -6,10 +6,9 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {SignalLike, WritableSignalLike} from '../signal-like/signal-like';
 import {GridFocus, GridFocusCell, GridFocusInputs} from './grid-focus';
 import {GridData, RowCol} from './grid-data';
-import {signal} from '@angular/core';
+import {SignalLike, WritableSignalLike, signal} from '../signal-like/signal-like';
 
 /** Represents a cell in a grid that can be selected. */
 export interface GridSelectionCell extends GridFocusCell {

--- a/src/aria/private/behaviors/grid/grid.spec.ts
+++ b/src/aria/private/behaviors/grid/grid.spec.ts
@@ -6,16 +6,16 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {signal, Signal, WritableSignal} from '@angular/core';
+import {signal, SignalLike, WritableSignalLike} from '../signal-like/signal-like';
 import {Grid, GridInputs} from './grid';
 import {createGridA, createGridD, TestBaseGridCell} from './grid-data.spec';
 import {WrapStrategy} from './grid-navigation';
 
 interface TestGridCell extends TestBaseGridCell {
-  element: WritableSignal<HTMLElement>;
-  disabled: WritableSignal<boolean>;
-  selected: WritableSignal<boolean>;
-  selectable: WritableSignal<boolean>;
+  element: WritableSignalLike<HTMLElement>;
+  disabled: WritableSignalLike<boolean>;
+  selected: WritableSignalLike<boolean>;
+  selectable: WritableSignalLike<boolean>;
 }
 
 function createTestCell(): Omit<TestGridCell, keyof TestBaseGridCell> {
@@ -36,7 +36,7 @@ function createTestGrid(createGridFn: () => TestBaseGridCell[][]): TestGridCell[
 }
 
 function setupGrid(
-  cells: Signal<TestGridCell[][]>,
+  cells: SignalLike<TestGridCell[][]>,
   inputs: Partial<GridInputs<TestGridCell>> = {},
 ): Grid<TestGridCell> {
   const gridInputs: GridInputs<TestGridCell> = {

--- a/src/aria/private/behaviors/grid/grid.ts
+++ b/src/aria/private/behaviors/grid/grid.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {computed, linkedSignal, signal} from '@angular/core';
 import {GridData, BaseGridCell, GridDataInputs, RowCol} from './grid-data';
 import {GridFocus, GridFocusCell, GridFocusInputs} from './grid-focus';
 import {
@@ -16,7 +15,7 @@ import {
   GridNavigationInputs,
 } from './grid-navigation';
 import {GridSelectionCell, GridSelectionInputs, GridSelection} from './grid-selection';
-import {SignalLike} from '../signal-like/signal-like';
+import {computed, linkedSignal, signal, SignalLike} from '../signal-like/signal-like';
 
 /** The selection operations that can be performed after a navigation operation. */
 export interface NavOptions {

--- a/src/aria/private/behaviors/label/BUILD
+++ b/src/aria/private/behaviors/label/BUILD
@@ -22,6 +22,7 @@ ng_project(
     deps = [
         ":label",
         "//:node_modules/@angular/core",
+        "//src/aria/private/behaviors/signal-like",
     ],
 )
 

--- a/src/aria/private/behaviors/label/label.spec.ts
+++ b/src/aria/private/behaviors/label/label.spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {signal, WritableSignal} from '@angular/core';
+import {signal, WritableSignalLike} from '../signal-like/signal-like';
 import {LabelControl, LabelControlInputs, LabelControlOptionalInputs} from './label';
 
 // This is a helper type for the initial values passed to the setup function.
@@ -20,7 +20,7 @@ type TestLabelControlInputs = LabelControlInputs & Required<LabelControlOptional
 
 // This is a helper type to make all properties of LabelControlInputs writable signals.
 type WritableLabelControlInputs = {
-  [K in keyof TestLabelControlInputs]: WritableSignal<
+  [K in keyof TestLabelControlInputs]: WritableSignalLike<
     TestLabelControlInputs[K] extends {(): infer T} ? T : never
   >;
 };

--- a/src/aria/private/behaviors/list-focus/BUILD.bazel
+++ b/src/aria/private/behaviors/list-focus/BUILD.bazel
@@ -21,6 +21,7 @@ ng_project(
     deps = [
         ":list-focus",
         "//:node_modules/@angular/core",
+        "//src/aria/private/behaviors/signal-like",
     ],
 )
 

--- a/src/aria/private/behaviors/list-focus/list-focus.spec.ts
+++ b/src/aria/private/behaviors/list-focus/list-focus.spec.ts
@@ -6,11 +6,11 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Signal, signal, WritableSignal} from '@angular/core';
+import {SignalLike, signal, WritableSignalLike} from '../signal-like/signal-like';
 import {ListFocus, ListFocusInputs, ListFocusItem} from './list-focus';
 
 type TestItem = ListFocusItem & {
-  disabled: WritableSignal<boolean>;
+  disabled: WritableSignalLike<boolean>;
 };
 
 type TestInputs = Partial<ListFocusInputs<ListFocusItem>> & {
@@ -30,7 +30,7 @@ export function getListFocus(inputs: TestInputs = {}): ListFocus<ListFocusItem> 
   });
 }
 
-function getItems(length: number): Signal<ListFocusItem[]> {
+function getItems(length: number): SignalLike<ListFocusItem[]> {
   return signal(
     Array.from({length}).map((_, i) => {
       return {

--- a/src/aria/private/behaviors/list-focus/list-focus.ts
+++ b/src/aria/private/behaviors/list-focus/list-focus.ts
@@ -6,8 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {computed, signal} from '@angular/core';
-import {SignalLike, WritableSignalLike} from '../signal-like/signal-like';
+import {computed, signal, SignalLike, WritableSignalLike} from '../signal-like/signal-like';
 
 /** Represents an item in a collection, such as a listbox option, than may receive focus. */
 export interface ListFocusItem {

--- a/src/aria/private/behaviors/list-selection/BUILD.bazel
+++ b/src/aria/private/behaviors/list-selection/BUILD.bazel
@@ -24,6 +24,7 @@ ng_project(
         "//:node_modules/@angular/core",
         "//src/aria/private/behaviors/list-focus",
         "//src/aria/private/behaviors/list-focus:unit_test_sources",
+        "//src/aria/private/behaviors/signal-like",
     ],
 )
 

--- a/src/aria/private/behaviors/list-selection/list-selection.spec.ts
+++ b/src/aria/private/behaviors/list-selection/list-selection.spec.ts
@@ -6,14 +6,14 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Signal, signal, WritableSignal} from '@angular/core';
+import {SignalLike, signal, WritableSignalLike} from '../signal-like/signal-like';
 import {ListSelectionItem, ListSelection, ListSelectionInputs} from './list-selection';
 import {getListFocus} from '../list-focus/list-focus.spec';
 import {ListFocus} from '../list-focus/list-focus';
 
 type TestItem = ListSelectionItem<number> & {
-  disabled: WritableSignal<boolean>;
-  selectable: WritableSignal<boolean>;
+  disabled: WritableSignalLike<boolean>;
+  selectable: WritableSignalLike<boolean>;
 };
 type TestInputs = Partial<ListSelectionInputs<TestItem, number>> & {
   numItems?: number;
@@ -34,7 +34,7 @@ function getSelection(inputs: TestInputs = {}): ListSelection<ListSelectionItem<
   });
 }
 
-function getItems(length: number): Signal<TestItem[]> {
+function getItems(length: number): SignalLike<TestItem[]> {
   return signal(
     Array.from({length}).map((_, i) => {
       return {

--- a/src/aria/private/behaviors/list-selection/list-selection.ts
+++ b/src/aria/private/behaviors/list-selection/list-selection.ts
@@ -6,8 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {computed, signal} from '@angular/core';
-import {SignalLike, WritableSignalLike} from '../signal-like/signal-like';
+import {computed, signal, SignalLike, WritableSignalLike} from '../signal-like/signal-like';
 import {ListFocus, ListFocusInputs, ListFocusItem} from '../list-focus/list-focus';
 
 /** Represents an item in a collection, such as a listbox option, that can be selected. */

--- a/src/aria/private/behaviors/list-typeahead/BUILD.bazel
+++ b/src/aria/private/behaviors/list-typeahead/BUILD.bazel
@@ -24,6 +24,7 @@ ng_project(
         "//:node_modules/@angular/core",
         "//src/aria/private/behaviors/list-focus",
         "//src/aria/private/behaviors/list-focus:unit_test_sources",
+        "//src/aria/private/behaviors/signal-like",
     ],
 )
 

--- a/src/aria/private/behaviors/list-typeahead/list-typeahead.spec.ts
+++ b/src/aria/private/behaviors/list-typeahead/list-typeahead.spec.ts
@@ -6,13 +6,13 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Signal, signal, WritableSignal} from '@angular/core';
+import {SignalLike, signal, WritableSignalLike} from '../signal-like/signal-like';
 import {ListTypeaheadItem, ListTypeahead, ListTypeaheadInputs} from './list-typeahead';
 import {getListFocus} from '../list-focus/list-focus.spec';
 import {ListFocus} from '../list-focus/list-focus';
 
 type TestItem = ListTypeaheadItem & {
-  disabled: WritableSignal<boolean>;
+  disabled: WritableSignalLike<boolean>;
 };
 type TestInputs = Partial<ListTypeaheadInputs<TestItem>> & {
   numItems?: number;
@@ -31,7 +31,7 @@ function getTypeahead(inputs: TestInputs = {}): ListTypeahead<TestItem> {
   });
 }
 
-function getItems(length: number): Signal<TestItem[]> {
+function getItems(length: number): SignalLike<TestItem[]> {
   return signal(
     Array.from({length}).map((_, i) => {
       return {
@@ -79,14 +79,14 @@ describe('List Typeahead', () => {
 
     it('should skip disabled items', () => {
       items[1].disabled.set(true);
-      (typeahead.inputs.softDisabled as WritableSignal<boolean>).set(false);
+      (typeahead.inputs.softDisabled as WritableSignalLike<boolean>).set(false);
       typeahead.search('i');
       expect(typeahead.inputs.focusManager.activeIndex()).toBe(2);
     });
 
     it('should not skip disabled items', () => {
       items[1].disabled.set(true);
-      (typeahead.inputs.softDisabled as WritableSignal<boolean>).set(true);
+      (typeahead.inputs.softDisabled as WritableSignalLike<boolean>).set(true);
       typeahead.search('i');
       expect(typeahead.inputs.focusManager.activeIndex()).toBe(1);
     });

--- a/src/aria/private/behaviors/list-typeahead/list-typeahead.ts
+++ b/src/aria/private/behaviors/list-typeahead/list-typeahead.ts
@@ -6,8 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {computed, signal} from '@angular/core';
-import {SignalLike} from '../signal-like/signal-like';
+import {computed, signal, SignalLike} from '../signal-like/signal-like';
 import {ListFocus, ListFocusInputs, ListFocusItem} from '../list-focus/list-focus';
 
 /**

--- a/src/aria/private/behaviors/list/BUILD.bazel
+++ b/src/aria/private/behaviors/list/BUILD.bazel
@@ -26,6 +26,7 @@ ng_project(
     deps = [
         ":list",
         "//:node_modules/@angular/core",
+        "//src/aria/private/behaviors/signal-like",
         "//src/cdk/keycodes",
         "//src/cdk/testing/private",
     ],

--- a/src/aria/private/behaviors/list/list.spec.ts
+++ b/src/aria/private/behaviors/list/list.spec.ts
@@ -6,14 +6,14 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {signal, WritableSignal} from '@angular/core';
+import {signal, WritableSignalLike} from '../signal-like/signal-like';
 import {List, ListItem, ListInputs} from './list';
 
 type TestItem<V> = ListItem<V> & {
-  disabled: WritableSignal<boolean>;
-  selectable: WritableSignal<boolean>;
-  searchTerm: WritableSignal<string>;
-  value: WritableSignal<V>;
+  disabled: WritableSignalLike<boolean>;
+  selectable: WritableSignalLike<boolean>;
+  searchTerm: WritableSignalLike<string>;
+  value: WritableSignalLike<V>;
 };
 
 type TestInputs<V> = ListInputs<TestItem<V>, V>;

--- a/src/aria/private/behaviors/list/list.ts
+++ b/src/aria/private/behaviors/list/list.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {computed, signal} from '@angular/core';
+import {computed, signal} from '../signal-like/signal-like';
 import {ListFocus, ListFocusInputs, ListFocusItem} from '../list-focus/list-focus';
 import {
   ListNavigation,

--- a/src/aria/private/behaviors/popup/BUILD.bazel
+++ b/src/aria/private/behaviors/popup/BUILD.bazel
@@ -21,6 +21,7 @@ ng_project(
     deps = [
         ":popup",
         "//:node_modules/@angular/core",
+        "//src/aria/private/behaviors/signal-like",
     ],
 )
 

--- a/src/aria/private/behaviors/popup/popup.spec.ts
+++ b/src/aria/private/behaviors/popup/popup.spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {signal} from '@angular/core';
+import {signal} from '../signal-like/signal-like';
 import {PopupTypes, PopupControl, PopupControlInputs} from './popup';
 
 type TestInputs = Partial<Pick<PopupControlInputs, 'expanded'>>;

--- a/src/aria/private/behaviors/signal-like/BUILD.bazel
+++ b/src/aria/private/behaviors/signal-like/BUILD.bazel
@@ -5,5 +5,7 @@ package(default_visibility = ["//visibility:public"])
 ts_project(
     name = "signal-like",
     srcs = ["signal-like.ts"],
-    deps = [],
+    deps = [
+        "//:node_modules/@angular/core",
+    ],
 )

--- a/src/aria/private/behaviors/signal-like/signal-like.ts
+++ b/src/aria/private/behaviors/signal-like/signal-like.ts
@@ -6,11 +6,24 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import {
+  createComputed,
+  createLinkedSignal,
+  createSignal,
+  linkedSignalSetFn,
+  linkedSignalUpdateFn,
+  SIGNAL,
+  untracked as primitiveUntracked,
+} from '@angular/core/primitives/signals';
+
+export {primitiveUntracked as untracked};
+
 export type SignalLike<T> = () => T;
 
 export interface WritableSignalLike<T> extends SignalLike<T> {
   set(value: T): void;
   update(updateFn: (value: T) => T): void;
+  asReadonly(): SignalLike<T>;
 }
 
 /** Converts a getter setter style signal to a WritableSignalLike. */
@@ -22,5 +35,29 @@ export function convertGetterSetterToWritableSignalLike<T>(
   return Object.assign(getter, {
     set: setter,
     update: (updateCallback: (v: T) => T) => setter(updateCallback(getter())),
+    asReadonly: () => getter,
+  });
+}
+
+export function computed<T>(computation: () => T): SignalLike<T> {
+  const computed = createComputed(computation);
+  // TODO: Remove the `toString` after https://github.com/angular/angular/pull/65948 is merged.
+  computed.toString = () => `[Computed: ${computed()}]`;
+  return computed;
+}
+
+export function signal<T>(initialValue: T): WritableSignalLike<T> {
+  const [get, set, update] = createSignal(initialValue);
+  // tslint:disable-next-line:ban Have to use `Object.assign` to preserve the getter function.
+  return Object.assign(get, {set, update, asReadonly: () => get});
+}
+
+export function linkedSignal<T>(sourceFn: () => T): WritableSignalLike<T> {
+  const getter = createLinkedSignal(sourceFn, s => s);
+  // tslint:disable-next-line:ban Have to use `Object.assign` to preserve the getter function.
+  return Object.assign(getter, {
+    set: (v: T) => linkedSignalSetFn(getter[SIGNAL], v),
+    update: (updater: (v: T) => T) => linkedSignalUpdateFn(getter[SIGNAL], updater),
+    asReadonly: () => getter,
   });
 }

--- a/src/aria/private/combobox/combobox.spec.ts
+++ b/src/aria/private/combobox/combobox.spec.ts
@@ -6,23 +6,22 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {signal, WritableSignal} from '@angular/core';
 import {ComboboxInputs, ComboboxPattern} from './combobox';
 import {OptionPattern} from '../listbox/option';
 import {ComboboxListboxPattern} from '../listbox/combobox-listbox';
 import {createKeyboardEvent} from '@angular/cdk/testing/private';
-import {SignalLike} from '../behaviors/signal-like/signal-like';
+import {SignalLike, signal, WritableSignalLike} from '../behaviors/signal-like/signal-like';
 import {ModifierKeys} from '@angular/cdk/testing';
 import {TreeItemPattern} from '../tree/tree';
 import {ComboboxTreePattern} from '../tree/combobox-tree';
 
 // Test types
 type TestOption = OptionPattern<string> & {
-  disabled: WritableSignal<boolean>;
+  disabled: WritableSignalLike<boolean>;
 };
 
 type TestInputs = {
-  readonly [K in keyof ComboboxInputs<TestOption, string>]: WritableSignal<
+  readonly [K in keyof ComboboxInputs<TestOption, string>]: WritableSignalLike<
     ComboboxInputs<TestOption, string>[K] extends SignalLike<infer T> ? T : never
   >;
 };
@@ -65,7 +64,7 @@ function _type(
   combobox: ComboboxPattern<any, string>,
   allOptions: TestOption[] | TreeItemPattern<string>[],
   popup: ComboboxListboxPattern<string> | ComboboxTreePattern<string>,
-  firstMatch: WritableSignal<string | undefined>,
+  firstMatch: WritableSignalLike<string | undefined>,
   backspace = false,
 ) {
   combobox.onFocusIn();
@@ -77,9 +76,9 @@ function _type(
   );
   const options = allOptions.filter(o => o.searchTerm().startsWith(text));
   if (popup instanceof ComboboxListboxPattern) {
-    (popup.inputs.items as WritableSignal<any[]>).set(options);
+    (popup.inputs.items as WritableSignalLike<any[]>).set(options);
   } else if (popup instanceof ComboboxTreePattern) {
-    (popup.inputs.allItems as WritableSignal<any[]>).set(options);
+    (popup.inputs.allItems as WritableSignalLike<any[]>).set(options);
   }
   firstMatch.set(options[0]?.value());
   combobox.onFilter();
@@ -87,7 +86,7 @@ function _type(
 
 function getComboboxPattern(
   inputs: Partial<{
-    [K in keyof TestInputs]: TestInputs[K] extends WritableSignal<infer T> ? T : never;
+    [K in keyof TestInputs]: TestInputs[K] extends WritableSignalLike<infer T> ? T : never;
   }> = {},
 ) {
   const containerEl = signal(document.createElement('div'));
@@ -205,13 +204,13 @@ function getTreePattern(
         children: signal([]),
       });
 
-      (tree.inputs.allItems as WritableSignal<TreeItemPattern<string>[]>).update(items =>
+      (tree.inputs.allItems as WritableSignalLike<TreeItemPattern<string>[]>).update(items =>
         items.concat(treeItem),
       );
 
       if (node.children) {
         const children = createTreeItems(node.children, treeItem);
-        (treeItem.inputs.children as WritableSignal<TreeItemPattern<string>[]>).set(children);
+        (treeItem.inputs.children as WritableSignalLike<TreeItemPattern<string>[]>).set(children);
       }
 
       return treeItem;
@@ -225,7 +224,7 @@ function getTreePattern(
 describe('Combobox with Listbox Pattern', () => {
   function getPatterns(
     inputs: Partial<{
-      [K in keyof TestInputs]: TestInputs[K] extends WritableSignal<infer T> ? T : never;
+      [K in keyof TestInputs]: TestInputs[K] extends WritableSignalLike<infer T> ? T : never;
     }> = {},
   ) {
     const {combobox, inputEl, containerEl, firstMatch, inputValue} = getComboboxPattern(inputs);
@@ -241,7 +240,7 @@ describe('Combobox with Listbox Pattern', () => {
       'Cranberry',
     ]);
 
-    (combobox.inputs.popupControls as WritableSignal<any>).set(listbox);
+    (combobox.inputs.popupControls as WritableSignalLike<any>).set(listbox);
 
     return {
       combobox,
@@ -371,7 +370,7 @@ describe('Combobox with Listbox Pattern', () => {
     let listbox: ComboboxListboxPattern<string>;
     let inputEl: HTMLInputElement;
     let options: () => TestOption[];
-    let firstMatch: WritableSignal<string | undefined>;
+    let firstMatch: WritableSignalLike<string | undefined>;
 
     function type(text: string, opts: {backspace?: boolean} = {}) {
       _type(text, inputEl, combobox, options(), listbox, firstMatch, opts.backspace);
@@ -620,7 +619,7 @@ describe('Combobox with Listbox Pattern', () => {
     describe('with multi-select', () => {
       it('should allow users to select multiple options', () => {
         const {combobox, listbox, inputEl} = getPatterns({readonly: true});
-        (listbox.inputs.multi as WritableSignal<boolean>).set(true);
+        (listbox.inputs.multi as WritableSignalLike<boolean>).set(true);
 
         combobox.onClick(clickOption(listbox.inputs.items(), 1));
         combobox.onClick(clickOption(listbox.inputs.items(), 2));
@@ -635,7 +634,7 @@ describe('Combobox with Listbox Pattern', () => {
 describe('Combobox with Tree Pattern', () => {
   function getPatterns(
     inputs: Partial<{
-      [K in keyof TestInputs]: TestInputs[K] extends WritableSignal<infer T> ? T : never;
+      [K in keyof TestInputs]: TestInputs[K] extends WritableSignalLike<infer T> ? T : never;
     }> = {},
   ) {
     const {combobox, inputEl, containerEl, firstMatch, inputValue} = getComboboxPattern(inputs);
@@ -645,7 +644,7 @@ describe('Combobox with Tree Pattern', () => {
       {value: 'Grains', children: [{value: 'Rice'}, {value: 'Wheat'}]},
     ]);
 
-    (combobox.inputs.popupControls as WritableSignal<any>).set(tree);
+    (combobox.inputs.popupControls as WritableSignalLike<any>).set(tree);
 
     return {
       combobox,
@@ -743,7 +742,7 @@ describe('Combobox with Tree Pattern', () => {
     let tree: ComboboxTreePattern<string>;
     let inputEl: HTMLInputElement;
     let items: () => TreeItemPattern<string>[];
-    let firstMatch: WritableSignal<string | undefined>;
+    let firstMatch: WritableSignalLike<string | undefined>;
 
     function type(text: string, opts: {backspace?: boolean} = {}) {
       _type(text, inputEl, combobox, items(), tree, firstMatch, opts.backspace);

--- a/src/aria/private/combobox/combobox.ts
+++ b/src/aria/private/combobox/combobox.ts
@@ -7,8 +7,12 @@
  */
 
 import {KeyboardEventManager, PointerEventManager} from '../behaviors/event-manager';
-import {computed, signal} from '@angular/core';
-import {SignalLike, WritableSignalLike} from '../behaviors/signal-like/signal-like';
+import {
+  computed,
+  signal,
+  SignalLike,
+  WritableSignalLike,
+} from '../behaviors/signal-like/signal-like';
 import {ListItem} from '../behaviors/list/list';
 
 /** Represents the required inputs for a combobox. */

--- a/src/aria/private/grid/grid.ts
+++ b/src/aria/private/grid/grid.ts
@@ -6,8 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {computed, signal, untracked} from '@angular/core';
-import {SignalLike} from '../behaviors/signal-like/signal-like';
+import {SignalLike, computed, signal, untracked} from '../behaviors/signal-like/signal-like';
 import {KeyboardEventManager, PointerEventManager, Modifier} from '../behaviors/event-manager';
 import {NavOptions, Grid, GridInputs as GridBehaviorInputs} from '../behaviors/grid';
 import type {GridRowPattern} from './row';

--- a/src/aria/private/grid/widget.ts
+++ b/src/aria/private/grid/widget.ts
@@ -6,10 +6,14 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {computed, signal, Signal, WritableSignal} from '@angular/core';
 import {KeyboardEventManager, Modifier} from '../behaviors/event-manager';
 import {ListNavigationItem} from '../behaviors/list-navigation/list-navigation';
-import {SignalLike} from '../behaviors/signal-like/signal-like';
+import {
+  SignalLike,
+  computed,
+  signal,
+  WritableSignalLike,
+} from '../behaviors/signal-like/signal-like';
 import type {GridCellPattern} from './cell';
 
 /** The inputs for the `GridCellWidgetPattern`. */
@@ -36,35 +40,35 @@ export class GridCellWidgetPattern implements ListNavigationItem {
   readonly element: SignalLike<HTMLElement> = () => this.inputs.element();
 
   /** The element that should receive focus. */
-  readonly widgetHost: Signal<HTMLElement> = computed(
+  readonly widgetHost: SignalLike<HTMLElement> = computed(
     () => this.inputs.focusTarget() ?? this.element(),
   );
 
   /** The index of the widget within the cell. */
-  readonly index: Signal<number> = computed(() =>
+  readonly index: SignalLike<number> = computed(() =>
     this.inputs.cell().inputs.widgets().indexOf(this),
   );
 
   /** Whether the widget is disabled. */
-  readonly disabled: Signal<boolean> = computed(
+  readonly disabled: SignalLike<boolean> = computed(
     () => this.inputs.disabled() || this.inputs.cell().disabled(),
   );
 
   /** The tab index for the widget. */
-  readonly tabIndex: Signal<-1 | 0> = computed(() => this.inputs.cell().widgetTabIndex());
+  readonly tabIndex: SignalLike<-1 | 0> = computed(() => this.inputs.cell().widgetTabIndex());
 
   /** Whether the widget is the active item in the widget list. */
-  readonly active: Signal<boolean> = computed(() => this.inputs.cell().activeWidget() === this);
+  readonly active: SignalLike<boolean> = computed(() => this.inputs.cell().activeWidget() === this);
 
   /** Whether the widget is currently activated. */
-  readonly isActivated: WritableSignal<boolean> = signal(false);
+  readonly isActivated: WritableSignalLike<boolean> = signal(false);
 
   /** The last event that caused the widget to be activated. */
-  readonly lastActivateEvent: WritableSignal<KeyboardEvent | FocusEvent | undefined> =
+  readonly lastActivateEvent: WritableSignalLike<KeyboardEvent | FocusEvent | undefined> =
     signal(undefined);
 
   /** The last event that caused the widget to be deactivated. */
-  readonly lastDeactivateEvent: WritableSignal<KeyboardEvent | FocusEvent | undefined> =
+  readonly lastDeactivateEvent: WritableSignalLike<KeyboardEvent | FocusEvent | undefined> =
     signal(undefined);
 
   /** The keyboard event manager for the widget. */

--- a/src/aria/private/listbox/BUILD.bazel
+++ b/src/aria/private/listbox/BUILD.bazel
@@ -24,6 +24,7 @@ ng_project(
     deps = [
         ":listbox",
         "//:node_modules/@angular/core",
+        "//src/aria/private/behaviors/signal-like",
         "//src/cdk/keycodes",
         "//src/cdk/testing/private",
     ],

--- a/src/aria/private/listbox/combobox-listbox.ts
+++ b/src/aria/private/listbox/combobox-listbox.ts
@@ -6,9 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {computed} from '@angular/core';
 import {ListboxInputs, ListboxPattern} from './listbox';
-import {SignalLike} from '../behaviors/signal-like/signal-like';
+import {SignalLike, computed} from '../behaviors/signal-like/signal-like';
 import {OptionPattern} from './option';
 import {ComboboxPattern, ComboboxListboxControls} from '../combobox/combobox';
 

--- a/src/aria/private/listbox/listbox.spec.ts
+++ b/src/aria/private/listbox/listbox.spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {signal, WritableSignal} from '@angular/core';
+import {signal, WritableSignalLike} from '../behaviors/signal-like/signal-like';
 import {ListboxInputs, ListboxPattern} from './listbox';
 import {OptionPattern} from './option';
 import {createKeyboardEvent} from '@angular/cdk/testing/private';
@@ -14,7 +14,7 @@ import {ModifierKeys} from '@angular/cdk/testing';
 
 type TestInputs = ListboxInputs<string>;
 type TestOption = OptionPattern<string> & {
-  disabled: WritableSignal<boolean>;
+  disabled: WritableSignalLike<boolean>;
 };
 type TestListbox = ListboxPattern<string>;
 
@@ -245,7 +245,7 @@ describe('Listbox Pattern', () => {
       });
 
       it('should not be able to change selection when in readonly mode', () => {
-        const readonly = listbox.inputs.readonly as WritableSignal<boolean>;
+        const readonly = listbox.inputs.readonly as WritableSignalLike<boolean>;
         readonly.set(true);
         listbox.onKeydown(space());
         expect(listbox.inputs.values()).toEqual([]);
@@ -362,7 +362,7 @@ describe('Listbox Pattern', () => {
       });
 
       it('should not be able to change selection when in readonly mode', () => {
-        const readonly = listbox.inputs.readonly as WritableSignal<boolean>;
+        const readonly = listbox.inputs.readonly as WritableSignalLike<boolean>;
         readonly.set(true);
         listbox.onKeydown(space());
         expect(listbox.inputs.values()).toEqual([]);
@@ -386,7 +386,7 @@ describe('Listbox Pattern', () => {
       });
 
       it('should not change the selected state of disabled options on Shift + ArrowUp / ArrowDown', () => {
-        (listbox.inputs.softDisabled as WritableSignal<boolean>).set(true);
+        (listbox.inputs.softDisabled as WritableSignalLike<boolean>).set(true);
         options[1].disabled.set(true);
         listbox.onKeydown(shift());
         listbox.onKeydown(down({shift: true}));
@@ -541,7 +541,7 @@ describe('Listbox Pattern', () => {
       });
 
       it('should not be able to change selection when in readonly mode', () => {
-        const readonly = listbox.inputs.readonly as WritableSignal<boolean>;
+        const readonly = listbox.inputs.readonly as WritableSignalLike<boolean>;
         readonly.set(true);
         listbox.onKeydown(down());
         expect(listbox.inputs.values()).toEqual(['Apple']);
@@ -555,7 +555,7 @@ describe('Listbox Pattern', () => {
 
       it('should not select disabled options', () => {
         options[2].disabled.set(true);
-        (listbox.inputs.softDisabled as WritableSignal<boolean>).set(true);
+        (listbox.inputs.softDisabled as WritableSignalLike<boolean>).set(true);
         expect(listbox.inputs.values()).toEqual(['Apple']);
         listbox.onKeydown(down());
         expect(listbox.inputs.values()).toEqual(['Apricot']);

--- a/src/aria/private/listbox/listbox.ts
+++ b/src/aria/private/listbox/listbox.ts
@@ -8,8 +8,7 @@
 
 import {OptionPattern} from './option';
 import {KeyboardEventManager, PointerEventManager, Modifier} from '../behaviors/event-manager';
-import {computed, signal} from '@angular/core';
-import {SignalLike} from '../behaviors/signal-like/signal-like';
+import {computed, signal, SignalLike} from '../behaviors/signal-like/signal-like';
 import {List, ListInputs} from '../behaviors/list/list';
 
 /** Represents the required inputs for a listbox. */

--- a/src/aria/private/menu/menu.spec.ts
+++ b/src/aria/private/menu/menu.spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {signal, WritableSignal} from '@angular/core';
+import {signal, WritableSignalLike} from '../behaviors/signal-like/signal-like';
 import {MenuPattern, MenuBarPattern, MenuItemPattern, MenuTriggerPattern} from './menu';
 import {createKeyboardEvent} from '@angular/cdk/testing/private';
 import {ModifierKeys} from '@angular/cdk/testing';
@@ -14,7 +14,7 @@ import {ModifierKeys} from '@angular/cdk/testing';
 // Test types
 type TestMenuItem = MenuItemPattern<string> & {
   inputs: {
-    disabled: WritableSignal<boolean>;
+    disabled: WritableSignalLike<boolean>;
   };
 };
 
@@ -130,10 +130,10 @@ function getMenuPattern(
   );
 
   if (parent instanceof MenuTriggerPattern) {
-    (parent.menu as WritableSignal<MenuPattern<string>>).set(menu);
+    (parent.menu as WritableSignalLike<MenuPattern<string>>).set(menu);
     parent.inputs.element()?.appendChild(menu.inputs.element()!);
   } else if (parent instanceof MenuItemPattern) {
-    (parent.submenu as WritableSignal<MenuPattern<string>>).set(menu);
+    (parent.submenu as WritableSignalLike<MenuPattern<string>>).set(menu);
     parent.inputs.element()?.appendChild(menu.inputs.element()!);
   }
 

--- a/src/aria/private/menu/menu.ts
+++ b/src/aria/private/menu/menu.ts
@@ -6,9 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {computed, Signal, signal} from '@angular/core';
 import {KeyboardEventManager} from '../behaviors/event-manager';
-import {SignalLike} from '../behaviors/signal-like/signal-like';
+import {computed, signal, SignalLike} from '../behaviors/signal-like/signal-like';
 import {List, ListInputs, ListItem} from '../behaviors/list/list';
 
 /** The inputs for the MenuBarPattern class. */
@@ -135,8 +134,8 @@ export class MenuPattern<V> {
   typeaheadRegexp = /^.$/;
 
   /** The root of the menu. */
-  root: Signal<MenuTriggerPattern<V> | MenuBarPattern<V> | MenuPattern<V> | undefined> = computed(
-    () => {
+  root: SignalLike<MenuTriggerPattern<V> | MenuBarPattern<V> | MenuPattern<V> | undefined> =
+    computed(() => {
       const parent = this.inputs.parent();
 
       if (!parent) {
@@ -154,8 +153,7 @@ export class MenuPattern<V> {
       }
 
       return grandparent?.root();
-    },
-  );
+    });
 
   /** Handles keyboard events for the menu. */
   keydownManager = computed(() => {

--- a/src/aria/private/tabs/tabs.spec.ts
+++ b/src/aria/private/tabs/tabs.spec.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {signal} from '@angular/core';
 import {
   TabInputs,
   TabPattern,
@@ -15,7 +14,7 @@ import {
   TabPanelInputs,
   TabPanelPattern,
 } from './tabs';
-import {SignalLike, WritableSignalLike} from '../behaviors/signal-like/signal-like';
+import {signal, SignalLike, WritableSignalLike} from '../behaviors/signal-like/signal-like';
 import {createKeyboardEvent} from '@angular/cdk/testing/private';
 import {ModifierKeys} from '@angular/cdk/testing';
 

--- a/src/aria/private/tabs/tabs.ts
+++ b/src/aria/private/tabs/tabs.ts
@@ -6,10 +6,14 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {computed, signal, WritableSignal} from '@angular/core';
 import {KeyboardEventManager, PointerEventManager} from '../behaviors/event-manager';
 import {ExpansionItem, ListExpansionInputs, ListExpansion} from '../behaviors/expansion/expansion';
-import {SignalLike, WritableSignalLike} from '../behaviors/signal-like/signal-like';
+import {
+  SignalLike,
+  computed,
+  signal,
+  WritableSignalLike,
+} from '../behaviors/signal-like/signal-like';
 import {LabelControl, LabelControlOptionalInputs} from '../behaviors/label/label';
 import {ListFocus} from '../behaviors/list-focus/list-focus';
 import {
@@ -144,7 +148,7 @@ export class TabListPattern {
   readonly activeTab: SignalLike<TabPattern | undefined> = () => this.inputs.activeItem();
 
   /** The currently selected tab. */
-  readonly selectedTab: WritableSignal<TabPattern | undefined> = signal(undefined);
+  readonly selectedTab: WritableSignalLike<TabPattern | undefined> = signal(undefined);
 
   /** Whether the tablist is vertically or horizontally oriented. */
   readonly orientation: SignalLike<'vertical' | 'horizontal'> = () => this.inputs.orientation();

--- a/src/aria/private/toolbar/toolbar-widget.ts
+++ b/src/aria/private/toolbar/toolbar-widget.ts
@@ -6,8 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {computed} from '@angular/core';
-import {SignalLike} from '../behaviors/signal-like/signal-like';
+import {SignalLike, computed} from '../behaviors/signal-like/signal-like';
 import {ListItem} from '../behaviors/list/list';
 import type {ToolbarPattern} from './toolbar';
 import {ToolbarWidgetGroupPattern} from './toolbar-widget-group';

--- a/src/aria/private/toolbar/toolbar.spec.ts
+++ b/src/aria/private/toolbar/toolbar.spec.ts
@@ -6,28 +6,32 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {computed, signal, WritableSignal} from '@angular/core';
 import {ToolbarInputs, ToolbarPattern} from './toolbar';
 import {ToolbarWidgetPattern} from './toolbar-widget';
 import {ToolbarWidgetGroupPattern} from './toolbar-widget-group';
 import {createKeyboardEvent} from '@angular/cdk/testing/private';
-import {SignalLike} from '../behaviors/signal-like/signal-like';
+import {
+  SignalLike,
+  computed,
+  signal,
+  WritableSignalLike,
+} from '../behaviors/signal-like/signal-like';
 import {ModifierKeys} from '@angular/cdk/testing';
 
 // Test types
 type TestWidget = ToolbarWidgetPattern<string> & {
-  inputs: {disabled: WritableSignal<boolean>};
+  inputs: {disabled: WritableSignalLike<boolean>};
 };
 
 type TestWidgetGroup = ToolbarWidgetGroupPattern<ToolbarWidgetPattern<string>, string> & {
-  disabled: WritableSignal<boolean>;
-  items: WritableSignal<TestWidget[]>;
+  disabled: WritableSignalLike<boolean>;
+  items: WritableSignalLike<TestWidget[]>;
 };
 
 type TestItem = TestWidget;
 
 type TestInputs = {
-  readonly [K in keyof ToolbarInputs<string>]: WritableSignal<
+  readonly [K in keyof ToolbarInputs<string>]: WritableSignalLike<
     ToolbarInputs<string>[K] extends SignalLike<infer T> ? T : never
   >;
 };
@@ -52,9 +56,9 @@ function clickItem(item: ToolbarWidgetPattern<string>, mods?: ModifierKeys) {
 
 function getToolbarPattern(
   inputs: Partial<{
-    [K in keyof TestInputs]: TestInputs[K] extends WritableSignal<infer T> ? T : never;
+    [K in keyof TestInputs]: TestInputs[K] extends WritableSignalLike<infer T> ? T : never;
   }>,
-  items: WritableSignal<TestItem[]>,
+  items: WritableSignalLike<TestItem[]>,
 ) {
   const element = signal(document.createElement('div'));
   const activeItem = signal<TestItem | undefined>(undefined);
@@ -122,7 +126,7 @@ function getWidgetGroupPattern(id: string, toolbar: ToolbarPattern<string>): Tes
 
 function getPatterns(
   inputs: Partial<{
-    [K in keyof TestInputs]: TestInputs[K] extends WritableSignal<infer T> ? T : never;
+    [K in keyof TestInputs]: TestInputs[K] extends WritableSignalLike<infer T> ? T : never;
   }> = {},
 ) {
   const items = signal<TestItem[]>([]);
@@ -146,8 +150,8 @@ function getPatterns(
   // [                [        group 0       ]          [       group 1        ]]
   // [item 0, item 1, [item 2, item 3, item 4], item 5, [item 6, item 7, item 8]]
 
-  (group0.inputs.items as WritableSignal<any>).set(items().slice(2, 5) as TestWidget[]);
-  (group1.inputs.items as WritableSignal<any>).set(items().slice(6, 9) as TestWidget[]);
+  (group0.inputs.items as WritableSignalLike<any>).set(items().slice(2, 5) as TestWidget[]);
+  (group1.inputs.items as WritableSignalLike<any>).set(items().slice(6, 9) as TestWidget[]);
 
   toolbar.setDefaultState();
   return {toolbar, items: items(), group0, group1};

--- a/src/aria/private/toolbar/toolbar.ts
+++ b/src/aria/private/toolbar/toolbar.ts
@@ -6,8 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {computed} from '@angular/core';
-import {SignalLike} from '../behaviors/signal-like/signal-like';
+import {computed, SignalLike} from '../behaviors/signal-like/signal-like';
 import {KeyboardEventManager} from '../behaviors/event-manager';
 import {List, ListInputs} from '../behaviors/list/list';
 import {ToolbarWidgetPattern} from './toolbar-widget';

--- a/src/aria/private/tree/combobox-tree.ts
+++ b/src/aria/private/tree/combobox-tree.ts
@@ -6,9 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {computed} from '@angular/core';
 import {TreeInputs, TreePattern, TreeItemPattern} from './tree';
-import {SignalLike} from '../behaviors/signal-like/signal-like';
+import {computed, SignalLike} from '../behaviors/signal-like/signal-like';
 import {ComboboxPattern, ComboboxTreeControls} from '../combobox/combobox';
 
 export type ComboboxTreeInputs<V> = TreeInputs<V> & {

--- a/src/aria/private/tree/tree.spec.ts
+++ b/src/aria/private/tree/tree.spec.ts
@@ -6,16 +6,15 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {WritableSignal, signal} from '@angular/core';
 import {TreeInputs, TreeItemInputs, TreeItemPattern, TreePattern} from './tree';
 import {createKeyboardEvent} from '@angular/cdk/testing/private';
 import {ModifierKeys} from '@angular/cdk/testing';
-import {SignalLike} from '../behaviors/signal-like/signal-like';
+import {WritableSignalLike, signal, SignalLike} from '../behaviors/signal-like/signal-like';
 
 // Converts the SignalLike type to WritableSignal type for controlling test inputs.
 type WritableSignalOverrides<O> = {
   [K in keyof O as O[K] extends SignalLike<any> ? K : never]: O[K] extends SignalLike<infer T>
-    ? WritableSignal<T>
+    ? WritableSignalLike<T>
     : never;
 };
 

--- a/src/aria/private/tree/tree.ts
+++ b/src/aria/private/tree/tree.ts
@@ -6,8 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {computed} from '@angular/core';
-import {SignalLike, WritableSignalLike} from '../behaviors/signal-like/signal-like';
+import {SignalLike, computed, WritableSignalLike} from '../behaviors/signal-like/signal-like';
 import {List, ListInputs, ListItem} from '../behaviors/list/list';
 import {ExpansionItem, ListExpansion} from '../behaviors/expansion/expansion';
 import {KeyboardEventManager, PointerEventManager, Modifier} from '../behaviors/event-manager';

--- a/src/aria/private/ui-pattern-rules.md
+++ b/src/aria/private/ui-pattern-rules.md
@@ -31,8 +31,8 @@ All .ts files should begin with an @license comment.
 ### Imports
 
 - Imports should be at the top of the file and kept in alphabetical order.
-- The only allowed external APIs are `signal`, and `computed` from `@angular/core`.
 - All other dependencies must come from inside of the ui-patterns folder.
+- Signal primitives, like `signal` and `computed`,  must be imported from `signal-like.ts`
 
 ### Type Definition
 


### PR DESCRIPTION
Changes the internal behavior implementation to use the signal primitives instead of Angular's Signal implementation