### PR TITLE
build: update repository to use node 22.21.1 in bazel

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -56,7 +56,7 @@ rules_ts_ext.deps(
 use_repo(rules_ts_ext, **{"npm_typescript": "components_npm_typescript"})
 
 node = use_extension("@rules_nodejs//nodejs:extensions.bzl", "node")
-node.toolchain(node_version = "22.12.0")
+node.toolchain(node_version = "22.21.1")
 use_repo(node, "nodejs_toolchains")
 
 pnpm = use_extension("@aspect_rules_js//npm:extensions.bzl", "pnpm")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1082,7 +1082,7 @@
     "@@rules_nodejs+//nodejs:extensions.bzl%node": {
       "general": {
         "bzlTransitiveDigest": "NwcLXHrbh2hoorA/Ybmcpjxsn/6avQmewDglodkDrgo=",
-        "usagesDigest": "4EFhtm5twnSpJMz+Rq0fm1mZHX4kbpwtqhRGWppSY1A=",
+        "usagesDigest": "4jLY+BAguyvY29nKxwYLVsSmokO7X7k0X0T7mSe5FEM=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -1095,7 +1095,7 @@
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "22.12.0",
+              "node_version": "22.21.1",
               "include_headers": false,
               "platform": "linux_amd64"
             }
@@ -1108,7 +1108,7 @@
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "22.12.0",
+              "node_version": "22.21.1",
               "include_headers": false,
               "platform": "linux_arm64"
             }
@@ -1121,7 +1121,7 @@
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "22.12.0",
+              "node_version": "22.21.1",
               "include_headers": false,
               "platform": "linux_s390x"
             }
@@ -1134,7 +1134,7 @@
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "22.12.0",
+              "node_version": "22.21.1",
               "include_headers": false,
               "platform": "linux_ppc64le"
             }
@@ -1147,7 +1147,7 @@
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "22.12.0",
+              "node_version": "22.21.1",
               "include_headers": false,
               "platform": "darwin_amd64"
             }
@@ -1160,7 +1160,7 @@
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "22.12.0",
+              "node_version": "22.21.1",
               "include_headers": false,
               "platform": "darwin_arm64"
             }
@@ -1173,7 +1173,7 @@
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "22.12.0",
+              "node_version": "22.21.1",
               "include_headers": false,
               "platform": "windows_amd64"
             }
@@ -1186,7 +1186,7 @@
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "22.12.0",
+              "node_version": "22.21.1",
               "include_headers": false,
               "platform": "windows_arm64"
             }


### PR DESCRIPTION
The repository was updated to use node 22.21.1 via nvm, but bazel had not been updated to match