### PR TITLE
build: enable strict property initialization for entire repo

### DIFF
--- a/docs/src/assets/stackblitz/tsconfig.json
+++ b/docs/src/assets/stackblitz/tsconfig.json
@@ -19,6 +19,7 @@
     "noUnusedLocals": false,
     "useDefineForClassFields": false,
     "strictNullChecks": true,
+    "strictPropertyInitialization": true,
     "noImplicitReturns": true,
     "strictFunctionTypes": true,
     "noImplicitOverride": true,

--- a/src/aria/tree/tree-item.ts
+++ b/src/aria/tree/tree-item.ts
@@ -119,7 +119,7 @@ export class TreeItem<V> extends DeferredContentAware implements OnInit, OnDestr
   );
 
   /** The UI pattern for this item. */
-  _pattern: TreeItemPattern<V>;
+  _pattern!: TreeItemPattern<V>;
 
   constructor() {
     super();

--- a/src/bazel-tsconfig-build.json
+++ b/src/bazel-tsconfig-build.json
@@ -11,6 +11,7 @@
     "noUnusedParameters": false,
     "noUnusedLocals": false,
     "strictNullChecks": true,
+    "strictPropertyInitialization": true,
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
     "strictFunctionTypes": true,

--- a/src/cdk-experimental/tsconfig.json
+++ b/src/cdk-experimental/tsconfig.json
@@ -4,7 +4,6 @@
   "compilerOptions": {
     "rootDir": "..",
     "baseUrl": ".",
-    "strictPropertyInitialization": true,
     "paths": {
       "@angular/cdk/*": ["../cdk/*"],
       "@angular/cdk-experimental/*": ["../cdk-experimental/*"]

--- a/src/cdk/a11y/focus-trap/configurable-focus-trap.spec.ts
+++ b/src/cdk/a11y/focus-trap/configurable-focus-trap.spec.ts
@@ -119,7 +119,7 @@ class SimpleFocusTrap implements AfterViewInit {
 
   @ViewChild('focusTrapElement') focusTrapElement!: ElementRef;
 
-  focusTrap: ConfigurableFocusTrap;
+  focusTrap!: ConfigurableFocusTrap;
 
   ngAfterViewInit() {
     this.focusTrap = this._focusTrapFactory.create(this.focusTrapElement.nativeElement);

--- a/src/cdk/a11y/focus-trap/event-listener-inert-strategy.spec.ts
+++ b/src/cdk/a11y/focus-trap/event-listener-inert-strategy.spec.ts
@@ -90,11 +90,11 @@ class SimpleFocusTrap implements AfterViewInit {
   @ViewChild('firstFocusable') firstFocusableElement!: ElementRef<HTMLElement>;
   @ViewChild('secondFocusable') secondFocusableElement!: ElementRef<HTMLElement>;
 
-  focusTrap: ConfigurableFocusTrap;
+  focusTrap!: ConfigurableFocusTrap;
 
   // Since our custom stubbing in `patchElementFocus` won't update
   // the `document.activeElement`, we need to keep track of it here.
-  activeElement: Element | null;
+  activeElement: Element | null = null;
 
   ngAfterViewInit() {
     // Ensure consistent focus timing across browsers.

--- a/src/cdk/a11y/live-announcer/live-announcer.spec.ts
+++ b/src/cdk/a11y/live-announcer/live-announcer.spec.ts
@@ -421,5 +421,5 @@ class TestModal {
 class DivWithCdkAriaLive {
   politeness: AriaLivePoliteness = 'polite';
   content = 'Initial content';
-  duration: number;
+  duration!: number;
 }

--- a/src/cdk/menu/menu-item.spec.ts
+++ b/src/cdk/menu/menu-item.spec.ts
@@ -210,5 +210,5 @@ class MenuItemWithBoldElement {}
   imports: [CdkMenuModule, FakeMatIcon],
 })
 class MenuItemWithMultipleNestings {
-  typeahead: string;
+  typeahead = '';
 }

--- a/src/cdk/overlay/overlay.spec.ts
+++ b/src/cdk/overlay/overlay.spec.ts
@@ -1135,10 +1135,10 @@ class TestComponentWithTemplatePortals {
 }
 
 class FakePositionStrategy implements PositionStrategy {
-  element: HTMLElement;
+  element: HTMLElement | undefined;
 
   apply(): void {
-    this.element.classList.add('fake-positioned');
+    this.element?.classList.add('fake-positioned');
   }
 
   attach(overlayRef: OverlayRef) {
@@ -1150,7 +1150,7 @@ class FakePositionStrategy implements PositionStrategy {
 
 class FakeScrollStrategy implements ScrollStrategy {
   isEnabled = false;
-  overlayRef: OverlayRef;
+  overlayRef: OverlayRef | undefined;
 
   attach(overlayRef: OverlayRef) {
     this.overlayRef = overlayRef;

--- a/src/cdk/portal/portal.spec.ts
+++ b/src/cdk/portal/portal.spec.ts
@@ -756,10 +756,10 @@ class PizzaMsg {
 class SaveParentNodeOnInit implements AfterViewInit {
   private _elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
 
-  parentOnViewInit: HTMLElement;
+  parentOnViewInit: HTMLElement | null = null;
 
   ngAfterViewInit() {
-    this.parentOnViewInit = this._elementRef.nativeElement.parentElement!;
+    this.parentOnViewInit = this._elementRef.nativeElement.parentElement;
   }
 }
 

--- a/src/cdk/schematics/tsconfig.json
+++ b/src/cdk/schematics/tsconfig.json
@@ -6,6 +6,7 @@
     "moduleResolution": "node",
     "rootDir": ".",
     "strictNullChecks": true,
+    "strictPropertyInitialization": true,
     "noPropertyAccessFromIndexSignature": true,
     "strict": true,
     "useUnknownInCatchVariables": true,

--- a/src/cdk/table/text-column.spec.ts
+++ b/src/cdk/table/text-column.spec.ts
@@ -170,8 +170,8 @@ class BasicTextColumnApp {
     {propertyA: 'a_2', propertyB: 'b_2', propertyC: 'c_2'},
   ];
 
-  headerTextB: string;
-  dataAccessorA: (data: TestData) => string;
+  headerTextB!: string;
+  dataAccessorA!: (data: TestData) => string;
   justifyC = 'start' as const;
 }
 

--- a/src/cdk/testing/tests/test-sub-component.ts
+++ b/src/cdk/testing/tests/test-sub-component.ts
@@ -21,6 +21,6 @@ import {ChangeDetectionStrategy, Component, Input, ViewEncapsulation} from '@ang
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TestSubComponent {
-  @Input() title: string;
-  @Input() items: string[];
+  @Input() title = '';
+  @Input() items: string[] = [];
 }

--- a/src/cdk/tsconfig.json
+++ b/src/cdk/tsconfig.json
@@ -4,7 +4,6 @@
   "compilerOptions": {
     "rootDir": "..",
     "baseUrl": ".",
-    "strictPropertyInitialization": true,
     "paths": {
       "@angular/cdk/*": ["./*"]
     }

--- a/src/components-examples/tsconfig.json
+++ b/src/components-examples/tsconfig.json
@@ -4,7 +4,6 @@
   "compilerOptions": {
     "rootDir": "..",
     "baseUrl": ".",
-    "strictPropertyInitialization": true,
     "paths": {
       "@angular/aria/*": ["../aria/*"],
       "@angular/cdk/*": ["../cdk/*"],

--- a/src/dev-app/tsconfig.json
+++ b/src/dev-app/tsconfig.json
@@ -5,7 +5,6 @@
     // Needed for Moment.js since it doesn't have a default export.
     "rootDir": "..",
     "baseUrl": ".",
-    "strictPropertyInitialization": true,
     "paths": {
       "@angular/aria": ["../aria"],
       "@angular/aria/*": ["../aria/*"],

--- a/src/google-maps/tsconfig.json
+++ b/src/google-maps/tsconfig.json
@@ -5,8 +5,7 @@
     "rootDir": "..",
     "baseUrl": ".",
     "paths": {},
-    "types": ["jasmine", "google.maps"],
-    "strictPropertyInitialization": true
+    "types": ["jasmine", "google.maps"]
   },
   "include": ["./**/*.ts", "../dev-mode-types.d.ts"]
 }

--- a/src/material-experimental/tsconfig.json
+++ b/src/material-experimental/tsconfig.json
@@ -4,7 +4,6 @@
   "compilerOptions": {
     "rootDir": "..",
     "baseUrl": ".",
-    "strictPropertyInitialization": true,
     "paths": {
       "@angular/cdk/*": ["../cdk/*"],
       "@angular/material/*": ["../material/*"],

--- a/src/material-moment-adapter/tsconfig.json
+++ b/src/material-moment-adapter/tsconfig.json
@@ -4,7 +4,6 @@
   "compilerOptions": {
     "rootDir": "..",
     "baseUrl": ".",
-    "strictPropertyInitialization": true,
     "paths": {
       "@angular/cdk/*": ["../cdk/*"],
       "@angular/material/*": ["../material/*"],

--- a/src/material/timepicker/timepicker.ts
+++ b/src/material/timepicker/timepicker.ts
@@ -143,7 +143,7 @@ export class MatTimepicker<D> implements OnDestroy, MatOptionParentComponent {
   private _overlayRef: OverlayRef | null = null;
   private _portal: TemplatePortal<unknown> | null = null;
   private _optionsCacheKey: string | null = null;
-  private _localeChanges: Subscription;
+  private _localeChanges: Subscription | undefined;
   private _onOpenRender: AfterRenderRef | null = null;
 
   protected _panelTemplate = viewChild.required<TemplateRef<unknown>>('panelTemplate');
@@ -307,7 +307,7 @@ export class MatTimepicker<D> implements OnDestroy, MatOptionParentComponent {
 
   ngOnDestroy(): void {
     this._keyManager.destroy();
-    this._localeChanges.unsubscribe();
+    this._localeChanges?.unsubscribe();
     this._onOpenRender?.destroy();
     this._overlayRef?.dispose();
   }

--- a/src/material/tsconfig.json
+++ b/src/material/tsconfig.json
@@ -4,7 +4,6 @@
   "compilerOptions": {
     "rootDirs": ["..", "../../tools"],
     "baseUrl": ".",
-    "strictPropertyInitialization": true,
     "paths": {
       "@angular/cdk": ["../cdk"],
       "@angular/cdk/*": ["../cdk/*"],

--- a/src/youtube-player/tsconfig.json
+++ b/src/youtube-player/tsconfig.json
@@ -5,8 +5,7 @@
     "rootDir": "..",
     "baseUrl": ".",
     "paths": {},
-    "types": ["jasmine"],
-    "strictPropertyInitialization": true
+    "types": ["jasmine"]
   },
   "include": ["*.ts", "../dev-mode-types.d.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "noFallthroughCasesInSwitch": true,
     "noUnusedLocals": false,
     "strictNullChecks": true,
+    "strictPropertyInitialization": true,
     "noPropertyAccessFromIndexSignature": true,
     "useUnknownInCatchVariables": true,
     "noImplicitOverride": true,


### PR DESCRIPTION
Enables strict property initialization for the whole repo and fixes a few failures that weren't caught earlier.