### PR TITLE
docs(theming): add prebuilt themes section documenting M2 and M3 themes

### DIFF
--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -18,7 +18,7 @@ The `ng add` command will install Angular Material, the [Component Dev Kit (CDK)
 
 1. Choose a prebuilt theme name, or "custom" for a custom theme:
 
-   You can choose from [prebuilt material design themes](https://material.angular.dev/guide/theming#pre-built-themes) or set up an extensible [custom theme](https://material.angular.dev/guide/theming#defining-a-theme).
+   You can choose from [prebuilt material design themes](https://material.angular.dev/guide/theming#prebuilt-themes) or set up an extensible [custom theme](https://material.angular.dev/guide/theming#getting-started).
 
 2. Set up global Angular Material typography styles:
 

--- a/guides/theming.md
+++ b/guides/theming.md
@@ -216,6 +216,43 @@ pop-up contexts, such as the date picker. The Material Design density guidance
 explicitly discourages changes to density for such interactions because they
 don't compete for space in the application's layout.
 
+## Prebuilt Themes
+
+Angular Material includes eight prebuilt theme CSS files as an alternative to
+defining a custom theme with Sass. Four of these themes use the current Material
+3 design system, while the other four use the older Material 2 design system.
+
+If you want your application to follow the modern Material 3 design language,
+make sure to use one of the M3 themes. The M2 themes are provided for backwards
+compatibility and will be removed in a future version.
+
+| Theme                    | Design system | Light or dark? | Palettes (primary, tertiary) |
+|--------------------------|---------------|----------------|------------------------------|
+| `azure-blue.css`         | **M3**        | Light          | azure, blue                  |
+| `rose-red.css`           | **M3**        | Light          | rose, red                    |
+| `cyan-orange.css`        | **M3**        | Dark           | cyan, orange                 |
+| `magenta-violet.css`     | **M3**        | Dark           | magenta, violet              |
+| `deeppurple-amber.css`   | M2            | Light          | deep-purple, amber           |
+| `indigo-pink.css`        | M2            | Light          | indigo, pink                 |
+| `pink-bluegrey.css`      | M2            | Dark           | pink, blue-grey              |
+| `purple-green.css`       | M2            | Dark           | purple, green                |
+
+You can find the prebuilt theme files in the `prebuilt-themes` directory of
+Angular Material’s npm package (`@angular/material/prebuilt-themes`). To include
+a prebuilt theme in your application, add the chosen CSS file to the `styles`
+array of your project’s `angular.json` file:
+
+```json
+"styles": [
+  "@angular/material/prebuilt-themes/azure-blue.css"
+]
+```
+
+You can [reference the source code for these prebuilt themes][prebuilt] to see
+examples of complete theme definitions.
+
+[prebuilt]: https://github.com/angular/components/blob/main/src/material/core/theming/prebuilt
+
 ## Color Palettes
 
 A color palette is a set of similar colors with different hues ranging from


### PR DESCRIPTION
## What kind of change does this PR introduce?

Documentation improvement

## What is the current behavior?

The theming guide does not mention prebuilt themes at all. Developers who use a prebuilt theme have no way to know from the docs which themes use the M2 design system and which use M3. This causes confusion when components look different from the Material Design documentation site (which uses M3).

Additionally, the getting-started guide links to `theming#pre-built-themes` which is a broken anchor.

Closes #30565

## What is the new behavior?

Adds a "Prebuilt Themes" section to the theming guide that:
- Lists all eight prebuilt themes in a table
- Identifies which themes use M3 and which use M2
- Shows the light/dark mode and color palettes for each theme
- Notes that M2 themes are provided for backwards compatibility
- Includes instructions for adding a prebuilt theme via `angular.json`
- Links to the source code for the prebuilt theme definitions

Also fixes the broken anchor in the getting-started guide to point to the new section.

## Additional context

The prebuilt theme source files confirm:
- **M3 themes** (use `system.theme`): `azure-blue`, `rose-red`, `cyan-orange`, `magenta-violet`
- **M2 themes** (use `m2.define-light-theme`/`m2.define-dark-theme`): `indigo-pink`, `deeppurple-amber`, `pink-bluegrey`, `purple-green`