### PR TITLE
feat(material/dialog): support string and HTMLElement for restoreFocus

### DIFF
--- a/goldens/material/dialog/index.api.md
+++ b/goldens/material/dialog/index.api.md
@@ -143,7 +143,7 @@ export class MatDialogConfig<D = any> {
     minWidth?: number | string;
     panelClass?: string | string[];
     position?: DialogPosition;
-    restoreFocus?: boolean;
+    restoreFocus?: boolean | string | HTMLElement;
     role?: DialogRole;
     scrollStrategy?: ScrollStrategy;
     viewContainerRef?: ViewContainerRef;

--- a/src/material/dialog/dialog-config.ts
+++ b/src/material/dialog/dialog-config.ts
@@ -130,10 +130,14 @@ export class MatDialogConfig<D = any> {
   autoFocus?: AutoFocusTarget | string | boolean = 'first-tabbable';
 
   /**
-   * Whether the dialog should restore focus to the
-   * previously-focused element, after it's closed.
+   * Whether the dialog should restore focus to the previously-focused element upon closing.
+   * Has the following behavior based on the type that is passed in:
+   * - `boolean` - when true, will return focus to the element that was focused before the dialog
+   *    was opened, otherwise won't restore focus at all.
+   * - `string` - focus will be restored to the first element that matches the CSS selector.
+   * - `HTMLElement` - focus will be restored to the specific element.
    */
-  restoreFocus?: boolean = true;
+  restoreFocus?: boolean | string | HTMLElement = true;
 
   /** Whether to wait for the opening animation to finish before trapping focus. */
   delayFocusTrap?: boolean = true;


### PR DESCRIPTION
Aligns MatDialogConfig.restoreFocus with the CDK DialogConfig to allow specifying a CSS selector or HTMLElement to restore focus to when the dialog closes.