### PR TITLE
build: disable formatting on styles and templates

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -17,3 +17,9 @@ pnpm-lock.yaml
 
 # TODO: Enable formatting on markdown files
 **/*.md
+
+# TODO: enable formatting on templates and styles.
+# For styles specifically the formatting ends up causing build failures.
+**/*.scss
+**/*.css
+**/*.html

--- a/integration/harness-e2e-cli/pnpm-workspace.yaml
+++ b/integration/harness-e2e-cli/pnpm-workspace.yaml
@@ -1,5 +1,5 @@
 packages:
- - .
+  - .
 
 # The minimum age of a release to be considered for dependency installation.
 # The value is in minutes (1440 minutes = 1 day).

--- a/integration/ng-add-standalone/pnpm-workspace.yaml
+++ b/integration/ng-add-standalone/pnpm-workspace.yaml
@@ -1,5 +1,5 @@
 packages:
- - .
+  - .
 
 # The minimum age of a release to be considered for dependency installation.
 # The value is in minutes (1440 minutes = 1 day).

--- a/integration/ng-add/pnpm-workspace.yaml
+++ b/integration/ng-add/pnpm-workspace.yaml
@@ -1,5 +1,5 @@
 packages:
- - .
+  - .
 
 # The minimum age of a release to be considered for dependency installation.
 # The value is in minutes (1440 minutes = 1 day).


### PR DESCRIPTION
It looks like `ng-dev` enabled formatting on HTML and CSS/Sass files at some point. These changes disable it for our repo, because reformatting all the files ends up causing build failures.

Fixes angular#32589.