### PR TITLE
docs(google-maps): use inject() instead of constructor injection in examples

### DIFF
--- a/src/google-maps/map-directions-renderer/README.md
+++ b/src/google-maps/map-directions-renderer/README.md
@@ -21,28 +21,26 @@ Using the `MapDirectionsService` requires the Directions API to be enabled in Go
 
 ```typescript
 // google-maps-demo.component.ts
-import {Component} from '@angular/core';
+import {Component, inject} from '@angular/core';
 import {GoogleMap, MapDirectionsRenderer, MapDirectionsService} from '@angular/google-maps';
+import {map} from 'rxjs/operators';
 
 @Component({
   selector: 'google-map-demo',
   templateUrl: 'google-map-demo.html',
-    imports: [GoogleMap, MapDirectionsRenderer],
+  imports: [GoogleMap, MapDirectionsRenderer],
 })
 export class GoogleMapDemo {
   center: google.maps.LatLngLiteral = {lat: 24, lng: 12};
   zoom = 4;
 
-  readonly directionsResults$: Observable<google.maps.DirectionsResult|undefined>;
+  private mapDirectionsService = inject(MapDirectionsService);
 
-  constructor(mapDirectionsService: MapDirectionsService) {
-    const request: google.maps.DirectionsRequest = {
-      destination: {lat: 12, lng: 4},
-      origin: {lat: 14, lng: 8},
-      travelMode: google.maps.TravelMode.DRIVING
-    };
-    this.directionsResults$ = mapDirectionsService.route(request).pipe(map(response => response.result));
-  }
+  readonly directionsResults$ = this.mapDirectionsService.route({
+    destination: {lat: 12, lng: 4},
+    origin: {lat: 14, lng: 8},
+    travelMode: google.maps.TravelMode.DRIVING,
+  }).pipe(map(response => response.result));
 }
 ```
 

--- a/src/google-maps/map-geocoder/README.md
+++ b/src/google-maps/map-geocoder/README.md
@@ -24,7 +24,7 @@ has billing enabled. See [here](https://developers.google.com/maps/documentation
 
 ```typescript
 // google-maps-demo.component.ts
-import {Component} from '@angular/core';
+import {Component, inject} from '@angular/core';
 import {MapGeocoder} from '@angular/google-maps';
 
 @Component({
@@ -32,8 +32,10 @@ import {MapGeocoder} from '@angular/google-maps';
   templateUrl: 'google-map-demo.html',
 })
 export class GoogleMapDemo {
-  constructor(geocoder: MapGeocoder) {
-    geocoder.geocode({
+  private geocoder = inject(MapGeocoder);
+
+  search() {
+    this.geocoder.geocode({
       address: '1600 Amphitheatre Parkway, Mountain View, CA'
     }).subscribe(({results}) => {
       console.log(results);


### PR DESCRIPTION
## What kind of change does this PR introduce?

Documentation update.

## What is the current behavior?

The `MapGeocoder` and `MapDirectionsRenderer` README examples use constructor
injection to obtain services. The `MapDirectionsRenderer` example is also
missing the `import {map} from 'rxjs/operators'` import and has inconsistent
indentation on the `imports` array.

## What is the new behavior?

- Use `inject()` instead of constructor injection, consistent with the modern
  Angular standalone pattern used across the rest of the docs.
- Add the missing `import {map} from 'rxjs/operators'` to the directions
  renderer example so the code compiles as shown.
- Fix indentation of the `imports` array in the directions renderer example.
- Simplify the directions renderer example by using a field initializer instead
  of assigning inside the constructor.

## Additional context

Both `MapGeocoder` and `MapDirectionsService` are `providedIn: 'root'`, so they
work with `inject()` without any additional provider configuration.