### PR TITLE
refactor: eliminate 'any' type in cdk coercion utilities

### DIFF
--- a/goldens/cdk/coercion/index.api.md
+++ b/goldens/cdk/coercion/index.api.md
@@ -16,25 +16,25 @@ export function coerceArray<T>(value: T | T[]): T[];
 export function coerceArray<T>(value: T | readonly T[]): readonly T[];
 
 // @public
-export function coerceBooleanProperty(value: any): boolean;
+export function coerceBooleanProperty(value: unknown): boolean;
 
 // @public
-export function coerceCssPixelValue(value: any): string;
+export function coerceCssPixelValue(value: unknown): string;
 
 // @public
 export function coerceElement<T>(elementOrRef: ElementRef<T> | T): T;
 
 // @public
-export function coerceNumberProperty(value: any): number;
+export function coerceNumberProperty(value: unknown): number;
 
 // @public (undocumented)
-export function coerceNumberProperty<D>(value: any, fallback: D): number | D;
+export function coerceNumberProperty<D>(value: unknown, fallback: D): number | D;
 
 // @public
-export function coerceStringArray(value: any, separator?: string | RegExp): string[];
+export function coerceStringArray(value: unknown, separator?: string | RegExp): string[];
 
 // @public
-export function _isNumberValue(value: any): boolean;
+export function _isNumberValue(value: unknown): boolean;
 
 // @public
 export type NumberInput = string | number | null | undefined;

--- a/src/cdk/coercion/boolean-property.ts
+++ b/src/cdk/coercion/boolean-property.ts
@@ -13,6 +13,6 @@
 export type BooleanInput = string | boolean | null | undefined;
 
 /** Coerces a data-bound value (typically a string) to a boolean. */
-export function coerceBooleanProperty(value: any): boolean {
-  return value != null && `${value}` !== 'false';
+export function coerceBooleanProperty(value: unknown): boolean {
+  return value != null && String(value) !== 'false';
 }

--- a/src/cdk/coercion/css-pixel-value.ts
+++ b/src/cdk/coercion/css-pixel-value.ts
@@ -7,10 +7,10 @@
  */
 
 /** Coerces a value to a CSS pixel value. */
-export function coerceCssPixelValue(value: any): string {
+export function coerceCssPixelValue(value: unknown): string {
   if (value == null) {
     return '';
   }
 
-  return typeof value === 'string' ? value : `${value}px`;
+  return typeof value === 'string' ? value : `${String(value)}px`;
 }

--- a/src/cdk/coercion/number-property.ts
+++ b/src/cdk/coercion/number-property.ts
@@ -13,9 +13,9 @@
 export type NumberInput = string | number | null | undefined;
 
 /** Coerces a data-bound value (typically a string) to a number. */
-export function coerceNumberProperty(value: any): number;
-export function coerceNumberProperty<D>(value: any, fallback: D): number | D;
-export function coerceNumberProperty(value: any, fallbackValue = 0) {
+export function coerceNumberProperty(value: unknown): number;
+export function coerceNumberProperty<D>(value: unknown, fallback: D): number | D;
+export function coerceNumberProperty(value: unknown, fallbackValue = 0) {
   if (_isNumberValue(value)) {
     return Number(value);
   }
@@ -26,9 +26,9 @@ export function coerceNumberProperty(value: any, fallbackValue = 0) {
  * Whether the provided value is considered a number.
  * @docs-private
  */
-export function _isNumberValue(value: any): boolean {
+export function _isNumberValue(value: unknown): boolean {
   // parseFloat(value) handles most of the cases we're interested in (it treats null, empty string,
   // and other non-number values as NaN, where Number just uses 0) but it considers the string
   // '123hello' to be a valid number. Therefore we also check if Number(value) is NaN.
-  return !isNaN(parseFloat(value as any)) && !isNaN(Number(value));
+  return !isNaN(parseFloat(String(value))) && !isNaN(Number(value));
 }

--- a/src/cdk/coercion/string-array.ts
+++ b/src/cdk/coercion/string-array.ts
@@ -23,13 +23,13 @@
  * @param value the value to coerce into an array of strings
  * @param separator split-separator if value isn't an array
  */
-export function coerceStringArray(value: any, separator: string | RegExp = /\s+/): string[] {
+export function coerceStringArray(value: unknown, separator: string | RegExp = /\s+/): string[] {
   const result = [];
 
   if (value != null) {
-    const sourceValues = Array.isArray(value) ? value : `${value}`.split(separator);
+    const sourceValues = Array.isArray(value) ? value : String(value).split(separator);
     for (const sourceValue of sourceValues) {
-      const trimmedString = `${sourceValue}`.trim();
+      const trimmedString = String(sourceValue).trim();
       if (trimmedString) {
         result.push(trimmedString);
       }


### PR DESCRIPTION
`String(foo)` vs `${foo}`: change is required because TypeScript doesn't allow implicit string coercion in template literals (like `${foo}`) when the type is `unknown`. Using `String(foo)` behaves exactly the same way at runtime but explicitly tells the TypeScript compiler that the conversion is intentional and safe.