### PR TITLE
fix(material/tooltip): add opt-in for better touch device detection

### DIFF
--- a/goldens/material/tooltip/index.api.md
+++ b/goldens/material/tooltip/index.api.md
@@ -92,6 +92,7 @@ export class MatTooltip implements OnDestroy, AfterViewInit {
 
 // @public
 export interface MatTooltipDefaultOptions {
+    detectHoverCapability?: boolean;
     disableTooltipInteractivity?: boolean;
     hideDelay: number;
     position?: TooltipPosition;


### PR DESCRIPTION
Currently the touch device detection in the tooltip is based purely on the `Platform` provider which isn't able to detect some newer iOS devices properly. These changes add an additional check through a media query.

The check is currently opt-in, because it can cause false positives in tests that run in headless browsers.

Fixes #32503.
Fixes #25287.