### PR TITLE
refactor(material/slider): switch tests away from fakeAsync

### DIFF
--- a/src/material/slider/slider.spec.ts
+++ b/src/material/slider/slider.spec.ts
@@ -14,14 +14,7 @@ import {
   provideFakeDirectionality,
 } from '@angular/cdk/testing/private';
 import {Component, Provider, QueryList, Type, ViewChild, ViewChildren} from '@angular/core';
-import {
-  ComponentFixture,
-  TestBed,
-  fakeAsync,
-  flush,
-  tick,
-  waitForAsync,
-} from '@angular/core/testing';
+import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 import {FormControl, FormGroup, FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {By} from '@angular/platform-browser';
 import {MatSliderModule} from './slider-module';
@@ -120,55 +113,54 @@ describe('MatSlider', () => {
       checkInput(input, {min: 0, max: 100, value: 0, step: 1, translateX: 0});
     });
 
-    it('should update by click', fakeAsync(() => {
-      setValueByClick(slider, input, 25);
+    it('should update by click', async () => {
+      await setValueByClick(slider, input, 25);
       checkInput(input, {min: 0, max: 100, value: 25, step: 1, translateX: 75});
 
-      setValueByClick(slider, input, 50);
+      await setValueByClick(slider, input, 50);
       checkInput(input, {min: 0, max: 100, value: 50, step: 1, translateX: 150});
 
-      setValueByClick(slider, input, 75);
+      await setValueByClick(slider, input, 75);
       checkInput(input, {min: 0, max: 100, value: 75, step: 1, translateX: 225});
 
-      setValueByClick(slider, input, 100);
+      await setValueByClick(slider, input, 100);
       checkInput(input, {min: 0, max: 100, value: 100, step: 1, translateX: 300});
-    }));
+    });
 
-    it('should update by slide', fakeAsync(() => {
-      slideToValue(slider, input, 25);
+    it('should update by slide', async () => {
+      await slideToValue(slider, input, 25);
       checkInput(input, {min: 0, max: 100, value: 25, step: 1, translateX: 75});
 
-      slideToValue(slider, input, 50);
+      await slideToValue(slider, input, 50);
       checkInput(input, {min: 0, max: 100, value: 50, step: 1, translateX: 150});
 
-      slideToValue(slider, input, 75);
+      await slideToValue(slider, input, 75);
       checkInput(input, {min: 0, max: 100, value: 75, step: 1, translateX: 225});
 
-      slideToValue(slider, input, 100);
+      await slideToValue(slider, input, 100);
       checkInput(input, {min: 0, max: 100, value: 100, step: 1, translateX: 300});
-    }));
+    });
 
-    it('should not slide before the track', fakeAsync(() => {
-      slideToValue(slider, input, -10);
+    it('should not slide before the track', async () => {
+      await slideToValue(slider, input, -10);
       expect(input.value).toBe(0);
       checkInput(input, {min: 0, max: 100, value: 0, step: 1, translateX: 0});
-    }));
+    });
 
-    it('should not slide past the track', fakeAsync(() => {
-      slideToValue(slider, input, 110);
+    it('should not slide past the track', async () => {
+      await slideToValue(slider, input, 110);
       expect(input.value).toBe(100);
       checkInput(input, {min: 0, max: 100, value: 100, step: 1, translateX: 300});
-    }));
+    });
 
     // TODO(wagnermaciel): Fix this test case (behavior works as intended in browser).
-    // it('should not break when the page layout changes', fakeAsync(async () => {
+    // it('should not break when the page layout changes', async () => {
     //   slider._elementRef.nativeElement.style.marginLeft = '100px';
-    //   tick(200);
     //   fixture.detectChanges();
-    //   setValueByClick(slider, input, 25);
+    //   await setValueByClick(slider, input, 25);
     //   checkInput(input, {min: 0, max: 100, value: 25, step: 1, translateX: 75});
     //   slider._elementRef.nativeElement.style.marginLeft = 'initial';
-    // }));
+    // });
   });
 
   describe('standard range slider', () => {
@@ -195,68 +187,68 @@ describe('MatSlider', () => {
       expect(slider.step).toBe(1);
     });
 
-    it('should update by start input click', fakeAsync(() => {
-      setValueByClick(slider, startInput, 25);
+    it('should update by start input click', async () => {
+      await setValueByClick(slider, startInput, 25);
       checkInput(startInput, {min: 0, max: 100, value: 25, translateX: 75});
       checkInput(endInput, {min: 25, max: 100, value: 100, translateX: 300});
-    }));
+    });
 
-    it('should update by end input click', fakeAsync(() => {
-      setValueByClick(slider, endInput, 75);
+    it('should update by end input click', async () => {
+      await setValueByClick(slider, endInput, 75);
       checkInput(startInput, {min: 0, max: 75, value: 0, translateX: 0});
       checkInput(endInput, {min: 0, max: 100, value: 75, translateX: 225});
-    }));
+    });
 
-    it('should update by start thumb slide', fakeAsync(() => {
-      slideToValue(slider, startInput, 75);
+    it('should update by start thumb slide', async () => {
+      await slideToValue(slider, startInput, 75);
       checkInput(startInput, {min: 0, max: 100, value: 75, translateX: 225});
       checkInput(endInput, {min: 75, max: 100, value: 100, translateX: 300});
-    }));
+    });
 
-    it('should update by end thumb slide', fakeAsync(() => {
-      slideToValue(slider, endInput, 25);
+    it('should update by end thumb slide', async () => {
+      await slideToValue(slider, endInput, 25);
       checkInput(startInput, {min: 0, max: 25, value: 0, translateX: 0});
       checkInput(endInput, {min: 0, max: 100, value: 25, translateX: 75});
-    }));
+    });
 
-    it('should not allow start thumb to slide before the track', fakeAsync(() => {
-      slideToValue(slider, startInput, -10);
+    it('should not allow start thumb to slide before the track', async () => {
+      await slideToValue(slider, startInput, -10);
       checkInput(startInput, {min: 0, max: 100, value: 0, translateX: 0});
       checkInput(endInput, {min: 0, max: 100, value: 100, translateX: 300});
-    }));
+    });
 
-    it('should not allow end thumb to slide past the track', fakeAsync(() => {
-      slideToValue(slider, endInput, 110);
+    it('should not allow end thumb to slide past the track', async () => {
+      await slideToValue(slider, endInput, 110);
       checkInput(startInput, {min: 0, max: 100, value: 0, translateX: 0});
       checkInput(endInput, {min: 0, max: 100, value: 100, translateX: 300});
-    }));
+    });
 
-    it('should not allow start thumb to slide past the end thumb', fakeAsync(() => {
-      slideToValue(slider, endInput, 50);
-      slideToValue(slider, startInput, 55);
+    it('should not allow start thumb to slide past the end thumb', async () => {
+      await slideToValue(slider, endInput, 50);
+      await slideToValue(slider, startInput, 55);
       checkInput(startInput, {min: 0, max: 50, value: 50, translateX: 150});
       checkInput(endInput, {min: 50, max: 100, value: 50, translateX: 150});
-    }));
+    });
 
-    it('should not allow end thumb to slide past the start thumb', fakeAsync(() => {
-      slideToValue(slider, startInput, 50);
-      slideToValue(slider, endInput, 45);
+    it('should not allow end thumb to slide past the start thumb', async () => {
+      await slideToValue(slider, startInput, 50);
+      await slideToValue(slider, endInput, 45);
       checkInput(startInput, {min: 0, max: 50, value: 50, translateX: 150});
       checkInput(endInput, {min: 50, max: 100, value: 50, translateX: 150});
-    }));
+    });
 
     // TODO(wagnermaciel): Fix this test case (behavior works as intended in browser).
-    // it('should not break when the page layout changes', fakeAsync(() => {
+    // it('should not break when the page layout changes', async () => {
     //   slider._elementRef.nativeElement.style.marginLeft = '100px';
-    //   setValueByClick(slider, startInput, 25);
+    //   await setValueByClick(slider, startInput, 25);
     //   checkInput(startInput, {min: 0, max: 100, value: 25, translateX: 75});
     //   checkInput(endInput, {min: 25, max: 100, value: 100, translateX: 300});
 
-    //   setValueByClick(slider, endInput, 75);
+    //   await setValueByClick(slider, endInput, 75);
     //   checkInput(startInput, {min: 0, max: 75, value: 25, translateX: 75});
     //   checkInput(endInput, {min: 25, max: 100, value: 75, translateX: 225});
     //   slider._elementRef.nativeElement.style.marginLeft = 'initial';
-    // }));
+    // });
   });
 
   describe('slider with min/max bindings', () => {
@@ -327,14 +319,14 @@ describe('MatSlider', () => {
       checkInput(input, {min: -25, max: 75, value: 25, translateX: 150});
     });
 
-    it('should update the thumb translateX when the max changes', fakeAsync(() => {
-      setValueByClick(slider, input, 50);
+    it('should update the thumb translateX when the max changes', async () => {
+      await setValueByClick(slider, input, 50);
       checkInput(input, {min: 25, max: 75, value: 50, translateX: 150});
       fixture.componentInstance.max = 125;
       fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       checkInput(input, {min: 25, max: 125, value: 50, translateX: 75});
-    }));
+    });
   });
 
   describe('range slider with min/max bindings', () => {
@@ -387,14 +379,14 @@ describe('MatSlider', () => {
         checkInput(endInput, {min: 60, max: 75, value: 60, translateX: 0});
       });
 
-      it('where the new start tx is greater than the old end tx', fakeAsync(() => {
+      it('where the new start tx is greater than the old end tx', async () => {
         fixture.componentInstance.min = 0;
         fixture.componentInstance.max = 100;
         fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
 
-        slideToValue(slider, startInput, 10);
-        slideToValue(slider, endInput, 20);
+        await slideToValue(slider, startInput, 10);
+        await slideToValue(slider, endInput, 20);
 
         checkInput(startInput, {min: 0, max: 20, value: 10, translateX: 30});
         checkInput(endInput, {min: 10, max: 100, value: 20, translateX: 60});
@@ -405,16 +397,16 @@ describe('MatSlider', () => {
 
         checkInput(startInput, {min: -1000, max: 20, value: 10, translateX: 275.5});
         checkInput(endInput, {min: 10, max: 100, value: 20, translateX: 278});
-      }));
+      });
 
-      it('where the new end tx is less than the old start tx', fakeAsync(() => {
+      it('where the new end tx is less than the old start tx', async () => {
         fixture.componentInstance.min = 0;
         fixture.componentInstance.max = 100;
         fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
 
-        slideToValue(slider, endInput, 92);
-        slideToValue(slider, startInput, 91);
+        await slideToValue(slider, endInput, 92);
+        await slideToValue(slider, startInput, 91);
 
         checkInput(startInput, {min: 0, max: 92, value: 91, translateX: 273});
         checkInput(endInput, {min: 91, max: 100, value: 92, translateX: 276});
@@ -425,7 +417,7 @@ describe('MatSlider', () => {
 
         checkInput(startInput, {min: 90, max: 92, value: 91, translateX: 30});
         checkInput(endInput, {min: 91, max: 100, value: 92, translateX: 60});
-      }));
+      });
 
       it('that make min and max equal', () => {
         fixture.componentInstance.min = 75;
@@ -476,14 +468,14 @@ describe('MatSlider', () => {
         checkInput(startInput, {min: 25, max: 50, value: 50, translateX: 300});
       });
 
-      it('where the new start tx is greater than the old end tx', fakeAsync(() => {
+      it('where the new start tx is greater than the old end tx', async () => {
         fixture.componentInstance.min = 0;
         fixture.componentInstance.max = 100;
         fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
 
-        slideToValue(slider, startInput, 1);
-        slideToValue(slider, endInput, 2);
+        await slideToValue(slider, startInput, 1);
+        await slideToValue(slider, endInput, 2);
 
         checkInput(startInput, {min: 0, max: 2, value: 1, translateX: 3});
         checkInput(endInput, {min: 1, max: 100, value: 2, translateX: 6});
@@ -494,16 +486,16 @@ describe('MatSlider', () => {
 
         checkInput(startInput, {min: 0, max: 2, value: 1, translateX: 30});
         checkInput(endInput, {min: 1, max: 10, value: 2, translateX: 60});
-      }));
+      });
 
-      it('where the new end tx is less than the old start tx', fakeAsync(() => {
+      it('where the new end tx is less than the old start tx', async () => {
         fixture.componentInstance.min = 0;
         fixture.componentInstance.max = 100;
         fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
 
-        slideToValue(slider, endInput, 95);
-        slideToValue(slider, startInput, 90);
+        await slideToValue(slider, endInput, 95);
+        await slideToValue(slider, startInput, 90);
 
         checkInput(startInput, {min: 0, max: 95, value: 90, translateX: 270});
         checkInput(endInput, {min: 90, max: 100, value: 95, translateX: 285});
@@ -514,7 +506,7 @@ describe('MatSlider', () => {
 
         checkInput(startInput, {min: 0, max: 95, value: 90, translateX: 27});
         checkInput(endInput, {min: 90, max: 1000, value: 95, translateX: 28.5});
-      }));
+      });
 
       it('that make min and max equal', () => {
         fixture.componentInstance.max = 25;
@@ -544,8 +536,9 @@ describe('MatSlider', () => {
     let slider: MatSlider;
     let input: MatSliderThumb;
 
+    let fixture: ComponentFixture<any>;
     beforeEach(waitForAsync(() => {
-      const fixture = createComponent(DisabledSlider);
+      fixture = createComponent(DisabledSlider);
       fixture.detectChanges();
       const sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider));
       slider = sliderDebugElement.componentInstance;
@@ -661,31 +654,29 @@ describe('MatSlider', () => {
       dispatchPointerEvent(input._hostElement, 'pointerup', thumbX, thumbY);
     }
 
-    it('should show the hover ripple on pointerenter', fakeAsync(() => {
+    it('should show the hover ripple on pointerenter', () => {
       // Doesn't make sense to test for pointerenter events on touch devices.
       expect(isRippleVisible('hover')).toBeFalse();
       pointerenter();
       expect(isRippleVisible('hover')).toBeTrue();
-    }));
+    });
 
-    it('should hide the hover ripple on pointerleave', fakeAsync(() => {
+    it('should hide the hover ripple on pointerleave', () => {
       // Doesn't make sense to test for pointerleave events on touch devices.
       pointerenter();
       pointerleave();
       expect(isRippleVisible('hover')).toBeFalse();
-    }));
+    });
 
-    it('should show the focus ripple on pointerdown', fakeAsync(() => {
+    it('should show the focus ripple on pointerdown', () => {
       expect(isRippleVisible('focus')).toBeFalse();
       pointerdown();
-      flush();
       expect(isRippleVisible('focus')).toBeTrue();
-    }));
+    });
 
-    it('should continue to show the focus ripple on pointerup', fakeAsync(() => {
+    it('should continue to show the focus ripple on pointerup', () => {
       pointerdown();
       pointerup();
-      flush();
 
       // The slider immediately loses focus on pointerup for Safari.
       if (platform.SAFARI) {
@@ -693,69 +684,61 @@ describe('MatSlider', () => {
       } else {
         expect(isRippleVisible('focus')).toBeTrue();
       }
-    }));
+    });
 
-    it('should hide the focus ripple on blur', fakeAsync(() => {
+    it('should hide the focus ripple on blur', () => {
       pointerdown();
       pointerup();
       blur();
-      flush();
       expect(isRippleVisible('focus')).toBeFalse();
-    }));
+    });
 
-    it('should show the active ripple on pointerdown', fakeAsync(() => {
+    it('should show the active ripple on pointerdown', () => {
       expect(isRippleVisible('active')).toBeFalse();
       pointerdown();
       expect(isRippleVisible('active')).toBeTrue();
-      flush();
-    }));
+    });
 
-    it('should hide the active ripple on pointerup', fakeAsync(() => {
+    it('should hide the active ripple on pointerup', () => {
       pointerdown();
       pointerup();
-      flush();
       expect(isRippleVisible('active')).toBeFalse();
-    }));
+    });
 
     // Edge cases.
 
-    it('should not show the hover ripple if the thumb is already focused', fakeAsync(() => {
+    it('should not show the hover ripple if the thumb is already focused', () => {
       pointerdown();
       pointerenter();
-      flush();
       expect(isRippleVisible('hover')).toBeFalse();
-    }));
+    });
 
-    it('should hide the hover ripple if the thumb is focused', fakeAsync(() => {
+    it('should hide the hover ripple if the thumb is focused', () => {
       pointerenter();
       pointerdown();
-      flush();
       expect(isRippleVisible('hover')).toBeFalse();
-    }));
+    });
 
-    it('should not hide the focus ripple if the thumb is pressed', fakeAsync(() => {
+    it('should not hide the focus ripple if the thumb is pressed', () => {
       pointerdown();
       blur();
-      flush();
       expect(isRippleVisible('focus')).toBeTrue();
-    }));
+    });
 
-    it('should not hide the hover ripple on blur if the thumb is hovered', fakeAsync(() => {
+    it('should not hide the hover ripple on blur if the thumb is hovered', () => {
       pointerenter();
       pointerdown();
       pointerup();
       blur();
-      flush();
       expect(isRippleVisible('hover')).toBeTrue();
-    }));
+    });
 
-    it('should hide the focus ripple on drag end if the thumb already lost focus', fakeAsync(() => {
+    it('should hide the focus ripple on drag end if the thumb already lost focus', () => {
       pointerdown();
       blur();
       pointerup();
-      flush();
       expect(isRippleVisible('focus')).toBeFalse();
-    }));
+    });
   });
 
   describe('slider with set value', () => {
@@ -774,10 +757,10 @@ describe('MatSlider', () => {
       checkInput(input, {min: 0, max: 100, value: 50, translateX: 150});
     });
 
-    it('should update the value', fakeAsync(() => {
-      slideToValue(slider, input, 75);
+    it('should update the value', async () => {
+      await slideToValue(slider, input, 75);
       checkInput(input, {min: 0, max: 100, value: 75, translateX: 225});
-    }));
+    });
   });
 
   describe('range slider with set value', () => {
@@ -794,24 +777,24 @@ describe('MatSlider', () => {
       endInput = slider._getInput(_MatThumb.END) as MatSliderRangeThumb;
     }));
 
-    it('should set the correct initial values', fakeAsync(() => {
+    it('should set the correct initial values', async () => {
       checkInput(startInput, {min: 0, max: 75, value: 25, translateX: 75});
       checkInput(endInput, {min: 25, max: 100, value: 75, translateX: 225});
-    }));
+    });
 
-    it('should update the start value', fakeAsync(() => {
+    it('should update the start value', async () => {
       checkInput(startInput, {min: 0, max: 75, value: 25, translateX: 75});
       checkInput(endInput, {min: 25, max: 100, value: 75, translateX: 225});
-      slideToValue(slider, startInput, 30);
+      await slideToValue(slider, startInput, 30);
       checkInput(startInput, {min: 0, max: 75, value: 30, translateX: 90});
       checkInput(endInput, {min: 30, max: 100, value: 75, translateX: 225});
-    }));
+    });
 
-    it('should update the end value', fakeAsync(() => {
-      slideToValue(slider, endInput, 77);
+    it('should update the end value', async () => {
+      await slideToValue(slider, endInput, 77);
       checkInput(startInput, {min: 0, max: 77, value: 25, translateX: 75});
       checkInput(endInput, {min: 25, max: 100, value: 77, translateX: 231});
-    }));
+    });
   });
 
   describe('slider with set step', () => {
@@ -827,34 +810,34 @@ describe('MatSlider', () => {
       input = slider._getInput(_MatThumb.END) as MatSliderThumb;
     }));
 
-    it('should update to the value based on the step', fakeAsync(() => {
-      slideToValue(slider, input, 30);
+    it('should update to the value based on the step', async () => {
+      await slideToValue(slider, input, 30);
       expect(input.value).toBe(25);
-    }));
+    });
 
-    it('should not add decimals to the value if it is a whole number', fakeAsync(() => {
+    it('should not add decimals to the value if it is a whole number', async () => {
       fixture.componentInstance.step = 0.1;
       fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
-      slideToValue(slider, input, 11);
+      await slideToValue(slider, input, 11);
       expect(input.value).toBe(11);
-    }));
+    });
 
-    it('should truncate long decimal values when using a decimal step', fakeAsync(() => {
+    it('should truncate long decimal values when using a decimal step', async () => {
       fixture.componentInstance.step = 0.5;
       fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
-      slideToValue(slider, input, 55.555);
+      await slideToValue(slider, input, 55.555);
       expect(input.value).toBe(55.5);
-    }));
+    });
 
-    it('should update the value on step change', fakeAsync(() => {
-      slideToValue(slider, input, 30);
+    it('should update the value on step change', async () => {
+      await slideToValue(slider, input, 30);
       fixture.componentInstance.step = 50;
       fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(input.value).toBe(50);
-    }));
+    });
   });
 
   describe('range slider with set step', () => {
@@ -872,56 +855,56 @@ describe('MatSlider', () => {
       endInput = slider._getInput(_MatThumb.END) as MatSliderRangeThumb;
     }));
 
-    it('should set the correct start value on slide', fakeAsync(() => {
-      slideToValue(slider, startInput, 30);
+    it('should set the correct start value on slide', async () => {
+      await slideToValue(slider, startInput, 30);
       expect(startInput.value).toBe(25);
-    }));
+    });
 
-    it('should set the correct end value on slide', fakeAsync(() => {
-      slideToValue(slider, endInput, 45);
+    it('should set the correct end value on slide', async () => {
+      await slideToValue(slider, endInput, 45);
       expect(endInput.value).toBe(50);
-    }));
+    });
 
-    it('should not add decimals to the end value if it is a whole number', fakeAsync(() => {
+    it('should not add decimals to the end value if it is a whole number', async () => {
       fixture.componentInstance.step = 0.1;
       fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
-      slideToValue(slider, endInput, 11);
+      await slideToValue(slider, endInput, 11);
       expect(endInput.value).toBe(11);
-    }));
+    });
 
-    it('should not add decimals to the start value if it is a whole number', fakeAsync(() => {
+    it('should not add decimals to the start value if it is a whole number', async () => {
       fixture.componentInstance.step = 0.1;
       fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
-      slideToValue(slider, startInput, 11);
+      await slideToValue(slider, startInput, 11);
       expect(startInput.value).toBe(11);
-    }));
+    });
 
-    it('should truncate long decimal start values when using a decimal step', fakeAsync(() => {
+    it('should truncate long decimal start values when using a decimal step', async () => {
       fixture.componentInstance.step = 0.1;
       fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
-      slideToValue(slider, startInput, 33.666);
+      await slideToValue(slider, startInput, 33.666);
       expect(startInput.value).toBe(33.7);
-    }));
+    });
 
-    it('should truncate long decimal end values when using a decimal step', fakeAsync(() => {
+    it('should truncate long decimal end values when using a decimal step', async () => {
       fixture.componentInstance.step = 0.1;
       fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
-      slideToValue(slider, endInput, 33.6666);
+      await slideToValue(slider, endInput, 33.6666);
       expect(endInput.value).toBe(33.7);
-    }));
+    });
 
     describe('should handle step changes', () => {
-      it('where the new start tx is greater than the old end tx', fakeAsync(() => {
+      it('where the new start tx is greater than the old end tx', async () => {
         fixture.componentInstance.step = 0;
         fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
 
-        slideToValue(slider, startInput, 45);
-        slideToValue(slider, endInput, 46);
+        await slideToValue(slider, startInput, 45);
+        await slideToValue(slider, endInput, 46);
 
         checkInput(startInput, {min: 0, max: 46, value: 45, translateX: 135});
         checkInput(endInput, {min: 45, max: 100, value: 46, translateX: 138});
@@ -932,15 +915,15 @@ describe('MatSlider', () => {
 
         checkInput(startInput, {min: 0, max: 50, value: 50, translateX: 150});
         checkInput(endInput, {min: 50, max: 100, value: 50, translateX: 150});
-      }));
+      });
 
-      it('where the new end tx is less than the old start tx', fakeAsync(() => {
+      it('where the new end tx is less than the old start tx', async () => {
         fixture.componentInstance.step = 0;
         fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
 
-        slideToValue(slider, startInput, 21);
-        slideToValue(slider, endInput, 22);
+        await slideToValue(slider, startInput, 21);
+        await slideToValue(slider, endInput, 22);
 
         checkInput(startInput, {min: 0, max: 22, value: 21, translateX: 63});
         checkInput(endInput, {min: 21, max: 100, value: 22, translateX: 66});
@@ -951,7 +934,7 @@ describe('MatSlider', () => {
 
         checkInput(startInput, {min: 0, max: 0, value: 0, translateX: 0});
         checkInput(endInput, {min: 0, max: 100, value: 0, translateX: 0});
-      }));
+      });
     });
   });
 
@@ -973,25 +956,24 @@ describe('MatSlider', () => {
       input = slider._getInput(_MatThumb.END) as MatSliderThumb;
     });
 
-    it('should set the aria-valuetext attribute with the given `displayWith` function', fakeAsync(() => {
+    it('should set the aria-valuetext attribute with the given `displayWith` function', async () => {
       expect(input._hostElement.getAttribute('aria-valuetext')).toBe('$1');
-      setValueByClick(slider, input, 199);
+      await setValueByClick(slider, input, 199);
       fixture.detectChanges();
-      flush();
       expect(input._hostElement.getAttribute('aria-valuetext')).toBe('$199');
-    }));
+    });
 
-    it('should invoke the passed-in `displayWith` function with the value', fakeAsync(() => {
+    it('should invoke the passed-in `displayWith` function with the value', async () => {
       spyOn(slider, 'displayWith').and.callThrough();
-      setValueByClick(slider, input, 199);
+      await setValueByClick(slider, input, 199);
       expect(slider.displayWith).toHaveBeenCalledWith(199);
-    }));
+    });
 
-    it('should format the thumb label based on the passed-in `displayWith` function', fakeAsync(() => {
-      setValueByClick(slider, input, 149);
+    it('should format the thumb label based on the passed-in `displayWith` function', async () => {
+      await setValueByClick(slider, input, 149);
       fixture.detectChanges();
       expect(valueIndicatorTextElement.textContent).toBe('$149');
-    }));
+    });
   });
 
   describe('range slider with custom thumb label formatting', () => {
@@ -1020,38 +1002,38 @@ describe('MatSlider', () => {
       )!;
     });
 
-    it('should set the aria-valuetext attribute with the given `displayWith` function', fakeAsync(() => {
+    it('should set the aria-valuetext attribute with the given `displayWith` function', async () => {
       expect(startInput._hostElement.getAttribute('aria-valuetext')).toBe('$1');
       expect(endInput._hostElement.getAttribute('aria-valuetext')).toBe('$200');
-      setValueByClick(slider, startInput, 25);
-      setValueByClick(slider, endInput, 81);
+      await setValueByClick(slider, startInput, 25);
+      await setValueByClick(slider, endInput, 81);
       expect(startInput._hostElement.getAttribute('aria-valuetext')).toBe('$25');
       expect(endInput._hostElement.getAttribute('aria-valuetext')).toBe('$81');
-    }));
+    });
 
-    it('should invoke the passed-in `displayWith` function with the start value', fakeAsync(() => {
+    it('should invoke the passed-in `displayWith` function with the start value', async () => {
       spyOn(slider, 'displayWith').and.callThrough();
-      setValueByClick(slider, startInput, 197);
+      await setValueByClick(slider, startInput, 197);
       expect(slider.displayWith).toHaveBeenCalledWith(197);
-    }));
+    });
 
-    it('should invoke the passed-in `displayWith` function with the end value', fakeAsync(() => {
+    it('should invoke the passed-in `displayWith` function with the end value', async () => {
       spyOn(slider, 'displayWith').and.callThrough();
-      setValueByClick(slider, endInput, 72);
+      await setValueByClick(slider, endInput, 72);
       expect(slider.displayWith).toHaveBeenCalledWith(72);
-    }));
+    });
 
-    it('should format the start thumb label based on the passed-in `displayWith` function', fakeAsync(() => {
-      setValueByClick(slider, startInput, 120);
+    it('should format the start thumb label based on the passed-in `displayWith` function', async () => {
+      await setValueByClick(slider, startInput, 120);
       fixture.detectChanges();
       expect(startValueIndicatorTextElement.textContent).toBe('$120');
-    }));
+    });
 
-    it('should format the end thumb label based on the passed-in `displayWith` function', fakeAsync(() => {
-      setValueByClick(slider, endInput, 70);
+    it('should format the end thumb label based on the passed-in `displayWith` function', async () => {
+      await setValueByClick(slider, endInput, 70);
       fixture.detectChanges();
       expect(endValueIndicatorTextElement.textContent).toBe('$70');
-    }));
+    });
   });
 
   describe('slider with value property binding', () => {
@@ -1146,10 +1128,10 @@ describe('MatSlider', () => {
       input = slider._getInput(_MatThumb.END) as MatSliderThumb;
     }));
 
-    it('works in RTL languages', fakeAsync(() => {
-      setValueByClick(slider, input, 25, true);
+    it('works in RTL languages', async () => {
+      await setValueByClick(slider, input, 25, true);
       checkInput(input, {min: 0, max: 100, value: 75, translateX: 75});
-    }));
+    });
 
     it('should position the tick marks correctly with a misaligned step (rtl)', () => {
       slider.showTickMarks = true;
@@ -1174,8 +1156,9 @@ describe('MatSlider', () => {
     let startInput: MatSliderThumb;
     let endInput: MatSliderThumb;
 
+    let fixture: ComponentFixture<any>;
     beforeEach(waitForAsync(() => {
-      const fixture = createComponent(StandardRangeSlider, [provideFakeDirectionality('rtl')]);
+      fixture = createComponent(StandardRangeSlider, [provideFakeDirectionality('rtl')]);
       fixture.detectChanges();
       const sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider));
       slider = sliderDebugElement.componentInstance;
@@ -1183,13 +1166,13 @@ describe('MatSlider', () => {
       endInput = slider._getInput(_MatThumb.END) as MatSliderRangeThumb;
     }));
 
-    it('works in RTL languages', fakeAsync(() => {
-      setValueByClick(slider, startInput, 90, true);
+    it('works in RTL languages', async () => {
+      await setValueByClick(slider, startInput, 90, true);
       checkInput(startInput, {min: 0, max: 100, value: 10, translateX: 270});
 
-      setValueByClick(slider, endInput, 10, true);
+      await setValueByClick(slider, endInput, 10, true);
       checkInput(endInput, {min: 10, max: 100, value: 90, translateX: 30});
-    }));
+    });
   });
 
   describe('slider with ngModel', () => {
@@ -1205,34 +1188,34 @@ describe('MatSlider', () => {
       input = slider._getInput(_MatThumb.END) as MatSliderThumb;
     }));
 
-    it('should update the model', fakeAsync(() => {
-      slideToValue(slider, input, 19);
+    it('should update the model', async () => {
+      await slideToValue(slider, input, 19);
       fixture.detectChanges();
       expect(fixture.componentInstance.val).toBe(19);
       checkInput(input, {min: 0, max: 100, value: 19, translateX: 57});
-    }));
+    });
 
-    it('should update the slider', fakeAsync(() => {
+    it('should update the slider', async () => {
       fixture.componentInstance.val = 20;
       fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
-      flush();
+      await fixture.whenStable();
       checkInput(input, {min: 0, max: 100, value: 20, translateX: 60});
-    }));
+    });
 
-    it('should be able to reset a slider by setting the model back to undefined', fakeAsync(() => {
+    it('should be able to reset a slider by setting the model back to undefined', async () => {
       fixture.componentInstance.val = 5;
       fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
-      flush();
+      await fixture.whenStable();
       checkInput(input, {min: 0, max: 100, value: 5, translateX: 15});
 
       fixture.componentInstance.val = undefined;
       fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
-      flush();
+      await fixture.whenStable();
       checkInput(input, {min: 0, max: 100, value: 0, translateX: 0});
-    }));
+    });
   });
 
   describe('range slider with ngModel', () => {
@@ -1250,92 +1233,91 @@ describe('MatSlider', () => {
       endInput = slider._getInput(_MatThumb.END) as MatSliderRangeThumb;
     }));
 
-    it('should update the models on input value changes', fakeAsync(() => {
-      slideToValue(slider, startInput, 25);
+    it('should update the models on input value changes', async () => {
+      await slideToValue(slider, startInput, 25);
       fixture.detectChanges();
-      flush();
+      await fixture.whenStable();
       checkInput(startInput, {min: 0, max: 100, value: 25, translateX: 75});
 
-      slideToValue(slider, endInput, 75);
+      await slideToValue(slider, endInput, 75);
       fixture.detectChanges();
-      flush();
+      await fixture.whenStable();
       checkInput(endInput, {min: 25, max: 100, value: 75, translateX: 225});
-    }));
+    });
 
-    it('should update the thumbs on ngModel value change', fakeAsync(() => {
+    it('should update the thumbs on ngModel value change', async () => {
       fixture.componentInstance.startVal = 50;
       fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
-      flush();
+      await fixture.whenStable();
       checkInput(startInput, {min: 0, max: 100, value: 50, translateX: 150});
 
       fixture.componentInstance.endVal = 75;
       fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
-      flush();
+      await fixture.whenStable();
       checkInput(endInput, {min: 50, max: 100, value: 75, translateX: 225});
-    }));
+    });
 
-    it('should be able to reset a start input', fakeAsync(() => {
+    it('should be able to reset a start input', async () => {
       fixture.componentInstance.startVal = 5;
       fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
-      flush();
+      await fixture.whenStable();
       checkInput(startInput, {min: 0, max: 100, value: 5, translateX: 15});
 
       fixture.componentInstance.startVal = undefined;
       fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
-      flush();
+      await fixture.whenStable();
       checkInput(startInput, {min: 0, max: 100, value: 0, translateX: 0});
-    }));
+    });
 
-    it('should be able to reset an end input', fakeAsync(() => {
+    it('should be able to reset an end input', async () => {
       fixture.componentInstance.endVal = 99;
       fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
-      flush();
+      await fixture.whenStable();
       checkInput(endInput, {min: 0, max: 100, value: 99, translateX: 297});
 
       fixture.componentInstance.endVal = undefined;
       fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
-      flush();
+      await fixture.whenStable();
       checkInput(endInput, {min: 0, max: 100, value: 0, translateX: 0});
-    }));
+    });
   });
 
   describe('range slider w/ NgModel edge case', () => {
-    it('should initialize correctly despite NgModel `null` bug', fakeAsync(() => {
+    it('should initialize correctly despite NgModel `null` bug', async () => {
       const fixture = createComponent(RangeSliderWithNgModelEdgeCase);
       fixture.detectChanges();
+      await fixture.whenStable();
       const sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider));
       const slider = sliderDebugElement.componentInstance;
       const startInput = slider._getInput(_MatThumb.START) as MatSliderRangeThumb;
       const endInput = slider._getInput(_MatThumb.END) as MatSliderRangeThumb;
-      flush();
       checkInput(startInput, {min: -1, max: -0.3, value: -0.7, translateX: 90});
       checkInput(endInput, {min: -0.7, max: 0, value: -0.3, translateX: 210});
-    }));
+    });
   });
 
   describe('slider with form group', () => {
-    it('should reset to initial min-max value when form reset is done', fakeAsync(() => {
+    it('should reset to initial min-max value when form reset is done', async () => {
       const fixture = createComponent(SliderWithFormGroup);
       fixture.detectChanges();
       const sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider));
       const slider = sliderDebugElement.componentInstance;
       const minInput = slider._getInput(_MatThumb.START) as MatSliderRangeThumb;
       const maxInput = slider._getInput(_MatThumb.END) as MatSliderRangeThumb;
-      flush();
 
       expect(minInput.value).toBe(0);
       expect(maxInput.value).toBe(10);
-      slideToValue(slider, minInput, 20);
+      await slideToValue(slider, minInput, 20);
       fixture.componentInstance.fg.reset();
       expect(minInput.value).toBe(0);
       expect(maxInput.value).toBe(10);
-    }));
+    });
   });
 
   describe('slider as a custom form control', () => {
@@ -1351,11 +1333,11 @@ describe('MatSlider', () => {
       input = slider._getInput(_MatThumb.END) as MatSliderThumb;
     }));
 
-    it('should update the control on slide', fakeAsync(() => {
+    it('should update the control on slide', async () => {
       expect(fixture.componentInstance.control.value).toBe(0);
-      slideToValue(slider, input, 19);
+      await slideToValue(slider, input, 19);
       expect(fixture.componentInstance.control.value).toBe(19);
-    }));
+    });
 
     it('should update the value when the control is set', () => {
       expect(input.value).toBe(0);
@@ -1375,7 +1357,7 @@ describe('MatSlider', () => {
       expect(slider.disabled).toBe(false);
     });
 
-    it('should have the correct control state initially and after interaction', fakeAsync(() => {
+    it('should have the correct control state initially and after interaction', async () => {
       let sliderControl = fixture.componentInstance.control;
 
       // The control should start off valid, pristine, and untouched.
@@ -1385,7 +1367,7 @@ describe('MatSlider', () => {
 
       // After changing the value, the control should become dirty (not pristine),
       // but remain untouched.
-      setValueByClick(slider, input, 50);
+      await setValueByClick(slider, input, 50);
 
       expect(sliderControl.valid).toBe(true);
       expect(sliderControl.pristine).toBe(false);
@@ -1399,7 +1381,7 @@ describe('MatSlider', () => {
       expect(sliderControl.valid).toBe(true);
       expect(sliderControl.pristine).toBe(false);
       expect(sliderControl.touched).toBe(true);
-    }));
+    });
   });
 
   describe('range slider as a custom form control', () => {
@@ -1417,17 +1399,17 @@ describe('MatSlider', () => {
       endInput = slider._getInput(_MatThumb.END) as MatSliderRangeThumb;
     }));
 
-    it('should update the start input control on slide', fakeAsync(() => {
+    it('should update the start input control on slide', async () => {
       expect(fixture.componentInstance.startInputControl.value).toBe(0);
-      slideToValue(slider, startInput, 20);
+      await slideToValue(slider, startInput, 20);
       expect(fixture.componentInstance.startInputControl.value).toBe(20);
-    }));
+    });
 
-    it('should update the end input control on slide', fakeAsync(() => {
+    it('should update the end input control on slide', async () => {
       expect(fixture.componentInstance.endInputControl.value).toBe(100);
-      slideToValue(slider, endInput, 80);
+      await slideToValue(slider, endInput, 80);
       expect(fixture.componentInstance.endInputControl.value).toBe(80);
-    }));
+    });
 
     it('should update the start input value when the start input control is set', () => {
       expect(startInput.value).toBe(0);
@@ -1461,7 +1443,7 @@ describe('MatSlider', () => {
       expect(slider.disabled).toBe(false);
     });
 
-    it('should have the correct start input control state initially and after interaction', fakeAsync(() => {
+    it('should have the correct start input control state initially and after interaction', async () => {
       let sliderControl = fixture.componentInstance.startInputControl;
 
       // The control should start off valid, pristine, and untouched.
@@ -1471,7 +1453,7 @@ describe('MatSlider', () => {
 
       // After changing the value, the control should become dirty (not pristine),
       // but remain untouched.
-      setValueByClick(slider, startInput, 25);
+      await setValueByClick(slider, startInput, 25);
 
       expect(sliderControl.valid).toBe(true);
       expect(sliderControl.pristine).toBe(false);
@@ -1485,9 +1467,9 @@ describe('MatSlider', () => {
       expect(sliderControl.valid).toBe(true);
       expect(sliderControl.pristine).toBe(false);
       expect(sliderControl.touched).toBe(true);
-    }));
+    });
 
-    it('should have the correct end input control state initially and after interaction', fakeAsync(() => {
+    it('should have the correct end input control state initially and after interaction', async () => {
       let sliderControl = fixture.componentInstance.endInputControl;
 
       // The control should start off valid, pristine, and untouched.
@@ -1497,7 +1479,7 @@ describe('MatSlider', () => {
 
       // After changing the value, the control should become dirty (not pristine),
       // but remain untouched.
-      setValueByClick(slider, endInput, 75);
+      await setValueByClick(slider, endInput, 75);
 
       expect(sliderControl.valid).toBe(true);
       expect(sliderControl.pristine).toBe(false);
@@ -1511,7 +1493,7 @@ describe('MatSlider', () => {
       expect(sliderControl.valid).toBe(true);
       expect(sliderControl.pristine).toBe(false);
       expect(sliderControl.touched).toBe(true);
-    }));
+    });
   });
 
   describe('slider with a two-way binding', () => {
@@ -1527,10 +1509,10 @@ describe('MatSlider', () => {
       input = slider._getInput(_MatThumb.END) as MatSliderThumb;
     });
 
-    it('should sync the value binding in both directions', fakeAsync(() => {
+    it('should sync the value binding in both directions', async () => {
       checkInput(input, {min: 0, max: 100, value: 0, step: 1, translateX: 0});
 
-      slideToValue(slider, input, 10);
+      await slideToValue(slider, input, 10);
       expect(fixture.componentInstance.value).toBe(10);
       checkInput(input, {min: 0, max: 100, value: 10, step: 1, translateX: 30});
 
@@ -1539,7 +1521,7 @@ describe('MatSlider', () => {
       fixture.detectChanges();
       expect(fixture.componentInstance.value).toBe(20);
       checkInput(input, {min: 0, max: 100, value: 20, step: 1, translateX: 60});
-    }));
+    });
   });
 
   describe('range slider with a two-way binding', () => {
@@ -1557,11 +1539,11 @@ describe('MatSlider', () => {
       startInput = slider._getInput(_MatThumb.START) as MatSliderRangeThumb;
     }));
 
-    it('should sync the start value binding in both directions', fakeAsync(() => {
+    it('should sync the start value binding in both directions', async () => {
       expect(fixture.componentInstance.startValue).toBe(0);
       expect(startInput.value).toBe(0);
 
-      slideToValue(slider, startInput, 10);
+      await slideToValue(slider, startInput, 10);
 
       expect(fixture.componentInstance.startValue).toBe(10);
       expect(startInput.value).toBe(10);
@@ -1571,13 +1553,13 @@ describe('MatSlider', () => {
       fixture.detectChanges();
       expect(fixture.componentInstance.startValue).toBe(20);
       expect(startInput.value).toBe(20);
-    }));
+    });
 
-    it('should sync the end value binding in both directions', fakeAsync(() => {
+    it('should sync the end value binding in both directions', async () => {
       expect(fixture.componentInstance.endValue).toBe(100);
       expect(endInput.value).toBe(100);
 
-      slideToValue(slider, endInput, 90);
+      await slideToValue(slider, endInput, 90);
       expect(fixture.componentInstance.endValue).toBe(90);
       expect(endInput.value).toBe(90);
 
@@ -1586,7 +1568,7 @@ describe('MatSlider', () => {
       fixture.detectChanges();
       expect(fixture.componentInstance.endValue).toBe(80);
       expect(endInput.value).toBe(80);
-    }));
+    });
   });
 
   describe('slider with tick marks', () => {
@@ -2071,7 +2053,7 @@ class SliderWithFormGroup {
 }
 
 /** Clicks on the MatSlider at the coordinates corresponding to the given value. */
-function setValueByClick(
+async function setValueByClick(
   slider: MatSlider,
   input: MatSliderThumb,
   value: number,
@@ -2087,11 +2069,11 @@ function setValueByClick(
   input.focus();
   dispatchPointerEvent(inputElement, 'pointerup', x, y);
   dispatchEvent(input._hostElement, new Event('change'));
-  flush();
+  await new Promise(r => setTimeout(r, 0));
 }
 
 /** Slides the MatSlider's thumb to the given value. */
-function slideToValue(slider: MatSlider, input: MatSliderThumb, value: number) {
+async function slideToValue(slider: MatSlider, input: MatSliderThumb, value: number) {
   const sliderElement = slider._elementRef.nativeElement;
   const {x: startX, y: startY} = getCoordsForValue(slider, input.value);
   const {x: endX, y: endY} = getCoordsForValue(slider, value);
@@ -2103,7 +2085,7 @@ function slideToValue(slider: MatSlider, input: MatSliderThumb, value: number) {
   dispatchEvent(input._hostElement, new Event('input'));
   dispatchPointerEvent(sliderElement, 'pointerup', endX, endY);
   dispatchEvent(input._hostElement, new Event('change'));
-  tick(10);
+  await new Promise(r => setTimeout(r, 0));
 }
 
 /** Returns the x and y coordinates for the given slider value. */

--- a/src/material/slider/testing/slider-harness.spec.ts
+++ b/src/material/slider/testing/slider-harness.spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {Component, signal} from '@angular/core';
-import {ComponentFixture, fakeAsync, TestBed} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {HarnessLoader, parallel} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatSliderModule} from '../slider-module';
@@ -140,7 +140,7 @@ describe('MatSliderHarness', () => {
     expect(await thumb.getDisplayValue()).toBe('#73');
   });
 
-  it('should get the min/max values of a slider thumb', fakeAsync(async () => {
+  it('should get the min/max values of a slider thumb', async () => {
     const instance = fixture.componentInstance;
     const slider = await loader.getHarness(MatSliderHarness.with({selector: '#range'}));
     const [start, end] = await parallel(() => [slider.getStartThumb(), slider.getEndThumb()]);
@@ -149,7 +149,7 @@ describe('MatSliderHarness', () => {
     expect(await start.getMaxValue()).toBe(instance.rangeSliderEndValue);
     expect(await end.getMinValue()).toBe(instance.rangeSliderStartValue);
     expect(await end.getMaxValue()).toBe(instance.rangeSliderMax);
-  }));
+  });
 
   it('should get the disabled state of a slider thumb', async () => {
     const slider = await loader.getHarness(MatSliderHarness);


### PR DESCRIPTION
Reworks the slider tests not to depend on `fakeAsync` anymore.