### PR TITLE
fix(multiple): change aria keyboard manager to only handle repeated events in correct places

### DIFF
--- a/src/aria/private/accordion/accordion.ts
+++ b/src/aria/private/accordion/accordion.ts
@@ -74,8 +74,8 @@ export class AccordionGroupPattern {
   /** The keydown event manager for the accordion trigger. */
   keydown = computed(() => {
     return new KeyboardEventManager()
-      .on(this.prevKey, () => this.navigationBehavior.prev())
-      .on(this.nextKey, () => this.navigationBehavior.next())
+      .on(this.prevKey, () => this.navigationBehavior.prev(), {ignoreRepeat: false})
+      .on(this.nextKey, () => this.navigationBehavior.next(), {ignoreRepeat: false})
       .on('Home', () => this.navigationBehavior.first())
       .on('End', () => this.navigationBehavior.last())
       .on(' ', () => this.toggle())

--- a/src/aria/private/behaviors/event-manager/event-manager.ts
+++ b/src/aria/private/behaviors/event-manager/event-manager.ts
@@ -24,6 +24,7 @@ export interface EventWithModifiers extends Event {
  * This library has not yet had a need for stopPropagationImmediate.
  */
 export interface EventHandlerOptions {
+  ignoreRepeat?: boolean;
   stopPropagation: boolean;
   preventDefault: boolean;
 }

--- a/src/aria/private/behaviors/event-manager/keyboard-event-manager.ts
+++ b/src/aria/private/behaviors/event-manager/keyboard-event-manager.ts
@@ -30,6 +30,7 @@ type KeyCode = string | SignalLike<string> | RegExp;
  */
 export class KeyboardEventManager<T extends KeyboardEvent> extends EventManager<T> {
   options: EventHandlerOptions = {
+    ignoreRepeat: true,
     preventDefault: true,
     stopPropagation: true,
   };
@@ -50,7 +51,7 @@ export class KeyboardEventManager<T extends KeyboardEvent> extends EventManager<
 
     this.configs.push({
       handler: handler,
-      matcher: event => this._isMatch(event, key, modifiers),
+      matcher: event => this._isMatch(event, key, modifiers, options),
       ...this.options,
       ...options,
     });
@@ -73,8 +74,18 @@ export class KeyboardEventManager<T extends KeyboardEvent> extends EventManager<
     };
   }
 
-  private _isMatch(event: T, key: KeyCode, modifiers: ModifierInputs) {
+  private _isMatch(
+    event: T,
+    key: KeyCode,
+    modifiers: ModifierInputs,
+    options?: Partial<EventHandlerOptions>,
+  ): boolean {
     if (!hasModifiers(event, modifiers)) {
+      return false;
+    }
+
+    // Default is to ignore repeated key events unless explicitly set to false.
+    if (event.repeat && options?.ignoreRepeat !== false) {
       return false;
     }
 

--- a/src/aria/private/combobox/combobox.ts
+++ b/src/aria/private/combobox/combobox.ts
@@ -250,8 +250,8 @@ export class ComboboxPattern<T extends ListItem<V>, V> {
     }
 
     manager
-      .on('ArrowDown', () => this.next())
-      .on('ArrowUp', () => this.prev())
+      .on('ArrowDown', () => this.next(), {ignoreRepeat: false})
+      .on('ArrowUp', () => this.prev(), {ignoreRepeat: false})
       .on('Home', () => this.first())
       .on('End', () => this.last());
 

--- a/src/aria/private/grid/cell.ts
+++ b/src/aria/private/grid/cell.ts
@@ -181,11 +181,15 @@ export class GridCellPattern implements GridCell {
     // Start list navigation.
     manager
       .on('Escape', () => this.stopNavigation())
-      .on(this.prevKey(), () =>
-        this._advance(() => this.navigationBehavior.prev({focusElement: false})),
+      .on(
+        this.prevKey(),
+        () => this._advance(() => this.navigationBehavior.prev({focusElement: false})),
+        {ignoreRepeat: false},
       )
-      .on(this.nextKey(), () =>
-        this._advance(() => this.navigationBehavior.next({focusElement: false})),
+      .on(
+        this.nextKey(),
+        () => this._advance(() => this.navigationBehavior.next({focusElement: false})),
+        {ignoreRepeat: false},
       )
       .on('Home', () => this._advance(() => this.navigationBehavior.next({focusElement: false})))
       .on('End', () => this._advance(() => this.navigationBehavior.next({focusElement: false})));

--- a/src/aria/private/grid/grid.ts
+++ b/src/aria/private/grid/grid.ts
@@ -116,10 +116,10 @@ export class GridPattern {
       selectOne: this.inputs.enableSelection() && this.inputs.selectionMode() === 'follow',
     };
     manager
-      .on('ArrowUp', () => this.gridBehavior.up(opts))
-      .on('ArrowDown', () => this.gridBehavior.down(opts))
-      .on(this.prevColKey(), () => this.gridBehavior.left(opts))
-      .on(this.nextColKey(), () => this.gridBehavior.right(opts))
+      .on('ArrowUp', () => this.gridBehavior.up(opts), {ignoreRepeat: false})
+      .on('ArrowDown', () => this.gridBehavior.down(opts), {ignoreRepeat: false})
+      .on(this.prevColKey(), () => this.gridBehavior.left(opts), {ignoreRepeat: false})
+      .on(this.nextColKey(), () => this.gridBehavior.right(opts), {ignoreRepeat: false})
       .on('Home', () => this.gridBehavior.firstInRow(opts))
       .on('End', () => this.gridBehavior.lastInRow(opts))
       .on([Modifier.Ctrl], 'Home', () => this.gridBehavior.first(opts))

--- a/src/aria/private/listbox/listbox.ts
+++ b/src/aria/private/listbox/listbox.ts
@@ -79,8 +79,8 @@ export class ListboxPattern<V> {
 
     if (this.readonly()) {
       return manager
-        .on(this.prevKey, () => this.listBehavior.prev())
-        .on(this.nextKey, () => this.listBehavior.next())
+        .on(this.prevKey, () => this.listBehavior.prev(), {ignoreRepeat: false})
+        .on(this.nextKey, () => this.listBehavior.next(), {ignoreRepeat: false})
         .on('Home', () => this.listBehavior.first())
         .on('End', () => this.listBehavior.last())
         .on(this.typeaheadRegexp, e => this.listBehavior.search(e.key));
@@ -88,8 +88,8 @@ export class ListboxPattern<V> {
 
     if (!this.followFocus()) {
       manager
-        .on(this.prevKey, () => this.listBehavior.prev())
-        .on(this.nextKey, () => this.listBehavior.next())
+        .on(this.prevKey, () => this.listBehavior.prev(), {ignoreRepeat: false})
+        .on(this.nextKey, () => this.listBehavior.next(), {ignoreRepeat: false})
         .on('Home', () => this.listBehavior.first())
         .on('End', () => this.listBehavior.last())
         .on(this.typeaheadRegexp, e => this.listBehavior.search(e.key));
@@ -97,8 +97,8 @@ export class ListboxPattern<V> {
 
     if (this.followFocus()) {
       manager
-        .on(this.prevKey, () => this.listBehavior.prev({selectOne: true}))
-        .on(this.nextKey, () => this.listBehavior.next({selectOne: true}))
+        .on(this.prevKey, () => this.listBehavior.prev({selectOne: true}), {ignoreRepeat: false})
+        .on(this.nextKey, () => this.listBehavior.next({selectOne: true}), {ignoreRepeat: false})
         .on('Home', () => this.listBehavior.first({selectOne: true}))
         .on('End', () => this.listBehavior.last({selectOne: true}))
         .on(this.typeaheadRegexp, e => this.listBehavior.search(e.key, {selectOne: true}));
@@ -107,8 +107,12 @@ export class ListboxPattern<V> {
     if (this.inputs.multi()) {
       manager
         .on(Modifier.Any, 'Shift', () => this.listBehavior.anchor(this.listBehavior.activeIndex()))
-        .on(Modifier.Shift, this.prevKey, () => this.listBehavior.prev({selectRange: true}))
-        .on(Modifier.Shift, this.nextKey, () => this.listBehavior.next({selectRange: true}))
+        .on(Modifier.Shift, this.prevKey, () => this.listBehavior.prev({selectRange: true}), {
+          ignoreRepeat: false,
+        })
+        .on(Modifier.Shift, this.nextKey, () => this.listBehavior.next({selectRange: true}), {
+          ignoreRepeat: false,
+        })
         .on([Modifier.Ctrl | Modifier.Shift, Modifier.Meta | Modifier.Shift], 'Home', () =>
           this.listBehavior.first({selectRange: true, anchor: false}),
         )
@@ -137,8 +141,12 @@ export class ListboxPattern<V> {
 
     if (this.inputs.multi() && this.followFocus()) {
       manager
-        .on([Modifier.Ctrl, Modifier.Meta], this.prevKey, () => this.listBehavior.prev())
-        .on([Modifier.Ctrl, Modifier.Meta], this.nextKey, () => this.listBehavior.next())
+        .on([Modifier.Ctrl, Modifier.Meta], this.prevKey, () => this.listBehavior.prev(), {
+          ignoreRepeat: false,
+        })
+        .on([Modifier.Ctrl, Modifier.Meta], this.nextKey, () => this.listBehavior.next(), {
+          ignoreRepeat: false,
+        })
         .on([Modifier.Ctrl, Modifier.Meta], ' ', () => this.listBehavior.toggle())
         .on([Modifier.Ctrl, Modifier.Meta], 'Enter', () => this.listBehavior.toggle())
         .on([Modifier.Ctrl, Modifier.Meta], 'Home', () => this.listBehavior.first())

--- a/src/aria/private/menu/menu.ts
+++ b/src/aria/private/menu/menu.ts
@@ -158,8 +158,8 @@ export class MenuPattern<V> {
   /** Handles keyboard events for the menu. */
   keydownManager = computed(() => {
     return new KeyboardEventManager()
-      .on('ArrowDown', () => this.next())
-      .on('ArrowUp', () => this.prev())
+      .on('ArrowDown', () => this.next(), {ignoreRepeat: false})
+      .on('ArrowUp', () => this.prev(), {ignoreRepeat: false})
       .on('Home', () => this.first())
       .on('End', () => this.last())
       .on('Enter', () => this.trigger())
@@ -485,8 +485,8 @@ export class MenuBarPattern<V> {
   /** Handles keyboard events for the menu. */
   keydownManager = computed(() => {
     return new KeyboardEventManager()
-      .on(this._nextKey, () => this.next())
-      .on(this._previousKey, () => this.prev())
+      .on(this._nextKey, () => this.next(), {ignoreRepeat: false})
+      .on(this._previousKey, () => this.prev(), {ignoreRepeat: false})
       .on('End', () => this.listBehavior.last())
       .on('Home', () => this.listBehavior.first())
       .on('Enter', () => this.inputs.activeItem()?.open({first: true}))

--- a/src/aria/private/tabs/tabs.ts
+++ b/src/aria/private/tabs/tabs.ts
@@ -184,11 +184,15 @@ export class TabListPattern {
   /** The keydown event manager for the tablist. */
   readonly keydown = computed(() => {
     return new KeyboardEventManager()
-      .on(this.prevKey, () =>
-        this._navigate(() => this.navigationBehavior.prev(), this.followFocus()),
+      .on(
+        this.prevKey,
+        () => this._navigate(() => this.navigationBehavior.prev(), this.followFocus()),
+        {ignoreRepeat: false},
       )
-      .on(this.nextKey, () =>
-        this._navigate(() => this.navigationBehavior.next(), this.followFocus()),
+      .on(
+        this.nextKey,
+        () => this._navigate(() => this.navigationBehavior.next(), this.followFocus()),
+        {ignoreRepeat: false},
       )
       .on('Home', () => this._navigate(() => this.navigationBehavior.first(), this.followFocus()))
       .on('End', () => this._navigate(() => this.navigationBehavior.last(), this.followFocus()))

--- a/src/aria/private/toolbar/toolbar.ts
+++ b/src/aria/private/toolbar/toolbar.ts
@@ -80,10 +80,10 @@ export class ToolbarPattern<V> {
     const manager = new KeyboardEventManager();
 
     return manager
-      .on(this._nextKey, () => this.listBehavior.next())
-      .on(this._prevKey, () => this.listBehavior.prev())
-      .on(this._altNextKey, () => this._groupNext())
-      .on(this._altPrevKey, () => this._groupPrev())
+      .on(this._nextKey, () => this.listBehavior.next(), {ignoreRepeat: false})
+      .on(this._prevKey, () => this.listBehavior.prev(), {ignoreRepeat: false})
+      .on(this._altNextKey, () => this._groupNext(), {ignoreRepeat: false})
+      .on(this._altPrevKey, () => this._groupPrev(), {ignoreRepeat: false})
       .on(' ', () => this.select())
       .on('Enter', () => this.select())
       .on('Home', () => this.listBehavior.first())
@@ -179,7 +179,7 @@ export class ToolbarPattern<V> {
 
   /** Handles click events for the toolbar. */
   onClick(event: MouseEvent) {
-    if (this.disabled()) return;
+    if (this.disabled() || (event as PointerEvent).pointerType === '') return;
     this._goto(event);
   }
 

--- a/src/aria/private/tree/tree.ts
+++ b/src/aria/private/tree/tree.ts
@@ -216,8 +216,8 @@ export class TreePattern<V> implements TreeInputs<V> {
     const tree = this.treeBehavior;
 
     manager
-      .on(this.prevKey, () => tree.prev({selectOne: this.followFocus()}))
-      .on(this.nextKey, () => tree.next({selectOne: this.followFocus()}))
+      .on(this.prevKey, () => tree.prev({selectOne: this.followFocus()}), {ignoreRepeat: false})
+      .on(this.nextKey, () => tree.next({selectOne: this.followFocus()}), {ignoreRepeat: false})
       .on('Home', () => tree.first({selectOne: this.followFocus()}))
       .on('End', () => tree.last({selectOne: this.followFocus()}))
       .on(this.typeaheadRegexp, e => tree.search(e.key, {selectOne: this.followFocus()}))
@@ -230,8 +230,12 @@ export class TreePattern<V> implements TreeInputs<V> {
         // TODO: Tracking the anchor by index can break if the
         // tree is expanded or collapsed causing the index to change.
         .on(Modifier.Any, 'Shift', () => tree.anchor(this.treeBehavior.activeIndex()))
-        .on(Modifier.Shift, this.prevKey, () => tree.prev({selectRange: true}))
-        .on(Modifier.Shift, this.nextKey, () => tree.next({selectRange: true}))
+        .on(Modifier.Shift, this.prevKey, () => tree.prev({selectRange: true}), {
+          ignoreRepeat: false,
+        })
+        .on(Modifier.Shift, this.nextKey, () => tree.next({selectRange: true}), {
+          ignoreRepeat: false,
+        })
         .on([Modifier.Ctrl | Modifier.Shift, Modifier.Meta | Modifier.Shift], 'Home', () =>
           tree.first({selectRange: true, anchor: false}),
         )
@@ -258,8 +262,8 @@ export class TreePattern<V> implements TreeInputs<V> {
 
     if (this.inputs.multi() && this.followFocus()) {
       manager
-        .on([Modifier.Ctrl, Modifier.Meta], this.prevKey, () => tree.prev())
-        .on([Modifier.Ctrl, Modifier.Meta], this.nextKey, () => tree.next())
+        .on([Modifier.Ctrl, Modifier.Meta], this.prevKey, () => tree.prev(), {ignoreRepeat: false})
+        .on([Modifier.Ctrl, Modifier.Meta], this.nextKey, () => tree.next(), {ignoreRepeat: false})
         .on([Modifier.Ctrl, Modifier.Meta], this.expandKey, () => this._expandOrFirstChild())
         .on([Modifier.Ctrl, Modifier.Meta], this.collapseKey, () => this._collapseOrParent())
         .on([Modifier.Ctrl, Modifier.Meta], ' ', () => tree.toggle())

--- a/src/aria/toolbar/toolbar.spec.ts
+++ b/src/aria/toolbar/toolbar.spec.ts
@@ -23,7 +23,10 @@ describe('Toolbar', () => {
   };
 
   const click = (element: HTMLElement, eventInit?: PointerEventInit) => {
-    element.dispatchEvent(new PointerEvent('click', {bubbles: true, ...eventInit}));
+    element.dispatchEvent(
+      // Include pointerType to better simulate a real mouse click v.s. enter keyboard event.
+      new PointerEvent('click', {bubbles: true, pointerType: 'mouse', ...eventInit}),
+    );
     fixture.detectChanges();
   };
 


### PR DESCRIPTION
The angular-aria keyboard manager ignores the event.repeat parameter so holding down a key will cause it to loop even when that behavior is not desired. In general, repeated events should only be handled when navigating with arrow keys, and especially not when toggling (as then it just goes from off to on to off and so on).

Another issue is that the browser can interpret a keyboard space or enter as a click in certain cases. This is true with the toolbar so added check for a proper mouse event to handle the click (else already handled with keyboard) as well as updated spec to  pass a proper event.

Note: we are missing tests for this but they probably need to be added at a higher level so that we can catch for not just the repeat issue but also issues like the click above. Else can just add explicit repeat but keyDown events but that isn't as useful.

Fixes b/479281429.