### PR TITLE
docs: disallow docs-content for search indexer

### DIFF
--- a/docs/src/robots.txt
+++ b/docs/src/robots.txt
@@ -1,3 +1,3 @@
 Sitemap: https://material.angular.dev/sitemap.xml
 User-agent: *
-Disallow:
+Disallow: /docs-content/


### PR DESCRIPTION
Some users are reporting seeing these pages show up in search results, e.g. https://next.material.angular.dev/docs-content/api-docs/material-card-testing