### PR TITLE
fix(material/slide-toggle): overly broad selector

### DIFF
--- a/src/material/slide-toggle/slide-toggle.scss
+++ b/src/material/slide-toggle/slide-toggle.scss
@@ -33,11 +33,6 @@ $fallbacks: m3-slide-toggle.get-tokens();
   }
 }
 
-// Ensure no label element (with a click handler) present to ensure hidden from screen readers.
-label:empty {
-  display: none;
-}
-
 .mdc-switch__track {
   overflow: hidden;
   position: relative;
@@ -554,6 +549,11 @@ label:empty {
 
   .mdc-switch--disabled + label {
     color: token-utils.slot(slide-toggle-disabled-label-text-color, $fallbacks);
+  }
+
+  // Ensure no label element (with a click handler) present to ensure hidden from screen readers.
+  label:empty {
+    display: none;
   }
 }
 


### PR DESCRIPTION
Fixes that the `label:empty` selector in the slide toggle was applying to all labels on the page.

Fixes #32736.