### PR TITLE
docs(cdk/menu): fix typo in menu-trigger comment

### DIFF
--- a/src/cdk/menu/menu-trigger.ts
+++ b/src/cdk/menu/menu-trigger.ts
@@ -373,7 +373,7 @@ export class CdkMenuTrigger extends CdkMenuTriggerBase implements OnChanges, OnD
     }
   }
 
-  /** Sets thte `type` attribute of the trigger. */
+  /** Sets the `type` attribute of the trigger. */
   private _setType() {
     const element = this._elementRef.nativeElement;
 


### PR DESCRIPTION
## Summary
- Fix typo "thte" → "the" in `_setType` method documentation

## Test plan
- No tests needed (documentation change only)

