### PR TITLE
refactor(material/table): add filterPredicate non-object warning

### DIFF
--- a/src/material/table/table-data-source.ts
+++ b/src/material/table/table-data-source.ts
@@ -233,6 +233,15 @@ export class MatTableDataSource<
    * @returns Whether the filter matches against the data
    */
   filterPredicate: (data: T, filter: string) => boolean = (data: T, filter: string): boolean => {
+    if (
+      (typeof ngDevMode === 'undefined' || ngDevMode) &&
+      (typeof data !== 'object' || data === null)
+    ) {
+      console.warn(
+        'Default implementation of filterPredicate requires data to be a non-null object.',
+      );
+    }
+
     // Transform the filter by converting it to lowercase and removing whitespace.
     const transformedFilter = filter.trim().toLowerCase();
     // Loops over the values in the array and returns true if any of them match the filter string


### PR DESCRIPTION
Add a run-time warning to `MatTableDataSource.filterPredicate` (follow-up to https://github.com/angular/components/pull/32394).

Also:
  - removed `any` type from `table-data-source.spec.ts`,
  - added filtering unit tests.