### PR TITLE
fix(material/list): missing padding inline in list option

### DIFF
--- a/src/dev-app/list/list-demo.html
+++ b/src/dev-app/list/list-demo.html
@@ -326,7 +326,17 @@
         Fries
       </mat-list-option>
     </mat-selection-list>
-
+    
+    <h4>Hidden selector and single selection</h4>
+  
+    <mat-selection-list [multiple]="false" hideSingleSelectionIndicator>
+      <mat-list-option [togglePosition]="togglePosition">
+        Boots
+        <mat-icon matListItemIcon>chevron_right</mat-icon>
+      </mat-list-option>
+      <mat-list-option [togglePosition]="togglePosition"> Shoes </mat-list-option>
+    </mat-selection-list>
+    
     <button matButton="elevated" (click)="toggleCheckboxPosition()">
       Toggle checkbox position
     </button>

--- a/src/material/list/_list-inherited-structure.scss
+++ b/src/material/list/_list-inherited-structure.scss
@@ -332,10 +332,13 @@ $fallbacks: m3-list.get-tokens();
 
   .mdc-list-item--with-trailing-icon {
     &.mdc-list-item {
-      // This is the same in RTL, but we need the specificity.
-      &, [dir='rtl'] & {
-        padding-left: 0;
+      & {
         padding-right: 0;
+      }
+      
+      [dir='rtl'] & {
+        padding-left: 0;
+        padding-right: 16px;
       }
     }
 


### PR DESCRIPTION
# Summary

This PR fixes the lack of padding in list-option if hideSingleSelectionIndicator is true and togglePosition is before

Issue  #31174