### PR TITLE
fix(aria/combobox): Add announcement for empty results to autocomplete demo

### DIFF
--- a/src/components-examples/aria/autocomplete/autocomplete-auto-select/autocomplete-auto-select-example.html
+++ b/src/components-examples/aria/autocomplete/autocomplete-auto-select/autocomplete-auto-select-example.html
@@ -17,6 +17,10 @@
     </button>
   </div>
 
+  <div class="cdk-visually-hidden"[cdkAriaLive]="'polite'">
+    {{countries().length === 0 ? 'No results found' : ''}}
+  </div>
+
   <ng-template ngComboboxPopupContainer>
     <ng-template
       [cdkConnectedOverlay]="{origin, usePopover: 'inline', matchWidth: true}"

--- a/src/components-examples/aria/autocomplete/autocomplete-auto-select/autocomplete-auto-select-example.ts
+++ b/src/components-examples/aria/autocomplete/autocomplete-auto-select/autocomplete-auto-select-example.ts
@@ -23,6 +23,7 @@ import {
   viewChildren,
 } from '@angular/core';
 import {COUNTRIES} from '../countries';
+import {CdkAriaLive} from '@angular/cdk/a11y';
 import {OverlayModule} from '@angular/cdk/overlay';
 import {FormsModule} from '@angular/forms';
 
@@ -32,6 +33,7 @@ import {FormsModule} from '@angular/forms';
   templateUrl: 'autocomplete-auto-select-example.html',
   styleUrl: '../autocomplete.css',
   imports: [
+    CdkAriaLive,
     Combobox,
     ComboboxInput,
     ComboboxPopup,


### PR DESCRIPTION
Show how to incorporate an announcement with cdkAriaLive in the autocomplete example.