### PR TITLE
build: remove deprecated compiler option

### DIFF
--- a/docs/src/assets/stackblitz/tsconfig.json
+++ b/docs/src/assets/stackblitz/tsconfig.json
@@ -2,7 +2,6 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
-    "baseUrl": "./",
     "outDir": "./dist/out-tsc",
     "sourceMap": true,
     "declaration": false,

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
-    "baseUrl": "./",
     "outDir": "../dist/out-tsc",
     "forceConsistentCasingInFileNames": true,
     "allowSyntheticDefaultImports": true,

--- a/integration/ng-add-standalone/tsconfig.json
+++ b/integration/ng-add-standalone/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
-    "baseUrl": "./",
     "outDir": "./dist/out-tsc",
     "forceConsistentCasingInFileNames": true,
     "strict": true,

--- a/integration/ng-add/tsconfig.json
+++ b/integration/ng-add/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
-    "baseUrl": "./",
     "outDir": "./dist/out-tsc",
     "forceConsistentCasingInFileNames": true,
     "strict": true,

--- a/integration/yarn-pnp-compat/tsconfig.json
+++ b/integration/yarn-pnp-compat/tsconfig.json
@@ -2,7 +2,6 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
-    "baseUrl": "./",
     "outDir": "./dist/out-tsc",
     "forceConsistentCasingInFileNames": true,
     "strict": true,

--- a/src/aria/tsconfig.json
+++ b/src/aria/tsconfig.json
@@ -3,7 +3,6 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "..",
-    "baseUrl": ".",
     "paths": {
       "@angular/cdk/*": ["../cdk/*"],
       "@angular/aria/*": ["../aria/*"]

--- a/src/bazel-tsconfig-build.json
+++ b/src/bazel-tsconfig-build.json
@@ -3,7 +3,6 @@
 // used by Bazel to build the sources for an entry-point.
 {
   "compilerOptions": {
-    "baseUrl": ".",
     "declaration": true,
     "stripInternal": false,
     "experimentalDecorators": true,

--- a/src/cdk-experimental/tsconfig.json
+++ b/src/cdk-experimental/tsconfig.json
@@ -3,7 +3,6 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "..",
-    "baseUrl": ".",
     "paths": {
       "@angular/cdk/*": ["../cdk/*"],
       "@angular/cdk-experimental/*": ["../cdk-experimental/*"]

--- a/src/cdk/tsconfig.json
+++ b/src/cdk/tsconfig.json
@@ -3,7 +3,6 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "..",
-    "baseUrl": ".",
     "paths": {
       "@angular/cdk/*": ["./*"]
     }

--- a/src/components-examples/tsconfig.json
+++ b/src/components-examples/tsconfig.json
@@ -3,7 +3,6 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "..",
-    "baseUrl": ".",
     "paths": {
       "@angular/aria/*": ["../aria/*"],
       "@angular/cdk/*": ["../cdk/*"],

--- a/src/dev-app/tsconfig.json
+++ b/src/dev-app/tsconfig.json
@@ -4,7 +4,6 @@
   "compilerOptions": {
     // Needed for Moment.js since it doesn't have a default export.
     "rootDir": "..",
-    "baseUrl": ".",
     "paths": {
       "@angular/aria": ["../aria"],
       "@angular/aria/*": ["../aria/*"],

--- a/src/e2e-app/tsconfig.json
+++ b/src/e2e-app/tsconfig.json
@@ -3,7 +3,6 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "..",
-    "baseUrl": ".",
     "paths": {
       "@angular/cdk/*": ["../cdk/*"],
       "@angular/material/*": ["../material/*"],

--- a/src/google-maps/tsconfig.json
+++ b/src/google-maps/tsconfig.json
@@ -3,7 +3,6 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "..",
-    "baseUrl": ".",
     "paths": {},
     "types": ["jasmine", "google.maps"]
   },

--- a/src/material-date-fns-adapter/tsconfig.json
+++ b/src/material-date-fns-adapter/tsconfig.json
@@ -3,7 +3,6 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "..",
-    "baseUrl": ".",
     "paths": {
       "@angular/cdk/*": ["../cdk/*"],
       "@angular/material/*": ["../material/*"],

--- a/src/material-experimental/tsconfig.json
+++ b/src/material-experimental/tsconfig.json
@@ -3,7 +3,6 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "..",
-    "baseUrl": ".",
     "paths": {
       "@angular/cdk/*": ["../cdk/*"],
       "@angular/material/*": ["../material/*"],

--- a/src/material-luxon-adapter/tsconfig.json
+++ b/src/material-luxon-adapter/tsconfig.json
@@ -3,7 +3,6 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "..",
-    "baseUrl": ".",
     "paths": {
       "@angular/cdk/*": ["../cdk/*"],
       "@angular/material/*": ["../material/*"],

--- a/src/material-moment-adapter/tsconfig.json
+++ b/src/material-moment-adapter/tsconfig.json
@@ -3,7 +3,6 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "..",
-    "baseUrl": ".",
     "paths": {
       "@angular/cdk/*": ["../cdk/*"],
       "@angular/material/*": ["../material/*"],

--- a/src/material/tsconfig.json
+++ b/src/material/tsconfig.json
@@ -3,7 +3,6 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "rootDirs": ["..", "../../tools"],
-    "baseUrl": ".",
     "paths": {
       "@angular/cdk": ["../cdk"],
       "@angular/cdk/*": ["../cdk/*"],

--- a/src/youtube-player/tsconfig.json
+++ b/src/youtube-player/tsconfig.json
@@ -3,7 +3,6 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "..",
-    "baseUrl": ".",
     "paths": {},
     "types": ["jasmine"]
   },

--- a/tools/dgeni/bazel-bin.ts
+++ b/tools/dgeni/bazel-bin.ts
@@ -84,10 +84,6 @@ if (require.main === module) {
       });
     }
 
-    // Base URL for the `tsParser`. The base URL refer to the directory that includes all
-    // package sources that need to be processed by Dgeni.
-    tsParser.options.baseUrl = packagePath;
-
     // This is ensures that the Dgeni TypeScript processor is able to parse node modules such
     // as the Angular packages which might be needed for doc items. e.g. if a class implements
     // the "AfterViewInit" interface from "@angular/core". This needs to be relative to the

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,7 +24,6 @@
     "target": "es2022",
     "lib": ["es2020", "dom"],
     "types": ["jasmine"],
-    "baseUrl": ".",
     "paths": {
       "@angular/aria": ["./src/aria"],
       "@angular/aria/*": ["./src/aria/*"],


### PR DESCRIPTION
Removes the `baseUrl` option from the various configs since it's deprecated and will trigger an error in TypeScript 6.