### PR TITLE
fix(material/table): add aria-expanded to expandable rows example

### DIFF
--- a/src/components-examples/material/table/table-expandable-rows/table-expandable-rows-example.html
+++ b/src/components-examples/material/table/table-expandable-rows/table-expandable-rows-example.html
@@ -12,8 +12,8 @@
     <td mat-cell *matCellDef="let element">
       <button
         matIconButton
-        [attr.aria-label]="isExpanded(element) ? 'collapse row' : 'expand row'"
-        [attr.aria-expanded]="isExpanded(element)"
+        [aria-label]="isExpanded(element) ? 'collapse row' : 'expand row'"
+        [aria-expanded]="isExpanded(element)"
         (click)="toggle(element); $event.stopPropagation()"
         class="example-toggle-button"
         [class.example-toggle-button-expanded]="isExpanded(element)">


### PR DESCRIPTION
## What kind of change does this PR introduce?
Accessibility fix (example)

## What is the current behavior?
The "Table with expandable rows" example does not convey the expanded/collapsed state to assistive technology. Screen reader users have no way to know whether a row is currently expanded, and the toggle button always says "expand row" regardless of state.

Closes #15020

## What is the new behavior?
- Added `[attr.aria-expanded]="isExpanded(element)"` to the toggle button, so screen readers announce the expanded/collapsed state
- Changed `aria-label` from a static `"expand row"` to a dynamic binding that says `"collapse row"` when expanded and `"expand row"` when collapsed

## Additional context
The [WAI-ARIA Authoring Practices](https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/) recommend using `aria-expanded` on disclosure triggers to communicate state to assistive technology. The existing button element already provides keyboard accessibility (focusable, activatable via Enter/Space), so only the ARIA state attribute was missing.