### PR TITLE
docs(cdk/portal): clarify CdkPortal query pattern and use signal-based viewChild

### DIFF
--- a/src/cdk/portal/portal.md
+++ b/src/cdk/portal/portal.md
@@ -46,8 +46,15 @@ Usage:
 </p>
 ```
 
-A component can use `@ViewChild` or `@ViewChildren` to get a reference to a
-`CdkPortal`.
+A component can use `viewChild` or `viewChildren` to get a reference to a
+`CdkPortal`. Query by the `CdkPortal` class rather than a template reference variable to ensure the
+query works with both syntaxes above.
+
+```ts
+import {CdkPortal} from '@angular/cdk/portal';
+
+readonly myPortal = viewChild(CdkPortal);
+```
 
 ##### `ComponentPortal`
 Used to create a portal from a component type.
@@ -68,11 +75,13 @@ Usage:
 ```
 
 ```ts
-@ViewChild('templatePortalContent') templatePortalContent: TemplateRef<unknown>;
+private _viewContainerRef = inject(ViewContainerRef);
+
+readonly templatePortalContent = viewChild<TemplateRef<unknown>>('templatePortalContent');
 
 ngAfterViewInit() {
   this.templatePortal = new TemplatePortal(
-    this.templatePortalContent,
+    this.templatePortalContent()!,
     this._viewContainerRef
   );
 }
@@ -87,9 +96,10 @@ Usage:
 ```
 
 ```ts
-@ViewChild('domPortalContent') domPortalContent: ElementRef<HTMLElement>;
+readonly domPortalContent = viewChild<ElementRef<HTMLElement>>('domPortalContent');
+
 ngAfterViewInit() {
-  this.domPortal = new DomPortal(this.domPortalContent);
+  this.domPortal = new DomPortal(this.domPortalContent()!);
 }
 ```
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
Documentation improvement

## What is the current behavior?
The portal documentation says a component can use `@ViewChild` or `@ViewChildren` to get a reference to a `CdkPortal`, but does not show how. Users who try using a template reference variable (e.g., `@ViewChild('myRef')`) find it returns `undefined` when using the `*cdkPortal` structural directive syntax.

Additionally, the `TemplatePortal` and `DomPortal` examples use the legacy `@ViewChild` decorator instead of signal-based `viewChild` queries.

Closes #21092

## What is the new behavior?
- Clarifies that `CdkPortal` should be queried by class (not template reference variable) to work with both `<ng-template cdkPortal>` and `*cdkPortal` syntaxes
- Adds an explicit code example showing `viewChild(CdkPortal)`
- Updates `TemplatePortal` example to use `viewChild` signal query and `inject(ViewContainerRef)`
- Updates `DomPortal` example to use `viewChild` signal query

## Additional context
The previous PR #25127 attempted to fix this by removing the `*cdkPortal` syntax from the docs entirely, but was closed. This PR takes a different approach by keeping both syntaxes and adding guidance on the correct query pattern, as suggested in the issue comments.