### PR TITLE
fix(material/tooltip): wrong type for shape token

### DIFF
--- a/src/material/tooltip/_m3-tooltip.scss
+++ b/src/material/tooltip/_m3-tooltip.scss
@@ -7,10 +7,11 @@
   $system: m3-utils.get-system($theme);
 
   @return (
-    base: (),
+    base: (
+      tooltip-container-shape: map.get($system, corner-extra-small),
+    ),
     color: (
       tooltip-container-color: map.get($system, inverse-surface),
-      tooltip-container-shape: map.get($system, corner-extra-small),
       tooltip-supporting-text-color: map.get($system, inverse-on-surface),
     ),
     typography: (


### PR DESCRIPTION
Fixes that the `container-shape` token was categorized as `color`, even though it should be `base`.

Fixes #32929.