### PR TITLE
perf(aria/grid): avoid excessive change detections

### DIFF
--- a/goldens/aria/grid/index.api.md
+++ b/goldens/aria/grid/index.api.md
@@ -67,8 +67,8 @@ export class GridCellWidget {
     readonly focusTarget: _angular_core.InputSignal<ElementRef<any> | HTMLElement | undefined>;
     readonly id: _angular_core.InputSignal<string>;
     get isActivated(): Signal<boolean>;
-    readonly onActivate: _angular_core.OutputEmitterRef<KeyboardEvent | FocusEvent | undefined>;
-    readonly onDeactivate: _angular_core.OutputEmitterRef<KeyboardEvent | FocusEvent | undefined>;
+    readonly onActivate: _angular_core.OutputEmitterRef<FocusEvent | KeyboardEvent | undefined>;
+    readonly onDeactivate: _angular_core.OutputEmitterRef<FocusEvent | KeyboardEvent | undefined>;
     readonly _pattern: GridCellWidgetPattern;
     protected readonly _tabIndex: Signal<number>;
     readonly tabindex: _angular_core.InputSignal<number | undefined>;

--- a/goldens/aria/private/index.api.md
+++ b/goldens/aria/private/index.api.md
@@ -407,6 +407,7 @@ export interface GridInputs extends Omit<GridInputs$1<GridCellPattern>, 'cells'>
 // @public
 export class GridPattern {
     constructor(inputs: GridInputs);
+    readonly acceptsPointerMove: SignalLike<boolean>;
     readonly activeCell: SignalLike<GridCellPattern | undefined>;
     readonly activeDescendant: SignalLike<string | undefined>;
     readonly anchorCell: SignalLike<GridCellPattern | undefined>;

--- a/src/aria/private/grid/grid.ts
+++ b/src/aria/private/grid/grid.ts
@@ -93,6 +93,16 @@ export class GridPattern {
     this.inputs.textDirection() === 'rtl' ? 'ArrowLeft' : 'ArrowRight',
   );
 
+  /** Whether the grid pattern is currently accepting `pointermove` events. */
+  readonly acceptsPointerMove = computed(() => {
+    return (
+      !this.disabled() &&
+      this.inputs.enableSelection() &&
+      this.inputs.enableRangeSelection() &&
+      this.dragging()
+    );
+  });
+
   /** The keydown event manager for the grid. */
   readonly keydown = computed(() => {
     const manager = new KeyboardEventManager();
@@ -252,20 +262,13 @@ export class GridPattern {
 
   /** Handles pointermove events on the grid. */
   onPointermove(event: PointerEvent) {
-    if (
-      this.disabled() ||
-      !this.inputs.enableSelection() ||
-      !this.inputs.enableRangeSelection() ||
-      !this.dragging()
-    ) {
-      return;
-    }
+    if (this.acceptsPointerMove()) {
+      const cell = this.inputs.getCell(event.target as Element);
 
-    const cell = this.inputs.getCell(event.target as Element);
-
-    // Dragging anchor.
-    if (cell !== undefined) {
-      this.gridBehavior.gotoCell(cell, {anchor: true});
+      // Dragging anchor.
+      if (cell !== undefined) {
+        this.gridBehavior.gotoCell(cell, {anchor: true});
+      }
     }
   }
 


### PR DESCRIPTION
Fixes that the grid was running change detection on `pointermove` events even when the user isn't dragging to select cells.

Fixes #32700.