### PR TITLE
refactor(material/tooltip): drop NgClass dependency

### DIFF
--- a/goldens/material/tooltip/index.api.md
+++ b/goldens/material/tooltip/index.api.md
@@ -143,7 +143,7 @@ export class TooltipComponent implements OnDestroy {
     protected _onShow(): void;
     show(delay: number): void;
     _tooltip: ElementRef<HTMLElement>;
-    tooltipClass: string | string[] | Set<string> | {
+    tooltipClass: string | string[] | {
         [key: string]: unknown;
     };
     _triggerElement: HTMLElement;

--- a/src/material/tooltip/BUILD.bazel
+++ b/src/material/tooltip/BUILD.bazel
@@ -72,7 +72,6 @@ ng_project(
         ":css",
     ],
     deps = [
-        "//:node_modules/@angular/common",
         "//:node_modules/@angular/core",
         "//:node_modules/rxjs",
         "//src/cdk/coercion",

--- a/src/material/tooltip/tooltip.html
+++ b/src/material/tooltip/tooltip.html
@@ -1,7 +1,7 @@
 <div
   #tooltip
   class="mdc-tooltip mat-mdc-tooltip"
-  [ngClass]="tooltipClass"
+  [class]="tooltipClass"
   (animationend)="_handleAnimationEnd($event)"
   [class.mdc-tooltip--multiline]="_isMultiline">
   <div class="mat-mdc-tooltip-surface mdc-tooltip__surface">{{message}}</div>

--- a/src/material/tooltip/tooltip.ts
+++ b/src/material/tooltip/tooltip.ts
@@ -33,7 +33,6 @@ import {
   DOCUMENT,
   Renderer2,
 } from '@angular/core';
-import {NgClass} from '@angular/common';
 import {Platform} from '@angular/cdk/platform';
 import {AriaDescriber, FocusMonitor} from '@angular/cdk/a11y';
 import {Directionality} from '@angular/cdk/bidi';
@@ -719,7 +718,8 @@ export class MatTooltip implements OnDestroy, AfterViewInit {
     tooltipClass: string | string[] | Set<string> | {[key: string]: unknown},
   ) {
     if (this._tooltipInstance) {
-      this._tooltipInstance.tooltipClass = tooltipClass;
+      this._tooltipInstance.tooltipClass =
+        tooltipClass instanceof Set ? Array.from(tooltipClass) : tooltipClass;
       this._tooltipInstance._markForCheck();
     }
   }
@@ -951,7 +951,6 @@ export class MatTooltip implements OnDestroy, AfterViewInit {
     '(mouseleave)': '_handleMouseLeave($event)',
     'aria-hidden': 'true',
   },
-  imports: [NgClass],
 })
 export class TooltipComponent implements OnDestroy {
   private _changeDetectorRef = inject(ChangeDetectorRef);
@@ -963,8 +962,8 @@ export class TooltipComponent implements OnDestroy {
   /** Message to display in the tooltip */
   message!: string;
 
-  /** Classes to be added to the tooltip. Supports the same syntax as `ngClass`. */
-  tooltipClass!: string | string[] | Set<string> | {[key: string]: unknown};
+  /** Classes to be added to the tooltip. */
+  tooltipClass!: string | string[] | {[key: string]: unknown};
 
   /** The timeout ID of any current timer set to show the tooltip */
   private _showTimeoutId: ReturnType<typeof setTimeout> | undefined;


### PR DESCRIPTION
Remove the dependency on `NgClass` in the tooltip in favor of the `[class]` binding.