### PR TITLE
docs: show component tokens default value

### DIFF
--- a/docs/src/app/pages/component-viewer/token-table.html
+++ b/docs/src/app/pages/component-viewer/token-table.html
@@ -24,9 +24,9 @@
   </mat-form-field>
 
   <mat-form-field subscriptSizing="dynamic" appearance="outline">
-    <mat-label>Filter by system token</mat-label>
-    <input #systemTokenInput matInput [value]="systemTokenFilter()"
-           (input)="systemTokenFilter.set(systemTokenInput.value)"/>
+    <mat-label>Filter by default value</mat-label>
+    <input #defaultValueInput matInput [value]="defaultValueFilter()"
+           (input)="defaultValueFilter.set(defaultValueInput.value)"/>
   </mat-form-field>
 
   <button mat-button (click)="reset()">Reset filters</button>
@@ -38,7 +38,7 @@
       <tr>
         <th>Name</th>
         <th class="docs-type-header">Type</th>
-        <th class="docs-system-header">Based on system token</th>
+        <th class="docs-value-header">Default value</th>
       </tr>
     </thead>
 
@@ -47,13 +47,7 @@
         <tr>
           <td><token-name [name]="token.overridesName"/></td>
           <td>{{token.type | titlecase}}</td>
-          <td>
-            @if (token.derivedFrom) {
-              <token-name [name]="token.derivedFrom"/>
-            } @else {
-              None
-            }
-          </td>
+          <td>{{token.value}}</td>
         </tr>
       } @empty {
         <tr>

--- a/docs/src/app/pages/component-viewer/token-table.scss
+++ b/docs/src/app/pages/component-viewer/token-table.scss
@@ -32,6 +32,6 @@ thead {
   width: 10%;
 }
 
-.docs-system-header {
+.docs-value-header {
   width: 30%;
 }

--- a/docs/src/app/pages/component-viewer/token-table.ts
+++ b/docs/src/app/pages/component-viewer/token-table.ts
@@ -24,6 +24,7 @@ export interface Token {
   prefix: string;
   type: TokenType;
   derivedFrom?: string;
+  value: string | number | null;
 }
 
 @Component({
@@ -51,24 +52,24 @@ export class TokenTable {
 
   protected readonly nameFilter = signal('');
   protected readonly typeFilter = signal<TokenType | null>(null);
-  protected readonly systemTokenFilter = signal('');
+  protected readonly defaultValueFilter = signal('');
   protected readonly types: TokenType[] = ['base', 'color', 'typography', 'density'];
   protected readonly filteredTokens = computed(() => {
     const name = this.nameFilter().trim().toLowerCase();
     const typeFilter = this.typeFilter();
-    const systemTokenFilter = this.systemTokenFilter();
+    const defaultValueFilter = this.defaultValueFilter();
 
     return this.tokens().filter(
       token =>
         (!name || token.overridesName.toLowerCase().includes(name)) &&
         (!typeFilter || token.type === typeFilter) &&
-        (!systemTokenFilter || token.derivedFrom?.toLowerCase().includes(systemTokenFilter)),
+        (!defaultValueFilter || token.value?.toString().toLowerCase().includes(defaultValueFilter)),
     );
   });
 
   protected reset() {
     this.nameFilter.set('');
     this.typeFilter.set(null);
-    this.systemTokenFilter.set('');
+    this.defaultValueFilter.set('');
   }
 }

--- a/tools/extract-tokens/extract-tokens.mts
+++ b/tools/extract-tokens/extract-tokens.mts
@@ -13,7 +13,7 @@ interface ExtractedToken {
   /** Type of the token (color, typography etc.) */
   type: 'color' | 'typography' | 'density' | 'base';
   /** Value of the token. */
-  value: string | number;
+  value: string | number | null;
   /** Name under which the token can be referred to inside the `overrides` mixin. */
   overridesName: string;
 }
@@ -142,6 +142,7 @@ function extractTokens(themePath: string): Token[] {
       overridesName: token.overridesName,
       // Set to `undefined` so the key gets dropped from the JSON if there's no value.
       derivedFrom: derivedFrom || undefined,
+      value: token.value,
     };
   });
 }


### PR DESCRIPTION
Show default value of component tokens in styling tab to better understand their meanings.
Related issues : 
- https://github.com/angular/components/issues/30425 
- https://github.com/angular/components/issues/28933

## Why?
It is not always obvious to understand what certain tokens correspond to and what type/unit are expected (color, numeric, ...).  For example in the expansion panel component, the `container-shape` token can be ambiguous, one might expect to set something like ‘rounded’ or 'small' when it is actually a size that is expected (12px by default).

What is often necessary is to inspect the generated code, locate the related CSS property to identify the token used, and then override the token.

## Solutions
In order to make the documentation self-sufficient, we could display more context about tokens:
1. A description
2. The default value

Both would be great to add, but 1 needs a lot more work as the description are not available/written yet. This PR adds solution 2.

## What this PR contains
In each component styling page, I replaced the "Based on system token" column by a "Default value" column in the tokens table. Why?
- The default value is a useful information to understand a token, and is more precise than the previous column.
- "Based on system token" column was incomplete. For example: the default value `--mat-sys-on-surface` would be shown as "None" in the old column. The reason is that the default value need to contain "var()" to be detected as a system token.
- We could improve the detection of `derivedFrom`, but keeping both columns seemed redundant to me as it is fairly easy to identify the token system used in the default value.
- Changed type of Token `value` to include `null` which was the case for some tokens (for example: `elevated-disabled-container-color` in chip component).
- Replaced the system token filter by a default value filter.

### Before
<img width="1600" height="778" alt="image" src="https://github.com/user-attachments/assets/b1ba821e-6059-4955-a08c-aa29e556e6f6" />

### After
<img width="1612" height="774" alt="image" src="https://github.com/user-attachments/assets/e1f118ba-055e-4da6-8579-0c8bd8e0a0ba" />

## Going further

- Should I remove `derivedFrom` attribute from Token interface? It's not used anywhere else.
- The default value is easily readable 95% of the time, but there are cases where this is not ideal. For example the value for button `small-ripple-color` token is : `color-mix(in srgb, var(--mat-sys-on-primary-container) calc(var(--mat-sys-pressed-state-layer-opacity) * 100%), transparent)`. 
Do we want to improve this? How?
- Most component tokens are based on a system token but I think system tokens also lack context. IMO, we need a complete list of CSS system variables with, as for component tokens, a description and a default value. What do you think?
- Being able to dynamically tweak the tokens value and see the result in real time would be great.


Note: First PR here so please let me know what I can improve :)