### PR TITLE
fix(google-maps): fix mismatch in clusterer types

### DIFF
--- a/goldens/google-maps/index.api.md
+++ b/goldens/google-maps/index.api.md
@@ -51,8 +51,6 @@ export type Calculator = (markers: google.maps.Marker[], clusterIconStylesCount:
 // @public (undocumented)
 export interface Cluster {
     // (undocumented)
-    new (options: ClusterOptions): Cluster;
-    // (undocumented)
     bounds?: google.maps.LatLngBounds;
     // (undocumented)
     count: number;
@@ -61,7 +59,7 @@ export interface Cluster {
     // (undocumented)
     marker?: Marker;
     // (undocumented)
-    readonly markers?: Marker[];
+    markers?: Marker[];
     // (undocumented)
     position: google.maps.LatLng;
     // (undocumented)

--- a/src/google-maps/map-marker-clusterer/map-marker-clusterer-types.ts
+++ b/src/google-maps/map-marker-clusterer/map-marker-clusterer-types.ts
@@ -22,13 +22,12 @@ export interface ClusterOptions {
 
 export interface Cluster {
   marker?: Marker;
-  readonly markers?: Marker[];
+  markers?: Marker[];
   bounds?: google.maps.LatLngBounds;
   position: google.maps.LatLng;
   count: number;
   push(marker: Marker): void;
   delete(): void;
-  new (options: ClusterOptions): Cluster;
 }
 
 export declare class MarkerClusterer extends google.maps.OverlayView {


### PR DESCRIPTION
Fixes that the clusterer types seem to no longer match with the ones on npm, causing a type error.

Fixes #32696.