### PR TITLE
fix(material/radio): hide empty labels

### DIFF
--- a/src/material/form-field/_mdc-text-field-structure-overrides.scss
+++ b/src/material/form-field/_mdc-text-field-structure-overrides.scss
@@ -3,14 +3,7 @@
 @use '../core/style/vendor-prefixes';
 
 $fallbacks: m3-form-field.get-tokens();
-
-// TODO(b/263527625): should be removed when this is addressed on the MDC side.
-// MDC sets a will-change on this element, because of the animation. This can cause
-// scrolling performance degradation on pages with a lot of form fields so we reset it.
-// The animation is on a `transform` which is hardware-accelerated already.
-// This flag is used to re-add the `will-change` internally since removing it causes a
-// lot of screenshot diffs.
-$_enable-form-field-will-change-reset: true;
+$_is-external-build: true;
 
 // Mixin that can be included to override the default MDC text-field
 // styles to fit our needs. See individual comments for context on why
@@ -45,7 +38,13 @@ $_enable-form-field-will-change-reset: true;
     // clicking the label to focus the input.
     pointer-events: all;
 
-    @if ($_enable-form-field-will-change-reset) {
+    // TODO(b/263527625): should be removed when this is addressed on the MDC side.
+    // MDC sets a will-change on this element, because of the animation. This can cause
+    // scrolling performance degradation on pages with a lot of form fields so we reset it.
+    // The animation is on a `transform` which is hardware-accelerated already.
+    // This flag is used to re-add the `will-change` internally since removing it causes a
+    // lot of screenshot diffs.
+    @if ($_is-external-build) {
       will-change: auto;
     }
   }
@@ -81,7 +80,8 @@ $_enable-form-field-will-change-reset: true;
     height: auto;
     flex: auto;
 
-    @if ($_enable-form-field-will-change-reset) {
+    // TODO(b/263527625): should be removed when this is addressed on the MDC side.
+    @if ($_is-external-build) {
       will-change: auto;
     }
   }

--- a/src/material/radio/radio.scss
+++ b/src/material/radio/radio.scss
@@ -4,6 +4,7 @@
 @use './radio-common';
 
 $fallbacks: m3-radio.get-tokens();
+$_is-external-build: true;
 
 .mat-mdc-radio-button {
   -webkit-tap-highlight-color: transparent;
@@ -15,6 +16,14 @@ $fallbacks: m3-radio.get-tokens();
   // user of this. Therefore we add the pointer cursor on top of MDC's styles.
   label {
     cursor: pointer;
+
+    // TODO(crisbeto): disable internally due to a large amount of breakages.
+    // Prevent the label from taking up space when it's empty.
+    @if ($_is-external-build) {
+      &:empty {
+        display: none;
+      }
+    }
   }
 
   .mdc-radio__background::before {


### PR DESCRIPTION
We have similar logic in the checkbox and slide toggle so these changes apply it to the radio button: hiding the label when it's empty so it doesn't affect the layout.