### PR TITLE
refactor(google-maps): switch tests away from fakeAsync

### DIFF
--- a/src/google-maps/map-advanced-marker/map-advanced-marker.spec.ts
+++ b/src/google-maps/map-advanced-marker/map-advanced-marker.spec.ts
@@ -1,5 +1,5 @@
 import {Component, ViewChild} from '@angular/core';
-import {TestBed, fakeAsync, flush} from '@angular/core/testing';
+import {TestBed} from '@angular/core/testing';
 
 import {DEFAULT_OPTIONS, GoogleMap} from '../google-map/google-map';
 import {
@@ -22,13 +22,13 @@ describe('MapAdvancedMarker', () => {
     (window.google as any) = undefined;
   });
 
-  it('initializes a Google Map advanced marker', fakeAsync(() => {
+  it('initializes a Google Map advanced marker', () => {
     const advancedMarkerSpy = createAdvancedMarkerSpy(DEFAULT_MARKER_OPTIONS);
     const advancedMarkerConstructorSpy = createAdvancedMarkerConstructorSpy(advancedMarkerSpy);
 
     const fixture = TestBed.createComponent(TestApp);
     fixture.detectChanges();
-    flush();
+
     expect(advancedMarkerConstructorSpy).toHaveBeenCalledWith({
       ...DEFAULT_MARKER_OPTIONS,
       title: undefined,
@@ -37,9 +37,9 @@ describe('MapAdvancedMarker', () => {
       zIndex: undefined,
       map: mapSpy,
     });
-  }));
+  });
 
-  it('sets advanced marker inputs', fakeAsync(() => {
+  it('sets advanced marker inputs', () => {
     const options: google.maps.marker.AdvancedMarkerElementOptions = {
       position: {lat: 3, lng: 5},
       title: 'marker title',
@@ -59,12 +59,11 @@ describe('MapAdvancedMarker', () => {
     fixture.componentInstance.zIndex = options.zIndex!;
 
     fixture.detectChanges();
-    flush();
 
     expect(advancedMarkerConstructorSpy).toHaveBeenCalledWith(options);
-  }));
+  });
 
-  it('sets marker options, ignoring map', fakeAsync(() => {
+  it('sets marker options, ignoring map', () => {
     const options: google.maps.marker.AdvancedMarkerElementOptions = {
       position: {lat: 3, lng: 5},
       title: 'marker title',
@@ -78,12 +77,11 @@ describe('MapAdvancedMarker', () => {
     const fixture = TestBed.createComponent(TestApp);
     fixture.componentInstance.options = options;
     fixture.detectChanges();
-    flush();
 
     expect(advancedMarkerConstructorSpy).toHaveBeenCalledWith({...options, map: mapSpy});
-  }));
+  });
 
-  it('gives precedence to specific inputs over options', fakeAsync(() => {
+  it('gives precedence to specific inputs over options', () => {
     const options: google.maps.marker.AdvancedMarkerElementOptions = {
       position: {lat: 3, lng: 5},
       title: 'marker title',
@@ -112,12 +110,11 @@ describe('MapAdvancedMarker', () => {
     fixture.componentInstance.options = options!;
 
     fixture.detectChanges();
-    flush();
 
     expect(advancedMarkerConstructorSpy).toHaveBeenCalledWith(expectedOptions);
-  }));
+  });
 
-  it('initializes marker event handlers', fakeAsync(() => {
+  it('initializes marker event handlers', () => {
     const advancedMarkerSpy = createAdvancedMarkerSpy(DEFAULT_MARKER_OPTIONS);
     createAdvancedMarkerConstructorSpy(advancedMarkerSpy);
 
@@ -125,7 +122,6 @@ describe('MapAdvancedMarker', () => {
     const nativeSpy = advancedMarkerSpy.addEventListener;
     const fixture = TestBed.createComponent(TestApp);
     fixture.detectChanges();
-    flush();
 
     expect(customSpy).toHaveBeenCalledWith('click', jasmine.any(Function));
     expect(nativeSpy).toHaveBeenCalledWith('dblclick', jasmine.any(Function));
@@ -136,16 +132,15 @@ describe('MapAdvancedMarker', () => {
     expect(customSpy).not.toHaveBeenCalledWith('drag', jasmine.any(Function));
     expect(customSpy).not.toHaveBeenCalledWith('dragend', jasmine.any(Function));
     expect(customSpy).not.toHaveBeenCalledWith('dragstart', jasmine.any(Function));
-  }));
+  });
 
-  it('should be able to add an event listener after init', fakeAsync(() => {
+  it('should be able to add an event listener after init', () => {
     const advancedMarkerSpy = createAdvancedMarkerSpy(DEFAULT_MARKER_OPTIONS);
     createAdvancedMarkerConstructorSpy(advancedMarkerSpy);
 
     const addSpy = advancedMarkerSpy.addListener;
     const fixture = TestBed.createComponent(TestApp);
     fixture.detectChanges();
-    flush();
 
     expect(addSpy).not.toHaveBeenCalledWith('drag', jasmine.any(Function));
 
@@ -155,7 +150,7 @@ describe('MapAdvancedMarker', () => {
 
     expect(addSpy).toHaveBeenCalledWith('drag', jasmine.any(Function));
     subscription.unsubscribe();
-  }));
+  });
 });
 
 @Component({

--- a/src/google-maps/map-bicycling-layer/map-bicycling-layer.spec.ts
+++ b/src/google-maps/map-bicycling-layer/map-bicycling-layer.spec.ts
@@ -1,5 +1,5 @@
 import {Component} from '@angular/core';
-import {TestBed, fakeAsync, flush} from '@angular/core/testing';
+import {TestBed} from '@angular/core/testing';
 
 import {DEFAULT_OPTIONS, GoogleMap} from '../google-map/google-map';
 import {
@@ -23,16 +23,15 @@ describe('MapBicyclingLayer', () => {
     (window.google as any) = undefined;
   });
 
-  it('initializes a Google Map Bicycling Layer', fakeAsync(() => {
+  it('initializes a Google Map Bicycling Layer', () => {
     const bicyclingLayerSpy = createBicyclingLayerSpy();
     const bicyclingLayerConstructorSpy = createBicyclingLayerConstructorSpy(bicyclingLayerSpy);
     const fixture = TestBed.createComponent(TestApp);
     fixture.detectChanges();
-    flush();
 
     expect(bicyclingLayerConstructorSpy).toHaveBeenCalled();
     expect(bicyclingLayerSpy.setMap).toHaveBeenCalledWith(mapSpy);
-  }));
+  });
 });
 
 @Component({

--- a/src/google-maps/map-circle/map-circle.spec.ts
+++ b/src/google-maps/map-circle/map-circle.spec.ts
@@ -1,5 +1,5 @@
 import {Component, ViewChild} from '@angular/core';
-import {TestBed, fakeAsync, flush} from '@angular/core/testing';
+import {TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
 import {DEFAULT_OPTIONS, GoogleMap} from '../google-map/google-map';
@@ -38,19 +38,18 @@ describe('MapCircle', () => {
     (window.google as any) = undefined;
   });
 
-  it('initializes a Google Map Circle', fakeAsync(() => {
+  it('initializes a Google Map Circle', () => {
     const circleSpy = createCircleSpy({});
     const circleConstructorSpy = createCircleConstructorSpy(circleSpy);
 
     const fixture = TestBed.createComponent(TestApp);
     fixture.detectChanges();
-    flush();
 
     expect(circleConstructorSpy).toHaveBeenCalledWith({center: undefined, radius: undefined});
     expect(circleSpy.setMap).toHaveBeenCalledWith(mapSpy);
-  }));
+  });
 
-  it('sets center and radius from input', fakeAsync(() => {
+  it('sets center and radius from input', () => {
     const center: google.maps.LatLngLiteral = {lat: 3, lng: 5};
     const radius = 15;
     const options: google.maps.CircleOptions = {center, radius};
@@ -61,12 +60,11 @@ describe('MapCircle', () => {
     fixture.componentInstance.center = center;
     fixture.componentInstance.radius = radius;
     fixture.detectChanges();
-    flush();
 
     expect(circleConstructorSpy).toHaveBeenCalledWith(options);
-  }));
+  });
 
-  it('gives precedence to other inputs over options', fakeAsync(() => {
+  it('gives precedence to other inputs over options', () => {
     const center: google.maps.LatLngLiteral = {lat: 3, lng: 5};
     const radius = 15;
     const expectedOptions: google.maps.CircleOptions = {...circleOptions, center, radius};
@@ -78,12 +76,11 @@ describe('MapCircle', () => {
     fixture.componentInstance.center = center;
     fixture.componentInstance.radius = radius;
     fixture.detectChanges();
-    flush();
 
     expect(circleConstructorSpy).toHaveBeenCalledWith(expectedOptions);
-  }));
+  });
 
-  it('exposes methods that provide information about the Circle', fakeAsync(() => {
+  it('exposes methods that provide information about the Circle', () => {
     const circleSpy = createCircleSpy(circleOptions);
     createCircleConstructorSpy(circleSpy);
 
@@ -92,7 +89,6 @@ describe('MapCircle', () => {
       .query(By.directive(MapCircle))!
       .injector.get<MapCircle>(MapCircle);
     fixture.detectChanges();
-    flush();
 
     circleComponent.getCenter();
     expect(circleSpy.getCenter).toHaveBeenCalled();
@@ -108,16 +104,15 @@ describe('MapCircle', () => {
 
     circleSpy.getVisible.and.returnValue(true);
     expect(circleComponent.getVisible()).toBe(true);
-  }));
+  });
 
-  it('initializes Circle event handlers', fakeAsync(() => {
+  it('initializes Circle event handlers', () => {
     const circleSpy = createCircleSpy(circleOptions);
     createCircleConstructorSpy(circleSpy);
 
     const addSpy = circleSpy.addListener;
     const fixture = TestBed.createComponent(TestApp);
     fixture.detectChanges();
-    flush();
 
     expect(addSpy).toHaveBeenCalledWith('center_changed', jasmine.any(Function));
     expect(addSpy).toHaveBeenCalledWith('click', jasmine.any(Function));
@@ -132,16 +127,15 @@ describe('MapCircle', () => {
     expect(addSpy).not.toHaveBeenCalledWith('mouseup', jasmine.any(Function));
     expect(addSpy).not.toHaveBeenCalledWith('radius_changed', jasmine.any(Function));
     expect(addSpy).toHaveBeenCalledWith('rightclick', jasmine.any(Function));
-  }));
+  });
 
-  it('should be able to add an event listener after init', fakeAsync(() => {
+  it('should be able to add an event listener after init', () => {
     const circleSpy = createCircleSpy(circleOptions);
     createCircleConstructorSpy(circleSpy);
 
     const addSpy = circleSpy.addListener;
     const fixture = TestBed.createComponent(TestApp);
     fixture.detectChanges();
-    flush();
 
     expect(addSpy).not.toHaveBeenCalledWith('dragend', jasmine.any(Function));
 
@@ -151,7 +145,7 @@ describe('MapCircle', () => {
 
     expect(addSpy).toHaveBeenCalledWith('dragend', jasmine.any(Function));
     subscription.unsubscribe();
-  }));
+  });
 });
 
 @Component({

--- a/src/google-maps/map-directions-renderer/map-directions-renderer.spec.ts
+++ b/src/google-maps/map-directions-renderer/map-directions-renderer.spec.ts
@@ -1,5 +1,5 @@
 import {Component, ViewChild} from '@angular/core';
-import {TestBed, fakeAsync, flush} from '@angular/core/testing';
+import {TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {MapDirectionsRenderer} from './map-directions-renderer';
 import {DEFAULT_OPTIONS, GoogleMap} from '../google-map/google-map';
@@ -28,7 +28,7 @@ describe('MapDirectionsRenderer', () => {
     (window.google as any) = undefined;
   });
 
-  it('initializes a Google Maps DirectionsRenderer', fakeAsync(() => {
+  it('initializes a Google Maps DirectionsRenderer', () => {
     const directionsRendererSpy = createDirectionsRendererSpy({directions: DEFAULT_DIRECTIONS});
     const directionsRendererConstructorSpy =
       createDirectionsRendererConstructorSpy(directionsRendererSpy);
@@ -36,16 +36,15 @@ describe('MapDirectionsRenderer', () => {
     const fixture = TestBed.createComponent(TestApp);
     fixture.componentInstance.options = {directions: DEFAULT_DIRECTIONS};
     fixture.detectChanges();
-    flush();
 
     expect(directionsRendererConstructorSpy).toHaveBeenCalledWith({
       directions: DEFAULT_DIRECTIONS,
       map: jasmine.any(Object),
     });
     expect(directionsRendererSpy.setMap).toHaveBeenCalledWith(mapSpy);
-  }));
+  });
 
-  it('sets directions from directions input', fakeAsync(() => {
+  it('sets directions from directions input', () => {
     const directionsRendererSpy = createDirectionsRendererSpy({directions: DEFAULT_DIRECTIONS});
     const directionsRendererConstructorSpy =
       createDirectionsRendererConstructorSpy(directionsRendererSpy);
@@ -53,16 +52,15 @@ describe('MapDirectionsRenderer', () => {
     const fixture = TestBed.createComponent(TestApp);
     fixture.componentInstance.directions = DEFAULT_DIRECTIONS;
     fixture.detectChanges();
-    flush();
 
     expect(directionsRendererConstructorSpy).toHaveBeenCalledWith({
       directions: DEFAULT_DIRECTIONS,
       map: jasmine.any(Object),
     });
     expect(directionsRendererSpy.setMap).toHaveBeenCalledWith(mapSpy);
-  }));
+  });
 
-  it('gives precedence to directions over options', fakeAsync(() => {
+  it('gives precedence to directions over options', () => {
     const updatedDirections: google.maps.DirectionsResult = {
       geocoded_waypoints: [{partial_match: false, place_id: 'test', types: []}],
       request: {
@@ -80,16 +78,15 @@ describe('MapDirectionsRenderer', () => {
     fixture.componentInstance.options = {directions: DEFAULT_DIRECTIONS};
     fixture.componentInstance.directions = updatedDirections;
     fixture.detectChanges();
-    flush();
 
     expect(directionsRendererConstructorSpy).toHaveBeenCalledWith({
       directions: updatedDirections,
       map: jasmine.any(Object),
     });
     expect(directionsRendererSpy.setMap).toHaveBeenCalledWith(mapSpy);
-  }));
+  });
 
-  it('exposes methods that provide information from the DirectionsRenderer', fakeAsync(() => {
+  it('exposes methods that provide information from the DirectionsRenderer', () => {
     const directionsRendererSpy = createDirectionsRendererSpy({});
     createDirectionsRendererConstructorSpy(directionsRendererSpy);
 
@@ -99,7 +96,6 @@ describe('MapDirectionsRenderer', () => {
       .query(By.directive(MapDirectionsRenderer))!
       .injector.get<MapDirectionsRenderer>(MapDirectionsRenderer);
     fixture.detectChanges();
-    flush();
 
     directionsRendererSpy.getDirections.and.returnValue(DEFAULT_DIRECTIONS);
     expect(directionsRendererComponent.getDirections()).toBe(DEFAULT_DIRECTIONS);
@@ -109,21 +105,20 @@ describe('MapDirectionsRenderer', () => {
 
     directionsRendererSpy.getRouteIndex.and.returnValue(10);
     expect(directionsRendererComponent.getRouteIndex()).toBe(10);
-  }));
+  });
 
-  it('initializes DirectionsRenderer event handlers', fakeAsync(() => {
+  it('initializes DirectionsRenderer event handlers', () => {
     const directionsRendererSpy = createDirectionsRendererSpy({});
     createDirectionsRendererConstructorSpy(directionsRendererSpy);
 
     const fixture = TestBed.createComponent(TestApp);
     fixture.detectChanges();
-    flush();
 
     expect(directionsRendererSpy.addListener).toHaveBeenCalledWith(
       'directions_changed',
       jasmine.any(Function),
     );
-  }));
+  });
 });
 
 @Component({

--- a/src/google-maps/map-ground-overlay/map-ground-overlay.spec.ts
+++ b/src/google-maps/map-ground-overlay/map-ground-overlay.spec.ts
@@ -1,5 +1,5 @@
 import {Component, ViewChild} from '@angular/core';
-import {TestBed, fakeAsync, flush} from '@angular/core/testing';
+import {TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
 import {DEFAULT_OPTIONS, GoogleMap} from '../google-map/google-map';
@@ -29,7 +29,7 @@ describe('MapGroundOverlay', () => {
     (window.google as any) = undefined;
   });
 
-  it('initializes a Google Map Ground Overlay', fakeAsync(() => {
+  it('initializes a Google Map Ground Overlay', () => {
     const groundOverlaySpy = createGroundOverlaySpy(url, bounds, groundOverlayOptions);
     const groundOverlayConstructorSpy = createGroundOverlayConstructorSpy(groundOverlaySpy);
 
@@ -40,13 +40,12 @@ describe('MapGroundOverlay', () => {
     fixture.componentInstance.opacity = opacity;
     fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
-    flush();
 
     expect(groundOverlayConstructorSpy).toHaveBeenCalledWith(url, bounds, groundOverlayOptions);
     expect(groundOverlaySpy.setMap).toHaveBeenCalledWith(mapSpy);
-  }));
+  });
 
-  it('exposes methods that provide information about the Ground Overlay', fakeAsync(() => {
+  it('exposes methods that provide information about the Ground Overlay', () => {
     const groundOverlaySpy = createGroundOverlaySpy(url, bounds, groundOverlayOptions);
     createGroundOverlayConstructorSpy(groundOverlaySpy);
 
@@ -59,7 +58,6 @@ describe('MapGroundOverlay', () => {
     fixture.componentInstance.opacity = opacity;
     fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
-    flush();
 
     groundOverlayComponent.getBounds();
     expect(groundOverlaySpy.getBounds).toHaveBeenCalled();
@@ -69,9 +67,9 @@ describe('MapGroundOverlay', () => {
 
     groundOverlaySpy.getUrl.and.returnValue(url);
     expect(groundOverlayComponent.getUrl()).toBe(url);
-  }));
+  });
 
-  it('initializes Ground Overlay event handlers', fakeAsync(() => {
+  it('initializes Ground Overlay event handlers', () => {
     const groundOverlaySpy = createGroundOverlaySpy(url, bounds, groundOverlayOptions);
     createGroundOverlayConstructorSpy(groundOverlaySpy);
 
@@ -81,13 +79,12 @@ describe('MapGroundOverlay', () => {
     fixture.componentInstance.bounds = bounds;
     fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
-    flush();
 
     expect(addSpy).toHaveBeenCalledWith('click', jasmine.any(Function));
     expect(addSpy).not.toHaveBeenCalledWith('dblclick', jasmine.any(Function));
-  }));
+  });
 
-  it('should be able to add an event listener after init', fakeAsync(() => {
+  it('should be able to add an event listener after init', () => {
     const groundOverlaySpy = createGroundOverlaySpy(url, bounds, groundOverlayOptions);
     createGroundOverlayConstructorSpy(groundOverlaySpy);
 
@@ -97,7 +94,6 @@ describe('MapGroundOverlay', () => {
     fixture.componentInstance.bounds = bounds;
     fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
-    flush();
 
     expect(addSpy).not.toHaveBeenCalledWith('dblclick', jasmine.any(Function));
 
@@ -107,9 +103,9 @@ describe('MapGroundOverlay', () => {
 
     expect(addSpy).toHaveBeenCalledWith('dblclick', jasmine.any(Function));
     subscription.unsubscribe();
-  }));
+  });
 
-  it('should be able to change the image after init', fakeAsync(() => {
+  it('should be able to change the image after init', () => {
     const groundOverlaySpy = createGroundOverlaySpy(url, bounds, groundOverlayOptions);
     const groundOverlayConstructorSpy = createGroundOverlayConstructorSpy(groundOverlaySpy);
 
@@ -120,7 +116,6 @@ describe('MapGroundOverlay', () => {
     fixture.componentInstance.opacity = opacity;
     fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
-    flush();
 
     expect(groundOverlayConstructorSpy).toHaveBeenCalledWith(url, bounds, groundOverlayOptions);
     expect(groundOverlaySpy.setMap).toHaveBeenCalledWith(mapSpy);
@@ -134,26 +129,24 @@ describe('MapGroundOverlay', () => {
     expect(groundOverlaySpy.setMap).toHaveBeenCalledTimes(2);
     expect(groundOverlaySpy.setMap).toHaveBeenCalledWith(null);
     expect(groundOverlaySpy.setMap).toHaveBeenCalledWith(mapSpy);
-  }));
+  });
 
-  it('should recreate the ground overlay when the bounds change', fakeAsync(() => {
+  it('should recreate the ground overlay when the bounds change', () => {
     const groundOverlaySpy = createGroundOverlaySpy(url, bounds, groundOverlayOptions);
     createGroundOverlayConstructorSpy(groundOverlaySpy);
 
     const fixture = TestBed.createComponent(TestApp);
     fixture.detectChanges();
-    flush();
 
     const oldOverlay = fixture.componentInstance.groundOverlay.groundOverlay;
     fixture.componentInstance.bounds = {...bounds};
     fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
-    flush();
 
     const newOverlay = fixture.componentInstance.groundOverlay.groundOverlay;
     expect(newOverlay).toBeTruthy();
     expect(newOverlay).not.toBe(oldOverlay);
-  }));
+  });
 });
 
 @Component({

--- a/src/google-maps/map-heatmap-layer/map-heatmap-layer.spec.ts
+++ b/src/google-maps/map-heatmap-layer/map-heatmap-layer.spec.ts
@@ -1,5 +1,5 @@
 import {Component, ViewChild} from '@angular/core';
-import {TestBed, fakeAsync, flush} from '@angular/core/testing';
+import {TestBed} from '@angular/core/testing';
 
 import {DEFAULT_OPTIONS, GoogleMap} from '../google-map/google-map';
 
@@ -28,32 +28,30 @@ describe('MapHeatmapLayer', () => {
     (window.google as any) = undefined;
   });
 
-  it('initializes a Google Map heatmap layer', fakeAsync(() => {
+  it('initializes a Google Map heatmap layer', () => {
     const heatmapSpy = createHeatmapLayerSpy();
     const heatmapConstructorSpy = createHeatmapLayerConstructorSpy(heatmapSpy);
 
     const fixture = TestBed.createComponent(TestApp);
     fixture.detectChanges();
-    flush();
 
     expect(heatmapConstructorSpy).toHaveBeenCalledWith({
       data: [],
       map: mapSpy,
     });
-  }));
+  });
 
-  it('should throw if the `visualization` library has not been loaded', fakeAsync(() => {
+  it('should throw if the `visualization` library has not been loaded', () => {
     createHeatmapLayerConstructorSpy(createHeatmapLayerSpy());
     delete (window.google.maps as any).visualization;
 
     expect(() => {
       const fixture = TestBed.createComponent(TestApp);
       fixture.detectChanges();
-      flush();
     }).toThrowError(/Namespace `google.maps.visualization` not found, cannot construct heatmap/);
-  }));
+  });
 
-  it('sets heatmap inputs', fakeAsync(() => {
+  it('sets heatmap inputs', () => {
     const options: google.maps.visualization.HeatmapLayerOptions = {
       map: mapSpy,
       data: [
@@ -69,12 +67,11 @@ describe('MapHeatmapLayer', () => {
     fixture.componentInstance.data = options.data!;
     fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
-    flush();
 
     expect(heatmapConstructorSpy).toHaveBeenCalledWith(options);
-  }));
+  });
 
-  it('sets heatmap options, ignoring map', fakeAsync(() => {
+  it('sets heatmap options, ignoring map', () => {
     const options: Partial<google.maps.visualization.HeatmapLayerOptions> = {
       radius: 5,
       dissipating: true,
@@ -92,25 +89,24 @@ describe('MapHeatmapLayer', () => {
     fixture.componentInstance.options = options;
     fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
-    flush();
 
     expect(heatmapConstructorSpy).toHaveBeenCalledWith({...options, map: mapSpy, data});
-  }));
+  });
 
-  it('exposes methods that provide information about the heatmap', fakeAsync(() => {
+  it('exposes methods that provide information about the heatmap', () => {
     const heatmapSpy = createHeatmapLayerSpy();
     createHeatmapLayerConstructorSpy(heatmapSpy);
 
     const fixture = TestBed.createComponent(TestApp);
     fixture.detectChanges();
-    flush();
+
     const heatmap = fixture.componentInstance.heatmap;
 
     heatmapSpy.getData.and.returnValue([] as any);
     expect(heatmap.getData()).toEqual([]);
-  }));
+  });
 
-  it('should update the heatmap data when the input changes', fakeAsync(() => {
+  it('should update the heatmap data when the input changes', () => {
     const heatmapSpy = createHeatmapLayerSpy();
     const heatmapConstructorSpy = createHeatmapLayerConstructorSpy(heatmapSpy);
     let data = [
@@ -123,7 +119,6 @@ describe('MapHeatmapLayer', () => {
     fixture.componentInstance.data = data;
     fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
-    flush();
 
     expect(heatmapConstructorSpy).toHaveBeenCalledWith(jasmine.objectContaining({data}));
     data = [
@@ -136,9 +131,9 @@ describe('MapHeatmapLayer', () => {
     fixture.detectChanges();
 
     expect(heatmapSpy.setData).toHaveBeenCalledWith(data);
-  }));
+  });
 
-  it('should create a LatLng object if a LatLngLiteral is passed in', fakeAsync(() => {
+  it('should create a LatLng object if a LatLngLiteral is passed in', () => {
     const latLngConstructor = createLatLngConstructorSpy(latLngSpy);
     createHeatmapLayerConstructorSpy(createHeatmapLayerSpy());
     const fixture = TestBed.createComponent(TestApp);
@@ -148,12 +143,11 @@ describe('MapHeatmapLayer', () => {
     ];
     fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
-    flush();
 
     expect(latLngConstructor).toHaveBeenCalledWith(1, 2);
     expect(latLngConstructor).toHaveBeenCalledWith(3, 4);
     expect(latLngConstructor).toHaveBeenCalledTimes(2);
-  }));
+  });
 });
 
 @Component({

--- a/src/google-maps/map-info-window/map-info-window.spec.ts
+++ b/src/google-maps/map-info-window/map-info-window.spec.ts
@@ -1,5 +1,5 @@
 import {Component, ViewChild} from '@angular/core';
-import {TestBed, fakeAsync, flush} from '@angular/core/testing';
+import {TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
 import {DEFAULT_OPTIONS, GoogleMap} from '../google-map/google-map';
@@ -25,7 +25,7 @@ describe('MapInfoWindow', () => {
     (window.google as any) = undefined;
   });
 
-  it('initializes a Google Map Info Window', fakeAsync(() => {
+  it('initializes a Google Map Info Window', () => {
     const infoWindowSpy = createInfoWindowSpy({});
     const infoWindowConstructorSpy = createInfoWindowConstructorSpy(infoWindowSpy);
 
@@ -36,9 +36,9 @@ describe('MapInfoWindow', () => {
       position: undefined,
       content: jasmine.any(Node),
     });
-  }));
+  });
 
-  it('sets position', fakeAsync(() => {
+  it('sets position', () => {
     const position: google.maps.LatLngLiteral = {lat: 5, lng: 7};
     const infoWindowSpy = createInfoWindowSpy({position});
     const infoWindowConstructorSpy = createInfoWindowConstructorSpy(infoWindowSpy);
@@ -46,15 +46,14 @@ describe('MapInfoWindow', () => {
     const fixture = TestBed.createComponent(TestApp);
     fixture.componentInstance.position = position;
     fixture.detectChanges();
-    flush();
 
     expect(infoWindowConstructorSpy).toHaveBeenCalledWith({
       position,
       content: jasmine.any(Node),
     });
-  }));
+  });
 
-  it('sets options', fakeAsync(() => {
+  it('sets options', () => {
     const options: google.maps.InfoWindowOptions = {
       position: {lat: 3, lng: 5},
       maxWidth: 50,
@@ -66,15 +65,14 @@ describe('MapInfoWindow', () => {
     const fixture = TestBed.createComponent(TestApp);
     fixture.componentInstance.options = options;
     fixture.detectChanges();
-    flush();
 
     expect(infoWindowConstructorSpy).toHaveBeenCalledWith({
       ...options,
       content: jasmine.any(Node),
     });
-  }));
+  });
 
-  it('gives preference to position over options', fakeAsync(() => {
+  it('gives preference to position over options', () => {
     const position: google.maps.LatLngLiteral = {lat: 5, lng: 7};
     const options: google.maps.InfoWindowOptions = {
       position: {lat: 3, lng: 5},
@@ -88,16 +86,15 @@ describe('MapInfoWindow', () => {
     fixture.componentInstance.options = options;
     fixture.componentInstance.position = position;
     fixture.detectChanges();
-    flush();
 
     expect(infoWindowConstructorSpy).toHaveBeenCalledWith({
       ...options,
       position,
       content: jasmine.any(Node),
     });
-  }));
+  });
 
-  it('exposes methods that change the configuration of the info window', fakeAsync(() => {
+  it('exposes methods that change the configuration of the info window', () => {
     const fakeMarker = {} as unknown as google.maps.Marker;
     const fakeMarkerComponent = {
       marker: fakeMarker,
@@ -111,7 +108,6 @@ describe('MapInfoWindow', () => {
       .query(By.directive(MapInfoWindow))!
       .injector.get<MapInfoWindow>(MapInfoWindow);
     fixture.detectChanges();
-    flush();
 
     infoWindowComponent.close();
     expect(infoWindowSpy.close).toHaveBeenCalled();
@@ -124,9 +120,9 @@ describe('MapInfoWindow', () => {
         shouldFocus: undefined,
       }),
     );
-  }));
+  });
 
-  it('should not try to reopen info window multiple times for the same marker', fakeAsync(() => {
+  it('should not try to reopen info window multiple times for the same marker', () => {
     const fakeMarker = {} as unknown as google.maps.Marker;
     const fakeMarkerComponent = {
       marker: fakeMarker,
@@ -140,7 +136,6 @@ describe('MapInfoWindow', () => {
       .query(By.directive(MapInfoWindow))!
       .injector.get<MapInfoWindow>(MapInfoWindow);
     fixture.detectChanges();
-    flush();
 
     infoWindowComponent.open(fakeMarkerComponent);
     expect(infoWindowSpy.open).toHaveBeenCalledTimes(1);
@@ -151,9 +146,9 @@ describe('MapInfoWindow', () => {
     infoWindowComponent.close();
     infoWindowComponent.open(fakeMarkerComponent);
     expect(infoWindowSpy.open).toHaveBeenCalledTimes(2);
-  }));
+  });
 
-  it('exposes methods that provide information about the info window', fakeAsync(() => {
+  it('exposes methods that provide information about the info window', () => {
     const infoWindowSpy = createInfoWindowSpy({});
     createInfoWindowConstructorSpy(infoWindowSpy);
 
@@ -162,7 +157,6 @@ describe('MapInfoWindow', () => {
       .query(By.directive(MapInfoWindow))!
       .injector.get<MapInfoWindow>(MapInfoWindow);
     fixture.detectChanges();
-    flush();
 
     infoWindowSpy.getContent.and.returnValue('test content');
     expect(infoWindowComponent.getContent()).toBe('test content');
@@ -172,32 +166,30 @@ describe('MapInfoWindow', () => {
 
     infoWindowSpy.getZIndex.and.returnValue(5);
     expect(infoWindowComponent.getZIndex()).toBe(5);
-  }));
+  });
 
-  it('initializes info window event handlers', fakeAsync(() => {
+  it('initializes info window event handlers', () => {
     const infoWindowSpy = createInfoWindowSpy({});
     createInfoWindowConstructorSpy(infoWindowSpy);
 
     const addSpy = infoWindowSpy.addListener;
     const fixture = TestBed.createComponent(TestApp);
     fixture.detectChanges();
-    flush();
 
     expect(addSpy).toHaveBeenCalledWith('closeclick', jasmine.any(Function));
     expect(addSpy).not.toHaveBeenCalledWith('content_changed', jasmine.any(Function));
     expect(addSpy).not.toHaveBeenCalledWith('domready', jasmine.any(Function));
     expect(addSpy).not.toHaveBeenCalledWith('position_changed', jasmine.any(Function));
     expect(addSpy).not.toHaveBeenCalledWith('zindex_changed', jasmine.any(Function));
-  }));
+  });
 
-  it('should be able to add an event listener after init', fakeAsync(() => {
+  it('should be able to add an event listener after init', () => {
     const infoWindowSpy = createInfoWindowSpy({});
     createInfoWindowConstructorSpy(infoWindowSpy);
 
     const addSpy = infoWindowSpy.addListener;
     const fixture = TestBed.createComponent(TestApp);
     fixture.detectChanges();
-    flush();
 
     expect(addSpy).not.toHaveBeenCalledWith('zindex_changed', jasmine.any(Function));
 
@@ -207,9 +199,9 @@ describe('MapInfoWindow', () => {
 
     expect(addSpy).toHaveBeenCalledWith('zindex_changed', jasmine.any(Function));
     subscription.unsubscribe();
-  }));
+  });
 
-  it('should be able to open an info window without passing in an anchor', fakeAsync(() => {
+  it('should be able to open an info window without passing in an anchor', () => {
     const infoWindowSpy = createInfoWindowSpy({});
     createInfoWindowConstructorSpy(infoWindowSpy);
 
@@ -218,13 +210,12 @@ describe('MapInfoWindow', () => {
       .query(By.directive(MapInfoWindow))!
       .injector.get<MapInfoWindow>(MapInfoWindow);
     fixture.detectChanges();
-    flush();
 
     infoWindowComponent.open();
     expect(infoWindowSpy.open).toHaveBeenCalledTimes(1);
-  }));
+  });
 
-  it('should allow for the focus behavior to be changed when opening the info window', fakeAsync(() => {
+  it('should allow for the focus behavior to be changed when opening the info window', () => {
     const fakeMarker = {} as unknown as google.maps.Marker;
     const fakeMarkerComponent = {
       marker: fakeMarker,
@@ -238,7 +229,6 @@ describe('MapInfoWindow', () => {
       .query(By.directive(MapInfoWindow))!
       .injector.get<MapInfoWindow>(MapInfoWindow);
     fixture.detectChanges();
-    flush();
 
     infoWindowComponent.open(fakeMarkerComponent, false);
     expect(infoWindowSpy.open).toHaveBeenCalledWith(
@@ -246,7 +236,7 @@ describe('MapInfoWindow', () => {
         shouldFocus: false,
       }),
     );
-  }));
+  });
 });
 
 @Component({

--- a/src/google-maps/map-kml-layer/map-kml-layer.spec.ts
+++ b/src/google-maps/map-kml-layer/map-kml-layer.spec.ts
@@ -1,5 +1,5 @@
 import {Component, ViewChild} from '@angular/core';
-import {TestBed, fakeAsync, flush} from '@angular/core/testing';
+import {TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
 import {DEFAULT_OPTIONS, GoogleMap} from '../google-map/google-map';
@@ -31,19 +31,18 @@ describe('MapKmlLayer', () => {
     (window.google as any) = undefined;
   });
 
-  it('initializes a Google Map Kml Layer', fakeAsync(() => {
+  it('initializes a Google Map Kml Layer', () => {
     const kmlLayerSpy = createKmlLayerSpy({});
     const kmlLayerConstructorSpy = createKmlLayerConstructorSpy(kmlLayerSpy);
 
     const fixture = TestBed.createComponent(TestApp);
     fixture.detectChanges();
-    flush();
 
     expect(kmlLayerConstructorSpy).toHaveBeenCalledWith({url: undefined});
     expect(kmlLayerSpy.setMap).toHaveBeenCalledWith(mapSpy);
-  }));
+  });
 
-  it('sets url from input', fakeAsync(() => {
+  it('sets url from input', () => {
     const options: google.maps.KmlLayerOptions = {url: DEMO_URL};
     const kmlLayerSpy = createKmlLayerSpy(options);
     const kmlLayerConstructorSpy = createKmlLayerConstructorSpy(kmlLayerSpy);
@@ -51,12 +50,11 @@ describe('MapKmlLayer', () => {
     const fixture = TestBed.createComponent(TestApp);
     fixture.componentInstance.url = DEMO_URL;
     fixture.detectChanges();
-    flush();
 
     expect(kmlLayerConstructorSpy).toHaveBeenCalledWith(options);
-  }));
+  });
 
-  it('gives precedence to url input over options', fakeAsync(() => {
+  it('gives precedence to url input over options', () => {
     const expectedUrl = 'www.realurl.kml';
     const expectedOptions: google.maps.KmlLayerOptions = {...DEFAULT_KML_OPTIONS, url: expectedUrl};
     const kmlLayerSpy = createKmlLayerSpy(expectedOptions);
@@ -66,12 +64,11 @@ describe('MapKmlLayer', () => {
     fixture.componentInstance.options = DEFAULT_KML_OPTIONS;
     fixture.componentInstance.url = expectedUrl;
     fixture.detectChanges();
-    flush();
 
     expect(kmlLayerConstructorSpy).toHaveBeenCalledWith(expectedOptions);
-  }));
+  });
 
-  it('exposes methods that provide information about the KmlLayer', fakeAsync(() => {
+  it('exposes methods that provide information about the KmlLayer', () => {
     const kmlLayerSpy = createKmlLayerSpy(DEFAULT_KML_OPTIONS);
     createKmlLayerConstructorSpy(kmlLayerSpy);
 
@@ -80,7 +77,6 @@ describe('MapKmlLayer', () => {
       .query(By.directive(MapKmlLayer))!
       .injector.get<MapKmlLayer>(MapKmlLayer);
     fixture.detectChanges();
-    flush();
 
     kmlLayerComponent.getDefaultViewport();
     expect(kmlLayerSpy.getDefaultViewport).toHaveBeenCalled();
@@ -107,30 +103,28 @@ describe('MapKmlLayer', () => {
 
     kmlLayerSpy.getZIndex.and.returnValue(3);
     expect(kmlLayerComponent.getZIndex()).toBe(3);
-  }));
+  });
 
-  it('initializes KmlLayer event handlers', fakeAsync(() => {
+  it('initializes KmlLayer event handlers', () => {
     const kmlLayerSpy = createKmlLayerSpy(DEFAULT_KML_OPTIONS);
     createKmlLayerConstructorSpy(kmlLayerSpy);
 
     const addSpy = kmlLayerSpy.addListener;
     const fixture = TestBed.createComponent(TestApp);
     fixture.detectChanges();
-    flush();
 
     expect(addSpy).toHaveBeenCalledWith('click', jasmine.any(Function));
     expect(addSpy).not.toHaveBeenCalledWith('defaultviewport_changed', jasmine.any(Function));
     expect(addSpy).toHaveBeenCalledWith('status_changed', jasmine.any(Function));
-  }));
+  });
 
-  it('should be able to add an event listener after init', fakeAsync(() => {
+  it('should be able to add an event listener after init', () => {
     const kmlLayerSpy = createKmlLayerSpy(DEFAULT_KML_OPTIONS);
     createKmlLayerConstructorSpy(kmlLayerSpy);
 
     const addSpy = kmlLayerSpy.addListener;
     const fixture = TestBed.createComponent(TestApp);
     fixture.detectChanges();
-    flush();
 
     expect(addSpy).not.toHaveBeenCalledWith('defaultviewport_changed', jasmine.any(Function));
 
@@ -140,7 +134,7 @@ describe('MapKmlLayer', () => {
 
     expect(addSpy).toHaveBeenCalledWith('defaultviewport_changed', jasmine.any(Function));
     subscription.unsubscribe();
-  }));
+  });
 });
 
 @Component({

--- a/src/google-maps/map-marker/map-marker.spec.ts
+++ b/src/google-maps/map-marker/map-marker.spec.ts
@@ -1,5 +1,5 @@
 import {Component, ViewChild} from '@angular/core';
-import {TestBed, fakeAsync, flush} from '@angular/core/testing';
+import {TestBed} from '@angular/core/testing';
 
 import {DEFAULT_OPTIONS, GoogleMap} from '../google-map/google-map';
 import {
@@ -22,13 +22,12 @@ describe('MapMarker', () => {
     (window.google as any) = undefined;
   });
 
-  it('initializes a Google Map marker', fakeAsync(() => {
+  it('initializes a Google Map marker', () => {
     const markerSpy = createMarkerSpy(DEFAULT_MARKER_OPTIONS);
     const markerConstructorSpy = createMarkerConstructorSpy(markerSpy);
 
     const fixture = TestBed.createComponent(TestApp);
     fixture.detectChanges();
-    flush();
 
     expect(markerConstructorSpy).toHaveBeenCalledWith({
       ...DEFAULT_MARKER_OPTIONS,
@@ -39,9 +38,9 @@ describe('MapMarker', () => {
       visible: undefined,
       map: mapSpy,
     });
-  }));
+  });
 
-  it('sets marker inputs', fakeAsync(() => {
+  it('sets marker inputs', () => {
     const options: google.maps.MarkerOptions = {
       position: {lat: 3, lng: 5},
       title: 'marker title',
@@ -62,12 +61,11 @@ describe('MapMarker', () => {
     fixture.componentInstance.icon = 'icon.png';
     fixture.componentInstance.visible = false;
     fixture.detectChanges();
-    flush();
 
     expect(markerConstructorSpy).toHaveBeenCalledWith(options);
-  }));
+  });
 
-  it('sets marker options, ignoring map', fakeAsync(() => {
+  it('sets marker options, ignoring map', () => {
     const options: google.maps.MarkerOptions = {
       position: {lat: 3, lng: 5},
       title: 'marker title',
@@ -82,12 +80,11 @@ describe('MapMarker', () => {
     const fixture = TestBed.createComponent(TestApp);
     fixture.componentInstance.options = options;
     fixture.detectChanges();
-    flush();
 
     expect(markerConstructorSpy).toHaveBeenCalledWith({...options, map: mapSpy});
-  }));
+  });
 
-  it('gives precedence to specific inputs over options', fakeAsync(() => {
+  it('gives precedence to specific inputs over options', () => {
     const options: google.maps.MarkerOptions = {
       position: {lat: 3, lng: 5},
       title: 'marker title',
@@ -114,18 +111,17 @@ describe('MapMarker', () => {
     fixture.componentInstance.clickable = expectedOptions.clickable!;
     fixture.componentInstance.options = options;
     fixture.detectChanges();
-    flush();
 
     expect(markerConstructorSpy).toHaveBeenCalledWith(expectedOptions);
-  }));
+  });
 
-  it('exposes methods that provide information about the marker', fakeAsync(() => {
+  it('exposes methods that provide information about the marker', () => {
     const markerSpy = createMarkerSpy(DEFAULT_MARKER_OPTIONS);
     createMarkerConstructorSpy(markerSpy);
 
     const fixture = TestBed.createComponent(TestApp);
     fixture.detectChanges();
-    flush();
+
     const marker = fixture.componentInstance.marker;
 
     markerSpy.getAnimation.and.returnValue(null);
@@ -163,16 +159,15 @@ describe('MapMarker', () => {
 
     markerSpy.getZIndex.and.returnValue(2);
     expect(marker.getZIndex()).toBe(2);
-  }));
+  });
 
-  it('initializes marker event handlers', fakeAsync(() => {
+  it('initializes marker event handlers', () => {
     const markerSpy = createMarkerSpy(DEFAULT_MARKER_OPTIONS);
     createMarkerConstructorSpy(markerSpy);
 
     const addSpy = markerSpy.addListener;
     const fixture = TestBed.createComponent(TestApp);
     fixture.detectChanges();
-    flush();
 
     expect(addSpy).toHaveBeenCalledWith('click', jasmine.any(Function));
     expect(addSpy).toHaveBeenCalledWith('position_changed', jasmine.any(Function));
@@ -195,16 +190,15 @@ describe('MapMarker', () => {
     expect(addSpy).not.toHaveBeenCalledWith('title_changed', jasmine.any(Function));
     expect(addSpy).not.toHaveBeenCalledWith('visible_changed', jasmine.any(Function));
     expect(addSpy).not.toHaveBeenCalledWith('zindex_changed', jasmine.any(Function));
-  }));
+  });
 
-  it('should be able to add an event listener after init', fakeAsync(() => {
+  it('should be able to add an event listener after init', () => {
     const markerSpy = createMarkerSpy(DEFAULT_MARKER_OPTIONS);
     createMarkerConstructorSpy(markerSpy);
 
     const addSpy = markerSpy.addListener;
     const fixture = TestBed.createComponent(TestApp);
     fixture.detectChanges();
-    flush();
 
     expect(addSpy).not.toHaveBeenCalledWith('flat_changed', jasmine.any(Function));
 
@@ -214,7 +208,7 @@ describe('MapMarker', () => {
 
     expect(addSpy).toHaveBeenCalledWith('flat_changed', jasmine.any(Function));
     subscription.unsubscribe();
-  }));
+  });
 });
 
 @Component({

--- a/src/google-maps/map-polygon/map-polygon.spec.ts
+++ b/src/google-maps/map-polygon/map-polygon.spec.ts
@@ -1,5 +1,5 @@
 import {Component, ViewChild} from '@angular/core';
-import {TestBed, fakeAsync, flush} from '@angular/core/testing';
+import {TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
 import {DEFAULT_OPTIONS, GoogleMap} from '../google-map/google-map';
@@ -35,19 +35,18 @@ describe('MapPolygon', () => {
     (window.google as any) = undefined;
   });
 
-  it('initializes a Google Map Polygon', fakeAsync(() => {
+  it('initializes a Google Map Polygon', () => {
     const polygonSpy = createPolygonSpy({});
     const polygonConstructorSpy = createPolygonConstructorSpy(polygonSpy);
 
     const fixture = TestBed.createComponent(TestApp);
     fixture.detectChanges();
-    flush();
 
     expect(polygonConstructorSpy).toHaveBeenCalledWith({paths: undefined});
     expect(polygonSpy.setMap).toHaveBeenCalledWith(mapSpy);
-  }));
+  });
 
-  it('sets path from input', fakeAsync(() => {
+  it('sets path from input', () => {
     const paths: google.maps.LatLngLiteral[] = [{lat: 3, lng: 5}];
     const options: google.maps.PolygonOptions = {paths};
     const polygonSpy = createPolygonSpy(options);
@@ -56,12 +55,11 @@ describe('MapPolygon', () => {
     const fixture = TestBed.createComponent(TestApp);
     fixture.componentInstance.paths = paths;
     fixture.detectChanges();
-    flush();
 
     expect(polygonConstructorSpy).toHaveBeenCalledWith(options);
-  }));
+  });
 
-  it('gives precedence to path input over options', fakeAsync(() => {
+  it('gives precedence to path input over options', () => {
     const paths: google.maps.LatLngLiteral[] = [{lat: 3, lng: 5}];
     const expectedOptions: google.maps.PolygonOptions = {...polygonOptions, paths};
     const polygonSpy = createPolygonSpy(expectedOptions);
@@ -71,12 +69,11 @@ describe('MapPolygon', () => {
     fixture.componentInstance.options = polygonOptions;
     fixture.componentInstance.paths = paths;
     fixture.detectChanges();
-    flush();
 
     expect(polygonConstructorSpy).toHaveBeenCalledWith(expectedOptions);
-  }));
+  });
 
-  it('exposes methods that provide information about the Polygon', fakeAsync(() => {
+  it('exposes methods that provide information about the Polygon', () => {
     const polygonSpy = createPolygonSpy(polygonOptions);
     createPolygonConstructorSpy(polygonSpy);
 
@@ -85,7 +82,6 @@ describe('MapPolygon', () => {
       .query(By.directive(MapPolygon))!
       .injector.get<MapPolygon>(MapPolygon);
     fixture.detectChanges();
-    flush();
 
     polygonSpy.getDraggable.and.returnValue(true);
     expect(polygonComponent.getDraggable()).toBe(true);
@@ -101,16 +97,15 @@ describe('MapPolygon', () => {
 
     polygonSpy.getVisible.and.returnValue(true);
     expect(polygonComponent.getVisible()).toBe(true);
-  }));
+  });
 
-  it('initializes Polygon event handlers', fakeAsync(() => {
+  it('initializes Polygon event handlers', () => {
     const polygonSpy = createPolygonSpy(polygonOptions);
     createPolygonConstructorSpy(polygonSpy);
 
     const addSpy = polygonSpy.addListener;
     const fixture = TestBed.createComponent(TestApp);
     fixture.detectChanges();
-    flush();
 
     expect(addSpy).toHaveBeenCalledWith('click', jasmine.any(Function));
     expect(addSpy).not.toHaveBeenCalledWith('dblclick', jasmine.any(Function));
@@ -123,16 +118,15 @@ describe('MapPolygon', () => {
     expect(addSpy).not.toHaveBeenCalledWith('mouseover', jasmine.any(Function));
     expect(addSpy).not.toHaveBeenCalledWith('mouseup', jasmine.any(Function));
     expect(addSpy).toHaveBeenCalledWith('rightclick', jasmine.any(Function));
-  }));
+  });
 
-  it('should be able to add an event listener after init', fakeAsync(() => {
+  it('should be able to add an event listener after init', () => {
     const polygonSpy = createPolygonSpy(polygonOptions);
     createPolygonConstructorSpy(polygonSpy);
 
     const addSpy = polygonSpy.addListener;
     const fixture = TestBed.createComponent(TestApp);
     fixture.detectChanges();
-    flush();
 
     expect(addSpy).not.toHaveBeenCalledWith('dragend', jasmine.any(Function));
 
@@ -142,7 +136,7 @@ describe('MapPolygon', () => {
 
     expect(addSpy).toHaveBeenCalledWith('dragend', jasmine.any(Function));
     subscription.unsubscribe();
-  }));
+  });
 });
 
 @Component({

--- a/src/google-maps/map-polyline/map-polyline.spec.ts
+++ b/src/google-maps/map-polyline/map-polyline.spec.ts
@@ -1,5 +1,5 @@
 import {Component, ViewChild} from '@angular/core';
-import {TestBed, fakeAsync, flush} from '@angular/core/testing';
+import {TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
 import {DEFAULT_OPTIONS, GoogleMap} from '../google-map/google-map';
@@ -39,19 +39,18 @@ describe('MapPolyline', () => {
     (window.google as any) = undefined;
   });
 
-  it('initializes a Google Map Polyline', fakeAsync(() => {
+  it('initializes a Google Map Polyline', () => {
     const polylineSpy = createPolylineSpy({});
     const polylineConstructorSpy = createPolylineConstructorSpy(polylineSpy);
 
     const fixture = TestBed.createComponent(TestApp);
     fixture.detectChanges();
-    flush();
 
     expect(polylineConstructorSpy).toHaveBeenCalledWith({path: undefined});
     expect(polylineSpy.setMap).toHaveBeenCalledWith(mapSpy);
-  }));
+  });
 
-  it('sets path from input', fakeAsync(() => {
+  it('sets path from input', () => {
     const path: google.maps.LatLngLiteral[] = [{lat: 3, lng: 5}];
     const options: google.maps.PolylineOptions = {path};
     const polylineSpy = createPolylineSpy(options);
@@ -60,12 +59,11 @@ describe('MapPolyline', () => {
     const fixture = TestBed.createComponent(TestApp);
     fixture.componentInstance.path = path;
     fixture.detectChanges();
-    flush();
 
     expect(polylineConstructorSpy).toHaveBeenCalledWith(options);
-  }));
+  });
 
-  it('gives precedence to path input over options', fakeAsync(() => {
+  it('gives precedence to path input over options', () => {
     const path: google.maps.LatLngLiteral[] = [{lat: 3, lng: 5}];
     const expectedOptions: google.maps.PolylineOptions = {...polylineOptions, path};
     const polylineSpy = createPolylineSpy(expectedOptions);
@@ -75,12 +73,11 @@ describe('MapPolyline', () => {
     fixture.componentInstance.options = polylineOptions;
     fixture.componentInstance.path = path;
     fixture.detectChanges();
-    flush();
 
     expect(polylineConstructorSpy).toHaveBeenCalledWith(expectedOptions);
-  }));
+  });
 
-  it('exposes methods that provide information about the Polyline', fakeAsync(() => {
+  it('exposes methods that provide information about the Polyline', () => {
     const polylineSpy = createPolylineSpy(polylineOptions);
     createPolylineConstructorSpy(polylineSpy);
 
@@ -89,7 +86,6 @@ describe('MapPolyline', () => {
       .query(By.directive(MapPolyline))!
       .injector.get<MapPolyline>(MapPolyline);
     fixture.detectChanges();
-    flush();
 
     polylineSpy.getDraggable.and.returnValue(true);
     expect(polylineComponent.getDraggable()).toBe(true);
@@ -102,16 +98,15 @@ describe('MapPolyline', () => {
 
     polylineSpy.getVisible.and.returnValue(true);
     expect(polylineComponent.getVisible()).toBe(true);
-  }));
+  });
 
-  it('initializes Polyline event handlers', fakeAsync(() => {
+  it('initializes Polyline event handlers', () => {
     const polylineSpy = createPolylineSpy(polylineOptions);
     createPolylineConstructorSpy(polylineSpy);
 
     const addSpy = polylineSpy.addListener;
     const fixture = TestBed.createComponent(TestApp);
     fixture.detectChanges();
-    flush();
 
     expect(addSpy).toHaveBeenCalledWith('click', jasmine.any(Function));
     expect(addSpy).not.toHaveBeenCalledWith('dblclick', jasmine.any(Function));
@@ -124,16 +119,15 @@ describe('MapPolyline', () => {
     expect(addSpy).not.toHaveBeenCalledWith('mouseover', jasmine.any(Function));
     expect(addSpy).not.toHaveBeenCalledWith('mouseup', jasmine.any(Function));
     expect(addSpy).toHaveBeenCalledWith('rightclick', jasmine.any(Function));
-  }));
+  });
 
-  it('should be able to add an event listener after init', fakeAsync(() => {
+  it('should be able to add an event listener after init', () => {
     const polylineSpy = createPolylineSpy(polylineOptions);
     createPolylineConstructorSpy(polylineSpy);
 
     const addSpy = polylineSpy.addListener;
     const fixture = TestBed.createComponent(TestApp);
     fixture.detectChanges();
-    flush();
 
     expect(addSpy).not.toHaveBeenCalledWith('dragend', jasmine.any(Function));
 
@@ -143,7 +137,7 @@ describe('MapPolyline', () => {
 
     expect(addSpy).toHaveBeenCalledWith('dragend', jasmine.any(Function));
     subscription.unsubscribe();
-  }));
+  });
 });
 
 @Component({

--- a/src/google-maps/map-rectangle/map-rectangle.spec.ts
+++ b/src/google-maps/map-rectangle/map-rectangle.spec.ts
@@ -1,5 +1,5 @@
 import {Component, ViewChild} from '@angular/core';
-import {TestBed, fakeAsync, flush} from '@angular/core/testing';
+import {TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
 import {DEFAULT_OPTIONS, GoogleMap} from '../google-map/google-map';
@@ -31,19 +31,18 @@ describe('MapRectangle', () => {
     (window.google as any) = undefined;
   });
 
-  it('initializes a Google Map Rectangle', fakeAsync(() => {
+  it('initializes a Google Map Rectangle', () => {
     const rectangleSpy = createRectangleSpy({});
     const rectangleConstructorSpy = createRectangleConstructorSpy(rectangleSpy);
 
     const fixture = TestBed.createComponent(TestApp);
     fixture.detectChanges();
-    flush();
 
     expect(rectangleConstructorSpy).toHaveBeenCalledWith({bounds: undefined});
     expect(rectangleSpy.setMap).toHaveBeenCalledWith(mapSpy);
-  }));
+  });
 
-  it('sets bounds from input', fakeAsync(() => {
+  it('sets bounds from input', () => {
     const bounds: google.maps.LatLngBoundsLiteral = {east: 3, north: 5, west: -3, south: -5};
     const options: google.maps.RectangleOptions = {bounds};
     const rectangleSpy = createRectangleSpy(options);
@@ -52,12 +51,11 @@ describe('MapRectangle', () => {
     const fixture = TestBed.createComponent(TestApp);
     fixture.componentInstance.bounds = bounds;
     fixture.detectChanges();
-    flush();
 
     expect(rectangleConstructorSpy).toHaveBeenCalledWith(options);
-  }));
+  });
 
-  it('gives precedence to bounds input over options', fakeAsync(() => {
+  it('gives precedence to bounds input over options', () => {
     const bounds: google.maps.LatLngBoundsLiteral = {east: 3, north: 5, west: -3, south: -5};
     const expectedOptions: google.maps.RectangleOptions = {...rectangleOptions, bounds};
     const rectangleSpy = createRectangleSpy(expectedOptions);
@@ -67,12 +65,11 @@ describe('MapRectangle', () => {
     fixture.componentInstance.options = rectangleOptions;
     fixture.componentInstance.bounds = bounds;
     fixture.detectChanges();
-    flush();
 
     expect(rectangleConstructorSpy).toHaveBeenCalledWith(expectedOptions);
-  }));
+  });
 
-  it('exposes methods that provide information about the Rectangle', fakeAsync(() => {
+  it('exposes methods that provide information about the Rectangle', () => {
     const rectangleSpy = createRectangleSpy(rectangleOptions);
     createRectangleConstructorSpy(rectangleSpy);
 
@@ -81,7 +78,6 @@ describe('MapRectangle', () => {
       .query(By.directive(MapRectangle))!
       .injector.get<MapRectangle>(MapRectangle);
     fixture.detectChanges();
-    flush();
 
     rectangleComponent.getBounds();
     expect(rectangleSpy.getBounds).toHaveBeenCalled();
@@ -94,16 +90,15 @@ describe('MapRectangle', () => {
 
     rectangleSpy.getVisible.and.returnValue(true);
     expect(rectangleComponent.getVisible()).toBe(true);
-  }));
+  });
 
-  it('initializes Rectangle event handlers', fakeAsync(() => {
+  it('initializes Rectangle event handlers', () => {
     const rectangleSpy = createRectangleSpy(rectangleOptions);
     createRectangleConstructorSpy(rectangleSpy);
 
     const addSpy = rectangleSpy.addListener;
     const fixture = TestBed.createComponent(TestApp);
     fixture.detectChanges();
-    flush();
 
     expect(addSpy).toHaveBeenCalledWith('bounds_changed', jasmine.any(Function));
     expect(addSpy).toHaveBeenCalledWith('click', jasmine.any(Function));
@@ -117,16 +112,15 @@ describe('MapRectangle', () => {
     expect(addSpy).not.toHaveBeenCalledWith('mouseover', jasmine.any(Function));
     expect(addSpy).not.toHaveBeenCalledWith('mouseup', jasmine.any(Function));
     expect(addSpy).toHaveBeenCalledWith('rightclick', jasmine.any(Function));
-  }));
+  });
 
-  it('should be able to add an event listener after init', fakeAsync(() => {
+  it('should be able to add an event listener after init', () => {
     const rectangleSpy = createRectangleSpy(rectangleOptions);
     createRectangleConstructorSpy(rectangleSpy);
 
     const addSpy = rectangleSpy.addListener;
     const fixture = TestBed.createComponent(TestApp);
     fixture.detectChanges();
-    flush();
 
     expect(addSpy).not.toHaveBeenCalledWith('dragend', jasmine.any(Function));
 
@@ -136,7 +130,7 @@ describe('MapRectangle', () => {
 
     expect(addSpy).toHaveBeenCalledWith('dragend', jasmine.any(Function));
     subscription.unsubscribe();
-  }));
+  });
 });
 
 @Component({

--- a/src/google-maps/map-traffic-layer/map-traffic-layer.spec.ts
+++ b/src/google-maps/map-traffic-layer/map-traffic-layer.spec.ts
@@ -1,5 +1,5 @@
 import {Component} from '@angular/core';
-import {TestBed, fakeAsync, flush} from '@angular/core/testing';
+import {TestBed} from '@angular/core/testing';
 
 import {DEFAULT_OPTIONS, GoogleMap} from '../google-map/google-map';
 import {
@@ -24,17 +24,16 @@ describe('MapTrafficLayer', () => {
     (window.google as any) = undefined;
   });
 
-  it('initializes a Google Map Traffic Layer', fakeAsync(() => {
+  it('initializes a Google Map Traffic Layer', () => {
     const trafficLayerSpy = createTrafficLayerSpy(trafficLayerOptions);
     const trafficLayerConstructorSpy = createTrafficLayerConstructorSpy(trafficLayerSpy);
     const fixture = TestBed.createComponent(TestApp);
     fixture.componentInstance.autoRefresh = false;
     fixture.detectChanges();
-    flush();
 
     expect(trafficLayerConstructorSpy).toHaveBeenCalledWith(trafficLayerOptions);
     expect(trafficLayerSpy.setMap).toHaveBeenCalledWith(mapSpy);
-  }));
+  });
 });
 
 @Component({

--- a/src/google-maps/map-transit-layer/map-transit-layer.spec.ts
+++ b/src/google-maps/map-transit-layer/map-transit-layer.spec.ts
@@ -1,5 +1,5 @@
 import {Component} from '@angular/core';
-import {TestBed, fakeAsync, flush} from '@angular/core/testing';
+import {TestBed} from '@angular/core/testing';
 
 import {DEFAULT_OPTIONS, GoogleMap} from '../google-map/google-map';
 import {
@@ -23,17 +23,16 @@ describe('MapTransitLayer', () => {
     (window.google as any) = undefined;
   });
 
-  it('initializes a Google Map Transit Layer', fakeAsync(() => {
+  it('initializes a Google Map Transit Layer', () => {
     const transitLayerSpy = createTransitLayerSpy();
     const transitLayerConstructorSpy = createTransitLayerConstructorSpy(transitLayerSpy);
 
     const fixture = TestBed.createComponent(TestApp);
     fixture.detectChanges();
-    flush();
 
     expect(transitLayerConstructorSpy).toHaveBeenCalled();
     expect(transitLayerSpy.setMap).toHaveBeenCalledWith(mapSpy);
-  }));
+  });
 });
 
 @Component({


### PR DESCRIPTION
Reworks the Google Maps tests to not depend on `fakeAsync`.