### PR TITLE
fix(material/core): expose strong focus indicator structural styles

### DIFF
--- a/src/material/_index.scss
+++ b/src/material/_index.scss
@@ -37,7 +37,7 @@
 @forward './core/core' show core, app-background, elevation-classes;
 @forward './core/ripple/ripple' show ripple;
 @forward './core/focus-indicators/private' show strong-focus-indicators,
-  strong-focus-indicators-color, strong-focus-indicators-theme;
+  strong-focus-indicators-color, strong-focus-indicators-theme, strong-focus-indicators-structure;
 @forward './core/style/elevation' show elevation, overridable-elevation, elevation-transition;
 
 // Theme bundles

--- a/src/material/core/focus-indicators/_private.scss
+++ b/src/material/core/focus-indicators/_private.scss
@@ -11,7 +11,7 @@ $default-border-color: transparent;
 $default-border-radius: 4px;
 
 // Mixin that renders the focus indicator structural styles.
-@mixin structural-styling() {
+@mixin strong-focus-indicators-structure() {
   .mat-focus-indicator {
     position: relative;
 

--- a/src/material/core/focus-indicators/structural-styles.scss
+++ b/src/material/core/focus-indicators/structural-styles.scss
@@ -1,3 +1,3 @@
 @use './private';
 
-@include private.structural-styling();
+@include private.strong-focus-indicators-structure();


### PR DESCRIPTION
Exposes the structural styles for strong focus indicators so users can use them in their own components.

Fixes #32773.