### PR TITLE
docs: use standalone import in getting-started guide

### DIFF
--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -40,16 +40,13 @@ You're done! Angular Material is now configured to be used in your application.
 
 Let's display a slide toggle component in your app and verify that everything works.
 
-You need to import the `MatSlideToggleModule` that you want to display by adding the following lines to
-your standalone component's imports, or otherwise your component's `NgModule`.
+You need to import the `MatSlideToggle` component by adding it to your component's `imports`:
 
 ```ts
-import { MatSlideToggleModule } from '@angular/material/slide-toggle';
+import {MatSlideToggle} from '@angular/material/slide-toggle';
 
-@Component ({
-  imports: [
-    MatSlideToggleModule,
-  ]
+@Component({
+  imports: [MatSlideToggle],
 })
 class AppComponent {}
 ```


### PR DESCRIPTION
## What kind of change does this PR introduce?
Documentation

## What is the current behavior?
The getting-started guide imports `MatSlideToggleModule` and mentions `NgModule` as an alternative import target:

> "adding the following lines to your standalone component's imports, or otherwise your component's NgModule."

This is outdated since Angular now defaults to standalone components and the NgModule approach is legacy.

Partially addresses #32709

## What is the new behavior?
- Imports `MatSlideToggle` (the standalone component) directly instead of `MatSlideToggleModule`
- Removes the NgModule fallback mention
- Cleans up the code formatting to match the Angular style guide (no spaces inside braces, compact imports array)

## Additional context
This is a follow-up to PRs #32815 and #32825 which converted other docs from NgModule patterns to the standalone pattern. The getting-started guide is one of the first pages new users see, so it should reflect current best practices.