### PR TITLE
fix(aria/menu): itemSelected not emitted when menu is attached to a trigger

### DIFF
--- a/src/aria/menu/menu.spec.ts
+++ b/src/aria/menu/menu.spec.ts
@@ -626,6 +626,17 @@ describe('Menu Trigger Pattern', () => {
       expect(isExpanded()).toBe(false);
     });
   });
+
+  describe('Selection', () => {
+    beforeEach(() => setupMenu());
+
+    it('should select an item on click', () => {
+      spyOn(fixture.componentInstance, 'itemSelected');
+      click(getTrigger());
+      click(getItem('Apple')!);
+      expect(fixture.componentInstance.itemSelected).toHaveBeenCalledWith('Apple');
+    });
+  });
 });
 
 describe('Menu Bar Pattern', () => {
@@ -987,7 +998,7 @@ class StandaloneMenuExample {
   template: `
 <button ngMenuTrigger [menu]="menu">Open menu</button>
 
-<div ngMenu [expansionDelay]="0" #menu="ngMenu">
+<div ngMenu [expansionDelay]="0" #menu="ngMenu" (itemSelected)="itemSelected($event)">
   <ng-template ngMenuContent>
     <div ngMenuItem value='Apple' searchTerm='Apple'>Apple</div>
     <div ngMenuItem value='Banana' searchTerm='Banana'>Banana</div>
@@ -1007,7 +1018,9 @@ class StandaloneMenuExample {
   `,
   imports: [Menu, MenuItem, MenuTrigger, MenuContent],
 })
-class MenuTriggerExample {}
+class MenuTriggerExample {
+  itemSelected(value: string) {}
+}
 
 @Component({
   template: `

--- a/src/aria/private/menu/menu.ts
+++ b/src/aria/private/menu/menu.ts
@@ -357,26 +357,21 @@ export class MenuPattern<V> {
 
   /** Submits the menu. */
   submit(item = this.inputs.activeItem()) {
+    if (!item || item.disabled() || item.submenu()) {
+      return;
+    }
+
     const root = this.root();
 
-    if (item && !item.disabled()) {
-      const isMenu = root instanceof MenuPattern;
-      const isMenuBar = root instanceof MenuBarPattern;
-      const isMenuTrigger = root instanceof MenuTriggerPattern;
-
-      if (!item.submenu() && isMenuTrigger) {
-        root.close({refocus: true});
-      }
-
-      if (!item.submenu() && isMenuBar) {
-        root.close();
-        root?.inputs.itemSelected?.(item.value());
-      }
-
-      if (!item.submenu() && isMenu) {
-        root.inputs.activeItem()?.close({refocus: true});
-        root?.inputs.itemSelected?.(item.value());
-      }
+    if (root instanceof MenuTriggerPattern) {
+      root.close({refocus: true});
+      root?.inputs.menu()?.inputs.itemSelected?.(item.value());
+    } else if (root instanceof MenuBarPattern) {
+      root.close();
+      root?.inputs.itemSelected?.(item.value());
+    } else if (root instanceof MenuPattern) {
+      root.inputs.activeItem()?.close({refocus: true});
+      root?.inputs.itemSelected?.(item.value());
     }
   }
 


### PR DESCRIPTION
The logic that dispatches `itemSelected` wasn't accounting for the case where the menu root is a trigger.

Fixes #32865.