### PR TITLE
docs(theming): mention mat.theme mixin in M2 to M3 migration guide

### DIFF
--- a/guides/material-2.md
+++ b/guides/material-2.md
@@ -1090,9 +1090,24 @@ for how to read values from an M3 theme).
 
 ### Pass a new M3 theme in your global theme styles
 
-Create a new M3 theme object using `define-theme` and pass it everywhere you were previously passing
-your M2 theme. All Angular Material mixins that take an M2 theme are compatible with M3 themes as
-well.
+Replace your M2 theme with an M3 theme. For v19 and later, use the `mat.theme`
+mixin as described in the [theming guide][theming]:
+
+```scss
+@use '@angular/material' as mat;
+
+html {
+  @include mat.theme((
+    color: mat.$violet-palette,
+    typography: Roboto,
+    density: 0,
+  ));
+}
+```
+
+Alternatively, you can create a theme object with `mat.define-theme` and pass it
+to individual component theme mixins. This approach is needed for backwards
+compatibility helpers such as `color-variants-backwards-compatibility`.
 
 ### Update usages of APIs that are not supported for Material 3 themes
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Documentation improvement

## What is the current behavior?

The M2 to M3 migration section in the Material 2 theming guide only references
`mat.define-theme` as the way to create an M3 theme. Since Angular Material v19,
the recommended approach is the `mat.theme` mixin, but the migration guide does
not mention it. This causes confusion for developers following the migration
guide who then find different APIs in the main theming guide.

Closes #30266

## What is the new behavior?

Updates the "Pass a new M3 theme in your global theme styles" section to:
- Show the `mat.theme` mixin as the primary recommended approach for v19+
- Include a code example using the `mat.theme` mixin
- Explain that `mat.define-theme` is still available as an alternative for use
  with backwards compatibility helpers like `color-variants-backwards-compatibility`
- Link to the main theming guide for full details

## Additional context

The `mat.define-theme` function still exists and is valid for creating theme
objects that can be passed to individual component mixins. The `mat.theme` mixin
is the v19+ approach that directly emits CSS variables. Both are correct, but
the migration guide should mention the preferred approach first.