### PR TITLE
docs: use standalone component pattern in harness guide examples

### DIFF
--- a/guides/using-component-harnesses.md
+++ b/guides/using-component-harnesses.md
@@ -48,11 +48,11 @@ let loader: HarnessLoader;
 
 describe('my-component', () => {
   beforeEach(async () => {
-    TestBed.configureTestingModule({imports: [MyModule], declarations: [UserProfile]});
+    await TestBed.configureTestingModule({imports: [UserProfile]}).compileComponents();
     fixture = TestBed.createComponent(UserProfile);
     loader = TestbedHarnessEnvironment.loader(fixture);
   });
-}
+});
 ```
 
 This code creates a fixture for `UserProfile` and then creates a `HarnessLoader` for that fixture.
@@ -172,10 +172,9 @@ describe('issue-report-selector', () => {
   let fixture: ComponentFixture<IssueReportSelector>;
 
   beforeEach(async () => {
-    TestBed.configureTestingModule({
-      imports: [IssueReportSelectorModule],
-      declarations: [IssueReportSelector],
-    });
+    await TestBed.configureTestingModule({
+      imports: [IssueReportSelector],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(IssueReportSelector);
     fixture.detectChanges();
@@ -204,10 +203,9 @@ describe('issue-report-selector', () => {
   let loader: HarnessLoader;
 
   beforeEach(async () => {
-    TestBed.configureTestingModule({
-      imports: [IssueReportSelectorModule],
-      declarations: [IssueReportSelector],
-    });
+    await TestBed.configureTestingModule({
+      imports: [IssueReportSelector],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(IssueReportSelector);
     fixture.detectChanges();


### PR DESCRIPTION
## What kind of change does this PR introduce?
Documentation

## What is the current behavior?
The "Using component harnesses" guide uses the legacy `declarations` + NgModule `imports` pattern in its TestBed setup examples:

```ts
TestBed.configureTestingModule({
  imports: [IssueReportSelectorModule],
  declarations: [IssueReportSelector],
});
```

This is the NgModule-based testing pattern which is outdated now that Angular defaults to standalone components.

Partially addresses #32709

## What is the new behavior?
All three TestBed configuration examples are updated to use the standalone component pattern:

```ts
await TestBed.configureTestingModule({
  imports: [IssueReportSelector],
}).compileComponents();
```

Changes:
- Removed `declarations` arrays (standalone components are imported, not declared)
- Removed NgModule imports (e.g., `IssueReportSelectorModule`, `MyModule`)
- Added `await` and `.compileComponents()` to follow current best practices
- Fixed a minor syntax issue (missing closing parenthesis on `describe` block)

## Additional context
The two comparison examples ("without harnesses" and "with harnesses") were both updated to maintain their parallel structure. This is a follow-up to the standalone migration work in PRs #32815, #32825, #32826, and #32827.