### PR TITLE
build: avoid syntax errors in generated JS file

### DIFF
--- a/tools/bazel/web_test_suite.bzl
+++ b/tools/bazel/web_test_suite.bzl
@@ -50,13 +50,13 @@ def ng_web_test_suite(deps = [], static_css = [], **kwargs):
             output_to_bindir = True,
             cmd = """
         files=($(execpaths %s))
-        # Escape all double-quotes so that the content can be safely inlined into the
-        # JS template. Note that it needs to be escaped a second time because the string
-        # will be evaluated first in Bash and will then be stored in the JS output.
-        css_content=$$(cat $${files[0]} | sed 's/"/\\\\"/g')
-        js_template='var cssElement = document.createElement("style"); \
+        # Escape backticks, backslashes, and dollar signs so that the content can be safely
+        # inlined into the JS template. Note that it needs to be escaped a second time because
+        # the string will be evaluated first in Bash and will then be stored in the JS output.
+        css_content=$$(cat $${files[0]} | sed -e 's/\\\\/\\\\\\\\/g' -e 's/`/\\\\`/g' -e 's/\\$$/\\\\$$/g')
+        js_template='const cssElement = document.createElement("style"); \
                     cssElement.type = "text/css"; \
-                    cssElement.innerHTML = "'"$$css_content"'"; \
+                    cssElement.innerHTML = `'"$$css_content"'`; \
                     document.head.appendChild(cssElement);'
          echo "$$js_template" > $@
       """ % css_label,


### PR DESCRIPTION
The `web_test_suite` rule generates a JS file on-the-fly which inserts CSS dependencies into the current page. Currently this file uses double quotes for the string which breaks if there are new lines in the file. This is currently blocking #32961 and #32962.

These changes switch to using multi-line strings to avoid the issue.