### PR TITLE
docs(material/datepicker): fix typo in aria-accessible-name comment

### DIFF
--- a/src/material/datepicker/aria-accessible-name.ts
+++ b/src/material/datepicker/aria-accessible-name.ts
@@ -70,7 +70,7 @@ function ssrSafeIsElement(node: Node): node is Element {
 }
 
 /**
- * Determine if argument node is an HTMLInputElement based on `nodeName` property. This funciton is
+ * Determine if argument node is an HTMLInputElement based on `nodeName` property. This function is
  * safe to use with server-side rendering.
  */
 function ssrSafeIsHTMLInputElement(node: Node): node is HTMLInputElement {


### PR DESCRIPTION
## Summary
- Fix typo "funciton" → "function" in ssrSafeIsHTMLInputElement documentation

## Test plan
- No tests needed (documentation change only)
