### PR TITLE
fix(multiple): expand type for restoreFocus

### DIFF
--- a/goldens/cdk/dialog/index.api.md
+++ b/goldens/cdk/dialog/index.api.md
@@ -144,7 +144,7 @@ export class DialogConfig<D = unknown, R = unknown, C extends DialogContainer = 
     panelClass?: string | string[];
     positionStrategy?: PositionStrategy;
     providers?: StaticProvider[] | ((dialogRef: R, config: DialogConfig<D, R, C>, container: C) => StaticProvider[]);
-    restoreFocus?: boolean | string | HTMLElement;
+    restoreFocus?: RestoreFocusValue;
     role?: DialogRole;
     scrollStrategy?: ScrollStrategy;
     templateContext?: Record<string, any> | (() => Record<string, any>);
@@ -194,6 +194,9 @@ export class DialogRef<R = unknown, C = unknown> {
 
 // @public
 export type DialogRole = 'dialog' | 'alertdialog';
+
+// @public
+export type RestoreFocusValue = boolean | string | HTMLElement;
 
 // @public (undocumented)
 export function throwDialogContentAlreadyAttachedError(): void;

--- a/goldens/material/bottom-sheet/index.api.md
+++ b/goldens/material/bottom-sheet/index.api.md
@@ -18,6 +18,7 @@ import { InjectionToken } from '@angular/core';
 import { Injector } from '@angular/core';
 import { Observable } from 'rxjs';
 import { OnDestroy } from '@angular/core';
+import { RestoreFocusValue } from '@angular/cdk/dialog';
 import { ScrollStrategy } from '@angular/cdk/overlay';
 import { TemplateRef } from '@angular/core';
 import { ViewContainerRef } from '@angular/core';
@@ -63,7 +64,7 @@ export class MatBottomSheetConfig<D = any> {
     maxHeight?: number | string;
     minHeight?: number | string;
     panelClass?: string | string[];
-    restoreFocus?: boolean;
+    restoreFocus?: RestoreFocusValue;
     scrollStrategy?: ScrollStrategy;
     viewContainerRef?: ViewContainerRef;
 }

--- a/goldens/material/dialog/index.api.md
+++ b/goldens/material/dialog/index.api.md
@@ -26,6 +26,7 @@ import { Observable } from 'rxjs';
 import { OnChanges } from '@angular/core';
 import { OnDestroy } from '@angular/core';
 import { OnInit } from '@angular/core';
+import { RestoreFocusValue } from '@angular/cdk/dialog';
 import { ScrollStrategy } from '@angular/cdk/overlay';
 import { SimpleChanges } from '@angular/core';
 import { Subject } from 'rxjs';
@@ -143,7 +144,7 @@ export class MatDialogConfig<D = any> {
     minWidth?: number | string;
     panelClass?: string | string[];
     position?: DialogPosition;
-    restoreFocus?: boolean;
+    restoreFocus?: RestoreFocusValue;
     role?: DialogRole;
     scrollStrategy?: ScrollStrategy;
     viewContainerRef?: ViewContainerRef;

--- a/goldens/material/dialog/testing/index.api.md
+++ b/goldens/material/dialog/testing/index.api.md
@@ -22,6 +22,7 @@ import * as i0 from '@angular/core';
 import { Injector } from '@angular/core';
 import { Observable } from 'rxjs';
 import { OnDestroy } from '@angular/core';
+import { RestoreFocusValue } from '@angular/cdk/dialog';
 import { ScrollStrategy } from '@angular/cdk/overlay';
 import { Subject } from 'rxjs';
 import { TemplateRef } from '@angular/core';

--- a/src/cdk/dialog/dialog-config.ts
+++ b/src/cdk/dialog/dialog-config.ts
@@ -16,6 +16,16 @@ import {FocusOrigin} from '../a11y';
 /** Options for where to set focus to automatically on dialog open */
 export type AutoFocusTarget = 'dialog' | 'first-tabbable' | 'first-heading';
 
+/**
+ * Value that determines the focus restoration behavior for a dialog.
+ * The values represent the following behaviors:
+ * - `boolean` - when true, will return focus to the element that was focused before the dialog
+ *    was opened, otherwise won't restore focus at all.
+ * - `string` - focus will be restored to the first element that matches the CSS selector.
+ * - `HTMLElement` - focus will be restored to the specific element.
+ */
+export type RestoreFocusValue = boolean | string | HTMLElement;
+
 /** Valid ARIA roles for a dialog. */
 export type DialogRole = 'dialog' | 'alertdialog';
 
@@ -121,15 +131,8 @@ export class DialogConfig<D = unknown, R = unknown, C extends DialogContainer = 
    */
   autoFocus?: AutoFocusTarget | string | boolean = 'first-tabbable';
 
-  /**
-   * Whether the dialog should restore focus to the previously-focused element upon closing.
-   * Has the following behavior based on the type that is passed in:
-   * - `boolean` - when true, will return focus to the element that was focused before the dialog
-   *    was opened, otherwise won't restore focus at all.
-   * - `string` - focus will be restored to the first element that matches the CSS selector.
-   * - `HTMLElement` - focus will be restored to the specific element.
-   */
-  restoreFocus?: boolean | string | HTMLElement = true;
+  /** Configures the focus restoration behavior. See `RestoreFocusValue` for more information. */
+  restoreFocus?: RestoreFocusValue = true;
 
   /**
    * Scroll strategy to be used for the dialog. This determines how

--- a/src/material/bottom-sheet/bottom-sheet-config.ts
+++ b/src/material/bottom-sheet/bottom-sheet-config.ts
@@ -9,6 +9,7 @@
 import {InjectionToken, Injector, ViewContainerRef} from '@angular/core';
 import {Direction} from '@angular/cdk/bidi';
 import {ScrollStrategy} from '@angular/cdk/overlay';
+import {RestoreFocusValue} from '@angular/cdk/dialog';
 
 /** Options for where to set focus to automatically on dialog open */
 export type AutoFocusTarget = 'dialog' | 'first-tabbable' | 'first-heading';
@@ -71,11 +72,8 @@ export class MatBottomSheetConfig<D = any> {
    */
   autoFocus?: AutoFocusTarget | string | boolean = 'first-tabbable';
 
-  /**
-   * Whether the bottom sheet should restore focus to the
-   * previously-focused element, after it's closed.
-   */
-  restoreFocus?: boolean = true;
+  /** Configures the focus restoration behavior. See `RestoreFocusValue` for more information. */
+  restoreFocus?: RestoreFocusValue = true;
 
   /** Scroll strategy to be used for the bottom sheet. */
   scrollStrategy?: ScrollStrategy;

--- a/src/material/dialog/dialog-config.ts
+++ b/src/material/dialog/dialog-config.ts
@@ -9,7 +9,7 @@
 import {ViewContainerRef, Injector} from '@angular/core';
 import {Direction} from '@angular/cdk/bidi';
 import {ScrollStrategy} from '@angular/cdk/overlay';
-import {DialogConfig} from '@angular/cdk/dialog';
+import {DialogConfig, RestoreFocusValue} from '@angular/cdk/dialog';
 
 /** Options for where to set focus to automatically on dialog open */
 export type AutoFocusTarget = 'dialog' | 'first-tabbable' | 'first-heading';
@@ -129,11 +129,8 @@ export class MatDialogConfig<D = any> {
    */
   autoFocus?: AutoFocusTarget | string | boolean = 'first-tabbable';
 
-  /**
-   * Whether the dialog should restore focus to the
-   * previously-focused element, after it's closed.
-   */
-  restoreFocus?: boolean = true;
+  /** Configures the focus restoration behavior. See `RestoreFocusValue` for more information. */
+  restoreFocus?: RestoreFocusValue = true;
 
   /** Whether to wait for the opening animation to finish before trapping focus. */
   delayFocusTrap?: boolean = true;


### PR DESCRIPTION
Fixes that the dialog and bottom sheet didn't expose all the possible values for the `restoreValue` option from the CDK dialog, even though they pass the value straight through to it.

Fixes #32875.