### PR TITLE
docs(material/button): document iconPositionEnd and matButtonIcon attributes

### DIFF
--- a/src/material/button/button.md
+++ b/src/material/button/button.md
@@ -43,6 +43,47 @@ the `extended` attribute, mini FABs do not.
 </button>
 ```
 
+### Icon positioning
+
+Buttons can contain icons alongside text. By default, icons (`mat-icon`, `.material-icons`, or
+elements with the `matButtonIcon` attribute) are projected **before** the button label.
+
+```html
+<button matButton>
+  <mat-icon>favorite</mat-icon>
+  Like
+</button>
+```
+
+To place an icon **after** the button label, add the `iconPositionEnd` attribute to the icon element:
+
+```html
+<button matButton>
+  Send
+  <mat-icon iconPositionEnd>send</mat-icon>
+</button>
+```
+
+You can also use both positions at once:
+
+```html
+<button matButton>
+  <mat-icon>arrow_back</mat-icon>
+  Navigate
+  <mat-icon iconPositionEnd>arrow_forward</mat-icon>
+</button>
+```
+
+If you are using a custom icon element that is not a `mat-icon` or `.material-icons`, add the
+`matButtonIcon` attribute so that the button can project it into the correct slot:
+
+```html
+<button matButton>
+  <my-custom-icon matButtonIcon>custom</my-custom-icon>
+  Action
+</button>
+```
+
 ### Interactive disabled buttons
 Native disabled `<button>` elements cannot receive focus and do not dispatch any events. This can
 be problematic in some cases because it can prevent the app from telling the user why the button is


### PR DESCRIPTION
## What kind of change does this PR introduce?
Documentation

## What is the current behavior?
The `iconPositionEnd` and `matButtonIcon` attributes used for icon content projection in buttons are not documented anywhere in the button overview. Users have to discover these features by reading the template source code or the MDC migration guide.

Closes #26259

## What is the new behavior?
Added an "Icon positioning" section to `button.md` that documents:

- **Default icon position**: icons (`mat-icon`, `.material-icons`, `[matButtonIcon]`) are projected before the label
- **`iconPositionEnd`**: attribute to place an icon after the label
- **Both positions**: using leading and trailing icons together
- **`matButtonIcon`**: attribute for custom icon elements that need to participate in content projection

## Additional context
These are not Angular directives in the traditional sense — they are CSS attribute selectors used for [multi-slot content projection](https://angular.dev/guide/components/content-projection#multiple-content-placeholders) in the button template. They have been supported since the MDC migration but were never added to the documentation.

A comment on the issue also mentions `matMenuItemIcon` for menu items, but that is scoped to a different component and can be addressed in a separate PR if needed.