### PR TITLE
fix(multiple): not all symbols exported in some aria packages

### DIFF
--- a/src/aria/accordion/index.ts
+++ b/src/aria/accordion/index.ts
@@ -6,11 +6,4 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-export {AccordionPanel} from './accordion-panel';
-export {AccordionGroup} from './accordion-group';
-export {AccordionTrigger} from './accordion-trigger';
-export {AccordionContent} from './accordion-content';
-
-// This needs to be re-exported, because it's used by the accordion components.
-// See: https://github.com/angular/components/issues/30663.
-export {DeferredContent as ɵɵDeferredContent} from '../private';
+export * from './public-api';

--- a/src/aria/grid/index.ts
+++ b/src/aria/grid/index.ts
@@ -6,7 +6,4 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-export {Grid} from './grid';
-export {GridCell} from './grid-cell';
-export {GridRow} from './grid-row';
-export {GridCellWidget} from './grid-cell-widget';
+export * from './public-api';


### PR DESCRIPTION
Fixes that a couple of Aria packages weren't exporting all the necessary symbols.

Fixes #32584.