### PR TITLE
fix(cdk/testing): Skip task tracking if zone patches aren't present

### DIFF
--- a/src/cdk/testing/testbed/task-state-zone-interceptor.ts
+++ b/src/cdk/testing/testbed/task-state-zone-interceptor.ts
@@ -56,6 +56,13 @@ export class TaskStateZoneInterceptor {
     return {stable: !state.macroTask && !state.microTask};
   }
 
+  static isInProxyZone(): boolean {
+    if (typeof Zone === 'undefined') {
+      return false;
+    }
+    return ((Zone as any)['ProxyZoneSpec'] as ProxyZoneStatic | undefined)?.get() !== undefined;
+  }
+
   /**
    * Sets up the custom task state Zone interceptor in the  `ProxyZone`. Throws if
    * no `ProxyZone` could be found.

--- a/src/cdk/testing/testbed/testbed-harness-environment.ts
+++ b/src/cdk/testing/testbed/testbed-harness-environment.ts
@@ -106,7 +106,7 @@ export class TestbedHarnessEnvironment extends HarnessEnvironment<Element> {
   ) {
     super(rawRootElement);
     this._options = {...defaultEnvironmentOptions, ...options};
-    if (typeof Zone !== 'undefined') {
+    if (TaskStateZoneInterceptor.isInProxyZone()) {
       this._taskState = TaskStateZoneInterceptor.setup();
     }
     this._stabilizeCallback = () => this.forceStabilize();
@@ -178,6 +178,9 @@ export class TestbedHarnessEnvironment extends HarnessEnvironment<Element> {
   /**
    * Waits for all scheduled or running async tasks to complete. This allows harness
    * authors to wait for async tasks outside of the Angular zone.
+   *
+   * This only works when Zone.js is present _and_ patches are applied to the test framework
+   * by `zone.js/testing` (Jasmine and Jest only) or another script.
    */
   async waitForTasksOutsideAngular(): Promise<void> {
     // If we run in the fake async zone, we run "flush" to run any scheduled tasks. This


### PR DESCRIPTION
This commit omits the initialization of the `taskState` when the constructor executes outside the proxy zone. This would generally indicate that either `zone.js/dist/zone-testing.js` was not included _or_ it does not include patches for the test framework being used (e.g. Vitest). In this case, we should simply omit the initialization of task state tracking, meaning that `waitForTasksOutsideAngular` will "not work" and simply be a `Promise.resolve`.

fixes https://github.com/angular/components/issues/32542