### PR TITLE
fix(cdk/table): throw when multiple row templates are used with virtual scrolling

### DIFF
--- a/src/cdk/table/table.md
+++ b/src/cdk/table/table.md
@@ -173,6 +173,10 @@ If you're showing a large amount of data in your table, you can use virtual scro
 smooth experience for the user. To enable virtual scrolling, you have to wrap the CDK table in a
 `cdk-virtual-scroll-viewport` element and add some CSS to make it scrollable.
 
+**Note:** tables with virtual scrolling have the following limitations:
+* `fixedLayout` is always enabled, in order to prevent jumping when rows are swapped out.
+* Conditional templates via the `when` input are [not supported at the moment](https://github.com/angular/components/issues/32670).
+
 <!-- example(cdk-table-virtual-scroll) -->
 
 ### Alternate HTML to using native table

--- a/src/material/table/table.md
+++ b/src/material/table/table.md
@@ -183,6 +183,10 @@ virtual scrolling which will only render the the visible rows in the DOM as the 
 To enable virtual scrolling you have to wrap the Material table in a `<cdk-virtual-scroll-viewport>`
 element and add CSS to make the viewport scrollable.
 
+**Note:** tables with virtual scrolling have the following limitations:
+* `fixedLayout` is always enabled, in order to prevent jumping when rows are swapped out.
+* Conditional templates via the `when` input are [not supported at the moment](https://github.com/angular/components/issues/32670).
+
 <!-- example(table-virtual-scroll) -->
 
 #### Sorting


### PR DESCRIPTION
Since we reuse rows when virtual scrolling is enabled, supporting multiple row templates is tricky. These changes throw an error and update the docs.