### PR TITLE
perf(aria): drop `debugName` from signals

### DIFF
--- a/src/aria/private/behaviors/signal-like/signal-like.ts
+++ b/src/aria/private/behaviors/signal-like/signal-like.ts
@@ -40,23 +40,17 @@ export function convertGetterSetterToWritableSignalLike<T>(
 }
 
 export function computed<T>(computation: () => T): SignalLike<T> {
-  const computed = createComputed(computation);
-  // TODO: Remove the `toString` after https://github.com/angular/angular/pull/65948 is merged.
-  computed.toString = () => `[Computed: ${computed()}]`;
-  computed[SIGNAL].debugName = '';
-  return computed;
+  return createComputed(computation);
 }
 
 export function signal<T>(initialValue: T): WritableSignalLike<T> {
   const [get, set, update] = createSignal(initialValue);
-  get[SIGNAL].debugName = '';
   // tslint:disable-next-line:ban Have to use `Object.assign` to preserve the getter function.
   return Object.assign(get, {set, update, asReadonly: () => get});
 }
 
 export function linkedSignal<T>(sourceFn: () => T): WritableSignalLike<T> {
   const getter = createLinkedSignal(sourceFn, s => s);
-  getter[SIGNAL].debugName = '';
   // tslint:disable-next-line:ban Have to use `Object.assign` to preserve the getter function.
   return Object.assign(getter, {
     set: (v: T) => linkedSignalSetFn(getter[SIGNAL], v),


### PR DESCRIPTION
The `debugName` would always be assigned into a reactive node, incurring the overhead of an additional property in each signal-like instance _and_ introducing additional hidden classes for the JS VM to deal with.

---

I noticed this in heap snapshots:

<img width="1597" height="44" alt="Screenshot 2026-03-08 at 13 23 49" src="https://github.com/user-attachments/assets/f8cb38c4-3d5b-46da-b0bf-a47ad2d5d7bb" />

which is now:

<img width="1591" height="23" alt="Screenshot 2026-03-08 at 13 24 09" src="https://github.com/user-attachments/assets/abe44a18-df45-4f6a-bc74-1e0038f32753" />

Since the name was assigned the empty string, I decided to remove it altogether.