### PR TITLE
docs(theming): fix incorrect M2 API names in theming-your-components guide

### DIFF
--- a/guides/theming-your-components.md
+++ b/guides/theming-your-components.md
@@ -942,7 +942,7 @@ configuration.
 
 $theme: mat.m2-define-light-theme((
   color: (
-    primary: mat.define-palette(mat.$indigo-palette, 500),
+    primary: mat.m2-define-palette(mat.$m2-indigo-palette, 500),
   ),
   ...
 ));


### PR DESCRIPTION
## What kind of change does this PR introduce?

Documentation fix

## What is the current behavior?

The M2 Support section of the `theming-your-components` guide uses incorrect
Sass API names:
- `mat.define-palette` instead of `mat.m2-define-palette`
- `mat.$indigo-palette` instead of `mat.$m2-indigo-palette`

These names do not exist in the flat `@angular/material` namespace. Since v19,
M2 APIs are re-exported with the `m2-` prefix
(`@forward './core/m2' as m2-*` in `_index.scss`), so the correct names are
`mat.m2-define-palette` and `mat.$m2-indigo-palette`.

## What is the new behavior?

Updates the code example in the M2 Support section to use the correct prefixed
API names that match the current `@angular/material` public API.

## Additional context

The `material-2.md` guide already uses the correct `m2-` prefixed names
throughout. This change aligns the `theming-your-components.md` guide with that
convention.