### PR TITLE
fix(aria/toolbar): show outline on selected items when forced colors active in examples

### DIFF
--- a/src/components-examples/aria/toolbar/toolbar-common.css
+++ b/src/components-examples/aria/toolbar/toolbar-common.css
@@ -185,3 +185,11 @@
 .example-option[aria-selected='false'] .example-option-icon {
   visibility: hidden;
 }
+
+@media (forced-colors: active) {
+  .example-button[aria-pressed='true'],
+  .example-button[aria-checked='true'],
+  .example-option[aria-selected='true'] {
+    outline: solid 2px;
+  }
+}


### PR DESCRIPTION
Add additional styling when forced colors is active to show an extra outline in the toolbar examples.