### PR TITLE
refactor(multiple): strongly type SimpleChanges

### DIFF
--- a/goldens/cdk/a11y/index.api.md
+++ b/goldens/cdk/a11y/index.api.md
@@ -114,7 +114,7 @@ export class CdkTrapFocus implements OnDestroy, AfterContentInit, OnChanges, DoC
     // (undocumented)
     ngDoCheck(): void;
     // (undocumented)
-    ngOnChanges(changes: SimpleChanges): void;
+    ngOnChanges(changes: SimpleChanges<this>): void;
     // (undocumented)
     ngOnDestroy(): void;
     // (undocumented)

--- a/goldens/cdk/accordion/index.api.md
+++ b/goldens/cdk/accordion/index.api.md
@@ -24,14 +24,12 @@ export class CdkAccordion implements OnDestroy, OnChanges {
     // (undocumented)
     static ngAcceptInputType_multi: unknown;
     // (undocumented)
-    ngOnChanges(changes: SimpleChanges): void;
+    ngOnChanges(changes: SimpleChanges<this>): void;
     // (undocumented)
     ngOnDestroy(): void;
     openAll(): void;
     readonly _openCloseAllActions: Subject<boolean>;
-    readonly _stateChanges: Subject<{
-        [propName: string]: i0.SimpleChange<any>;
-    }>;
+    readonly _stateChanges: Subject<SimpleChanges<this>>;
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<CdkAccordion, "cdk-accordion, [cdkAccordion]", ["cdkAccordion"], { "multi": { "alias": "multi"; "required": false; }; }, {}, never, never, true, never>;
     // (undocumented)

--- a/goldens/cdk/drag-drop/index.api.md
+++ b/goldens/cdk/drag-drop/index.api.md
@@ -76,7 +76,7 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
     // (undocumented)
     ngAfterViewInit(): void;
     // (undocumented)
-    ngOnChanges(changes: SimpleChanges): void;
+    ngOnChanges(changes: SimpleChanges<this>): void;
     // (undocumented)
     ngOnDestroy(): void;
     previewClass: string | string[];

--- a/goldens/cdk/menu/index.api.md
+++ b/goldens/cdk/menu/index.api.md
@@ -217,7 +217,7 @@ export class CdkMenuTrigger extends CdkMenuTriggerBase implements OnChanges, OnD
     getMenu(): Menu | undefined;
     _handleClick(): void;
     // (undocumented)
-    ngOnChanges(changes: SimpleChanges): void;
+    ngOnChanges(changes: SimpleChanges<this>): void;
     // (undocumented)
     ngOnDestroy(): void;
     open(): void;

--- a/goldens/cdk/overlay/index.api.md
+++ b/goldens/cdk/overlay/index.api.md
@@ -78,7 +78,7 @@ export class CdkConnectedOverlay implements OnDestroy, OnChanges {
     // (undocumented)
     static ngAcceptInputType_push: unknown;
     // (undocumented)
-    ngOnChanges(changes: SimpleChanges): void;
+    ngOnChanges(changes: SimpleChanges<this>): void;
     // (undocumented)
     ngOnDestroy(): void;
     get offsetX(): number;

--- a/goldens/cdk/table/index.api.md
+++ b/goldens/cdk/table/index.api.md
@@ -46,7 +46,7 @@ export abstract class BaseRowDef implements OnChanges {
     extractCellTemplate(column: CdkColumnDef): TemplateRef<any>;
     getColumnsDiff(): IterableChanges<any> | null;
     // (undocumented)
-    ngOnChanges(changes: SimpleChanges): void;
+    ngOnChanges(changes: SimpleChanges<this>): void;
     // (undocumented)
     template: TemplateRef<any>;
     // (undocumented)
@@ -187,7 +187,7 @@ export class CdkFooterRowDef extends BaseRowDef implements CanStick, OnChanges {
     // (undocumented)
     static ngAcceptInputType_sticky: unknown;
     // (undocumented)
-    ngOnChanges(changes: SimpleChanges): void;
+    ngOnChanges(changes: SimpleChanges<this>): void;
     resetStickyChanged(): void;
     get sticky(): boolean;
     set sticky(value: boolean);
@@ -233,7 +233,7 @@ export class CdkHeaderRowDef extends BaseRowDef implements CanStick, OnChanges {
     // (undocumented)
     static ngAcceptInputType_sticky: unknown;
     // (undocumented)
-    ngOnChanges(changes: SimpleChanges): void;
+    ngOnChanges(changes: SimpleChanges<this>): void;
     resetStickyChanged(): void;
     get sticky(): boolean;
     set sticky(value: boolean);

--- a/goldens/google-maps/index.api.md
+++ b/goldens/google-maps/index.api.md
@@ -210,7 +210,7 @@ export class DeprecatedMapMarkerClusterer implements OnInit, AfterContentInit, O
     // (undocumented)
     ngAfterContentInit(): void;
     // (undocumented)
-    ngOnChanges(changes: SimpleChanges): void;
+    ngOnChanges(changes: SimpleChanges<this>): void;
     // (undocumented)
     ngOnDestroy(): void;
     // (undocumented)
@@ -271,7 +271,7 @@ export class GoogleMap implements OnChanges, OnInit, OnDestroy {
     readonly maptypeidChanged: Observable<void>;
     get mapTypes(): google.maps.MapTypeRegistry;
     // (undocumented)
-    ngOnChanges(changes: SimpleChanges): void;
+    ngOnChanges(changes: SimpleChanges<this>): void;
     // (undocumented)
     ngOnDestroy(): void;
     // (undocumented)
@@ -328,7 +328,7 @@ export class MapAdvancedMarker implements OnInit, OnChanges, OnDestroy, MapAncho
     readonly mapRightclick: Observable<MouseEvent>;
     readonly markerInitialized: EventEmitter<google.maps.marker.AdvancedMarkerElement>;
     // (undocumented)
-    ngOnChanges(changes: SimpleChanges): void;
+    ngOnChanges(changes: SimpleChanges<this>): void;
     // (undocumented)
     ngOnDestroy(): void;
     // (undocumented)
@@ -457,7 +457,7 @@ export class MapDirectionsRenderer implements OnInit, OnChanges, OnDestroy {
     getPanel(): Node | null;
     getRouteIndex(): number;
     // (undocumented)
-    ngOnChanges(changes: SimpleChanges): void;
+    ngOnChanges(changes: SimpleChanges<this>): void;
     // (undocumented)
     ngOnDestroy(): void;
     // (undocumented)
@@ -546,7 +546,7 @@ export class MapHeatmapLayer implements OnInit, OnChanges, OnDestroy {
     heatmap?: google.maps.visualization.HeatmapLayer;
     readonly heatmapInitialized: EventEmitter<google.maps.visualization.HeatmapLayer>;
     // (undocumented)
-    ngOnChanges(changes: SimpleChanges): void;
+    ngOnChanges(changes: SimpleChanges<this>): void;
     // (undocumented)
     ngOnDestroy(): void;
     // (undocumented)
@@ -654,7 +654,7 @@ export class MapMarker implements OnInit, OnChanges, OnDestroy, MapAnchorPoint, 
     marker?: google.maps.Marker;
     readonly markerInitialized: EventEmitter<google.maps.Marker>;
     // (undocumented)
-    ngOnChanges(changes: SimpleChanges): void;
+    ngOnChanges(changes: SimpleChanges<this>): void;
     // (undocumented)
     ngOnDestroy(): void;
     // (undocumented)
@@ -686,7 +686,7 @@ export class MapMarkerClusterer implements OnInit, OnChanges, OnDestroy {
     // (undocumented)
     _markers: QueryList<MarkerDirective>;
     // (undocumented)
-    ngOnChanges(changes: SimpleChanges): Promise<void>;
+    ngOnChanges(changes: SimpleChanges<this>): Promise<void>;
     // (undocumented)
     ngOnDestroy(): void;
     // (undocumented)

--- a/goldens/material/autocomplete/index.api.md
+++ b/goldens/material/autocomplete/index.api.md
@@ -176,7 +176,7 @@ export class MatAutocompleteTrigger implements ControlValueAccessor, AfterViewIn
     // (undocumented)
     ngAfterViewInit(): void;
     // (undocumented)
-    ngOnChanges(changes: SimpleChanges): void;
+    ngOnChanges(changes: SimpleChanges<this>): void;
     // (undocumented)
     ngOnDestroy(): void;
     _onChange: (value: any) => void;

--- a/goldens/material/checkbox/index.api.md
+++ b/goldens/material/checkbox/index.api.md
@@ -85,7 +85,7 @@ export class MatCheckbox implements AfterViewInit, OnChanges, ControlValueAccess
     // (undocumented)
     ngAfterViewInit(): void;
     // (undocumented)
-    ngOnChanges(changes: SimpleChanges): void;
+    ngOnChanges(changes: SimpleChanges<this>): void;
     // (undocumented)
     _onBlur(): void;
     // (undocumented)

--- a/goldens/material/datepicker/index.api.md
+++ b/goldens/material/datepicker/index.api.md
@@ -130,7 +130,7 @@ export class MatCalendar<D> implements AfterContentInit, AfterViewChecked, OnDes
     // (undocumented)
     ngAfterViewChecked(): void;
     // (undocumented)
-    ngOnChanges(changes: SimpleChanges): void;
+    ngOnChanges(changes: SimpleChanges<this>): void;
     // (undocumented)
     ngOnDestroy(): void;
     get selected(): DateRange<D> | D | null;
@@ -200,7 +200,7 @@ export class MatCalendarBody<D = any> implements OnChanges, OnDestroy, AfterView
     // (undocumented)
     ngAfterViewChecked(): void;
     // (undocumented)
-    ngOnChanges(changes: SimpleChanges): void;
+    ngOnChanges(changes: SimpleChanges<this>): void;
     // (undocumented)
     ngOnDestroy(): void;
     numCols: number;
@@ -504,7 +504,7 @@ export class MatDatepickerToggle<D> implements AfterContentInit, OnChanges, OnDe
     // (undocumented)
     ngAfterContentInit(): void;
     // (undocumented)
-    ngOnChanges(changes: SimpleChanges): void;
+    ngOnChanges(changes: SimpleChanges<this>): void;
     // (undocumented)
     ngOnDestroy(): void;
     // (undocumented)
@@ -569,7 +569,7 @@ export class MatDateRangeInput<D> implements MatFormFieldControl<DateRange<D>>, 
     ngAfterContentInit(): void;
     ngControl: NgControl | null;
     // (undocumented)
-    ngOnChanges(changes: SimpleChanges): void;
+    ngOnChanges(changes: SimpleChanges<this>): void;
     // (undocumented)
     ngOnDestroy(): void;
     onContainerClick(): void;
@@ -693,7 +693,7 @@ export class MatMonthView<D> implements AfterContentInit, OnChanges, OnDestroy {
     // (undocumented)
     ngAfterContentInit(): void;
     // (undocumented)
-    ngOnChanges(changes: SimpleChanges): void;
+    ngOnChanges(changes: SimpleChanges<this>): void;
     // (undocumented)
     ngOnDestroy(): void;
     _previewChanged({ event, value: cell }: MatCalendarUserEvent<MatCalendarCell<D> | null>): void;

--- a/goldens/material/dialog/index.api.md
+++ b/goldens/material/dialog/index.api.md
@@ -105,7 +105,7 @@ export class MatDialogClose implements OnInit, OnChanges {
     // (undocumented)
     _matDialogClose: any;
     // (undocumented)
-    ngOnChanges(changes: SimpleChanges): void;
+    ngOnChanges(changes: SimpleChanges<this>): void;
     // (undocumented)
     ngOnInit(): void;
     // (undocumented)

--- a/goldens/material/expansion/index.api.md
+++ b/goldens/material/expansion/index.api.md
@@ -96,7 +96,33 @@ export class MatExpansionPanel extends CdkAccordionItem implements AfterContentI
     get hideToggle(): boolean;
     set hideToggle(value: boolean);
     readonly _inputChanges: Subject<{
-        [propName: string]: i0.SimpleChange<any>;
+        hideToggle?: i0.SimpleChange<boolean> | undefined;
+        togglePosition?: i0.SimpleChange<MatAccordionTogglePosition> | undefined;
+        readonly afterExpand?: i0.SimpleChange<EventEmitter<void>> | undefined;
+        readonly afterCollapse?: i0.SimpleChange<EventEmitter<void>> | undefined;
+        readonly _inputChanges?: i0.SimpleChange<Subject</*elided*/ any>> | undefined;
+        accordion?: i0.SimpleChange<MatAccordionBase> | undefined;
+        _lazyContent?: i0.SimpleChange<MatExpansionPanelContent> | undefined;
+        _body?: i0.SimpleChange<ElementRef<HTMLElement>> | undefined;
+        _portal?: i0.SimpleChange<TemplatePortal<any>> | undefined;
+        _headerId?: i0.SimpleChange<string> | undefined;
+        _hasSpacing?: i0.SimpleChange<() => boolean> | undefined;
+        _getExpandedState?: i0.SimpleChange<() => MatExpansionPanelState> | undefined;
+        toggle?: i0.SimpleChange<() => void> | undefined;
+        close?: i0.SimpleChange<() => void> | undefined;
+        open?: i0.SimpleChange<() => void> | undefined;
+        ngAfterContentInit?: i0.SimpleChange<() => void> | undefined;
+        ngOnChanges?: i0.SimpleChange<(changes: /*elided*/ any) => void> | undefined;
+        ngOnDestroy?: i0.SimpleChange<() => void> | undefined;
+        _containsFocus?: i0.SimpleChange<() => boolean> | undefined;
+        readonly closed?: i0.SimpleChange<EventEmitter<void>> | undefined;
+        readonly opened?: i0.SimpleChange<EventEmitter<void>> | undefined;
+        readonly destroyed?: i0.SimpleChange<EventEmitter<void>> | undefined;
+        readonly expandedChange?: i0.SimpleChange<EventEmitter<boolean>> | undefined;
+        readonly id?: i0.SimpleChange<string> | undefined;
+        expanded?: i0.SimpleChange<boolean> | undefined;
+        disabled?: i0.SimpleChange<boolean> | undefined;
+        ngOnInit?: i0.SimpleChange<() => void> | undefined;
     }>;
     _lazyContent: MatExpansionPanelContent;
     // (undocumented)
@@ -104,7 +130,7 @@ export class MatExpansionPanel extends CdkAccordionItem implements AfterContentI
     // (undocumented)
     ngAfterContentInit(): void;
     // (undocumented)
-    ngOnChanges(changes: SimpleChanges): void;
+    ngOnChanges(changes: SimpleChanges<this>): void;
     // (undocumented)
     ngOnDestroy(): void;
     open(): void;

--- a/goldens/material/list/index.api.md
+++ b/goldens/material/list/index.api.md
@@ -254,7 +254,7 @@ export class MatSelectionList extends MatListBase implements SelectionList, Cont
     // (undocumented)
     ngAfterViewInit(): void;
     // (undocumented)
-    ngOnChanges(changes: SimpleChanges): void;
+    ngOnChanges(changes: SimpleChanges<this>): void;
     // (undocumented)
     ngOnDestroy(): void;
     _onTouched: () => void;

--- a/goldens/material/select/index.api.md
+++ b/goldens/material/select/index.api.md
@@ -309,7 +309,7 @@ export class MatSelect implements AfterContentInit, OnChanges, OnDestroy, OnInit
     // (undocumented)
     ngDoCheck(): void;
     // (undocumented)
-    ngOnChanges(changes: SimpleChanges): void;
+    ngOnChanges(changes: SimpleChanges<this>): void;
     // (undocumented)
     ngOnDestroy(): void;
     // (undocumented)

--- a/goldens/material/slide-toggle/index.api.md
+++ b/goldens/material/slide-toggle/index.api.md
@@ -72,7 +72,7 @@ export class MatSlideToggle implements OnDestroy, AfterContentInit, OnChanges, C
     // (undocumented)
     ngAfterContentInit(): void;
     // (undocumented)
-    ngOnChanges(changes: SimpleChanges): void;
+    ngOnChanges(changes: SimpleChanges<this>): void;
     // (undocumented)
     ngOnDestroy(): void;
     _noopAnimations: boolean;

--- a/goldens/material/tabs/index.api.md
+++ b/goldens/material/tabs/index.api.md
@@ -158,7 +158,7 @@ export class MatTab implements OnInit, OnChanges, OnDestroy {
     // (undocumented)
     static ngAcceptInputType_disabled: unknown;
     // (undocumented)
-    ngOnChanges(changes: SimpleChanges): void;
+    ngOnChanges(changes: SimpleChanges<this>): void;
     // (undocumented)
     ngOnDestroy(): void;
     // (undocumented)

--- a/goldens/youtube-player/index.api.md
+++ b/goldens/youtube-player/index.api.md
@@ -69,7 +69,7 @@ export class YouTubePlayer implements AfterViewInit, OnChanges, OnDestroy {
     // (undocumented)
     ngAfterViewInit(): void;
     // (undocumented)
-    ngOnChanges(changes: SimpleChanges): void;
+    ngOnChanges(changes: SimpleChanges<this>): void;
     // (undocumented)
     ngOnDestroy(): void;
     pauseVideo(): void;

--- a/src/cdk/a11y/focus-trap/focus-trap.ts
+++ b/src/cdk/a11y/focus-trap/focus-trap.ts
@@ -471,7 +471,7 @@ export class CdkTrapFocus implements OnDestroy, AfterContentInit, OnChanges, DoC
     }
   }
 
-  ngOnChanges(changes: SimpleChanges) {
+  ngOnChanges(changes: SimpleChanges<this>) {
     const autoCaptureChange = changes['autoCapture'];
 
     if (

--- a/src/cdk/accordion/accordion.ts
+++ b/src/cdk/accordion/accordion.ts
@@ -36,7 +36,7 @@ export const CDK_ACCORDION = new InjectionToken<CdkAccordion>('CdkAccordion');
 })
 export class CdkAccordion implements OnDestroy, OnChanges {
   /** Emits when the state of the accordion changes */
-  readonly _stateChanges = new Subject<SimpleChanges>();
+  readonly _stateChanges = new Subject<SimpleChanges<this>>();
 
   /** Stream that emits true/false when openAll/closeAll is triggered. */
   readonly _openCloseAllActions: Subject<boolean> = new Subject<boolean>();
@@ -59,7 +59,7 @@ export class CdkAccordion implements OnDestroy, OnChanges {
     this._openCloseAllActions.next(false);
   }
 
-  ngOnChanges(changes: SimpleChanges) {
+  ngOnChanges(changes: SimpleChanges<this>) {
     this._stateChanges.next(changes);
   }
 

--- a/src/cdk/drag-drop/directives/drag.ts
+++ b/src/cdk/drag-drop/directives/drag.ts
@@ -315,7 +315,7 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
     );
   }
 
-  ngOnChanges(changes: SimpleChanges) {
+  ngOnChanges(changes: SimpleChanges<this>) {
     const rootSelectorChange = changes['rootElementSelector'];
     const positionChange = changes['freeDragPosition'];
 

--- a/src/cdk/menu/menu-trigger.ts
+++ b/src/cdk/menu/menu-trigger.ts
@@ -145,7 +145,7 @@ export class CdkMenuTrigger extends CdkMenuTriggerBase implements OnChanges, OnD
     return this.childMenu;
   }
 
-  ngOnChanges(changes: SimpleChanges) {
+  ngOnChanges(changes: SimpleChanges<this>) {
     if (changes['menuPosition'] && this.overlayRef) {
       this.overlayRef.updatePositionStrategy(this._getOverlayPositionStrategy());
     }

--- a/src/cdk/overlay/overlay-directives.ts
+++ b/src/cdk/overlay/overlay-directives.ts
@@ -323,7 +323,7 @@ export class CdkConnectedOverlay implements OnDestroy, OnChanges {
     this._overlayRef?.dispose();
   }
 
-  ngOnChanges(changes: SimpleChanges) {
+  ngOnChanges(changes: SimpleChanges<this>) {
     if (this._position) {
       this._updatePositionStrategy(this._position);
       this._overlayRef?.updateSize({

--- a/src/cdk/table/row.ts
+++ b/src/cdk/table/row.ts
@@ -51,7 +51,7 @@ export abstract class BaseRowDef implements OnChanges {
   constructor(...args: unknown[]);
   constructor() {}
 
-  ngOnChanges(changes: SimpleChanges): void {
+  ngOnChanges(changes: SimpleChanges<this>): void {
     // Create a new columns differ if one does not yet exist. Initialize it based on initial value
     // of the columns property or an empty array if none is provided.
     if (!this._columnsDiffer) {
@@ -116,7 +116,7 @@ export class CdkHeaderRowDef extends BaseRowDef implements CanStick, OnChanges {
 
   // Prerender fails to recognize that ngOnChanges in a part of this class through inheritance.
   // Explicitly define it so that the method is called as part of the Angular lifecycle.
-  override ngOnChanges(changes: SimpleChanges): void {
+  override ngOnChanges(changes: SimpleChanges<this>): void {
     super.ngOnChanges(changes);
   }
 
@@ -167,7 +167,7 @@ export class CdkFooterRowDef extends BaseRowDef implements CanStick, OnChanges {
 
   // Prerender fails to recognize that ngOnChanges in a part of this class through inheritance.
   // Explicitly define it so that the method is called as part of the Angular lifecycle.
-  override ngOnChanges(changes: SimpleChanges): void {
+  override ngOnChanges(changes: SimpleChanges<this>): void {
     super.ngOnChanges(changes);
   }
 

--- a/src/google-maps/deprecated-map-marker-clusterer/deprecated-map-marker-clusterer.ts
+++ b/src/google-maps/deprecated-map-marker-clusterer/deprecated-map-marker-clusterer.ts
@@ -261,7 +261,7 @@ export class DeprecatedMapMarkerClusterer
     }
   }
 
-  ngOnChanges(changes: SimpleChanges) {
+  ngOnChanges(changes: SimpleChanges<this>) {
     const {
       markerClusterer: clusterer,
       ariaLabelFn,

--- a/src/google-maps/google-map/google-map.ts
+++ b/src/google-maps/google-map/google-map.ts
@@ -274,7 +274,7 @@ export class GoogleMap implements OnChanges, OnInit, OnDestroy {
     }
   }
 
-  ngOnChanges(changes: SimpleChanges) {
+  ngOnChanges(changes: SimpleChanges<this>) {
     if (changes['height'] || changes['width']) {
       this._setSize();
     }

--- a/src/google-maps/map-advanced-marker/map-advanced-marker.ts
+++ b/src/google-maps/map-advanced-marker/map-advanced-marker.ts
@@ -230,7 +230,7 @@ export class MapAdvancedMarker
     });
   }
 
-  ngOnChanges(changes: SimpleChanges) {
+  ngOnChanges(changes: SimpleChanges<this>) {
     const {advancedMarker, _content, _position, _title, _draggable, _zIndex} = this;
     if (advancedMarker) {
       if (changes['title']) {

--- a/src/google-maps/map-directions-renderer/map-directions-renderer.ts
+++ b/src/google-maps/map-directions-renderer/map-directions-renderer.ts
@@ -107,7 +107,7 @@ export class MapDirectionsRenderer implements OnInit, OnChanges, OnDestroy {
     });
   }
 
-  ngOnChanges(changes: SimpleChanges) {
+  ngOnChanges(changes: SimpleChanges<this>) {
     if (this.directionsRenderer) {
       if (changes['options']) {
         this.directionsRenderer.setOptions(this._combineOptions());

--- a/src/google-maps/map-heatmap-layer/map-heatmap-layer.ts
+++ b/src/google-maps/map-heatmap-layer/map-heatmap-layer.ts
@@ -119,7 +119,7 @@ export class MapHeatmapLayer implements OnInit, OnChanges, OnDestroy {
     });
   }
 
-  ngOnChanges(changes: SimpleChanges) {
+  ngOnChanges(changes: SimpleChanges<this>) {
     const {_data, heatmap} = this;
 
     if (heatmap) {

--- a/src/google-maps/map-marker-clusterer/map-marker-clusterer.ts
+++ b/src/google-maps/map-marker-clusterer/map-marker-clusterer.ts
@@ -107,7 +107,7 @@ export class MapMarkerClusterer implements OnInit, OnChanges, OnDestroy {
     }
   }
 
-  async ngOnChanges(changes: SimpleChanges) {
+  async ngOnChanges(changes: SimpleChanges<this>) {
     const change = changes['renderer'] || changes['algorithm'];
 
     // Since the options are set in the constructor, we have to recreate the cluster if they change.

--- a/src/google-maps/map-marker/map-marker.ts
+++ b/src/google-maps/map-marker/map-marker.ts
@@ -316,7 +316,7 @@ export class MapMarker implements OnInit, OnChanges, OnDestroy, MapAnchorPoint, 
     });
   }
 
-  ngOnChanges(changes: SimpleChanges) {
+  ngOnChanges(changes: SimpleChanges<this>) {
     const {marker, _title, _position, _label, _clickable, _icon, _visible} = this;
 
     if (marker) {

--- a/src/material/autocomplete/autocomplete-trigger.ts
+++ b/src/material/autocomplete/autocomplete-trigger.ts
@@ -255,7 +255,7 @@ export class MatAutocompleteTrigger
     this._cleanupWindowBlur = this._renderer.listen('window', 'blur', this._windowBlurHandler);
   }
 
-  ngOnChanges(changes: SimpleChanges) {
+  ngOnChanges(changes: SimpleChanges<this>) {
     if (changes['position'] && this._positionStrategy) {
       this._setStrategyPositions(this._positionStrategy);
 

--- a/src/material/checkbox/checkbox.ts
+++ b/src/material/checkbox/checkbox.ts
@@ -252,7 +252,7 @@ export class MatCheckbox
     this.disabledInteractive = this._options?.disabledInteractive ?? false;
   }
 
-  ngOnChanges(changes: SimpleChanges) {
+  ngOnChanges(changes: SimpleChanges<this>) {
     if (changes['required']) {
       this._validatorChangeFn();
     }

--- a/src/material/datepicker/calendar-body.ts
+++ b/src/material/datepicker/calendar-body.ts
@@ -284,7 +284,7 @@ export class MatCalendarBody<D = any> implements OnChanges, OnDestroy, AfterView
     return this.startValue === value || this.endValue === value;
   }
 
-  ngOnChanges(changes: SimpleChanges) {
+  ngOnChanges(changes: SimpleChanges<this>) {
     const columnChanges = changes['numCols'];
     const {rows, numCols} = this;
 

--- a/src/material/datepicker/calendar.ts
+++ b/src/material/datepicker/calendar.ts
@@ -459,18 +459,24 @@ export class MatCalendar<D> implements AfterContentInit, AfterViewChecked, OnDes
     this.stateChanges.complete();
   }
 
-  ngOnChanges(changes: SimpleChanges) {
+  ngOnChanges(changes: SimpleChanges<this>) {
     // Ignore date changes that are at a different time on the same day. This fixes issues where
     // the calendar re-renders when there is no meaningful change to [minDate] or [maxDate]
     // (#24435).
     const minDateChange: SimpleChange | undefined =
       changes['minDate'] &&
-      !this._dateAdapter.sameDate(changes['minDate'].previousValue, changes['minDate'].currentValue)
+      !this._dateAdapter.sameDate(
+        changes['minDate'].previousValue as D | null,
+        changes['minDate'].currentValue as D | null,
+      )
         ? changes['minDate']
         : undefined;
     const maxDateChange: SimpleChange | undefined =
       changes['maxDate'] &&
-      !this._dateAdapter.sameDate(changes['maxDate'].previousValue, changes['maxDate'].currentValue)
+      !this._dateAdapter.sameDate(
+        changes['maxDate'].previousValue as D | null,
+        changes['maxDate'].currentValue as D | null,
+      )
         ? changes['maxDate']
         : undefined;
 

--- a/src/material/datepicker/date-range-input.ts
+++ b/src/material/datepicker/date-range-input.ts
@@ -339,7 +339,7 @@ export class MatDateRangeInput<D>
     });
   }
 
-  ngOnChanges(changes: SimpleChanges) {
+  ngOnChanges(changes: SimpleChanges<this>) {
     if (dateInputsHaveChanged(changes, this._dateAdapter)) {
       this.stateChanges.next(undefined);
     }

--- a/src/material/datepicker/datepicker-base.ts
+++ b/src/material/datepicker/datepicker-base.ts
@@ -563,7 +563,7 @@ export abstract class MatDatepickerBase<
     });
   }
 
-  ngOnChanges(changes: SimpleChanges) {
+  ngOnChanges(changes: SimpleChanges<this>) {
     const positionChange = changes['xPosition'] || changes['yPosition'];
 
     if (positionChange && !positionChange.firstChange && this._overlayRef) {

--- a/src/material/datepicker/datepicker-input-base.ts
+++ b/src/material/datepicker/datepicker-input-base.ts
@@ -267,7 +267,7 @@ export abstract class MatDatepickerInputBase<S, D = ExtractDateTypeFromSelection
     this._isInitialized = true;
   }
 
-  ngOnChanges(changes: SimpleChanges) {
+  ngOnChanges(changes: SimpleChanges<this>) {
     if (dateInputsHaveChanged(changes, this._dateAdapter)) {
       this.stateChanges.next(undefined);
     }

--- a/src/material/datepicker/datepicker-toggle.ts
+++ b/src/material/datepicker/datepicker-toggle.ts
@@ -101,7 +101,7 @@ export class MatDatepickerToggle<D> implements AfterContentInit, OnChanges, OnDe
     this.tabIndex = parsedTabIndex || parsedTabIndex === 0 ? parsedTabIndex : null;
   }
 
-  ngOnChanges(changes: SimpleChanges) {
+  ngOnChanges(changes: SimpleChanges<this>) {
     if (changes['datepicker']) {
       this._watchStateChanges();
     }

--- a/src/material/datepicker/month-view.ts
+++ b/src/material/datepicker/month-view.ts
@@ -241,7 +241,7 @@ export class MatMonthView<D> implements AfterContentInit, OnChanges, OnDestroy {
       .subscribe(() => this._init());
   }
 
-  ngOnChanges(changes: SimpleChanges) {
+  ngOnChanges(changes: SimpleChanges<this>) {
     const comparisonChange = changes['comparisonStart'] || changes['comparisonEnd'];
 
     if (comparisonChange && !comparisonChange.firstChange) {

--- a/src/material/dialog/dialog-content-directives.ts
+++ b/src/material/dialog/dialog-content-directives.ts
@@ -64,8 +64,8 @@ export class MatDialogClose implements OnInit, OnChanges {
     }
   }
 
-  ngOnChanges(changes: SimpleChanges) {
-    const proxiedChange = changes['_matDialogClose'] || changes['_matDialogCloseResult'];
+  ngOnChanges(changes: SimpleChanges<this>) {
+    const proxiedChange = changes['_matDialogClose'];
 
     if (proxiedChange) {
       this.dialogResult = proxiedChange.currentValue;

--- a/src/material/expansion/expansion-panel.ts
+++ b/src/material/expansion/expansion-panel.ts
@@ -129,7 +129,7 @@ export class MatExpansionPanel
   @Output() readonly afterCollapse = new EventEmitter<void>();
 
   /** Stream that emits for changes in `@Input` properties. */
-  readonly _inputChanges = new Subject<SimpleChanges>();
+  readonly _inputChanges = new Subject<SimpleChanges<MatExpansionPanel>>();
 
   /** Optionally defined accordion the expansion panel belongs to. */
   override accordion = inject<MatAccordionBase>(MAT_ACCORDION, {optional: true, skipSelf: true})!;
@@ -212,7 +212,7 @@ export class MatExpansionPanel
     this._setupAnimationEvents();
   }
 
-  ngOnChanges(changes: SimpleChanges) {
+  ngOnChanges(changes: SimpleChanges<this>) {
     this._inputChanges.next(changes);
   }
 

--- a/src/material/list/selection-list.ts
+++ b/src/material/list/selection-list.ts
@@ -190,7 +190,7 @@ export class MatSelectionList
     this._watchForSelectionChange();
   }
 
-  ngOnChanges(changes: SimpleChanges) {
+  ngOnChanges(changes: SimpleChanges<this>) {
     const disabledChanges = changes['disabled'];
     const disableRippleChanges = changes['disableRipple'];
     const hideSingleSelectionIndicatorChanges = changes['hideSingleSelectionIndicator'];

--- a/src/material/select/select.ts
+++ b/src/material/select/select.ts
@@ -700,7 +700,7 @@ export class MatSelect
     }
   }
 
-  ngOnChanges(changes: SimpleChanges) {
+  ngOnChanges(changes: SimpleChanges<this>) {
     // Updating the disabled state is handled by the input, but we need to additionally let
     // the parent form field know to run change detection when the disabled state changes.
     if (changes['disabled'] || changes['userAriaDescribedBy']) {

--- a/src/material/slide-toggle/slide-toggle.ts
+++ b/src/material/slide-toggle/slide-toggle.ts
@@ -239,7 +239,7 @@ export class MatSlideToggle
     });
   }
 
-  ngOnChanges(changes: SimpleChanges): void {
+  ngOnChanges(changes: SimpleChanges<this>): void {
     if (changes['required']) {
       this._validatorOnChange();
     }

--- a/src/material/tabs/tab.ts
+++ b/src/material/tabs/tab.ts
@@ -142,7 +142,7 @@ export class MatTab implements OnInit, OnChanges, OnDestroy {
     inject(_CdkPrivateStyleLoader).load(_StructuralStylesLoader);
   }
 
-  ngOnChanges(changes: SimpleChanges): void {
+  ngOnChanges(changes: SimpleChanges<this>): void {
     if (changes.hasOwnProperty('textLabel') || changes.hasOwnProperty('disabled')) {
       this._stateChanges.next();
     }

--- a/src/youtube-player/youtube-player.ts
+++ b/src/youtube-player/youtube-player.ts
@@ -269,7 +269,7 @@ export class YouTubePlayer implements AfterViewInit, OnChanges, OnDestroy {
     this._conditionallyLoad();
   }
 
-  ngOnChanges(changes: SimpleChanges): void {
+  ngOnChanges(changes: SimpleChanges<this>): void {
     if (this._shouldRecreatePlayer(changes)) {
       this._conditionallyLoad();
     } else if (this._player) {


### PR DESCRIPTION
A few versions ago Angular added strong typing for the `SimpleChanges` object. These changes update our usages to be type safe.