### PR TITLE
fix(aria/combobox): fix autocomplete examples and add comments explaining combobox selection behavior

### DIFF
--- a/src/aria/private/combobox/combobox.ts
+++ b/src/aria/private/combobox/combobox.ts
@@ -641,8 +641,11 @@ export class ComboboxPattern<T extends ListItem<V>, V> {
   select(opts: {item?: T; commit?: boolean; close?: boolean} = {}) {
     const controls = this.listControls();
 
+    // When no item is specified (e.g. on keyboard toggle), get the active item instead.
+    // Note: this is only necessary for disabled check, as select/toggle will check active item too.
     const item = opts.item ?? controls?.getActiveItem();
 
+    // Check if item is disabled before proceeding.
     if (item?.disabled()) {
       return;
     }

--- a/src/components-examples/aria/autocomplete/autocomplete-auto-select/autocomplete-auto-select-example.html
+++ b/src/components-examples/aria/autocomplete/autocomplete-auto-select/autocomplete-auto-select-example.html
@@ -4,7 +4,6 @@
     <input
       aria-label="Label dropdown"
       placeholder="Select a country"
-      [(ngModel)]="query"
       ngComboboxInput
     />
     <button

--- a/src/components-examples/aria/autocomplete/autocomplete-auto-select/autocomplete-auto-select-example.ts
+++ b/src/components-examples/aria/autocomplete/autocomplete-auto-select/autocomplete-auto-select-example.ts
@@ -18,7 +18,6 @@ import {
   ChangeDetectionStrategy,
   Component,
   computed,
-  signal,
   viewChild,
   viewChildren,
 } from '@angular/core';
@@ -55,8 +54,11 @@ export class AutocompleteAutoSelectExample {
   /** A reference to the ng aria combobox. */
   combobox = viewChild<Combobox<string>>(Combobox);
 
+  /** A reference to the ng aria combobox input. */
+  comboboxInput = viewChild<ComboboxInput>(ComboboxInput);
+
   /** The query string used to filter the list of countries. */
-  query = signal('');
+  query = computed(() => this.comboboxInput()?.value() || '');
 
   /** The list of countries filtered by the query. */
   countries = computed(() =>
@@ -75,7 +77,7 @@ export class AutocompleteAutoSelectExample {
 
   /** Clears the query and the listbox value. */
   clear(): void {
-    this.query.set('');
+    this.comboboxInput()?.value.set('');
     this.listbox?.()?.values.set([]);
   }
 

--- a/src/components-examples/aria/autocomplete/autocomplete-disabled/autocomplete-disabled-example.html
+++ b/src/components-examples/aria/autocomplete/autocomplete-disabled/autocomplete-disabled-example.html
@@ -4,7 +4,6 @@
     <input
       aria-label="Label dropdown"
       placeholder="Select a country"
-      [(ngModel)]="query"
       ngComboboxInput
     />
   </div>

--- a/src/components-examples/aria/autocomplete/autocomplete-highlight/autocomplete-highlight-example.html
+++ b/src/components-examples/aria/autocomplete/autocomplete-highlight/autocomplete-highlight-example.html
@@ -4,7 +4,6 @@
     <input
       aria-label="Label dropdown"
       placeholder="Select a country"
-      [(ngModel)]="query"
       ngComboboxInput
     />
     <button

--- a/src/components-examples/aria/autocomplete/autocomplete-highlight/autocomplete-highlight-example.ts
+++ b/src/components-examples/aria/autocomplete/autocomplete-highlight/autocomplete-highlight-example.ts
@@ -18,7 +18,6 @@ import {
   ChangeDetectionStrategy,
   Component,
   computed,
-  signal,
   viewChild,
   viewChildren,
 } from '@angular/core';
@@ -53,8 +52,11 @@ export class AutocompleteHighlightExample {
   /** A reference to the ng aria combobox. */
   combobox = viewChild<Combobox<string>>(Combobox);
 
+  /** A reference to the ng aria combobox input. */
+  comboboxInput = viewChild<ComboboxInput>(ComboboxInput);
+
   /** The query string used to filter the list of countries. */
-  query = signal('');
+  query = computed(() => this.comboboxInput()?.value() || '');
 
   /** The list of countries filtered by the query. */
   countries = computed(() =>
@@ -73,7 +75,7 @@ export class AutocompleteHighlightExample {
 
   /** Clears the query and the listbox value. */
   clear(): void {
-    this.query.set('');
+    this.comboboxInput()?.value.set('');
     this.listbox?.()?.values.set([]);
   }
 

--- a/src/components-examples/aria/autocomplete/autocomplete-manual/autocomplete-manual-example.html
+++ b/src/components-examples/aria/autocomplete/autocomplete-manual/autocomplete-manual-example.html
@@ -4,7 +4,6 @@
     <input
       aria-label="Label dropdown"
       placeholder="Select a country"
-      [(ngModel)]="query"
       ngComboboxInput
     />
     <button

--- a/src/components-examples/aria/autocomplete/autocomplete-manual/autocomplete-manual-example.ts
+++ b/src/components-examples/aria/autocomplete/autocomplete-manual/autocomplete-manual-example.ts
@@ -18,7 +18,6 @@ import {
   ChangeDetectionStrategy,
   Component,
   computed,
-  signal,
   viewChild,
   viewChildren,
 } from '@angular/core';
@@ -53,8 +52,11 @@ export class AutocompleteManualExample {
   /** A reference to the ng aria combobox. */
   combobox = viewChild<Combobox<string>>(Combobox);
 
+  /** A reference to the ng aria combobox input. */
+  comboboxInput = viewChild<ComboboxInput>(ComboboxInput);
+
   /** The query string used to filter the list of countries. */
-  query = signal('');
+  query = computed(() => this.comboboxInput()?.value() || '');
 
   /** The list of countries filtered by the query. */
   countries = computed(() =>
@@ -73,7 +75,7 @@ export class AutocompleteManualExample {
 
   /** Clears the query and the listbox value. */
   clear(): void {
-    this.query.set('');
+    this.comboboxInput()?.value.set('');
     this.listbox?.()?.values.set([]);
   }
 


### PR DESCRIPTION
Autocomplete examples were actually incorrectly using ngModel to populate the input value, which was colliding with the ngComboboxInput usage of [value} so clearing the query did not work properly.

Updated all the examples to check and clear the value on the ComboboxInput instead.

Also added clarifying comments in the Combox behavior logic which checks for an active item, then drops it, but then checks again when selecting.