### PR TITLE
refactor(aria/accordion): make `AccordionGroup` and `AccordionTrigger` members protected for extensibility

### DIFF
--- a/src/aria/accordion/accordion-group.ts
+++ b/src/aria/accordion/accordion-group.ts
@@ -71,19 +71,19 @@ import {ACCORDION_GROUP} from './accordion-tokens';
 })
 export class AccordionGroup {
   /** A reference to the group element. */
-  private readonly _elementRef = inject(ElementRef);
+  protected readonly _elementRef = inject(ElementRef);
 
   /** A reference to the group element. */
   readonly element = this._elementRef.nativeElement as HTMLElement;
 
   /** The AccordionTriggers nested inside this group. */
-  private readonly _triggers = contentChildren(AccordionTrigger, {descendants: true});
+  protected readonly _triggers = contentChildren(AccordionTrigger, {descendants: true});
 
   /** The AccordionTrigger patterns nested inside this group. */
-  private readonly _triggerPatterns = computed(() => this._triggers().map(t => t._pattern));
+  protected readonly _triggerPatterns = computed(() => this._triggers().map(t => t._pattern));
 
   /** The AccordionPanels nested inside this group. */
-  private readonly _panels = contentChildren(AccordionPanel, {descendants: true});
+  protected readonly _panels = contentChildren(AccordionPanel, {descendants: true});
 
   /** The text direction (ltr or rtl). */
   readonly textDirection = inject(Directionality).valueSignal;
@@ -114,7 +114,7 @@ export class AccordionGroup {
     element: () => this.element,
   });
 
-  constructor() {
+  protected readonly _effects = [
     // Effect to link triggers with their corresponding panels and update the group's items.
     afterRenderEffect(() => {
       const triggers = this._triggers();
@@ -127,8 +127,8 @@ export class AccordionGroup {
           panel._accordionTriggerPattern.set(trigger._pattern);
         }
       }
-    });
-  }
+    }),
+  ];
 
   /** Expands all accordion panels if multi-expandable. */
   expandAll() {
@@ -141,7 +141,7 @@ export class AccordionGroup {
   }
 
   /** Gets the trigger pattern for a given element. */
-  private _getItem(element: Element | null | undefined): AccordionTriggerPattern | undefined {
+  protected _getItem(element: Element | null | undefined): AccordionTriggerPattern | undefined {
     let target = element;
 
     while (target) {

--- a/src/aria/accordion/accordion-trigger.ts
+++ b/src/aria/accordion/accordion-trigger.ts
@@ -61,7 +61,7 @@ export class AccordionTrigger {
   readonly element = this._elementRef.nativeElement as HTMLElement;
 
   /** The parent AccordionGroup. */
-  private readonly _accordionGroup = inject(ACCORDION_GROUP);
+  protected readonly _accordionGroup = inject(ACCORDION_GROUP);
 
   /** A unique identifier for the widget. */
   readonly id = input(inject(_IdGenerator).getId('ng-accordion-trigger-', true));

--- a/src/aria/accordion/public-api.ts
+++ b/src/aria/accordion/public-api.ts
@@ -10,6 +10,7 @@ export {AccordionPanel} from './accordion-panel';
 export {AccordionGroup} from './accordion-group';
 export {AccordionTrigger} from './accordion-trigger';
 export {AccordionContent} from './accordion-content';
+export {ACCORDION_GROUP} from './accordion-tokens';
 
 // This needs to be re-exported, because it's used by the accordion components.
 // See: https://github.com/angular/components/issues/30663.


### PR DESCRIPTION
This pull request refactors the `AccordionGroup` and `AccordionTrigger` classes to improve extensibility and internal access for derived classes. Most private members and methods are now marked as `protected`, and some initialization logic is moved to a protected property. Additionally, the `ACCORDION_GROUP` token is now exported in the public API.

### Refactoring for Extensibility

* Changed most `private` members and methods in `AccordionGroup` and `AccordionTrigger` to `protected` to allow access in subclasses. (`src/aria/accordion/accordion-group.ts`, `src/aria/accordion/accordion-trigger.ts`) [[1]](diffhunk://#diff-d12824be112fc5a4bf7e08417fd727dd22e51c252d7a3bfaefb519c18a9d4952L74-R86) [[2]](diffhunk://#diff-d12824be112fc5a4bf7e08417fd727dd22e51c252d7a3bfaefb519c18a9d4952L144-R144) [[3]](diffhunk://#diff-9b7877d44b7b5040bdb193bf37b48342dff55e7b5ba695a473e2726cfb8904d8L64-R64)
* Moved effect initialization in `AccordionGroup` from the constructor to a protected readonly `_effects` property, making it easier for subclasses to extend or override effect logic. (`src/aria/accordion/accordion-group.ts`) [[1]](diffhunk://#diff-d12824be112fc5a4bf7e08417fd727dd22e51c252d7a3bfaefb519c18a9d4952L117-R117) [[2]](diffhunk://#diff-d12824be112fc5a4bf7e08417fd727dd22e51c252d7a3bfaefb519c18a9d4952L130-R131)

### Public API Update

* Added `ACCORDION_GROUP` to the public exports in `public-api.ts`, making it available for consumers of the library. (`src/aria/accordion/public-api.ts`)