### PR TITLE
fix(aria/menu): expand selector for trigger

### DIFF
--- a/goldens/aria/menu/index.api.md
+++ b/goldens/aria/menu/index.api.md
@@ -99,7 +99,7 @@ export class MenuTrigger<V> {
     readonly softDisabled: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly textDirection: _angular_core.WritableSignal<_angular_cdk_bidi.Direction>;
     // (undocumented)
-    static ɵdir: _angular_core.ɵɵDirectiveDeclaration<MenuTrigger<any>, "button[ngMenuTrigger]", ["ngMenuTrigger"], { "menu": { "alias": "menu"; "required": false; "isSignal": true; }; "disabled": { "alias": "disabled"; "required": false; "isSignal": true; }; "softDisabled": { "alias": "softDisabled"; "required": false; "isSignal": true; }; }, {}, never, never, true, never>;
+    static ɵdir: _angular_core.ɵɵDirectiveDeclaration<MenuTrigger<any>, "[ngMenuTrigger]", ["ngMenuTrigger"], { "menu": { "alias": "menu"; "required": false; "isSignal": true; }; "disabled": { "alias": "disabled"; "required": false; "isSignal": true; }; "softDisabled": { "alias": "softDisabled"; "required": false; "isSignal": true; }; }, {}, never, never, true, never>;
     // (undocumented)
     static ɵfac: _angular_core.ɵɵFactoryDeclaration<MenuTrigger<any>, never>;
 }

--- a/src/aria/menu/menu-trigger.ts
+++ b/src/aria/menu/menu-trigger.ts
@@ -41,7 +41,7 @@ import type {Menu} from './menu';
  * @see [MenuBar](guide/aria/menubar)
  */
 @Directive({
-  selector: 'button[ngMenuTrigger]',
+  selector: '[ngMenuTrigger]',
   exportAs: 'ngMenuTrigger',
   host: {
     '[attr.tabindex]': '_pattern.tabIndex()',


### PR DESCRIPTION
Allows non-button elements to be set as menu triggers since users might be applying it to custom components.

Fixes #32616.