### PR TITLE
feat(material-temporal-adapter): add Temporal API date adapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ node_modules
 /packages
 /pubspec.lock
 /src/.pub
+PR_DESCRIPTION.md
 /src/.packages
 /src/packages
 /src/pubspec.lock

--- a/.ng-dev/commit-message.mts
+++ b/.ng-dev/commit-message.mts
@@ -95,6 +95,7 @@ export const commitMessage: CommitMessageConfig = {
     'material-moment-adapter',
     'material-date-fns-adapter',
     'material-luxon-adapter',
+    'material-temporal-adapter',
     'youtube-player',
     'material-angular-io',
   ],

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,11 @@
+{
+  "servers": {
+    "io.github.ChromeDevTools/chrome-devtools-mcp": {
+      "command": "npx",
+      "args": ["-y", "chrome-devtools-mcp"],
+      "env": {},
+      "type": "stdio"
+    }
+  },
+  "inputs": []
+}

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,267 @@
+## AI assistance disclosure
+This work was implemented by AI tools (Claude Opus 4.5 and GPT-5.2-Codex) under my orchestration.
+
+## Live Demo & Validation
+**[View Interactive Storybook & Matrix Test Suite](https://kbrilla.github.io/temporal-adapter-demo/)**
+Comprehensive playground demonstrating:
+*   Integration with Material Datepicker/Timepicker
+*   10+ Calendar systems (Japanese, Hebrew, Chinese, etc.)
+*   Automated Matrix Tests verifying all adapter operations
+
+## Summary
+Add a Temporal-based `DateAdapter` for Angular Material datepicker, supporting date-only, date+time, and timezone-aware date+time use cases.
+
+Fixes #25753
+
+## Background
+Temporal is a Stage 3 TC39 proposal providing immutable date/time primitives with explicit calendar and timezone semantics. This adapter enables Material datepicker to work with Temporal (native or polyfilled) without relying on JS `Date` as the internal model. The implementation follows patterns from existing adapters in this repo, especially `NativeDateAdapter`.
+
+## Scope / what’s in this PR
+- **Unified adapter**: `TemporalDateAdapter` (The primary 3-in-1 adapter recommended for general use). Supports switching modes via configuration:
+  - `date` → `Temporal.PlainDate`
+  - `datetime` → `Temporal.PlainDateTime`
+  - `zoned` → `Temporal.ZonedDateTime`
+- **Demonstration / Split adapters**: A set of 4 additional adapters illustrating different architectural splittings and strict type handling. These serve as architectural examples:
+  - `PlainDateAdapter`: Strictly for `Temporal.PlainDate`.
+  - `PlainDateTimeAdapter`: Strictly for `Temporal.PlainDateTime`.
+  - `ZonedDateTimeAdapter`: Strictly for `Temporal.ZonedDateTime`.
+  - `PlainTemporalAdapter`: A hybrid handling both `PlainDate` and `PlainDateTime`.
+- **Formatting** uses `Intl.DateTimeFormatOptions` with Temporal’s locale formatting.
+- **No runtime dependency** is added; consumers supply a Temporal implementation (native or polyfill).
+
+## Configuration
+### Unified adapter (`TemporalDateAdapter` / `MatTemporalDateAdapterOptions`)
+**Defaults**
+- `calendar`: `iso8601`
+- `outputCalendar`: same as `calendar`
+- `mode`: `date`
+- `overflow`: `reject`
+- `timezone`: system timezone (only when `mode: 'zoned'`)
+- `disambiguation`, `offset`, `rounding`: Temporal defaults (only when `mode: 'zoned'`)
+
+**Options**
+- `calendar`: calendar system to use for calculations.
+- `outputCalendar`: calendar system to use for output/formatting when different from calculations (MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDate/withCalendar, https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/withCalendar).
+- `mode`: `date | datetime | zoned`.
+- `timezone` (zoned only): IANA ID like `Europe/Warsaw` or `UTC`.
+- `disambiguation` (zoned only): `'compatible' | 'earlier' | 'later' | 'reject'` for DST gaps/overlaps (MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/toZonedDateTime, https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/from).
+- `offset` (zoned only): `'use' | 'ignore' | 'reject' | 'prefer'` for offset ambiguity on parse (MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/from).
+- `rounding` (zoned only): `{smallestUnit, roundingIncrement?, roundingMode?}` applied to zoned output (MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/round).
+- `firstDayOfWeek`: overrides the locale-derived week start.
+- `overflow`: `reject` throws on invalid dates, `constrain` clamps to the nearest valid date.
+
+**Notes**
+- `outputCalendar` uses `withCalendar` for display fields only; it does not re-resolve the instant, so `disambiguation`/`offset` are not applied during output conversion.
+- If `disambiguation`, `offset`, or `rounding` aren’t provided, the adapter relies on Temporal’s defaults.
+- `overflow` defaults to `reject` to avoid silent clamping and better match strict validation expectations.
+
+### Split adapters
+**`PlainTemporalAdapterOptions`** (for `PlainTemporalAdapter`)
+- `mode` (default: `datetime`): `date` → `PlainDate`, `datetime` → `PlainDateTime`.
+- `calendar` (default: `iso8601`): calendar system for calculations.
+- `outputCalendar` (default: same as `calendar`): calendar system for output/formatting.
+- `firstDayOfWeek` (default: locale-derived): overrides the locale-derived week start.
+- `overflow` (default: `reject`): `reject` throws on invalid dates, `constrain` clamps.
+
+**`ZonedDateTimeAdapterOptions`** (for `ZonedDateTimeAdapter`)
+- `calendar` (default: `iso8601`): calendar system for calculations.
+- `outputCalendar` (default: same as `calendar`): calendar system for output/formatting (MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/withCalendar).
+- `timezone` (default: system timezone): IANA ID like `Europe/Warsaw` or `UTC`.
+- `disambiguation`: `'compatible' | 'earlier' | 'later' | 'reject'` for DST gaps/overlaps (MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/toZonedDateTime, https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/from).
+- `offset`: `'use' | 'ignore' | 'reject' | 'prefer'` for offset ambiguity on parse (MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/from).
+- `rounding`: `{smallestUnit, roundingIncrement?, roundingMode?}` applied to zoned output (MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/round).
+- `firstDayOfWeek` (default: locale-derived): overrides the locale-derived week start.
+- `overflow` (default: `reject`): `reject` throws on invalid dates, `constrain` clamps.
+
+## Examples
+### Unified adapter option examples
+- `calendar`
+  ```ts
+  provideTemporalDateAdapter({mode: 'date', calendar: 'japanese'});
+  const value = Temporal.PlainDate.from('2024-01-15').withCalendar('japanese');
+  // Output example: adapter.format(value, {year: 'numeric'}) -> (Japanese era year, locale-dependent)
+  ```
+  → display and calculations use the Japanese calendar.
+- `outputCalendar`
+  ```ts
+  provideTemporalDateAdapter({mode: 'date', calendar: 'iso8601', outputCalendar: 'japanese'});
+  const value = Temporal.PlainDate.from('2024-01-15');
+  // Output example: adapter.format(value, {year: 'numeric'}) -> (Japanese era year, locale-dependent)
+  ```
+  → calculations use ISO, output uses the Japanese calendar.
+- `mode`
+  ```ts
+  provideTemporalDateAdapter({mode: 'datetime'});
+  const value = Temporal.PlainDateTime.from('2024-01-15T12:30');
+  // Output examples:
+  // mode: 'date'    -> adapter.toIso8601(value) -> 2024-01-15
+  // mode: 'datetime'-> adapter.toIso8601(value) -> 2024-01-15
+  // mode: 'zoned'   -> adapter.toIso8601(value) -> 2024-01-15T12:30:00+00:00[UTC]
+  ```
+  → values are `Temporal.PlainDateTime`.
+- `timezone`
+  ```ts
+  provideTemporalDateAdapter({mode: 'zoned', timezone: 'UTC'});
+  const value = Temporal.ZonedDateTime.from('2024-01-15T12:30[UTC]');
+  // Output example: adapter.toIso8601(value) -> 2024-01-15T12:30:00+00:00[UTC]
+  ```
+  → zoned values in UTC.
+- `disambiguation`
+  ```ts
+  provideTemporalDateAdapter({mode: 'zoned', timezone: 'America/New_York', disambiguation: 'later'});
+  const value = Temporal.PlainDateTime.from('2024-11-03T01:05').toZonedDateTime('America/New_York', {
+    disambiguation: 'later',
+  });
+  // Output examples (same local time):
+  // compatible -> adapter.toIso8601(value) -> 2024-11-03T01:05:00-04:00[America/New_York]
+  // earlier    -> adapter.toIso8601(value) -> 2024-11-03T01:05:00-04:00[America/New_York]
+  // later      -> adapter.toIso8601(value) -> 2024-11-03T01:05:00-05:00[America/New_York]
+  // reject     -> adapter.setTime(...) throws for ambiguous/nonexistent time
+  ```
+  → ambiguous times choose the later instant.
+- `offset`
+  ```ts
+  provideTemporalDateAdapter({mode: 'zoned', offset: 'ignore'});
+  const value = Temporal.ZonedDateTime.from('2019-12-23T12:00:00-02:00[America/Sao_Paulo]', {
+    offset: 'ignore',
+  });
+  // Output examples (same input string):
+  // use    -> adapter.toIso8601(value) -> 2019-12-23T11:00:00-03:00[America/Sao_Paulo]
+  // ignore -> adapter.toIso8601(value) -> 2019-12-23T12:00:00-03:00[America/Sao_Paulo]
+  // prefer -> adapter.toIso8601(value) -> 2019-12-23T12:00:00-03:00[America/Sao_Paulo]
+  // reject -> adapter.deserialize(...) -> invalid
+  ```
+  → keep local time when offset conflicts with zone on parse.
+- `rounding`
+  ```ts
+  provideTemporalDateAdapter({mode: 'zoned', rounding: {smallestUnit: 'minute', roundingIncrement: 5}});
+  const value = Temporal.ZonedDateTime.from('2024-01-15T12:34:56[UTC]');
+  // Output examples (roundingMode):
+  // halfExpand -> adapter.toIso8601(value) -> 2024-01-15T12:35:00+00:00[UTC]
+  // floor      -> adapter.toIso8601(value) -> 2024-01-15T12:30:00+00:00[UTC]
+  // ceil       -> adapter.toIso8601(value) -> 2024-01-15T12:35:00+00:00[UTC]
+  // trunc      -> adapter.toIso8601(value) -> 2024-01-15T12:30:00+00:00[UTC]
+  ```
+  → outputs rounded to 5-minute steps.
+- `firstDayOfWeek`
+  ```ts
+  provideTemporalDateAdapter({firstDayOfWeek: 1});
+  // Output example: adapter.getFirstDayOfWeek() -> 1
+  ```
+  → weeks start on Monday.
+- `overflow`
+  ```ts
+  provideTemporalDateAdapter({overflow: 'reject'});
+  // Output example (reject): adapter.createDate(2024, 1, 31) -> throws
+  provideTemporalDateAdapter({overflow: 'constrain'});
+  // Output example (constrain): adapter.createDate(2024, 1, 31) -> 2024-02-29
+  ```
+  → invalid dates throw; invalid dates clamp.
+
+**Form control example (overflow)**
+```ts
+provideTemporalDateAdapter({mode: 'date', overflow: 'constrain'});
+const control = new FormControl(Temporal.PlainDate.from({year: 2024, month: 2, day: 31}));
+```
+Effect: the value is clamped to the last valid day of the month (e.g. 2024-02-29) instead of throwing.
+
+### Split adapter option examples
+```ts
+providePlainTemporalAdapter({mode: 'date', calendar: 'iso8601', outputCalendar: 'japanese'});
+provideZonedDateTimeAdapter({timezone: 'UTC', disambiguation: 'reject', rounding: {smallestUnit: 'minute'}});
+```
+
+## Usage examples
+```ts
+import {provideTemporalDateAdapter} from '@angular/material-temporal-adapter';
+
+provideTemporalDateAdapter({mode: 'date'});
+provideTemporalDateAdapter({mode: 'datetime'});
+provideTemporalDateAdapter({mode: 'zoned'}); // default: system timezone
+provideTemporalDateAdapter({mode: 'zoned', timezone: 'UTC'});
+```
+
+```ts
+import {
+  providePlainTemporalAdapter,
+  provideZonedDateTimeAdapter,
+} from '@angular/material-temporal-adapter/adapter/split';
+
+providePlainTemporalAdapter({mode: 'date'});
+providePlainTemporalAdapter({mode: 'datetime'});
+provideZonedDateTimeAdapter({timezone: 'Europe/Warsaw'});
+```
+
+## Migration patterns
+- **From `NativeDateAdapter` (`Date`)**: switch to `mode: 'date'`, replace `Date` with `Temporal.PlainDate`. If you rely on timezone/time-of-day behavior, use `mode: 'zoned'` with the system timezone instead.
+- **From `MomentDateAdapter`/`LuxonDateAdapter` (date+time)**: use `mode: 'datetime'`, replace values with `Temporal.PlainDateTime`.
+- **From timezone-aware usage**: use `mode: 'zoned'` + `timezone`, replace values with `Temporal.ZonedDateTime`.
+- **From Luxon `defaultOutputCalendar`**: keep `calendar` for calculations, set `outputCalendar` for display.
+- **From apps relying on DST/offset rules or rounding**: configure `disambiguation`, `offset`, and `rounding` in `zoned` mode.
+- **Incremental/explicit type choice**: use split adapters (`PlainTemporalAdapter` or `ZonedDateTimeAdapter`).
+- If a Temporal polyfill is needed, load it before bootstrapping the app.
+- If you provide custom `MAT_DATE_FORMATS`, ensure they are `Intl.DateTimeFormatOptions` (Temporal ignores parse formats and parses ISO strings only).
+
+**Custom display formats**
+```ts
+import {MatDateFormats} from '@angular/material/core';
+import {provideTemporalDateAdapter, MAT_TEMPORAL_DATE_FORMATS} from '@angular/material-temporal-adapter';
+
+const MY_TEMPORAL_FORMATS = {
+  ...MAT_TEMPORAL_DATE_FORMATS,
+  display: {
+    ...MAT_TEMPORAL_DATE_FORMATS.display,
+    dateInput: {year: 'numeric', month: 'long', day: 'numeric'},
+  },
+} satisfies MatDateFormats;
+
+bootstrapApplication(AppComponent, {
+  providers: [provideTemporalDateAdapter(MY_TEMPORAL_FORMATS, {mode: 'date'})],
+});
+```
+
+**MAT token notes**
+- `MAT_DATE_LOCALE`: locale string used for formatting and week info.
+- `MAT_DATE_FORMATS`: must be `Intl.DateTimeFormatOptions` (parse formats ignored).
+
+## Comparison and mapping
+- Follows the same `DateAdapter` contract as `NativeDateAdapter`, `MomentDateAdapter`, `LuxonDateAdapter`, and `DateFnsAdapter`.
+- Uses `Intl.DateTimeFormatOptions` for display formatting (like `NativeDateAdapter`), but the backing values are Temporal types instead of `Date`.
+
+**Option mapping (approximate)**
+| Existing adapter | Option | Temporal equivalent | Notes |
+| --- | --- | --- | --- |
+| NativeDateAdapter | n/a | `mode: 'date'` | Temporal `PlainDate` is the closest analogue to `Date` for date-only use. |
+| MomentDateAdapter | `useUtc: true` | `mode: 'zoned', timezone: 'UTC'` | Use zoned+UTC for UTC-centric workflows. |
+| MomentDateAdapter | `strict: true` | `overflow: 'reject'` | Temporal parsing is ISO-only; `overflow` controls invalid date creation. |
+| LuxonDateAdapter | `useUtc: true` | `mode: 'zoned', timezone: 'UTC'` | Similar UTC behavior. |
+| LuxonDateAdapter | `firstDayOfWeek` | `firstDayOfWeek` | Same semantics. |
+| LuxonDateAdapter | `defaultOutputCalendar` | `outputCalendar` | Calendar used for output/formatting (calculations use `calendar`). |
+| DateFnsAdapter | n/a | `MAT_DATE_LOCALE` + `MAT_DATE_FORMATS` | Temporal adapter also uses locale + formats. |
+
+## Notable design choices / dilemmas (with resolution)
+### 1) Temporal typings source (TypeScript not shipping them yet)
+TypeScript does not currently ship `lib.esnext.temporal` in the version used here, so this PR includes local declarations to type the adapter until the repo upgrades to a TS version that includes Temporal libs.
+
+Reference: https://github.com/microsoft/TypeScript/pull/62628
+
+### 2) API Extractor goldens
+API Extractor had trouble resolving the global `Temporal` namespace in this setup. Additionally, existing adapter packages (moment/luxon/date-fns) don’t have API goldens. For consistency and to avoid introducing a blocked/flaky step, this PR does not add API golden coverage for this adapter package.
+
+### 3) Formatting implementation note
+`Intl.DateTimeFormat` is used for localization (same overall approach as other adapters). Zoned values are formatted using the configured timezone.
+
+## Tests
+- Unit tests cover all `mode` variants and timezone behavior, plus creation/parsing/formatting/time operations.
+- Latest run: `pnpm test src/material-temporal-adapter --no-watch` on Chromium (local).
+  - Result: 141 passed, 2 skipped (Islamic calendar suite skipped because `islamic` calendar is not supported by the current Temporal implementation).
+- Note: split adapters (`PlainTemporalAdapter`, `ZonedDateTimeAdapter`) are not explicitly covered by a dedicated spec yet.
+
+## Open questions (feedback requested)
+1) Calendar type: keep `calendar` as `string` (max flexibility) vs trying to constrain it (risk of being incomplete/locale-dependent).
+2) Positioning: should this adapter be documented as “ready” like other adapters, or called out as “early” given current ecosystem support for Temporal?
+3) Should `mode` be required for the unified adapter (no implicit default), or keep the default `date` mode?
+4) Should `overflow` default to `reject` (strict) or align with Temporal’s `constrain` default?
+5) Should we add migration examples to the public docs (datepicker/timepicker) instead of only in the PR description?
+
+

--- a/goldens/BUILD.bazel
+++ b/goldens/BUILD.bazel
@@ -48,3 +48,8 @@ api_golden_test_npm_package(
     golden_dir = "goldens/aria",
     npm_package = "src/aria/npm_package",
 )
+
+# Note: material-temporal-adapter API golden tests are not included because
+# api-extractor cannot resolve the global Temporal namespace (similar to how
+# material-moment-adapter, material-luxon-adapter, and material-date-fns-adapter
+# also don't have API golden tests).

--- a/packages.bzl
+++ b/packages.bzl
@@ -8,6 +8,7 @@ ANGULAR_COMPONENTS_SCOPED_PACKAGES = ["@angular/%s" % p for p in [
     "material-luxon-adapter",
     "material-moment-adapter",
     "material-date-fns-adapter",
+    "material-temporal-adapter",
 ]]
 
 PKG_GROUP_REPLACEMENTS = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,16 +6,10 @@ settings:
 
 catalogs:
   default:
-    '@angular-devkit/build-angular':
-      specifier: 21.1.0-rc.0
-      version: 21.1.0-rc.0
     '@angular-devkit/core':
       specifier: 21.1.0-rc.0
       version: 21.1.0-rc.0
     '@angular-devkit/schematics':
-      specifier: 21.1.0-rc.0
-      version: 21.1.0-rc.0
-    '@angular/cli':
       specifier: 21.1.0-rc.0
       version: 21.1.0-rc.0
     '@angular/common':
@@ -39,16 +33,10 @@ catalogs:
     '@angular/platform-browser':
       specifier: 21.1.0-rc.0
       version: 21.1.0-rc.0
-    '@angular/platform-browser-dynamic':
-      specifier: 21.1.0-rc.0
-      version: 21.1.0-rc.0
     '@angular/platform-server':
       specifier: 21.1.0-rc.0
       version: 21.1.0-rc.0
     '@angular/router':
-      specifier: 21.1.0-rc.0
-      version: 21.1.0-rc.0
-    '@angular/ssr':
       specifier: 21.1.0-rc.0
       version: 21.1.0-rc.0
     '@schematics/angular':
@@ -69,10 +57,10 @@ importers:
     dependencies:
       '@angular-devkit/core':
         specifier: 'catalog:'
-        version: 21.1.0-rc.0(chokidar@5.0.0)
+        version: 21.1.0-rc.0
       '@angular-devkit/schematics':
         specifier: 'catalog:'
-        version: 21.1.0-rc.0(chokidar@5.0.0)
+        version: 21.1.0-rc.0
       '@angular/common':
         specifier: 'catalog:'
         version: 21.1.0-rc.0(@angular/compiler-cli@21.1.0-rc.0(@angular/compiler@21.1.0-rc.0)(typescript@5.9.2))(@angular/core@21.1.0-rc.0(@angular/compiler@21.1.0-rc.0)(rxjs@6.6.7)(zone.js@0.16.0))(rxjs@6.6.7)
@@ -166,7 +154,7 @@ importers:
         version: 16.0.3(rollup@4.55.1)
       '@schematics/angular':
         specifier: 'catalog:'
-        version: 21.1.0-rc.0(chokidar@5.0.0)
+        version: 21.1.0-rc.0
       '@types/babel__core':
         specifier: ^7.1.18
         version: 7.20.5
@@ -9891,6 +9879,15 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
+  '@angular-devkit/core@21.1.0-rc.0':
+    dependencies:
+      ajv: 8.17.1
+      ajv-formats: 3.0.1
+      jsonc-parser: 3.3.1
+      picomatch: 4.0.3
+      rxjs: 7.8.2
+      source-map: 0.7.6
+
   '@angular-devkit/core@21.1.0-rc.0(chokidar@5.0.0)':
     dependencies:
       ajv: 8.17.1
@@ -9901,6 +9898,16 @@ snapshots:
       source-map: 0.7.6
     optionalDependencies:
       chokidar: 5.0.0
+
+  '@angular-devkit/schematics@21.1.0-rc.0':
+    dependencies:
+      '@angular-devkit/core': 21.1.0-rc.0
+      jsonc-parser: 3.3.1
+      magic-string: 0.30.21
+      ora: 9.0.0
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - chokidar
 
   '@angular-devkit/schematics@21.1.0-rc.0(chokidar@5.0.0)':
     dependencies:
@@ -12783,6 +12790,14 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.55.1':
     optional: true
 
+  '@schematics/angular@21.1.0-rc.0':
+    dependencies:
+      '@angular-devkit/core': 21.1.0-rc.0
+      '@angular-devkit/schematics': 21.1.0-rc.0
+      jsonc-parser: 3.3.1
+    transitivePeerDependencies:
+      - chokidar
+
   '@schematics/angular@21.1.0-rc.0(chokidar@5.0.0)':
     dependencies:
       '@angular-devkit/core': 21.1.0-rc.0(chokidar@5.0.0)
@@ -15236,6 +15251,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  follow-redirects@1.15.11: {}
+
   follow-redirects@1.15.11(debug@4.4.3):
     optionalDependencies:
       debug: 4.4.3(supports-color@10.2.2)
@@ -15842,6 +15859,14 @@ snapshots:
       micromatch: 4.0.8
     transitivePeerDependencies:
       - supports-color
+
+  http-proxy@1.18.1:
+    dependencies:
+      eventemitter3: 4.0.7
+      follow-redirects: 1.15.11
+      requires-port: 1.0.0
+    transitivePeerDependencies:
+      - debug
 
   http-proxy@1.18.1(debug@4.4.3):
     dependencies:
@@ -16537,7 +16562,7 @@ snapshots:
       dom-serialize: 2.2.1
       glob: 7.2.3
       graceful-fs: 4.2.11
-      http-proxy: 1.18.1(debug@4.4.3)
+      http-proxy: 1.18.1
       isbinaryfile: 4.0.10
       lodash: 4.17.21
       log4js: 6.9.1

--- a/src/material-temporal-adapter/BUILD.bazel
+++ b/src/material-temporal-adapter/BUILD.bazel
@@ -1,0 +1,51 @@
+load("//tools:defaults.bzl", "ng_package", "ng_project", "ng_web_test_suite")
+
+package(default_visibility = ["//visibility:public"])
+
+ng_project(
+    name = "material-temporal-adapter",
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["**/*.spec.ts"],
+    ),
+    deps = [
+        "//:node_modules/@angular/core",
+        "//src:dev_mode_types",
+        "//src/material/core",
+    ],
+)
+
+ng_project(
+    name = "unit_test_sources",
+    testonly = True,
+    srcs = glob(
+        ["**/*.spec.ts"],
+        exclude = ["**/*.e2e.spec.ts"],
+    ),
+    deps = [
+        ":material-temporal-adapter",
+        "//:node_modules/@angular/core",
+        "//src/material/core",
+    ],
+)
+
+ng_web_test_suite(
+    name = "unit_tests",
+    deps = [
+        ":unit_test_sources",
+    ],
+)
+
+ng_package(
+    name = "npm_package",
+    package_name = "@angular/material-temporal-adapter",
+    srcs = ["package.json"],
+    nested_packages = ["//src/material-temporal-adapter/schematics:npm_package"],
+    tags = ["release-package"],
+    visibility = [
+        "//:__pkg__",
+        "//goldens:__pkg__",
+        "//integration:__subpackages__",
+    ],
+    deps = [":material-temporal-adapter"],
+)

--- a/src/material-temporal-adapter/adapter/index.ts
+++ b/src/material-temporal-adapter/adapter/index.ts
@@ -1,0 +1,124 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {NgModule, Provider} from '@angular/core';
+import {DateAdapter, MAT_DATE_FORMATS, MatDateFormats} from '@angular/material/core';
+import {
+  MAT_TEMPORAL_DATE_ADAPTER_OPTIONS,
+  MatTemporalDateAdapterOptions,
+  TemporalDateAdapter,
+} from './temporal-date-adapter';
+import {MAT_TEMPORAL_DATE_FORMATS} from './temporal-date-formats';
+
+export * from './temporal-date-adapter';
+export * from './temporal-date-formats';
+
+/**
+ * Module providing the Temporal date adapter.
+ * @deprecated Use `provideTemporalDateAdapter` instead.
+ */
+@NgModule({
+  providers: [
+    {
+      provide: DateAdapter,
+      useClass: TemporalDateAdapter,
+    },
+  ],
+})
+export class TemporalModule {}
+
+/**
+ * Module providing the Temporal date adapter with default formats.
+ *
+ * @example
+ * ```typescript
+ * import { MatTemporalModule } from '@angular/material-temporal-adapter';
+ *
+ * @NgModule({
+ *   imports: [MatTemporalModule],
+ * })
+ * export class AppModule {}
+ * ```
+ */
+@NgModule({
+  providers: [provideTemporalDateAdapter()],
+})
+export class MatTemporalModule {}
+
+/**
+ * Provider function for the Temporal date adapter.
+ *
+ * @param formats Custom date formats to use. Defaults to MAT_TEMPORAL_DATE_FORMATS.
+ * @param options Configuration options for the adapter.
+ * @returns Array of providers for the Temporal date adapter.
+ *
+ * @example
+ * ```typescript
+ * import { provideTemporalDateAdapter } from '@angular/material-temporal-adapter';
+ *
+ * bootstrapApplication(AppComponent, {
+ *   providers: [
+ *     provideTemporalDateAdapter(),
+ *   ],
+ * });
+ * ```
+ *
+ * @example
+ * With custom options:
+ * ```typescript
+ * import {
+ *   provideTemporalDateAdapter,
+ *   MAT_TEMPORAL_DATETIME_FORMATS
+ * } from '@angular/material-temporal-adapter';
+ *
+ * bootstrapApplication(AppComponent, {
+ *   providers: [
+ *     provideTemporalDateAdapter(MAT_TEMPORAL_DATETIME_FORMATS, {
+ *       calendar: 'islamic',
+ *       mode: 'datetime',
+ *     }),
+ *   ],
+ * });
+ * ```
+ */
+export function provideTemporalDateAdapter(
+  formats: MatDateFormats = MAT_TEMPORAL_DATE_FORMATS,
+  options?: Partial<MatTemporalDateAdapterOptions>,
+): Provider[] {
+  const providers: Provider[] = [
+    {
+      provide: DateAdapter,
+      useClass: TemporalDateAdapter,
+    },
+    {provide: MAT_DATE_FORMATS, useValue: formats},
+  ];
+
+  if (options) {
+    const zonedOptions = options.mode === 'zoned' ? options : null;
+    providers.push({
+      provide: MAT_TEMPORAL_DATE_ADAPTER_OPTIONS,
+      useValue: {
+        calendar: options.calendar ?? 'iso8601',
+        outputCalendar: options.outputCalendar,
+        mode: options.mode ?? 'date',
+        firstDayOfWeek: options.firstDayOfWeek,
+        overflow: options.overflow,
+        ...(zonedOptions
+          ? {
+              timezone: zonedOptions.timezone,
+              disambiguation: zonedOptions.disambiguation,
+              offset: zonedOptions.offset,
+              rounding: zonedOptions.rounding,
+            }
+          : {}),
+      },
+    });
+  }
+
+  return providers;
+}

--- a/src/material-temporal-adapter/adapter/split-adapters.spec.ts
+++ b/src/material-temporal-adapter/adapter/split-adapters.spec.ts
@@ -1,0 +1,1378 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {TestBed} from '@angular/core/testing';
+import {DateAdapter} from '@angular/material/core';
+import {
+  MAT_BASE_TEMPORAL_OPTIONS,
+  MAT_PLAIN_TEMPORAL_ADAPTER_OPTIONS,
+  MAT_ZONED_DATETIME_OPTIONS,
+  PlainDateAdapter,
+  PlainDateTimeAdapter,
+  PlainTemporalAdapter,
+  ZonedDateTimeAdapter,
+} from './split';
+
+/**
+ * 0-based month index constants for ISO8601/Gregorian calendar tests.
+ * These are NOT month names - they're indices matching Angular Material's
+ * DateAdapter API where months are 0-indexed (January=0, December=11).
+ *
+ * For non-ISO calendars (Hebrew, Islamic, etc.), the adapters also use
+ * 0-based month indices, but the number of months may differ:
+ * - Hebrew calendar: 12-13 months (13 in leap years)
+ * - Islamic calendar: 12 months
+ * - Chinese calendar: 12-13 months
+ */
+const JAN = 0,
+  FEB = 1,
+  MAR = 2;
+
+/** Check if Temporal API is available. */
+const hasTemporal = typeof (globalThis as {Temporal?: unknown}).Temporal !== 'undefined';
+
+/** Describe function that skips tests if Temporal is not available. */
+const describeTemporal: (description: string, specDefinitions: () => void) => void = hasTemporal
+  ? describe
+  : xdescribe;
+
+/** Check if a calendar is supported by the Temporal implementation. */
+function supportsCalendar(calendarId: string): boolean {
+  if (!hasTemporal) {
+    return false;
+  }
+  try {
+    Temporal.PlainDate.from({year: 2024, month: 1, day: 1, calendar: calendarId});
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Describe function that skips tests if the calendar is not supported. */
+const describeIfCalendarSupported = (calendarId: string) =>
+  supportsCalendar(calendarId) ? describeTemporal : xdescribe;
+
+/** Type guard helpers using duck typing (since Temporal types are interfaces, not classes) */
+function isPlainDate(value: unknown): value is Temporal.PlainDate {
+  return (
+    value != null &&
+    typeof value === 'object' &&
+    'calendarId' in value &&
+    !('hour' in value) &&
+    !('timeZoneId' in value)
+  );
+}
+
+function isPlainDateTime(value: unknown): value is Temporal.PlainDateTime {
+  return (
+    value != null &&
+    typeof value === 'object' &&
+    'calendarId' in value &&
+    'hour' in value &&
+    !('timeZoneId' in value)
+  );
+}
+
+function isZonedDateTime(value: unknown): value is Temporal.ZonedDateTime {
+  return value != null && typeof value === 'object' && 'timeZoneId' in value;
+}
+
+// =============================================================================
+// PlainTemporalAdapter Tests (configurable date/datetime mode)
+// =============================================================================
+describeTemporal('PlainTemporalAdapter in date mode', () => {
+  let adapter: PlainTemporalAdapter;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        {provide: DateAdapter, useClass: PlainTemporalAdapter},
+        {provide: MAT_PLAIN_TEMPORAL_ADAPTER_OPTIONS, useValue: {mode: 'date'}},
+      ],
+    });
+    adapter = TestBed.inject(DateAdapter) as PlainTemporalAdapter;
+    adapter.setLocale('en-US');
+  });
+
+  it('should create a date', () => {
+    const date = adapter.createDate(2017, JAN, 1);
+    expect(adapter.isValid(date)).toBe(true);
+  });
+
+  it('should clone a date', () => {
+    const date = adapter.createDate(2017, JAN, 1);
+    const clone = adapter.clone(date);
+    expect(clone).not.toBe(date);
+    expect(adapter.getYear(clone)).toEqual(adapter.getYear(date));
+  });
+
+  it('should create PlainDate in date mode', () => {
+    const date = adapter.createDate(2024, JAN, 15);
+    expect(isPlainDate(date)).toBe(true);
+  });
+
+  it('should return today as PlainDate', () => {
+    const today = adapter.today();
+    expect(isPlainDate(today)).toBe(true);
+  });
+
+  it('should return original date when setting time in date mode', () => {
+    const date = adapter.createDate(2024, JAN, 15);
+    const withTime = adapter.setTime(date, 14, 30, 0);
+    // In date mode, setTime just returns the original date unchanged
+    // (with a console.warn in dev mode)
+    expect(isPlainDate(withTime)).toBe(true);
+    expect(adapter.getHours(withTime)).toBe(0); // No time component on PlainDate
+  });
+
+  it('should get month names', () => {
+    const monthNames = adapter.getMonthNames('long');
+    expect(monthNames.length).toBeGreaterThanOrEqual(12);
+  });
+
+  it('should get day of week names', () => {
+    const dayNames = adapter.getDayOfWeekNames('long');
+    expect(dayNames.length).toBe(7);
+  });
+});
+
+describeTemporal('PlainTemporalAdapter in datetime mode', () => {
+  let adapter: PlainTemporalAdapter;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        {provide: DateAdapter, useClass: PlainTemporalAdapter},
+        {provide: MAT_PLAIN_TEMPORAL_ADAPTER_OPTIONS, useValue: {mode: 'datetime'}},
+      ],
+    });
+    adapter = TestBed.inject(DateAdapter) as PlainTemporalAdapter;
+    adapter.setLocale('en-US');
+  });
+
+  it('should create a date', () => {
+    const date = adapter.createDate(2017, JAN, 1);
+    expect(adapter.isValid(date)).toBe(true);
+  });
+
+  it('should clone a date', () => {
+    const date = adapter.createDate(2017, JAN, 1);
+    const clone = adapter.clone(date);
+    expect(clone).not.toBe(date);
+    expect(adapter.getYear(clone)).toEqual(adapter.getYear(date));
+  });
+
+  it('should get and set time', () => {
+    const date = adapter.createDate(2024, JAN, 1);
+    const withTime = adapter.setTime(date, 14, 30, 45);
+    expect(adapter.getHours(withTime)).toBe(14);
+    expect(adapter.getMinutes(withTime)).toBe(30);
+    expect(adapter.getSeconds(withTime)).toBe(45);
+  });
+
+  it('should create PlainDateTime in datetime mode', () => {
+    const date = adapter.createDate(2024, JAN, 15);
+    expect(isPlainDateTime(date)).toBe(true);
+  });
+
+  it('should return today as PlainDateTime', () => {
+    const today = adapter.today();
+    expect(isPlainDateTime(today)).toBe(true);
+  });
+
+  it('should preserve PlainDateTime type when setting time', () => {
+    const date = adapter.createDate(2024, JAN, 15);
+    const withTime = adapter.setTime(date, 14, 30, 0);
+    expect(isPlainDateTime(withTime)).toBe(true);
+  });
+
+  it('should throw for invalid hours', () => {
+    const date = adapter.today();
+    expect(() => adapter.setTime(date, -1, 0, 0)).toThrowError(/Invalid hours/);
+    expect(() => adapter.setTime(date, 24, 0, 0)).toThrowError(/Invalid hours/);
+  });
+
+  it('should throw for invalid minutes', () => {
+    const date = adapter.today();
+    expect(() => adapter.setTime(date, 0, -1, 0)).toThrowError(/Invalid minutes/);
+    expect(() => adapter.setTime(date, 0, 60, 0)).toThrowError(/Invalid minutes/);
+  });
+
+  it('should throw for invalid seconds', () => {
+    const date = adapter.today();
+    expect(() => adapter.setTime(date, 0, 0, -1)).toThrowError(/Invalid seconds/);
+    expect(() => adapter.setTime(date, 0, 0, 60)).toThrowError(/Invalid seconds/);
+  });
+
+  it('should parse time string', () => {
+    const result = adapter.parseTime('14:30', 'HH:mm');
+    expect(result).not.toBeNull();
+    expect(adapter.getHours(result!)).toBe(14);
+    expect(adapter.getMinutes(result!)).toBe(30);
+  });
+});
+
+describeTemporal('PlainTemporalAdapter with overflow constrain', () => {
+  let adapter: PlainTemporalAdapter;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        {provide: DateAdapter, useClass: PlainTemporalAdapter},
+        {
+          provide: MAT_PLAIN_TEMPORAL_ADAPTER_OPTIONS,
+          useValue: {mode: 'date', overflow: 'constrain'},
+        },
+      ],
+    });
+    adapter = TestBed.inject(DateAdapter) as PlainTemporalAdapter;
+    adapter.setLocale('en-US');
+  });
+
+  it('should constrain February 30 to February 29 (leap year)', () => {
+    const constrained = adapter.createDate(2024, FEB, 30);
+    expect(adapter.getDate(constrained)).toBe(29);
+  });
+
+  it('should constrain addCalendarMonths', () => {
+    // March 31 + (-1 month) should constrain to Feb 29 (leap year)
+    const date = adapter.createDate(2024, MAR, 31);
+    const result = adapter.addCalendarMonths(date, -1);
+    expect(adapter.getMonth(result)).toBe(FEB);
+    expect(adapter.getDate(result)).toBe(29);
+  });
+
+  it('should constrain addCalendarYears', () => {
+    // Feb 29 2024 + 1 year should constrain to Feb 28 2025 (non-leap year)
+    const date = adapter.createDate(2024, FEB, 29);
+    const result = adapter.addCalendarYears(date, 1);
+    expect(adapter.getYear(result)).toBe(2025);
+    expect(adapter.getMonth(result)).toBe(FEB);
+    expect(adapter.getDate(result)).toBe(28);
+  });
+
+  it('should constrain invalid month (15) to December (11)', () => {
+    // Month 15 should constrain to 12 (December = index 11)
+    const constrained = adapter.createDate(2024, 15, 1);
+    expect(adapter.getMonth(constrained)).toBe(11); // December
+    expect(adapter.getDate(constrained)).toBe(1);
+  });
+
+  it('should NOT throw for invalid month in constrain mode', () => {
+    // Unlike reject mode, constrain should not throw
+    expect(() => adapter.createDate(2024, 15, 1)).not.toThrow();
+    expect(() => adapter.createDate(2024, -1, 1)).not.toThrow();
+  });
+});
+
+describeTemporal('PlainTemporalAdapter with overflow reject', () => {
+  let adapter: PlainTemporalAdapter;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        {provide: DateAdapter, useClass: PlainTemporalAdapter},
+        {provide: MAT_PLAIN_TEMPORAL_ADAPTER_OPTIONS, useValue: {mode: 'date', overflow: 'reject'}},
+      ],
+    });
+    adapter = TestBed.inject(DateAdapter) as PlainTemporalAdapter;
+    adapter.setLocale('en-US');
+  });
+
+  it('should reject invalid month index', () => {
+    expect(() => adapter.createDate(2024, 12, 1)).toThrowError(/Invalid month/);
+    expect(() => adapter.createDate(2024, -1, 1)).toThrowError(/Invalid month/);
+  });
+
+  it('should reject invalid date', () => {
+    expect(() => adapter.createDate(2024, JAN, 0)).toThrowError(/Invalid date/);
+  });
+
+  it('should reject February 30', () => {
+    expect(() => adapter.createDate(2024, FEB, 30)).toThrow();
+  });
+});
+
+// =============================================================================
+// ZonedDateTimeAdapter Tests (date + time + timezone)
+// =============================================================================
+describeTemporal('ZonedDateTimeAdapter', () => {
+  let adapter: ZonedDateTimeAdapter;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        {provide: DateAdapter, useClass: ZonedDateTimeAdapter},
+        {provide: MAT_ZONED_DATETIME_OPTIONS, useValue: {timezone: 'UTC'}},
+      ],
+    });
+    adapter = TestBed.inject(DateAdapter) as ZonedDateTimeAdapter;
+    adapter.setLocale('en-US');
+  });
+
+  // Basic date operations
+  it('should create a date', () => {
+    const date = adapter.createDate(2017, JAN, 1);
+    expect(adapter.isValid(date)).toBe(true);
+  });
+
+  it('should get year', () => {
+    expect(adapter.getYear(adapter.createDate(2017, JAN, 1))).toBe(2017);
+  });
+
+  it('should get month', () => {
+    expect(adapter.getMonth(adapter.createDate(2017, JAN, 1))).toBe(JAN);
+  });
+
+  it('should get date', () => {
+    expect(adapter.getDate(adapter.createDate(2017, JAN, 1))).toBe(1);
+  });
+
+  it('should clone a date', () => {
+    const date = adapter.createDate(2017, JAN, 1);
+    const clone = adapter.clone(date);
+    expect(clone).not.toBe(date);
+    expect(adapter.getYear(clone)).toEqual(adapter.getYear(date));
+  });
+
+  // Time support
+  it('should get and set time', () => {
+    const date = adapter.createDate(2024, JAN, 1);
+    const withTime = adapter.setTime(date, 14, 30, 45);
+    expect(adapter.getHours(withTime)).toBe(14);
+    expect(adapter.getMinutes(withTime)).toBe(30);
+    expect(adapter.getSeconds(withTime)).toBe(45);
+  });
+
+  it('should throw for invalid hours', () => {
+    const date = adapter.today();
+    expect(() => adapter.setTime(date, -1, 0, 0)).toThrowError(/Invalid hours/);
+    expect(() => adapter.setTime(date, 24, 0, 0)).toThrowError(/Invalid hours/);
+  });
+
+  it('should parse time string', () => {
+    const result = adapter.parseTime('14:30', 'HH:mm');
+    expect(result).not.toBeNull();
+    expect(adapter.getHours(result!)).toBe(14);
+    expect(adapter.getMinutes(result!)).toBe(30);
+  });
+
+  // Type-specific tests
+  it('should return ZonedDateTime type', () => {
+    const date = adapter.createDate(2024, JAN, 15);
+    expect(isZonedDateTime(date)).toBe(true);
+  });
+
+  it('should include timezone in ISO string', () => {
+    const date = adapter.createDate(2024, JAN, 15);
+    const iso = adapter.toIso8601(date);
+    expect(iso).toContain('[UTC]');
+  });
+
+  it('should preserve timezone when cloning', () => {
+    const date = adapter.createDate(2024, JAN, 15);
+    const clone = adapter.clone(date);
+    expect(clone.timeZoneId).toBe('UTC');
+  });
+
+  // Overflow tests (default is reject)
+  it('should reject February 30 with default overflow reject', () => {
+    expect(() => adapter.createDate(2024, FEB, 30)).toThrowError(/Invalid date/);
+  });
+
+  it('should get month names', () => {
+    const monthNames = adapter.getMonthNames('long');
+    expect(monthNames.length).toBeGreaterThanOrEqual(12);
+  });
+
+  it('should get day of week names', () => {
+    const dayNames = adapter.getDayOfWeekNames('long');
+    expect(dayNames.length).toBe(7);
+  });
+});
+
+describeTemporal('ZonedDateTimeAdapter with overflow constrain', () => {
+  let adapter: ZonedDateTimeAdapter;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        {provide: DateAdapter, useClass: ZonedDateTimeAdapter},
+        {provide: MAT_ZONED_DATETIME_OPTIONS, useValue: {timezone: 'UTC', overflow: 'constrain'}},
+      ],
+    });
+    adapter = TestBed.inject(DateAdapter) as ZonedDateTimeAdapter;
+    adapter.setLocale('en-US');
+  });
+
+  it('should constrain February 30 to February 29 (leap year)', () => {
+    const constrained = adapter.createDate(2024, FEB, 30);
+    expect(adapter.getDate(constrained)).toBe(29);
+  });
+
+  it('should constrain addCalendarYears', () => {
+    // Feb 29 2024 + 1 year should constrain to Feb 28 2025 (non-leap year)
+    const date = adapter.createDate(2024, FEB, 29);
+    const result = adapter.addCalendarYears(date, 1);
+    expect(adapter.getYear(result)).toBe(2025);
+    expect(adapter.getMonth(result)).toBe(FEB);
+    expect(adapter.getDate(result)).toBe(28);
+  });
+
+  it('should constrain invalid month (15) to December (11)', () => {
+    // Month 15 should constrain to 12 (December = index 11)
+    const constrained = adapter.createDate(2024, 15, 1);
+    expect(adapter.getMonth(constrained)).toBe(11); // December
+    expect(adapter.getDate(constrained)).toBe(1);
+  });
+
+  it('should NOT throw for invalid month in constrain mode', () => {
+    // Unlike reject mode, constrain should not throw
+    expect(() => adapter.createDate(2024, 15, 1)).not.toThrow();
+    expect(() => adapter.createDate(2024, -1, 1)).not.toThrow();
+  });
+});
+
+describeTemporal('ZonedDateTimeAdapter with specific timezone', () => {
+  let adapter: ZonedDateTimeAdapter;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        {provide: DateAdapter, useClass: ZonedDateTimeAdapter},
+        {provide: MAT_ZONED_DATETIME_OPTIONS, useValue: {timezone: 'America/New_York'}},
+      ],
+    });
+    adapter = TestBed.inject(DateAdapter) as ZonedDateTimeAdapter;
+    adapter.setLocale('en-US');
+  });
+
+  it('should use specified timezone', () => {
+    const date = adapter.createDate(2024, JAN, 15);
+    expect(date.timeZoneId).toBe('America/New_York');
+  });
+
+  it('should handle DST transitions', () => {
+    // March 10, 2024 2:00 AM is when DST starts in New York
+    const date = adapter.createDate(2024, MAR, 10);
+    expect(adapter.isValid(date)).toBe(true);
+  });
+});
+
+describeTemporal('ZonedDateTimeAdapter with disambiguation reject', () => {
+  let adapter: ZonedDateTimeAdapter;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        {provide: DateAdapter, useClass: ZonedDateTimeAdapter},
+        {
+          provide: MAT_ZONED_DATETIME_OPTIONS,
+          useValue: {timezone: 'America/New_York', disambiguation: 'reject'},
+        },
+      ],
+    });
+    adapter = TestBed.inject(DateAdapter) as ZonedDateTimeAdapter;
+    adapter.setLocale('en-US');
+  });
+
+  it('should reject ambiguous time during DST gap', () => {
+    // March 10, 2024 2:30 AM does not exist in New York (DST gap)
+    const date = adapter.createDate(2024, MAR, 10);
+    expect(() => adapter.setTime(date, 2, 30, 0)).toThrow();
+  });
+});
+
+describeTemporal('ZonedDateTimeAdapter with rounding', () => {
+  let adapter: ZonedDateTimeAdapter;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        {provide: DateAdapter, useClass: ZonedDateTimeAdapter},
+        {
+          provide: MAT_ZONED_DATETIME_OPTIONS,
+          useValue: {
+            timezone: 'UTC',
+            rounding: {smallestUnit: 'minute', roundingIncrement: 15, roundingMode: 'halfExpand'},
+          },
+        },
+      ],
+    });
+    adapter = TestBed.inject(DateAdapter) as ZonedDateTimeAdapter;
+    adapter.setLocale('en-US');
+  });
+
+  it('should round to 15-minute increments in toIso8601', () => {
+    // Create via createDate with setTime to get 12:38
+    const date = adapter.createDate(2024, JAN, 15);
+    const dateWithTime = adapter.setTime(date, 12, 38, 0);
+    const iso = adapter.toIso8601(dateWithTime);
+    // 38 minutes rounds to 45 with halfExpand and 15-minute increments (38 > 37.5)
+    expect(iso).toContain('12:45:00');
+  });
+
+  it('should round down when closer to lower increment', () => {
+    const date = adapter.createDate(2024, JAN, 15);
+    const dateWithTime = adapter.setTime(date, 12, 37, 0);
+    const iso = adapter.toIso8601(dateWithTime);
+    // 37 minutes rounds to 30 (37 <= 37.5)
+    expect(iso).toContain('12:30:00');
+  });
+});
+
+// =============================================================================
+// Calendar Support Tests
+// =============================================================================
+describeIfCalendarSupported('hebrew')('PlainTemporalAdapter with Hebrew calendar', () => {
+  let adapter: PlainTemporalAdapter;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        {provide: DateAdapter, useClass: PlainTemporalAdapter},
+        {provide: MAT_PLAIN_TEMPORAL_ADAPTER_OPTIONS, useValue: {mode: 'date', calendar: 'hebrew'}},
+      ],
+    });
+    adapter = TestBed.inject(DateAdapter) as PlainTemporalAdapter;
+    adapter.setLocale('he-IL');
+  });
+
+  it('should create date with Hebrew calendar', () => {
+    // Hebrew year 5784 (2023-2024), first month (Tishrei = index 0)
+    const date = adapter.createDate(5784, 0, 1);
+    expect(adapter.isValid(date)).toBe(true);
+    expect((date as Temporal.PlainDate).calendarId).toBe('hebrew');
+  });
+
+  it('should get at least 12 months for Hebrew calendar', () => {
+    // Note: getMonthNames() returns a fixed number of months based on a reference year.
+    // For Hebrew calendar, it may return 12 or 13 depending on the implementation.
+    // The important thing is that it handles non-Gregorian months correctly.
+    const monthNames = adapter.getMonthNames('long');
+    expect(monthNames.length).toBeGreaterThanOrEqual(12);
+    expect(monthNames.length).toBeLessThanOrEqual(13);
+  });
+
+  it('should report correct months in year for Hebrew leap year', () => {
+    // Hebrew year 5784 is a leap year (has 13 months with Adar I and Adar II)
+    // The date's monthsInYear property should report 13
+    const leapYearDate = adapter.createDate(5784, 0, 1) as Temporal.PlainDate;
+    expect(leapYearDate.monthsInYear).toBe(13);
+  });
+
+  it('should report correct months in year for Hebrew non-leap year', () => {
+    // Hebrew year 5785 is NOT a leap year (has 12 months)
+    const nonLeapYearDate = adapter.createDate(5785, 0, 1) as Temporal.PlainDate;
+    expect(nonLeapYearDate.monthsInYear).toBe(12);
+  });
+
+  it('should get day of week names in Hebrew locale', () => {
+    const dayNames = adapter.getDayOfWeekNames('long');
+    expect(dayNames.length).toBe(7);
+    // Hebrew day names should contain Hebrew characters
+    const hebrewCharRegex = /[\u0590-\u05FF]/;
+    dayNames.forEach(name => {
+      expect(hebrewCharRegex.test(name)).toBe(true);
+    });
+  });
+
+  it('should handle month navigation across leap/non-leap boundary', () => {
+    // Start in Adar II (month 6) of leap year 5784
+    const adarII = adapter.createDate(5784, 6, 1);
+    expect(adapter.isValid(adarII)).toBe(true);
+
+    // Move to next month (Nisan = month 7)
+    const nisan = adapter.addCalendarMonths(adarII, 1);
+    expect(adapter.getMonth(nisan)).toBe(7);
+  });
+});
+
+describeIfCalendarSupported('islamic')('ZonedDateTimeAdapter with Islamic calendar', () => {
+  let adapter: ZonedDateTimeAdapter;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        {provide: DateAdapter, useClass: ZonedDateTimeAdapter},
+        {
+          provide: MAT_ZONED_DATETIME_OPTIONS,
+          useValue: {timezone: 'UTC', calendar: 'islamic'},
+        },
+      ],
+    });
+    adapter = TestBed.inject(DateAdapter) as ZonedDateTimeAdapter;
+    adapter.setLocale('ar-SA');
+  });
+
+  it('should create date with Islamic calendar', () => {
+    const date = adapter.createDate(1445, 0, 1);
+    expect(adapter.isValid(date)).toBe(true);
+  });
+
+  it('should get day of week names in Arabic locale', () => {
+    const dayNames = adapter.getDayOfWeekNames('long');
+    expect(dayNames.length).toBe(7);
+    // Arabic day names should contain Arabic characters
+    const arabicCharRegex = /[\u0600-\u06FF]/;
+    dayNames.forEach(name => {
+      expect(arabicCharRegex.test(name)).toBe(true);
+    });
+  });
+});
+
+// =============================================================================
+// Output Calendar Tests
+// =============================================================================
+describeTemporal('PlainTemporalAdapter with outputCalendar', () => {
+  let adapter: PlainTemporalAdapter;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        {provide: DateAdapter, useClass: PlainTemporalAdapter},
+        {
+          provide: MAT_PLAIN_TEMPORAL_ADAPTER_OPTIONS,
+          useValue: {mode: 'date', calendar: 'iso8601', outputCalendar: 'japanese'},
+        },
+      ],
+    });
+    adapter = TestBed.inject(DateAdapter) as PlainTemporalAdapter;
+    adapter.setLocale('ja-JP');
+  });
+
+  it('should store dates in ISO8601 but format in Japanese calendar', () => {
+    const date = adapter.createDate(2024, JAN, 1);
+    // Stored as ISO8601
+    expect((date as Temporal.PlainDate).calendarId).toBe('iso8601');
+    // Formatted as Japanese
+    const formatted = adapter.format(date, {year: 'numeric'});
+    const expected = Temporal.PlainDate.from('2024-01-01')
+      .withCalendar('japanese')
+      .toLocaleString('ja-JP', {year: 'numeric', calendar: 'japanese'});
+    expect(formatted).toBe(expected);
+  });
+});
+
+// =============================================================================
+// Edge Case Tests - Security and Robustness
+// =============================================================================
+describeTemporal('PlainTemporalAdapter edge cases', () => {
+  let adapter: PlainTemporalAdapter;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        {provide: DateAdapter, useClass: PlainTemporalAdapter},
+        {
+          provide: MAT_PLAIN_TEMPORAL_ADAPTER_OPTIONS,
+          useValue: {mode: 'datetime'},
+        },
+      ],
+    });
+    adapter = TestBed.inject(DateAdapter) as PlainTemporalAdapter;
+  });
+
+  describe('parse with epoch milliseconds edge cases', () => {
+    it('should handle valid epoch milliseconds', () => {
+      const date = adapter.parse(0);
+      expect(adapter.isValid(date!)).toBe(true);
+    });
+
+    it('should handle negative epoch milliseconds', () => {
+      const date = adapter.parse(-86400000); // 1969-12-31
+      expect(adapter.isValid(date!)).toBe(true);
+    });
+
+    it('should return invalid for Infinity', () => {
+      const date = adapter.parse(Infinity);
+      expect(adapter.isValid(date!)).toBe(false);
+    });
+
+    it('should return invalid for -Infinity', () => {
+      const date = adapter.parse(-Infinity);
+      expect(adapter.isValid(date!)).toBe(false);
+    });
+
+    it('should return invalid for NaN', () => {
+      const date = adapter.parse(NaN);
+      expect(adapter.isValid(date!)).toBe(false);
+    });
+
+    it('should return invalid for values exceeding JS Date range (positive)', () => {
+      const date = adapter.parse(8.65e15); // Beyond ±8.64e15
+      expect(adapter.isValid(date!)).toBe(false);
+    });
+
+    it('should return invalid for values exceeding JS Date range (negative)', () => {
+      const date = adapter.parse(-8.65e15);
+      expect(adapter.isValid(date!)).toBe(false);
+    });
+
+    it('should handle boundary value at positive limit', () => {
+      const date = adapter.parse(8.64e15);
+      expect(adapter.isValid(date!)).toBe(true);
+    });
+
+    it('should handle boundary value at negative limit', () => {
+      const date = adapter.parse(-8.64e15);
+      expect(adapter.isValid(date!)).toBe(true);
+    });
+  });
+
+  describe('parseTime edge cases', () => {
+    it('should return invalid for very long strings (DoS prevention)', () => {
+      const longString = '12:30:00'.padEnd(100, ' ');
+      const result = adapter.parseTime(longString);
+      expect(adapter.isValid(result!)).toBe(false);
+    });
+
+    it('should return invalid for 33+ character strings', () => {
+      const result = adapter.parseTime('a'.repeat(33));
+      expect(adapter.isValid(result!)).toBe(false);
+    });
+
+    it('should accept 32 character strings', () => {
+      // 32 chars is the limit, but it still needs to be valid time format
+      const result = adapter.parseTime('12:30:00'); // Valid time under 32 chars
+      expect(adapter.isValid(result!)).toBe(true);
+    });
+
+    it('should handle null', () => {
+      const result = adapter.parseTime(null);
+      expect(result).toBeNull();
+    });
+
+    it('should handle empty string', () => {
+      const result = adapter.parseTime('');
+      expect(result).toBeNull();
+    });
+
+    it('should return invalid for whitespace-only string', () => {
+      const result = adapter.parseTime('   ');
+      expect(adapter.isValid(result!)).toBe(false);
+    });
+  });
+
+  describe('setTime edge cases', () => {
+    it('should throw for NaN hours in dev mode', () => {
+      const today = adapter.today();
+      expect(() => adapter.setTime(today, NaN, 0, 0)).toThrowError(/Invalid hours/);
+    });
+
+    it('should throw for Infinity minutes in dev mode', () => {
+      const today = adapter.today();
+      expect(() => adapter.setTime(today, 0, Infinity, 0)).toThrowError(/Invalid minutes/);
+    });
+
+    it('should throw for -Infinity seconds in dev mode', () => {
+      const today = adapter.today();
+      expect(() => adapter.setTime(today, 0, 0, -Infinity)).toThrowError(/Invalid seconds/);
+    });
+
+    it('should throw for negative hours', () => {
+      const today = adapter.today();
+      expect(() => adapter.setTime(today, -1, 0, 0)).toThrowError(/Invalid hours/);
+    });
+
+    it('should throw for hours > 23', () => {
+      const today = adapter.today();
+      expect(() => adapter.setTime(today, 24, 0, 0)).toThrowError(/Invalid hours/);
+    });
+
+    it('should throw for minutes > 59', () => {
+      const today = adapter.today();
+      expect(() => adapter.setTime(today, 0, 60, 0)).toThrowError(/Invalid minutes/);
+    });
+
+    it('should throw for seconds > 59', () => {
+      const today = adapter.today();
+      expect(() => adapter.setTime(today, 0, 0, 60)).toThrowError(/Invalid seconds/);
+    });
+  });
+});
+
+describeTemporal('ZonedDateTimeAdapter edge cases', () => {
+  let adapter: ZonedDateTimeAdapter;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        {provide: DateAdapter, useClass: ZonedDateTimeAdapter},
+        {
+          provide: MAT_ZONED_DATETIME_OPTIONS,
+          useValue: {calendar: 'iso8601', timezone: 'UTC'},
+        },
+      ],
+    });
+    adapter = TestBed.inject(DateAdapter) as ZonedDateTimeAdapter;
+  });
+
+  describe('parse with epoch milliseconds edge cases', () => {
+    it('should handle valid epoch milliseconds', () => {
+      const date = adapter.parse(0);
+      expect(adapter.isValid(date!)).toBe(true);
+    });
+
+    it('should return invalid for Infinity', () => {
+      const date = adapter.parse(Infinity);
+      expect(adapter.isValid(date!)).toBe(false);
+    });
+
+    it('should return invalid for NaN', () => {
+      const date = adapter.parse(NaN);
+      expect(adapter.isValid(date!)).toBe(false);
+    });
+
+    it('should return invalid for values exceeding JS Date range', () => {
+      const date = adapter.parse(9e15);
+      expect(adapter.isValid(date!)).toBe(false);
+    });
+  });
+
+  describe('parseTime edge cases', () => {
+    it('should return invalid for very long strings (DoS prevention)', () => {
+      const longString = '12:30:00'.padEnd(100, ' ');
+      const result = adapter.parseTime(longString);
+      expect(adapter.isValid(result!)).toBe(false);
+    });
+
+    it('should handle null', () => {
+      expect(adapter.parseTime(null)).toBeNull();
+    });
+
+    it('should handle empty string', () => {
+      expect(adapter.parseTime('')).toBeNull();
+    });
+  });
+
+  describe('setTime edge cases', () => {
+    it('should throw for NaN hours in dev mode', () => {
+      const today = adapter.today();
+      expect(() => adapter.setTime(today, NaN, 0, 0)).toThrowError(/Invalid hours/);
+    });
+
+    it('should throw for Infinity minutes in dev mode', () => {
+      const today = adapter.today();
+      expect(() => adapter.setTime(today, 0, Infinity, 0)).toThrowError(/Invalid minutes/);
+    });
+  });
+});
+
+// =============================================================================
+// PlainDateAdapter Tests (date-only, internal adapter)
+// =============================================================================
+describeTemporal('PlainDateAdapter (via PlainTemporalAdapter date mode)', () => {
+  let adapter: PlainTemporalAdapter;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        {provide: DateAdapter, useClass: PlainTemporalAdapter},
+        {
+          provide: MAT_PLAIN_TEMPORAL_ADAPTER_OPTIONS,
+          useValue: {mode: 'date'},
+        },
+      ],
+    });
+    adapter = TestBed.inject(DateAdapter) as PlainTemporalAdapter;
+  });
+
+  it('should create PlainDate instances', () => {
+    const date = adapter.createDate(2024, JAN, 15);
+    expect(isPlainDate(date)).toBe(true);
+    expect(isPlainDateTime(date)).toBe(false);
+  });
+
+  it('should return 0 for time methods on PlainDate', () => {
+    const date = adapter.createDate(2024, JAN, 15);
+    expect(adapter.getHours(date)).toBe(0);
+    expect(adapter.getMinutes(date)).toBe(0);
+    expect(adapter.getSeconds(date)).toBe(0);
+  });
+
+  it('should return invalid for parseTime in date mode', () => {
+    const result = adapter.parseTime('12:30');
+    expect(adapter.isValid(result!)).toBe(false);
+  });
+
+  it('should parse epoch milliseconds in date mode', () => {
+    const date = adapter.parse(1704067200000); // 2024-01-01 00:00:00 UTC
+    expect(adapter.isValid(date!)).toBe(true);
+    expect(isPlainDate(date)).toBe(true);
+  });
+
+  it('should handle invalid epoch in date mode', () => {
+    const date = adapter.parse(Infinity);
+    expect(adapter.isValid(date!)).toBe(false);
+  });
+});
+
+// =============================================================================
+// Invalid Date Handling Tests
+// =============================================================================
+describeTemporal('Invalid date handling across adapters', () => {
+  describe('PlainTemporalAdapter invalid dates', () => {
+    let adapter: PlainTemporalAdapter;
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        providers: [
+          {provide: DateAdapter, useClass: PlainTemporalAdapter},
+          {
+            provide: MAT_PLAIN_TEMPORAL_ADAPTER_OPTIONS,
+            useValue: {mode: 'datetime', overflow: 'reject'},
+          },
+        ],
+      });
+      adapter = TestBed.inject(DateAdapter) as PlainTemporalAdapter;
+    });
+
+    it('should recognize invalid sentinel as invalid', () => {
+      const invalid = adapter.invalid();
+      expect(adapter.isValid(invalid)).toBe(false);
+    });
+
+    it('should recognize invalid sentinel as date instance', () => {
+      const invalid = adapter.invalid();
+      expect(adapter.isDateInstance(invalid)).toBe(true);
+    });
+
+    it('should throw when formatting invalid date', () => {
+      const invalid = adapter.invalid();
+      expect(() => adapter.format(invalid, {year: 'numeric'})).toThrowError(/Cannot format/);
+    });
+
+    it('should throw for invalid month index', () => {
+      expect(() => adapter.createDate(2024, 12, 1)).toThrowError(/Invalid month/);
+    });
+
+    it('should throw for invalid day', () => {
+      expect(() => adapter.createDate(2024, FEB, 30)).toThrowError(/Invalid date/);
+    });
+
+    it('should throw when cloning invalid date (sentinel has NaN values)', () => {
+      const invalid = adapter.invalid();
+      // Clone throws because invalid sentinel has NaN values which Temporal.PlainDate.from rejects
+      expect(() => adapter.clone(invalid)).toThrowError();
+    });
+  });
+
+  describe('ZonedDateTimeAdapter invalid dates', () => {
+    let adapter: ZonedDateTimeAdapter;
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        providers: [
+          {provide: DateAdapter, useClass: ZonedDateTimeAdapter},
+          {
+            provide: MAT_ZONED_DATETIME_OPTIONS,
+            useValue: {calendar: 'iso8601', timezone: 'UTC', overflow: 'reject'},
+          },
+        ],
+      });
+      adapter = TestBed.inject(DateAdapter) as ZonedDateTimeAdapter;
+    });
+
+    it('should recognize invalid sentinel as invalid', () => {
+      const invalid = adapter.invalid();
+      expect(adapter.isValid(invalid)).toBe(false);
+    });
+
+    it('should throw when formatting invalid date', () => {
+      const invalid = adapter.invalid();
+      expect(() => adapter.format(invalid, {year: 'numeric'})).toThrowError(/Cannot format/);
+    });
+
+    it('should throw for invalid month in reject mode', () => {
+      expect(() => adapter.createDate(2024, 12, 1)).toThrowError(/Invalid month/);
+    });
+  });
+});
+
+// =============================================================================
+// Deserialize Tests
+// =============================================================================
+describeTemporal('Deserialize methods', () => {
+  describe('PlainTemporalAdapter deserialize', () => {
+    let adapter: PlainTemporalAdapter;
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        providers: [
+          {provide: DateAdapter, useClass: PlainTemporalAdapter},
+          {
+            provide: MAT_PLAIN_TEMPORAL_ADAPTER_OPTIONS,
+            useValue: {mode: 'datetime'},
+          },
+        ],
+      });
+      adapter = TestBed.inject(DateAdapter) as PlainTemporalAdapter;
+    });
+
+    it('should deserialize valid ISO date string', () => {
+      const result = adapter.deserialize('2024-01-15');
+      expect(adapter.isValid(result!)).toBe(true);
+      expect(adapter.getYear(result!)).toBe(2024);
+    });
+
+    it('should deserialize valid ISO datetime string', () => {
+      const result = adapter.deserialize('2024-01-15T10:30:00');
+      expect(adapter.isValid(result!)).toBe(true);
+      expect(adapter.getHours(result!)).toBe(10);
+    });
+
+    it('should return null for empty string', () => {
+      expect(adapter.deserialize('')).toBeNull();
+    });
+
+    it('should return invalid for malformed string', () => {
+      const result = adapter.deserialize('not-a-date');
+      expect(adapter.isValid(result!)).toBe(false);
+    });
+  });
+
+  describe('ZonedDateTimeAdapter deserialize', () => {
+    let adapter: ZonedDateTimeAdapter;
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        providers: [
+          {provide: DateAdapter, useClass: ZonedDateTimeAdapter},
+          {
+            provide: MAT_ZONED_DATETIME_OPTIONS,
+            useValue: {calendar: 'iso8601', timezone: 'America/New_York'},
+          },
+        ],
+      });
+      adapter = TestBed.inject(DateAdapter) as ZonedDateTimeAdapter;
+    });
+
+    it('should deserialize ISO date string to zoned datetime', () => {
+      const result = adapter.deserialize('2024-01-15');
+      expect(adapter.isValid(result!)).toBe(true);
+      expect(isZonedDateTime(result)).toBe(true);
+    });
+
+    it('should return null for empty string', () => {
+      expect(adapter.deserialize('')).toBeNull();
+    });
+  });
+});
+
+// =============================================================================
+// toIso8601 Tests
+// =============================================================================
+describeTemporal('toIso8601 methods', () => {
+  describe('PlainTemporalAdapter toIso8601', () => {
+    let adapter: PlainTemporalAdapter;
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        providers: [
+          {provide: DateAdapter, useClass: PlainTemporalAdapter},
+          {
+            provide: MAT_PLAIN_TEMPORAL_ADAPTER_OPTIONS,
+            useValue: {mode: 'datetime'},
+          },
+        ],
+      });
+      adapter = TestBed.inject(DateAdapter) as PlainTemporalAdapter;
+    });
+
+    it('should return ISO date string (date part only)', () => {
+      const date = adapter.createDate(2024, JAN, 15);
+      const iso = adapter.toIso8601(date);
+      expect(iso).toBe('2024-01-15');
+    });
+  });
+
+  describe('ZonedDateTimeAdapter toIso8601', () => {
+    let adapter: ZonedDateTimeAdapter;
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        providers: [
+          {provide: DateAdapter, useClass: ZonedDateTimeAdapter},
+          {
+            provide: MAT_ZONED_DATETIME_OPTIONS,
+            useValue: {calendar: 'iso8601', timezone: 'UTC'},
+          },
+        ],
+      });
+      adapter = TestBed.inject(DateAdapter) as ZonedDateTimeAdapter;
+    });
+
+    it('should return full ZonedDateTime string with timezone', () => {
+      const date = adapter.createDate(2024, JAN, 15);
+      const iso = adapter.toIso8601(date);
+      expect(iso).toContain('2024-01-15');
+      expect(iso).toContain('[UTC]');
+    });
+  });
+});
+
+// =============================================================================
+// Clone Tests
+// =============================================================================
+describeTemporal('Clone methods create new instances', () => {
+  describe('PlainTemporalAdapter clone', () => {
+    let adapter: PlainTemporalAdapter;
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        providers: [
+          {provide: DateAdapter, useClass: PlainTemporalAdapter},
+          {
+            provide: MAT_PLAIN_TEMPORAL_ADAPTER_OPTIONS,
+            useValue: {mode: 'datetime'},
+          },
+        ],
+      });
+      adapter = TestBed.inject(DateAdapter) as PlainTemporalAdapter;
+    });
+
+    it('should create a new instance with same values', () => {
+      const original = adapter.createDate(2024, JAN, 15);
+      const cloned = adapter.clone(original);
+
+      expect(cloned).not.toBe(original); // Different reference
+      expect(adapter.getYear(cloned)).toBe(adapter.getYear(original));
+      expect(adapter.getMonth(cloned)).toBe(adapter.getMonth(original));
+      expect(adapter.getDate(cloned)).toBe(adapter.getDate(original));
+    });
+  });
+
+  describe('ZonedDateTimeAdapter clone', () => {
+    let adapter: ZonedDateTimeAdapter;
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        providers: [
+          {provide: DateAdapter, useClass: ZonedDateTimeAdapter},
+          {
+            provide: MAT_ZONED_DATETIME_OPTIONS,
+            useValue: {calendar: 'iso8601', timezone: 'America/New_York'},
+          },
+        ],
+      });
+      adapter = TestBed.inject(DateAdapter) as ZonedDateTimeAdapter;
+    });
+
+    it('should create a new instance with same values', () => {
+      const original = adapter.createDate(2024, JAN, 15);
+      const cloned = adapter.clone(original);
+
+      expect(cloned).not.toBe(original);
+      expect(adapter.getYear(cloned)).toBe(adapter.getYear(original));
+      expect((cloned as Temporal.ZonedDateTime).timeZoneId).toBe(
+        (original as Temporal.ZonedDateTime).timeZoneId,
+      );
+    });
+  });
+});
+
+// =============================================================================
+// addSeconds Tests
+// =============================================================================
+describeTemporal('addSeconds methods', () => {
+  describe('PlainTemporalAdapter addSeconds', () => {
+    let adapter: PlainTemporalAdapter;
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        providers: [
+          {provide: DateAdapter, useClass: PlainTemporalAdapter},
+          {
+            provide: MAT_PLAIN_TEMPORAL_ADAPTER_OPTIONS,
+            useValue: {mode: 'datetime'},
+          },
+        ],
+      });
+      adapter = TestBed.inject(DateAdapter) as PlainTemporalAdapter;
+    });
+
+    it('should add positive seconds', () => {
+      const date = adapter.setTime(adapter.createDate(2024, JAN, 15), 10, 30, 0);
+      const result = adapter.addSeconds(date, 90);
+      expect(adapter.getMinutes(result)).toBe(31);
+      expect(adapter.getSeconds(result)).toBe(30);
+    });
+
+    it('should add negative seconds', () => {
+      const date = adapter.setTime(adapter.createDate(2024, JAN, 15), 10, 30, 30);
+      const result = adapter.addSeconds(date, -90);
+      expect(adapter.getMinutes(result)).toBe(29);
+      expect(adapter.getSeconds(result)).toBe(0);
+    });
+
+    it('should handle day overflow', () => {
+      const date = adapter.setTime(adapter.createDate(2024, JAN, 15), 23, 59, 59);
+      const result = adapter.addSeconds(date, 2);
+      expect(adapter.getDate(result)).toBe(16);
+      expect(adapter.getHours(result)).toBe(0);
+      expect(adapter.getMinutes(result)).toBe(0);
+      expect(adapter.getSeconds(result)).toBe(1);
+    });
+  });
+
+  describe('ZonedDateTimeAdapter addSeconds', () => {
+    let adapter: ZonedDateTimeAdapter;
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        providers: [
+          {provide: DateAdapter, useClass: ZonedDateTimeAdapter},
+          {
+            provide: MAT_ZONED_DATETIME_OPTIONS,
+            useValue: {calendar: 'iso8601', timezone: 'UTC'},
+          },
+        ],
+      });
+      adapter = TestBed.inject(DateAdapter) as ZonedDateTimeAdapter;
+    });
+
+    it('should add seconds correctly', () => {
+      const date = adapter.setTime(adapter.createDate(2024, JAN, 15), 10, 30, 0);
+      const result = adapter.addSeconds(date, 3600);
+      expect(adapter.getHours(result)).toBe(11);
+    });
+  });
+});
+
+// =============================================================================
+// PlainDateAdapter Standalone Tests
+// =============================================================================
+describeTemporal('PlainDateAdapter (Standalone)', () => {
+  let adapter: PlainDateAdapter;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        {provide: DateAdapter, useClass: PlainDateAdapter},
+        {provide: MAT_BASE_TEMPORAL_OPTIONS, useValue: {overflow: 'reject'}},
+      ],
+    });
+    adapter = TestBed.inject(DateAdapter) as PlainDateAdapter;
+    adapter.setLocale('en-US');
+  });
+
+  it('should create a date', () => {
+    const date = adapter.createDate(2024, JAN, 15);
+    expect(adapter.isValid(date)).toBe(true);
+    expect(adapter.getYear(date)).toBe(2024);
+  });
+
+  it('should reject invalid dates in reject mode', () => {
+    expect(() => adapter.createDate(2024, FEB, 30)).toThrowError(/Invalid date/);
+  });
+
+  it('should return invalid for parseTime', () => {
+    const result = adapter.parseTime('12:30');
+    expect(adapter.isValid(result!)).toBe(false);
+  });
+});
+
+describeTemporal('PlainDateAdapter (Standalone) with overflow constrain', () => {
+  let adapter: PlainDateAdapter;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        {provide: DateAdapter, useClass: PlainDateAdapter},
+        {provide: MAT_BASE_TEMPORAL_OPTIONS, useValue: {overflow: 'constrain'}},
+      ],
+    });
+    adapter = TestBed.inject(DateAdapter) as PlainDateAdapter;
+    adapter.setLocale('en-US');
+  });
+
+  it('should constrain invalid dates', () => {
+    const date = adapter.createDate(2024, FEB, 30);
+    expect(adapter.getDate(date)).toBe(29);
+  });
+
+  it('should constrain invalid month (15)', () => {
+    const date = adapter.createDate(2024, 15, 1);
+    expect(adapter.getMonth(date)).toBe(11); // December
+  });
+});
+
+// =============================================================================
+// PlainDateTimeAdapter Standalone Tests
+// =============================================================================
+describeTemporal('PlainDateTimeAdapter (Standalone)', () => {
+  let adapter: PlainDateTimeAdapter;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        {provide: DateAdapter, useClass: PlainDateTimeAdapter},
+        {provide: MAT_BASE_TEMPORAL_OPTIONS, useValue: {overflow: 'reject'}},
+      ],
+    });
+    adapter = TestBed.inject(DateAdapter) as PlainDateTimeAdapter;
+    adapter.setLocale('en-US');
+  });
+
+  it('should create a date', () => {
+    const date = adapter.createDate(2024, JAN, 15);
+    expect(adapter.isValid(date)).toBe(true);
+  });
+
+  it('should set time correctly', () => {
+    const date = adapter.createDate(2024, JAN, 15);
+    const withTime = adapter.setTime(date, 14, 30, 0);
+    expect(adapter.getHours(withTime)).toBe(14);
+  });
+
+  it('should validate time in setTime', () => {
+    const date = adapter.createDate(2024, JAN, 15);
+    expect(() => adapter.setTime(date, 25, 0, 0)).toThrowError(/Invalid hours/);
+  });
+});
+
+describeTemporal('PlainDateTimeAdapter (Standalone) with overflow constrain', () => {
+  let adapter: PlainDateTimeAdapter;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        {provide: DateAdapter, useClass: PlainDateTimeAdapter},
+        {provide: MAT_BASE_TEMPORAL_OPTIONS, useValue: {overflow: 'constrain'}},
+      ],
+    });
+    adapter = TestBed.inject(DateAdapter) as PlainDateTimeAdapter;
+    adapter.setLocale('en-US');
+  });
+
+  it('should constrain invalid dates', () => {
+    const date = adapter.createDate(2024, FEB, 30);
+    expect(adapter.getDate(date)).toBe(29);
+  });
+});
+
+describeTemporal('PlainTemporalAdapter Date consistency', () => {
+  let adapter: PlainTemporalAdapter;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        {provide: DateAdapter, useClass: PlainTemporalAdapter},
+        {provide: MAT_PLAIN_TEMPORAL_ADAPTER_OPTIONS, useValue: {mode: 'date'}},
+      ],
+    });
+    adapter = TestBed.inject(DateAdapter) as PlainTemporalAdapter;
+  });
+
+  it('should return invalid for parseTime in date mode', () => {
+    const result = adapter.parseTime('14:30');
+    expect(adapter.isValid(result!)).toBe(false);
+  });
+});

--- a/src/material-temporal-adapter/adapter/split/base-temporal-adapter.ts
+++ b/src/material-temporal-adapter/adapter/split/base-temporal-adapter.ts
@@ -1,0 +1,256 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {inject, InjectionToken} from '@angular/core';
+import {DateAdapter, MAT_DATE_LOCALE} from '@angular/material/core';
+
+/**
+ * Configuration options for split Temporal adapters.
+ */
+export interface BaseTemporalAdapterOptions {
+  /** Calendar system to use (e.g., 'iso8601', 'hebrew', 'islamic'). Defaults to 'iso8601'. */
+  calendar: string;
+  /** Calendar system to use for output/formatting. Defaults to `calendar` if not set. */
+  outputCalendar?: string;
+  /** First day of week (0 = Sunday, 6 = Saturday). If not set, derived from locale. */
+  firstDayOfWeek?: number;
+  /**
+   * How to handle out-of-range values in date arithmetic.
+   * - 'reject': Throw an error for invalid dates (default)
+   * - 'constrain': Clamp to the nearest valid value
+   */
+  overflow?: 'reject' | 'constrain';
+}
+
+/** Injection token for base Temporal adapter options. */
+export const MAT_BASE_TEMPORAL_OPTIONS = new InjectionToken<BaseTemporalAdapterOptions>(
+  'MAT_BASE_TEMPORAL_OPTIONS',
+);
+
+/** Interface for Intl.Locale with weekInfo support. */
+interface IntlWithLocale {
+  Locale?: new (locale: string) => {
+    getWeekInfo?: () => {firstDay: number};
+    weekInfo?: {firstDay: number};
+  };
+}
+
+type TemporalDateLike = Temporal.PlainDate | Temporal.PlainDateTime;
+
+/**
+ * Base class for split Temporal adapters.
+ * Contains shared functionality for PlainDate and PlainDateTime adapters.
+ *
+ * @template T The Temporal type this adapter works with.
+ */
+export abstract class BaseTemporalAdapter<T extends TemporalDateLike> extends DateAdapter<T> {
+  protected readonly _calendar: string;
+  protected readonly _outputCalendar: string | null;
+  protected readonly _firstDayOfWeek?: number;
+  protected readonly _overflow: 'reject' | 'constrain';
+  protected readonly _matDateLocale = inject(MAT_DATE_LOCALE, {optional: true});
+
+  constructor() {
+    super();
+    const options = inject(MAT_BASE_TEMPORAL_OPTIONS, {optional: true});
+    this._calendar = options?.calendar ?? 'iso8601';
+    this._outputCalendar = options?.outputCalendar ?? null;
+    this._firstDayOfWeek = options?.firstDayOfWeek;
+    this._overflow = options?.overflow ?? 'reject';
+
+    if (this._matDateLocale) {
+      super.setLocale(this._matDateLocale);
+    } else {
+      super.setLocale(this._getDefaultLocale());
+    }
+  }
+
+  /** Gets the calendar ID string. */
+  protected _getCalendarId(): string {
+    return this._calendar;
+  }
+
+  /** Gets the calendar ID string for output/formatting. */
+  protected _getOutputCalendarId(): string {
+    return this._outputCalendar || this._calendar;
+  }
+
+  /** Gets the default locale from the browser or system. */
+  private _getDefaultLocale(): string {
+    if (typeof navigator !== 'undefined' && navigator.language) {
+      return navigator.language;
+    }
+    return 'en-US';
+  }
+
+  // ========================
+  // Common DateAdapter methods
+  // ========================
+
+  getYear(date: T): number {
+    return date.year;
+  }
+
+  getMonth(date: T): number {
+    return date.month - 1; // Convert 1-indexed to 0-indexed
+  }
+
+  getDate(date: T): number {
+    return date.day;
+  }
+
+  getDayOfWeek(date: T): number {
+    const dayOfWeek = date.dayOfWeek;
+    return dayOfWeek === 7 ? 0 : dayOfWeek; // Convert Monday=1..Sunday=7 to Sunday=0..Saturday=6
+  }
+
+  getMonthNames(style: 'long' | 'short' | 'narrow'): string[] {
+    const monthsInYear = this._getMonthsInYear();
+    const options: Intl.DateTimeFormatOptions = {
+      month: style,
+      calendar: this._getOutputCalendarId(),
+    };
+
+    return Array.from({length: monthsInYear}, (_, i) => {
+      const date = Temporal.PlainDate.from({
+        year: 2024,
+        month: i + 1,
+        day: 1,
+        calendar: this._getOutputCalendarId(),
+      });
+      return this._formatWithLocale(date, options);
+    });
+  }
+
+  getDateNames(): string[] {
+    const options: Intl.DateTimeFormatOptions = {
+      day: 'numeric',
+      calendar: this._getOutputCalendarId(),
+    };
+
+    return Array.from({length: 31}, (_, i) => {
+      const date = Temporal.PlainDate.from({
+        year: 2024,
+        month: 1,
+        day: i + 1,
+        calendar: this._getOutputCalendarId(),
+      });
+      return this._formatWithLocale(date, options);
+    });
+  }
+
+  getDayOfWeekNames(style: 'long' | 'short' | 'narrow'): string[] {
+    const options: Intl.DateTimeFormatOptions = {
+      weekday: style,
+    };
+
+    // Jan 7, 2024 was a Sunday in ISO8601 calendar.
+    // Day-of-week names are locale-dependent, not calendar-dependent,
+    // so we format directly without calendar conversion.
+    return Array.from({length: 7}, (_, i) => {
+      const date = Temporal.PlainDate.from({
+        year: 2024,
+        month: 1,
+        day: 7 + i,
+        calendar: 'iso8601',
+      });
+      return date.toLocaleString(this.locale, options).replace(/[\u200e\u200f]/g, '');
+    });
+  }
+
+  getYearName(date: T): string {
+    const options: Intl.DateTimeFormatOptions = {
+      year: 'numeric',
+      calendar: this._getOutputCalendarId(),
+    };
+    return this._formatWithLocale(date, options);
+  }
+
+  getFirstDayOfWeek(): number {
+    if (this._firstDayOfWeek !== undefined) {
+      return this._firstDayOfWeek;
+    }
+
+    const intlWithLocale = Intl as IntlWithLocale;
+    if (typeof Intl !== 'undefined' && intlWithLocale.Locale) {
+      try {
+        const locale = new intlWithLocale.Locale!(this.locale);
+        const weekInfo = locale.getWeekInfo?.() || locale.weekInfo;
+        if (weekInfo?.firstDay !== undefined) {
+          return weekInfo.firstDay === 7 ? 0 : weekInfo.firstDay;
+        }
+      } catch {
+        // Fall through to default
+      }
+    }
+
+    return 0; // Default to Sunday
+  }
+
+  getNumDaysInMonth(date: T): number {
+    return date.daysInMonth;
+  }
+
+  addCalendarYears(date: T, years: number): T {
+    return date.add({years}, {overflow: this._overflow}) as T;
+  }
+
+  addCalendarMonths(date: T, months: number): T {
+    return date.add({months}, {overflow: this._overflow}) as T;
+  }
+
+  addCalendarDays(date: T, days: number): T {
+    return date.add({days}, {overflow: this._overflow}) as T;
+  }
+
+  format(date: T, displayFormat: Intl.DateTimeFormatOptions): string {
+    if (!this.isValid(date)) {
+      throw Error('BaseTemporalAdapter: Cannot format invalid date.');
+    }
+
+    const options: Intl.DateTimeFormatOptions = {
+      ...displayFormat,
+      calendar: this._getOutputCalendarId(),
+    };
+    return this._formatWithLocale(date, options);
+  }
+
+  /** Gets the number of months in the current calendar year. */
+  protected _getMonthsInYear(): number {
+    try {
+      const refDate = Temporal.PlainDate.from({
+        year: 2024,
+        month: 1,
+        day: 1,
+        calendar: this._getOutputCalendarId(),
+      });
+      return refDate.monthsInYear;
+    } catch {
+      return 12;
+    }
+  }
+
+  /** Formats a Temporal date using its built-in locale formatter. */
+  protected _formatWithLocale(date: TemporalDateLike, options: Intl.DateTimeFormatOptions): string {
+    const outputCalendar = this._getOutputCalendarId();
+    const dateForOutput =
+      outputCalendar === (date as {calendarId?: string}).calendarId
+        ? date
+        : date.withCalendar(outputCalendar);
+    const temporal = dateForOutput as unknown as {
+      toLocaleString: (locales?: string | string[], options?: Intl.DateTimeFormatOptions) => string;
+    };
+    return temporal.toLocaleString(this.locale, options).replace(/[\u200e\u200f]/g, '');
+  }
+
+  /** Parses an ISO 8601 string. Returns null if parsing fails. */
+  protected abstract _parseString(value: string): T | null;
+
+  /** Creates a date from epoch milliseconds. */
+  protected abstract _createFromEpochMs(ms: number): T;
+}

--- a/src/material-temporal-adapter/adapter/split/index.ts
+++ b/src/material-temporal-adapter/adapter/split/index.ts
@@ -1,0 +1,235 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Provider} from '@angular/core';
+import {DateAdapter, MAT_DATE_FORMATS, MatDateFormats} from '@angular/material/core';
+import {
+  MAT_PLAIN_TEMPORAL_ADAPTER_OPTIONS,
+  PlainTemporalAdapter,
+  PlainTemporalAdapterOptions,
+} from './plain-temporal-adapter';
+import {
+  MAT_ZONED_DATETIME_OPTIONS,
+  ZonedDateTimeAdapter,
+  ZonedDateTimeAdapterOptions,
+} from './zoned-datetime-adapter';
+
+// Export base adapter for extension
+export {BaseTemporalAdapter, MAT_BASE_TEMPORAL_OPTIONS} from './base-temporal-adapter';
+
+// Export specific adapters
+export {PlainDateAdapter} from './plain-date-adapter';
+export {PlainDateTimeAdapter} from './plain-datetime-adapter';
+
+// Export the two main adapters
+export {
+  PlainTemporalAdapter,
+  PlainTemporalAdapterOptions,
+  PlainTemporalType,
+  MAT_PLAIN_TEMPORAL_ADAPTER_OPTIONS,
+} from './plain-temporal-adapter';
+
+export {
+  ZonedDateTimeAdapter,
+  ZonedDateTimeAdapterOptions,
+  MAT_ZONED_DATETIME_OPTIONS,
+} from './zoned-datetime-adapter';
+
+// ========================
+// Default formats
+// ========================
+
+/** Default date formats for PlainTemporalAdapter in date mode. */
+export const MAT_PLAIN_DATE_FORMATS: MatDateFormats = {
+  parse: {
+    dateInput: null,
+    timeInput: null,
+  },
+  display: {
+    dateInput: {year: 'numeric', month: 'numeric', day: 'numeric'},
+    timeInput: {hour: 'numeric', minute: 'numeric'},
+    monthYearLabel: {year: 'numeric', month: 'short'},
+    dateA11yLabel: {year: 'numeric', month: 'long', day: 'numeric'},
+    monthYearA11yLabel: {year: 'numeric', month: 'long'},
+    timeOptionLabel: {hour: 'numeric', minute: 'numeric'},
+  },
+};
+
+/** Default date formats for PlainTemporalAdapter in datetime mode (includes time). */
+export const MAT_PLAIN_DATETIME_FORMATS: MatDateFormats = {
+  parse: {
+    dateInput: null,
+    timeInput: null,
+  },
+  display: {
+    dateInput: {
+      year: 'numeric',
+      month: 'numeric',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: 'numeric',
+    },
+    timeInput: {hour: 'numeric', minute: 'numeric'},
+    monthYearLabel: {year: 'numeric', month: 'short'},
+    dateA11yLabel: {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: 'numeric',
+    },
+    monthYearA11yLabel: {year: 'numeric', month: 'long'},
+    timeOptionLabel: {hour: 'numeric', minute: 'numeric'},
+  },
+};
+
+/** Default date formats for ZonedDateTimeAdapter (includes time and timezone). */
+export const MAT_ZONED_DATETIME_FORMATS: MatDateFormats = {
+  parse: {
+    dateInput: null,
+    timeInput: null,
+  },
+  display: {
+    dateInput: {
+      year: 'numeric',
+      month: 'numeric',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: 'numeric',
+      timeZoneName: 'short',
+    },
+    timeInput: {hour: 'numeric', minute: 'numeric'},
+    monthYearLabel: {year: 'numeric', month: 'short'},
+    dateA11yLabel: {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: 'numeric',
+    },
+    monthYearA11yLabel: {year: 'numeric', month: 'long'},
+    timeOptionLabel: {hour: 'numeric', minute: 'numeric'},
+  },
+};
+
+// ========================
+// Provider functions
+// ========================
+
+/**
+ * Provides PlainTemporalAdapter for date or date+time scenarios without timezone.
+ *
+ * This is the recommended adapter for most use cases:
+ * - Use `mode: 'date'` for date-only pickers
+ * - Use `mode: 'datetime'` for date+time pickers without timezone
+ *
+ * For timezone-aware scenarios, use `provideZonedDateTimeAdapter` instead.
+ *
+ * @example
+ * ```typescript
+ * import { providePlainTemporalAdapter, MAT_PLAIN_DATE_FORMATS } from '@angular/material-temporal-adapter/split';
+ *
+ * // Date only
+ * bootstrapApplication(AppComponent, {
+ *   providers: [providePlainTemporalAdapter(MAT_PLAIN_DATE_FORMATS, { mode: 'date' })],
+ * });
+ *
+ * // Date + time (default)
+ * bootstrapApplication(AppComponent, {
+ *   providers: [providePlainTemporalAdapter()],
+ * });
+ *
+ * // With Hebrew calendar
+ * bootstrapApplication(AppComponent, {
+ *   providers: [providePlainTemporalAdapter(MAT_PLAIN_DATETIME_FORMATS, {
+ *     mode: 'datetime',
+ *     calendar: 'hebrew',
+ *   })],
+ * });
+ * ```
+ */
+export function providePlainTemporalAdapter(
+  formats: MatDateFormats = MAT_PLAIN_DATETIME_FORMATS,
+  options?: Partial<PlainTemporalAdapterOptions>,
+): Provider[] {
+  const providers: Provider[] = [
+    {provide: DateAdapter, useClass: PlainTemporalAdapter},
+    {provide: MAT_DATE_FORMATS, useValue: formats},
+  ];
+
+  if (options) {
+    providers.push({
+      provide: MAT_PLAIN_TEMPORAL_ADAPTER_OPTIONS,
+      useValue: {
+        mode: options.mode ?? 'datetime',
+        calendar: options.calendar ?? 'iso8601',
+        outputCalendar: options.outputCalendar,
+        firstDayOfWeek: options.firstDayOfWeek,
+        overflow: options.overflow,
+      } satisfies PlainTemporalAdapterOptions,
+    });
+  }
+
+  return providers;
+}
+
+/**
+ * Provides ZonedDateTimeAdapter for timezone-aware date+time scenarios.
+ *
+ * Use this adapter when you need timezone support. For UTC, pass `{ timezone: 'UTC' }`.
+ *
+ * @example
+ * ```typescript
+ * import { provideZonedDateTimeAdapter } from '@angular/material-temporal-adapter/split';
+ *
+ * // System timezone (default)
+ * bootstrapApplication(AppComponent, {
+ *   providers: [provideZonedDateTimeAdapter()],
+ * });
+ *
+ * // UTC timezone
+ * bootstrapApplication(AppComponent, {
+ *   providers: [provideZonedDateTimeAdapter(formats, { timezone: 'UTC' })],
+ * });
+ *
+ * // Specific timezone
+ * bootstrapApplication(AppComponent, {
+ *   providers: [provideZonedDateTimeAdapter(formats, {
+ *     timezone: 'America/New_York',
+ *     calendar: 'iso8601',
+ *   })],
+ * });
+ * ```
+ */
+export function provideZonedDateTimeAdapter(
+  formats: MatDateFormats = MAT_ZONED_DATETIME_FORMATS,
+  options?: Partial<ZonedDateTimeAdapterOptions>,
+): Provider[] {
+  const providers: Provider[] = [
+    {provide: DateAdapter, useClass: ZonedDateTimeAdapter},
+    {provide: MAT_DATE_FORMATS, useValue: formats},
+  ];
+
+  if (options) {
+    providers.push({
+      provide: MAT_ZONED_DATETIME_OPTIONS,
+      useValue: {
+        calendar: options.calendar ?? 'iso8601',
+        outputCalendar: options.outputCalendar,
+        timezone: options.timezone,
+        firstDayOfWeek: options.firstDayOfWeek,
+        overflow: options.overflow,
+        disambiguation: options.disambiguation,
+        offset: options.offset,
+        rounding: options.rounding,
+      } satisfies ZonedDateTimeAdapterOptions,
+    });
+  }
+
+  return providers;
+}

--- a/src/material-temporal-adapter/adapter/split/plain-date-adapter.ts
+++ b/src/material-temporal-adapter/adapter/split/plain-date-adapter.ts
@@ -1,0 +1,213 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Injectable} from '@angular/core';
+import {BaseTemporalAdapter} from './base-temporal-adapter';
+
+/**
+ * Sentinel object representing an invalid PlainDate.
+ * Since Temporal throws instead of creating invalid dates, we use this marker.
+ */
+const INVALID_PLAIN_DATE = Object.freeze({
+  _invalid: true,
+  year: NaN,
+  month: NaN,
+  day: NaN,
+  dayOfWeek: NaN,
+  daysInMonth: NaN,
+  monthsInYear: NaN,
+}) as unknown as Temporal.PlainDate;
+
+/**
+ * DateAdapter implementation for `Temporal.PlainDate`.
+ *
+ * This adapter is for date-only scenarios (no time component).
+ * For date+time, use `PlainDateTimeAdapter`.
+ * For timezone-aware dates, use `ZonedDateTimeAdapter`.
+ *
+ * @example
+ * ```typescript
+ * import { providePlainDateAdapter } from '@angular/material-temporal-adapter';
+ *
+ * bootstrapApplication(AppComponent, {
+ *   providers: [providePlainDateAdapter()],
+ * });
+ * ```
+ */
+@Injectable()
+export class PlainDateAdapter extends BaseTemporalAdapter<Temporal.PlainDate> {
+  /**
+   * Clones the given date.
+   * Note: Temporal objects are immutable, so the original cannot be mutated.
+   * However, we still create a new object because:
+   * 1. The DateAdapter interface contract specifies "A new date"
+   * 2. Consumer code may use reference equality checks (clone !== original)
+   * 3. Consistency with other date adapters (NativeDateAdapter, LuxonDateAdapter)
+   */
+  clone(date: Temporal.PlainDate): Temporal.PlainDate {
+    return Temporal.PlainDate.from(date.toString());
+  }
+
+  createDate(year: number, month: number, date: number): Temporal.PlainDate {
+    if ((typeof ngDevMode === 'undefined' || ngDevMode) && this._overflow === 'reject') {
+      const monthsInYear = this._getMonthsInYearForDate(year);
+      if (month < 0 || month > monthsInYear - 1) {
+        throw Error(
+          `Invalid month index "${month}". Month index has to be between 0 and ${monthsInYear - 1}.`,
+        );
+      }
+      if (date < 1) {
+        throw Error(`Invalid date "${date}". Date has to be greater than 0.`);
+      }
+    }
+
+    try {
+      return Temporal.PlainDate.from(
+        {
+          year,
+          month: month + 1, // Convert 0-indexed to 1-indexed
+          day: date,
+          calendar: this._getCalendarId(),
+        },
+        {overflow: this._overflow},
+      );
+    } catch (e) {
+      if ((typeof ngDevMode === 'undefined' || ngDevMode) && this._overflow === 'reject') {
+        throw Error(`Invalid date "${date}" for month with index "${month}".`);
+      }
+      return this.invalid();
+    }
+  }
+
+  /** Gets the number of months in a specific year for the configured calendar. */
+  private _getMonthsInYearForDate(year: number): number {
+    try {
+      const refDate = Temporal.PlainDate.from({
+        year,
+        month: 1,
+        day: 1,
+        calendar: this._getCalendarId(),
+      });
+      return refDate.monthsInYear;
+    } catch {
+      return 12;
+    }
+  }
+
+  today(): Temporal.PlainDate {
+    return Temporal.Now.plainDateISO().withCalendar(this._getCalendarId());
+  }
+
+  parse(value: unknown, parseFormat?: any): Temporal.PlainDate | null {
+    if (typeof value === 'number') {
+      return this._createFromEpochMs(value);
+    }
+    if (typeof value === 'string') {
+      return value ? (this._parseString(value) ?? this.invalid()) : null;
+    }
+    if (this.isDateInstance(value)) {
+      return this.clone(value);
+    }
+    return value ? this.invalid() : null;
+  }
+
+  toIso8601(date: Temporal.PlainDate): string {
+    return date.toString();
+  }
+
+  override deserialize(value: unknown): Temporal.PlainDate | null {
+    if (typeof value === 'string') {
+      if (!value) return null;
+      const parsed = this._parseString(value);
+      return parsed && this.isValid(parsed) ? parsed : this.invalid();
+    }
+    return super.deserialize(value);
+  }
+
+  isDateInstance(obj: unknown): obj is Temporal.PlainDate {
+    if (obj == null || typeof obj !== 'object') return false;
+    if ((obj as {_invalid?: boolean})._invalid) return true;
+    return obj instanceof (Temporal.PlainDate as unknown as new (...args: unknown[]) => unknown);
+  }
+
+  isValid(date: Temporal.PlainDate): boolean {
+    if ((date as unknown as {_invalid?: boolean})._invalid) return false;
+    return date != null && typeof date.year === 'number' && !isNaN(date.year);
+  }
+
+  invalid(): Temporal.PlainDate {
+    return INVALID_PLAIN_DATE;
+  }
+
+  // Time methods - PlainDate has no time, return 0
+  override getHours(_date: Temporal.PlainDate): number {
+    return 0;
+  }
+
+  override getMinutes(_date: Temporal.PlainDate): number {
+    return 0;
+  }
+
+  override getSeconds(_date: Temporal.PlainDate): number {
+    return 0;
+  }
+
+  override setTime(
+    target: Temporal.PlainDate,
+    hours: number,
+    minutes: number,
+    seconds: number,
+  ): Temporal.PlainDate {
+    // PlainDate cannot hold time - convert to PlainDateTime
+    // This is a design decision: caller should use PlainDateTimeAdapter if time is needed
+    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+      console.warn(
+        'PlainDateAdapter.setTime: PlainDate cannot hold time. ' +
+          'Use PlainDateTimeAdapter for date+time scenarios.',
+      );
+    }
+    return target; // Return unchanged
+  }
+
+  override parseTime(_value: unknown, _parseFormat?: any): Temporal.PlainDate | null {
+    // PlainDate cannot hold time
+    return this.invalid();
+  }
+
+  override addSeconds(date: Temporal.PlainDate, _amount: number): Temporal.PlainDate {
+    // PlainDate cannot hold time - return unchanged
+    return date;
+  }
+
+  protected _parseString(value: string): Temporal.PlainDate | null {
+    if (!value) return null;
+    try {
+      return Temporal.PlainDate.from(value).withCalendar(this._getCalendarId());
+    } catch {
+      return null;
+    }
+  }
+
+  protected _createFromEpochMs(ms: number): Temporal.PlainDate {
+    if (!Number.isFinite(ms) || ms > 8.64e15 || ms < -8.64e15) {
+      return this.invalid();
+    }
+    try {
+      const instant = Temporal.Instant.fromEpochMilliseconds(ms);
+      const zdt = instant.toZonedDateTimeISO(Temporal.Now.timeZoneId());
+      return Temporal.PlainDate.from({
+        year: zdt.year,
+        month: zdt.month,
+        day: zdt.day,
+        calendar: this._getCalendarId(),
+      });
+    } catch {
+      return this.invalid();
+    }
+  }
+}

--- a/src/material-temporal-adapter/adapter/split/plain-datetime-adapter.ts
+++ b/src/material-temporal-adapter/adapter/split/plain-datetime-adapter.ts
@@ -1,0 +1,296 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Injectable} from '@angular/core';
+import {BaseTemporalAdapter} from './base-temporal-adapter';
+
+/**
+ * Sentinel object representing an invalid PlainDateTime.
+ */
+const INVALID_PLAIN_DATETIME = Object.freeze({
+  _invalid: true,
+  year: NaN,
+  month: NaN,
+  day: NaN,
+  hour: NaN,
+  minute: NaN,
+  second: NaN,
+  millisecond: NaN,
+  dayOfWeek: NaN,
+  daysInMonth: NaN,
+  monthsInYear: NaN,
+}) as unknown as Temporal.PlainDateTime;
+
+/**
+ * DateAdapter implementation for `Temporal.PlainDateTime`.
+ *
+ * This adapter is for date+time scenarios without timezone awareness.
+ * For date-only, use `PlainDateAdapter`.
+ * For timezone-aware dates, use `ZonedDateTimeAdapter`.
+ *
+ * @example
+ * ```typescript
+ * import { providePlainDateTimeAdapter } from '@angular/material-temporal-adapter';
+ *
+ * bootstrapApplication(AppComponent, {
+ *   providers: [providePlainDateTimeAdapter()],
+ * });
+ * ```
+ */
+@Injectable()
+export class PlainDateTimeAdapter extends BaseTemporalAdapter<Temporal.PlainDateTime> {
+  /**
+   * Clones the given date.
+   * Note: Temporal objects are immutable, so the original cannot be mutated.
+   * However, we still create a new object because:
+   * 1. The DateAdapter interface contract specifies "A new date"
+   * 2. Consumer code may use reference equality checks (clone !== original)
+   * 3. Consistency with other date adapters (NativeDateAdapter, LuxonDateAdapter)
+   */
+  clone(date: Temporal.PlainDateTime): Temporal.PlainDateTime {
+    return Temporal.PlainDateTime.from(date.toString());
+  }
+
+  createDate(year: number, month: number, date: number): Temporal.PlainDateTime {
+    if ((typeof ngDevMode === 'undefined' || ngDevMode) && this._overflow === 'reject') {
+      const monthsInYear = this._getMonthsInYearForDate(year);
+      if (month < 0 || month > monthsInYear - 1) {
+        throw Error(
+          `Invalid month index "${month}". Month index has to be between 0 and ${monthsInYear - 1}.`,
+        );
+      }
+      if (date < 1) {
+        throw Error(`Invalid date "${date}". Date has to be greater than 0.`);
+      }
+    }
+
+    try {
+      return Temporal.PlainDateTime.from(
+        {
+          year,
+          month: month + 1,
+          day: date,
+          hour: 0,
+          minute: 0,
+          second: 0,
+          calendar: this._getCalendarId(),
+        },
+        {overflow: this._overflow},
+      );
+    } catch (e) {
+      if ((typeof ngDevMode === 'undefined' || ngDevMode) && this._overflow === 'reject') {
+        throw Error(`Invalid date "${date}" for month with index "${month}".`);
+      }
+      return this.invalid();
+    }
+  }
+
+  /** Gets the number of months in a specific year for the configured calendar. */
+  private _getMonthsInYearForDate(year: number): number {
+    try {
+      const refDate = Temporal.PlainDate.from({
+        year,
+        month: 1,
+        day: 1,
+        calendar: this._getCalendarId(),
+      });
+      return refDate.monthsInYear;
+    } catch {
+      return 12;
+    }
+  }
+
+  today(): Temporal.PlainDateTime {
+    return Temporal.Now.plainDateTimeISO().withCalendar(this._getCalendarId());
+  }
+
+  parse(value: unknown, parseFormat?: any): Temporal.PlainDateTime | null {
+    if (typeof value === 'number') {
+      return this._createFromEpochMs(value);
+    }
+    if (typeof value === 'string') {
+      return value ? (this._parseString(value) ?? this.invalid()) : null;
+    }
+    if (this.isDateInstance(value)) {
+      return this.clone(value);
+    }
+    return value ? this.invalid() : null;
+  }
+
+  toIso8601(date: Temporal.PlainDateTime): string {
+    return date.toPlainDate().toString();
+  }
+
+  override deserialize(value: unknown): Temporal.PlainDateTime | null {
+    if (typeof value === 'string') {
+      if (!value) return null;
+      const parsed = this._parseString(value);
+      return parsed && this.isValid(parsed) ? parsed : this.invalid();
+    }
+    return super.deserialize(value);
+  }
+
+  isDateInstance(obj: unknown): obj is Temporal.PlainDateTime {
+    if (obj == null || typeof obj !== 'object') return false;
+    if ((obj as {_invalid?: boolean})._invalid) return true;
+    return (
+      obj instanceof (Temporal.PlainDateTime as unknown as new (...args: unknown[]) => unknown)
+    );
+  }
+
+  isValid(date: Temporal.PlainDateTime): boolean {
+    if ((date as unknown as {_invalid?: boolean})._invalid) return false;
+    return date != null && typeof date.year === 'number' && !isNaN(date.year);
+  }
+
+  invalid(): Temporal.PlainDateTime {
+    return INVALID_PLAIN_DATETIME;
+  }
+
+  // Time methods
+  override getHours(date: Temporal.PlainDateTime): number {
+    return date.hour;
+  }
+
+  override getMinutes(date: Temporal.PlainDateTime): number {
+    return date.minute;
+  }
+
+  override getSeconds(date: Temporal.PlainDateTime): number {
+    return date.second;
+  }
+
+  override setTime(
+    target: Temporal.PlainDateTime,
+    hours: number,
+    minutes: number,
+    seconds: number,
+  ): Temporal.PlainDateTime {
+    // Validate inputs are finite numbers within valid ranges
+    if (!Number.isFinite(hours) || hours < 0 || hours > 23) {
+      if (typeof ngDevMode === 'undefined' || ngDevMode) {
+        throw Error(
+          `Invalid hours "${hours}". Hours value must be a finite number between 0 and 23.`,
+        );
+      }
+      return this.invalid();
+    }
+    if (!Number.isFinite(minutes) || minutes < 0 || minutes > 59) {
+      if (typeof ngDevMode === 'undefined' || ngDevMode) {
+        throw Error(
+          `Invalid minutes "${minutes}". Minutes value must be a finite number between 0 and 59.`,
+        );
+      }
+      return this.invalid();
+    }
+    if (!Number.isFinite(seconds) || seconds < 0 || seconds > 59) {
+      if (typeof ngDevMode === 'undefined' || ngDevMode) {
+        throw Error(
+          `Invalid seconds "${seconds}". Seconds value must be a finite number between 0 and 59.`,
+        );
+      }
+      return this.invalid();
+    }
+
+    return target.with({hour: hours, minute: minutes, second: seconds, millisecond: 0});
+  }
+
+  override parseTime(value: unknown, parseFormat?: any): Temporal.PlainDateTime | null {
+    if (value == null || value === '') return null;
+
+    if (typeof value === 'string') {
+      if (value.trim() === '') return this.invalid();
+
+      // Reject very long strings to prevent potential DoS from regex backtracking
+      if (value.length > 32) {
+        return this.invalid();
+      }
+
+      const timeMatch = value
+        .toUpperCase()
+        .match(/^(\d?\d)[:.](\d?\d)(?:[:.](\d?\d))?\s*(AM|PM)?$/i);
+
+      if (timeMatch) {
+        let hours = parseInt(timeMatch[1], 10);
+        const minutes = parseInt(timeMatch[2], 10);
+        const seconds = timeMatch[3] ? parseInt(timeMatch[3], 10) : 0;
+        const amPm = timeMatch[4] as 'AM' | 'PM' | undefined;
+
+        if (hours === 12) {
+          hours = amPm === 'AM' ? 0 : hours;
+        } else if (amPm === 'PM') {
+          hours += 12;
+        }
+
+        if (
+          hours >= 0 &&
+          hours <= 23 &&
+          minutes >= 0 &&
+          minutes <= 59 &&
+          seconds >= 0 &&
+          seconds <= 59
+        ) {
+          return this.setTime(this.today(), hours, minutes, seconds);
+        }
+      }
+
+      // Try ISO time
+      try {
+        const time = Temporal.PlainTime.from(value);
+        return this.setTime(this.today(), time.hour, time.minute, time.second);
+      } catch {
+        return this.invalid();
+      }
+    }
+
+    return this.parse(value, parseFormat);
+  }
+
+  override addSeconds(date: Temporal.PlainDateTime, amount: number): Temporal.PlainDateTime {
+    return date.add({seconds: amount});
+  }
+
+  protected _parseString(value: string): Temporal.PlainDateTime | null {
+    if (!value) return null;
+    try {
+      // Try PlainDateTime first
+      try {
+        return Temporal.PlainDateTime.from(value).withCalendar(this._getCalendarId());
+      } catch {
+        // Fall back to PlainDate and convert
+        const plainDate = Temporal.PlainDate.from(value);
+        return plainDate
+          .toPlainDateTime({hour: 0, minute: 0, second: 0})
+          .withCalendar(this._getCalendarId());
+      }
+    } catch {
+      return null;
+    }
+  }
+
+  protected _createFromEpochMs(ms: number): Temporal.PlainDateTime {
+    if (!Number.isFinite(ms) || ms > 8.64e15 || ms < -8.64e15) {
+      return this.invalid();
+    }
+    try {
+      const instant = Temporal.Instant.fromEpochMilliseconds(ms);
+      const zdt = instant.toZonedDateTimeISO(Temporal.Now.timeZoneId());
+      return Temporal.PlainDateTime.from({
+        year: zdt.year,
+        month: zdt.month,
+        day: zdt.day,
+        hour: zdt.hour,
+        minute: zdt.minute,
+        second: zdt.second,
+        calendar: this._getCalendarId(),
+      });
+    } catch {
+      return this.invalid();
+    }
+  }
+}

--- a/src/material-temporal-adapter/adapter/split/plain-temporal-adapter.ts
+++ b/src/material-temporal-adapter/adapter/split/plain-temporal-adapter.ts
@@ -1,0 +1,686 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {inject, Injectable, InjectionToken} from '@angular/core';
+import {DateAdapter, MAT_DATE_LOCALE} from '@angular/material/core';
+
+/** Plain date/datetime type - either PlainDate or PlainDateTime depending on mode */
+export type PlainTemporalType = Temporal.PlainDate | Temporal.PlainDateTime;
+
+/**
+ * Sentinel object representing an invalid PlainDate.
+ */
+const INVALID_PLAIN_DATE = Object.freeze({
+  _invalid: true,
+  year: NaN,
+  month: NaN,
+  day: NaN,
+  dayOfWeek: NaN,
+  daysInMonth: NaN,
+  monthsInYear: NaN,
+}) as unknown as Temporal.PlainDate;
+
+/**
+ * Sentinel object representing an invalid PlainDateTime.
+ */
+const INVALID_PLAIN_DATETIME = Object.freeze({
+  _invalid: true,
+  year: NaN,
+  month: NaN,
+  day: NaN,
+  hour: NaN,
+  minute: NaN,
+  second: NaN,
+  millisecond: NaN,
+  dayOfWeek: NaN,
+  daysInMonth: NaN,
+  monthsInYear: NaN,
+}) as unknown as Temporal.PlainDateTime;
+
+/** Configuration options for PlainTemporalAdapter. */
+export interface PlainTemporalAdapterOptions {
+  /**
+   * Mode for the adapter.
+   * - 'date': Uses Temporal.PlainDate (no time component)
+   * - 'datetime': Uses Temporal.PlainDateTime (with time, no timezone)
+   * @default 'datetime'
+   */
+  mode: 'date' | 'datetime';
+
+  /**
+   * Calendar system to use.
+   * @default 'iso8601'
+   */
+  calendar?: string;
+
+  /**
+   * Calendar system to use for output/formatting.
+   * Defaults to `calendar` if not set.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDate/withCalendar
+   */
+  outputCalendar?: string;
+
+  /**
+   * First day of week (0 = Sunday, 6 = Saturday).
+   * If not set, determined from locale.
+   */
+  firstDayOfWeek?: number;
+
+  /**
+   * How to handle out-of-range values in date creation.
+   * - 'reject': Throw for invalid dates (default)
+   * - 'constrain': Clamp to nearest valid date
+   * @default 'reject'
+   */
+  overflow?: 'reject' | 'constrain';
+}
+
+/** InjectionToken for PlainTemporalAdapter options. */
+export const MAT_PLAIN_TEMPORAL_ADAPTER_OPTIONS = new InjectionToken<PlainTemporalAdapterOptions>(
+  'MAT_PLAIN_TEMPORAL_ADAPTER_OPTIONS',
+  {
+    providedIn: 'root',
+    factory: () => ({mode: 'datetime', overflow: 'reject'}),
+  },
+);
+
+/** Interface for Intl.Locale with weekInfo support. */
+interface IntlWithLocale {
+  Locale?: new (locale: string) => {
+    getWeekInfo?: () => {firstDay: number};
+    weekInfo?: {firstDay: number};
+  };
+}
+
+/**
+ * DateAdapter implementation for `Temporal.PlainDate` and `Temporal.PlainDateTime`.
+ *
+ * This adapter handles date and date-time scenarios without timezone awareness.
+ * Use the `mode` option to choose between:
+ * - 'date': Only date, no time (PlainDate)
+ * - 'datetime': Date with time (PlainDateTime)
+ *
+ * For timezone-aware dates, use `ZonedDateTimeAdapter`.
+ *
+ * @example
+ * ```typescript
+ * import { providePlainTemporalAdapter } from '@angular/material-temporal-adapter/split';
+ *
+ * // Date only
+ * bootstrapApplication(AppComponent, {
+ *   providers: [providePlainTemporalAdapter(formats, { mode: 'date' })],
+ * });
+ *
+ * // Date + time (default)
+ * bootstrapApplication(AppComponent, {
+ *   providers: [providePlainTemporalAdapter()],
+ * });
+ * ```
+ */
+@Injectable()
+export class PlainTemporalAdapter extends DateAdapter<PlainTemporalType> {
+  private readonly _mode: 'date' | 'datetime';
+  private readonly _calendar: string;
+  private readonly _outputCalendar: string | null;
+  private readonly _firstDayOfWeek?: number;
+  private readonly _overflow: 'reject' | 'constrain';
+
+  constructor() {
+    super();
+
+    const dateLocale = inject(MAT_DATE_LOCALE, {optional: true});
+    const options = inject<PlainTemporalAdapterOptions>(MAT_PLAIN_TEMPORAL_ADAPTER_OPTIONS, {
+      optional: true,
+    });
+
+    this._mode = options?.mode ?? 'datetime';
+    this._calendar = options?.calendar ?? 'iso8601';
+    this._outputCalendar = options?.outputCalendar ?? null;
+    this._firstDayOfWeek = options?.firstDayOfWeek;
+    this._overflow = options?.overflow ?? 'reject';
+    this.setLocale(dateLocale || this._getDefaultLocale());
+  }
+
+  /** Gets the default locale from the browser or system. */
+  private _getDefaultLocale(): string {
+    if (typeof navigator !== 'undefined' && navigator.language) {
+      return navigator.language;
+    }
+    return 'en-US';
+  }
+
+  /** Gets the calendar ID string. */
+  private _getCalendarId(): string {
+    return this._calendar;
+  }
+
+  /** Gets the calendar ID string for output/formatting. */
+  private _getOutputCalendarId(): string {
+    return this._outputCalendar || this._calendar;
+  }
+
+  /** Whether the adapter is in datetime mode */
+  private get _isDateTime(): boolean {
+    return this._mode === 'datetime';
+  }
+
+  // ========================
+  // DateAdapter implementation
+  // ========================
+
+  getYear(date: PlainTemporalType): number {
+    return date.year;
+  }
+
+  getMonth(date: PlainTemporalType): number {
+    return date.month - 1; // Convert 1-indexed to 0-indexed
+  }
+
+  getDate(date: PlainTemporalType): number {
+    return date.day;
+  }
+
+  getDayOfWeek(date: PlainTemporalType): number {
+    const dayOfWeek = date.dayOfWeek;
+    return dayOfWeek === 7 ? 0 : dayOfWeek;
+  }
+
+  getMonthNames(style: 'long' | 'short' | 'narrow'): string[] {
+    const monthsInYear = this._getMonthsInYear();
+    const options: Intl.DateTimeFormatOptions = {
+      month: style,
+      calendar: this._getOutputCalendarId(),
+    };
+
+    return Array.from({length: monthsInYear}, (_, i) => {
+      const date = Temporal.PlainDate.from({
+        year: 2024,
+        month: i + 1,
+        day: 1,
+        calendar: this._getOutputCalendarId(),
+      });
+      return this._formatWithLocale(date, options);
+    });
+  }
+
+  getDateNames(): string[] {
+    const options: Intl.DateTimeFormatOptions = {
+      day: 'numeric',
+      calendar: this._getOutputCalendarId(),
+    };
+
+    return Array.from({length: 31}, (_, i) => {
+      const date = Temporal.PlainDate.from({
+        year: 2024,
+        month: 1,
+        day: i + 1,
+        calendar: this._getOutputCalendarId(),
+      });
+      return this._formatWithLocale(date, options);
+    });
+  }
+
+  getDayOfWeekNames(style: 'long' | 'short' | 'narrow'): string[] {
+    const options: Intl.DateTimeFormatOptions = {
+      weekday: style,
+    };
+
+    // Jan 7, 2024 was a Sunday in ISO8601 calendar.
+    // Day-of-week names are locale-dependent, not calendar-dependent,
+    // so we format directly without calendar conversion.
+    return Array.from({length: 7}, (_, i) => {
+      const date = Temporal.PlainDate.from({
+        year: 2024,
+        month: 1,
+        day: 7 + i,
+        calendar: 'iso8601',
+      });
+      return date.toLocaleString(this.locale, options).replace(/[\u200e\u200f]/g, '');
+    });
+  }
+
+  getYearName(date: PlainTemporalType): string {
+    const options: Intl.DateTimeFormatOptions = {
+      year: 'numeric',
+      calendar: this._getOutputCalendarId(),
+    };
+    return this._formatWithLocale(date, options);
+  }
+
+  getFirstDayOfWeek(): number {
+    if (this._firstDayOfWeek !== undefined) {
+      return this._firstDayOfWeek;
+    }
+
+    const intlWithLocale = Intl as IntlWithLocale;
+    if (typeof Intl !== 'undefined' && intlWithLocale.Locale) {
+      try {
+        const locale = new intlWithLocale.Locale!(this.locale);
+        const weekInfo = locale.getWeekInfo?.() || locale.weekInfo;
+        if (weekInfo?.firstDay !== undefined) {
+          return weekInfo.firstDay === 7 ? 0 : weekInfo.firstDay;
+        }
+      } catch {
+        // Fall through
+      }
+    }
+
+    return 0;
+  }
+
+  getNumDaysInMonth(date: PlainTemporalType): number {
+    return date.daysInMonth;
+  }
+
+  /**
+   * Clones the given date.
+   * Note: Temporal objects are immutable, so the original cannot be mutated.
+   * However, we still create a new object because:
+   * 1. The DateAdapter interface contract specifies "A new date"
+   * 2. Consumer code may use reference equality checks (clone !== original)
+   * 3. Consistency with other date adapters (NativeDateAdapter, LuxonDateAdapter)
+   */
+  clone(date: PlainTemporalType): PlainTemporalType {
+    // Use from(date) instead of from(date.toString()) to preserve sub-millisecond precision
+    if (this._isPlainDateTime(date)) {
+      return Temporal.PlainDateTime.from(date);
+    }
+    return Temporal.PlainDate.from(date);
+  }
+
+  createDate(year: number, month: number, date: number): PlainTemporalType {
+    if ((typeof ngDevMode === 'undefined' || ngDevMode) && this._overflow === 'reject') {
+      const monthsInYear = this._getMonthsInYearForDate(year);
+      if (month < 0 || month > monthsInYear - 1) {
+        throw Error(
+          `Invalid month index "${month}". Month index has to be between 0 and ${monthsInYear - 1}.`,
+        );
+      }
+      if (date < 1) {
+        throw Error(`Invalid date "${date}". Date has to be greater than 0.`);
+      }
+    }
+
+    try {
+      const temporalMonth = month + 1; // Convert 0-indexed to 1-indexed
+      const overflowOption = {overflow: this._overflow};
+
+      if (this._isDateTime) {
+        return Temporal.PlainDateTime.from(
+          {
+            year,
+            month: temporalMonth,
+            day: date,
+            hour: 0,
+            minute: 0,
+            second: 0,
+            calendar: this._getCalendarId(),
+          },
+          overflowOption,
+        );
+      } else {
+        return Temporal.PlainDate.from(
+          {
+            year,
+            month: temporalMonth,
+            day: date,
+            calendar: this._getCalendarId(),
+          },
+          overflowOption,
+        );
+      }
+    } catch (e) {
+      if ((typeof ngDevMode === 'undefined' || ngDevMode) && this._overflow === 'reject') {
+        throw Error(`Invalid date "${date}" for month with index "${month}".`);
+      }
+      return this.invalid();
+    }
+  }
+
+  today(): PlainTemporalType {
+    if (this._isDateTime) {
+      return Temporal.Now.plainDateTimeISO().withCalendar(this._getCalendarId());
+    }
+    return Temporal.Now.plainDateISO().withCalendar(this._getCalendarId());
+  }
+
+  parse(value: unknown, parseFormat?: any): PlainTemporalType | null {
+    if (typeof value === 'number') {
+      return this._createFromEpochMs(value);
+    }
+    if (typeof value === 'string') {
+      return value ? (this._parseString(value) ?? this.invalid()) : null;
+    }
+    if (this.isDateInstance(value)) {
+      return this.clone(value);
+    }
+    return value ? this.invalid() : null;
+  }
+
+  format(date: PlainTemporalType, displayFormat: Intl.DateTimeFormatOptions): string {
+    if (!this.isValid(date)) {
+      throw Error('PlainTemporalAdapter: Cannot format invalid date.');
+    }
+
+    const options: Intl.DateTimeFormatOptions = {
+      ...displayFormat,
+      calendar: this._getOutputCalendarId(),
+    };
+    return this._formatWithLocale(date, options);
+  }
+
+  addCalendarYears(date: PlainTemporalType, years: number): PlainTemporalType {
+    return date.add({years}, {overflow: this._overflow}) as PlainTemporalType;
+  }
+
+  addCalendarMonths(date: PlainTemporalType, months: number): PlainTemporalType {
+    return date.add({months}, {overflow: this._overflow}) as PlainTemporalType;
+  }
+
+  addCalendarDays(date: PlainTemporalType, days: number): PlainTemporalType {
+    return date.add({days}, {overflow: this._overflow}) as PlainTemporalType;
+  }
+
+  toIso8601(date: PlainTemporalType): string {
+    if (this._isPlainDateTime(date)) {
+      return date.toPlainDate().toString();
+    }
+    return date.toString();
+  }
+
+  override deserialize(value: unknown): PlainTemporalType | null {
+    if (typeof value === 'string') {
+      if (!value) return null;
+      const parsed = this._parseString(value);
+      return parsed && this.isValid(parsed) ? parsed : this.invalid();
+    }
+    return super.deserialize(value);
+  }
+
+  isDateInstance(obj: unknown): obj is PlainTemporalType {
+    if (obj == null || typeof obj !== 'object') return false;
+    if ((obj as {_invalid?: boolean})._invalid) return true;
+    return (
+      obj instanceof (Temporal.PlainDate as unknown as new (...args: unknown[]) => unknown) ||
+      obj instanceof (Temporal.PlainDateTime as unknown as new (...args: unknown[]) => unknown)
+    );
+  }
+
+  isValid(date: PlainTemporalType): boolean {
+    if ((date as unknown as {_invalid?: boolean})._invalid) return false;
+    return date != null && typeof date.year === 'number' && !isNaN(date.year);
+  }
+
+  invalid(): PlainTemporalType {
+    return this._isDateTime ? INVALID_PLAIN_DATETIME : INVALID_PLAIN_DATE;
+  }
+
+  // ========================
+  // Time methods
+  // ========================
+
+  override getHours(date: PlainTemporalType): number {
+    if (this._isPlainDateTime(date)) {
+      return date.hour;
+    }
+    return 0;
+  }
+
+  override getMinutes(date: PlainTemporalType): number {
+    if (this._isPlainDateTime(date)) {
+      return date.minute;
+    }
+    return 0;
+  }
+
+  override getSeconds(date: PlainTemporalType): number {
+    if (this._isPlainDateTime(date)) {
+      return date.second;
+    }
+    return 0;
+  }
+
+  override setTime(
+    target: PlainTemporalType,
+    hours: number,
+    minutes: number,
+    seconds: number,
+  ): PlainTemporalType {
+    // Validate inputs are finite numbers within valid ranges
+    if (!Number.isFinite(hours) || hours < 0 || hours > 23) {
+      if (typeof ngDevMode === 'undefined' || ngDevMode) {
+        throw Error(
+          `Invalid hours "${hours}". Hours value must be a finite number between 0 and 23.`,
+        );
+      }
+      return this.invalid();
+    }
+    if (!Number.isFinite(minutes) || minutes < 0 || minutes > 59) {
+      if (typeof ngDevMode === 'undefined' || ngDevMode) {
+        throw Error(
+          `Invalid minutes "${minutes}". Minutes value must be a finite number between 0 and 59.`,
+        );
+      }
+      return this.invalid();
+    }
+    if (!Number.isFinite(seconds) || seconds < 0 || seconds > 59) {
+      if (typeof ngDevMode === 'undefined' || ngDevMode) {
+        throw Error(
+          `Invalid seconds "${seconds}". Seconds value must be a finite number between 0 and 59.`,
+        );
+      }
+      return this.invalid();
+    }
+
+    if (this._isPlainDateTime(target)) {
+      return target.with({hour: hours, minute: minutes, second: seconds, millisecond: 0});
+    }
+
+    // In 'date' mode, time is not supported
+    if (this._mode === 'date') {
+      if (typeof ngDevMode === 'undefined' || ngDevMode) {
+        console.warn(
+          'PlainTemporalAdapter.setTime: Called in date mode. ' +
+            'Use mode: "datetime" for date+time scenarios.',
+        );
+      }
+      return target;
+    }
+
+    // Mode is datetime but got PlainDate - convert
+    return (target as Temporal.PlainDate)
+      .toPlainDateTime({hour: hours, minute: minutes, second: seconds})
+      .withCalendar(this._getCalendarId());
+  }
+
+  override parseTime(value: unknown, parseFormat?: any): PlainTemporalType | null {
+    if (!this._isDateTime) {
+      return this.invalid();
+    }
+
+    if (value == null || value === '') return null;
+
+    if (typeof value === 'string') {
+      if (value.trim() === '') return this.invalid();
+
+      // Reject very long strings to prevent potential DoS from regex backtracking
+      if (value.length > 32) {
+        return this.invalid();
+      }
+
+      const timeMatch = value
+        .toUpperCase()
+        .match(/^(\d?\d)[:.](\d?\d)(?:[:.](\d?\d))?\s*(AM|PM)?$/i);
+
+      if (timeMatch) {
+        let hours = parseInt(timeMatch[1], 10);
+        const minutes = parseInt(timeMatch[2], 10);
+        const seconds = timeMatch[3] ? parseInt(timeMatch[3], 10) : 0;
+        const amPm = timeMatch[4] as 'AM' | 'PM' | undefined;
+
+        if (hours === 12) {
+          hours = amPm === 'AM' ? 0 : hours;
+        } else if (amPm === 'PM') {
+          hours += 12;
+        }
+
+        if (
+          hours >= 0 &&
+          hours <= 23 &&
+          minutes >= 0 &&
+          minutes <= 59 &&
+          seconds >= 0 &&
+          seconds <= 59
+        ) {
+          return this.setTime(this.today(), hours, minutes, seconds);
+        }
+      }
+
+      try {
+        const time = Temporal.PlainTime.from(value);
+        return this.setTime(this.today(), time.hour, time.minute, time.second);
+      } catch {
+        return this.invalid();
+      }
+    }
+
+    return this.parse(value, parseFormat);
+  }
+
+  override addSeconds(date: PlainTemporalType, amount: number): PlainTemporalType {
+    if (this._isPlainDateTime(date)) {
+      return date.add({seconds: amount});
+    }
+
+    // In 'date' mode, time operations are not supported
+    if (this._mode === 'date') {
+      if (typeof ngDevMode === 'undefined' || ngDevMode) {
+        console.warn(
+          'PlainTemporalAdapter.addSeconds: Called in date mode. ' +
+            'Use mode: "datetime" for date+time scenarios.',
+        );
+      }
+      return date;
+    }
+
+    // Mode is datetime but got PlainDate - convert to PlainDateTime at midnight then add seconds
+    return (date as Temporal.PlainDate)
+      .toPlainDateTime({hour: 0, minute: 0, second: 0})
+      .add({seconds: amount})
+      .withCalendar(this._getCalendarId());
+  }
+
+  // ========================
+  // Private helpers
+  // ========================
+
+  private _formatWithLocale(date: PlainTemporalType, options: Intl.DateTimeFormatOptions): string {
+    const outputCalendar = this._getOutputCalendarId();
+    const dateForOutput =
+      outputCalendar === (date as {calendarId?: string}).calendarId
+        ? date
+        : date.withCalendar(outputCalendar);
+    const temporal = dateForOutput as unknown as {
+      toLocaleString: (locales?: string | string[], options?: Intl.DateTimeFormatOptions) => string;
+    };
+    return temporal.toLocaleString(this.locale, options).replace(/[\u200e\u200f]/g, '');
+  }
+
+  private _parseString(value: string): PlainTemporalType | null {
+    if (!value) return null;
+    try {
+      if (this._isDateTime) {
+        try {
+          return Temporal.PlainDateTime.from(value).withCalendar(this._getCalendarId());
+        } catch {
+          const plainDate = Temporal.PlainDate.from(value);
+          return plainDate
+            .toPlainDateTime({hour: 0, minute: 0, second: 0})
+            .withCalendar(this._getCalendarId());
+        }
+      } else {
+        return Temporal.PlainDate.from(value).withCalendar(this._getCalendarId());
+      }
+    } catch {
+      return null;
+    }
+  }
+
+  private _createFromEpochMs(ms: number): PlainTemporalType {
+    // Validate input: must be a finite number within JavaScript's Date range
+    // (±8.64e15 ms from Unix epoch, approximately ±273,000 years)
+    if (!Number.isFinite(ms) || ms > 8.64e15 || ms < -8.64e15) {
+      return this.invalid();
+    }
+
+    try {
+      const instant = Temporal.Instant.fromEpochMilliseconds(ms);
+      const zdt = instant.toZonedDateTimeISO(Temporal.Now.timeZoneId());
+
+      if (this._isDateTime) {
+        return Temporal.PlainDateTime.from({
+          year: zdt.year,
+          month: zdt.month,
+          day: zdt.day,
+          hour: zdt.hour,
+          minute: zdt.minute,
+          second: zdt.second,
+          calendar: this._getCalendarId(),
+        });
+      }
+      return Temporal.PlainDate.from({
+        year: zdt.year,
+        month: zdt.month,
+        day: zdt.day,
+        calendar: this._getCalendarId(),
+      });
+    } catch {
+      return this.invalid();
+    }
+  }
+
+  /** Type guard for PlainDateTime - excludes invalid sentinel objects */
+  private _isPlainDateTime(date: PlainTemporalType): date is Temporal.PlainDateTime {
+    // Check for invalid sentinel first
+    if ((date as unknown as {_invalid?: boolean})._invalid) {
+      return false;
+    }
+    return 'hour' in date && typeof date.hour === 'number' && !isNaN(date.hour);
+  }
+
+  /** Gets the number of months in the current calendar year. */
+  private _getMonthsInYear(): number {
+    try {
+      const refDate = Temporal.PlainDate.from({
+        year: 2024,
+        month: 1,
+        day: 1,
+        calendar: this._getOutputCalendarId(),
+      });
+      return refDate.monthsInYear;
+    } catch {
+      return 12;
+    }
+  }
+
+  /** Gets the number of months in a specific year for the configured calendar. */
+  private _getMonthsInYearForDate(year: number): number {
+    try {
+      const refDate = Temporal.PlainDate.from({
+        year,
+        month: 1,
+        day: 1,
+        calendar: this._getCalendarId(),
+      });
+      return refDate.monthsInYear;
+    } catch {
+      return 12;
+    }
+  }
+}

--- a/src/material-temporal-adapter/adapter/split/zoned-datetime-adapter.ts
+++ b/src/material-temporal-adapter/adapter/split/zoned-datetime-adapter.ts
@@ -1,0 +1,616 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {inject, Injectable, InjectionToken} from '@angular/core';
+import {DateAdapter, MAT_DATE_LOCALE} from '@angular/material/core';
+
+/**
+ * Configuration options for ZonedDateTimeAdapter.
+ */
+export interface ZonedDateTimeAdapterOptions {
+  /** Calendar system to use (e.g., 'iso8601', 'hebrew', 'islamic'). Defaults to 'iso8601'. */
+  calendar: string;
+  /**
+   * Calendar system to use for output/formatting. Defaults to `calendar` if not set.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/withCalendar
+   */
+  outputCalendar?: string;
+  /** Timezone ID (e.g., 'America/New_York', 'UTC'). Defaults to system timezone. */
+  timezone?: string;
+  /** First day of week (0 = Sunday, 6 = Saturday). If not set, derived from locale. */
+  firstDayOfWeek?: number;
+  /**
+   * How to resolve ambiguous or nonexistent local times when converting to ZonedDateTime.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/toZonedDateTime
+   * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/from
+   */
+  disambiguation?: 'compatible' | 'earlier' | 'later' | 'reject';
+  /**
+   * How to resolve offset ambiguity when parsing zoned strings with explicit offsets.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/from
+   */
+  offset?: 'use' | 'ignore' | 'reject' | 'prefer';
+  /**
+   * Optional rounding applied to zoned values before output/serialization.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/round
+   */
+  rounding?: {
+    smallestUnit: string;
+    roundingIncrement?: number;
+    roundingMode?: 'ceil' | 'floor' | 'trunc' | 'halfExpand';
+  };
+  /**
+   * How to handle out-of-range values in date creation.
+   * - 'reject': Throw for invalid dates (default)
+   * - 'constrain': Clamp to nearest valid date
+   * @default 'reject'
+   */
+  overflow?: 'reject' | 'constrain';
+}
+
+/** Injection token for ZonedDateTimeAdapter options. */
+export const MAT_ZONED_DATETIME_OPTIONS = new InjectionToken<ZonedDateTimeAdapterOptions>(
+  'MAT_ZONED_DATETIME_OPTIONS',
+);
+
+/**
+ * Sentinel object representing an invalid ZonedDateTime.
+ */
+const INVALID_ZONED_DATETIME = Object.freeze({
+  _invalid: true,
+  year: NaN,
+  month: NaN,
+  day: NaN,
+  hour: NaN,
+  minute: NaN,
+  second: NaN,
+  millisecond: NaN,
+  dayOfWeek: NaN,
+  daysInMonth: NaN,
+  monthsInYear: NaN,
+  timeZoneId: 'UTC',
+  epochNanoseconds: BigInt(0),
+}) as unknown as Temporal.ZonedDateTime;
+
+/** Interface for Intl.Locale with weekInfo support. */
+interface IntlWithLocale {
+  Locale?: new (locale: string) => {
+    getWeekInfo?: () => {firstDay: number};
+    weekInfo?: {firstDay: number};
+  };
+}
+
+/**
+ * DateAdapter implementation for `Temporal.ZonedDateTime`.
+ *
+ * This adapter is for timezone-aware date+time scenarios.
+ * For date-only, use `PlainDateAdapter`.
+ * For date+time without timezone, use `PlainDateTimeAdapter`.
+ *
+ * @example
+ * ```typescript
+ * import { provideZonedDateTimeAdapter } from '@angular/material-temporal-adapter';
+ *
+ * bootstrapApplication(AppComponent, {
+ *   providers: [
+ *     provideZonedDateTimeAdapter({
+ *       timezone: 'America/New_York',
+ *     }),
+ *   ],
+ * });
+ * ```
+ */
+@Injectable()
+export class ZonedDateTimeAdapter extends DateAdapter<Temporal.ZonedDateTime> {
+  private readonly _calendar: string;
+  private readonly _outputCalendar: string | null;
+  private readonly _timezone: string;
+  private readonly _firstDayOfWeek?: number;
+  private readonly _overflow: 'reject' | 'constrain';
+  private readonly _disambiguation?: 'compatible' | 'earlier' | 'later' | 'reject';
+  private readonly _offset?: 'use' | 'ignore' | 'reject' | 'prefer';
+  private readonly _rounding?: {
+    smallestUnit: string;
+    roundingIncrement?: number;
+    roundingMode?: 'ceil' | 'floor' | 'trunc' | 'halfExpand';
+  };
+  private readonly _matDateLocale = inject(MAT_DATE_LOCALE, {optional: true});
+
+  constructor() {
+    super();
+    const options = inject(MAT_ZONED_DATETIME_OPTIONS, {optional: true});
+    this._calendar = options?.calendar ?? 'iso8601';
+    this._outputCalendar = options?.outputCalendar ?? null;
+    this._timezone = options?.timezone ?? Temporal.Now.timeZoneId();
+    this._firstDayOfWeek = options?.firstDayOfWeek;
+    this._overflow = options?.overflow ?? 'reject';
+    this._disambiguation = options?.disambiguation;
+    this._offset = options?.offset;
+    this._rounding = options?.rounding;
+
+    if (this._matDateLocale) {
+      super.setLocale(this._matDateLocale);
+    } else {
+      super.setLocale(this._getDefaultLocale());
+    }
+  }
+
+  private _getDefaultLocale(): string {
+    if (typeof navigator !== 'undefined' && navigator.language) {
+      return navigator.language;
+    }
+    return 'en-US';
+  }
+
+  private _getCalendarId(): string {
+    return this._calendar;
+  }
+
+  private _getOutputCalendarId(): string {
+    return this._outputCalendar || this._calendar;
+  }
+
+  private _getZonedFromOptions(): {
+    overflow?: 'reject' | 'constrain';
+    disambiguation?: 'compatible' | 'earlier' | 'later' | 'reject';
+    offset?: 'use' | 'ignore' | 'reject' | 'prefer';
+  } {
+    return {
+      overflow: this._overflow,
+      disambiguation: this._disambiguation,
+      offset: this._offset,
+    };
+  }
+
+  private _getDisambiguationOption():
+    | {disambiguation?: 'compatible' | 'earlier' | 'later' | 'reject'}
+    | undefined {
+    return this._disambiguation ? {disambiguation: this._disambiguation} : undefined;
+  }
+
+  private _maybeRoundZoned(date: Temporal.ZonedDateTime): Temporal.ZonedDateTime {
+    if (!this._rounding) {
+      return date;
+    }
+    return date.round(this._rounding);
+  }
+
+  // ========================
+  // DateAdapter implementation
+  // ========================
+
+  getYear(date: Temporal.ZonedDateTime): number {
+    return date.year;
+  }
+
+  getMonth(date: Temporal.ZonedDateTime): number {
+    return date.month - 1;
+  }
+
+  getDate(date: Temporal.ZonedDateTime): number {
+    return date.day;
+  }
+
+  getDayOfWeek(date: Temporal.ZonedDateTime): number {
+    const dayOfWeek = date.dayOfWeek;
+    return dayOfWeek === 7 ? 0 : dayOfWeek;
+  }
+
+  getMonthNames(style: 'long' | 'short' | 'narrow'): string[] {
+    const monthsInYear = this._getMonthsInYear();
+    const options: Intl.DateTimeFormatOptions = {
+      month: style,
+      calendar: this._getOutputCalendarId(),
+    };
+
+    return Array.from({length: monthsInYear}, (_, i) => {
+      const date = Temporal.PlainDate.from({
+        year: 2024,
+        month: i + 1,
+        day: 1,
+        calendar: this._getOutputCalendarId(),
+      });
+      const zdt = date
+        .toPlainDateTime({hour: 12, minute: 0, second: 0})
+        .toZonedDateTime(this._timezone, this._getDisambiguationOption());
+      return this._formatWithLocale(zdt, options);
+    });
+  }
+
+  getDateNames(): string[] {
+    const options: Intl.DateTimeFormatOptions = {
+      day: 'numeric',
+      calendar: this._getOutputCalendarId(),
+    };
+
+    return Array.from({length: 31}, (_, i) => {
+      const date = Temporal.PlainDate.from({
+        year: 2024,
+        month: 1,
+        day: i + 1,
+        calendar: this._getOutputCalendarId(),
+      });
+      const zdt = date
+        .toPlainDateTime({hour: 12, minute: 0, second: 0})
+        .toZonedDateTime(this._timezone, this._getDisambiguationOption());
+      return this._formatWithLocale(zdt, options);
+    });
+  }
+
+  getDayOfWeekNames(style: 'long' | 'short' | 'narrow'): string[] {
+    const options: Intl.DateTimeFormatOptions = {
+      weekday: style,
+    };
+
+    // Jan 7, 2024 was a Sunday in ISO8601 calendar.
+    // Day-of-week names are locale-dependent, not calendar-dependent,
+    // so we format directly without calendar conversion.
+    return Array.from({length: 7}, (_, i) => {
+      const date = Temporal.PlainDate.from({
+        year: 2024,
+        month: 1,
+        day: 7 + i,
+        calendar: 'iso8601',
+      });
+      return date.toLocaleString(this.locale, options).replace(/[\u200e\u200f]/g, '');
+    });
+  }
+
+  getYearName(date: Temporal.ZonedDateTime): string {
+    const options: Intl.DateTimeFormatOptions = {
+      year: 'numeric',
+      calendar: this._getOutputCalendarId(),
+    };
+    return this._formatWithLocale(date, options);
+  }
+
+  getFirstDayOfWeek(): number {
+    if (this._firstDayOfWeek !== undefined) {
+      return this._firstDayOfWeek;
+    }
+
+    const intlWithLocale = Intl as IntlWithLocale;
+    if (typeof Intl !== 'undefined' && intlWithLocale.Locale) {
+      try {
+        const locale = new intlWithLocale.Locale!(this.locale);
+        const weekInfo = locale.getWeekInfo?.() || locale.weekInfo;
+        if (weekInfo?.firstDay !== undefined) {
+          return weekInfo.firstDay === 7 ? 0 : weekInfo.firstDay;
+        }
+      } catch {
+        // Fall through
+      }
+    }
+
+    return 0;
+  }
+
+  getNumDaysInMonth(date: Temporal.ZonedDateTime): number {
+    return date.daysInMonth;
+  }
+
+  /**
+   * Clones the given date.
+   * Note: Temporal objects are immutable, so the original cannot be mutated.
+   * However, we still create a new object because:
+   * 1. The DateAdapter interface contract specifies "A new date"
+   * 2. Consumer code may use reference equality checks (clone !== original)
+   * 3. Consistency with other date adapters (NativeDateAdapter, LuxonDateAdapter)
+   */
+  clone(date: Temporal.ZonedDateTime): Temporal.ZonedDateTime {
+    // For ZonedDateTime, we need to use toString() since from() requires timeZone property
+    return Temporal.ZonedDateTime.from(date.toString());
+  }
+
+  createDate(year: number, month: number, date: number): Temporal.ZonedDateTime {
+    if ((typeof ngDevMode === 'undefined' || ngDevMode) && this._overflow === 'reject') {
+      const monthsInYear = this._getMonthsInYearForDate(year);
+      if (month < 0 || month > monthsInYear - 1) {
+        throw Error(
+          `Invalid month index "${month}". Month index has to be between 0 and ${monthsInYear - 1}.`,
+        );
+      }
+      if (date < 1) {
+        throw Error(`Invalid date "${date}". Date has to be greater than 0.`);
+      }
+    }
+
+    try {
+      const plainDate = Temporal.PlainDate.from(
+        {
+          year,
+          month: month + 1,
+          day: date,
+          calendar: this._getCalendarId(),
+        },
+        {overflow: this._overflow},
+      );
+      // PlainDate -> PlainDateTime -> ZonedDateTime
+      return plainDate
+        .toPlainDateTime({hour: 0, minute: 0, second: 0})
+        .toZonedDateTime(this._timezone, this._getDisambiguationOption());
+    } catch (e) {
+      if ((typeof ngDevMode === 'undefined' || ngDevMode) && this._overflow === 'reject') {
+        throw Error(`Invalid date "${date}" for month with index "${month}".`);
+      }
+      return this.invalid();
+    }
+  }
+
+  today(): Temporal.ZonedDateTime {
+    return Temporal.Now.zonedDateTimeISO(this._timezone).withCalendar(this._getCalendarId());
+  }
+
+  parse(value: unknown, parseFormat?: any): Temporal.ZonedDateTime | null {
+    if (typeof value === 'number') {
+      return this._createFromEpochMs(value);
+    }
+    if (typeof value === 'string') {
+      return value ? (this._parseString(value) ?? this.invalid()) : null;
+    }
+    if (this.isDateInstance(value)) {
+      return this.clone(value);
+    }
+    return value ? this.invalid() : null;
+  }
+
+  format(date: Temporal.ZonedDateTime, displayFormat: Intl.DateTimeFormatOptions): string {
+    if (!this.isValid(date)) {
+      throw Error('ZonedDateTimeAdapter: Cannot format invalid date.');
+    }
+
+    const options: Intl.DateTimeFormatOptions = {
+      ...displayFormat,
+      calendar: this._getOutputCalendarId(),
+    };
+    return this._formatWithLocale(this._maybeRoundZoned(date), options);
+  }
+
+  addCalendarYears(date: Temporal.ZonedDateTime, years: number): Temporal.ZonedDateTime {
+    return date.add({years}, {overflow: this._overflow});
+  }
+
+  addCalendarMonths(date: Temporal.ZonedDateTime, months: number): Temporal.ZonedDateTime {
+    return date.add({months}, {overflow: this._overflow});
+  }
+
+  addCalendarDays(date: Temporal.ZonedDateTime, days: number): Temporal.ZonedDateTime {
+    return date.add({days}, {overflow: this._overflow});
+  }
+
+  toIso8601(date: Temporal.ZonedDateTime): string {
+    return this._maybeRoundZoned(date).toString();
+  }
+
+  override deserialize(value: unknown): Temporal.ZonedDateTime | null {
+    if (typeof value === 'string') {
+      if (!value) return null;
+      const parsed = this._parseString(value);
+      return parsed && this.isValid(parsed) ? parsed : this.invalid();
+    }
+    return super.deserialize(value);
+  }
+
+  isDateInstance(obj: unknown): obj is Temporal.ZonedDateTime {
+    if (obj == null || typeof obj !== 'object') return false;
+    if ((obj as {_invalid?: boolean})._invalid) return true;
+    return (
+      obj instanceof (Temporal.ZonedDateTime as unknown as new (...args: unknown[]) => unknown)
+    );
+  }
+
+  isValid(date: Temporal.ZonedDateTime): boolean {
+    if ((date as unknown as {_invalid?: boolean})._invalid) return false;
+    return date != null && typeof date.year === 'number' && !isNaN(date.year);
+  }
+
+  invalid(): Temporal.ZonedDateTime {
+    return INVALID_ZONED_DATETIME;
+  }
+
+  // Time methods
+  override getHours(date: Temporal.ZonedDateTime): number {
+    return date.hour;
+  }
+
+  override getMinutes(date: Temporal.ZonedDateTime): number {
+    return date.minute;
+  }
+
+  override getSeconds(date: Temporal.ZonedDateTime): number {
+    return date.second;
+  }
+
+  override setTime(
+    target: Temporal.ZonedDateTime,
+    hours: number,
+    minutes: number,
+    seconds: number,
+  ): Temporal.ZonedDateTime {
+    // Validate inputs are finite numbers within valid ranges
+    if (!Number.isFinite(hours) || hours < 0 || hours > 23) {
+      if (typeof ngDevMode === 'undefined' || ngDevMode) {
+        throw Error(
+          `Invalid hours "${hours}". Hours value must be a finite number between 0 and 23.`,
+        );
+      }
+      return this.invalid();
+    }
+    if (!Number.isFinite(minutes) || minutes < 0 || minutes > 59) {
+      if (typeof ngDevMode === 'undefined' || ngDevMode) {
+        throw Error(
+          `Invalid minutes "${minutes}". Minutes value must be a finite number between 0 and 59.`,
+        );
+      }
+      return this.invalid();
+    }
+    if (!Number.isFinite(seconds) || seconds < 0 || seconds > 59) {
+      if (typeof ngDevMode === 'undefined' || ngDevMode) {
+        throw Error(
+          `Invalid seconds "${seconds}". Seconds value must be a finite number between 0 and 59.`,
+        );
+      }
+      return this.invalid();
+    }
+    return Temporal.ZonedDateTime.from(
+      {
+        year: target.year,
+        month: target.month,
+        day: target.day,
+        hour: hours,
+        minute: minutes,
+        second: seconds,
+        millisecond: 0,
+        timeZone: target.timeZoneId,
+        calendar: this._getCalendarId(),
+      },
+      this._getZonedFromOptions(),
+    );
+  }
+
+  override parseTime(value: unknown, parseFormat?: any): Temporal.ZonedDateTime | null {
+    if (value == null || value === '') return null;
+
+    if (typeof value === 'string') {
+      if (value.trim() === '') return this.invalid();
+
+      // Reject very long strings to prevent potential DoS from regex backtracking
+      if (value.length > 32) {
+        return this.invalid();
+      }
+
+      const timeMatch = value
+        .toUpperCase()
+        .match(/^(\d?\d)[:.](\d?\d)(?:[:.](\d?\d))?\s*(AM|PM)?$/i);
+      if (timeMatch) {
+        let hours = parseInt(timeMatch[1], 10);
+        const minutes = parseInt(timeMatch[2], 10);
+        const seconds = timeMatch[3] ? parseInt(timeMatch[3], 10) : 0;
+        const amPm = timeMatch[4] as 'AM' | 'PM' | undefined;
+
+        if (hours === 12) {
+          hours = amPm === 'AM' ? 0 : hours;
+        } else if (amPm === 'PM') {
+          hours += 12;
+        }
+
+        if (
+          hours >= 0 &&
+          hours <= 23 &&
+          minutes >= 0 &&
+          minutes <= 59 &&
+          seconds >= 0 &&
+          seconds <= 59
+        ) {
+          return this.setTime(this.today(), hours, minutes, seconds);
+        }
+      }
+
+      try {
+        const time = Temporal.PlainTime.from(value);
+        return this.setTime(this.today(), time.hour, time.minute, time.second);
+      } catch {
+        return this.invalid();
+      }
+    }
+
+    return this.parse(value, parseFormat);
+  }
+
+  override addSeconds(date: Temporal.ZonedDateTime, amount: number): Temporal.ZonedDateTime {
+    return date.add({seconds: amount});
+  }
+
+  private _formatWithLocale(
+    date: Temporal.ZonedDateTime,
+    options: Intl.DateTimeFormatOptions,
+  ): string {
+    const outputCalendar = this._getOutputCalendarId();
+    const dateForOutput =
+      outputCalendar === (date as {calendarId?: string}).calendarId
+        ? date
+        : date.withCalendar(outputCalendar);
+    const temporal = dateForOutput as unknown as {
+      toLocaleString: (locales?: string | string[], options?: Intl.DateTimeFormatOptions) => string;
+    };
+    return temporal.toLocaleString(this.locale, options).replace(/[\u200e\u200f]/g, '');
+  }
+
+  private _parseString(value: string): Temporal.ZonedDateTime | null {
+    if (!value) return null;
+    try {
+      // Try ZonedDateTime first
+      try {
+        return Temporal.ZonedDateTime.from(value, this._getZonedFromOptions()).withCalendar(
+          this._getCalendarId(),
+        );
+      } catch {
+        if (value.includes('[')) {
+          return null;
+        }
+        // Try PlainDate and convert
+        const plainDate = Temporal.PlainDate.from(value);
+        return plainDate
+          .toPlainDateTime({hour: 0, minute: 0, second: 0})
+          .toZonedDateTime(this._timezone, this._getDisambiguationOption())
+          .withCalendar(this._getCalendarId());
+      }
+    } catch {
+      return null;
+    }
+  }
+
+  private _createFromEpochMs(ms: number): Temporal.ZonedDateTime {
+    // Validate input: must be a finite number within JavaScript's Date range
+    // (±8.64e15 ms from Unix epoch, approximately ±273,000 years)
+    if (!Number.isFinite(ms) || ms > 8.64e15 || ms < -8.64e15) {
+      return this.invalid();
+    }
+
+    try {
+      const instant = Temporal.Instant.fromEpochMilliseconds(ms);
+      return instant.toZonedDateTimeISO(this._timezone).withCalendar(this._getCalendarId());
+    } catch {
+      return this.invalid();
+    }
+  }
+
+  /** Gets the number of months in the current calendar year. */
+  private _getMonthsInYear(): number {
+    try {
+      const refDate = Temporal.PlainDate.from({
+        year: 2024,
+        month: 1,
+        day: 1,
+        calendar: this._getOutputCalendarId(),
+      });
+      return refDate.monthsInYear;
+    } catch {
+      return 12;
+    }
+  }
+
+  /** Gets the number of months in a specific year for the configured calendar. */
+  private _getMonthsInYearForDate(year: number): number {
+    try {
+      const refDate = Temporal.PlainDate.from({
+        year,
+        month: 1,
+        day: 1,
+        calendar: this._getCalendarId(),
+      });
+      return refDate.monthsInYear;
+    } catch {
+      return 12;
+    }
+  }
+}

--- a/src/material-temporal-adapter/adapter/temporal-date-adapter.spec.ts
+++ b/src/material-temporal-adapter/adapter/temporal-date-adapter.spec.ts
@@ -1,0 +1,2109 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {TestBed} from '@angular/core/testing';
+import {DateAdapter, MAT_DATE_LOCALE} from '@angular/material/core';
+import {
+  MAT_TEMPORAL_DATE_ADAPTER_OPTIONS,
+  TemporalDateAdapter,
+  TemporalDateType,
+  TemporalModule,
+} from './index';
+import {
+  MAT_PLAIN_TEMPORAL_ADAPTER_OPTIONS,
+  MAT_ZONED_DATETIME_OPTIONS,
+  PlainTemporalAdapter,
+  ZonedDateTimeAdapter,
+} from './split';
+
+const JAN = 0,
+  FEB = 1,
+  MAR = 2,
+  APR = 3,
+  MAY = 4,
+  JUN = 5,
+  JUL = 6,
+  AUG = 7,
+  SEP = 8,
+  OCT = 9,
+  NOV = 10,
+  DEC = 11;
+
+const hasTemporal = typeof (globalThis as {Temporal?: unknown}).Temporal !== 'undefined';
+const describe: (description: string, specDefinitions: () => void) => void = hasTemporal
+  ? (globalThis as any).describe
+  : (globalThis as any).xdescribe;
+const supportsCalendar = (calendarId: string): boolean => {
+  if (!hasTemporal) {
+    return false;
+  }
+
+  try {
+    Temporal.PlainDate.from({year: 2024, month: 1, day: 1, calendar: calendarId});
+    return true;
+  } catch {
+    return false;
+  }
+};
+const describeIfCalendarSupported = (calendarId: string) =>
+  supportsCalendar(calendarId) ? describe : xdescribe;
+
+describe('TemporalDateAdapter', () => {
+  let adapter: DateAdapter<TemporalDateType>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({imports: [TemporalModule]});
+    adapter = TestBed.inject(DateAdapter);
+    adapter.setLocale('en-US');
+  });
+
+  it('should get year', () => {
+    expect(adapter.getYear(adapter.createDate(2017, JAN, 1))).toBe(2017);
+  });
+
+  it('should get month', () => {
+    expect(adapter.getMonth(adapter.createDate(2017, JAN, 1))).toBe(0);
+  });
+
+  it('should get date', () => {
+    expect(adapter.getDate(adapter.createDate(2017, JAN, 1))).toBe(1);
+  });
+
+  it('should get day of week', () => {
+    // January 1, 2017 was a Sunday
+    expect(adapter.getDayOfWeek(adapter.createDate(2017, JAN, 1))).toBe(0);
+    // January 2, 2017 was a Monday
+    expect(adapter.getDayOfWeek(adapter.createDate(2017, JAN, 2))).toBe(1);
+  });
+
+  it('should get long month names', () => {
+    expect(adapter.getMonthNames('long')).toEqual([
+      'January',
+      'February',
+      'March',
+      'April',
+      'May',
+      'June',
+      'July',
+      'August',
+      'September',
+      'October',
+      'November',
+      'December',
+    ]);
+  });
+
+  it('should get short month names', () => {
+    expect(adapter.getMonthNames('short')).toEqual([
+      'Jan',
+      'Feb',
+      'Mar',
+      'Apr',
+      'May',
+      'Jun',
+      'Jul',
+      'Aug',
+      'Sep',
+      'Oct',
+      'Nov',
+      'Dec',
+    ]);
+  });
+
+  it('should get narrow month names', () => {
+    expect(adapter.getMonthNames('narrow')).toEqual([
+      'J',
+      'F',
+      'M',
+      'A',
+      'M',
+      'J',
+      'J',
+      'A',
+      'S',
+      'O',
+      'N',
+      'D',
+    ]);
+  });
+
+  it('should get date names', () => {
+    expect(adapter.getDateNames()).toEqual([
+      '1',
+      '2',
+      '3',
+      '4',
+      '5',
+      '6',
+      '7',
+      '8',
+      '9',
+      '10',
+      '11',
+      '12',
+      '13',
+      '14',
+      '15',
+      '16',
+      '17',
+      '18',
+      '19',
+      '20',
+      '21',
+      '22',
+      '23',
+      '24',
+      '25',
+      '26',
+      '27',
+      '28',
+      '29',
+      '30',
+      '31',
+    ]);
+  });
+
+  it('should get long day of week names', () => {
+    expect(adapter.getDayOfWeekNames('long')).toEqual([
+      'Sunday',
+      'Monday',
+      'Tuesday',
+      'Wednesday',
+      'Thursday',
+      'Friday',
+      'Saturday',
+    ]);
+  });
+
+  it('should get short day of week names', () => {
+    expect(adapter.getDayOfWeekNames('short')).toEqual([
+      'Sun',
+      'Mon',
+      'Tue',
+      'Wed',
+      'Thu',
+      'Fri',
+      'Sat',
+    ]);
+  });
+
+  it('should get narrow day of week names', () => {
+    expect(adapter.getDayOfWeekNames('narrow')).toEqual(['S', 'M', 'T', 'W', 'T', 'F', 'S']);
+  });
+
+  it('should get year name', () => {
+    expect(adapter.getYearName(adapter.createDate(2017, JAN, 1))).toBe('2017');
+  });
+
+  it('should get first day of week', () => {
+    expect(adapter.getFirstDayOfWeek()).toBeGreaterThanOrEqual(0);
+    expect(adapter.getFirstDayOfWeek()).toBeLessThanOrEqual(6);
+  });
+
+  it('should get number of days in month', () => {
+    expect(adapter.getNumDaysInMonth(adapter.createDate(2017, JAN, 1))).toBe(31);
+    expect(adapter.getNumDaysInMonth(adapter.createDate(2017, FEB, 1))).toBe(28);
+    expect(adapter.getNumDaysInMonth(adapter.createDate(2016, FEB, 1))).toBe(29); // Leap year
+    expect(adapter.getNumDaysInMonth(adapter.createDate(2017, APR, 1))).toBe(30);
+  });
+
+  it('should clone', () => {
+    const date = adapter.createDate(2017, JAN, 1);
+    const clone = adapter.clone(date);
+
+    expect(clone).not.toBe(date);
+    expect(adapter.getYear(clone)).toEqual(adapter.getYear(date));
+    expect(adapter.getMonth(clone)).toEqual(adapter.getMonth(date));
+    expect(adapter.getDate(clone)).toEqual(adapter.getDate(date));
+  });
+
+  it('should create date', () => {
+    const date = adapter.createDate(2017, JAN, 1);
+    expect(adapter.getYear(date)).toBe(2017);
+    expect(adapter.getMonth(date)).toBe(JAN);
+    expect(adapter.getDate(date)).toBe(1);
+  });
+
+  it('should not create date with month over/under-flow', () => {
+    expect(() => adapter.createDate(2017, 12, 1)).toThrow();
+    expect(() => adapter.createDate(2017, -1, 1)).toThrow();
+  });
+
+  it('should not create date with date over/under-flow', () => {
+    expect(() => adapter.createDate(2017, JAN, 32)).toThrow();
+    expect(() => adapter.createDate(2017, JAN, 0)).toThrow();
+  });
+
+  it('should create date with low year number', () => {
+    expect(adapter.getYear(adapter.createDate(-1, JAN, 1))).toBe(-1);
+    expect(adapter.getYear(adapter.createDate(0, JAN, 1))).toBe(0);
+    expect(adapter.getYear(adapter.createDate(50, JAN, 1))).toBe(50);
+    expect(adapter.getYear(adapter.createDate(99, JAN, 1))).toBe(99);
+    expect(adapter.getYear(adapter.createDate(100, JAN, 1))).toBe(100);
+  });
+
+  it('should create today', () => {
+    const today = adapter.today();
+    const jsToday = new Date();
+    expect(adapter.getYear(today)).toBe(jsToday.getFullYear());
+    expect(adapter.getMonth(today)).toBe(jsToday.getMonth());
+    expect(adapter.getDate(today)).toBe(jsToday.getDate());
+  });
+
+  it('should parse ISO 8601 date string', () => {
+    const date = adapter.parse('2017-01-02', null);
+    expect(date).not.toBeNull();
+    expect(adapter.getYear(date!)).toBe(2017);
+    expect(adapter.getMonth(date!)).toBe(JAN);
+    expect(adapter.getDate(date!)).toBe(2);
+  });
+
+  it('should parse number', () => {
+    const timestamp = new Date(2017, JAN, 1).getTime();
+    const date = adapter.parse(timestamp, null);
+    expect(date).not.toBeNull();
+    expect(adapter.getYear(date!)).toBe(2017);
+    expect(adapter.getMonth(date!)).toBe(JAN);
+    expect(adapter.getDate(date!)).toBe(1);
+  });
+
+  it('should return invalid for JS Date (not supported)', () => {
+    const jsDate = new Date(2017, JAN, 1);
+    const date = adapter.parse(jsDate, null);
+    // Temporal adapter doesn't accept JS Date - use Temporal types instead
+    expect(adapter.isValid(date!)).toBe(false);
+  });
+
+  it('should parse empty string as null', () => {
+    expect(adapter.parse('', null)).toBeNull();
+  });
+
+  it('should parse invalid value as invalid', () => {
+    const d = adapter.parse('hello', null);
+    expect(d).not.toBeNull();
+    expect(adapter.isDateInstance(d)).toBe(true);
+    expect(adapter.isValid(d as TemporalDateType)).toBe(false);
+  });
+
+  it('should parse Temporal date', () => {
+    const date = adapter.createDate(2017, JAN, 1);
+    const parsedDate = adapter.parse(date, null);
+    expect(parsedDate).not.toBeNull();
+    expect(adapter.getYear(parsedDate!)).toBe(2017);
+    expect(adapter.getMonth(parsedDate!)).toBe(JAN);
+    expect(adapter.getDate(parsedDate!)).toBe(1);
+    expect(parsedDate).not.toBe(date);
+  });
+
+  it('should format date', () => {
+    const date = adapter.createDate(2017, JAN, 2);
+    const formatted = adapter.format(date, {year: 'numeric', month: '2-digit', day: '2-digit'});
+    expect(formatted).toBeTruthy();
+    // Format may vary by locale, just check it contains the right components
+    expect(formatted).toContain('2017');
+    expect(formatted).toContain('01');
+    expect(formatted).toContain('02');
+  });
+
+  it('should throw when formatting invalid date', () => {
+    expect(() => adapter.format(adapter.invalid(), {year: 'numeric'})).toThrowError(
+      /Cannot format invalid date/,
+    );
+  });
+
+  it('should add years', () => {
+    expect(adapter.addCalendarYears(adapter.createDate(2017, JAN, 1), 1)).toEqual(
+      adapter.createDate(2018, JAN, 1),
+    );
+    expect(adapter.addCalendarYears(adapter.createDate(2017, JAN, 1), -1)).toEqual(
+      adapter.createDate(2016, JAN, 1),
+    );
+  });
+
+  it('should respect leap years when adding years (throws with reject overflow)', () => {
+    const feb29 = adapter.createDate(2016, FEB, 29);
+    // Default overflow is 'reject', so adding a year to Feb 29 should throw
+    // since 2017 doesn't have Feb 29
+    expect(() => adapter.addCalendarYears(feb29, 1)).toThrow();
+  });
+
+  it('should add months', () => {
+    expect(adapter.addCalendarMonths(adapter.createDate(2017, JAN, 1), 1)).toEqual(
+      adapter.createDate(2017, FEB, 1),
+    );
+    expect(adapter.addCalendarMonths(adapter.createDate(2017, JAN, 1), -1)).toEqual(
+      adapter.createDate(2016, DEC, 1),
+    );
+  });
+
+  it('should respect month length differences when adding months (throws with reject overflow)', () => {
+    const jan31 = adapter.createDate(2017, JAN, 31);
+    // Default overflow is 'reject', so adding a month to Jan 31 should throw
+    // since February doesn't have 31 days
+    expect(() => adapter.addCalendarMonths(jan31, 1)).toThrow();
+  });
+
+  it('should add days', () => {
+    expect(adapter.addCalendarDays(adapter.createDate(2017, JAN, 1), 1)).toEqual(
+      adapter.createDate(2017, JAN, 2),
+    );
+    expect(adapter.addCalendarDays(adapter.createDate(2017, JAN, 1), -1)).toEqual(
+      adapter.createDate(2016, DEC, 31),
+    );
+  });
+
+  it('should produce ISO 8601 string', () => {
+    const date = adapter.createDate(2017, JAN, 2);
+    expect(adapter.toIso8601(date)).toBe('2017-01-02');
+  });
+
+  it('should create valid dates from valid ISO strings', () => {
+    assertValidDate(adapter, adapter.deserialize('1985-04-12'), true);
+    assertValidDate(adapter, adapter.deserialize('2017-01-01'), true);
+    expect(adapter.deserialize('')).toBeNull();
+    expect(adapter.deserialize(null)).toBeNull();
+    // Temporal adapter doesn't accept JS Date - test that it returns invalid
+    assertValidDate(adapter, adapter.deserialize(new Date(2017, JAN, 1)), false);
+    assertValidDate(adapter, adapter.deserialize(new Date(NaN)), false);
+  });
+
+  it('should create invalid date', () => {
+    assertValidDate(adapter, adapter.invalid(), false);
+  });
+
+  it('should count today as a valid date instance', () => {
+    const d = adapter.today();
+    expect(adapter.isValid(d)).toBe(true);
+    expect(adapter.isDateInstance(d)).toBe(true);
+  });
+
+  it('should count an invalid date as an invalid date instance', () => {
+    const d = adapter.invalid();
+    expect(adapter.isValid(d)).toBe(false);
+    expect(adapter.isDateInstance(d)).toBe(true);
+  });
+
+  it('should count a string as not a date instance', () => {
+    const d = '1/1/2017';
+    expect(adapter.isDateInstance(d)).toBe(false);
+  });
+
+  it('should count a Date as not a date instance', () => {
+    const d = new Date();
+    expect(adapter.isDateInstance(d)).toBe(false);
+  });
+
+  it('should return the date when deserializing a Temporal date', () => {
+    // Temporal types are immutable, so returning the same instance is safe
+    const date = adapter.createDate(2017, JAN, 1);
+    const deserialized = adapter.deserialize(date);
+    expect(deserialized).not.toBeNull();
+    expect(adapter.getYear(deserialized!)).toBe(2017);
+    // Immutable objects don't need to be cloned
+    expect(deserialized).toBe(date);
+  });
+
+  it('should provide a method to return a valid date or null', () => {
+    const d = adapter.today();
+    expect(adapter.getValidDateOrNull(d)).toBe(d);
+    expect(adapter.getValidDateOrNull(adapter.invalid())).toBeNull();
+  });
+
+  it('should compare dates', () => {
+    expect(
+      adapter.compareDate(adapter.createDate(2017, JAN, 1), adapter.createDate(2017, JAN, 2)),
+    ).toBeLessThan(0);
+    expect(
+      adapter.compareDate(adapter.createDate(2017, JAN, 1), adapter.createDate(2017, FEB, 1)),
+    ).toBeLessThan(0);
+    expect(
+      adapter.compareDate(adapter.createDate(2017, JAN, 1), adapter.createDate(2018, JAN, 1)),
+    ).toBeLessThan(0);
+    expect(
+      adapter.compareDate(adapter.createDate(2017, JAN, 1), adapter.createDate(2017, JAN, 1)),
+    ).toBe(0);
+    expect(
+      adapter.compareDate(adapter.createDate(2018, JAN, 1), adapter.createDate(2017, JAN, 1)),
+    ).toBeGreaterThan(0);
+    expect(
+      adapter.compareDate(adapter.createDate(2017, FEB, 1), adapter.createDate(2017, JAN, 1)),
+    ).toBeGreaterThan(0);
+    expect(
+      adapter.compareDate(adapter.createDate(2017, JAN, 2), adapter.createDate(2017, JAN, 1)),
+    ).toBeGreaterThan(0);
+  });
+
+  it('should clamp date at lower bound', () => {
+    expect(
+      adapter.clampDate(
+        adapter.createDate(2017, JAN, 1),
+        adapter.createDate(2018, JAN, 1),
+        adapter.createDate(2019, JAN, 1),
+      ),
+    ).toEqual(adapter.createDate(2018, JAN, 1));
+  });
+
+  it('should clamp date at upper bound', () => {
+    expect(
+      adapter.clampDate(
+        adapter.createDate(2020, JAN, 1),
+        adapter.createDate(2018, JAN, 1),
+        adapter.createDate(2019, JAN, 1),
+      ),
+    ).toEqual(adapter.createDate(2019, JAN, 1));
+  });
+
+  it('should clamp date already within bounds', () => {
+    expect(
+      adapter.clampDate(
+        adapter.createDate(2018, FEB, 1),
+        adapter.createDate(2018, JAN, 1),
+        adapter.createDate(2019, JAN, 1),
+      ),
+    ).toEqual(adapter.createDate(2018, FEB, 1));
+  });
+});
+
+describe('TemporalDateAdapter with datetime mode', () => {
+  let adapter: DateAdapter<TemporalDateType>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [TemporalModule],
+      providers: [
+        {
+          provide: MAT_TEMPORAL_DATE_ADAPTER_OPTIONS,
+          useValue: {calendar: 'iso8601', mode: 'datetime'},
+        },
+      ],
+    });
+    adapter = TestBed.inject(DateAdapter);
+    adapter.setLocale('en-US');
+  });
+
+  it('should get hours', () => {
+    const date = adapter.createDate(2024, JAN, 1);
+    const withTime = adapter.setTime(date, 14, 30, 45);
+    expect(adapter.getHours(withTime)).toBe(14);
+  });
+
+  it('should get minutes', () => {
+    const date = adapter.createDate(2024, JAN, 1);
+    const withTime = adapter.setTime(date, 14, 30, 45);
+    expect(adapter.getMinutes(withTime)).toBe(30);
+  });
+
+  it('should get seconds', () => {
+    const date = adapter.createDate(2024, JAN, 1);
+    const withTime = adapter.setTime(date, 14, 30, 45);
+    expect(adapter.getSeconds(withTime)).toBe(45);
+  });
+
+  it('should set time', () => {
+    const date = adapter.createDate(2024, JAN, 1);
+    const withTime = adapter.setTime(date, 14, 30, 45);
+    expect(adapter.getHours(withTime)).toBe(14);
+    expect(adapter.getMinutes(withTime)).toBe(30);
+    expect(adapter.getSeconds(withTime)).toBe(45);
+  });
+
+  it('should throw when passing invalid hours to setTime', () => {
+    const date = adapter.today();
+    expect(() => adapter.setTime(date, -1, 0, 0)).toThrowError(/Invalid hours/);
+    expect(() => adapter.setTime(date, 24, 0, 0)).toThrowError(/Invalid hours/);
+  });
+
+  it('should throw when passing invalid minutes to setTime', () => {
+    const date = adapter.today();
+    expect(() => adapter.setTime(date, 0, -1, 0)).toThrowError(/Invalid minutes/);
+    expect(() => adapter.setTime(date, 0, 60, 0)).toThrowError(/Invalid minutes/);
+  });
+
+  it('should throw when passing invalid seconds to setTime', () => {
+    const date = adapter.today();
+    expect(() => adapter.setTime(date, 0, 0, -1)).toThrowError(/Invalid seconds/);
+    expect(() => adapter.setTime(date, 0, 0, 60)).toThrowError(/Invalid seconds/);
+  });
+
+  it('should parse time string', () => {
+    const result = adapter.parseTime('14:30', 'HH:mm');
+    expect(result).not.toBeNull();
+    expect(adapter.getHours(result!)).toBe(14);
+    expect(adapter.getMinutes(result!)).toBe(30);
+  });
+
+  it('should parse 12-hour time string with AM/PM', () => {
+    const result = adapter.parseTime('2:30 PM', 'h:mm a');
+    expect(result).not.toBeNull();
+    expect(adapter.getHours(result!)).toBe(14);
+    expect(adapter.getMinutes(result!)).toBe(30);
+  });
+
+  it('should parse padded time string', () => {
+    const result = adapter.parseTime('03:04:05', 'HH:mm:ss');
+    expect(result).not.toBeNull();
+    expect(adapter.isValid(result!)).toBe(true);
+    expect(adapter.getHours(result!)).toBe(3);
+    expect(adapter.getMinutes(result!)).toBe(4);
+    expect(adapter.getSeconds(result!)).toBe(5);
+  });
+
+  it('should return invalid date when parsing invalid time string', () => {
+    const abc = adapter.parseTime('abc', 'HH:mm');
+    expect(abc).not.toBeNull();
+    expect(adapter.isValid(abc!)).toBe(false);
+
+    const spaces = adapter.parseTime('    ', 'HH:mm');
+    expect(spaces).not.toBeNull();
+    expect(adapter.isValid(spaces!)).toBe(false);
+  });
+
+  it('should return invalid date when parsing out-of-range time values', () => {
+    const invalidHours = adapter.parseTime('24:05', 'HH:mm');
+    expect(invalidHours).not.toBeNull();
+    expect(adapter.isValid(invalidHours!)).toBe(false);
+
+    const invalidMinutes = adapter.parseTime('00:61', 'HH:mm');
+    expect(invalidMinutes).not.toBeNull();
+    expect(adapter.isValid(invalidMinutes!)).toBe(false);
+
+    const invalidSeconds = adapter.parseTime('14:52:78', 'HH:mm:ss');
+    expect(invalidSeconds).not.toBeNull();
+    expect(adapter.isValid(invalidSeconds!)).toBe(false);
+  });
+
+  it('should return null when parsing empty or undefined time values', () => {
+    expect(adapter.parseTime(undefined, 'HH:mm')).toBeNull();
+    expect(adapter.parseTime('', 'HH:mm')).toBeNull();
+  });
+
+  it('should add seconds', () => {
+    const date = adapter.createDate(2024, JAN, 1);
+    const withTime = adapter.setTime(date, 12, 30, 0);
+    const result = adapter.addSeconds(withTime, 90);
+    expect(adapter.getMinutes(result)).toBe(31);
+    expect(adapter.getSeconds(result)).toBe(30);
+  });
+
+  it('should preserve time when cloning', () => {
+    const date = adapter.createDate(2024, JAN, 15);
+    const withTime = adapter.setTime(date, 14, 30, 45);
+    const clone = adapter.clone(withTime);
+    expect(adapter.getHours(clone)).toBe(14);
+    expect(adapter.getMinutes(clone)).toBe(30);
+    expect(adapter.getSeconds(clone)).toBe(45);
+  });
+});
+
+describeIfCalendarSupported('hebrew')('TemporalDateAdapter with custom calendar', () => {
+  let adapter: DateAdapter<TemporalDateType>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [TemporalModule],
+      providers: [
+        {
+          provide: MAT_TEMPORAL_DATE_ADAPTER_OPTIONS,
+          useValue: {calendar: 'hebrew', mode: 'date'},
+        },
+      ],
+    });
+    adapter = TestBed.inject(DateAdapter);
+    adapter.setLocale('he-IL');
+  });
+
+  it('should create date with Hebrew calendar', () => {
+    const date = adapter.createDate(5784, 0, 1); // First month of Hebrew year 5784
+    expect(adapter.isValid(date)).toBe(true);
+  });
+
+  it('should get correct number of months for Hebrew calendar', () => {
+    // Hebrew calendar can have 12 or 13 months depending on leap year
+    const monthNames = adapter.getMonthNames('long');
+    expect(monthNames.length).toBeGreaterThanOrEqual(12);
+  });
+
+  it('should get day of week names in Hebrew locale regardless of calendar', () => {
+    // Day-of-week names are locale-dependent, not calendar-dependent.
+    // Hebrew locale should return Hebrew names regardless of calendar system.
+    const dayNames = adapter.getDayOfWeekNames('long');
+    expect(dayNames.length).toBe(7);
+    // Hebrew day names (Sunday = יום ראשון, etc.)
+    // Verify they're Hebrew strings (contain Hebrew characters)
+    const hebrewCharRegex = /[\u0590-\u05FF]/;
+    dayNames.forEach(name => {
+      expect(hebrewCharRegex.test(name)).toBe(true);
+    });
+  });
+});
+
+describeIfCalendarSupported('japanese')('TemporalDateAdapter with outputCalendar option', () => {
+  let adapter: DateAdapter<TemporalDateType>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [TemporalModule],
+      providers: [
+        {
+          provide: MAT_TEMPORAL_DATE_ADAPTER_OPTIONS,
+          useValue: {calendar: 'iso8601', outputCalendar: 'japanese', mode: 'date'},
+        },
+      ],
+    });
+    adapter = TestBed.inject(DateAdapter);
+    adapter.setLocale('ja-JP');
+  });
+
+  it('should format using the output calendar', () => {
+    const date = adapter.createDate(2024, 0, 1);
+    const formatted = adapter.format(date, {year: 'numeric'});
+    const expected = Temporal.PlainDate.from('2024-01-01')
+      .withCalendar('japanese')
+      .toLocaleString('ja-JP', {year: 'numeric', calendar: 'japanese'});
+
+    expect(formatted).toBe(expected);
+  });
+});
+
+describeIfCalendarSupported('japanese')(
+  'TemporalDateAdapter outputCalendar with non-ISO calendar inputs',
+  () => {
+    let adapter: DateAdapter<TemporalDateType>;
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        imports: [TemporalModule],
+        providers: [
+          {
+            provide: MAT_TEMPORAL_DATE_ADAPTER_OPTIONS,
+            useValue: {calendar: 'japanese', outputCalendar: 'iso8601', mode: 'date'},
+          },
+        ],
+      });
+      adapter = TestBed.inject(DateAdapter);
+      adapter.setLocale('en-US');
+    });
+
+    it('should format without errors when outputCalendar differs', () => {
+      const date = adapter.createDate(2024, JAN, 1);
+      const formatted = adapter.format(date, {year: 'numeric'});
+      const expected = Temporal.PlainDate.from('2024-01-01').toLocaleString('en-US', {
+        year: 'numeric',
+        calendar: 'iso8601',
+      });
+      expect(formatted).toBe(expected);
+    });
+  },
+);
+
+describe('TemporalDateAdapter with firstDayOfWeek option', () => {
+  let adapter: DateAdapter<TemporalDateType>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [TemporalModule],
+      providers: [
+        {
+          provide: MAT_TEMPORAL_DATE_ADAPTER_OPTIONS,
+          useValue: {calendar: 'iso8601', mode: 'date', firstDayOfWeek: 1},
+        },
+      ],
+    });
+    adapter = TestBed.inject(DateAdapter);
+  });
+
+  it('should use custom first day of week', () => {
+    expect(adapter.getFirstDayOfWeek()).toBe(1); // Monday
+  });
+});
+
+describe('TemporalDateAdapter with zoned options', () => {
+  let adapter: DateAdapter<TemporalDateType>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [TemporalModule],
+      providers: [
+        {
+          provide: MAT_TEMPORAL_DATE_ADAPTER_OPTIONS,
+          useValue: {
+            calendar: 'iso8601',
+            mode: 'zoned',
+            timezone: 'UTC',
+            rounding: {smallestUnit: 'minute', roundingIncrement: 5},
+            offset: 'ignore',
+          },
+        },
+      ],
+    });
+    adapter = TestBed.inject(DateAdapter);
+  });
+
+  it('should round zoned outputs when configured', () => {
+    const zdt = Temporal.ZonedDateTime.from('2024-01-15T12:34:56+00:00[UTC]');
+    const rounded = adapter.toIso8601(zdt);
+    const expected = zdt.round({smallestUnit: 'minute', roundingIncrement: 5}).toString();
+    expect(rounded).toBe(expected);
+  });
+
+  it('should honor offset handling when parsing zoned strings', () => {
+    const value = '2019-12-23T12:00:00-02:00[America/Sao_Paulo]';
+    const parsed = adapter.deserialize(value);
+    expect(parsed).not.toBeNull();
+    expect(adapter.isValid(parsed!)).toBe(true);
+  });
+});
+
+describe('TemporalDateAdapter disambiguation options', () => {
+  it('should throw for nonexistent local time when disambiguation is reject', () => {
+    TestBed.configureTestingModule({
+      imports: [TemporalModule],
+      providers: [
+        {
+          provide: MAT_TEMPORAL_DATE_ADAPTER_OPTIONS,
+          useValue: {
+            calendar: 'iso8601',
+            mode: 'zoned',
+            timezone: 'America/New_York',
+            disambiguation: 'reject',
+          },
+        },
+      ],
+    });
+    const adapter = TestBed.inject(DateAdapter);
+    const date = adapter.createDate(2024, MAR, 10); // DST spring-forward
+    expect(() => adapter.setTime(date, 2, 5, 0)).toThrow();
+  });
+
+  it('should choose earlier vs later offsets for ambiguous local times', () => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [TemporalModule],
+      providers: [
+        {
+          provide: MAT_TEMPORAL_DATE_ADAPTER_OPTIONS,
+          useValue: {
+            calendar: 'iso8601',
+            mode: 'zoned',
+            timezone: 'America/New_York',
+            disambiguation: 'earlier',
+          },
+        },
+      ],
+    });
+    const earlierAdapter = TestBed.inject(DateAdapter);
+    const date = earlierAdapter.createDate(2024, NOV, 3); // DST fall-back
+    const earlier = earlierAdapter.setTime(date, 1, 5, 0) as Temporal.ZonedDateTime;
+    expect(earlier.toString()).toContain('-04:00');
+
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [TemporalModule],
+      providers: [
+        {
+          provide: MAT_TEMPORAL_DATE_ADAPTER_OPTIONS,
+          useValue: {
+            calendar: 'iso8601',
+            mode: 'zoned',
+            timezone: 'America/New_York',
+            disambiguation: 'later',
+          },
+        },
+      ],
+    });
+    const laterAdapter = TestBed.inject(DateAdapter);
+    const later = laterAdapter.setTime(date, 1, 5, 0) as Temporal.ZonedDateTime;
+    expect(later.toString()).toContain('-05:00');
+  });
+
+  it('should use compatible behavior for gaps and overlaps', () => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [TemporalModule],
+      providers: [
+        {
+          provide: MAT_TEMPORAL_DATE_ADAPTER_OPTIONS,
+          useValue: {
+            calendar: 'iso8601',
+            mode: 'zoned',
+            timezone: 'America/New_York',
+            disambiguation: 'compatible',
+          },
+        },
+      ],
+    });
+    const adapter = TestBed.inject(DateAdapter);
+
+    const gapDate = adapter.createDate(2024, MAR, 10);
+    const gapResult = adapter.setTime(gapDate, 2, 5, 0) as Temporal.ZonedDateTime;
+    const gapExpected = Temporal.PlainDateTime.from('2024-03-10T02:05')
+      .toZonedDateTime('America/New_York', {disambiguation: 'compatible'})
+      .toString();
+    expect(gapResult.toString()).toBe(gapExpected);
+
+    const overlapDate = adapter.createDate(2024, NOV, 3);
+    const overlapResult = adapter.setTime(overlapDate, 1, 5, 0) as Temporal.ZonedDateTime;
+    const overlapExpected = Temporal.PlainDateTime.from('2024-11-03T01:05')
+      .toZonedDateTime('America/New_York', {disambiguation: 'compatible'})
+      .toString();
+    expect(overlapResult.toString()).toBe(overlapExpected);
+  });
+});
+
+describe('TemporalDateAdapter offset options', () => {
+  it('should reject invalid offsets when configured', () => {
+    TestBed.configureTestingModule({
+      imports: [TemporalModule],
+      providers: [
+        {
+          provide: MAT_TEMPORAL_DATE_ADAPTER_OPTIONS,
+          useValue: {calendar: 'iso8601', mode: 'zoned', offset: 'reject'},
+        },
+      ],
+    });
+    const adapter = TestBed.inject(DateAdapter);
+    const value = '2024-01-15T12:00:00+01:00[UTC]';
+    let expected: string | null = null;
+    try {
+      expected = Temporal.ZonedDateTime.from(value, {offset: 'reject'}).toString();
+    } catch {
+      expected = null;
+    }
+
+    const parsed = adapter.deserialize(value);
+    expect(parsed).not.toBeNull();
+    if (expected === null) {
+      expect(adapter.isValid(parsed!)).toBe(false);
+    } else {
+      expect((parsed as Temporal.ZonedDateTime).toString()).toBe(expected);
+    }
+  });
+
+  it('should apply offset "use" when configured', () => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [TemporalModule],
+      providers: [
+        {
+          provide: MAT_TEMPORAL_DATE_ADAPTER_OPTIONS,
+          useValue: {calendar: 'iso8601', mode: 'zoned', offset: 'use'},
+        },
+      ],
+    });
+    const adapter = TestBed.inject(DateAdapter);
+    const value = '2024-01-15T12:00:00+01:00[UTC]';
+    const parsed = adapter.deserialize(value) as Temporal.ZonedDateTime;
+    const expected = Temporal.ZonedDateTime.from(value, {offset: 'use'}).toString();
+    expect(parsed.toString()).toBe(expected);
+  });
+
+  it('should apply offset "ignore" when configured', () => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [TemporalModule],
+      providers: [
+        {
+          provide: MAT_TEMPORAL_DATE_ADAPTER_OPTIONS,
+          useValue: {calendar: 'iso8601', mode: 'zoned', offset: 'ignore'},
+        },
+      ],
+    });
+    const adapter = TestBed.inject(DateAdapter);
+    const value = '2019-12-23T12:00:00-02:00[America/Sao_Paulo]';
+    const parsed = adapter.deserialize(value) as Temporal.ZonedDateTime;
+    const expected = Temporal.ZonedDateTime.from(value, {offset: 'ignore'}).toString();
+    expect(parsed.toString()).toBe(expected);
+  });
+
+  it('should apply offset "prefer" when configured', () => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [TemporalModule],
+      providers: [
+        {
+          provide: MAT_TEMPORAL_DATE_ADAPTER_OPTIONS,
+          useValue: {calendar: 'iso8601', mode: 'zoned', offset: 'prefer'},
+        },
+      ],
+    });
+    const adapter = TestBed.inject(DateAdapter);
+    const value = '2019-12-23T12:00:00-02:00[America/Sao_Paulo]';
+    const parsed = adapter.deserialize(value) as Temporal.ZonedDateTime;
+    const expected = Temporal.ZonedDateTime.from(value, {offset: 'prefer'}).toString();
+    expect(parsed.toString()).toBe(expected);
+  });
+});
+
+describe('TemporalDateAdapter rounding options', () => {
+  it('should apply roundingMode when configured', () => {
+    TestBed.configureTestingModule({
+      imports: [TemporalModule],
+      providers: [
+        {
+          provide: MAT_TEMPORAL_DATE_ADAPTER_OPTIONS,
+          useValue: {
+            calendar: 'iso8601',
+            mode: 'zoned',
+            timezone: 'UTC',
+            rounding: {
+              smallestUnit: 'minute',
+              roundingIncrement: 5,
+              roundingMode: 'floor',
+            },
+          },
+        },
+      ],
+    });
+    const adapter = TestBed.inject(DateAdapter);
+    const value = Temporal.ZonedDateTime.from('2024-01-15T12:34:56[UTC]');
+    const expected = value
+      .round({smallestUnit: 'minute', roundingIncrement: 5, roundingMode: 'floor'})
+      .toString();
+    expect(adapter.toIso8601(value)).toBe(expected);
+  });
+
+  it('should apply different smallestUnit values', () => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [TemporalModule],
+      providers: [
+        {
+          provide: MAT_TEMPORAL_DATE_ADAPTER_OPTIONS,
+          useValue: {
+            calendar: 'iso8601',
+            mode: 'zoned',
+            timezone: 'UTC',
+            rounding: {smallestUnit: 'hour'},
+          },
+        },
+      ],
+    });
+    const adapter = TestBed.inject(DateAdapter);
+    const value = Temporal.ZonedDateTime.from('2024-01-15T12:34:56[UTC]');
+    const expected = value.round({smallestUnit: 'hour'}).toString();
+    expect(adapter.toIso8601(value)).toBe(expected);
+
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [TemporalModule],
+      providers: [
+        {
+          provide: MAT_TEMPORAL_DATE_ADAPTER_OPTIONS,
+          useValue: {
+            calendar: 'iso8601',
+            mode: 'zoned',
+            timezone: 'UTC',
+            rounding: {smallestUnit: 'day'},
+          },
+        },
+      ],
+    });
+    const dayAdapter = TestBed.inject(DateAdapter);
+    const dayExpected = value.round({smallestUnit: 'day'}).toString();
+    expect(dayAdapter.toIso8601(value)).toBe(dayExpected);
+  });
+});
+
+describe('Split adapters', () => {
+  it('PlainTemporalAdapter should honor outputCalendar', () => {
+    TestBed.configureTestingModule({
+      providers: [
+        {provide: DateAdapter, useClass: PlainTemporalAdapter},
+        {
+          provide: MAT_PLAIN_TEMPORAL_ADAPTER_OPTIONS,
+          useValue: {mode: 'date', calendar: 'iso8601', outputCalendar: 'japanese'},
+        },
+      ],
+    });
+    const adapter = TestBed.inject(DateAdapter) as PlainTemporalAdapter;
+    adapter.setLocale('ja-JP');
+    const date = adapter.createDate(2024, JAN, 1);
+    const formatted = adapter.format(date, {year: 'numeric'});
+    const expected = Temporal.PlainDate.from('2024-01-01')
+      .withCalendar('japanese')
+      .toLocaleString('ja-JP', {year: 'numeric', calendar: 'japanese'});
+    expect(formatted).toBe(expected);
+  });
+
+  it('PlainTemporalAdapter should honor firstDayOfWeek and overflow', () => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        {provide: DateAdapter, useClass: PlainTemporalAdapter},
+        {
+          provide: MAT_PLAIN_TEMPORAL_ADAPTER_OPTIONS,
+          useValue: {mode: 'date', firstDayOfWeek: 1, overflow: 'constrain'},
+        },
+      ],
+    });
+    const adapter = TestBed.inject(DateAdapter) as PlainTemporalAdapter;
+    expect(adapter.getFirstDayOfWeek()).toBe(1);
+    const constrained = adapter.createDate(2024, FEB, 31);
+    expect(adapter.getDate(constrained)).toBe(29);
+  });
+
+  it('PlainTemporalAdapter parseTime should set time on today', () => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        {provide: DateAdapter, useClass: PlainTemporalAdapter},
+        {provide: MAT_PLAIN_TEMPORAL_ADAPTER_OPTIONS, useValue: {mode: 'datetime'}},
+      ],
+    });
+    const adapter = TestBed.inject(DateAdapter) as PlainTemporalAdapter;
+    const parsed = adapter.parseTime('12:30', 'HH:mm') as Temporal.PlainDateTime;
+    expect(parsed.hour).toBe(12);
+    expect(parsed.minute).toBe(30);
+  });
+
+  it('ZonedDateTimeAdapter should honor disambiguation and rounding', () => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        {provide: DateAdapter, useClass: ZonedDateTimeAdapter},
+        {
+          provide: MAT_ZONED_DATETIME_OPTIONS,
+          useValue: {
+            timezone: 'America/New_York',
+            disambiguation: 'reject',
+            rounding: {smallestUnit: 'minute', roundingIncrement: 5},
+          },
+        },
+      ],
+    });
+    const adapter = TestBed.inject(DateAdapter) as ZonedDateTimeAdapter;
+    const date = adapter.createDate(2024, MAR, 10);
+    expect(() => adapter.setTime(date, 2, 5, 0)).toThrow();
+
+    const rounded = adapter.toIso8601(
+      Temporal.ZonedDateTime.from('2024-01-15T12:34:56[America/New_York]'),
+    );
+    const expected = Temporal.ZonedDateTime.from('2024-01-15T12:34:56[America/New_York]')
+      .round({smallestUnit: 'minute', roundingIncrement: 5})
+      .toString();
+    expect(rounded).toBe(expected);
+  });
+
+  it('ZonedDateTimeAdapter should honor firstDayOfWeek and parseTime', () => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        {provide: DateAdapter, useClass: ZonedDateTimeAdapter},
+        {
+          provide: MAT_ZONED_DATETIME_OPTIONS,
+          useValue: {timezone: 'UTC', firstDayOfWeek: 1},
+        },
+      ],
+    });
+    const adapter = TestBed.inject(DateAdapter) as ZonedDateTimeAdapter;
+    expect(adapter.getFirstDayOfWeek()).toBe(1);
+    const parsed = adapter.parseTime('12:30', 'HH:mm') as Temporal.ZonedDateTime;
+    expect(parsed.hour).toBe(12);
+    expect(parsed.minute).toBe(30);
+  });
+});
+
+describe('TemporalDateAdapter zoned parsing fallback', () => {
+  it('should parse date-only strings into zoned values using the configured timezone', () => {
+    TestBed.configureTestingModule({
+      imports: [TemporalModule],
+      providers: [
+        {
+          provide: MAT_TEMPORAL_DATE_ADAPTER_OPTIONS,
+          useValue: {calendar: 'iso8601', mode: 'zoned', timezone: 'UTC'},
+        },
+      ],
+    });
+    const adapter = TestBed.inject(DateAdapter);
+    const parsed = adapter.deserialize('2024-01-15') as Temporal.ZonedDateTime;
+    expect(adapter.isValid(parsed)).toBe(true);
+    expect(parsed.toString()).toContain('[UTC]');
+  });
+});
+
+describeIfCalendarSupported('islamic')('TemporalDateAdapter with Islamic calendar', () => {
+  let adapter: DateAdapter<TemporalDateType>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [TemporalModule],
+      providers: [
+        {
+          provide: MAT_TEMPORAL_DATE_ADAPTER_OPTIONS,
+          useValue: {calendar: 'islamic', mode: 'date'},
+        },
+      ],
+    });
+    adapter = TestBed.inject(DateAdapter);
+    adapter.setLocale('ar-SA');
+  });
+
+  it('should create date with Islamic calendar', () => {
+    const date = adapter.createDate(1445, 0, 1); // First month of Islamic year 1445
+    expect(adapter.isValid(date)).toBe(true);
+  });
+
+  it('should get month names for Islamic calendar', () => {
+    const monthNames = adapter.getMonthNames('long');
+    expect(monthNames.length).toBe(12);
+    // First month of Islamic calendar is Muharram
+    expect(monthNames[0]).toBeTruthy();
+  });
+
+  it('should get day of week names in Arabic locale regardless of calendar', () => {
+    // Day-of-week names are locale-dependent, not calendar-dependent.
+    // Arabic locale should return Arabic names regardless of calendar system.
+    const dayNames = adapter.getDayOfWeekNames('long');
+    expect(dayNames.length).toBe(7);
+    // Arabic day names (Sunday = الأحد, etc.)
+    // Verify they're Arabic strings (contain Arabic characters)
+    const arabicCharRegex = /[\u0600-\u06FF]/;
+    dayNames.forEach(name => {
+      expect(arabicCharRegex.test(name)).toBe(true);
+    });
+  });
+});
+
+describeIfCalendarSupported('japanese')('TemporalDateAdapter with Japanese calendar', () => {
+  let adapter: DateAdapter<TemporalDateType>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [TemporalModule],
+      providers: [
+        {
+          provide: MAT_TEMPORAL_DATE_ADAPTER_OPTIONS,
+          useValue: {calendar: 'japanese', mode: 'date'},
+        },
+      ],
+    });
+    adapter = TestBed.inject(DateAdapter);
+    adapter.setLocale('ja-JP');
+  });
+
+  it('should create date with Japanese calendar', () => {
+    // Reiwa 6 = 2024 in Gregorian
+    const date = adapter.createDate(2024, 0, 1);
+    expect(adapter.isValid(date)).toBe(true);
+  });
+
+  it('should get year name in Japanese era format', () => {
+    const date = adapter.createDate(2024, 0, 1);
+    const yearName = adapter.getYearName(date);
+    // Should contain Japanese era or year
+    expect(yearName).toBeTruthy();
+  });
+});
+
+describe('TemporalDateAdapter with Arabic locale', () => {
+  let adapter: DateAdapter<TemporalDateType>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [TemporalModule],
+    });
+    adapter = TestBed.inject(DateAdapter);
+    adapter.setLocale('ar-EG');
+  });
+
+  it('should get date names in Arabic numerals', () => {
+    const dateNames = adapter.getDateNames();
+    // Arabic numerals for 1: ١
+    expect(dateNames[0]).toBe('١');
+  });
+
+  it('should format date with Arabic numerals', () => {
+    const date = adapter.createDate(2024, 0, 15);
+    const formatted = adapter.format(date, {day: 'numeric'});
+    // Should contain Arabic numeral for 15: ١٥
+    expect(formatted).toBe('١٥');
+  });
+});
+
+describe('TemporalDateAdapter with MAT_DATE_LOCALE override', () => {
+  let adapter: DateAdapter<TemporalDateType>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [TemporalModule],
+      providers: [{provide: MAT_DATE_LOCALE, useValue: 'de-DE'}],
+    });
+
+    adapter = TestBed.inject(DateAdapter);
+  });
+
+  it('should take the default locale from MAT_DATE_LOCALE', () => {
+    const date = adapter.createDate(2017, JAN, 2);
+    const formatted = adapter.format(date, {year: 'numeric', month: 'long', day: 'numeric'});
+    // German format should include "Januar"
+    expect(formatted.toLowerCase()).toContain('januar');
+  });
+
+  it('should get month names in German', () => {
+    const monthNames = adapter.getMonthNames('long');
+    expect(monthNames[0].toLowerCase()).toContain('januar');
+    expect(monthNames[1].toLowerCase()).toContain('februar');
+  });
+});
+
+function assertValidDate(
+  adapter: DateAdapter<TemporalDateType>,
+  d: TemporalDateType | null,
+  valid: boolean,
+) {
+  expect(adapter.isDateInstance(d))
+    .withContext(`Expected ${d} to be a date instance`)
+    .not.toBeNull();
+  expect(adapter.isValid(d!))
+    .withContext(
+      `Expected ${d} to be ${valid ? 'valid' : 'invalid'}, but was ${valid ? 'invalid' : 'valid'}`,
+    )
+    .toBe(valid);
+}
+
+describeIfCalendarSupported('chinese')('TemporalDateAdapter with Chinese calendar', () => {
+  let adapter: DateAdapter<TemporalDateType>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [TemporalModule],
+      providers: [
+        {
+          provide: MAT_TEMPORAL_DATE_ADAPTER_OPTIONS,
+          useValue: {calendar: 'chinese', mode: 'date'},
+        },
+      ],
+    });
+    adapter = TestBed.inject(DateAdapter);
+    adapter.setLocale('zh-CN');
+  });
+
+  it('should create date with Chinese calendar', () => {
+    const date = adapter.createDate(2024, 0, 1);
+    expect(adapter.isValid(date)).toBe(true);
+  });
+
+  it('should get month names for Chinese calendar', () => {
+    const monthNames = adapter.getMonthNames('long');
+    expect(monthNames.length).toBeGreaterThanOrEqual(12);
+  });
+});
+
+describeIfCalendarSupported('persian')('TemporalDateAdapter with Persian calendar', () => {
+  let adapter: DateAdapter<TemporalDateType>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [TemporalModule],
+      providers: [
+        {
+          provide: MAT_TEMPORAL_DATE_ADAPTER_OPTIONS,
+          useValue: {calendar: 'persian', mode: 'date'},
+        },
+      ],
+    });
+    adapter = TestBed.inject(DateAdapter);
+    adapter.setLocale('fa-IR');
+  });
+
+  it('should create date with Persian calendar', () => {
+    // Persian year 1403 = 2024 in Gregorian
+    const date = adapter.createDate(1403, 0, 1);
+    expect(adapter.isValid(date)).toBe(true);
+  });
+
+  it('should get month names for Persian calendar', () => {
+    const monthNames = adapter.getMonthNames('long');
+    expect(monthNames.length).toBe(12);
+  });
+});
+
+describeIfCalendarSupported('buddhist')('TemporalDateAdapter with Buddhist calendar', () => {
+  let adapter: DateAdapter<TemporalDateType>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [TemporalModule],
+      providers: [
+        {
+          provide: MAT_TEMPORAL_DATE_ADAPTER_OPTIONS,
+          useValue: {calendar: 'buddhist', mode: 'date'},
+        },
+      ],
+    });
+    adapter = TestBed.inject(DateAdapter);
+    adapter.setLocale('th-TH');
+  });
+
+  it('should create date with Buddhist calendar', () => {
+    // Buddhist year 2567 = 2024 in Gregorian
+    const date = adapter.createDate(2567, 0, 1);
+    expect(adapter.isValid(date)).toBe(true);
+  });
+});
+
+describeIfCalendarSupported('indian')('TemporalDateAdapter with Indian calendar', () => {
+  let adapter: DateAdapter<TemporalDateType>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [TemporalModule],
+      providers: [
+        {
+          provide: MAT_TEMPORAL_DATE_ADAPTER_OPTIONS,
+          useValue: {calendar: 'indian', mode: 'date'},
+        },
+      ],
+    });
+    adapter = TestBed.inject(DateAdapter);
+    adapter.setLocale('hi-IN');
+  });
+
+  it('should create date with Indian calendar', () => {
+    const date = adapter.createDate(1946, 0, 1); // Indian National Calendar
+    expect(adapter.isValid(date)).toBe(true);
+  });
+});
+
+describeIfCalendarSupported('ethiopic')('TemporalDateAdapter with Ethiopian calendar', () => {
+  let adapter: DateAdapter<TemporalDateType>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [TemporalModule],
+      providers: [
+        {
+          provide: MAT_TEMPORAL_DATE_ADAPTER_OPTIONS,
+          useValue: {calendar: 'ethiopic', mode: 'date'},
+        },
+      ],
+    });
+    adapter = TestBed.inject(DateAdapter);
+    adapter.setLocale('am-ET');
+  });
+
+  it('should create date with Ethiopian calendar', () => {
+    // Ethiopian year 2016 = 2024 in Gregorian
+    const date = adapter.createDate(2016, 0, 1);
+    expect(adapter.isValid(date)).toBe(true);
+  });
+});
+
+describeIfCalendarSupported('coptic')('TemporalDateAdapter with Coptic calendar', () => {
+  let adapter: DateAdapter<TemporalDateType>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [TemporalModule],
+      providers: [
+        {
+          provide: MAT_TEMPORAL_DATE_ADAPTER_OPTIONS,
+          useValue: {calendar: 'coptic', mode: 'date'},
+        },
+      ],
+    });
+    adapter = TestBed.inject(DateAdapter);
+    adapter.setLocale('cop');
+  });
+
+  it('should create date with Coptic calendar', () => {
+    // Coptic year 1740 = 2024 in Gregorian
+    const date = adapter.createDate(1740, 0, 1);
+    expect(adapter.isValid(date)).toBe(true);
+  });
+});
+
+describe('TemporalDateAdapter with zoned mode (UTC)', () => {
+  let adapter: DateAdapter<TemporalDateType>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [TemporalModule],
+      providers: [
+        {
+          provide: MAT_TEMPORAL_DATE_ADAPTER_OPTIONS,
+          useValue: {calendar: 'iso8601', mode: 'zoned', timezone: 'UTC'},
+        },
+      ],
+    });
+    adapter = TestBed.inject(DateAdapter);
+  });
+
+  it('should create ZonedDateTime in UTC timezone', () => {
+    const date = adapter.createDate(2024, JAN, 15);
+    expect(adapter.isValid(date)).toBe(true);
+    expect((date as unknown as {timeZoneId: string}).timeZoneId).toBe('UTC');
+  });
+
+  it('should get year from ZonedDateTime', () => {
+    const date = adapter.createDate(2024, JAN, 15);
+    expect(adapter.getYear(date)).toBe(2024);
+  });
+
+  it('should get month from ZonedDateTime', () => {
+    const date = adapter.createDate(2024, JAN, 15);
+    expect(adapter.getMonth(date)).toBe(0); // January = 0
+  });
+
+  it('should get date from ZonedDateTime', () => {
+    const date = adapter.createDate(2024, JAN, 15);
+    expect(adapter.getDate(date)).toBe(15);
+  });
+
+  it('should format ZonedDateTime correctly', () => {
+    const date = adapter.createDate(2024, JAN, 15);
+    const formatted = adapter.format(date, {year: 'numeric', month: '2-digit', day: '2-digit'});
+    expect(formatted).toContain('2024');
+  });
+
+  it('should clone ZonedDateTime', () => {
+    const date = adapter.createDate(2024, JAN, 15);
+    const cloned = adapter.clone(date);
+    expect(adapter.sameDate(date, cloned)).toBe(true);
+  });
+
+  it('should add calendar days to ZonedDateTime', () => {
+    const date = adapter.createDate(2024, JAN, 15);
+    const result = adapter.addCalendarDays(date, 10);
+    expect(adapter.getDate(result)).toBe(25);
+  });
+
+  it('should add calendar months to ZonedDateTime', () => {
+    const date = adapter.createDate(2024, JAN, 15);
+    const result = adapter.addCalendarMonths(date, 1);
+    expect(adapter.getMonth(result)).toBe(1); // February
+  });
+
+  it('should add calendar years to ZonedDateTime', () => {
+    const date = adapter.createDate(2024, JAN, 15);
+    const result = adapter.addCalendarYears(date, 1);
+    expect(adapter.getYear(result)).toBe(2025);
+  });
+
+  it('should set time on ZonedDateTime', () => {
+    const date = adapter.createDate(2024, JAN, 15);
+    const withTime = adapter.setTime(date, 14, 30, 45);
+    expect(adapter.getHours(withTime)).toBe(14);
+    expect(adapter.getMinutes(withTime)).toBe(30);
+    expect(adapter.getSeconds(withTime)).toBe(45);
+  });
+
+  it('should add seconds to ZonedDateTime', () => {
+    const date = adapter.createDate(2024, JAN, 15);
+    const withTime = adapter.setTime(date, 12, 30, 0);
+    const result = adapter.addSeconds(withTime, 90);
+    expect(adapter.getMinutes(result)).toBe(31);
+    expect(adapter.getSeconds(result)).toBe(30);
+  });
+
+  it('should parse epoch milliseconds in zoned mode', () => {
+    // Create a known UTC timestamp: 2024-01-15T12:00:00Z
+    const epochMs = Date.UTC(2024, 0, 15, 12, 0, 0);
+    const date = adapter.parse(epochMs, null);
+    expect(date).not.toBeNull();
+    expect(adapter.isValid(date!)).toBe(true);
+    expect(adapter.getYear(date!)).toBe(2024);
+    expect(adapter.getMonth(date!)).toBe(0);
+    expect(adapter.getDate(date!)).toBe(15);
+  });
+
+  it('should deserialize ISO string in zoned mode', () => {
+    // ISO string with time will be parsed as ZonedDateTime
+    const date = adapter.deserialize('2024-01-15');
+    expect(date).not.toBeNull();
+    expect(adapter.isValid(date!)).toBe(true);
+    expect(adapter.getYear(date!)).toBe(2024);
+  });
+});
+
+describe('TemporalDateAdapter with zoned mode (specific timezone)', () => {
+  let adapter: DateAdapter<TemporalDateType>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [TemporalModule],
+      providers: [
+        {
+          provide: MAT_TEMPORAL_DATE_ADAPTER_OPTIONS,
+          useValue: {calendar: 'iso8601', mode: 'zoned', timezone: 'America/New_York'},
+        },
+      ],
+    });
+    adapter = TestBed.inject(DateAdapter);
+  });
+
+  it('should create ZonedDateTime in New York timezone', () => {
+    const date = adapter.createDate(2024, JAN, 15);
+    expect(adapter.isValid(date)).toBe(true);
+    expect((date as unknown as {timeZoneId: string}).timeZoneId).toBe('America/New_York');
+  });
+
+  it('should get today in New York timezone', () => {
+    const today = adapter.today();
+    expect(adapter.isValid(today)).toBe(true);
+    expect((today as unknown as {timeZoneId: string}).timeZoneId).toBe('America/New_York');
+  });
+});
+
+describe('TemporalDateAdapter edge cases', () => {
+  let adapter: DateAdapter<TemporalDateType>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({imports: [TemporalModule]});
+    adapter = TestBed.inject(DateAdapter);
+  });
+
+  it('should handle leap year February', () => {
+    // 2024 is a leap year
+    const leapYearFeb29 = adapter.createDate(2024, FEB, 29);
+    expect(adapter.isValid(leapYearFeb29)).toBe(true);
+    expect(adapter.getDate(leapYearFeb29)).toBe(29);
+  });
+
+  it('should throw for invalid date in non-leap year', () => {
+    // 2023 is not a leap year
+    expect(() => adapter.createDate(2023, FEB, 29)).toThrowError(/Invalid date/);
+  });
+
+  it('should handle month boundaries correctly', () => {
+    // January has 31 days
+    const jan31 = adapter.createDate(2024, JAN, 31);
+    expect(adapter.getDate(jan31)).toBe(31);
+
+    // April has 30 days
+    const apr30 = adapter.createDate(2024, APR, 30);
+    expect(adapter.getDate(apr30)).toBe(30);
+  });
+
+  it('should throw for day 0', () => {
+    expect(() => adapter.createDate(2024, JAN, 0)).toThrowError(/Invalid date/);
+  });
+
+  it('should throw for negative day', () => {
+    expect(() => adapter.createDate(2024, JAN, -1)).toThrowError(/Invalid date/);
+  });
+
+  it('should throw for invalid month', () => {
+    expect(() => adapter.createDate(2024, 12, 1)).toThrowError(/Invalid month/);
+    expect(() => adapter.createDate(2024, -1, 1)).toThrowError(/Invalid month/);
+  });
+
+  it('should handle year 0 (1 BCE)', () => {
+    const year0 = adapter.createDate(0, JAN, 1);
+    expect(adapter.isValid(year0)).toBe(true);
+    expect(adapter.getYear(year0)).toBe(0);
+  });
+
+  it('should handle negative years (BCE)', () => {
+    const bce = adapter.createDate(-100, JAN, 1);
+    expect(adapter.isValid(bce)).toBe(true);
+    expect(adapter.getYear(bce)).toBe(-100);
+  });
+
+  it('should handle far future dates', () => {
+    const farFuture = adapter.createDate(9999, DEC, 31);
+    expect(adapter.isValid(farFuture)).toBe(true);
+    expect(adapter.getYear(farFuture)).toBe(9999);
+  });
+
+  it('should compare dates correctly', () => {
+    const earlier = adapter.createDate(2024, JAN, 1);
+    const later = adapter.createDate(2024, JAN, 2);
+    const same = adapter.createDate(2024, JAN, 1);
+
+    expect(adapter.compareDate(earlier, later)).toBeLessThan(0);
+    expect(adapter.compareDate(later, earlier)).toBeGreaterThan(0);
+    expect(adapter.compareDate(earlier, same)).toBe(0);
+  });
+
+  it('should correctly identify same day', () => {
+    const date1 = adapter.createDate(2024, JAN, 15);
+    const date2 = adapter.createDate(2024, JAN, 15);
+    const date3 = adapter.createDate(2024, JAN, 16);
+
+    expect(adapter.sameDate(date1, date2)).toBe(true);
+    expect(adapter.sameDate(date1, date3)).toBe(false);
+  });
+
+  it('should clamp date within range', () => {
+    const min = adapter.createDate(2024, JAN, 5);
+    const max = adapter.createDate(2024, JAN, 25);
+    const tooEarly = adapter.createDate(2024, JAN, 1);
+    const tooLate = adapter.createDate(2024, JAN, 30);
+    const inRange = adapter.createDate(2024, JAN, 15);
+
+    expect(adapter.clampDate(tooEarly, min, max)).toEqual(min);
+    expect(adapter.clampDate(tooLate, min, max)).toEqual(max);
+    expect(adapter.clampDate(inRange, min, max)).toEqual(inRange);
+  });
+
+  it('should handle parsing ISO 8601 date format', () => {
+    // ISO format (the only format Temporal natively supports)
+    const iso = adapter.parse('2024-01-15', null);
+    expect(adapter.isValid(iso!)).toBe(true);
+    expect(adapter.getYear(iso!)).toBe(2024);
+    expect(adapter.getMonth(iso!)).toBe(JAN);
+    expect(adapter.getDate(iso!)).toBe(15);
+  });
+
+  it('should return invalid for non-ISO date formats', () => {
+    // US format - not supported (like NativeDateAdapter with Date.parse)
+    const us = adapter.parse('01/15/2024', null);
+    expect(adapter.isValid(us!)).toBe(false);
+
+    // European format - not supported
+    const eu = adapter.parse('15.01.2024', null);
+    expect(adapter.isValid(eu!)).toBe(false);
+  });
+
+  it('should return null for null/undefined parse input', () => {
+    expect(adapter.parse(null, null)).toBeNull();
+    expect(adapter.parse(undefined, null)).toBeNull();
+  });
+
+  it('should return invalid for unparseable string', () => {
+    const result = adapter.parse('not-a-date', null);
+    expect(adapter.isValid(result!)).toBe(false);
+  });
+
+  it('should throw for month rollover when adding months (reject mode)', () => {
+    // January 31 + 1 month would be February 31, which is invalid
+    // With default 'reject' overflow mode, this should throw
+    const jan31 = adapter.createDate(2024, JAN, 31);
+    expect(() => adapter.addCalendarMonths(jan31, 1)).toThrow();
+  });
+
+  it('should handle year rollover when adding months', () => {
+    const dec = adapter.createDate(2024, DEC, 15);
+    const jan = adapter.addCalendarMonths(dec, 1);
+    expect(adapter.getYear(jan)).toBe(2025);
+    expect(adapter.getMonth(jan)).toBe(0);
+  });
+
+  it('should handle day subtraction across month boundary', () => {
+    const jan1 = adapter.createDate(2024, JAN, 1);
+    const prevDay = adapter.addCalendarDays(jan1, -1);
+    expect(adapter.getYear(prevDay)).toBe(2023);
+    expect(adapter.getMonth(prevDay)).toBe(11); // December
+    expect(adapter.getDate(prevDay)).toBe(31);
+  });
+});
+
+describe('TemporalDateAdapter time edge cases', () => {
+  let adapter: DateAdapter<TemporalDateType>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [TemporalModule],
+      providers: [
+        {
+          provide: MAT_TEMPORAL_DATE_ADAPTER_OPTIONS,
+          useValue: {calendar: 'iso8601', mode: 'datetime'},
+        },
+      ],
+    });
+    adapter = TestBed.inject(DateAdapter);
+  });
+
+  it('should handle midnight correctly', () => {
+    const date = adapter.createDate(2024, JAN, 15);
+    const midnight = adapter.setTime(date, 0, 0, 0);
+    expect(adapter.getHours(midnight)).toBe(0);
+    expect(adapter.getMinutes(midnight)).toBe(0);
+    expect(adapter.getSeconds(midnight)).toBe(0);
+  });
+
+  it('should handle end of day correctly', () => {
+    const date = adapter.createDate(2024, JAN, 15);
+    const endOfDay = adapter.setTime(date, 23, 59, 59);
+    expect(adapter.getHours(endOfDay)).toBe(23);
+    expect(adapter.getMinutes(endOfDay)).toBe(59);
+    expect(adapter.getSeconds(endOfDay)).toBe(59);
+  });
+
+  it('should throw for invalid hours', () => {
+    const date = adapter.createDate(2024, JAN, 15);
+    expect(() => adapter.setTime(date, 24, 0, 0)).toThrowError(/Invalid hours/);
+    expect(() => adapter.setTime(date, -1, 0, 0)).toThrowError(/Invalid hours/);
+  });
+
+  it('should throw for invalid minutes', () => {
+    const date = adapter.createDate(2024, JAN, 15);
+    expect(() => adapter.setTime(date, 12, 60, 0)).toThrowError(/Invalid minutes/);
+    expect(() => adapter.setTime(date, 12, -1, 0)).toThrowError(/Invalid minutes/);
+  });
+
+  it('should throw for invalid seconds', () => {
+    const date = adapter.createDate(2024, JAN, 15);
+    expect(() => adapter.setTime(date, 12, 30, 60)).toThrowError(/Invalid seconds/);
+    expect(() => adapter.setTime(date, 12, 30, -1)).toThrowError(/Invalid seconds/);
+  });
+
+  it('should parse 12-hour time with AM/PM', () => {
+    const am = adapter.parseTime('9:30 AM', 'h:mm a');
+    expect(adapter.getHours(am!)).toBe(9);
+
+    const pm = adapter.parseTime('9:30 PM', 'h:mm a');
+    expect(adapter.getHours(pm!)).toBe(21);
+  });
+
+  it('should parse 12:00 AM as midnight', () => {
+    const midnight = adapter.parseTime('12:00 AM', 'h:mm a');
+    expect(adapter.getHours(midnight!)).toBe(0);
+  });
+
+  it('should parse 12:00 PM as noon', () => {
+    const noon = adapter.parseTime('12:00 PM', 'h:mm a');
+    expect(adapter.getHours(noon!)).toBe(12);
+  });
+
+  it('should handle seconds overflow in addSeconds', () => {
+    const date = adapter.createDate(2024, JAN, 15);
+    const withTime = adapter.setTime(date, 23, 59, 30);
+    const result = adapter.addSeconds(withTime, 60);
+
+    // Should roll over to next day
+    expect(adapter.getDate(result)).toBe(16);
+    expect(adapter.getHours(result)).toBe(0);
+    expect(adapter.getMinutes(result)).toBe(0);
+    expect(adapter.getSeconds(result)).toBe(30);
+  });
+
+  it('should handle negative seconds in addSeconds', () => {
+    const date = adapter.createDate(2024, JAN, 15);
+    const withTime = adapter.setTime(date, 0, 0, 30);
+    const result = adapter.addSeconds(withTime, -60);
+
+    // Should roll back to previous day
+    expect(adapter.getDate(result)).toBe(14);
+    expect(adapter.getHours(result)).toBe(23);
+    expect(adapter.getMinutes(result)).toBe(59);
+    expect(adapter.getSeconds(result)).toBe(30);
+  });
+
+  it('should compare times', () => {
+    // Use different dates to guarantee that we only compare the times.
+    const date1 = adapter.createDate(2024, JAN, 1);
+    const date2 = adapter.createDate(2024, FEB, 7);
+
+    const time1 = adapter.setTime(date1, 12, 0, 0);
+    const time2 = adapter.setTime(date2, 13, 0, 0);
+    expect(adapter.compareTime(time1, time2)).toBeLessThan(0);
+
+    const time3 = adapter.setTime(date1, 12, 50, 0);
+    const time4 = adapter.setTime(date2, 12, 51, 0);
+    expect(adapter.compareTime(time3, time4)).toBeLessThan(0);
+
+    const time5 = adapter.setTime(date1, 1, 2, 3);
+    const time6 = adapter.setTime(date2, 1, 2, 3);
+    expect(adapter.compareTime(time5, time6)).toBe(0);
+
+    const time7 = adapter.setTime(date1, 13, 0, 0);
+    const time8 = adapter.setTime(date2, 12, 0, 0);
+    expect(adapter.compareTime(time7, time8)).toBeGreaterThan(0);
+
+    const time9 = adapter.setTime(date1, 12, 50, 11);
+    const time10 = adapter.setTime(date2, 12, 50, 10);
+    expect(adapter.compareTime(time9, time10)).toBeGreaterThan(0);
+  });
+});
+
+describe('TemporalDateAdapter with zoned mode and UTC timezone', () => {
+  let adapter: DateAdapter<TemporalDateType>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [TemporalModule],
+      providers: [
+        {
+          provide: MAT_TEMPORAL_DATE_ADAPTER_OPTIONS,
+          useValue: {calendar: 'iso8601', mode: 'zoned', timezone: 'UTC'},
+        },
+      ],
+    });
+    adapter = TestBed.inject(DateAdapter);
+  });
+
+  it('should create ZonedDateTime in UTC timezone', () => {
+    const date = adapter.createDate(2024, JAN, 15);
+    expect(adapter.isValid(date)).toBe(true);
+    expect((date as unknown as {timeZoneId: string}).timeZoneId).toBe('UTC');
+  });
+
+  it('should handle time operations like zoned mode', () => {
+    const date = adapter.createDate(2024, JAN, 15);
+    const withTime = adapter.setTime(date, 14, 30, 45);
+    expect(adapter.getHours(withTime)).toBe(14);
+    expect(adapter.getMinutes(withTime)).toBe(30);
+    expect(adapter.getSeconds(withTime)).toBe(45);
+  });
+
+  it('should add seconds correctly', () => {
+    const date = adapter.createDate(2024, JAN, 15);
+    const withTime = adapter.setTime(date, 12, 30, 0);
+    const result = adapter.addSeconds(withTime, 90);
+    expect(adapter.getMinutes(result)).toBe(31);
+    expect(adapter.getSeconds(result)).toBe(30);
+  });
+
+  it('should get today in UTC', () => {
+    const today = adapter.today();
+    expect(adapter.isValid(today)).toBe(true);
+    expect((today as unknown as {timeZoneId: string}).timeZoneId).toBe('UTC');
+  });
+
+  it('should parse ISO string correctly', () => {
+    const date = adapter.parse('2024-01-15', null);
+    expect(date).not.toBeNull();
+    expect(adapter.isValid(date!)).toBe(true);
+    expect(adapter.getYear(date!)).toBe(2024);
+    expect(adapter.getMonth(date!)).toBe(0);
+    expect(adapter.getDate(date!)).toBe(15);
+  });
+});
+
+describe('TemporalDateAdapter with overflow: constrain', () => {
+  let adapter: DateAdapter<TemporalDateType>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [TemporalModule],
+      providers: [
+        {
+          provide: MAT_TEMPORAL_DATE_ADAPTER_OPTIONS,
+          useValue: {calendar: 'iso8601', mode: 'date', overflow: 'constrain'},
+        },
+      ],
+    });
+    adapter = TestBed.inject(DateAdapter);
+  });
+
+  it('should constrain Feb 31 to Feb 28 in non-leap year', () => {
+    const date = adapter.createDate(2023, FEB, 31);
+    expect(adapter.isValid(date)).toBe(true);
+    expect(adapter.getMonth(date)).toBe(1); // February
+    expect(adapter.getDate(date)).toBe(28);
+  });
+
+  it('should constrain Feb 31 to Feb 29 in leap year', () => {
+    const date = adapter.createDate(2024, FEB, 31);
+    expect(adapter.isValid(date)).toBe(true);
+    expect(adapter.getMonth(date)).toBe(1); // February
+    expect(adapter.getDate(date)).toBe(29);
+  });
+
+  it('should constrain Apr 31 to Apr 30', () => {
+    const date = adapter.createDate(2024, APR, 31);
+    expect(adapter.isValid(date)).toBe(true);
+    expect(adapter.getMonth(date)).toBe(3); // April
+    expect(adapter.getDate(date)).toBe(30);
+  });
+
+  it('should constrain day 50 to end of month', () => {
+    const date = adapter.createDate(2024, JAN, 50);
+    expect(adapter.isValid(date)).toBe(true);
+    expect(adapter.getDate(date)).toBe(31); // January has 31 days
+  });
+
+  it('should handle valid dates normally', () => {
+    const date = adapter.createDate(2024, JAN, 15);
+    expect(adapter.isValid(date)).toBe(true);
+    expect(adapter.getDate(date)).toBe(15);
+  });
+
+  it('should constrain when adding years causes leap year overflow', () => {
+    const feb29 = adapter.createDate(2024, FEB, 29); // 2024 is leap year
+    const result = adapter.addCalendarYears(feb29, 1); // 2025 is NOT a leap year
+    expect(adapter.isValid(result)).toBe(true);
+    expect(adapter.getYear(result)).toBe(2025);
+    expect(adapter.getMonth(result)).toBe(FEB);
+    expect(adapter.getDate(result)).toBe(28); // Constrained to Feb 28
+  });
+
+  it('should constrain when adding months causes day overflow', () => {
+    const jan31 = adapter.createDate(2024, JAN, 31);
+    const result = adapter.addCalendarMonths(jan31, 1); // February has 29 days in 2024
+    expect(adapter.isValid(result)).toBe(true);
+    expect(adapter.getYear(result)).toBe(2024);
+    expect(adapter.getMonth(result)).toBe(FEB);
+    expect(adapter.getDate(result)).toBe(29); // Constrained to Feb 29
+  });
+
+  it('should constrain when subtracting years causes leap year overflow', () => {
+    const feb29 = adapter.createDate(2024, FEB, 29);
+    const result = adapter.addCalendarYears(feb29, -1); // 2023 is NOT a leap year
+    expect(adapter.isValid(result)).toBe(true);
+    expect(adapter.getYear(result)).toBe(2023);
+    expect(adapter.getMonth(result)).toBe(FEB);
+    expect(adapter.getDate(result)).toBe(28);
+  });
+
+  it('should constrain when adding months to 31st lands on 30-day month', () => {
+    const may31 = adapter.createDate(2024, MAY, 31);
+    const result = adapter.addCalendarMonths(may31, 1); // June has 30 days
+    expect(adapter.isValid(result)).toBe(true);
+    expect(adapter.getYear(result)).toBe(2024);
+    expect(adapter.getMonth(result)).toBe(JUN);
+    expect(adapter.getDate(result)).toBe(30);
+  });
+});
+
+describe('TemporalDateAdapter with overflow: reject (default)', () => {
+  let adapter: DateAdapter<TemporalDateType>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [TemporalModule],
+      providers: [
+        {
+          provide: MAT_TEMPORAL_DATE_ADAPTER_OPTIONS,
+          useValue: {calendar: 'iso8601', mode: 'date', overflow: 'reject'},
+        },
+      ],
+    });
+    adapter = TestBed.inject(DateAdapter);
+  });
+
+  it('should throw for Feb 31', () => {
+    expect(() => adapter.createDate(2024, FEB, 31)).toThrow();
+  });
+
+  it('should throw for Apr 31', () => {
+    expect(() => adapter.createDate(2024, APR, 31)).toThrow();
+  });
+
+  it('should allow valid dates', () => {
+    const date = adapter.createDate(2024, JAN, 15);
+    expect(adapter.isValid(date)).toBe(true);
+  });
+
+  it('should throw when adding years causes leap year overflow', () => {
+    const feb29 = adapter.createDate(2024, FEB, 29); // 2024 is leap year
+    // Adding 1 year should throw because 2025 doesn't have Feb 29
+    expect(() => adapter.addCalendarYears(feb29, 1)).toThrow();
+  });
+
+  it('should throw when subtracting years causes leap year overflow', () => {
+    const feb29 = adapter.createDate(2024, FEB, 29);
+    // Subtracting 1 year should throw because 2023 doesn't have Feb 29
+    expect(() => adapter.addCalendarYears(feb29, -1)).toThrow();
+  });
+
+  it('should throw when adding months causes day overflow', () => {
+    const jan31 = adapter.createDate(2024, JAN, 31);
+    // Adding 1 month should throw because February doesn't have 31 days
+    expect(() => adapter.addCalendarMonths(jan31, 1)).toThrow();
+  });
+
+  it('should throw when adding months to 31st lands on 30-day month', () => {
+    const may31 = adapter.createDate(2024, MAY, 31);
+    // Adding 1 month should throw because June only has 30 days
+    expect(() => adapter.addCalendarMonths(may31, 1)).toThrow();
+  });
+
+  it('should not throw for valid year arithmetic', () => {
+    const jan15 = adapter.createDate(2024, JAN, 15);
+    const result = adapter.addCalendarYears(jan15, 1);
+    expect(adapter.getYear(result)).toBe(2025);
+    expect(adapter.getMonth(result)).toBe(JAN);
+    expect(adapter.getDate(result)).toBe(15);
+  });
+
+  it('should not throw for valid month arithmetic', () => {
+    const jan15 = adapter.createDate(2024, JAN, 15);
+    const result = adapter.addCalendarMonths(jan15, 1);
+    expect(adapter.getYear(result)).toBe(2024);
+    expect(adapter.getMonth(result)).toBe(FEB);
+    expect(adapter.getDate(result)).toBe(15);
+  });
+
+  it('should not throw for valid day arithmetic', () => {
+    const jan15 = adapter.createDate(2024, JAN, 15);
+    const result = adapter.addCalendarDays(jan15, 10);
+    expect(adapter.getDate(result)).toBe(25);
+  });
+});
+
+describe('TemporalDateAdapter with calendar from Intl', () => {
+  let adapter: DateAdapter<TemporalDateType>;
+
+  beforeEach(() => {
+    // Get calendar string from Intl (this is the pattern users will likely use)
+    const intlCalendar = new Intl.DateTimeFormat().resolvedOptions().calendar;
+
+    TestBed.configureTestingModule({
+      imports: [TemporalModule],
+      providers: [
+        {
+          provide: MAT_TEMPORAL_DATE_ADAPTER_OPTIONS,
+          useValue: {
+            // Calendar from Intl is always a string
+            calendar: intlCalendar,
+            mode: 'date',
+          },
+        },
+      ],
+    });
+    adapter = TestBed.inject(DateAdapter);
+  });
+
+  it('should create date with calendar from Intl.DateTimeFormat', () => {
+    const date = adapter.createDate(2024, JAN, 15);
+    expect(adapter.isValid(date)).toBe(true);
+  });
+
+  it('should use user locale calendar system', () => {
+    // The calendar string from Intl should work correctly
+    const today = adapter.today();
+    expect(adapter.isValid(today)).toBe(true);
+  });
+});
+
+describe('TemporalDateAdapter strict consistency', () => {
+  let adapter: TemporalDateAdapter;
+
+  describe('with mode: "date"', () => {
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        imports: [TemporalModule],
+        providers: [
+          {
+            provide: MAT_TEMPORAL_DATE_ADAPTER_OPTIONS,
+            useValue: {mode: 'date'},
+          },
+        ],
+      });
+      adapter = TestBed.inject(DateAdapter) as TemporalDateAdapter;
+    });
+
+    it('should NOT allow time setting (returns strict original)', () => {
+      spyOn(console, 'warn');
+      const date = adapter.createDate(2024, JAN, 15);
+      const withTime = adapter.setTime(date, 12, 30, 0);
+      expect(console.warn).toHaveBeenCalled();
+      // Should remain a PlainDate or effectively unchanged
+      expect(withTime).toEqual(date);
+    });
+
+    it('should NOT allow parsing time strings implicitly', () => {
+      const result = adapter.parseTime('12:30', 'HH:mm');
+      expect(result).toBeTruthy();
+      if (result) {
+        expect(adapter.isValid(result)).toBe(false);
+      }
+    });
+
+    it('should NOT allow addSeconds (returns strict original)', () => {
+      spyOn(console, 'warn');
+      const date = adapter.createDate(2024, JAN, 15);
+      const result = adapter.addSeconds(date, 30);
+      expect(console.warn).toHaveBeenCalled();
+      expect(result).toEqual(date);
+    });
+  });
+});

--- a/src/material-temporal-adapter/adapter/temporal-date-adapter.ts
+++ b/src/material-temporal-adapter/adapter/temporal-date-adapter.ts
@@ -1,0 +1,1183 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Injectable, InjectionToken, inject} from '@angular/core';
+import {DateAdapter, MAT_DATE_LOCALE} from '@angular/material/core';
+
+/**
+ * Valid calendar identifiers supported by the Temporal API.
+ *
+ * Common calendars include:
+ * - 'iso8601' - ISO 8601 calendar (default, equivalent to Gregorian)
+ * - 'gregory' - Gregorian calendar
+ * - 'hebrew' - Hebrew calendar
+ * - 'islamic' - Islamic calendar
+ * - 'japanese' - Japanese calendar with era
+ * - 'chinese' - Chinese calendar
+ * - 'persian' - Persian/Solar Hijri calendar
+ * - 'buddhist' - Buddhist calendar (Thai)
+ * - 'indian' - Indian National Calendar
+ * - 'ethiopic' - Ethiopian calendar
+ * - 'coptic' - Coptic calendar
+ *
+ * For a complete list of supported calendars, see:
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/calendar
+ * @see https://tc39.es/proposal-temporal/docs/calendars.html
+ */
+export type TemporalCalendarId = string;
+
+/**
+ * Represents a date in the Temporal API format.
+ * Can be a PlainDate, PlainDateTime, or ZonedDateTime depending on the adapter mode.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDate
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime
+ */
+export type TemporalDateType = Temporal.PlainDate | Temporal.PlainDateTime | Temporal.ZonedDateTime;
+
+/**
+ * Mode for the Temporal adapter - determines which type is used internally.
+ * - 'date': Uses Temporal.PlainDate (for date-only pickers, no time/timezone)
+ * - 'datetime': Uses Temporal.PlainDateTime (for date-time pickers, no timezone)
+ * - 'zoned': Uses Temporal.ZonedDateTime (for date-time with timezone)
+ */
+export type TemporalAdapterMode = 'date' | 'datetime' | 'zoned';
+
+/** Disambiguation options for converting local date-times to time zones. */
+export type TemporalDisambiguation = 'compatible' | 'earlier' | 'later' | 'reject';
+
+/** Offset handling options for ambiguous offsets when parsing zoned strings. */
+export type TemporalOffsetOption = 'use' | 'ignore' | 'reject' | 'prefer';
+
+/** Rounding modes supported by Temporal rounding APIs. */
+export type TemporalRoundingMode = 'ceil' | 'floor' | 'trunc' | 'halfExpand';
+
+/** Rounding units supported by Temporal rounding APIs. */
+export type TemporalRoundingUnit =
+  | 'day'
+  | 'hour'
+  | 'minute'
+  | 'second'
+  | 'millisecond'
+  | 'microsecond'
+  | 'nanosecond'
+  | 'days'
+  | 'hours'
+  | 'minutes'
+  | 'seconds'
+  | 'milliseconds'
+  | 'microseconds'
+  | 'nanoseconds';
+
+/** Rounding options applied to zoned date-times before output/serialization. */
+export interface TemporalRoundingOptions {
+  smallestUnit: TemporalRoundingUnit;
+  roundingIncrement?: number;
+  roundingMode?: TemporalRoundingMode;
+}
+
+/** Configurable options for the `TemporalDateAdapter`. */
+export interface MatTemporalDateAdapterOptionsBase {
+  /**
+   * The calendar system to use for date calculations.
+   * Defaults to 'iso8601' (ISO 8601 calendar, equivalent to Gregorian).
+   *
+   * Pass a calendar ID string. You can get the user's preferred calendar from:
+   * `new Intl.DateTimeFormat().resolvedOptions().calendar`
+   *
+   * Common calendar IDs:
+   * - 'iso8601' - ISO 8601 calendar (default)
+   * - 'gregory' - Gregorian calendar
+   * - 'hebrew', 'islamic', 'japanese', 'chinese', 'persian', 'buddhist'
+   *
+   * @see https://tc39.es/proposal-temporal/docs/calendars.html
+   */
+  calendar: TemporalCalendarId;
+
+  /**
+   * The calendar system to use for output/formatting.
+   * If not set, the adapter uses `calendar` for both calculations and output.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDate/withCalendar
+   * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/withCalendar
+   */
+  outputCalendar?: TemporalCalendarId;
+
+  /**
+   * Sets the first day of week.
+   * Changing this will change how Angular Material components like DatePicker shows start of week.
+   * If not set, it will be determined from the locale.
+   */
+  firstDayOfWeek?: number;
+
+  /**
+   * How to handle out-of-range values in date creation.
+   * - 'reject': Throw an error for invalid dates like Feb 31 (default, strict mode)
+   * - 'constrain': Clamp to the nearest valid value (Feb 31 → Feb 28/29)
+   *
+   * This is similar to Moment.js strict mode, but applies to date values rather than format.
+   *
+   * @example
+   * ```typescript
+   * // Strict mode (default) - Feb 31 throws error
+   * { mode: 'date', overflow: 'reject' }
+   *
+   * // Lenient mode - Feb 31 becomes Feb 28/29
+   * { mode: 'date', overflow: 'constrain' }
+   * ```
+   */
+  overflow?: 'reject' | 'constrain';
+}
+
+export type MatTemporalDateAdapterOptions =
+  | (MatTemporalDateAdapterOptionsBase & {
+      /**
+       * The mode for the adapter, determining which Temporal type to use.
+       * - 'date': Uses Temporal.PlainDate (default, for date-only pickers)
+       * - 'datetime': Uses Temporal.PlainDateTime (for date-time pickers without timezone)
+       */
+      mode?: 'date' | 'datetime';
+      /** Timezone is only valid for zoned mode. */
+      timezone?: never;
+    })
+  | (MatTemporalDateAdapterOptionsBase & {
+      /**
+       * The mode for the adapter, determining which Temporal type to use.
+       * - 'zoned': Uses Temporal.ZonedDateTime (for date-time pickers with timezone)
+       */
+      mode: 'zoned';
+      /**
+       * The timezone to use when mode is 'zoned'.
+       * Can be an IANA timezone identifier (e.g., 'America/New_York', 'Europe/London')
+       * or 'UTC' for UTC time.
+       * Defaults to system timezone if mode is 'zoned' and timezone is not specified.
+       *
+       * @example
+       * ```typescript
+       * // Use UTC timezone (similar to useUtc: true in Moment/Luxon adapters)
+       * { mode: 'zoned', timezone: 'UTC' }
+       *
+       * // Use specific timezone
+       * { mode: 'zoned', timezone: 'America/New_York' }
+       *
+       * // Use system timezone (default)
+       * { mode: 'zoned' }
+       * ```
+       */
+      timezone?: string;
+
+      /**
+       * How to resolve ambiguous or nonexistent local times when converting to ZonedDateTime.
+       * Defaults to Temporal's "compatible" behavior.
+       *
+       * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/toZonedDateTime
+       * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/from
+       */
+      disambiguation?: TemporalDisambiguation;
+
+      /**
+       * How to resolve offset ambiguity when parsing zoned strings with explicit offsets.
+       * Defaults to Temporal's "reject" behavior.
+       *
+       * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/from
+       */
+      offset?: TemporalOffsetOption;
+
+      /**
+       * Optional rounding applied to zoned values before output/serialization.
+       *
+       * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/round
+       */
+      rounding?: TemporalRoundingOptions;
+    });
+
+/** InjectionToken for TemporalDateAdapter to configure options. */
+export const MAT_TEMPORAL_DATE_ADAPTER_OPTIONS = new InjectionToken<MatTemporalDateAdapterOptions>(
+  'MAT_TEMPORAL_DATE_ADAPTER_OPTIONS',
+  {
+    providedIn: 'root',
+    factory: () => ({
+      calendar: 'iso8601',
+      mode: 'date',
+      overflow: 'reject',
+    }),
+  },
+);
+
+/**
+ * Extended Intl namespace with Locale constructor.
+ * This interface provides typing for features that may not be available
+ * in all browsers or TypeScript versions.
+ */
+interface IntlWithLocale {
+  Locale?: {
+    new (localeTag: string): {
+      getWeekInfo?: () => {firstDay: number};
+      weekInfo?: {firstDay: number};
+    };
+  };
+}
+
+/** Creates an array and fills it with values. */
+function range<T>(length: number, valueFunction: (index: number) => T): T[] {
+  const valuesArray = Array(length);
+  for (let i = 0; i < length; i++) {
+    valuesArray[i] = valueFunction(i);
+  }
+  return valuesArray;
+}
+
+/**
+ * DateAdapter implementation using the Temporal API.
+ *
+ * The Temporal API provides modern, immutable date/time handling with proper
+ * support for calendars, time zones, and internationalization.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal
+ *
+ * Note: The Temporal API may require a polyfill in browsers without native support.
+ * Popular polyfill options include:
+ * - `@js-temporal/polyfill` (reference implementation)
+ * - `temporal-polyfill` (lightweight alternative)
+ *
+ * Install one of these and ensure it's loaded before using this adapter.
+ */
+@Injectable()
+export class TemporalDateAdapter extends DateAdapter<TemporalDateType> {
+  private readonly _calendar: TemporalCalendarId;
+  private readonly _outputCalendar: TemporalCalendarId | null;
+  private readonly _firstDayOfWeek: number | undefined;
+  private readonly _mode: TemporalAdapterMode;
+  private _timezone: string | null;
+  private readonly _overflow: 'reject' | 'constrain';
+  private readonly _disambiguation?: TemporalDisambiguation;
+  private readonly _offset?: TemporalOffsetOption;
+  private readonly _rounding?: TemporalRoundingOptions;
+
+  constructor(...args: unknown[]);
+
+  constructor() {
+    super();
+
+    const dateLocale = inject(MAT_DATE_LOCALE, {optional: true});
+    const options = inject<MatTemporalDateAdapterOptions>(MAT_TEMPORAL_DATE_ADAPTER_OPTIONS, {
+      optional: true,
+    });
+
+    this._calendar = options?.calendar || 'iso8601';
+    this._outputCalendar = options?.outputCalendar ?? null;
+    this._firstDayOfWeek = options?.firstDayOfWeek;
+    this._mode = options?.mode || 'date';
+    this._overflow = options?.overflow || 'reject';
+    // For zoned mode, use provided timezone or resolve to system timezone lazily.
+    this._timezone = options?.timezone ?? null;
+    const zonedOptions = options && options.mode === 'zoned' ? options : null;
+    this._disambiguation = zonedOptions?.disambiguation;
+    this._offset = zonedOptions?.offset;
+    this._rounding = zonedOptions?.rounding;
+    this.setLocale(dateLocale || this._getDefaultLocale());
+  }
+
+  /** Gets the year component of the given date. */
+  getYear(date: TemporalDateType): number {
+    return date.year;
+  }
+
+  /**
+   * Gets the month component of the given date.
+   * Returns 0-indexed month (0 = January) to match DateAdapter interface.
+   * Note: Temporal uses 1-indexed months internally.
+   */
+  getMonth(date: TemporalDateType): number {
+    // Temporal uses 1-indexed months, DateAdapter expects 0-indexed
+    return date.month - 1;
+  }
+
+  /** Gets the date of the month component of the given date. */
+  getDate(date: TemporalDateType): number {
+    return date.day;
+  }
+
+  /**
+   * Gets the day of the week component of the given date.
+   * Returns 0-indexed day (0 = Sunday) to match DateAdapter interface.
+   * Note: Temporal uses 1-indexed days starting from Monday.
+   */
+  getDayOfWeek(date: TemporalDateType): number {
+    // Temporal.dayOfWeek is 1 (Monday) to 7 (Sunday)
+    // DateAdapter expects 0 (Sunday) to 6 (Saturday)
+    const temporalDayOfWeek = date.dayOfWeek;
+    return temporalDayOfWeek === 7 ? 0 : temporalDayOfWeek;
+  }
+
+  /** Gets a list of names for the months. */
+  getMonthNames(style: 'long' | 'short' | 'narrow'): string[] {
+    const monthsInYear = this._getMonthsInYearForOutput(2017);
+
+    const options: Intl.DateTimeFormatOptions = {
+      month: style,
+      calendar: this._getOutputCalendarId(),
+    };
+
+    return range(monthsInYear, i => {
+      // Create a date in the middle of each month to avoid edge cases
+      const date = Temporal.PlainDate.from({
+        year: 2017,
+        month: i + 1,
+        day: 1,
+        calendar: this._getOutputCalendarId(),
+      });
+      return this._formatWithLocale(date, options);
+    });
+  }
+
+  /** Gets a list of names for the dates of the month. */
+  getDateNames(): string[] {
+    const options: Intl.DateTimeFormatOptions = {
+      day: 'numeric',
+      calendar: this._getOutputCalendarId(),
+    };
+
+    return range(31, i => {
+      const date = Temporal.PlainDate.from({
+        year: 2017,
+        month: 1,
+        day: i + 1,
+        calendar: this._getOutputCalendarId(),
+      });
+      return this._formatWithLocale(date, options);
+    });
+  }
+
+  /** Gets a list of names for the days of the week. */
+  getDayOfWeekNames(style: 'long' | 'short' | 'narrow'): string[] {
+    const options: Intl.DateTimeFormatOptions = {
+      weekday: style,
+    };
+
+    // Generate names starting from Sunday (day 0)
+    // January 1, 2017 was a Sunday
+    // Day-of-week names are locale-dependent, not calendar-dependent,
+    // so we format directly without calendar conversion.
+    return range(7, i => {
+      const date = Temporal.PlainDate.from({
+        year: 2017,
+        month: 1,
+        day: 1 + i,
+        calendar: 'iso8601',
+      });
+      return date.toLocaleString(this.locale, options).replace(/[\u200e\u200f]/g, '');
+    });
+  }
+
+  /** Gets the name for the year of the given date. */
+  getYearName(date: TemporalDateType): string {
+    const options: Intl.DateTimeFormatOptions = {
+      year: 'numeric',
+      calendar: this._getOutputCalendarId(),
+    };
+    return this._formatWithLocale(date, options);
+  }
+
+  /** Gets the first day of the week. */
+  getFirstDayOfWeek(): number {
+    if (this._firstDayOfWeek !== undefined) {
+      return this._firstDayOfWeek;
+    }
+
+    // Try to get first day from Intl.Locale if available
+    const intlWithLocale = Intl as IntlWithLocale;
+    if (typeof Intl !== 'undefined' && intlWithLocale.Locale) {
+      try {
+        const locale = new intlWithLocale.Locale(this.locale);
+
+        const firstDay = (locale.getWeekInfo?.() || locale.weekInfo)?.firstDay ?? 0;
+        // weekInfo.firstDay is 1-7 (Monday-Sunday), we need 0-6 (Sunday-Saturday)
+        return firstDay === 7 ? 0 : firstDay;
+      } catch {
+        // Fall through to default
+      }
+    }
+
+    // Default to Sunday
+    return 0;
+  }
+
+  /** Gets the number of days in the month of the given date. */
+  getNumDaysInMonth(date: TemporalDateType): number {
+    return date.daysInMonth;
+  }
+
+  /**
+   * Clones the given date.
+   * Note: Temporal objects are immutable, so the original cannot be mutated.
+   * However, we still create a new object because:
+   * 1. The DateAdapter interface contract specifies "A new date"
+   * 2. Consumer code may use reference equality checks (clone !== original)
+   * 3. Consistency with other date adapters (NativeDateAdapter, LuxonDateAdapter)
+   */
+  clone(date: TemporalDateType): TemporalDateType {
+    // Use from(date) instead of from(date.toString()) to preserve sub-millisecond precision
+    // Note: ZonedDateTime.from() requires a string since the object lacks 'timeZone' property
+    if (this._isZonedDateTime(date)) {
+      return Temporal.ZonedDateTime.from(date.toString());
+    }
+    if (this._isPlainDateTime(date)) {
+      return Temporal.PlainDateTime.from(date);
+    }
+    return Temporal.PlainDate.from(date);
+  }
+
+  /**
+   * Creates a date with the given year, month, and date.
+   * Month is 0-indexed (0 = January) to match DateAdapter interface.
+   */
+  createDate(year: number, month: number, date: number): TemporalDateType {
+    // Only validate in dev mode when using reject overflow
+    if ((typeof ngDevMode === 'undefined' || ngDevMode) && this._overflow === 'reject') {
+      const monthsInYear = this._getMonthsInYearForDate(year);
+      if (month < 0 || month > monthsInYear - 1) {
+        throw Error(
+          `Invalid month index "${month}". Month index has to be between 0 and ${monthsInYear - 1}.`,
+        );
+      }
+
+      if (date < 1) {
+        throw Error(`Invalid date "${date}". Date has to be greater than 0.`);
+      }
+    }
+
+    try {
+      // Temporal uses 1-indexed months
+      const temporalMonth = month + 1;
+      const overflowOption = {overflow: this._overflow};
+
+      if (this._mode === 'zoned') {
+        return Temporal.ZonedDateTime.from(
+          {
+            year,
+            month: temporalMonth,
+            day: date,
+            hour: 0,
+            minute: 0,
+            second: 0,
+            timeZone: this._getTimeZoneId(),
+            calendar: this._getCalendarId(),
+          },
+          this._getZonedFromOptions(),
+        );
+      } else if (this._mode === 'datetime') {
+        return Temporal.PlainDateTime.from(
+          {
+            year,
+            month: temporalMonth,
+            day: date,
+            hour: 0,
+            minute: 0,
+            second: 0,
+            calendar: this._getCalendarId(),
+          },
+          overflowOption,
+        );
+      } else {
+        // 'date' mode
+        return Temporal.PlainDate.from(
+          {
+            year,
+            month: temporalMonth,
+            day: date,
+            calendar: this._getCalendarId(),
+          },
+          overflowOption,
+        );
+      }
+    } catch (e) {
+      if ((typeof ngDevMode === 'undefined' || ngDevMode) && this._overflow === 'reject') {
+        throw Error(`Invalid date "${date}" for month with index "${month}".`);
+      }
+      return this.invalid();
+    }
+  }
+
+  /** Gets today's date. */
+  today(): TemporalDateType {
+    if (this._mode === 'zoned') {
+      return Temporal.Now.zonedDateTimeISO(this._getTimeZoneId()).withCalendar(
+        this._getCalendarId(),
+      );
+    }
+    if (this._mode === 'datetime') {
+      return Temporal.Now.plainDateTimeISO().withCalendar(this._getCalendarId());
+    }
+    return Temporal.Now.plainDateISO().withCalendar(this._getCalendarId());
+  }
+
+  /**
+   * Parses a date from a user-provided value.
+   *
+   * Similar to NativeDateAdapter, this method uses the native parsing capabilities:
+   * - For strings: Uses Temporal.from() which accepts ISO 8601 format
+   * - For numbers: Treats as epoch milliseconds
+   * - For Date objects: Extracts components directly
+   *
+   * The parseFormat parameter is ignored since Temporal has built-in ISO 8601 parsing.
+   *
+   * @param value The value to parse.
+   * @param parseFormat Ignored - Temporal handles parsing formats natively.
+   * @returns The parsed Temporal date, or null/invalid if parsing failed.
+   */
+  parse(value: unknown, parseFormat?: any): TemporalDateType | null {
+    // Temporal adapter only handles Temporal types, strings, and numbers
+    // Unlike NativeDateAdapter, we don't accept JS Date - use Temporal types instead
+    if (typeof value === 'number') {
+      return this._createFromEpochMs(value);
+    }
+    if (typeof value === 'string') {
+      return value ? (this._parseString(value) ?? this.invalid()) : null;
+    }
+    if (this._isTemporalDateType(value)) {
+      return this.clone(value);
+    }
+    return value ? this.invalid() : null;
+  }
+
+  /**
+   * Formats a date as a localized string using Temporal's locale formatting.
+   *
+   * This method only accepts `Intl.DateTimeFormatOptions` objects, following the same
+   * approach as the NativeDateAdapter.
+   *
+   * @param date The date to format.
+   * @param displayFormat The Intl.DateTimeFormatOptions to use for formatting.
+   * @returns The formatted date string.
+   */
+  format(date: TemporalDateType, displayFormat: Intl.DateTimeFormatOptions): string {
+    if (!this.isValid(date)) {
+      throw Error('TemporalDateAdapter: Cannot format invalid date.');
+    }
+
+    const options: Intl.DateTimeFormatOptions = {
+      ...displayFormat,
+      calendar: this._getOutputCalendarId(),
+    };
+
+    const dateForFormat = this._isZonedDateTime(date)
+      ? this._maybeRoundZoned(this._toZonedDateTime(date))
+      : date;
+    return this._formatWithLocale(dateForFormat, options);
+  }
+
+  /** Adds the given number of years to the date. */
+  addCalendarYears(date: TemporalDateType, years: number): TemporalDateType {
+    return date.add({years}, {overflow: this._overflow}) as TemporalDateType;
+  }
+
+  /** Adds the given number of months to the date. */
+  addCalendarMonths(date: TemporalDateType, months: number): TemporalDateType {
+    return date.add({months}, {overflow: this._overflow}) as TemporalDateType;
+  }
+
+  /** Adds the given number of days to the date. */
+  addCalendarDays(date: TemporalDateType, days: number): TemporalDateType {
+    return date.add({days}, {overflow: this._overflow}) as TemporalDateType;
+  }
+
+  /** Gets the RFC 3339 compatible string for the given date. */
+  toIso8601(date: TemporalDateType): string {
+    if (this._isZonedDateTime(date)) {
+      // For ZonedDateTime, return the full ISO string with timezone
+      return this._maybeRoundZoned(this._toZonedDateTime(date)).toString();
+    }
+    if (this._isPlainDateTime(date)) {
+      // For PlainDateTime, return date portion only for consistency
+      return date.toPlainDate().toString();
+    }
+    return date.toString();
+  }
+
+  /**
+   * Deserializes a value to a valid date object.
+   * Accepts ISO 8601 strings and Temporal types only.
+   * Unlike NativeDateAdapter, JS Date is not supported - use Temporal types.
+   */
+  override deserialize(value: unknown): TemporalDateType | null {
+    if (typeof value === 'string') {
+      if (!value) {
+        return null;
+      }
+      const parsed = this._parseString(value);
+      if (parsed && this.isValid(parsed)) {
+        return parsed;
+      }
+      return this.invalid();
+    }
+    // Temporal types handled by super.deserialize() via isDateInstance()
+    return super.deserialize(value);
+  }
+
+  /** Checks whether the given object is a date instance. */
+  isDateInstance(obj: unknown): obj is TemporalDateType {
+    return this._isTemporalDateType(obj);
+  }
+
+  /** Checks whether the given date is valid. */
+  isValid(date: TemporalDateType): boolean {
+    // Temporal doesn't create invalid dates - it throws instead.
+    // Our invalid() returns a sentinel object with NaN values and _invalid marker.
+    if ((date as {_invalid?: boolean})._invalid === true) {
+      return false;
+    }
+    return date != null && typeof date.year === 'number' && !isNaN(date.year);
+  }
+
+  /**
+   * Gets date instance that is not valid.
+   *
+   * Note: The Temporal API does not support invalid dates like `Date(NaN)`.
+   * Instead, we return a sentinel object with NaN values that will be detected
+   * by the `isValid()` method. This object should not be used for any date
+   * operations - only for representing an invalid state.
+   *
+   * @returns A sentinel object representing an invalid date.
+   */
+  invalid(): TemporalDateType {
+    // Temporal doesn't support invalid dates like Date(NaN).
+    // Return sentinel with _invalid marker and NaN values.
+    const baseInvalid = {
+      _invalid: true as const,
+      year: NaN,
+      month: NaN,
+      day: NaN,
+      calendarId: this._getCalendarId(),
+      dayOfWeek: NaN,
+      daysInMonth: NaN,
+      monthsInYear: NaN,
+    };
+
+    if (this._mode === 'zoned') {
+      return {
+        ...baseInvalid,
+        hour: NaN,
+        minute: NaN,
+        second: NaN,
+        millisecond: NaN,
+        timeZoneId: this._getTimeZoneId(),
+        epochNanoseconds: BigInt(0),
+      } as unknown as Temporal.ZonedDateTime;
+    }
+
+    if (this._mode === 'datetime') {
+      return {
+        ...baseInvalid,
+        hour: NaN,
+        minute: NaN,
+        second: NaN,
+        millisecond: NaN,
+      } as unknown as Temporal.PlainDateTime;
+    }
+
+    return baseInvalid as unknown as Temporal.PlainDate;
+  }
+
+  /**
+   * Sets the time of a date.
+   *
+   * Note: When the adapter is in 'date' mode and the target is a PlainDate,
+   * this method will convert it to a PlainDateTime. If you need to preserve
+   * the PlainDate type, consider using 'datetime' mode from the start.
+   *
+   * @param target Date whose time will be set.
+   * @param hours New hours to set (0-23).
+   * @param minutes New minutes to set (0-59).
+   * @param seconds New seconds to set (0-59).
+   * @returns A new date with the specified time. May be PlainDateTime even if input was PlainDate.
+   */
+  override setTime(
+    target: TemporalDateType,
+    hours: number,
+    minutes: number,
+    seconds: number,
+  ): TemporalDateType {
+    // Validate inputs are finite numbers within valid ranges
+    // These checks always run (not just in dev mode) to prevent NaN/Infinity propagation
+    if (!Number.isFinite(hours) || hours < 0 || hours > 23) {
+      if (typeof ngDevMode === 'undefined' || ngDevMode) {
+        throw Error(
+          `Invalid hours "${hours}". Hours value must be a finite number between 0 and 23.`,
+        );
+      }
+      return this.invalid();
+    }
+
+    if (!Number.isFinite(minutes) || minutes < 0 || minutes > 59) {
+      if (typeof ngDevMode === 'undefined' || ngDevMode) {
+        throw Error(
+          `Invalid minutes "${minutes}". Minutes value must be a finite number between 0 and 59.`,
+        );
+      }
+      return this.invalid();
+    }
+
+    if (!Number.isFinite(seconds) || seconds < 0 || seconds > 59) {
+      if (typeof ngDevMode === 'undefined' || ngDevMode) {
+        throw Error(
+          `Invalid seconds "${seconds}". Seconds value must be a finite number between 0 and 59.`,
+        );
+      }
+      return this.invalid();
+    }
+
+    // In 'date' mode, time is not supported
+    if (this._mode === 'date') {
+      if (typeof ngDevMode === 'undefined' || ngDevMode) {
+        console.warn(
+          'TemporalDateAdapter.setTime: Called in date mode. ' +
+            'Use mode: "datetime" or "zoned" for date+time scenarios.',
+        );
+      }
+      return target;
+    }
+
+    if (this._isZonedDateTime(target)) {
+      return Temporal.ZonedDateTime.from(
+        {
+          year: target.year,
+          month: target.month,
+          day: target.day,
+          hour: hours,
+          minute: minutes,
+          second: seconds,
+          millisecond: 0,
+          timeZone: this._toZonedDateTime(target).timeZoneId,
+          calendar: this._getCalendarId(),
+        },
+        this._getZonedFromOptions(),
+      );
+    }
+
+    if (this._isPlainDateTime(target)) {
+      return target.with({hour: hours, minute: minutes, second: seconds, millisecond: 0});
+    }
+
+    // If target is PlainDate, convert to PlainDateTime (or ZonedDateTime in zoned mode)
+    if (this._mode === 'zoned') {
+      return this._toPlainDate(target)
+        .toPlainDateTime({hour: hours, minute: minutes, second: seconds})
+        .toZonedDateTime(this._getTimeZoneId(), this._getDisambiguationOption());
+    }
+    return this._toPlainDate(target).toPlainDateTime({
+      hour: hours,
+      minute: minutes,
+      second: seconds,
+    });
+  }
+
+  /** Gets the hours component of the given date. */
+  override getHours(date: TemporalDateType): number {
+    if (this._isZonedDateTime(date)) {
+      return this._toZonedDateTime(date).hour;
+    }
+    if (this._isPlainDateTime(date)) {
+      return date.hour;
+    }
+    return 0;
+  }
+
+  /** Gets the minutes component of the given date. */
+  override getMinutes(date: TemporalDateType): number {
+    if (this._isZonedDateTime(date)) {
+      return this._toZonedDateTime(date).minute;
+    }
+    if (this._isPlainDateTime(date)) {
+      return date.minute;
+    }
+    return 0;
+  }
+
+  /** Gets the seconds component of the given date. */
+  override getSeconds(date: TemporalDateType): number {
+    if (this._isZonedDateTime(date)) {
+      return this._toZonedDateTime(date).second;
+    }
+    if (this._isPlainDateTime(date)) {
+      return date.second;
+    }
+    return 0;
+  }
+
+  /** Parses a time string into a date object. */
+  override parseTime(value: unknown, parseFormat: string | string[]): TemporalDateType | null {
+    // In 'date' mode, time parsing is not supported
+    if (this._mode === 'date') {
+      return this.invalid();
+    }
+
+    // Handle empty or undefined values
+    if (value == null || value === '') {
+      return null;
+    }
+
+    if (typeof value === 'string') {
+      // Treat whitespace-only strings as invalid, not null
+      if (value.trim() === '') {
+        return this.invalid();
+      }
+
+      // Reject very long strings to prevent potential DoS
+      if (value.length > 32) {
+        return this.invalid();
+      }
+
+      const timeMatch = value
+        .toUpperCase()
+        .match(/^(\d?\d)[:.](\d?\d)(?:[:.](\d?\d))?\s*(AM|PM)?$/i);
+
+      if (timeMatch) {
+        // Additional bounds check: reject obviously invalid digit sequences
+        if (timeMatch[1].length > 2 || timeMatch[2].length > 2 || (timeMatch[3]?.length ?? 0) > 2) {
+          return this.invalid();
+        }
+
+        let hours = parseInt(timeMatch[1], 10);
+        const minutes = parseInt(timeMatch[2], 10);
+        const seconds = timeMatch[3] ? parseInt(timeMatch[3], 10) : 0;
+        const amPm = timeMatch[4] as 'AM' | 'PM' | undefined;
+
+        if (hours === 12) {
+          hours = amPm === 'AM' ? 0 : hours;
+        } else if (amPm === 'PM') {
+          hours += 12;
+        }
+
+        if (
+          hours >= 0 &&
+          hours <= 23 &&
+          minutes >= 0 &&
+          minutes <= 59 &&
+          seconds >= 0 &&
+          seconds <= 59
+        ) {
+          return this.setTime(this.today(), hours, minutes, seconds);
+        }
+      }
+
+      // Try parsing as ISO time
+      try {
+        const time = Temporal.PlainTime.from(value);
+        return this.setTime(this.today(), time.hour, time.minute, time.second);
+      } catch {
+        return this.invalid();
+      }
+    }
+
+    return this.parse(value, parseFormat);
+  }
+
+  /**
+   * Adds seconds to the date.
+   *
+   * Note: When the input is a PlainDate, this method will convert it to
+   * a PlainDateTime starting at midnight (00:00:00) before adding seconds.
+   * The result will be a PlainDateTime (or ZonedDateTime in 'zoned' mode).
+   *
+   * @param date Date to which to add seconds.
+   * @param amount Amount of seconds to add (may be negative).
+   * @returns A new date with the seconds added. May be PlainDateTime even if input was PlainDate.
+   */
+  override addSeconds(date: TemporalDateType, amount: number): TemporalDateType {
+    if (this._mode === 'date') {
+      if (typeof ngDevMode === 'undefined' || ngDevMode) {
+        console.warn(
+          'TemporalDateAdapter.addSeconds: Called in date mode. ' +
+            'Use mode: "datetime" or "zoned" for date+time scenarios.',
+        );
+      }
+      return date;
+    }
+
+    if (this._isZonedDateTime(date)) {
+      return this._toZonedDateTime(date).add({seconds: amount});
+    }
+
+    if (this._isPlainDateTime(date)) {
+      // PlainDateTime has add method with seconds support
+      return this._toPlainDateTime(date).add({seconds: amount});
+    }
+
+    // For PlainDate, we need to convert to PlainDateTime first
+    const dateTime = this._toPlainDate(date).toPlainDateTime({hour: 0, minute: 0, second: 0});
+    if (this._mode === 'zoned') {
+      return dateTime
+        .toZonedDateTime(this._getTimeZoneId(), this._getDisambiguationOption())
+        .add({seconds: amount});
+    }
+    return dateTime.add({seconds: amount});
+  }
+
+  // ========================
+  // Private helper methods
+  // ========================
+
+  /** Gets the default locale from the browser or system. */
+  private _getDefaultLocale(): string {
+    if (typeof navigator !== 'undefined' && navigator.language) {
+      return navigator.language;
+    }
+    return 'en-US';
+  }
+
+  /** Gets the calendar ID string. */
+  private _getCalendarId(): string {
+    return this._calendar;
+  }
+
+  /** Gets the calendar ID string for output/formatting. */
+  private _getOutputCalendarId(): string {
+    return this._outputCalendar || this._calendar;
+  }
+
+  /** Gets the timezone ID, resolving to system timezone lazily if not provided. */
+  private _getTimeZoneId(): string {
+    if (this._timezone) {
+      return this._timezone;
+    }
+    this._timezone = Temporal.Now.timeZoneId();
+    return this._timezone;
+  }
+
+  /** Gets options for Temporal.ZonedDateTime.from. */
+  private _getZonedFromOptions(): {
+    overflow?: 'reject' | 'constrain';
+    disambiguation?: TemporalDisambiguation;
+    offset?: TemporalOffsetOption;
+  } {
+    return {
+      overflow: this._overflow,
+      disambiguation: this._disambiguation,
+      offset: this._offset,
+    };
+  }
+
+  /** Gets options for converting PlainDateTime to ZonedDateTime. */
+  private _getDisambiguationOption(): {disambiguation?: TemporalDisambiguation} | undefined {
+    return this._disambiguation ? {disambiguation: this._disambiguation} : undefined;
+  }
+
+  /** Applies rounding to zoned values when configured. */
+  private _maybeRoundZoned(date: Temporal.ZonedDateTime): Temporal.ZonedDateTime {
+    if (!this._rounding) {
+      return date;
+    }
+    return date.round(this._rounding);
+  }
+
+  /** Gets the number of months in a specific year for the configured calendar. */
+  private _getMonthsInYearForDate(year: number): number {
+    try {
+      const refDate = Temporal.PlainDate.from({
+        year,
+        month: 1,
+        day: 1,
+        calendar: this._getCalendarId(),
+      });
+      return refDate.monthsInYear;
+    } catch {
+      return 12; // Fallback to standard calendar
+    }
+  }
+
+  /** Gets the number of months in a specific year for the output calendar. */
+  private _getMonthsInYearForOutput(year: number): number {
+    try {
+      const refDate = Temporal.PlainDate.from({
+        year,
+        month: 1,
+        day: 1,
+        calendar: this._getOutputCalendarId(),
+      });
+      return refDate.monthsInYear;
+    } catch {
+      return 12;
+    }
+  }
+
+  /** Formats a Temporal date using its built-in locale formatter. */
+  private _formatWithLocale(date: TemporalDateType, options: Intl.DateTimeFormatOptions): string {
+    const outputCalendar = this._getOutputCalendarId();
+    const dateForOutput =
+      outputCalendar === (date as {calendarId?: string}).calendarId
+        ? date
+        : date.withCalendar(outputCalendar);
+    const temporal = dateForOutput as unknown as {
+      toLocaleString: (locales?: string | string[], options?: Intl.DateTimeFormatOptions) => string;
+    };
+    return temporal.toLocaleString(this.locale, options).replace(/[\u200e\u200f]/g, '');
+  }
+
+  /** Checks if a value is a Temporal.PlainDateTime. */
+  private _isPlainDateTime(value: unknown): value is Temporal.PlainDateTime {
+    return (
+      value != null &&
+      typeof value === 'object' &&
+      value instanceof (Temporal.PlainDateTime as unknown as new (...args: unknown[]) => unknown)
+    );
+  }
+
+  /**
+   * Checks if a value is a valid Temporal date type or an invalid date sentinel.
+   */
+  private _isTemporalDateType(value: unknown): value is TemporalDateType {
+    if (value == null || typeof value !== 'object') {
+      return false;
+    }
+
+    // Check for our sentinel invalid date object
+    if ((value as {_invalid?: boolean})._invalid === true) {
+      return true;
+    }
+
+    return (
+      value instanceof (Temporal.PlainDate as unknown as new (...args: unknown[]) => unknown) ||
+      value instanceof (Temporal.PlainDateTime as unknown as new (...args: unknown[]) => unknown) ||
+      value instanceof (Temporal.ZonedDateTime as unknown as new (...args: unknown[]) => unknown)
+    );
+  }
+
+  /**
+   * Checks if a value is a Temporal.ZonedDateTime.
+   */
+  private _isZonedDateTime(value: unknown): value is Temporal.ZonedDateTime {
+    if (value == null || typeof value !== 'object') {
+      return false;
+    }
+
+    return (
+      value instanceof (Temporal.ZonedDateTime as unknown as new (...args: unknown[]) => unknown)
+    );
+  }
+
+  /**
+   * Converts a TemporalDateType to Temporal.PlainDate for internal use.
+   * This is needed because our public interface doesn't expose Temporal types directly.
+   */
+  private _toPlainDate(date: TemporalDateType): Temporal.PlainDate {
+    if (this._isZonedDateTime(date)) {
+      return this._toZonedDateTime(date).toPlainDate();
+    }
+    if (this._isPlainDateTime(date)) {
+      return this._toPlainDateTime(date).toPlainDate();
+    }
+    return date as Temporal.PlainDate;
+  }
+
+  /**
+   * Converts a TemporalDateType to Temporal.PlainDateTime for internal use.
+   * This is needed because our public interface doesn't expose Temporal types directly.
+   */
+  private _toPlainDateTime(date: TemporalDateType): Temporal.PlainDateTime {
+    if (this._isZonedDateTime(date)) {
+      return this._toZonedDateTime(date).toPlainDateTime();
+    }
+    if (this._isPlainDateTime(date)) {
+      return date;
+    }
+    // Must be PlainDate - convert to PlainDateTime at midnight
+    return (date as Temporal.PlainDate).toPlainDateTime({hour: 0, minute: 0, second: 0});
+  }
+
+  /**
+   * Converts a TemporalDateType to Temporal.ZonedDateTime for internal use.
+   * This is needed because our public interface doesn't expose Temporal types directly.
+   */
+  private _toZonedDateTime(date: TemporalDateType): Temporal.ZonedDateTime {
+    return date as unknown as Temporal.ZonedDateTime;
+  }
+
+  /**
+   * Creates a Temporal date from epoch milliseconds.
+   * Uses local timezone for date/datetime modes, configured timezone for zoned modes.
+   */
+  private _createFromEpochMs(ms: number): TemporalDateType {
+    // Validate input: must be a finite number within JavaScript's Date range
+    // (±8.64e15 ms from Unix epoch, approximately ±273,000 years)
+    if (!Number.isFinite(ms) || ms > 8.64e15 || ms < -8.64e15) {
+      return this.invalid();
+    }
+
+    try {
+      const instant = Temporal.Instant.fromEpochMilliseconds(ms);
+      if (this._mode === 'zoned') {
+        return instant
+          .toZonedDateTimeISO(this._getTimeZoneId())
+          .withCalendar(this._getCalendarId());
+      }
+      // For date/datetime modes, use local timezone (like JS Date)
+      const zdt = instant.toZonedDateTimeISO(Temporal.Now.timeZoneId());
+      if (this._mode === 'datetime') {
+        return Temporal.PlainDateTime.from({
+          year: zdt.year,
+          month: zdt.month,
+          day: zdt.day,
+          hour: zdt.hour,
+          minute: zdt.minute,
+          second: zdt.second,
+          calendar: this._getCalendarId(),
+        });
+      }
+      return Temporal.PlainDate.from({
+        year: zdt.year,
+        month: zdt.month,
+        day: zdt.day,
+        calendar: this._getCalendarId(),
+      });
+    } catch {
+      return this.invalid();
+    }
+  }
+
+  /**
+   * Parses a string to a Temporal date using ISO 8601 format.
+   * Returns null if parsing fails.
+   */
+  private _parseString(value: string): TemporalDateType | null {
+    if (!value) {
+      return null;
+    }
+    try {
+      if (this._mode === 'zoned') {
+        try {
+          return Temporal.ZonedDateTime.from(value, this._getZonedFromOptions()).withCalendar(
+            this._getCalendarId(),
+          );
+        } catch {
+          if (value.includes('[')) {
+            return null;
+          }
+          const plainDate = Temporal.PlainDate.from(value);
+          return plainDate
+            .toPlainDateTime({hour: 0, minute: 0, second: 0})
+            .toZonedDateTime(this._getTimeZoneId(), this._getDisambiguationOption())
+            .withCalendar(this._getCalendarId());
+        }
+      } else if (this._mode === 'datetime') {
+        try {
+          return Temporal.PlainDateTime.from(value).withCalendar(this._getCalendarId());
+        } catch {
+          const plainDate = Temporal.PlainDate.from(value);
+          return plainDate
+            .toPlainDateTime({hour: 0, minute: 0, second: 0})
+            .withCalendar(this._getCalendarId());
+        }
+      }
+      return Temporal.PlainDate.from(value).withCalendar(this._getCalendarId());
+    } catch {
+      return null;
+    }
+  }
+}

--- a/src/material-temporal-adapter/adapter/temporal-date-formats.ts
+++ b/src/material-temporal-adapter/adapter/temporal-date-formats.ts
@@ -1,0 +1,83 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {MatDateFormats} from '@angular/material/core';
+
+/**
+ * Default date formats for the Temporal adapter.
+ *
+ * These formats use Intl.DateTimeFormatOptions for display, following the same
+ * pattern as NativeDateAdapter. Parse formats are null because Temporal API
+ * handles parsing via its own ISO 8601 compliant methods.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal
+ */
+export const MAT_TEMPORAL_DATE_FORMATS: MatDateFormats = {
+  parse: {
+    /**
+     * Parse format is null - Temporal handles parsing via Temporal.PlainDate.from(),
+     * Temporal.PlainDateTime.from(), and Temporal.ZonedDateTime.from() which accept
+     * ISO 8601 strings natively.
+     */
+    dateInput: null,
+    /** Time parse format is null - Temporal handles time parsing natively. */
+    timeInput: null,
+  },
+  display: {
+    /** Format used for displaying date in input field. */
+    dateInput: {year: 'numeric', month: '2-digit', day: '2-digit'},
+    /** Format used for displaying time in input field. */
+    timeInput: {hour: '2-digit', minute: '2-digit'},
+    /** Format used for month/year label in calendar header. */
+    monthYearLabel: {year: 'numeric', month: 'short'},
+    /** Format used for accessibility label for date. */
+    dateA11yLabel: {year: 'numeric', month: 'long', day: 'numeric'},
+    /** Format used for accessibility label for month/year. */
+    monthYearA11yLabel: {year: 'numeric', month: 'long'},
+    /** Format used for time options in time picker. */
+    timeOptionLabel: {hour: '2-digit', minute: '2-digit'},
+  },
+};
+
+/**
+ * Extended date formats for Temporal adapter with datetime support.
+ *
+ * Use this when working with date-time pickers that need to display
+ * both date and time information (e.g., PlainDateTime or ZonedDateTime modes).
+ */
+export const MAT_TEMPORAL_DATETIME_FORMATS: MatDateFormats = {
+  parse: {
+    /**
+     * Parse format is null - Temporal handles datetime parsing via
+     * Temporal.PlainDateTime.from() and Temporal.ZonedDateTime.from().
+     */
+    dateInput: null,
+    /** Time parse format is null - Temporal handles time parsing natively. */
+    timeInput: null,
+  },
+  display: {
+    dateInput: {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+    },
+    timeInput: {hour: '2-digit', minute: '2-digit', second: '2-digit'},
+    monthYearLabel: {year: 'numeric', month: 'short'},
+    dateA11yLabel: {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    },
+    monthYearA11yLabel: {year: 'numeric', month: 'long'},
+    timeOptionLabel: {hour: '2-digit', minute: '2-digit', second: '2-digit'},
+  },
+};

--- a/src/material-temporal-adapter/index.ts
+++ b/src/material-temporal-adapter/index.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+export * from './public-api';

--- a/src/material-temporal-adapter/package.json
+++ b/src/material-temporal-adapter/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@angular/material-temporal-adapter",
+  "version": "0.0.0-PLACEHOLDER",
+  "description": "Angular Material Temporal API Adapter for Datepicker",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/angular/components.git"
+  },
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/angular/components/issues"
+  },
+  "homepage": "https://github.com/angular/components#readme",
+  "peerDependencies": {
+    "@angular/material": "0.0.0-PLACEHOLDER",
+    "@angular/core": "0.0.0-NG"
+  },
+  "devDependencies": {
+    "@angular/material": "workspace:*"
+  },
+  "dependencies": {
+    "tslib": "^2.3.0"
+  },
+  "ng-update": {
+    "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
+  },
+  "schematics": "./schematics/collection.json",
+  "sideEffects": false
+}

--- a/src/material-temporal-adapter/public-api.ts
+++ b/src/material-temporal-adapter/public-api.ts
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+// ========================
+// Approach A: Single unified adapter with mode configuration
+// ========================
+export * from './adapter/index';
+
+// ========================
+// Approach B: Split adapters (one per Temporal type)
+// ========================
+// These are exported under a 'split' namespace to differentiate from the unified adapter.
+// Usage: import { providePlainDateAdapter } from '@angular/material-temporal-adapter/split';
+export * from './adapter/split/index';

--- a/src/material-temporal-adapter/schematics/BUILD.bazel
+++ b/src/material-temporal-adapter/schematics/BUILD.bazel
@@ -1,0 +1,35 @@
+load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
+load("//tools:defaults.bzl", "npm_package", "ts_project")
+
+package(default_visibility = ["//visibility:public"])
+
+copy_to_bin(
+    name = "schematics_assets",
+    srcs = glob(
+        ["**/*.json"],
+        exclude = ["tsconfig.json"],
+    ),
+)
+
+ts_project(
+    name = "schematics",
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["**/*.spec.ts"],
+    ),
+    tsconfig = "tsconfig.json",
+    deps = [
+        "//:node_modules/@angular-devkit/schematics",
+        "//:node_modules/@angular/core",
+        "//:node_modules/@types/node",
+    ],
+)
+
+# This package is intended to be combined into the main @angular/material-temporal-adapter package as a dep.
+npm_package(
+    name = "npm_package",
+    srcs = [
+        ":schematics",
+        ":schematics_assets",
+    ],
+)

--- a/src/material-temporal-adapter/schematics/collection.json
+++ b/src/material-temporal-adapter/schematics/collection.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../node_modules/@angular-devkit/schematics/collection-schema.json",
+  "schematics": {
+    "ng-add": {
+      "description": "Installs the Angular Material Temporal Adapter",
+      "factory": "./ng-add/index",
+      "hidden": true
+    }
+  }
+}

--- a/src/material-temporal-adapter/schematics/ng-add/index.ts
+++ b/src/material-temporal-adapter/schematics/ng-add/index.ts
@@ -1,0 +1,21 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Rule} from '@angular-devkit/schematics';
+
+/**
+ * Schematic entry point for ng-add.
+ *
+ * This is a no-op schematic that allows users to run `ng add @angular/material-temporal-adapter`.
+ * It provides a foundation for future enhancements like automatic setup.
+ */
+export default function (): Rule {
+  // Noop schematic so the CLI doesn't throw if users try to `ng add` this package.
+  // Also allows us to add more functionality in the future.
+  return () => {};
+}

--- a/src/material-temporal-adapter/schematics/package.json
+++ b/src/material-temporal-adapter/schematics/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/src/material-temporal-adapter/schematics/tsconfig.json
+++ b/src/material-temporal-adapter/schematics/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "node10",
+    "strict": true,
+    "sourceMap": true,
+    "declaration": true
+  }
+}

--- a/src/material-temporal-adapter/temporal.d.ts
+++ b/src/material-temporal-adapter/temporal.d.ts
@@ -1,0 +1,629 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+/**
+ * Type declarations for the Temporal API.
+ *
+ * The Temporal API provides modern date/time handling in JavaScript with support
+ * for calendars, time zones, and internationalization.
+ *
+ * These declarations will be replaced by TypeScript's built-in lib.esnext.temporal
+ * once it is released. See: https://github.com/microsoft/TypeScript/pull/62628
+ *
+ * For browsers that don't yet support Temporal natively, users should include a polyfill.
+ * Popular options:
+ * - `@js-temporal/polyfill` (reference implementation)
+ * - `temporal-polyfill` (lightweight alternative)
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal
+ * @see https://tc39.es/proposal-temporal/
+ */
+
+declare namespace Temporal {
+  /**
+   * Represents a date without time or timezone information.
+   */
+  interface PlainDate {
+    readonly year: number;
+    readonly month: number;
+    readonly monthCode: string;
+    readonly day: number;
+    readonly calendarId: string;
+    readonly dayOfWeek: number;
+    readonly dayOfYear: number;
+    readonly weekOfYear: number | undefined;
+    readonly yearOfWeek: number | undefined;
+    readonly daysInWeek: number;
+    readonly daysInMonth: number;
+    readonly daysInYear: number;
+    readonly monthsInYear: number;
+    readonly inLeapYear: boolean;
+    readonly era: string | undefined;
+    readonly eraYear: number | undefined;
+
+    toString(): string;
+    toLocaleString(locales?: string | string[], options?: Intl.DateTimeFormatOptions): string;
+    toJSON(): string;
+    valueOf(): never;
+    toPlainDateTime(time?: PlainTimeLike): PlainDateTime;
+    toPlainYearMonth(): PlainYearMonth;
+    toPlainMonthDay(): PlainMonthDay;
+    withCalendar(calendar: string): PlainDate;
+    with(dateLike: PlainDateLike, options?: AssignmentOptions): PlainDate;
+    add(duration: DurationLike, options?: ArithmeticOptions): PlainDate;
+    subtract(duration: DurationLike, options?: ArithmeticOptions): PlainDate;
+    until(other: PlainDateLike, options?: DifferenceOptions): Duration;
+    since(other: PlainDateLike, options?: DifferenceOptions): Duration;
+    equals(other: PlainDateLike): boolean;
+  }
+
+  /**
+   * Static PlainDate methods and constructor.
+   */
+  const PlainDate: {
+    prototype: PlainDate;
+    new (isoYear: number, isoMonth: number, isoDay: number, calendar?: string): PlainDate;
+    from(item: PlainDateLike | string, options?: AssignmentOptions): PlainDate;
+    compare(one: PlainDateLike, two: PlainDateLike): number;
+  };
+
+  /**
+   * Input for PlainDate operations.
+   */
+  interface PlainDateLike {
+    year?: number;
+    month?: number;
+    monthCode?: string;
+    day?: number;
+    calendar?: string;
+    era?: string;
+    eraYear?: number;
+  }
+
+  /**
+   * Represents a time without date or timezone information.
+   */
+  interface PlainTime {
+    readonly hour: number;
+    readonly minute: number;
+    readonly second: number;
+    readonly millisecond: number;
+    readonly microsecond: number;
+    readonly nanosecond: number;
+
+    toString(): string;
+    toJSON(): string;
+    valueOf(): never;
+    with(timeLike: PlainTimeLike, options?: AssignmentOptions): PlainTime;
+    add(duration: DurationLike): PlainTime;
+    subtract(duration: DurationLike): PlainTime;
+    until(other: PlainTimeLike, options?: DifferenceOptions): Duration;
+    since(other: PlainTimeLike, options?: DifferenceOptions): Duration;
+    equals(other: PlainTimeLike): boolean;
+    round(options: RoundTo): PlainTime;
+  }
+
+  /**
+   * Static PlainTime methods and constructor.
+   */
+  const PlainTime: {
+    prototype: PlainTime;
+    new (
+      hour?: number,
+      minute?: number,
+      second?: number,
+      millisecond?: number,
+      microsecond?: number,
+      nanosecond?: number,
+    ): PlainTime;
+    from(item: PlainTimeLike | string, options?: AssignmentOptions): PlainTime;
+    compare(one: PlainTimeLike, two: PlainTimeLike): number;
+  };
+
+  /**
+   * Input for PlainTime operations.
+   */
+  interface PlainTimeLike {
+    hour?: number;
+    minute?: number;
+    second?: number;
+    millisecond?: number;
+    microsecond?: number;
+    nanosecond?: number;
+  }
+
+  /**
+   * Represents a date and time without timezone information.
+   */
+  interface PlainDateTime {
+    readonly year: number;
+    readonly month: number;
+    readonly monthCode: string;
+    readonly day: number;
+    readonly hour: number;
+    readonly minute: number;
+    readonly second: number;
+    readonly millisecond: number;
+    readonly microsecond: number;
+    readonly nanosecond: number;
+    readonly calendarId: string;
+    readonly dayOfWeek: number;
+    readonly dayOfYear: number;
+    readonly weekOfYear: number | undefined;
+    readonly yearOfWeek: number | undefined;
+    readonly daysInWeek: number;
+    readonly daysInMonth: number;
+    readonly daysInYear: number;
+    readonly monthsInYear: number;
+    readonly inLeapYear: boolean;
+    readonly era: string | undefined;
+    readonly eraYear: number | undefined;
+
+    toString(): string;
+    toLocaleString(locales?: string | string[], options?: Intl.DateTimeFormatOptions): string;
+    toJSON(): string;
+    valueOf(): never;
+    toPlainDate(): PlainDate;
+    toPlainTime(): PlainTime;
+    toPlainYearMonth(): PlainYearMonth;
+    toPlainMonthDay(): PlainMonthDay;
+    toZonedDateTime(timeZone: string, options?: ToZonedDateTimeOptions): ZonedDateTime;
+    withCalendar(calendar: string): PlainDateTime;
+    withPlainDate(date: PlainDateLike): PlainDateTime;
+    withPlainTime(time?: PlainTimeLike): PlainDateTime;
+    with(dateTimeLike: PlainDateTimeLike, options?: AssignmentOptions): PlainDateTime;
+    add(duration: DurationLike, options?: ArithmeticOptions): PlainDateTime;
+    subtract(duration: DurationLike, options?: ArithmeticOptions): PlainDateTime;
+    until(other: PlainDateTimeLike, options?: DifferenceOptions): Duration;
+    since(other: PlainDateTimeLike, options?: DifferenceOptions): Duration;
+    equals(other: PlainDateTimeLike): boolean;
+    round(options: RoundTo): PlainDateTime;
+  }
+
+  /**
+   * Static PlainDateTime methods and constructor.
+   */
+  const PlainDateTime: {
+    prototype: PlainDateTime;
+    new (
+      isoYear: number,
+      isoMonth: number,
+      isoDay: number,
+      isoHour?: number,
+      isoMinute?: number,
+      isoSecond?: number,
+      isoMillisecond?: number,
+      isoMicrosecond?: number,
+      isoNanosecond?: number,
+      calendar?: string,
+    ): PlainDateTime;
+    from(item: PlainDateTimeLike | string, options?: AssignmentOptions): PlainDateTime;
+    compare(one: PlainDateTimeLike, two: PlainDateTimeLike): number;
+  };
+
+  /**
+   * Input for PlainDateTime operations.
+   */
+  interface PlainDateTimeLike {
+    year?: number;
+    month?: number;
+    monthCode?: string;
+    day?: number;
+    hour?: number;
+    minute?: number;
+    second?: number;
+    millisecond?: number;
+    microsecond?: number;
+    nanosecond?: number;
+    calendar?: string;
+    era?: string;
+    eraYear?: number;
+  }
+
+  /**
+   * Represents a date and time with timezone information.
+   */
+  interface ZonedDateTime {
+    readonly year: number;
+    readonly month: number;
+    readonly monthCode: string;
+    readonly day: number;
+    readonly hour: number;
+    readonly minute: number;
+    readonly second: number;
+    readonly millisecond: number;
+    readonly microsecond: number;
+    readonly nanosecond: number;
+    readonly timeZoneId: string;
+    readonly calendarId: string;
+    readonly dayOfWeek: number;
+    readonly dayOfYear: number;
+    readonly weekOfYear: number | undefined;
+    readonly yearOfWeek: number | undefined;
+    readonly hoursInDay: number;
+    readonly daysInWeek: number;
+    readonly daysInMonth: number;
+    readonly daysInYear: number;
+    readonly monthsInYear: number;
+    readonly inLeapYear: boolean;
+    readonly epochMilliseconds: number;
+    readonly epochNanoseconds: bigint;
+    readonly offset: string;
+    readonly offsetNanoseconds: number;
+    readonly era: string | undefined;
+    readonly eraYear: number | undefined;
+
+    toString(options?: ZonedDateTimeToStringOptions): string;
+    toJSON(): string;
+    valueOf(): never;
+    toPlainDate(): PlainDate;
+    toPlainDateTime(): PlainDateTime;
+    toPlainTime(): PlainTime;
+    toPlainYearMonth(): PlainYearMonth;
+    toPlainMonthDay(): PlainMonthDay;
+    toInstant(): Instant;
+    with(zonedDateTimeLike: Partial<ZonedDateTimeLike>, options?: AssignmentOptions): ZonedDateTime;
+    withCalendar(calendar: string): ZonedDateTime;
+    withTimeZone(timeZone: string): ZonedDateTime;
+    withPlainDate(date: PlainDateLike): ZonedDateTime;
+    withPlainTime(time?: PlainTimeLike): ZonedDateTime;
+    add(duration: DurationLike, options?: ArithmeticOptions): ZonedDateTime;
+    subtract(duration: DurationLike, options?: ArithmeticOptions): ZonedDateTime;
+    until(other: ZonedDateTimeLike, options?: DifferenceOptions): Duration;
+    since(other: ZonedDateTimeLike, options?: DifferenceOptions): Duration;
+    equals(other: ZonedDateTimeLike): boolean;
+    round(options: RoundTo): ZonedDateTime;
+    startOfDay(): ZonedDateTime;
+    getTimeZoneTransition(direction: 'next' | 'previous'): Instant | null;
+  }
+
+  /**
+   * Static ZonedDateTime methods and constructor.
+   */
+  const ZonedDateTime: {
+    prototype: ZonedDateTime;
+    from(item: ZonedDateTimeLike | string, options?: ZonedDateTimeAssignmentOptions): ZonedDateTime;
+    compare(one: ZonedDateTimeLike, two: ZonedDateTimeLike): number;
+  };
+
+  /**
+   * Input for ZonedDateTime operations.
+   */
+  interface ZonedDateTimeLike {
+    year?: number;
+    month?: number;
+    monthCode?: string;
+    day?: number;
+    hour?: number;
+    minute?: number;
+    second?: number;
+    millisecond?: number;
+    microsecond?: number;
+    nanosecond?: number;
+    offset?: string;
+    timeZone: string;
+    calendar?: string;
+    era?: string;
+    eraYear?: number;
+  }
+
+  /**
+   * Represents a point in time (an instant).
+   */
+  interface Instant {
+    readonly epochMilliseconds: number;
+    readonly epochNanoseconds: bigint;
+
+    toString(options?: InstantToStringOptions): string;
+    toJSON(): string;
+    valueOf(): never;
+    toZonedDateTimeISO(timeZone: string): ZonedDateTime;
+    toZonedDateTime(options: {timeZone: string; calendar: string}): ZonedDateTime;
+    add(duration: DurationLike): Instant;
+    subtract(duration: DurationLike): Instant;
+    until(other: Instant, options?: DifferenceOptions): Duration;
+    since(other: Instant, options?: DifferenceOptions): Duration;
+    equals(other: Instant): boolean;
+    round(options: RoundTo): Instant;
+  }
+
+  /**
+   * Static Instant methods and constructor.
+   */
+  const Instant: {
+    prototype: Instant;
+    from(item: Instant | string): Instant;
+    fromEpochMilliseconds(epochMilliseconds: number): Instant;
+    fromEpochNanoseconds(epochNanoseconds: bigint): Instant;
+    compare(one: Instant, two: Instant): number;
+  };
+
+  /**
+   * Represents a year and month without day or time.
+   */
+  interface PlainYearMonth {
+    readonly year: number;
+    readonly month: number;
+    readonly monthCode: string;
+    readonly calendarId: string;
+    readonly daysInMonth: number;
+    readonly daysInYear: number;
+    readonly monthsInYear: number;
+    readonly inLeapYear: boolean;
+    readonly era: string | undefined;
+    readonly eraYear: number | undefined;
+
+    toString(): string;
+    toLocaleString(locales?: string | string[], options?: Intl.DateTimeFormatOptions): string;
+    toJSON(): string;
+    valueOf(): never;
+    toPlainDate(day: {day: number}): PlainDate;
+    with(yearMonthLike: PlainYearMonthLike, options?: AssignmentOptions): PlainYearMonth;
+    add(duration: DurationLike, options?: ArithmeticOptions): PlainYearMonth;
+    subtract(duration: DurationLike, options?: ArithmeticOptions): PlainYearMonth;
+    until(other: PlainYearMonthLike, options?: DifferenceOptions): Duration;
+    since(other: PlainYearMonthLike, options?: DifferenceOptions): Duration;
+    equals(other: PlainYearMonthLike): boolean;
+  }
+
+  /**
+   * Static PlainYearMonth methods and constructor.
+   */
+  const PlainYearMonth: {
+    prototype: PlainYearMonth;
+    new (
+      isoYear: number,
+      isoMonth: number,
+      calendar?: string,
+      referenceISODay?: number,
+    ): PlainYearMonth;
+    from(item: PlainYearMonthLike | string, options?: AssignmentOptions): PlainYearMonth;
+    compare(one: PlainYearMonthLike, two: PlainYearMonthLike): number;
+  };
+
+  /**
+   * Input for PlainYearMonth operations.
+   */
+  interface PlainYearMonthLike {
+    year?: number;
+    month?: number;
+    monthCode?: string;
+    calendar?: string;
+    era?: string;
+    eraYear?: number;
+  }
+
+  /**
+   * Represents a month and day without year or time.
+   */
+  interface PlainMonthDay {
+    readonly monthCode: string;
+    readonly day: number;
+    readonly calendarId: string;
+
+    toString(): string;
+    toJSON(): string;
+    valueOf(): never;
+    toPlainDate(year: {year: number}): PlainDate;
+    with(monthDayLike: PlainMonthDayLike, options?: AssignmentOptions): PlainMonthDay;
+    equals(other: PlainMonthDayLike): boolean;
+  }
+
+  /**
+   * Static PlainMonthDay methods and constructor.
+   */
+  const PlainMonthDay: {
+    prototype: PlainMonthDay;
+    from(item: PlainMonthDayLike | string, options?: AssignmentOptions): PlainMonthDay;
+  };
+
+  /**
+   * Input for PlainMonthDay operations.
+   */
+  interface PlainMonthDayLike {
+    month?: number;
+    monthCode?: string;
+    day?: number;
+    calendar?: string;
+  }
+
+  /**
+   * Represents a duration of time.
+   */
+  interface Duration {
+    readonly years: number;
+    readonly months: number;
+    readonly weeks: number;
+    readonly days: number;
+    readonly hours: number;
+    readonly minutes: number;
+    readonly seconds: number;
+    readonly milliseconds: number;
+    readonly microseconds: number;
+    readonly nanoseconds: number;
+    readonly sign: -1 | 0 | 1;
+    readonly blank: boolean;
+
+    toString(): string;
+    toJSON(): string;
+    valueOf(): never;
+    with(durationLike: DurationLike): Duration;
+    negated(): Duration;
+    abs(): Duration;
+    add(other: DurationLike, options?: DurationArithmeticOptions): Duration;
+    subtract(other: DurationLike, options?: DurationArithmeticOptions): Duration;
+    round(options: DurationRoundOptions): Duration;
+    total(options: DurationTotalOptions): number;
+  }
+
+  /**
+   * Static Duration methods and constructor.
+   */
+  const Duration: {
+    prototype: Duration;
+    new (
+      years?: number,
+      months?: number,
+      weeks?: number,
+      days?: number,
+      hours?: number,
+      minutes?: number,
+      seconds?: number,
+      milliseconds?: number,
+      microseconds?: number,
+      nanoseconds?: number,
+    ): Duration;
+    from(item: DurationLike | string): Duration;
+    compare(one: DurationLike, two: DurationLike, options?: DurationCompareOptions): number;
+  };
+
+  /**
+   * Input for Duration operations.
+   */
+  interface DurationLike {
+    years?: number;
+    months?: number;
+    weeks?: number;
+    days?: number;
+    hours?: number;
+    minutes?: number;
+    seconds?: number;
+    milliseconds?: number;
+    microseconds?: number;
+    nanoseconds?: number;
+  }
+
+  /**
+   * The Now object provides methods for getting the current date/time.
+   */
+  const Now: {
+    instant(): Instant;
+    zonedDateTimeISO(timeZone?: string): ZonedDateTime;
+    zonedDateTime(calendar: string, timeZone?: string): ZonedDateTime;
+    plainDateTimeISO(timeZone?: string): PlainDateTime;
+    plainDateTime(calendar: string, timeZone?: string): PlainDateTime;
+    plainDateISO(timeZone?: string): PlainDate;
+    plainDate(calendar: string, timeZone?: string): PlainDate;
+    plainTimeISO(timeZone?: string): PlainTime;
+    timeZoneId(): string;
+  };
+
+  // Options types
+
+  interface AssignmentOptions {
+    overflow?: 'constrain' | 'reject';
+  }
+
+  interface ArithmeticOptions {
+    overflow?: 'constrain' | 'reject';
+  }
+
+  interface DifferenceOptions {
+    largestUnit?: string;
+    smallestUnit?: string;
+    roundingIncrement?: number;
+    roundingMode?:
+      | 'ceil'
+      | 'floor'
+      | 'expand'
+      | 'trunc'
+      | 'halfCeil'
+      | 'halfFloor'
+      | 'halfExpand'
+      | 'halfTrunc'
+      | 'halfEven';
+  }
+
+  interface RoundTo {
+    smallestUnit: string;
+    roundingIncrement?: number;
+    roundingMode?:
+      | 'ceil'
+      | 'floor'
+      | 'expand'
+      | 'trunc'
+      | 'halfCeil'
+      | 'halfFloor'
+      | 'halfExpand'
+      | 'halfTrunc'
+      | 'halfEven';
+  }
+
+  interface ToZonedDateTimeOptions {
+    disambiguation?: 'compatible' | 'earlier' | 'later' | 'reject';
+  }
+
+  interface ZonedDateTimeAssignmentOptions extends AssignmentOptions {
+    disambiguation?: 'compatible' | 'earlier' | 'later' | 'reject';
+    offset?: 'use' | 'prefer' | 'ignore' | 'reject';
+  }
+
+  interface ZonedDateTimeToStringOptions {
+    calendarName?: 'auto' | 'always' | 'never' | 'critical';
+    timeZoneName?: 'auto' | 'never' | 'critical';
+    offset?: 'auto' | 'never';
+    fractionalSecondDigits?: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 'auto';
+    smallestUnit?: string;
+    roundingMode?:
+      | 'ceil'
+      | 'floor'
+      | 'expand'
+      | 'trunc'
+      | 'halfCeil'
+      | 'halfFloor'
+      | 'halfExpand'
+      | 'halfTrunc'
+      | 'halfEven';
+  }
+
+  interface InstantToStringOptions {
+    timeZone?: string;
+    fractionalSecondDigits?: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 'auto';
+    smallestUnit?: string;
+    roundingMode?:
+      | 'ceil'
+      | 'floor'
+      | 'expand'
+      | 'trunc'
+      | 'halfCeil'
+      | 'halfFloor'
+      | 'halfExpand'
+      | 'halfTrunc'
+      | 'halfEven';
+  }
+
+  interface DurationArithmeticOptions {
+    relativeTo?: PlainDateLike | ZonedDateTimeLike | string;
+  }
+
+  interface DurationRoundOptions {
+    largestUnit?: string;
+    smallestUnit?: string;
+    roundingIncrement?: number;
+    roundingMode?:
+      | 'ceil'
+      | 'floor'
+      | 'expand'
+      | 'trunc'
+      | 'halfCeil'
+      | 'halfFloor'
+      | 'halfExpand'
+      | 'halfTrunc'
+      | 'halfEven';
+    relativeTo?: PlainDateLike | ZonedDateTimeLike | string;
+  }
+
+  interface DurationTotalOptions {
+    unit: string;
+    relativeTo?: PlainDateLike | ZonedDateTimeLike | string;
+  }
+
+  interface DurationCompareOptions {
+    relativeTo?: PlainDateLike | ZonedDateTimeLike | string;
+  }
+}

--- a/src/material-temporal-adapter/tsconfig.json
+++ b/src/material-temporal-adapter/tsconfig.json
@@ -1,0 +1,14 @@
+// Configuration for IDEs only.
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "..",
+    "baseUrl": ".",
+    "paths": {
+      "@angular/cdk/*": ["../cdk/*"],
+      "@angular/material/*": ["../material/*"],
+      "@angular/material": ["../material/public-api.ts"]
+    }
+  },
+  "include": ["./**/*.ts", "../dev-mode-types.d.ts", "./temporal.d.ts"]
+}

--- a/src/material/datepicker/datepicker.md
+++ b/src/material/datepicker/datepicker.md
@@ -369,6 +369,63 @@ The easiest way to ensure this is to import one of the provided date adapters:
   </tbody>
 </table>
 
+`provideTemporalDateAdapter` or `MatTemporalModule` (installed via `ng add @angular/material-temporal-adapter`)
+
+<table>
+  <tbody>
+    <tr>
+      <th align="left" scope="row">Date type</th>
+      <td><code>Temporal.PlainDate</code>, <code>Temporal.PlainDateTime</code>, or <code>Temporal.ZonedDateTime</code> (configurable)</td>
+    </tr>
+    <tr>
+      <th align="left" scope="row">Supported locales</th>
+      <td>Depends on the platform’s Intl/Temporal support</td>
+    </tr>
+    <tr>
+      <th align="left" scope="row">Dependencies</th>
+      <td>Temporal (native or polyfill, e.g. <code>@js-temporal/polyfill</code>)</td>
+    </tr>
+    <tr>
+      <th align="left" scope="row">Import from</th>
+      <td><code>@angular/material-temporal-adapter</code></td>
+    </tr>
+  </tbody>
+</table>
+
+Note: if your environment doesn’t support Temporal natively, you’ll need a polyfill (e.g. <code>@js-temporal/polyfill</code> or <code>temporal-polyfill</code>) loaded before using the adapter.
+Temporal uses `Intl.DateTimeFormatOptions` for `MAT_DATE_FORMATS`; parse formats are ignored (Temporal parses ISO strings only).
+
+#### Temporal adapter options
+- `mode`: `date | datetime | zoned` (default: `date`).
+- `timezone` (zoned only): IANA ID like `Europe/Warsaw` or `UTC` (default: system timezone).
+- `calendar`: calendar system for calculations (default: `iso8601`).
+- `outputCalendar`: calendar system for output/formatting (default: same as `calendar`) — MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDate/withCalendar
+- `disambiguation` (zoned only): `'compatible' | 'earlier' | 'later' | 'reject'` for DST gaps/overlaps — MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/toZonedDateTime
+- `offset` (zoned only): `'use' | 'ignore' | 'reject' | 'prefer'` for offset ambiguity on parse — MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/from
+- `rounding` (zoned only): `{smallestUnit, roundingIncrement?, roundingMode?}` applied to zoned output — MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/round
+- `overflow`: `reject` (default) or `constrain` for invalid dates.
+
+#### Migration examples (Temporal)
+```ts
+// NativeDateAdapter -> Temporal date-only
+provideTemporalDateAdapter({mode: 'date'});
+// Value: Temporal.PlainDate.from('2024-01-15')
+const value = Temporal.PlainDate.from('2024-01-15');
+```
+
+```ts
+// Moment/Luxon UTC workflows
+provideTemporalDateAdapter({mode: 'zoned', timezone: 'UTC'});
+// Value: Temporal.ZonedDateTime.from('2024-01-15T12:30[UTC]')
+const value = Temporal.ZonedDateTime.from('2024-01-15T12:30[UTC]');
+```
+
+```ts
+// Luxon defaultOutputCalendar equivalent
+provideTemporalDateAdapter({calendar: 'iso8601', outputCalendar: 'japanese'});
+// Values remain ISO; output labels render in Japanese calendar
+```
+
 `provideMomentDateAdapter` or `MatMomentDateModule` (installed via `ng add @angular/material-moment-adapter`)
 
 <table>

--- a/src/material/timepicker/timepicker.md
+++ b/src/material/timepicker/timepicker.md
@@ -211,6 +211,62 @@ The easiest way to ensure this is to import one of the provided date adapters:
   </tbody>
 </table>
 
+`provideTemporalDateAdapter` or `MatTemporalModule` (installed via `ng add @angular/material-temporal-adapter`)
+
+<table>
+  <tbody>
+    <tr>
+      <th align="left" scope="row">Date type</th>
+      <td><code>Temporal.PlainDate</code>, <code>Temporal.PlainDateTime</code>, or <code>Temporal.ZonedDateTime</code> (configurable)</td>
+    </tr>
+    <tr>
+      <th align="left" scope="row">Supported locales</th>
+      <td>Depends on the platform’s Intl/Temporal support</td>
+    </tr>
+    <tr>
+      <th align="left" scope="row">Dependencies</th>
+      <td>Temporal (native or polyfill, e.g. <code>@js-temporal/polyfill</code>)</td>
+    </tr>
+    <tr>
+      <th align="left" scope="row">Import from</th>
+      <td><code>@angular/material-temporal-adapter</code></td>
+    </tr>
+  </tbody>
+</table>
+
+Note: if your environment doesn’t support Temporal natively, you’ll need a polyfill (e.g. <code>@js-temporal/polyfill</code> or <code>temporal-polyfill</code>) loaded before using the adapter.
+Temporal uses `Intl.DateTimeFormatOptions` for `MAT_DATE_FORMATS`; parse formats are ignored (Temporal parses ISO strings only).
+
+#### Temporal adapter options
+- `mode`: `date | datetime | zoned` (default: `date`).
+- `timezone` (zoned only): IANA ID like `Europe/Warsaw` or `UTC` (default: system timezone).
+- `calendar`: calendar system for calculations (default: `iso8601`).
+- `outputCalendar`: calendar system for output/formatting (default: same as `calendar`) — MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDate/withCalendar
+- `disambiguation` (zoned only): `'compatible' | 'earlier' | 'later' | 'reject'` for DST gaps/overlaps — MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/toZonedDateTime
+- `offset` (zoned only): `'use' | 'ignore' | 'reject' | 'prefer'` for offset ambiguity on parse — MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/from
+- `rounding` (zoned only): `{smallestUnit, roundingIncrement?, roundingMode?}` applied to zoned output — MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/round
+- `overflow`: `reject` (default) or `constrain` for invalid dates.
+
+#### Migration examples (Temporal)
+```ts
+// Timepicker with date+time (no timezone)
+provideTemporalDateAdapter({mode: 'datetime'});
+// Value: Temporal.PlainDateTime.from('2024-01-15T12:30')
+const value = Temporal.PlainDateTime.from('2024-01-15T12:30');
+```
+
+```ts
+// Timepicker with timezone
+provideTemporalDateAdapter({mode: 'zoned', timezone: 'UTC'});
+// Value: Temporal.ZonedDateTime.from('2024-01-15T12:30[UTC]')
+const value = Temporal.ZonedDateTime.from('2024-01-15T12:30[UTC]');
+```
+
+```ts
+// Rounded output for time options (e.g. 5-minute steps)
+provideTemporalDateAdapter({mode: 'zoned', rounding: {smallestUnit: 'minute', roundingIncrement: 5}});
+```
+
 `provideMomentDateAdapter` or `MatMomentDateModule` (installed via `ng add @angular/material-moment-adapter`)
 
 <table>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -38,6 +38,7 @@
       "@angular/material-moment-adapter": ["./src/material-moment-adapter"],
       "@angular/material-luxon-adapter": ["./src/material-luxon-adapter"],
       "@angular/material-date-fns-adapter": ["./src/material-date-fns-adapter"],
+      "@angular/material-temporal-adapter": ["./src/material-temporal-adapter"],
       "@angular/components-examples": ["./src/components-examples"],
       "@angular/components-examples/*": ["./src/components-examples/*"],
       "@angular/google-maps": ["./src/google-maps"],


### PR DESCRIPTION
> ⚡ Also available as a community package today:
> **`@kbrilla/material-temporal-adapter`**
> https://github.com/kbrilla/material-temporal-adapter
> This PR remains open in case the team wants to adopt upstream.

## AI assistance disclosure
This work was implemented by AI tools (Claude Opus 4.5 and GPT-5.2-Codex) under my orchestration.

## Live Demo & Validation
**[View Interactive Storybook & Matrix Test Suite](https://kbrilla.github.io/temporal-adapter-demo/)**
Comprehensive playground demonstrating:
*   Integration with Material Datepicker/Timepicker
*   10+ Calendar systems (Japanese, Hebrew, Chinese, etc.)
*   Automated Matrix Tests verifying all adapter operations

## Summary
Add a Temporal-based `DateAdapter` for Angular Material datepicker, supporting date-only, date+time, and timezone-aware date+time use cases.

Fixes #25753

## Background
Temporal is a Stage 3 TC39 proposal providing immutable date/time primitives with explicit calendar and timezone semantics. This adapter enables Material datepicker to work with Temporal (native or polyfilled) without relying on JS `Date` as the internal model. The implementation follows patterns from existing adapters in this repo, especially `NativeDateAdapter`.

## Scope / what’s in this PR
- **Unified adapter**: `TemporalDateAdapter` (The primary 3-in-1 adapter recommended for general use). Supports switching modes via configuration:
  - `date` → `Temporal.PlainDate`
  - `datetime` → `Temporal.PlainDateTime`
  - `zoned` → `Temporal.ZonedDateTime`
- **Demonstration / Split adapters**: A set of 4 additional adapters illustrating different architectural splittings and strict type handling. These serve as architectural examples:
  - `PlainDateAdapter`: Strictly for `Temporal.PlainDate`.
  - `PlainDateTimeAdapter`: Strictly for `Temporal.PlainDateTime`.
  - `ZonedDateTimeAdapter`: Strictly for `Temporal.ZonedDateTime`.
  - `PlainTemporalAdapter`: A hybrid handling both `PlainDate` and `PlainDateTime`.
- **Formatting** uses `Intl.DateTimeFormatOptions` with Temporal’s locale formatting.
- **No runtime dependency** is added; consumers supply a Temporal implementation (native or polyfill).

## Configuration
### Unified adapter (`TemporalDateAdapter` / `MatTemporalDateAdapterOptions`)
**Defaults**
- `calendar`: `iso8601`
- `outputCalendar`: same as `calendar`
- `mode`: `date`
- `overflow`: `reject`
- `timezone`: system timezone (only when `mode: 'zoned'`)
- `disambiguation`, `offset`, `rounding`: Temporal defaults (only when `mode: 'zoned'`)

**Options**
- `calendar`: calendar system to use for calculations.
- `outputCalendar`: calendar system to use for output/formatting when different from calculations (MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDate/withCalendar, https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/withCalendar).
- `mode`: `date | datetime | zoned`.
- `timezone` (zoned only): IANA ID like `Europe/Warsaw` or `UTC`.
- `disambiguation` (zoned only): `'compatible' | 'earlier' | 'later' | 'reject'` for DST gaps/overlaps (MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/toZonedDateTime, https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/from).
- `offset` (zoned only): `'use' | 'ignore' | 'reject' | 'prefer'` for offset ambiguity on parse (MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/from).
- `rounding` (zoned only): `{smallestUnit, roundingIncrement?, roundingMode?}` applied to zoned output (MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/round).
- `firstDayOfWeek`: overrides the locale-derived week start.
- `overflow`: `reject` throws on invalid dates, `constrain` clamps to the nearest valid date.

**Notes**
- `outputCalendar` uses `withCalendar` for display fields only; it does not re-resolve the instant, so `disambiguation`/`offset` are not applied during output conversion.
- If `disambiguation`, `offset`, or `rounding` aren’t provided, the adapter relies on Temporal’s defaults.
- `overflow` defaults to `reject` to avoid silent clamping and better match strict validation expectations.

### Split adapters
**`PlainTemporalAdapterOptions`** (for `PlainTemporalAdapter`)
- `mode` (default: `datetime`): `date` → `PlainDate`, `datetime` → `PlainDateTime`.
- `calendar` (default: `iso8601`): calendar system for calculations.
- `outputCalendar` (default: same as `calendar`): calendar system for output/formatting.
- `firstDayOfWeek` (default: locale-derived): overrides the locale-derived week start.
- `overflow` (default: `reject`): `reject` throws on invalid dates, `constrain` clamps.

**`ZonedDateTimeAdapterOptions`** (for `ZonedDateTimeAdapter`)
- `calendar` (default: `iso8601`): calendar system for calculations.
- `outputCalendar` (default: same as `calendar`): calendar system for output/formatting (MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/withCalendar).
- `timezone` (default: system timezone): IANA ID like `Europe/Warsaw` or `UTC`.
- `disambiguation`: `'compatible' | 'earlier' | 'later' | 'reject'` for DST gaps/overlaps (MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/toZonedDateTime, https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/from).
- `offset`: `'use' | 'ignore' | 'reject' | 'prefer'` for offset ambiguity on parse (MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/from).
- `rounding`: `{smallestUnit, roundingIncrement?, roundingMode?}` applied to zoned output (MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/round).
- `firstDayOfWeek` (default: locale-derived): overrides the locale-derived week start.
- `overflow` (default: `reject`): `reject` throws on invalid dates, `constrain` clamps.

## Examples
### Unified adapter option examples
- `calendar`
  ```ts
  provideTemporalDateAdapter({mode: 'date', calendar: 'japanese'});
  const value = Temporal.PlainDate.from('2024-01-15').withCalendar('japanese');
  // Output example: adapter.format(value, {year: 'numeric'}) -> (Japanese era year, locale-dependent)
  ```
  → display and calculations use the Japanese calendar.
- `outputCalendar`
  ```ts
  provideTemporalDateAdapter({mode: 'date', calendar: 'iso8601', outputCalendar: 'japanese'});
  const value = Temporal.PlainDate.from('2024-01-15');
  // Output example: adapter.format(value, {year: 'numeric'}) -> (Japanese era year, locale-dependent)
  ```
  → calculations use ISO, output uses the Japanese calendar.
- `mode`
  ```ts
  provideTemporalDateAdapter({mode: 'datetime'});
  const value = Temporal.PlainDateTime.from('2024-01-15T12:30');
  // Output examples:
  // mode: 'date'    -> adapter.toIso8601(value) -> 2024-01-15
  // mode: 'datetime'-> adapter.toIso8601(value) -> 2024-01-15
  // mode: 'zoned'   -> adapter.toIso8601(value) -> 2024-01-15T12:30:00+00:00[UTC]
  ```
  → values are `Temporal.PlainDateTime`.
- `timezone`
  ```ts
  provideTemporalDateAdapter({mode: 'zoned', timezone: 'UTC'});
  const value = Temporal.ZonedDateTime.from('2024-01-15T12:30[UTC]');
  // Output example: adapter.toIso8601(value) -> 2024-01-15T12:30:00+00:00[UTC]
  ```
  → zoned values in UTC.
- `disambiguation`
  ```ts
  provideTemporalDateAdapter({mode: 'zoned', timezone: 'America/New_York', disambiguation: 'later'});
  const value = Temporal.PlainDateTime.from('2024-11-03T01:05').toZonedDateTime('America/New_York', {
    disambiguation: 'later',
  });
  // Output examples (same local time):
  // compatible -> adapter.toIso8601(value) -> 2024-11-03T01:05:00-04:00[America/New_York]
  // earlier    -> adapter.toIso8601(value) -> 2024-11-03T01:05:00-04:00[America/New_York]
  // later      -> adapter.toIso8601(value) -> 2024-11-03T01:05:00-05:00[America/New_York]
  // reject     -> adapter.setTime(...) throws for ambiguous/nonexistent time
  ```
  → ambiguous times choose the later instant.
- `offset`
  ```ts
  provideTemporalDateAdapter({mode: 'zoned', offset: 'ignore'});
  const value = Temporal.ZonedDateTime.from('2019-12-23T12:00:00-02:00[America/Sao_Paulo]', {
    offset: 'ignore',
  });
  // Output examples (same input string):
  // use    -> adapter.toIso8601(value) -> 2019-12-23T11:00:00-03:00[America/Sao_Paulo]
  // ignore -> adapter.toIso8601(value) -> 2019-12-23T12:00:00-03:00[America/Sao_Paulo]
  // prefer -> adapter.toIso8601(value) -> 2019-12-23T12:00:00-03:00[America/Sao_Paulo]
  // reject -> adapter.deserialize(...) -> invalid
  ```
  → keep local time when offset conflicts with zone on parse.
- `rounding`
  ```ts
  provideTemporalDateAdapter({mode: 'zoned', rounding: {smallestUnit: 'minute', roundingIncrement: 5}});
  const value = Temporal.ZonedDateTime.from('2024-01-15T12:34:56[UTC]');
  // Output examples (roundingMode):
  // halfExpand -> adapter.toIso8601(value) -> 2024-01-15T12:35:00+00:00[UTC]
  // floor      -> adapter.toIso8601(value) -> 2024-01-15T12:30:00+00:00[UTC]
  // ceil       -> adapter.toIso8601(value) -> 2024-01-15T12:35:00+00:00[UTC]
  // trunc      -> adapter.toIso8601(value) -> 2024-01-15T12:30:00+00:00[UTC]
  ```
  → outputs rounded to 5-minute steps.
- `firstDayOfWeek`
  ```ts
  provideTemporalDateAdapter({firstDayOfWeek: 1});
  // Output example: adapter.getFirstDayOfWeek() -> 1
  ```
  → weeks start on Monday.
- `overflow`
  ```ts
  provideTemporalDateAdapter({overflow: 'reject'});
  // Output example (reject): adapter.createDate(2024, 1, 31) -> throws
  provideTemporalDateAdapter({overflow: 'constrain'});
  // Output example (constrain): adapter.createDate(2024, 1, 31) -> 2024-02-29
  ```
  → invalid dates throw; invalid dates clamp.

**Form control example (overflow)**
```ts
provideTemporalDateAdapter({mode: 'date', overflow: 'constrain'});
const control = new FormControl(Temporal.PlainDate.from({year: 2024, month: 2, day: 31}));
```
Effect: the value is clamped to the last valid day of the month (e.g. 2024-02-29) instead of throwing.

### Split adapter option examples
```ts
providePlainTemporalAdapter({mode: 'date', calendar: 'iso8601', outputCalendar: 'japanese'});
provideZonedDateTimeAdapter({timezone: 'UTC', disambiguation: 'reject', rounding: {smallestUnit: 'minute'}});
```

## Usage examples
```ts
import {provideTemporalDateAdapter} from '@angular/material-temporal-adapter';

provideTemporalDateAdapter({mode: 'date'});
provideTemporalDateAdapter({mode: 'datetime'});
provideTemporalDateAdapter({mode: 'zoned'}); // default: system timezone
provideTemporalDateAdapter({mode: 'zoned', timezone: 'UTC'});
```

```ts
import {
  providePlainTemporalAdapter,
  provideZonedDateTimeAdapter,
} from '@angular/material-temporal-adapter/adapter/split';

providePlainTemporalAdapter({mode: 'date'});
providePlainTemporalAdapter({mode: 'datetime'});
provideZonedDateTimeAdapter({timezone: 'Europe/Warsaw'});
```

## Migration patterns
- **From `NativeDateAdapter` (`Date`)**: switch to `mode: 'date'`, replace `Date` with `Temporal.PlainDate`. If you rely on timezone/time-of-day behavior, use `mode: 'zoned'` with the system timezone instead.
- **From `MomentDateAdapter`/`LuxonDateAdapter` (date+time)**: use `mode: 'datetime'`, replace values with `Temporal.PlainDateTime`.
- **From timezone-aware usage**: use `mode: 'zoned'` + `timezone`, replace values with `Temporal.ZonedDateTime`.
- **From Luxon `defaultOutputCalendar`**: keep `calendar` for calculations, set `outputCalendar` for display.
- **From apps relying on DST/offset rules or rounding**: configure `disambiguation`, `offset`, and `rounding` in `zoned` mode.
- **Incremental/explicit type choice**: use split adapters (`PlainTemporalAdapter` or `ZonedDateTimeAdapter`).
- If a Temporal polyfill is needed, load it before bootstrapping the app.
- If you provide custom `MAT_DATE_FORMATS`, ensure they are `Intl.DateTimeFormatOptions` (Temporal ignores parse formats and parses ISO strings only).

**Custom display formats**
```ts
import {MatDateFormats} from '@angular/material/core';
import {provideTemporalDateAdapter, MAT_TEMPORAL_DATE_FORMATS} from '@angular/material-temporal-adapter';

const MY_TEMPORAL_FORMATS = {
  ...MAT_TEMPORAL_DATE_FORMATS,
  display: {
    ...MAT_TEMPORAL_DATE_FORMATS.display,
    dateInput: {year: 'numeric', month: 'long', day: 'numeric'},
  },
} satisfies MatDateFormats;

bootstrapApplication(AppComponent, {
  providers: [provideTemporalDateAdapter(MY_TEMPORAL_FORMATS, {mode: 'date'})],
});
```

**MAT token notes**
- `MAT_DATE_LOCALE`: locale string used for formatting and week info.
- `MAT_DATE_FORMATS`: must be `Intl.DateTimeFormatOptions` (parse formats ignored).

## Comparison and mapping
- Follows the same `DateAdapter` contract as `NativeDateAdapter`, `MomentDateAdapter`, `LuxonDateAdapter`, and `DateFnsAdapter`.
- Uses `Intl.DateTimeFormatOptions` for display formatting (like `NativeDateAdapter`), but the backing values are Temporal types instead of `Date`.

**Option mapping (approximate)**
| Existing adapter | Option | Temporal equivalent | Notes |
| --- | --- | --- | --- |
| NativeDateAdapter | n/a | `mode: 'date'` | Temporal `PlainDate` is the closest analogue to `Date` for date-only use. |
| MomentDateAdapter | `useUtc: true` | `mode: 'zoned', timezone: 'UTC'` | Use zoned+UTC for UTC-centric workflows. |
| MomentDateAdapter | `strict: true` | `overflow: 'reject'` | Temporal parsing is ISO-only; `overflow` controls invalid date creation. |
| LuxonDateAdapter | `useUtc: true` | `mode: 'zoned', timezone: 'UTC'` | Similar UTC behavior. |
| LuxonDateAdapter | `firstDayOfWeek` | `firstDayOfWeek` | Same semantics. |
| LuxonDateAdapter | `defaultOutputCalendar` | `outputCalendar` | Calendar used for output/formatting (calculations use `calendar`). |
| DateFnsAdapter | n/a | `MAT_DATE_LOCALE` + `MAT_DATE_FORMATS` | Temporal adapter also uses locale + formats. |

## Notable design choices / dilemmas (with resolution)
### 1) Temporal typings source (TypeScript not shipping them yet)
TypeScript does not currently ship `lib.esnext.temporal` in the version used here, so this PR includes local declarations to type the adapter until the repo upgrades to a TS version that includes Temporal libs.

Reference: https://github.com/microsoft/TypeScript/pull/62628

### 2) API Extractor goldens
API Extractor had trouble resolving the global `Temporal` namespace in this setup. Additionally, existing adapter packages (moment/luxon/date-fns) don’t have API goldens. For consistency and to avoid introducing a blocked/flaky step, this PR does not add API golden coverage for this adapter package.

### 3) Formatting implementation note
`Intl.DateTimeFormat` is used for localization (same overall approach as other adapters). Zoned values are formatted using the configured timezone.

## Tests
- Unit tests cover all `mode` variants and timezone behavior, plus creation/parsing/formatting/time operations.
- Latest run: `pnpm test src/material-temporal-adapter --no-watch` on Chromium (local).
  - Result: 141 passed, 2 skipped (Islamic calendar suite skipped because `islamic` calendar is not supported by the current Temporal implementation).
- Note: split adapters (`PlainTemporalAdapter`, `ZonedDateTimeAdapter`) are not explicitly covered by a dedicated spec yet.

## Open questions (feedback requested)
1) Calendar type: keep `calendar` as `string` (max flexibility) vs trying to constrain it (risk of being incomplete/locale-dependent).
2) Positioning: should this adapter be documented as “ready” like other adapters, or called out as “early” given current ecosystem support for Temporal?
3) Should `mode` be required for the unified adapter (no implicit default), or keep the default `date` mode?
4) Should `overflow` default to `reject` (strict) or align with Temporal’s `constrain` default?
5) Should we add migration examples to the public docs (datepicker/timepicker) instead of only in the PR description?