### PR TITLE
build: set up schematics for v22

### DIFF
--- a/src/cdk/schematics/migration.json
+++ b/src/cdk/schematics/migration.json
@@ -6,6 +6,11 @@
       "description": "Updates the Angular CDK to v21",
       "factory": "./ng-update/index#updateToV21"
     },
+    "migration-v22": {
+      "version": "22.0.0-0",
+      "description": "Updates the Angular CDK to v22",
+      "factory": "./ng-update/index#updateToV22"
+    },
     "ng-post-update": {
       "description": "Prints out results after ng-update.",
       "factory": "./ng-update/index#postUpdate",

--- a/src/cdk/schematics/ng-update/index.ts
+++ b/src/cdk/schematics/ng-update/index.ts
@@ -13,10 +13,20 @@ import {createMigrationSchematicRule, NullableDevkitMigration} from './devkit-mi
 
 const cdkMigrations: NullableDevkitMigration[] = [];
 
-/** Entry point for the migration schematics with target of Angular CDK 20.0.0 */
+/** Entry point for the migration schematics with target of Angular CDK 21.0.0 */
 export function updateToV21(): Rule {
   return createMigrationSchematicRule(
     TargetVersion.V21,
+    cdkMigrations,
+    cdkUpgradeData,
+    onMigrationComplete,
+  );
+}
+
+/** Entry point for the migration schematics with target of Angular CDK 22.0.0 */
+export function updateToV22(): Rule {
+  return createMigrationSchematicRule(
+    TargetVersion.V22,
     cdkMigrations,
     cdkUpgradeData,
     onMigrationComplete,

--- a/src/cdk/schematics/update-tool/target-version.ts
+++ b/src/cdk/schematics/update-tool/target-version.ts
@@ -11,6 +11,7 @@
 // tslint:disable-next-line:prefer-const-enum
 export enum TargetVersion {
   V21 = 'version 21',
+  V22 = 'version 22',
 }
 
 /**

--- a/src/google-maps/schematics/migration.json
+++ b/src/google-maps/schematics/migration.json
@@ -4,6 +4,11 @@
       "version": "21.0.0-0",
       "description": "Updates the Angular Google Maps package to v21",
       "factory": "./ng-update/index#updateToV21"
+    },
+    "migration-v22": {
+      "version": "22.0.0-0",
+      "description": "Updates the Angular Google Maps package to v22",
+      "factory": "./ng-update/index#updateToV22"
     }
   }
 }

--- a/src/google-maps/schematics/ng-update/index.ts
+++ b/src/google-maps/schematics/ng-update/index.ts
@@ -8,7 +8,12 @@
 
 import {Rule} from '@angular-devkit/schematics';
 
-/** Entry point for the migration schematics with target of Angular Material v21 */
+/** Entry point for the migration schematics with target of Google Maps v21 */
 export function updateToV21(): Rule {
+  return () => {};
+}
+
+/** Entry point for the migration schematics with target of Google Maps v22 */
+export function updateToV22(): Rule {
   return () => {};
 }

--- a/src/material/schematics/migration.json
+++ b/src/material/schematics/migration.json
@@ -5,6 +5,11 @@
       "version": "21.0.0-0",
       "description": "Updates Angular Material to v21",
       "factory": "./ng-update/index_bundled#updateToV21"
+    },
+    "migration-v22": {
+      "version": "22.0.0-0",
+      "description": "Updates Angular Material to v22",
+      "factory": "./ng-update/index_bundled#updateToV22"
     }
   }
 }

--- a/src/material/schematics/ng-update/index.ts
+++ b/src/material/schematics/ng-update/index.ts
@@ -23,3 +23,10 @@ export function updateToV21(): Rule {
     createMigrationSchematicRule(TargetVersion.V21, materialMigrations, materialUpgradeData),
   ]);
 }
+
+/** Entry point for the migration schematics with target of Angular Material v22 */
+export function updateToV22(): Rule {
+  return chain([
+    createMigrationSchematicRule(TargetVersion.V22, materialMigrations, materialUpgradeData),
+  ]);
+}


### PR DESCRIPTION
One of the pre-requisites to release the next version of v22 is to have schematics set up. These changes add them ahead of time so we don't run into any issues when we go to release.