### PR TITLE
fix(material/list): navitation list active item color

### DIFF
--- a/src/material/list/list.scss
+++ b/src/material/list/list.scss
@@ -181,5 +181,9 @@ mat-action-list button {
 
   &.mdc-list-item--activated {
     background-color: token-utils.slot(list-active-indicator-color, $fallbacks);
+
+    .mdc-list-item__primary-text {
+      color: var(--mat-sys-on-secondary-container, currentColor);
+    }
   }
 }


### PR DESCRIPTION
Navigation List active items should have color of on-secondary-container, since they have a background color of secondary-container

Fixes #32734