### PR TITLE
fix(multiple): type issues when importing Aria directives

### DIFF
--- a/src/aria/accordion/public-api.ts
+++ b/src/aria/accordion/public-api.ts
@@ -13,4 +13,7 @@ export {AccordionContent} from './accordion-content';
 
 // This needs to be re-exported, because it's used by the accordion components.
 // See: https://github.com/angular/components/issues/30663.
-export {DeferredContent as ɵɵDeferredContent} from '../private';
+export {
+  DeferredContent as ɵɵDeferredContent,
+  DeferredContentAware as ɵɵDeferredContentAware,
+} from '../private';

--- a/src/aria/combobox/public-api.ts
+++ b/src/aria/combobox/public-api.ts
@@ -14,4 +14,7 @@ export {ComboboxPopupContainer} from './combobox-popup-container';
 
 // This needs to be re-exported, because it's used by the combobox components.
 // See: https://github.com/angular/components/issues/30663.
-export {DeferredContent as ɵɵDeferredContent} from '../private';
+export {
+  DeferredContent as ɵɵDeferredContent,
+  DeferredContentAware as ɵɵDeferredContentAware,
+} from '../private';

--- a/src/aria/listbox/public-api.ts
+++ b/src/aria/listbox/public-api.ts
@@ -8,3 +8,13 @@
 
 export {Listbox} from './listbox';
 export {Option} from './option';
+
+// This needs to be re-exported, because it's used by the listbox components.
+// See: https://github.com/angular/components/issues/30663.
+export {
+  Combobox as ɵɵCombobox,
+  ComboboxDialog as ɵɵComboboxDialog,
+  ComboboxInput as ɵɵComboboxInput,
+  ComboboxPopup as ɵɵComboboxPopup,
+  ComboboxPopupContainer as ɵɵComboboxPopupContainer,
+} from '../combobox';

--- a/src/aria/menu/public-api.ts
+++ b/src/aria/menu/public-api.ts
@@ -14,4 +14,7 @@ export {MenuContent} from './menu-content';
 
 // This needs to be re-exported, because it's used by the menu components.
 // See: https://github.com/angular/components/issues/30663.
-export {DeferredContent as ɵɵDeferredContent} from '../private';
+export {
+  DeferredContent as ɵɵDeferredContent,
+  DeferredContentAware as ɵɵDeferredContentAware,
+} from '../private';

--- a/src/aria/tabs/public-api.ts
+++ b/src/aria/tabs/public-api.ts
@@ -14,4 +14,7 @@ export {TabContent} from './tab-content';
 
 // This needs to be re-exported, because it's used by the tab components.
 // See: https://github.com/angular/components/issues/30663.
-export {DeferredContent as ɵɵDeferredContent} from '../private';
+export {
+  DeferredContent as ɵɵDeferredContent,
+  DeferredContentAware as ɵɵDeferredContentAware,
+} from '../private';

--- a/src/aria/tree/public-api.ts
+++ b/src/aria/tree/public-api.ts
@@ -13,3 +13,10 @@ export {TreeItemGroup} from './tree-item-group';
 // This needs to be re-exported, because it's used by the tree components.
 // See: https://github.com/angular/components/issues/30663.
 export {DeferredContent as ɵɵDeferredContent} from '../private';
+export {
+  Combobox as ɵɵCombobox,
+  ComboboxDialog as ɵɵComboboxDialog,
+  ComboboxInput as ɵɵComboboxInput,
+  ComboboxPopup as ɵɵComboboxPopup,
+  ComboboxPopupContainer as ɵɵComboboxPopupContainer,
+} from '../combobox';


### PR DESCRIPTION
Similar fix to #32522 that aims to capture the remaining host directives.

Related to https://github.com/angular/angular/issues/66069.