### PR TITLE
docs(cdk/a11y): remove incorrect auto-include claim for cdk-visually-hidden

### DIFF
--- a/src/cdk/a11y/a11y.md
+++ b/src/cdk/a11y/a11y.md
@@ -204,9 +204,7 @@ Screen readers and other assistive technology skip elements that have `display: 
 `visibility: hidden`, `opacity: 0`, `height: 0`, or `width: 0`. In some cases you may need to
 visually hide an element while keeping it available to assistive technology. You can do so using
 the `a11y-visually-hidden` Sass mixin, which emits the `.cdk-visually-hidden` CSS class.
-
-If you're using Angular Material, this class is included automatically by Angular Material's theming
-system. Otherwise, you can include this mixin in a global stylesheet.
+Include this mixin in a global stylesheet.
 
 ```scss
 @use '@angular/cdk';


### PR DESCRIPTION
## What kind of change does this PR introduce?

Documentation fix.

## What is the current behavior?

The CDK a11y docs state:

> If you're using Angular Material, this class is included automatically
> by Angular Material's theming system.

This is no longer true. The visually-hidden styles were removed from
Angular Material's core in #29812, so the `.cdk-visually-hidden` class
is no longer emitted automatically by Material's theming. Users must
explicitly include `cdk.a11y-visually-hidden()` in a global stylesheet.

Closes #30585

## What is the new behavior?

Remove the incorrect auto-include claim. The docs now simply instruct
users to include the mixin in a global stylesheet, without suggesting
it might already be included.