### PR TITLE
feat(material/tabs): add support for separate tab animation durations

### DIFF
--- a/goldens/material/tabs/index.api.md
+++ b/goldens/material/tabs/index.api.md
@@ -243,15 +243,17 @@ export class MatTabGroup implements AfterViewInit, AfterContentInit, AfterConten
     alignTabs: string | null;
     _allTabs: QueryList<MatTab>;
     readonly animationDone: EventEmitter<void>;
-    get animationDuration(): string;
-    set animationDuration(value: string | number);
-    // (undocumented)
-    protected _animationsDisabled(): boolean;
+    get animationDuration(): MatTabGroupAnimationDuration;
+    set animationDuration(value: MatTabGroupAnimationDuration);
     ariaLabel: string;
     ariaLabelledby: string;
     // @deprecated
     get backgroundColor(): ThemePalette;
     set backgroundColor(value: ThemePalette);
+    // (undocumented)
+    protected _bodyAnimationDuration: string;
+    // (undocumented)
+    protected _bodyAnimationsDisabled(): boolean;
     protected _bodyCentered(isCenter: boolean): void;
     color: ThemePalette;
     get contentTabIndex(): number | null;
@@ -271,6 +273,8 @@ export class MatTabGroup implements AfterViewInit, AfterContentInit, AfterConten
     _getTabIndex(index: number): number;
     _getTabLabelId(tab: MatTab, index: number): string;
     _handleClick(tab: MatTab, tabHeader: MatTabGroupBaseHeader, index: number): void;
+    // (undocumented)
+    protected _headerAnimationDuration: string;
     headerPosition: MatTabHeaderPosition;
     protected _isServer: boolean;
     // (undocumented)

--- a/src/material/tabs/_tabs-common.scss
+++ b/src/material/tabs/_tabs-common.scss
@@ -247,7 +247,7 @@ $mat-tab-animation-duration: 500ms !default;
   }
 
   .mdc-tab-indicator .mdc-tab-indicator__content {
-    transition-duration: var(--mat-tab-animation-duration, 250ms);
+    transition-duration: var(--mat-tab-header-animation-duration, 250ms);
   }
 
   .mat-mdc-tab-header-pagination {

--- a/src/material/tabs/tab-body.scss
+++ b/src/material/tabs/tab-body.scss
@@ -51,7 +51,7 @@
 .mat-tab-body-content-can-animate {
   // Note: there's a 1ms delay so that transition events
   // still fire even if the duration is set to zero.
-  transition: transform var(--mat-tab-animation-duration) 1ms cubic-bezier(0.35, 0, 0.25, 1);
+  transition: transform var(--mat-tab-body-animation-duration) 1ms cubic-bezier(0.35, 0, 0.25, 1);
 
   .mat-mdc-tab-body-wrapper._mat-animation-noopable & {
     transition: none;

--- a/src/material/tabs/tab-group.html
+++ b/src/material/tabs/tab-group.html
@@ -65,7 +65,7 @@
 
 <div
   class="mat-mdc-tab-body-wrapper"
-  [class._mat-animation-noopable]="_animationsDisabled()"
+  [class._mat-animation-noopable]="_bodyAnimationsDisabled()"
   #tabBodyWrapper>
   @for (tab of _tabs; track tab;) {
     <mat-tab-body role="tabpanel"
@@ -76,7 +76,7 @@
                  [class]="tab.bodyClass"
                  [content]="tab.content!"
                  [position]="tab.position!"
-                 [animationDuration]="animationDuration"
+                 [animationDuration]="_bodyAnimationDuration"
                  [preserveContent]="preserveContent"
                  (_onCentered)="_removeTabBodyWrapperHeight()"
                  (_onCentering)="_setTabBodyWrapperHeight($event)"

--- a/src/material/tabs/tab-group.spec.ts
+++ b/src/material/tabs/tab-group.spec.ts
@@ -460,6 +460,26 @@ describe('MatTabGroup', () => {
     });
   });
 
+  describe('animation duration', () => {
+    it('should set the body and header animation duration when value is a string', () => {
+      const fixture = TestBed.createComponent(TabsWithCustomAnimationDuration);
+      fixture.detectChanges();
+
+      const tabGroup = fixture.nativeElement.querySelector('.mat-mdc-tab-group');
+      expect(tabGroup.style.getPropertyValue('--mat-tab-body-animation-duration')).toBe('500ms');
+      expect(tabGroup.style.getPropertyValue('--mat-tab-header-animation-duration')).toBe('500ms');
+    });
+
+    it('should set the body and header animation duration when value is an object', () => {
+      const fixture = TestBed.createComponent(TabsWithObjectAnimationDuration);
+      fixture.detectChanges();
+
+      const tabGroup = fixture.nativeElement.querySelector('.mat-mdc-tab-group');
+      expect(tabGroup.style.getPropertyValue('--mat-tab-body-animation-duration')).toBe('100ms');
+      expect(tabGroup.style.getPropertyValue('--mat-tab-header-animation-duration')).toBe('200ms');
+    });
+  });
+
   describe('aria labelling', () => {
     let fixture: ComponentFixture<TabGroupWithAriaInputs>;
     let tab: HTMLElement;
@@ -1062,7 +1082,8 @@ describe('nested MatTabGroup with enabled animations', () => {
     tick();
 
     const tabGroup = fixture.nativeElement.querySelector('.mat-mdc-tab-group');
-    expect(tabGroup.style.getPropertyValue('--mat-tab-animation-duration')).toBe('500ms');
+    expect(tabGroup.style.getPropertyValue('--mat-tab-body-animation-duration')).toBe('500ms');
+    expect(tabGroup.style.getPropertyValue('--mat-tab-header-animation-duration')).toBe('500ms');
   }));
 });
 
@@ -1472,6 +1493,17 @@ class TabGroupWithIsActiveBinding {}
   imports: [MatTabsModule],
 })
 class TabsWithCustomAnimationDuration {}
+
+@Component({
+  template: `
+    <mat-tab-group [animationDuration]="{body: '100ms', header: '200ms'}">
+      <mat-tab label="One">Tab one content</mat-tab>
+      <mat-tab label="Two">Tab two content</mat-tab>
+    </mat-tab-group>
+  `,
+  imports: [MatTabsModule],
+})
+class TabsWithObjectAnimationDuration {}
 
 @Component({
   template: `

--- a/src/material/tabs/tab-nav-bar/tab-nav-bar.spec.ts
+++ b/src/material/tabs/tab-nav-bar/tab-nav-bar.spec.ts
@@ -530,7 +530,7 @@ describe('MatTabNavBar with enabled animations', () => {
     tick();
 
     const tabNavBar = fixture.nativeElement.querySelector('.mat-mdc-tab-nav-bar');
-    expect(tabNavBar.style.getPropertyValue('--mat-tab-animation-duration')).toBe('500ms');
+    expect(tabNavBar.style.getPropertyValue('--mat-tab-header-animation-duration')).toBe('500ms');
   }));
 });
 

--- a/src/material/tabs/tab-nav-bar/tab-nav-bar.ts
+++ b/src/material/tabs/tab-nav-bar/tab-nav-bar.ts
@@ -64,7 +64,7 @@ import {_CdkPrivateStyleLoader} from '@angular/cdk/private';
     '[class.mat-accent]': 'color === "accent"',
     '[class.mat-warn]': 'color === "warn"',
     '[class._mat-animation-noopable]': '_animationsDisabled',
-    '[style.--mat-tab-animation-duration]': 'animationDuration',
+    '[style.--mat-tab-header-animation-duration]': 'animationDuration',
   },
   encapsulation: ViewEncapsulation.None,
   // tslint:disable-next-line:validate-decorators


### PR DESCRIPTION
Currently users can control the animation duration for the tabs through the `animationDuration` input, however it's not particularly flexible because it sets the same duration for the header and body.

These changes add an extra signature that allows them to set the header/body durations separately.