### PR TITLE
fix(cdk/listbox): incorrect wording in error message

### DIFF
--- a/src/cdk/listbox/listbox.spec.ts
+++ b/src/cdk/listbox/listbox.spec.ts
@@ -926,7 +926,7 @@ describe('CdkOption and CdkListbox', () => {
       expect(() => {
         testComponent.formControl.setValue(['orange', 'banana']);
         fixture.detectChanges();
-      }).toThrowError('Listbox cannot have more than one selected value in multi-selection mode.');
+      }).toThrowError('Listbox cannot have more than one selected value in single selection mode.');
     });
 
     it('should throw when an invalid value is selected', () => {

--- a/src/cdk/listbox/listbox.ts
+++ b/src/cdk/listbox/listbox.ts
@@ -1018,7 +1018,7 @@ export class CdkListbox<T = unknown> implements AfterContentInit, OnDestroy, Con
       const invalidValues = this._getInvalidOptionValues(selected);
 
       if (!this.multiple && selected.length > 1) {
-        throw Error('Listbox cannot have more than one selected value in multi-selection mode.');
+        throw Error('Listbox cannot have more than one selected value in single selection mode.');
       }
 
       if (invalidValues.length) {


### PR DESCRIPTION
Fixes some incorrect wording in an error thrown by the CDK listbox.

Fixes #32643.