### PR TITLE
build: remove v21 migrations

### DIFF
--- a/src/cdk/schematics/migration.json
+++ b/src/cdk/schematics/migration.json
@@ -1,11 +1,6 @@
 {
   "$schema": "./node_modules/@angular-devkit/schematics/collection-schema.json",
   "schematics": {
-    "migration-v21": {
-      "version": "21.0.0-0",
-      "description": "Updates the Angular CDK to v21",
-      "factory": "./ng-update/index#updateToV21"
-    },
     "migration-v22": {
       "version": "22.0.0-0",
       "description": "Updates the Angular CDK to v22",

--- a/src/cdk/schematics/ng-update/index.ts
+++ b/src/cdk/schematics/ng-update/index.ts
@@ -13,16 +13,6 @@ import {createMigrationSchematicRule, NullableDevkitMigration} from './devkit-mi
 
 const cdkMigrations: NullableDevkitMigration[] = [];
 
-/** Entry point for the migration schematics with target of Angular CDK 21.0.0 */
-export function updateToV21(): Rule {
-  return createMigrationSchematicRule(
-    TargetVersion.V21,
-    cdkMigrations,
-    cdkUpgradeData,
-    onMigrationComplete,
-  );
-}
-
 /** Entry point for the migration schematics with target of Angular CDK 22.0.0 */
 export function updateToV22(): Rule {
   return createMigrationSchematicRule(

--- a/src/cdk/schematics/update-tool/target-version.ts
+++ b/src/cdk/schematics/update-tool/target-version.ts
@@ -10,7 +10,6 @@
 
 // tslint:disable-next-line:prefer-const-enum
 export enum TargetVersion {
-  V21 = 'version 21',
   V22 = 'version 22',
 }
 

--- a/src/google-maps/schematics/migration.json
+++ b/src/google-maps/schematics/migration.json
@@ -1,10 +1,5 @@
 {
   "schematics": {
-    "migration-v21": {
-      "version": "21.0.0-0",
-      "description": "Updates the Angular Google Maps package to v21",
-      "factory": "./ng-update/index#updateToV21"
-    },
     "migration-v22": {
       "version": "22.0.0-0",
       "description": "Updates the Angular Google Maps package to v22",

--- a/src/google-maps/schematics/ng-update/index.ts
+++ b/src/google-maps/schematics/ng-update/index.ts
@@ -8,11 +8,6 @@
 
 import {Rule} from '@angular-devkit/schematics';
 
-/** Entry point for the migration schematics with target of Google Maps v21 */
-export function updateToV21(): Rule {
-  return () => {};
-}
-
 /** Entry point for the migration schematics with target of Google Maps v22 */
 export function updateToV22(): Rule {
   return () => {};

--- a/src/material/schematics/migration.json
+++ b/src/material/schematics/migration.json
@@ -1,11 +1,6 @@
 {
   "$schema": "./node_modules/@angular-devkit/schematics/collection-schema.json",
   "schematics": {
-    "migration-v21": {
-      "version": "21.0.0-0",
-      "description": "Updates Angular Material to v21",
-      "factory": "./ng-update/index_bundled#updateToV21"
-    },
     "migration-v22": {
       "version": "22.0.0-0",
       "description": "Updates Angular Material to v22",

--- a/src/material/schematics/ng-update/index.ts
+++ b/src/material/schematics/ng-update/index.ts
@@ -17,13 +17,6 @@ import {materialUpgradeData} from './upgrade-data';
 
 const materialMigrations: NullableDevkitMigration[] = [];
 
-/** Entry point for the migration schematics with target of Angular Material v21 */
-export function updateToV21(): Rule {
-  return chain([
-    createMigrationSchematicRule(TargetVersion.V21, materialMigrations, materialUpgradeData),
-  ]);
-}
-
 /** Entry point for the migration schematics with target of Angular Material v22 */
 export function updateToV22(): Rule {
   return chain([


### PR DESCRIPTION
Now that we're on v22 in `main`, we don't need th v21 migrations anymore.