### PR TITLE
fix(aria/menu): remove aria-label binding from menu item value

### DIFF
--- a/src/aria/menu/menu-item.ts
+++ b/src/aria/menu/menu-item.ts
@@ -39,7 +39,6 @@ import type {MenuBar} from './menu-bar';
     '(focusin)': '_pattern.onFocusIn()',
     '[attr.tabindex]': '_pattern.tabIndex()',
     '[attr.data-active]': 'active()',
-    '[attr.aria-label]': 'value()',
     '[attr.aria-haspopup]': 'hasPopup()',
     '[attr.aria-expanded]': 'expanded()',
     '[attr.aria-disabled]': '_pattern.disabled()',
@@ -56,7 +55,7 @@ export class MenuItem<V> {
   /** The unique ID of the menu item. */
   readonly id = input(inject(_IdGenerator).getId('ng-menu-item-', true));
 
-  /** The value of the menu item, used as the default aria-label */
+  /** The value of the menu item. */
   readonly value = input.required<V>();
 
   /** Whether the menu item is disabled. */

--- a/src/aria/menu/menu.spec.ts
+++ b/src/aria/menu/menu.spec.ts
@@ -201,6 +201,15 @@ describe('Standalone Menu Pattern', () => {
       keydown(cherry!, ' ');
       expect(fixture.componentInstance.itemSelected).not.toHaveBeenCalled();
     });
+
+    it('should use aria-label for icon-only menu items', () => {
+      const iconOnlyItem = fixture.nativeElement.querySelector('#peach-item') as HTMLElement;
+      expect(iconOnlyItem).not.toBeNull();
+      expect(iconOnlyItem?.getAttribute('aria-label')).toBe('Peaches');
+      expect(iconOnlyItem?.getAttribute('aria-label')).not.toBe(
+        iconOnlyItem?.getAttribute('value'),
+      );
+    });
   });
 
   describe('Expansion', () => {
@@ -984,6 +993,7 @@ describe('Menu Bar Pattern', () => {
       </ng-template>
     </div>
 
+    <div ngMenuItem value='Peach' searchTerm='Peaches' aria-label='Peaches' id="peach-item"></div>
     <div ngMenuItem value='Cherry' searchTerm='Cherry' [disabled]="true">Cherry</div>
   </ng-template>
 </div>


### PR DESCRIPTION
Removes the `[attr.aria-label]="value()"` host binding from `ngMenuItem`.

Binding `value` to `aria-label` causes several issues:
1. Couples application logic/data (value) with UI accessibility state.
2. Creates i18n issues if the value is a non-localized identifier.
3. Overwrites explicitly provided `aria-label` attributes on the host element.
4. Overrides the native accessible name derivation (textContent) of the menuitem.

Fixes #32893