### PR TITLE
docs: add support policy section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ What do we mean by "high-quality" components?
 * Performance cost is minimized.
 * Code is clean and well-documented to serve as an example for Angular developers.
 
+## Support policy
+Angular Material and the CDK follow the same support and release policy as the Angular framework.
+For details on supported versions and update practices, see the
+[Angular support policy and schedule](https://angular.dev/reference/releases).
+
 ## Browser and screen reader support
 The Angular Components team supports the most recent two versions of all major browsers:
 Chrome (including Android), Firefox, Safari (including iOS), and  Edge.


### PR DESCRIPTION
## What kind of change does this PR introduce?
Documentation improvement

## What is the current behavior?
The repository README does not mention the support policy, leaving contributors and users uncertain about which versions are supported and how releases work.

Closes #32151

## What is the new behavior?
Adds a "Support policy" section to the README clarifying that Angular Material and the CDK follow the same support and release policy as the Angular framework, with a link to the [Angular support policy documentation](https://angular.dev/reference/releases).

## Additional context
A maintainer confirmed in the issue comments that Angular Material and the CDK share the same support policy as the framework.