### PR TITLE
refactor(cdk/portal): Deprecate `ComponentType`

### DIFF
--- a/goldens/cdk/overlay/index.api.md
+++ b/goldens/cdk/overlay/index.api.md
@@ -206,7 +206,7 @@ export class CloseScrollStrategy implements ScrollStrategy {
     enable(): void;
 }
 
-// @public
+// @public @deprecated
 export interface ComponentType<T> {
     // (undocumented)
     new (...args: any[]): T;

--- a/goldens/cdk/portal/index.api.md
+++ b/goldens/cdk/portal/index.api.md
@@ -81,7 +81,7 @@ export class ComponentPortal<T> extends Portal<ComponentRef<T>> {
     viewContainerRef?: ViewContainerRef | null;
 }
 
-// @public
+// @public @deprecated
 export interface ComponentType<T> {
     // (undocumented)
     new (...args: any[]): T;

--- a/src/cdk/portal/portal.ts
+++ b/src/cdk/portal/portal.ts
@@ -7,24 +7,30 @@
  */
 
 import {
-  TemplateRef,
-  ViewContainerRef,
-  ElementRef,
+  Binding,
   ComponentRef,
+  ElementRef,
   EmbeddedViewRef,
   Injector,
-  Binding,
+  TemplateRef,
+  ViewContainerRef,
 } from '@angular/core';
 import {
-  throwNullPortalOutletError,
-  throwPortalAlreadyAttachedError,
   throwNoPortalAttachedError,
   throwNullPortalError,
+  throwNullPortalOutletError,
+  throwPortalAlreadyAttachedError,
   throwPortalOutletAlreadyDisposedError,
   throwUnknownPortalTypeError,
 } from './portal-errors';
 
-/** Interface that can be used to generically type a class. */
+/**
+ * Interface that can be used to generically type a class.
+ *
+ * @deprecated Use `Type<T>` from `@angular/core` instead.
+ *
+ * @breaking-change 22.0.0
+ */
 export interface ComponentType<T> {
   new (...args: any[]): T;
 }


### PR DESCRIPTION
Recommendation is to use `Type<T>` from `@angular/core` which has the exact same interface definition