### PR TITLE
docs: convert @NgModule providers to bootstrapApplication

### DIFF
--- a/src/cdk/dialog/dialog.md
+++ b/src/cdk/dialog/dialog.md
@@ -117,14 +117,14 @@ class MyDialogContainer extends CdkDialogContainer {}
 
 ### Specifying global configuration defaults
 Default dialog options can be specified by providing an instance of `DialogConfig` for
-`DEFAULT_DIALOG_CONFIG` in your application's root module.
+`DEFAULT_DIALOG_CONFIG` in your app config.
 
 ```ts
-@NgModule({
+bootstrapApplication(MyApp, {
   providers: [
     {provide: DEFAULT_DIALOG_CONFIG, useValue: {hasBackdrop: false}}
   ]
-})
+});
 ```
 
 ### Sharing data with the Dialog component.

--- a/src/cdk/overlay/overlay.md
+++ b/src/cdk/overlay/overlay.md
@@ -97,11 +97,9 @@ The `FullscreenOverlayContainer` is an alternative to `OverlayContainer` that su
 displaying of overlay elements in
 [fullscreen mode](https://developer.mozilla.org/en-US/docs/Web/API/Element/requestFullScreen).
 
-`FullscreenOverlayContainer` can be enabled by providing it in your `NgModule`:
+`FullscreenOverlayContainer` can be enabled by providing it in your app config:
 ```ts
-@NgModule({
-  providers: [{provide: OverlayContainer, useClass: FullscreenOverlayContainer}],
-  // ...
-})
-export class MyModule { }
+bootstrapApplication(MyApp, {
+  providers: [{provide: OverlayContainer, useClass: FullscreenOverlayContainer}]
+});
 ```

--- a/src/material-experimental/README.md
+++ b/src/material-experimental/README.md
@@ -30,15 +30,16 @@ component by following these steps:
    ...
    ```
 
-3. Import the `NgModule` for the component you want to use. For example, the checkbox:
+3. Import the component you want to use. For example, the checkbox:
 ```ts
-  import {MatCheckboxModule} from '@angular/material/checkbox';
+import {Component} from '@angular/core';
+import {MatCheckbox} from '@angular/material/checkbox';
 
-  @NgModule({
-    declarations: [MyComponent],
-    imports: [MatCheckboxModule],
-  })
-  export class MyModule {}
+@Component({
+  imports: [MatCheckbox],
+  // ...
+})
+export class MyComponent {}
 ```
 
 4. Use the components just as you would the normal Angular Material components. For example,

--- a/src/material/bottom-sheet/bottom-sheet.md
+++ b/src/material/bottom-sheet/bottom-sheet.md
@@ -51,14 +51,14 @@ export class HobbitSheet {
 
 ### Specifying global configuration defaults
 Default bottom sheet options can be specified by providing an instance of `MatBottomSheetConfig`
-for `MAT_BOTTOM_SHEET_DEFAULT_OPTIONS` in your application's root module.
+for `MAT_BOTTOM_SHEET_DEFAULT_OPTIONS` in your app config.
 
 ```ts
-@NgModule({
+bootstrapApplication(MyApp, {
   providers: [
     {provide: MAT_BOTTOM_SHEET_DEFAULT_OPTIONS, useValue: {hasBackdrop: false}}
   ]
-})
+});
 ```
 
 

--- a/src/material/chips/chips.md
+++ b/src/material/chips/chips.md
@@ -111,8 +111,8 @@ By default, chips are displayed horizontally. To stack chips vertically, apply t
 
 Use the `MAT_CHIPS_DEFAULT_OPTIONS` token to specify default options for the chips module.
 
-```html
-@NgModule({
+```ts
+bootstrapApplication(MyApp, {
   providers: [
     {
       provide: MAT_CHIPS_DEFAULT_OPTIONS,
@@ -121,7 +121,7 @@ Use the `MAT_CHIPS_DEFAULT_OPTIONS` token to specify default options for the chi
       }
     }
   ]
-})
+});
 ```
 
 ### Interaction Patterns

--- a/src/material/core/ripple/ripple.md
+++ b/src/material/core/ripple/ripple.md
@@ -89,11 +89,11 @@ const globalRippleConfig: RippleGlobalOptions = {
   }
 };
 
-@NgModule({
+bootstrapApplication(MyApp, {
   providers: [
     {provide: MAT_RIPPLE_GLOBAL_OPTIONS, useValue: globalRippleConfig}
   ]
-})
+});
 ```
 
 All available global options can be seen in the `RippleGlobalOptions` interface.
@@ -158,12 +158,11 @@ export class AppGlobalRippleOptions implements RippleGlobalOptions {
 ```
 
 ```ts
-@NgModule({
+bootstrapApplication(MyApp, {
   providers: [
     {provide: MAT_RIPPLE_GLOBAL_OPTIONS, useExisting: AppGlobalRippleOptions},
   ]
-})
-export class MyModule {...}
+});
 ```
 
 Now that the global ripple options are set to a service we can inject, the service can be

--- a/src/material/dialog/dialog.md
+++ b/src/material/dialog/dialog.md
@@ -41,14 +41,14 @@ export class YourDialog {
 
 ### Specifying global configuration defaults
 Default dialog options can be specified by providing an instance of `MatDialogConfig` for
-MAT_DIALOG_DEFAULT_OPTIONS in your application's root module.
+MAT_DIALOG_DEFAULT_OPTIONS in your app config.
 
 ```ts
-@NgModule({
+bootstrapApplication(MyApp, {
   providers: [
     {provide: MAT_DIALOG_DEFAULT_OPTIONS, useValue: {hasBackdrop: false}}
   ]
-})
+});
 ```
 
 ### Sharing data with the Dialog component.

--- a/src/material/form-field/form-field.md
+++ b/src/material/form-field/form-field.md
@@ -27,11 +27,11 @@ Out of the box, if you do not specify an `appearance` for the `<mat-form-field>`
 appearance for your app.
 
 ```ts
-@NgModule({
+bootstrapApplication(MyApp, {
   providers: [
     {provide: MAT_FORM_FIELD_DEFAULT_OPTIONS, useValue: {appearance: 'outline'}}
   ]
-})
+});
 ```
 
 <!-- example(form-field-appearance) -->
@@ -54,15 +54,15 @@ field control, or to `auto` to restore the default behavior.
 <!-- example(form-field-label) -->
 
 The floating label behavior can be adjusted globally by providing a value for
-`MAT_FORM_FIELD_DEFAULT_OPTIONS` in your application's root module. Like the `floatLabel` input,
+`MAT_FORM_FIELD_DEFAULT_OPTIONS` in your app config. Like the `floatLabel` input,
 the option can be either set to `always` or `auto`.
 
 ```ts
-@NgModule({
+bootstrapApplication(MyApp, {
   providers: [
     {provide: MAT_FORM_FIELD_DEFAULT_OPTIONS, useValue: {floatLabel: 'always'}}
   ]
-})
+});
 ```
 
 ### Hint labels

--- a/src/material/input/input.md
+++ b/src/material/input/input.md
@@ -65,11 +65,11 @@ applies to all inputs. For convenience, `ShowOnDirtyErrorStateMatcher` is availa
 globally cause input errors to show when the input is dirty and invalid.
 
 ```ts
-@NgModule({
+bootstrapApplication(MyApp, {
   providers: [
     {provide: ErrorStateMatcher, useClass: ShowOnDirtyErrorStateMatcher}
   ]
-})
+});
 ```
 
 ### Auto-resizing `<textarea>` elements

--- a/src/material/select/select.md
+++ b/src/material/select/select.md
@@ -139,11 +139,11 @@ applies to all inputs. For convenience, `ShowOnDirtyErrorStateMatcher` is availa
 globally cause input errors to show when the input is dirty and invalid.
 
 ```ts
-@NgModule({
+bootstrapApplication(MyApp, {
   providers: [
     {provide: ErrorStateMatcher, useClass: ShowOnDirtyErrorStateMatcher}
   ]
-})
+});
 ```
 
 ### Keyboard interaction

--- a/src/material/snack-bar/snack-bar.md
+++ b/src/material/snack-bar/snack-bar.md
@@ -91,11 +91,11 @@ If you want to override the default snack bar options, you can do so using the
 `MAT_SNACK_BAR_DEFAULT_OPTIONS` injection token.
 
 ```ts
-@NgModule({
+bootstrapApplication(MyApp, {
   providers: [
     {provide: MAT_SNACK_BAR_DEFAULT_OPTIONS, useValue: {duration: 2500}}
   ]
-})
+});
 ```
 
 ### Accessibility

--- a/src/material/stepper/stepper.md
+++ b/src/material/stepper/stepper.md
@@ -153,17 +153,17 @@ However, it can be overridden the same way as mentioned above.
 
 In order to use the custom step states, you must add the `displayDefaultIndicatorType` option to
 the global default stepper options which can be specified by providing a value for
-`STEPPER_GLOBAL_OPTIONS` in your application's root module.
+`STEPPER_GLOBAL_OPTIONS` in your app config.
 
 ```ts
-@NgModule({
+bootstrapApplication(MyApp, {
   providers: [
     {
       provide: STEPPER_GLOBAL_OPTIONS,
       useValue: { displayDefaultIndicatorType: false }
     }
   ]
-})
+});
 ```
 
 <!-- example(stepper-states) -->
@@ -177,14 +177,14 @@ errors via the `showError` option in the `STEPPER_GLOBAL_OPTIONS` injection toke
 will not affect steppers marked as `linear`.
 
 ```ts
-@NgModule({
+bootstrapApplication(MyApp, {
   providers: [
     {
       provide: STEPPER_GLOBAL_OPTIONS,
       useValue: { showError: true }
     }
   ]
-})
+});
 ```
 
 <!-- example(stepper-errors) -->
@@ -213,16 +213,14 @@ viewport.
 
 ### Localizing labels
 Labels used by the stepper are provided through `MatStepperIntl`. Localization of these messages
-can be done by providing a subclass with translated values in your application root module.
+can be done by providing a subclass with translated values in your app config.
 
 ```ts
-@NgModule({
-  imports: [MatStepperModule],
+bootstrapApplication(MyApp, {
   providers: [
     {provide: MatStepperIntl, useClass: MyIntl},
-  ],
-})
-export class MyApp {}
+  ]
+});
 ```
 
 <!-- example(stepper-intl) -->

--- a/src/youtube-player/README.md
+++ b/src/youtube-player/README.md
@@ -8,8 +8,7 @@ File any bugs against the [angular/components repo](https://github.com/angular/c
 To install, run `ng add @angular/youtube-player`.
 
 ## Usage
-Import the component either by adding the `YouTubePlayerModule` to your app or by importing
-`YouTubePlayer` into a standalone component. Then add the `<youtube-player videoId="<your ID>"`
+Import `YouTubePlayer` into your component. Then add the `<youtube-player videoId="<your ID>"`
 to your template.
 
 ## Example
@@ -43,19 +42,17 @@ If you don't want it to be loaded, you can either control it on a per-component 
 Or at a global level using the `YOUTUBE_PLAYER_CONFIG` injection token:
 
 ```typescript
-import {NgModule} from '@angular/core';
-import {YouTubePlayer, YOUTUBE_PLAYER_CONFIG} from '@angular/youtube-player';
+import {bootstrapApplication} from '@angular/platform-browser';
+import {YOUTUBE_PLAYER_CONFIG} from '@angular/youtube-player';
 
-@NgModule({
-  imports: [YouTubePlayer],
+bootstrapApplication(MyApp, {
   providers: [{
     provide: YOUTUBE_PLAYER_CONFIG,
     useValue: {
       loadApi: false
     }
   }]
-})
-export class YourApp {}
+});
 ```
 
 ## Loading behavior
@@ -78,19 +75,17 @@ initialization, you can either pass in the `disablePlaceholder` input:
 Or set it at a global level using the `YOUTUBE_PLAYER_CONFIG` injection token:
 
 ```typescript
-import {NgModule} from '@angular/core';
-import {YouTubePlayer, YOUTUBE_PLAYER_CONFIG} from '@angular/youtube-player';
+import {bootstrapApplication} from '@angular/platform-browser';
+import {YOUTUBE_PLAYER_CONFIG} from '@angular/youtube-player';
 
-@NgModule({
-  imports: [YouTubePlayer],
+bootstrapApplication(MyApp, {
   providers: [{
     provide: YOUTUBE_PLAYER_CONFIG,
     useValue: {
       disablePlaceholder: true
     }
   }]
-})
-export class YourApp {}
+});
 ```
 
 ### Placeholder image quality


### PR DESCRIPTION
## What kind of change does this PR introduce?
Documentation update.

## What is the current behavior?
Several documentation pages across material, CDK, youtube-player, and material-experimental still use `@NgModule({ providers: [...] })` syntax when showing how to configure global providers. This is outdated — Angular now recommends the standalone `bootstrapApplication` API.

Closes #32709

## What is the new behavior?
All `@NgModule` provider code blocks in markdown documentation have been converted to use the modern `bootstrapApplication(MyApp, { providers: [...] })` pattern. Surrounding prose has been updated from "root module" to "app config" for consistency with existing docs (e.g. datepicker, timepicker).

### Files changed (13):
**Material:**
- `bottom-sheet.md` — `MAT_BOTTOM_SHEET_DEFAULT_OPTIONS`
- `chips.md` — `MAT_CHIPS_DEFAULT_OPTIONS` (also fixed code fence from `html` to `ts`)
- `ripple.md` — `MAT_RIPPLE_GLOBAL_OPTIONS` (2 occurrences)
- `dialog.md` — `MAT_DIALOG_DEFAULT_OPTIONS`
- `form-field.md` — `MAT_FORM_FIELD_DEFAULT_OPTIONS` (2 occurrences)
- `input.md` — `ErrorStateMatcher`
- `select.md` — `ErrorStateMatcher`
- `snack-bar.md` — `MAT_SNACK_BAR_DEFAULT_OPTIONS`
- `stepper.md` — `STEPPER_GLOBAL_OPTIONS` (2 occurrences) + `MatStepperIntl`

**CDK:**
- `dialog.md` — `DEFAULT_DIALOG_CONFIG`
- `overlay.md` — `OverlayContainer`

**Other:**
- `youtube-player/README.md` — `YOUTUBE_PLAYER_CONFIG` (2 occurrences)
- `material-experimental/README.md` — Updated `NgModule` import example to standalone component

## Additional context
The existing datepicker and timepicker docs already use `bootstrapApplication` syntax — this PR brings the remaining docs into alignment with that pattern. Only `@NgModule` code blocks with `providers` were converted; casual inline text mentions of `NgModule` (e.g. in autocomplete.md, icon.md) were left as-is since the issue author noted those may be a separate concern.