### PR TITLE
fix(core) : add missing relative path to system token import

### DIFF
--- a/src/material/_index.scss
+++ b/src/material/_index.scss
@@ -17,10 +17,10 @@
 @forward './core/theming/theming' as private-* show private-clamp-density;
 @forward './core/typography/typography' show typography-hierarchy;
 @forward './core/typography/typography-utils' show font-shorthand;
-@forward 'core/tokens/system' show system-level-colors,
+@forward './core/tokens/system' show system-level-colors,
     system-level-typography, system-level-elevation, system-level-shape,
     system-level-motion, system-level-state, theme, theme-overrides, m2-theme;
-@forward 'core/tokens/classes' show system-classes;
+@forward './core/tokens/classes' show system-classes;
 
 // Private/Internal
 @forward './core/density/private/all-density' show all-component-densities;

--- a/src/material/_index.scss
+++ b/src/material/_index.scss
@@ -143,4 +143,3 @@
   tree-base, tree-overrides;
 @forward './timepicker/timepicker-theme' as timepicker-* show timepicker-theme, timepicker-color,
   timepicker-typography, timepicker-density, timepicker-base, timepicker-overrides;
-  

--- a/src/material/_index.scss
+++ b/src/material/_index.scss
@@ -143,3 +143,4 @@
   tree-base, tree-overrides;
 @forward './timepicker/timepicker-theme' as timepicker-* show timepicker-theme, timepicker-color,
   timepicker-typography, timepicker-density, timepicker-base, timepicker-overrides;
+  


### PR DESCRIPTION
## Description
This PR fixes a typo in the `core/tokens/system` import path within `_index.scss`. 

The missing relative path indicator (`./`) was preventing the system tokens from loading properly, which resulted in the `theme` mixin being unavailable in versions 20.2.13 and 20.2.14. 

Updating the path to `@forward './core/tokens/system';` resolves the module resolution error and restores the expected behavior from version 19.x.

Fixes #32917