### PR TITLE
build(aria): setup infrastructure for code examples

### DIFF
--- a/src/aria/BUILD.bazel
+++ b/src/aria/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@aspect_bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//src/aria:config.bzl", "ARIA_TARGETS")
-load("//tools:defaults.bzl", "ng_package", "ts_project")
+load("//tools:defaults.bzl", "ng_examples_db", "ng_package", "ts_project")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -16,10 +16,26 @@ ts_project(
     deps = ["//:node_modules/@angular/core"],
 )
 
+ng_examples_db(
+    name = "aria_example_database",
+    srcs = glob(
+        include = [
+            "examples/**/*.md",
+        ],
+        # TODO: Remove this once examples are created. It should never be empty at that point.
+        allow_empty = True,
+    ),
+    out = "resources/code-examples.db",
+    path = "src/aria/examples",
+)
+
 ng_package(
     name = "npm_package",
     package_name = "@angular/aria",
-    srcs = ["package.json"],
+    srcs = [
+        "package.json",
+        "resources/code-examples.db",
+    ],
     nested_packages = select({
         "//:snapshot_adev_assets": [":adev_assets"],
         "//conditions:default": [],

--- a/src/aria/package.json
+++ b/src/aria/package.json
@@ -21,6 +21,12 @@
   "dependencies": {
     "tslib": "^2.3.0"
   },
+  "angular": {
+    "examples": {
+      "format": "sqlite",
+      "path": "./resources/code-examples.db"
+    }
+  },
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   },

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -5,6 +5,7 @@ load("@aspect_rules_js//npm:defs.bzl", _npm_package = "npm_package")
 load("@devinfra//bazel/http-server:index.bzl", _http_server = "http_server")
 load("@devinfra//bazel/spec-bundling:index.bzl", _spec_bundle = "spec_bundle")
 load("@devinfra//bazel/ts_project:index.bzl", "strict_deps_test")
+load("@rules_angular//src/ng_examples_db:index.bzl", _ng_examples_db = "ng_examples_db")
 load("@rules_angular//src/ng_package:index.bzl", _ng_package = "ng_package")
 load("@rules_angular//src/ng_package/text_replace:index.bzl", _text_replace = "text_replace")
 load("@rules_angular//src/ng_project:index.bzl", _ng_project = "ng_project")
@@ -26,6 +27,7 @@ extract_tokens = _extract_tokens
 ng_web_test_suite = _ng_web_test_suite
 spec_bundle = _spec_bundle
 http_server = _http_server
+ng_examples_db = _ng_examples_db
 
 def sass_binary(sourcemap = False, include_paths = [], **kwargs):
     _sass_binary(


### PR DESCRIPTION
This commit introduces the infrastructure for embedding code examples within Angular packages, enabling them to be consumed by the Angular CLI's MCP server.

The `@angular/aria` package is the first to adopt this new feature. A new `ng_examples_db` Bazel rule is used to build a SQLite database from markdown files containing code examples. This database is then included in the published npm package.

The `package.json` for `@angular/aria` has been updated with an `angular.examples` field to allow tooling to discover and use the code examples.