### PR TITLE
fix(material/radio): hide supporting elements from assistive technology

### DIFF
--- a/src/material/radio/radio.html
+++ b/src/material/radio/radio.html
@@ -1,7 +1,7 @@
 <div mat-internal-form-field [labelPosition]="labelPosition" #formField>
   <div class="mdc-radio" [class.mdc-radio--disabled]="disabled">
     <!-- Render this element first so the input is on top. -->
-    <div class="mat-mdc-radio-touch-target" (click)="_onTouchTargetClick($event)"></div>
+    <div class="mat-mdc-radio-touch-target" (click)="_onTouchTargetClick($event)" aria-hidden="true"></div>
     <!--
       Note that we set `aria-invalid="false"` on the input, because otherwise some screen readers
       will read out "required, invalid data" for each radio button that hasn't been checked.
@@ -22,14 +22,15 @@
            [attr.aria-describedby]="ariaDescribedby"
            [attr.aria-disabled]="disabled && disabledInteractive ? 'true' : null"
            (change)="_onInputInteraction($event)">
-    <div class="mdc-radio__background">
+    <div class="mdc-radio__background" aria-hidden="true">
       <div class="mdc-radio__outer-circle"></div>
       <div class="mdc-radio__inner-circle"></div>
     </div>
     <div mat-ripple class="mat-radio-ripple mat-focus-indicator"
          [matRippleTrigger]="_rippleTrigger.nativeElement"
          [matRippleDisabled]="_isRippleDisabled()"
-         [matRippleCentered]="true">
+         [matRippleCentered]="true"
+         aria-hidden="true">
       <div class="mat-ripple-element mat-radio-persistent-ripple"></div>
     </div>
   </div>

--- a/src/material/radio/radio.spec.ts
+++ b/src/material/radio/radio.spec.ts
@@ -868,6 +868,17 @@ describe('MatRadio', () => {
       expect(fruitRadioNativeInputs[0].hasAttribute('aria-describedby')).toBe(false);
     });
 
+    it('should hide supporting elements from assistive technology', () => {
+      const radioNativeElement = fruitRadioNativeElements[0];
+      const touchTarget = radioNativeElement.querySelector('.mat-mdc-radio-touch-target')!;
+      const background = radioNativeElement.querySelector('.mdc-radio__background')!;
+      const ripple = radioNativeElement.querySelector('.mat-radio-ripple')!;
+
+      expect(touchTarget.getAttribute('aria-hidden')).toBe('true');
+      expect(background.getAttribute('aria-hidden')).toBe('true');
+      expect(ripple.getAttribute('aria-hidden')).toBe('true');
+    });
+
     it('should focus on underlying input element when focus() is called', () => {
       for (let i = 0; i < fruitRadioInstances.length; i++) {
         expect(document.activeElement).not.toBe(fruitRadioNativeInputs[i]);


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix (accessibility).

## What is the current behavior?
VoiceOver on macOS reads the decorative `div` elements inside `mat-radio-button` (touch target, radio circle background, and ripple container) as "group", creating unnecessary navigation stops when using a screen reader to navigate through a radio group. Each radio button results in multiple "group" announcements instead of just the expected radio button label and state.

Closes #32797

## What is the new behavior?
The three supporting visual elements inside `mat-radio-button` now have `aria-hidden="true"`:

- `.mat-mdc-radio-touch-target` -- expanded hit area for touch interaction
- `.mdc-radio__background` -- visual radio circle (outer/inner circles)
- `.mat-radio-ripple` -- ripple effect container

This hides them from the accessibility tree so screen readers only announce the semantically meaningful `<input type="radio">` and `<label>` elements, resulting in one clean navigation stop per radio button.

## Additional context
This follows the same pattern used by `mat-checkbox`, which marks its decorative SVG checkmark with `aria-hidden="true"` (see `checkbox.html` line 33 and `checkbox.spec.ts` line 61-64).

A unit test has been added to verify all three elements have the `aria-hidden="true"` attribute.

**Files changed:**
- `src/material/radio/radio.html` -- Added `aria-hidden="true"` to 3 decorative elements
- `src/material/radio/radio.spec.ts` -- Added test verifying aria-hidden attributes