### PR TITLE
docs(material/dialog): clarify that default options replace rather than merge

### DIFF
--- a/src/cdk/dialog/dialog.md
+++ b/src/cdk/dialog/dialog.md
@@ -129,6 +129,18 @@ bootstrapApplication(MyApp, {
 });
 ```
 
+> **Note:** The value provided for `DEFAULT_DIALOG_CONFIG` **replaces** the built-in defaults
+> entirely rather than merging with them. For example, providing `{disableClose: true}` means that
+> all other defaults (such as `hasBackdrop`) will be `undefined`. If you only want to override
+> specific properties, spread the defaults first:
+>
+> ```ts
+> {provide: DEFAULT_DIALOG_CONFIG, useValue: {...new DialogConfig(), disableClose: true}}
+> ```
+>
+> When you call `dialog.open()` with a config, that config is merged on top of these defaults, so
+> per-dialog options always take precedence.
+
 ### Sharing data with the Dialog component.
 You can use the `data` option to pass information to the dialog component.
 

--- a/src/material/dialog/dialog.md
+++ b/src/material/dialog/dialog.md
@@ -53,6 +53,18 @@ bootstrapApplication(MyApp, {
 });
 ```
 
+> **Note:** The value provided for `MAT_DIALOG_DEFAULT_OPTIONS` **replaces** the built-in defaults
+> entirely rather than merging with them. For example, providing `{disableClose: true}` means that
+> all other defaults (such as `hasBackdrop`) will be `undefined`. If you only want to override
+> specific properties, spread the defaults first:
+>
+> ```ts
+> {provide: MAT_DIALOG_DEFAULT_OPTIONS, useValue: {...new MatDialogConfig(), disableClose: true}}
+> ```
+>
+> When you call `dialog.open()` with a config, that config is merged on top of these defaults, so
+> per-dialog options always take precedence.
+
 ### Sharing data with the Dialog component.
 If you want to share data with your dialog, you can use the `data`
 option to pass information to the dialog component.


### PR DESCRIPTION
## What kind of change does this PR introduce?
Documentation improvement.

## What is the current behavior?
The docs for `MAT_DIALOG_DEFAULT_OPTIONS` and `DEFAULT_DIALOG_CONFIG` show how to provide custom default options but do not mention that the provided value **replaces** the built-in defaults entirely. This leads to confusion when users provide a partial config (e.g. `{disableClose: true}`) and find that other defaults like `hasBackdrop` are lost.

This was confirmed as intended behavior by a maintainer in [#20631 (comment)](https://github.com/angular/components/issues/20631#issuecomment-685744868).

Closes #20631

## What is the new behavior?
Both `dialog.md` (Material) and `cdk/dialog/dialog.md` (CDK) now include a blockquote note after the default options code example that:

1. Explains that the provided value replaces the built-in defaults entirely (no automatic merging)
2. Shows the workaround for partial overrides using the spread operator: `{...new MatDialogConfig(), disableClose: true}`
3. Clarifies that per-dialog options passed to `dialog.open()` are merged on top of these defaults

The code examples were also updated to use `bootstrapApplication` and "app config" prose.

## Additional context
The replacement behavior comes from this line in the source:
```ts
config = {...(this._defaultOptions || new MatDialogConfig()), ...config};
```

When `MAT_DIALOG_DEFAULT_OPTIONS` is provided, it is used as-is (the `||` picks it over `new MatDialogConfig()`). The `open()` call then spreads the per-dialog config on top. This means a partial default like `{disableClose: true}` loses all other built-in defaults.

**Files changed:**
- `src/material/dialog/dialog.md` -- Added clarification note for `MAT_DIALOG_DEFAULT_OPTIONS`
- `src/cdk/dialog/dialog.md` -- Added clarification note for `DEFAULT_DIALOG_CONFIG`

Note: This PR partially overlaps with #32815 on the `@NgModule` to `bootstrapApplication` conversion for the dialog docs sections. If #32815 merges first, a minor conflict resolution will be needed.