### PR TITLE
docs: update remaining NgModule prose references to standalone pattern

### DIFF
--- a/src/cdk/listbox/listbox.md
+++ b/src/cdk/listbox/listbox.md
@@ -44,7 +44,7 @@ In addition to CSS classes, these directives add aria attributes that can be tar
 
 ### Getting started
 
-Import the `CdkListboxModule` into the `NgModule` in which you want to create a listbox. You can
+Import `CdkListbox` and `CdkOption` in the component where you want to create a listbox. You can
 then apply listbox directives to build your custom listbox. A typical listbox consists of the
 following directives:
 

--- a/src/cdk/menu/menu.md
+++ b/src/cdk/menu/menu.md
@@ -41,8 +41,8 @@ The available CSS classes are listed below, by directive.
 
 ### Getting started
 
-Import the `CdkMenuModule` into the `NgModule` in which you want to create menus. You can then apply
-menu directives to build your custom menu. A typical menu consists of the following directives:
+Import `CdkMenu`, `CdkMenuItem`, and `CdkMenuTrigger` in the component where you want to create
+menus. You can then apply menu directives to build your custom menu. A typical menu consists of the following directives:
 
 - `cdkMenuTriggerFor` - links a trigger element to an `ng-template` containing the menu to be opened
 - `cdkMenu` - creates the menu content opened by the trigger

--- a/src/material/autocomplete/autocomplete.md
+++ b/src/material/autocomplete/autocomplete.md
@@ -16,7 +16,7 @@ track the value of the input.
 
 > Note: It is possible to use template-driven forms instead, if you prefer. We use reactive forms
 in this example because it makes subscribing to changes in the input's value easy. For this
-example, be sure to import `ReactiveFormsModule` from `@angular/forms` into your `NgModule`.
+example, be sure to import `ReactiveFormsModule` from `@angular/forms` in your component.
 If you are unfamiliar with using reactive forms, you can read more about the subject in the
 [Angular documentation](https://angular.dev/guide/forms/reactive-forms).
 

--- a/src/material/icon/icon.md
+++ b/src/material/icon/icon.md
@@ -52,8 +52,8 @@ In order to guard against XSS vulnerabilities, any SVG URLs and HTML strings pas
 `MatIconRegistry` must be marked as trusted by using Angular's `DomSanitizer` service.
 
 `MatIconRegistry` fetches all remote SVG icons via Angular's `HttpClient` service. If you haven't
-included [`HttpClientModule` from the `@angular/common/http` package](https://angular.dev/guide/http)
-in your `NgModule` imports, you will get an error at runtime.
+included [`provideHttpClient()`](https://angular.dev/guide/http) in your app config, you will get
+an error at runtime.
 
 Note that `HttpClient` fetches SVG icons registered with a URL via `XmlHttpRequest`, subject to the
 [Same-origin policy](https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy). This


### PR DESCRIPTION
## What kind of change does this PR introduce?
Documentation

## What is the current behavior?
Several documentation files still reference `NgModule` in prose when describing how to import directives and configure providers. This is outdated since Angular now uses the standalone component pattern by default.

Partially addresses #32709 (follow-up to PR #32815 which converted code blocks)

## What is the new behavior?
Updated prose references in four files:

- **autocomplete.md**: "import `ReactiveFormsModule` into your `NgModule`" changed to "import `ReactiveFormsModule` in your component"
- **listbox.md**: "Import the `CdkListboxModule` into the `NgModule`" changed to "Import `CdkListbox` and `CdkOption` in the component"
- **icon.md**: "`HttpClientModule` in your `NgModule` imports" changed to "`provideHttpClient()` in your app config" (also replaces the deprecated `HttpClientModule` reference)
- **menu.md**: "Import the `CdkMenuModule` into the `NgModule`" changed to "Import `CdkMenu`, `CdkMenuItem`, and `CdkMenuTrigger` in the component"

## Additional context
PR #32815 converted `@NgModule` code blocks to `bootstrapApplication` syntax across 13 files. This follow-up PR handles the remaining prose-only references to `NgModule` that were not covered by that PR.