### PR TITLE
docs: remove BidiModule import requirement and use inject()

### DIFF
--- a/guides/bidirectionality.md
+++ b/guides/bidirectionality.md
@@ -12,7 +12,7 @@ of their container.
 ## Reading the text-direction in your own components
 
 `@angular/cdk/bidi` provides a `Directionality` injectable that can be used by any component
-in your application. To consume it, you must import `BidiModule` from `@angular/cdk/bidi`.
+in your application.
 
 `Directionality` provides two useful properties:
 * `value`: the current text direction, either `'ltr'` or `'rtl'`.
@@ -25,13 +25,12 @@ emit for changes to `dir` on `<html>` and `<body>`, as they are assumed to be st
 ```ts
 @Component({ /* ... */ })
 export class MyCustomComponent {
-  private dir: Direction;
+  private directionality = inject(Directionality);
+  private dir = this.directionality.value;
 
-  constructor(directionality: Directionality) {
-    this.dir = directionality.value;
-
-    directionality.change.subscribe(() => {
-      this.dir = directionality.value;
+  constructor() {
+    this.directionality.change.subscribe(() => {
+      this.dir = this.directionality.value;
     });
   }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?
Documentation

## What is the current behavior?
The bidirectionality guide states:

> "To consume it, you must import `BidiModule` from `@angular/cdk/bidi`."

This is incorrect because `Directionality` is decorated with `@Injectable({providedIn: 'root'})`, so no module import is needed. The guide also uses the older constructor injection pattern.

Partially addresses #32709

## What is the new behavior?
- Removed the incorrect `BidiModule` import requirement
- Updated the code example to use `inject(Directionality)` instead of constructor injection
- Simplified the example to use field initializers where possible

## Additional context
`Directionality` has been `providedIn: 'root'` for a while, so this instruction was already outdated. The `inject()` function is the recommended pattern in modern Angular.