### PR TITLE
docs(cdk/coercion): add guidance on Angular built-in input transforms

### DIFF
--- a/src/cdk/coercion/coercion.md
+++ b/src/cdk/coercion/coercion.md
@@ -1,49 +1,68 @@
 Utility functions for coercing `@Input`s into specific types.
 
-### Example
+### Relation to Angular's built-in input transforms
+
+Angular provides built-in equivalents for the most common coercion functions:
+
+| CDK coercion               | Angular built-in     |
+|----------------------------|----------------------|
+| `coerceBooleanProperty`    | `booleanAttribute`   |
+| `coerceNumberProperty`     | `numberAttribute`    |
+
+For new code, prefer Angular's built-in transforms with signal inputs:
 
 ```ts
-import {Directive, ElementRef} from '@angular/core';
-import {
-  coerceBooleanProperty,
-  BooleanInput,
-  NumberInput,
-  coerceNumberProperty,
-  coerceElement,
-} from '@angular/cdk/coercion';
+import {Component, input} from '@angular/core';
+import {booleanAttribute, numberAttribute} from '@angular/core';
 
-@Directive({
+@Component({
   selector: 'my-button',
   host: {
-    '[disabled]': 'disabled',
+    '[disabled]': 'disabled()',
     '(click)': 'greet()',
   }
 })
 class MyButton {
-  // Using `coerceBooleanProperty` allows for the disabled value of a button to be set as
-  // `<my-button disabled></my-button>` instead of `<my-button [disabled]="true"></my-button>`.
-  // It also allows for a string to be passed like `<my-button disabled="true"></my-button>`.
-  @Input()
-  get disabled() { return this._disabled; }
-  set disabled(value: BooleanInput) {
-    this._disabled = coerceBooleanProperty(value);
-  }
-  private _disabled = false;
-
-  // `coerceNumberProperty` turns any value coming in from the view into a number, allowing the
-  // consumer to use a shorthand string while storing the parsed number in memory. E.g. the consumer can write:
-  // `<my-button greetDelay="500"></my-button>` instead of `<my-button [greetDelay]="500"></my-button>`.
-  // The second parameter specifies a fallback value to be used if the value can't be
-  // parsed to a number.
-  @Input()
-  get greetDelay() { return this._greetDelay; }
-  set greetDelay(value: NumberInput) {
-    this._greetDelay = coerceNumberProperty(value, 0);
-  }
-  private _greetDelay = 0;
+  disabled = input(false, {transform: booleanAttribute});
+  greetDelay = input(0, {transform: numberAttribute});
 
   greet() {
-    setTimeout(() => alert('Hello!'), this.greetDelay);
+    setTimeout(() => alert('Hello!'), this.greetDelay());
+  }
+}
+```
+
+The CDK coercion functions remain useful when you need custom coercion
+logic that goes beyond simple boolean or number conversion, such as
+`coerceElement` or `coerceArray`.
+
+### Example
+
+```ts
+import {Component, ElementRef, input} from '@angular/core';
+import {coerceElement} from '@angular/cdk/coercion';
+import {booleanAttribute, numberAttribute} from '@angular/core';
+
+@Component({
+  selector: 'my-button',
+  host: {
+    '[disabled]': 'disabled()',
+    '(click)': 'greet()',
+  }
+})
+class MyButton {
+  // Angular's `booleanAttribute` allows the disabled value of a button to be set as
+  // `<my-button disabled></my-button>` instead of `<my-button [disabled]="true"></my-button>`.
+  disabled = input(false, {transform: booleanAttribute});
+
+  // Angular's `numberAttribute` turns any value coming in from the view into a number, allowing the
+  // consumer to use a shorthand string while storing the parsed number in memory.
+  // E.g. `<my-button greetDelay="500"></my-button>` instead of
+  // `<my-button [greetDelay]="500"></my-button>`.
+  greetDelay = input(0, {transform: numberAttribute});
+
+  greet() {
+    setTimeout(() => alert('Hello!'), this.greetDelay());
   }
 
   // `coerceElement` allows you to accept either an `ElementRef`


### PR DESCRIPTION
## What kind of change does this PR introduce?

Documentation improvement

## What is the current behavior?

The CDK coercion documentation only shows the legacy pattern of using
`coerceBooleanProperty` and `coerceNumberProperty` with `@Input()` getters
and setters. It does not mention that Angular now provides built-in equivalents
(`booleanAttribute` and `numberAttribute`) that work with signal inputs.

Closes #27718

## What is the new behavior?

Updates the coercion documentation to:
- Add a comparison table showing CDK coercion functions and their Angular
  built-in equivalents (`booleanAttribute`, `numberAttribute`)
- Recommend Angular's built-in transforms with signal inputs for new code
- Show a modern example using `input()` with `{transform: booleanAttribute}`
  and `{transform: numberAttribute}`
- Note that CDK-specific functions like `coerceElement` and `coerceArray`
  remain useful for custom coercion logic
- Modernize the example code to use signal inputs

## Additional context

Since Angular v16+, the `transform` option on `@Input()` made CDK coercion
less necessary for boolean and number inputs. Since Angular v17+, signal inputs
(`input()`) with transforms provide the cleanest API. The CDK coercion module
is still useful for `coerceElement`, `coerceArray`, and custom coercion logic.