### PR TITLE
refactor: remove remaining NgClass usages

### DIFF
--- a/src/cdk/drag-drop/directives/drop-list-shared.spec.ts
+++ b/src/cdk/drag-drop/directives/drop-list-shared.spec.ts
@@ -31,7 +31,7 @@ import {DragRef, Point, PreviewContainer} from '../drag-ref';
 import {moveItemInArray} from '../drag-utils';
 
 import {provideFakeDirectionality} from '@angular/cdk/testing/private/fake-directionality';
-import {NgClass, NgFor, NgIf, NgTemplateOutlet} from '@angular/common';
+import {NgFor, NgIf, NgTemplateOutlet} from '@angular/common';
 import {CDK_DRAG_CONFIG, DragAxis, DragDropConfig, DropListOrientation} from './config';
 import {CdkDrag} from './drag';
 import {CdkDragPlaceholder} from './drag-placeholder';
@@ -5402,7 +5402,7 @@ class DraggableInDropZoneWithCustomMultiNodePreview {
           @if (renderPlaceholder) {
             <div
               class="custom-placeholder"
-              [ngClass]="extraPlaceholderClass"
+              [class]="extraPlaceholderClass"
               *cdkDragPlaceholder>Custom placeholder</div>
           }
         </div>
@@ -5414,7 +5414,7 @@ class DraggableInDropZoneWithCustomMultiNodePreview {
       height: ${ITEM_HEIGHT * 3}px;
     }
   `,
-  imports: [CdkDropList, CdkDrag, CdkDragPlaceholder, NgClass],
+  imports: [CdkDropList, CdkDrag, CdkDragPlaceholder],
 })
 class DraggableInDropZoneWithCustomPlaceholder {
   @ViewChildren(CdkDrag) dragItems!: QueryList<CdkDrag>;

--- a/src/cdk/table/BUILD.bazel
+++ b/src/cdk/table/BUILD.bazel
@@ -16,7 +16,6 @@ ng_project(
     ),
     assets = [":table.css"],
     deps = [
-        "//:node_modules/@angular/common",
         "//:node_modules/@angular/core",
         "//:node_modules/rxjs",
         "//src:dev_mode_types",
@@ -42,7 +41,6 @@ ng_project(
     ),
     deps = [
         ":table",
-        "//:node_modules/@angular/common",
         "//:node_modules/@angular/core",
         "//:node_modules/@angular/platform-browser",
         "//:node_modules/rxjs",

--- a/src/cdk/table/table.spec.ts
+++ b/src/cdk/table/table.spec.ts
@@ -43,7 +43,6 @@ import {
   getTableUnknownColumnError,
   getTableUnknownDataSourceError,
 } from './table-errors';
-import {NgClass} from '@angular/common';
 import {CdkVirtualScrollViewport, ScrollingModule} from '../scrolling';
 import {dispatchFakeEvent} from '../testing/private';
 
@@ -2977,7 +2976,7 @@ class UndefinedColumnsCdkTableApp {
         <cdk-header-cell *cdkHeaderCellDef> Column A</cdk-header-cell>
         <cdk-cell *cdkCellDef="let row; let first = first;
                                let last = last; let even = even; let odd = odd"
-                  [ngClass]="{
+                  [class]="{
                     'custom-cell-class-first': enableCellContextClasses && first,
                     'custom-cell-class-last': enableCellContextClasses && last,
                     'custom-cell-class-even': enableCellContextClasses && even,
@@ -2989,7 +2988,7 @@ class UndefinedColumnsCdkTableApp {
       <cdk-header-row *cdkHeaderRowDef="columnsToRender"></cdk-header-row>
       <cdk-row *cdkRowDef="let row; columns: columnsToRender;
                            let first = first; let last = last; let even = even; let odd = odd"
-               [ngClass]="{
+               [class]="{
                  'custom-row-class-first': enableRowContextClasses && first,
                  'custom-row-class-last': enableRowContextClasses && last,
                  'custom-row-class-even': enableRowContextClasses && even,
@@ -2998,7 +2997,7 @@ class UndefinedColumnsCdkTableApp {
       </cdk-row>
     </cdk-table>
   `,
-  imports: [CdkTableModule, NgClass],
+  imports: [CdkTableModule],
 })
 class RowContextCdkTableApp {
   dataSource = new FakeDataSource();


### PR DESCRIPTION
Removes a couple of leftover usages of `NgClass` in tests.