### PR TITLE
feat(tree): add mat-focus-indicator to tree nodes.

### DIFF
--- a/src/material/tree/node.ts
+++ b/src/material/tree/node.ts
@@ -43,7 +43,7 @@ function isNoopTreeKeyManager<T extends TreeKeyManagerItem>(
   outputs: ['activation', 'expandedChange'],
   providers: [{provide: CdkTreeNode, useExisting: MatTreeNode}],
   host: {
-    'class': 'mat-tree-node',
+    'class': 'mat-tree-node mat-focus-indicator',
     '[attr.aria-expanded]': '_getAriaExpanded()',
     '[attr.aria-level]': 'level + 1',
     '[attr.aria-posinset]': '_getPositionInSet()',
@@ -151,7 +151,7 @@ export class MatTreeNodeDef<T> extends CdkTreeNodeDef<T> {
     {provide: CDK_TREE_NODE_OUTLET_NODE, useExisting: MatNestedTreeNode},
   ],
   host: {
-    'class': 'mat-nested-tree-node',
+    'class': 'mat-nested-tree-node mat-focus-indicator',
   },
 })
 export class MatNestedTreeNode<T, K = T>

--- a/src/material/tree/node.ts
+++ b/src/material/tree/node.ts
@@ -23,6 +23,8 @@ import {
   inject,
   HostAttributeToken,
 } from '@angular/core';
+import {_CdkPrivateStyleLoader} from '@angular/cdk/private';
+import {_StructuralStylesLoader} from '../core';
 import {NoopTreeKeyManager, TreeKeyManagerItem, TreeKeyManagerStrategy} from '@angular/cdk/a11y';
 
 /**
@@ -109,6 +111,7 @@ export class MatTreeNode<T, K = T> extends CdkTreeNode<T, K> implements OnInit, 
 
   constructor() {
     super();
+    inject(_CdkPrivateStyleLoader).load(_StructuralStylesLoader);
 
     const tabIndex = inject(new HostAttributeToken('tabindex'), {optional: true});
     this.tabIndexInputBinding = Number(tabIndex) || this.defaultTabIndex;


### PR DESCRIPTION
Adds "mat-focus-indicator" to "MatTreeNode" and "MatNestedTreeNode" host classes so the tree component aligns with Angular Material focus indicator styling.

No behavior changes. Keyboard navigation and accessibility remain unchanged.
Fixes #32774. 