### PR TITLE
test(multiple): remove checks for popover from test

### DIFF
--- a/src/cdk/overlay/position/flexible-connected-position-strategy.spec.ts
+++ b/src/cdk/overlay/position/flexible-connected-position-strategy.spec.ts
@@ -2992,10 +2992,6 @@ describe('FlexibleConnectedPositionStrategy', () => {
     });
 
     it('should be able to opt into placing the overlay inside an adjacent popover element', () => {
-      if (!('showPopover' in document.body)) {
-        return;
-      }
-
       attachOverlay({positionStrategy, usePopover: true});
 
       expect(containerElement.contains(overlayRef.hostElement)).toBe(false);
@@ -3004,10 +3000,6 @@ describe('FlexibleConnectedPositionStrategy', () => {
     });
 
     it('should re-attach the popover next to the origin element', () => {
-      if (!('showPopover' in document.body)) {
-        return;
-      }
-
       attachOverlay({positionStrategy, usePopover: true});
       expect(originElement.nextElementSibling).toBe(overlayRef.hostElement);
 
@@ -3020,10 +3012,6 @@ describe('FlexibleConnectedPositionStrategy', () => {
     });
 
     it('should insert the overlay as a child of a custom element', () => {
-      if (!('showPopover' in document.body)) {
-        return;
-      }
-
       positionStrategy.withPopoverLocation({type: 'parent', element: customHostElement});
       attachOverlay({positionStrategy, usePopover: true});
 
@@ -3033,10 +3021,6 @@ describe('FlexibleConnectedPositionStrategy', () => {
     });
 
     it('should insert the overlay as a child of the origin', () => {
-      if (!('showPopover' in document.body)) {
-        return;
-      }
-
       positionStrategy.withPopoverLocation({type: 'parent', element: originElement});
       attachOverlay({positionStrategy, usePopover: true});
 

--- a/src/material/autocomplete/autocomplete.spec.ts
+++ b/src/material/autocomplete/autocomplete.spec.ts
@@ -1,6 +1,6 @@
 import {Direction} from '@angular/cdk/bidi';
 import {DOWN_ARROW, ENTER, ESCAPE, SPACE, TAB, UP_ARROW} from '@angular/cdk/keycodes';
-import {OverlayContainer, OverlayModule, createCloseScrollStrategy} from '@angular/cdk/overlay';
+import {OverlayModule, createCloseScrollStrategy} from '@angular/cdk/overlay';
 import {_supportsShadowDom} from '@angular/cdk/platform';
 import {ScrollDispatcher} from '@angular/cdk/scrolling';
 import {
@@ -62,9 +62,6 @@ import {
 } from './index';
 
 describe('MatAutocomplete', () => {
-  const supportsPopover = 'showPopover' in document.body;
-  let overlayContainerElement: HTMLElement;
-
   // Creates a test component fixture.
   function createComponent<T>(component: Type<T>, providers: Provider[] = []) {
     TestBed.configureTestingModule({
@@ -74,21 +71,17 @@ describe('MatAutocomplete', () => {
       ],
     });
 
-    overlayContainerElement = TestBed.inject(OverlayContainer).getContainerElement();
     return TestBed.createComponent<T>(component);
   }
 
   function getOverlayHost(fixture: ComponentFixture<unknown>): HTMLElement | null {
-    return supportsPopover
-      ? fixture.nativeElement.querySelector('.cdk-overlay-popover')
-      : overlayContainerElement.querySelector('.cdk-overlay-connected-position-bounding-box');
+    return fixture.nativeElement.querySelector('.cdk-overlay-popover');
   }
 
   function getBackdrop(fixture: ComponentFixture<unknown>): HTMLElement | null {
-    const selector = '.cdk-overlay-backdrop';
-    return supportsPopover
-      ? getOverlayHost(fixture)?.querySelector(selector) || null
-      : overlayContainerElement.querySelector(selector);
+    return (
+      fixture.nativeElement.querySelector('.cdk-overlay-popover .cdk-overlay-backdrop') || null
+    );
   }
 
   describe('panel toggling', () => {

--- a/src/material/select/select.spec.ts
+++ b/src/material/select/select.spec.ts
@@ -15,7 +15,7 @@ import {
   TAB,
   UP_ARROW,
 } from '@angular/cdk/keycodes';
-import {OverlayContainer, OverlayModule, createCloseScrollStrategy} from '@angular/cdk/overlay';
+import {OverlayModule, createCloseScrollStrategy} from '@angular/cdk/overlay';
 import {ScrollDispatcher} from '@angular/cdk/scrolling';
 import {
   createKeyboardEvent,
@@ -76,7 +76,6 @@ import {
 const DEFAULT_TYPEAHEAD_DEBOUNCE_INTERVAL = 200;
 
 describe('MatSelect', () => {
-  const supportsPopover = 'showPopover' in document.body;
   let dir: WritableSignal<Direction>;
   let scrolledSubject = new Subject();
 
@@ -97,18 +96,11 @@ describe('MatSelect', () => {
   });
 
   function getOverlayHost(fixture: ComponentFixture<unknown>): HTMLElement | null {
-    return supportsPopover
-      ? fixture.nativeElement.querySelector('.cdk-overlay-popover')
-      : TestBed.inject(OverlayContainer)
-          .getContainerElement()
-          .querySelector('.cdk-overlay-connected-position-bounding-box');
+    return fixture.nativeElement.querySelector('.cdk-overlay-popover');
   }
 
   function getBackdrop(fixture: ComponentFixture<unknown>): HTMLElement | null {
-    const parent = supportsPopover
-      ? fixture.nativeElement
-      : TestBed.inject(OverlayContainer).getContainerElement();
-    return parent.querySelector('.cdk-overlay-backdrop');
+    return fixture.nativeElement.querySelector('.cdk-overlay-backdrop');
   }
 
   describe('core', () => {


### PR DESCRIPTION
After #32422 all our test environments should support popovers. These changes remove some workarounds meant to handle browsers that don't support it.