### PR TITLE
fix(multiple): wrap ngDevMode check around afterRenderEffect in aria primitives

### DIFF
--- a/src/aria/listbox/listbox.ts
+++ b/src/aria/listbox/listbox.ts
@@ -159,14 +159,14 @@ export class Listbox<V> {
       this._popup._controls.set(this._pattern as ComboboxListboxPattern<V>);
     }
 
-    afterRenderEffect(() => {
-      if (typeof ngDevMode === 'undefined' || ngDevMode) {
+    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+      afterRenderEffect(() => {
         const violations = this._pattern.validate();
         for (const violation of violations) {
           console.error(violation);
         }
-      }
-    });
+      });
+    }
 
     afterRenderEffect(() => {
       if (!this._hasFocused()) {

--- a/src/aria/toolbar/toolbar.ts
+++ b/src/aria/toolbar/toolbar.ts
@@ -109,14 +109,14 @@ export class Toolbar<V> {
   private _hasBeenFocused = signal(false);
 
   constructor() {
-    afterRenderEffect(() => {
-      if (typeof ngDevMode === 'undefined' || ngDevMode) {
+    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+      afterRenderEffect(() => {
         const violations = this._pattern.validate();
         for (const violation of violations) {
           console.error(violation);
         }
-      }
-    });
+      });
+    }
 
     afterRenderEffect(() => {
       if (!this._hasBeenFocused()) {


### PR DESCRIPTION
## Summary
- Move the `ngDevMode` check outside of `afterRenderEffect` in `aria/listbox` and `aria/toolbar`
- This ensures the effect is not registered at all in production, rather than registering an effect that does nothing

Follow-up to feedback from https://github.com/angular/components/pull/32663

🤖 Generated with [Claude Code](https://claude.ai/claude-code)