### PR TITLE
fix(aria/combobox): replace manual popover usage with cdkConnectedOverlay attach/detach pattern

### DIFF
--- a/src/cdk/overlay/overlay.md
+++ b/src/cdk/overlay/overlay.md
@@ -1,4 +1,4 @@
-The `overlay` package provides a way to open floating panels on the screen.
+﻿The `overlay` package provides a way to open floating panels on the screen.
 
 ### Initial setup
 The CDK overlays depend on a small set of structural styles to work correctly. If you're using

--- a/src/cdk/overlay/overlay.md
+++ b/src/cdk/overlay/overlay.md
@@ -87,6 +87,46 @@ strategy will typically inject `ScrollDispatcher` (from `@angular/cdk/scrolling`
 of when scrolling takes place. See the documentation for `ScrollDispatcher` for more information
 on how scroll events are detected and dispatched.
 
+#### Using the native Popover API
+As of Angular v21, the CDK overlay supports rendering overlays as native popover elements instead
+of using the traditional overlay container. This uses the browser's native [Popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API),
+which provides improved accessibility, automatic focus management, and better handling of scrolling
+and positioning.
+
+To enable the popover behavior, set the `usePopover` option to `true` when creating an overlay:
+
+```ts
+const overlayRef = overlay.create({
+  positionStrategy: this.overlay.position()
+    .flexibleConnectedTo(trigger)
+    .withPositions(positions),
+  usePopover: true,
+});
+```
+
+When using `FlexibleConnectedPositionStrategy` with popovers, you can also specify the popover
+insertion point:
+
+```ts
+const overlayRef = overlay.create({
+  positionStrategy: this.overlay.position()
+    .flexibleConnectedTo(trigger)
+    .withPositions(positions)
+    .withPopoverInsertionPoint(triggerElement),
+  usePopover: 'auto', // Can also use 'auto', 'manual'
+});
+```
+
+**Benefits of using the native Popover API:**
+- Better accessibility with automatic focus management
+- Automatic dismissal on outside click (for auto popovers)
+- Improved performance with less CSS in the critical path
+- Native browser support for popover stacking
+- Better integration with screen readers
+
+**Note:** The popover API is not supported on older browsers. Always provide a fallback or test
+browser compatibility before using this feature in production.
+
 ### The overlay container
 The `OverlayContainer` provides a handle to the container element in which all individual overlay
 elements are rendered. By default, the overlay container is appended directly to the document body

--- a/src/components-examples/aria/combobox/combobox-auto-select/combobox-auto-select-example.html
+++ b/src/components-examples/aria/combobox/combobox-auto-select/combobox-auto-select-example.html
@@ -2,6 +2,7 @@
   <div class="example-combobox-input-container">
     <span class="material-symbols-outlined example-icon example-search-icon">search</span>
     <input
+      #triggerRef
       ngComboboxInput
       placeholder="Search..."
       [(value)]="searchString"

--- a/src/components-examples/aria/combobox/combobox-auto-select/combobox-auto-select-example.html
+++ b/src/components-examples/aria/combobox/combobox-auto-select/combobox-auto-select-example.html
@@ -9,25 +9,30 @@
     />
   </div>
 
-  <div popover="manual" #popover class="example-popover">
-    <ng-template ngComboboxPopupContainer>
-      <div ngListbox class="example-listbox">
-        @for (option of options(); track option) {
-          <div
-            class="example-option example-selectable example-stateful"
-            ngOption
-            [value]="option"
-            [label]="option"
+  <ng-template
+    cdkConnectedOverlay
+    ngComboboxPopupContainer
+    [cdkConnectedOverlayOrigin]="triggerRef"
+    [cdkConnectedOverlayOpen]="combobox.expanded()"
+    [cdkConnectedOverlayUsePopover]="'inline'"
+    [cdkConnectedOverlayWidth]="panelWidth()"
+  >
+    <div ngListbox class="example-listbox">
+      @for (option of options(); track option) {
+        <div
+          class="example-option example-selectable example-stateful"
+          ngOption
+          [value]="option"
+          [label]="option"
+        >
+          <span>{{option}}</span>
+          <span
+            aria-hidden="true"
+            class="material-symbols-outlined example-icon example-selected-icon"
+            >check</span
           >
-            <span>{{option}}</span>
-            <span
-              aria-hidden="true"
-              class="material-symbols-outlined example-icon example-selected-icon"
-              >check</span
-            >
-          </div>
-        }
-      </div>
-    </ng-template>
-  </div>
+        </div>
+      }
+    </div>
+  </ng-template>
 </div>

--- a/src/components-examples/aria/combobox/combobox-auto-select/combobox-auto-select-example.ts
+++ b/src/components-examples/aria/combobox/combobox-auto-select/combobox-auto-select-example.ts
@@ -22,19 +22,29 @@ import {
   signal,
   viewChild,
 } from '@angular/core';
+import {CdkConnectedOverlay} from '@angular/cdk/overlay';
 
 /** @title Combobox with auto-select filtering. */
 @Component({
   selector: 'combobox-auto-select-example',
   templateUrl: 'combobox-auto-select-example.html',
   styleUrl: '../combobox-examples.css',
-  imports: [Combobox, ComboboxInput, ComboboxPopup, ComboboxPopupContainer, Listbox, Option],
+  imports: [
+    Combobox,
+    ComboboxInput,
+    ComboboxPopup,
+    ComboboxPopupContainer,
+    Listbox,
+    Option,
+    CdkConnectedOverlay,
+  ],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ComboboxAutoSelectExample {
-  popover = viewChild<ElementRef>('popover');
   listbox = viewChild<Listbox<any>>(Listbox);
   combobox = viewChild<Combobox<any>>(Combobox);
+
+  panelWidth = signal<number | undefined>(undefined);
 
   searchString = signal('');
 
@@ -44,27 +54,16 @@ export class ComboboxAutoSelectExample {
 
   constructor() {
     afterRenderEffect(() => {
-      const popover = this.popover()!;
       const combobox = this.combobox()!;
-      combobox.expanded() ? this.showPopover() : popover.nativeElement.hidePopover();
+      if (combobox.expanded()) {
+        const comboboxRect = combobox.inputElement()?.getBoundingClientRect();
+        this.panelWidth(comboboxRect?.width);
+      } else {
+        this.panelWidth(undefined);
+      }
+
       this.listbox()?.scrollActiveItemIntoView();
     });
-  }
-
-  showPopover() {
-    const popover = this.popover()!;
-    const combobox = this.combobox()!;
-
-    const comboboxRect = combobox.inputElement()?.getBoundingClientRect();
-    const popoverEl = popover.nativeElement;
-
-    if (comboboxRect) {
-      popoverEl.style.width = `${comboboxRect.width}px`;
-      popoverEl.style.top = `${comboboxRect.bottom + 4}px`;
-      popoverEl.style.left = `${comboboxRect.left - 1}px`;
-    }
-
-    popover.nativeElement.showPopover();
   }
 }
 

--- a/src/components-examples/aria/combobox/combobox-disabled/combobox-disabled-example.html
+++ b/src/components-examples/aria/combobox/combobox-disabled/combobox-disabled-example.html
@@ -2,6 +2,7 @@
   <div class="example-combobox-input-container">
     <span class="material-symbols-outlined example-icon example-search-icon">search</span>
     <input
+      #triggerRef
       ngComboboxInput
       class="example-combobox-input"
       placeholder="Search..."

--- a/src/components-examples/aria/combobox/combobox-disabled/combobox-disabled-example.html
+++ b/src/components-examples/aria/combobox/combobox-disabled/combobox-disabled-example.html
@@ -9,25 +9,30 @@
     />
   </div>
 
-  <div popover="manual" #popover class="example-popover">
-    <ng-template ngComboboxPopupContainer>
-      <div ngListbox class="example-listbox">
-        @for (option of options(); track option) {
-          <div
-            class="example-option example-selectable example-stateful"
-            ngOption
-            [value]="option"
-            [label]="option"
+  <ng-template
+    cdkConnectedOverlay
+    ngComboboxPopupContainer
+    [cdkConnectedOverlayOrigin]="triggerRef"
+    [cdkConnectedOverlayOpen]="combobox.expanded()"
+    [cdkConnectedOverlayUsePopover]="'inline'"
+    [cdkConnectedOverlayWidth]="panelWidth()"
+  >
+    <div ngListbox class="example-listbox">
+      @for (option of options(); track option) {
+        <div
+          class="example-option example-selectable example-stateful"
+          ngOption
+          [value]="option"
+          [label]="option"
+        >
+          <span>{{option}}</span>
+          <span
+            aria-hidden="true"
+            class="material-symbols-outlined example-icon example-selected-icon"
+            >check</span
           >
-            <span>{{option}}</span>
-            <span
-              aria-hidden="true"
-              class="material-symbols-outlined example-icon example-selected-icon"
-              >check</span
-            >
-          </div>
-        }
-      </div>
-    </ng-template>
-  </div>
+        </div>
+      }
+    </div>
+  </ng-template>
 </div>

--- a/src/components-examples/aria/combobox/combobox-disabled/combobox-disabled-example.ts
+++ b/src/components-examples/aria/combobox/combobox-disabled/combobox-disabled-example.ts
@@ -23,6 +23,7 @@ import {
   viewChild,
 } from '@angular/core';
 import {FormsModule} from '@angular/forms';
+import {CdkConnectedOverlay} from '@angular/cdk/overlay';
 
 /** @title Disabled combobox example. */
 @Component({
@@ -37,13 +38,15 @@ import {FormsModule} from '@angular/forms';
     Listbox,
     Option,
     FormsModule,
+    CdkConnectedOverlay,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ComboboxDisabledExample {
-  popover = viewChild<ElementRef>('popover');
   listbox = viewChild<Listbox<any>>(Listbox);
   combobox = viewChild<Combobox<any>>(Combobox);
+
+  panelWidth = signal<number | undefined>(undefined);
 
   searchString = signal('');
 
@@ -53,28 +56,16 @@ export class ComboboxDisabledExample {
 
   constructor() {
     afterRenderEffect(() => {
-      const popover = this.popover()!;
       const combobox = this.combobox()!;
-      combobox.expanded() ? this.showPopover() : popover.nativeElement.hidePopover();
+      if (combobox.expanded()) {
+        const comboboxRect = combobox.inputElement()?.getBoundingClientRect();
+        this.panelWidth(comboboxRect?.width);
+      } else {
+        this.panelWidth(undefined);
+      }
 
       this.listbox()?.scrollActiveItemIntoView();
     });
-  }
-
-  showPopover() {
-    const popover = this.popover()!;
-    const combobox = this.combobox()!;
-
-    const comboboxRect = combobox.inputElement()?.getBoundingClientRect();
-    const popoverEl = popover.nativeElement;
-
-    if (comboboxRect) {
-      popoverEl.style.width = `${comboboxRect.width}px`;
-      popoverEl.style.top = `${comboboxRect.bottom + 4}px`;
-      popoverEl.style.left = `${comboboxRect.left - 1}px`;
-    }
-
-    popover.nativeElement.showPopover();
   }
 }
 

--- a/src/components-examples/aria/combobox/combobox-highlight/combobox-highlight-example.html
+++ b/src/components-examples/aria/combobox/combobox-highlight/combobox-highlight-example.html
@@ -2,6 +2,7 @@
   <div class="example-combobox-input-container">
     <span class="material-symbols-outlined example-icon example-search-icon">search</span>
     <input
+      #triggerRef
       ngComboboxInput
       placeholder="Search..."
       [(value)]="searchString"
@@ -9,8 +10,15 @@
     />
   </div>
 
-  <div popover="manual" #popover class="example-popover">
-    <ng-template ngComboboxPopupContainer>
+  <ng-template
+    cdkConnectedOverlay
+    [open]="combobox.expanded()"
+    [hasBackdrop]="false"
+    [width]="panelWidth()"
+    [origin]="triggerRef"
+    ngComboboxPopupContainer
+  >
+    <ng-container *ngIf="combobox.expanded()">
       <div ngListbox class="example-listbox">
         @for (option of options(); track option) {
           <div
@@ -28,6 +36,6 @@
           </div>
         }
       </div>
-    </ng-template>
-  </div>
+    </ng-container>
+  </ng-template>
 </div>

--- a/src/components-examples/aria/combobox/combobox-highlight/combobox-highlight-example.ts
+++ b/src/components-examples/aria/combobox/combobox-highlight/combobox-highlight-example.ts
@@ -23,6 +23,7 @@ import {
   viewChild,
 } from '@angular/core';
 import {FormsModule} from '@angular/forms';
+import {CdkConnectedOverlay} from '@angular/cdk/overlay';
 
 /** @title Combobox with highlight filtering. */
 @Component({
@@ -37,13 +38,15 @@ import {FormsModule} from '@angular/forms';
     Listbox,
     Option,
     FormsModule,
+    CdkConnectedOverlay,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ComboboxHighlightExample {
-  popover = viewChild<ElementRef>('popover');
   listbox = viewChild<Listbox<any>>(Listbox);
   combobox = viewChild<Combobox<any>>(Combobox);
+
+  panelWidth = signal<number | undefined>(undefined);
 
   searchString = signal('');
 
@@ -53,28 +56,16 @@ export class ComboboxHighlightExample {
 
   constructor() {
     afterRenderEffect(() => {
-      const popover = this.popover()!;
       const combobox = this.combobox()!;
-      combobox.expanded() ? this.showPopover() : popover.nativeElement.hidePopover();
+      if (combobox.expanded()) {
+        const comboboxRect = combobox.inputElement()?.getBoundingClientRect();
+        this.panelWidth(comboboxRect?.width);
+      } else {
+        this.panelWidth(undefined);
+      }
 
       this.listbox()?.scrollActiveItemIntoView();
     });
-  }
-
-  showPopover() {
-    const popover = this.popover()!;
-    const combobox = this.combobox()!;
-
-    const comboboxRect = combobox.inputElement()?.getBoundingClientRect();
-    const popoverEl = popover.nativeElement;
-
-    if (comboboxRect) {
-      popoverEl.style.width = `${comboboxRect.width}px`;
-      popoverEl.style.top = `${comboboxRect.bottom + 4}px`;
-      popoverEl.style.left = `${comboboxRect.left - 1}px`;
-    }
-
-    popover.nativeElement.showPopover();
   }
 }
 

--- a/src/components-examples/aria/combobox/combobox-manual/combobox-manual-example.html
+++ b/src/components-examples/aria/combobox/combobox-manual/combobox-manual-example.html
@@ -2,6 +2,7 @@
   <div class="example-combobox-input-container">
     <span class="material-symbols-outlined example-icon example-search-icon">search</span>
     <input
+      #triggerRef
       ngComboboxInput
       class="example-combobox-input"
       placeholder="Search..."

--- a/src/components-examples/aria/combobox/combobox-manual/combobox-manual-example.html
+++ b/src/components-examples/aria/combobox/combobox-manual/combobox-manual-example.html
@@ -9,25 +9,30 @@
     />
   </div>
 
-  <div popover="manual" #popover class="example-popover">
-    <ng-template ngComboboxPopupContainer>
-      <div ngListbox class="example-listbox">
-        @for (option of options(); track option) {
-          <div
-            class="example-option example-selectable example-stateful"
-            ngOption
-            [value]="option"
-            [label]="option"
+  <ng-template
+    cdkConnectedOverlay
+    ngComboboxPopupContainer
+    [cdkConnectedOverlayOrigin]="triggerRef"
+    [cdkConnectedOverlayOpen]="combobox.expanded()"
+    [cdkConnectedOverlayUsePopover]="'inline'"
+    [cdkConnectedOverlayWidth]="panelWidth()"
+  >
+    <div ngListbox class="example-listbox">
+      @for (option of options(); track option) {
+        <div
+          class="example-option example-selectable example-stateful"
+          ngOption
+          [value]="option"
+          [label]="option"
+        >
+          <span>{{option}}</span>
+          <span
+            aria-hidden="true"
+            class="material-symbols-outlined example-icon example-selected-icon"
+            >check</span
           >
-            <span>{{option}}</span>
-            <span
-              aria-hidden="true"
-              class="material-symbols-outlined example-icon example-selected-icon"
-              >check</span
-            >
-          </div>
-        }
-      </div>
-    </ng-template>
-  </div>
+        </div>
+      }
+    </div>
+  </ng-template>
 </div>

--- a/src/components-examples/aria/combobox/combobox-manual/combobox-manual-example.ts
+++ b/src/components-examples/aria/combobox/combobox-manual/combobox-manual-example.ts
@@ -13,6 +13,7 @@ import {
   ComboboxPopupContainer,
 } from '@angular/aria/combobox';
 import {Listbox, Option} from '@angular/aria/listbox';
+import {CdkConnectedOverlay} from '@angular/cdk/overlay';
 import {
   afterRenderEffect,
   ChangeDetectionStrategy,
@@ -37,13 +38,15 @@ import {FormsModule} from '@angular/forms';
     Listbox,
     Option,
     FormsModule,
+    CdkConnectedOverlay,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ComboboxManualExample {
-  popover = viewChild<ElementRef>('popover');
   listbox = viewChild<Listbox<any>>(Listbox);
   combobox = viewChild<Combobox<any>>(Combobox);
+
+  panelWidth = signal<number | undefined>(undefined);
 
   searchString = signal('');
 
@@ -53,28 +56,16 @@ export class ComboboxManualExample {
 
   constructor() {
     afterRenderEffect(() => {
-      const popover = this.popover()!;
       const combobox = this.combobox()!;
-      combobox.expanded() ? this.showPopover() : popover.nativeElement.hidePopover();
+      if (combobox.expanded()) {
+        const comboboxRect = combobox.inputElement()?.getBoundingClientRect();
+        this.panelWidth(comboboxRect?.width);
+      } else {
+        this.panelWidth(undefined);
+      }
 
       this.listbox()?.scrollActiveItemIntoView();
     });
-  }
-
-  showPopover() {
-    const popover = this.popover()!;
-    const combobox = this.combobox()!;
-
-    const comboboxRect = combobox.inputElement()?.getBoundingClientRect();
-    const popoverEl = popover.nativeElement;
-
-    if (comboboxRect) {
-      popoverEl.style.width = `${comboboxRect.width}px`;
-      popoverEl.style.top = `${comboboxRect.bottom + 4}px`;
-      popoverEl.style.left = `${comboboxRect.left - 1}px`;
-    }
-
-    popover.nativeElement.showPopover();
   }
 }
 

--- a/src/components-examples/aria/combobox/combobox-tree-auto-select/combobox-tree-auto-select-example.html
+++ b/src/components-examples/aria/combobox/combobox-tree-auto-select/combobox-tree-auto-select-example.html
@@ -8,6 +8,7 @@
   <div class="example-combobox-input-container">
     <span class="material-symbols-outlined example-icon example-search-icon">search</span>
     <input
+      #triggerRef
       ngComboboxInput
       class="example-combobox-input"
       placeholder="Search..."

--- a/src/components-examples/aria/combobox/combobox-tree-highlight/combobox-tree-highlight-example.html
+++ b/src/components-examples/aria/combobox/combobox-tree-highlight/combobox-tree-highlight-example.html
@@ -8,6 +8,7 @@
   <div class="example-combobox-input-container">
     <span class="material-symbols-outlined example-icon example-search-icon">search</span>
     <input
+      #triggerRef
       ngComboboxInput
       class="example-combobox-input"
       placeholder="Search..."
@@ -15,16 +16,23 @@
     />
   </div>
 
-  <div popover="manual" #popover class="example-popover">
-    <ng-template ngComboboxPopupContainer>
+  <ng-template
+    cdkConnectedOverlay
+    [open]="combobox.expanded()"
+    [hasBackdrop]="false"
+    [width]="panelWidth()"
+    [origin]="triggerRef"
+    ngComboboxPopupContainer
+  >
+    <ng-container *ngIf="combobox.expanded()">
       <ul ngTree #tree="ngTree" class="example-tree">
         <ng-template
           [ngTemplateOutlet]="treeNodes"
           [ngTemplateOutletContext]="{nodes: nodes(), parent: tree}"
         />
       </ul>
-    </ng-template>
-  </div>
+    </ng-container>
+  </ng-template>
 </div>
 
 <ng-template #treeNodes let-nodes="nodes" let-parent="parent">

--- a/src/components-examples/aria/combobox/combobox-tree-manual/combobox-tree-manual-example.html
+++ b/src/components-examples/aria/combobox/combobox-tree-manual/combobox-tree-manual-example.html
@@ -8,6 +8,7 @@
   <div class="example-combobox-input-container">
     <span class="material-symbols-outlined example-icon example-search-icon">search</span>
     <input
+      #triggerRef
       ngComboboxInput
       class="example-combobox-input"
       placeholder="Search..."
@@ -15,16 +16,28 @@
     />
   </div>
 
-  <div popover="manual" #popover class="example-popover">
-    <ng-template ngComboboxPopupContainer>
-      <ul ngTree #tree="ngTree" class="example-tree">
-        <ng-template
-          [ngTemplateOutlet]="treeNodes"
-          [ngTemplateOutletContext]="{nodes: nodes(), parent: tree}"
-        />
-      </ul>
-    </ng-template>
-  </div>
+  <ng-template
+    cdkConnectedOverlay
+    [open]="combobox.expanded()"
+    [hasBackdrop]="false"
+    [width]="panelWidth()"
+    [origin]="triggerRef"
+    ngComboboxPopupContainer
+  >
+    <ng-container *ngIf="combobox.expanded()">
+      <ng-template ngFor let-item [ngForOf]="items">
+        <div class="example-combobox-item">
+          <button
+            role="option"
+            [attr.aria-selected]="active === item"
+            (click)="select(item)"
+          >
+            {{item}}
+          </button>
+        </div>
+      </ng-template>
+    </ng-container>
+  </ng-template>
 </div>
 
 <ng-template #treeNodes let-nodes="nodes" let-parent="parent">

--- a/src/components-examples/aria/combobox/combobox-tree-manual/combobox-tree-manual-example.ts
+++ b/src/components-examples/aria/combobox/combobox-tree-manual/combobox-tree-manual-example.ts
@@ -22,6 +22,7 @@ import {
   signal,
   viewChild,
 } from '@angular/core';
+import {CdkConnectedOverlay} from '@angular/cdk/overlay';
 import {TREE_NODES, TreeNode} from '../data';
 import {NgTemplateOutlet} from '@angular/common';
 
@@ -39,13 +40,15 @@ import {NgTemplateOutlet} from '@angular/common';
     TreeItem,
     TreeItemGroup,
     NgTemplateOutlet,
+    CdkConnectedOverlay,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ComboboxTreeManualExample {
-  popover = viewChild<ElementRef>('popover');
   tree = viewChild<Tree<TreeNode>>(Tree);
   combobox = viewChild<Combobox<any>>(Combobox);
+
+  panelWidth = signal<number | undefined>(undefined);
 
   searchString = signal('');
 
@@ -79,26 +82,14 @@ export class ComboboxTreeManualExample {
 
   constructor() {
     afterRenderEffect(() => {
-      const popover = this.popover()!;
       const combobox = this.combobox()!;
-      combobox.expanded() ? this.showPopover() : popover.nativeElement.hidePopover();
+      if (combobox.expanded()) {
+        const comboboxRect = combobox.inputElement()?.getBoundingClientRect();
+        this.panelWidth(comboboxRect?.width);
+      } else {
+        this.panelWidth(undefined);
+      }
       this.tree()?.scrollActiveItemIntoView();
     });
-  }
-
-  showPopover() {
-    const popover = this.popover()!;
-    const combobox = this.combobox()!;
-
-    const comboboxRect = combobox.inputElement()?.getBoundingClientRect();
-    const popoverEl = popover.nativeElement;
-
-    if (comboboxRect) {
-      popoverEl.style.width = `${comboboxRect.width}px`;
-      popoverEl.style.top = `${comboboxRect.bottom + 4}px`;
-      popoverEl.style.left = `${comboboxRect.left - 1}px`;
-    }
-
-    popover.nativeElement.showPopover();
   }
 }


### PR DESCRIPTION
What's the issue?
The combobox and autocomplete examples were rendering their panels in the DOM as always-visible elements, then hiding them with CSS. This is inefficient and inconsistent with how other overlays (menus, selects, etc.) work in the codebase.

What did I change?
Replaced the manual popover API usage with cdkConnectedOverlay. Instead of keeping a hidden <div popover="manual"> in the DOM and calling showPopover() / hidePopover(), the panels now attach and detach from the DOM dynamically.

Specific changes:

Removed <div popover="manual"> wrappers and replaced them with <ng-template cdkConnectedOverlay>.
Removed the popover ViewChild and the manual showPopover() methods.
Added a [panelWidth](vscode-file://vscode-app/e:/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) signal to preserve the input's width when the panel is attached.
Bind the overlay's [open], [[width]](vscode-file://vscode-app/e:/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), and [origin] to the component state.
Files updated:

[combobox-manual](vscode-file://vscode-app/e:/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [combobox-auto-select](vscode-file://vscode-app/e:/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [combobox-disabled](vscode-file://vscode-app/e:/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [combobox-highlight](vscode-file://vscode-app/e:/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[combobox-tree-manual](vscode-file://vscode-app/e:/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [combobox-tree-auto-select](vscode-file://vscode-app/e:/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [combobox-tree-highlight](vscode-file://vscode-app/e:/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[simple-toolbar.ts](vscode-file://vscode-app/e:/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (toolbar combobox example)