### PR TITLE
fix(aria/menu): Add label property for proper aria-label

### DIFF
--- a/src/aria/menu/menu-item.ts
+++ b/src/aria/menu/menu-item.ts
@@ -38,6 +38,7 @@ import type {MenuBar} from './menu-bar';
     '(focusin)': '_pattern.onFocusIn()',
     '[attr.tabindex]': '_pattern.tabIndex()',
     '[attr.data-active]': 'active()',
+    '[attr.aria-label]': 'value()',
     '[attr.aria-haspopup]': 'hasPopup()',
     '[attr.aria-expanded]': 'expanded()',
     '[attr.aria-disabled]': '_pattern.disabled()',
@@ -54,7 +55,7 @@ export class MenuItem<V> {
   /** The unique ID of the menu item. */
   readonly id = input(inject(_IdGenerator).getId('ng-menu-item-', true));
 
-  /** The value of the menu item. */
+  /** The value of the menu item, used as the default aria-label */
   readonly value = input.required<V>();
 
   /** Whether the menu item is disabled. */


### PR DESCRIPTION
Without an explicit aria-label set on the menu item, screen readers will just concatenate the text contents of the inner elements, which can result in a confusing announcement including the label as well as other secondary content like icon names.

Instead, setting the aria-label (to a specified label or else defaulting to the value) will result in a proper announcement.