### PR TITLE
fix(material/sidenav): use sidenav components in autosize example

### DIFF
--- a/src/components-examples/material/sidenav/sidenav-autosize/sidenav-autosize-example.html
+++ b/src/components-examples/material/sidenav/sidenav-autosize/sidenav-autosize-example.html
@@ -1,5 +1,5 @@
-<mat-drawer-container class="example-container" autosize>
-  <mat-drawer #drawer class="example-sidenav" mode="side">
+<mat-sidenav-container class="example-container" autosize>
+  <mat-sidenav #sidenav class="example-sidenav" mode="side">
     <p>Auto-resizing sidenav</p>
     @if (showFiller) {
       <p>Lorem, ipsum dolor sit amet consectetur.</p>
@@ -7,12 +7,12 @@
     <button (click)="showFiller = !showFiller" matButton="elevated">
       Toggle extra text
     </button>
-  </mat-drawer>
+  </mat-sidenav>
 
-  <div class="example-sidenav-content">
-    <button type="button" matButton (click)="drawer.toggle()">
+  <mat-sidenav-content class="example-sidenav-content">
+    <button type="button" matButton (click)="sidenav.toggle()">
       Toggle sidenav
     </button>
-  </div>
+  </mat-sidenav-content>
 
-</mat-drawer-container>
+</mat-sidenav-container>


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix (documentation example)

## What is the current behavior?
The "Autosize sidenav" example (`sidenav-autosize`) incorrectly uses `mat-drawer-container` and `mat-drawer` components instead of `mat-sidenav-container` and `mat-sidenav`. This is misleading because the example appears in the sidenav documentation under the "Resizing an open sidenav" section.

Closes #30616

## What is the new behavior?
The example now correctly uses `mat-sidenav-container`, `mat-sidenav`, and `mat-sidenav-content` — consistent with other sidenav examples in the documentation. The `autosize` attribute works identically since `MatSidenavContainer` extends `MatDrawerContainer`.

## Additional context
- The TypeScript file already imported `MatSidenavModule`, so only the template needed updating.
- The template variable was renamed from `#drawer` to `#sidenav` for consistency.
- The content wrapper was changed from a plain `<div>` to `<mat-sidenav-content>` to match other sidenav examples.