### PR TITLE
fix(youtube-player): apply startSeconds with disablePlaceholder and autoplay

### DIFF
--- a/src/youtube-player/youtube-player.spec.ts
+++ b/src/youtube-player/youtube-player.spec.ts
@@ -679,6 +679,22 @@ describe('YoutubePlayer', () => {
       expect(playerCtorSpy).toHaveBeenCalled();
     });
 
+    it('should apply startSeconds when disablePlaceholder and autoplay are both set', () => {
+      testComponent.disablePlaceholder = true;
+      testComponent.playerVars = {autoplay: 1};
+      testComponent.startSeconds = 30;
+      fixture.changeDetectorRef.markForCheck();
+      fixture.detectChanges();
+
+      // Simulate player state being PLAYING (autoplay has started the video)
+      playerSpy.getPlayerState.and.returnValue(window.YT!.PlayerState.PLAYING);
+      events.onReady({target: playerSpy});
+
+      // Should use seekTo instead of cueVideoById when player is already playing
+      expect(playerSpy.seekTo).toHaveBeenCalledWith(30, true);
+      expect(playerSpy.cueVideoById).not.toHaveBeenCalled();
+    });
+
     it('should allow for the placeholder image quality to be changed', () => {
       const placeholder = getPlaceholder(fixture);
       expect(placeholder.style.backgroundImage).toContain(

--- a/src/youtube-player/youtube-player.ts
+++ b/src/youtube-player/youtube-player.ts
@@ -628,11 +628,15 @@ export class YouTubePlayer implements AfterViewInit, OnChanges, OnDestroy {
         const state = player.getPlayerState();
         if (state === PlayerState.UNSTARTED || state === PlayerState.CUED || state == null) {
           this._cuePlayer();
-        } else if (playVideo && this.startSeconds && this.startSeconds > 0) {
-          // We have to use `seekTo` when `startSeconds` are specified to simulate it playing from
-          // a specific time. The "proper" way to do it would be to either go through `cueVideoById`
-          // or `playerVars.start`, but at the time of writing both end up resetting the video
-          // to the state as if the user hasn't interacted with it.
+        } else if (
+          (playVideo || this.playerVars?.autoplay === 1) &&
+          this.startSeconds &&
+          this.startSeconds > 0
+        ) {
+          // We have to use `seekTo` when `startSeconds` are specified with a playing video
+          // (either from user interaction or autoplay). The "proper" way to do it would be to
+          // either go through `cueVideoById` or `playerVars.start`, but at the time of writing
+          // both end up resetting the video to the state as if the user hasn't interacted with it.
           player.seekTo(this.startSeconds, true);
         }
 


### PR DESCRIPTION
## Description
Fixes a bug where the YouTube player ignores the `startSeconds` input when both `disablePlaceholder` and `playerVars.autoplay` are set.

## Problem
When using the YouTube player with:
-  `disablePlaceholder="true"`
- `playerVars="{autoplay: 1}"`
- `startSeconds="N"` (any non-zero value)

The video would autoplay but start from the beginning (0 seconds) instead of the specified start time.

## Solution
Modified the condition in `_createPlayer()` to check for `playerVars.autoplay === 1` in addition to the `playVideo` parameter. When the player is already playing (from autoplay), it now correctly uses `seekTo()` to jump to the specified `startSeconds`.

## Changes
- Updated `src/youtube-player/youtube-player.ts` to check for autoplay in playerVars
- Added test case in `src/youtube-player/youtube-player.spec.ts` to validate the fix
- Updated code comment to clarify the autoplay scenario

## Testing
- [x] All existing tests pass
- [x] New test added specifically for this scenario

## Related Issue
Fixes #32545
