### PR TITLE
fix(cdk/table): remove string-based DI tokens

### DIFF
--- a/goldens/material/sort/index.api.md
+++ b/goldens/material/sort/index.api.md
@@ -81,16 +81,12 @@ export class MatSortHeader implements MatSortable, OnDestroy, OnInit, AfterViewI
     // (undocumented)
     protected _animationsDisabled: boolean;
     arrowPosition: SortHeaderArrowPosition;
-    // (undocumented)
-    _columnDef: MatSortHeaderColumnDef | null;
     disableClear: boolean;
     disabled: boolean;
     _getAriaSortAttribute(): "none" | "ascending" | "descending";
     // (undocumented)
     _handleKeydown(event: KeyboardEvent): void;
     id: string;
-    // (undocumented)
-    _intl: MatSortHeaderIntl;
     // (undocumented)
     _isDisabled(): boolean;
     _isSorted(): boolean;
@@ -107,7 +103,7 @@ export class MatSortHeader implements MatSortable, OnDestroy, OnInit, AfterViewI
     protected _recentlyCleared: i0.WritableSignal<SortDirection | null>;
     _renderArrow(): boolean;
     // (undocumented)
-    _sort: MatSort;
+    protected _sort: MatSort;
     get sortActionDescription(): string;
     set sortActionDescription(value: string);
     start: SortDirection;

--- a/src/cdk/table/cell.ts
+++ b/src/cdk/table/cell.ts
@@ -72,10 +72,7 @@ export class CdkFooterCellDef implements CellDef {
  * Column definition for the CDK table.
  * Defines a set of cells available for a table column.
  */
-@Directive({
-  selector: '[cdkColumnDef]',
-  providers: [{provide: 'MAT_SORT_HEADER_COLUMN_DEF', useExisting: CdkColumnDef}],
-})
+@Directive({selector: '[cdkColumnDef]'})
 export class CdkColumnDef implements CanStick {
   _table? = inject(CDK_TABLE, {optional: true});
 

--- a/src/material/sort/BUILD.bazel
+++ b/src/material/sort/BUILD.bazel
@@ -82,6 +82,7 @@ ng_project(
         "//src:dev_mode_types",
         "//src/cdk/a11y",
         "//src/cdk/keycodes",
+        "//src/cdk/table",
         "//src/material/core",
     ],
 )

--- a/src/material/sort/sort-header.ts
+++ b/src/material/sort/sort-header.ts
@@ -22,6 +22,8 @@ import {
   signal,
   ChangeDetectorRef,
 } from '@angular/core';
+import {_CdkPrivateStyleLoader} from '@angular/cdk/private';
+import {CdkColumnDef} from '@angular/cdk/table';
 import {merge, Subscription} from 'rxjs';
 import {
   MAT_SORT_DEFAULT_OPTIONS,
@@ -32,8 +34,6 @@ import {
 } from './sort';
 import {SortDirection} from './sort-direction';
 import {getSortHeaderNotContainedWithinSortError} from './sort-errors';
-import {MatSortHeaderIntl} from './sort-header-intl';
-import {_CdkPrivateStyleLoader} from '@angular/cdk/private';
 import {_animationsDisabled, _StructuralStylesLoader} from '../core';
 
 /**
@@ -58,11 +58,6 @@ export type ArrowViewState = SortDirection | 'hint' | 'active';
 export interface ArrowViewStateTransition {
   fromState?: ArrowViewState;
   toState?: ArrowViewState;
-}
-
-/** Column definition associated with a `MatSortHeader`. */
-interface MatSortHeaderColumnDef {
-  name: string;
 }
 
 /**
@@ -91,11 +86,8 @@ interface MatSortHeaderColumnDef {
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MatSortHeader implements MatSortable, OnDestroy, OnInit, AfterViewInit {
-  _intl = inject(MatSortHeaderIntl);
-  _sort = inject(MatSort, {optional: true})!;
-  _columnDef = inject<MatSortHeaderColumnDef>('MAT_SORT_HEADER_COLUMN_DEF' as any, {
-    optional: true,
-  });
+  protected _sort = inject(MatSort, {optional: true})!;
+  private _columnDef = inject(CdkColumnDef, {optional: true});
   private _changeDetectorRef = inject(ChangeDetectorRef);
   private _focusMonitor = inject(FocusMonitor);
   private _elementRef = inject<ElementRef<HTMLElement>>(ElementRef);

--- a/src/material/table/cell.ts
+++ b/src/material/table/cell.ts
@@ -53,10 +53,7 @@ export class MatFooterCellDef extends CdkFooterCellDef {}
  */
 @Directive({
   selector: '[matColumnDef]',
-  providers: [
-    {provide: CdkColumnDef, useExisting: MatColumnDef},
-    {provide: 'MAT_SORT_HEADER_COLUMN_DEF', useExisting: MatColumnDef},
-  ],
+  providers: [{provide: CdkColumnDef, useExisting: MatColumnDef}],
 })
 export class MatColumnDef extends CdkColumnDef {
   /** Unique name for this column. */


### PR DESCRIPTION
String-based DI was accidentally supported, but since the introduction of the `inject` function it isn't supported officially in the types anymore. These changes remove our only usage so we don't get broken if support is removed in the future.