### PR TITLE
docs(cdk/overlay): rename template variable from trigger to origin in example

### DIFF
--- a/src/components-examples/cdk/overlay/cdk-overlay-basic/cdk-overlay-basic-example.html
+++ b/src/components-examples/cdk/overlay/cdk-overlay-basic/cdk-overlay-basic-example.html
@@ -1,12 +1,12 @@
-<!-- This button triggers the overlay and is it's origin -->
-<button (click)="isOpen = !isOpen" type="button" cdkOverlayOrigin #trigger="cdkOverlayOrigin">
+<!-- This button is the origin to which the overlay is attached -->
+<button (click)="isOpen = !isOpen" type="button" cdkOverlayOrigin #origin="cdkOverlayOrigin">
   {{isOpen ? "Close" : "Open"}}
 </button>
 
 <!-- This template displays the overlay content and is connected to the button -->
 <ng-template
   cdkConnectedOverlay
-  [cdkConnectedOverlayOrigin]="trigger"
+  [cdkConnectedOverlayOrigin]="origin"
   [cdkConnectedOverlayOpen]="isOpen"
   (detach)="isOpen = false"
 >


### PR DESCRIPTION
## What kind of change does this PR introduce?
Documentation improvement

## What is the current behavior?
The overlay basic example uses `#trigger` as the template reference variable name for the `cdkOverlayOrigin` element. This is confusing because it suggests the variable represents the element that triggers the overlay open/close, when in fact it identifies the attachment point (origin) for the connected overlay.

The comment also contains a typo: "it's" instead of "its".

Closes #31221

## What is the new behavior?
- Renamed `#trigger` to `#origin` to match the semantic role of the variable (it is the `cdkOverlayOrigin`)
- Updated the `[cdkConnectedOverlayOrigin]` binding to reference the renamed variable
- Reworded the comment for clarity and fixed the typo

## Additional context
This is a small but meaningful improvement for developers learning from this example. The original author of the issue noted that the `#trigger` name caused confusion about whether the variable was related to the open/close behavior vs. the positional attachment point. Using `#origin` aligns with the directive name (`cdkOverlayOrigin`) and the input name (`cdkConnectedOverlayOrigin`).