### PR TITLE
refactor(multiple): avoid rxjs interop

### DIFF
--- a/src/aria/combobox/combobox.ts
+++ b/src/aria/combobox/combobox.ts
@@ -19,9 +19,8 @@ import {
 } from '@angular/core';
 import {DeferredContentAware, ComboboxPattern} from '../private';
 import {Directionality} from '@angular/cdk/bidi';
-import {toSignal} from '@angular/core/rxjs-interop';
-import {ComboboxPopup} from './combobox-popup';
 import {COMBOBOX} from './combobox-tokens';
+import {ComboboxPopup} from './combobox-popup';
 
 /**
  * The container element that wraps a combobox input and popup, and orchestrates its behavior.
@@ -78,13 +77,8 @@ import {COMBOBOX} from './combobox-tokens';
   providers: [{provide: COMBOBOX, useExisting: Combobox}],
 })
 export class Combobox<V> {
-  /** The directionality (LTR / RTL) context for the application (or a subtree of it). */
-  private readonly _directionality = inject(Directionality);
-
   /** A signal wrapper for directionality. */
-  protected textDirection = toSignal(this._directionality.change, {
-    initialValue: this._directionality.value,
-  });
+  protected textDirection = inject(Directionality).valueSignal.asReadonly();
 
   /** The element that the combobox is attached to. */
   private readonly _elementRef = inject(ElementRef);

--- a/src/aria/listbox/listbox.ts
+++ b/src/aria/listbox/listbox.ts
@@ -20,7 +20,6 @@ import {
   untracked,
 } from '@angular/core';
 import {Directionality} from '@angular/cdk/bidi';
-import {toSignal} from '@angular/core/rxjs-interop';
 import {_IdGenerator} from '@angular/cdk/a11y';
 import {ComboboxListboxPattern, ListboxPattern} from '../private';
 import {ComboboxPopup} from '../combobox';
@@ -85,16 +84,11 @@ export class Listbox<V> {
   /** A reference to the host element. */
   readonly element = this._elementRef.nativeElement as HTMLElement;
 
-  /** The directionality (LTR / RTL) context for the application (or a subtree of it). */
-  private readonly _directionality = inject(Directionality);
-
   /** The Options nested inside of the Listbox. */
   private readonly _options = contentChildren(Option, {descendants: true});
 
   /** A signal wrapper for directionality. */
-  protected textDirection = toSignal(this._directionality.change, {
-    initialValue: this._directionality.value,
-  });
+  protected textDirection = inject(Directionality).valueSignal.asReadonly();
 
   /** The Option UIPatterns of the child Options. */
   protected items = computed(() => this._options().map(option => option._pattern));


### PR DESCRIPTION
We don't need to use the rxjs interop in Aria since the `Directionality` has a signal version of the `value`.