### PR TITLE
fix(material/select): disable position locking

### DIFF
--- a/src/material/select/select.html
+++ b/src/material/select/select.html
@@ -31,7 +31,6 @@
 
 <ng-template
   cdk-connected-overlay
-  cdkConnectedOverlayLockPosition
   cdkConnectedOverlayHasBackdrop
   cdkConnectedOverlayBackdropClass="cdk-overlay-transparent-backdrop"
   [cdkConnectedOverlayDisableClose]="true"


### PR DESCRIPTION
In #9789 we enabled locked positioning for `mat-select` due to the previous approach of laying out the panel. Then in #30628 we enabled flexible dimensions so it's able to shrink. This combination can cause the panel to shrink when the user scrolls it out of view.

These changes remove the locked positioning since it's not necessary anymore.

Fixes #32771.