### PR TITLE
build: switch Node.js toolchain to derive version from .nvmrc [patch]

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -60,6 +60,11 @@ node.toolchain(node_version_from_nvmrc = "//:.nvmrc")
 use_repo(node, "nodejs_toolchains")
 
 pnpm = use_extension("@aspect_rules_js//npm:extensions.bzl", "pnpm")
+pnpm.pnpm(
+    name = "pnpm",
+    pnpm_version = "10.26.0",
+    pnpm_version_integrity = "sha512-Oz9scl6+cSUGwKsa1BM8+GsfS2h+/85iqbOLTXLjlUJC5kMZD8UfoWQpScc19APevUT1yw7dZXq+Y6i2p+HkAg==",
+)
 use_repo(pnpm, "pnpm")
 
 npm = use_extension("@aspect_rules_js//npm:extensions.bzl", "npm")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -406,7 +406,7 @@
     "@@aspect_rules_js+//npm:extensions.bzl%pnpm": {
       "general": {
         "bzlTransitiveDigest": "fFcLmS3p3sFcn/GGOh4LxupnmV3++FYtXPG7KyQUZx4=",
-        "usagesDigest": "4zPPt9pTOwrdTWBmkgV1AbopWlVrIKP+Yokpw5c2X+g=",
+        "usagesDigest": "P+i0x4shIfQ52VgrfmEA2YOTpwyIfLRdaDta4gGRuoU=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -415,11 +415,11 @@
             "repoRuleId": "@@aspect_rules_js+//npm/private:npm_import.bzl%npm_import_rule",
             "attributes": {
               "package": "pnpm",
-              "version": "8.15.9",
+              "version": "10.26.0",
               "root_package": "",
               "link_workspace": "",
               "link_packages": {},
-              "integrity": "sha512-SZQ0ydj90aJ5Tr9FUrOyXApjOrzuW7Fee13pDzL0e1E6ypjNXP0AHDHw20VLw4BO3M1XhQHkyik6aBYWa72fgQ==",
+              "integrity": "sha512-Oz9scl6+cSUGwKsa1BM8+GsfS2h+/85iqbOLTXLjlUJC5kMZD8UfoWQpScc19APevUT1yw7dZXq+Y6i2p+HkAg==",
               "url": "",
               "commit": "",
               "patch_args": [
@@ -442,7 +442,7 @@
             "repoRuleId": "@@aspect_rules_js+//npm/private:npm_import.bzl%npm_import_links",
             "attributes": {
               "package": "pnpm",
-              "version": "8.15.9",
+              "version": "10.26.0",
               "dev": false,
               "root_package": "",
               "link_packages": {},


### PR DESCRIPTION
Remove hardcoded node.js version