### PR TITLE
docs(material/datepicker): fix incorrect provideLuxonDateAdapter usage for UTC

### DIFF
--- a/src/material/datepicker/datepicker.md
+++ b/src/material/datepicker/datepicker.md
@@ -422,11 +422,15 @@ export class MyComponent {
 <!-- example(datepicker-luxon) -->
 
 By default the `LuxonDateAdapter` creates dates in your time zone specific locale. You can change
-the default behaviour to parse dates as UTC by passing `useUtc: true` into `provideLuxonDateAdapter`:
+the default behaviour to parse dates as UTC by providing `MAT_LUXON_DATE_ADAPTER_OPTIONS` with
+`useUtc: true`:
 
 ```ts
 bootstrapApplication(MyApp, {
-  providers: [provideLuxonDateAdapter(undefined, {useUtc: true})]
+  providers: [
+    provideLuxonDateAdapter(),
+    {provide: MAT_LUXON_DATE_ADAPTER_OPTIONS, useValue: {useUtc: true}}
+  ]
 });
 ```
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Documentation fix

## What is the current behavior?

The datepicker overview docs show an incorrect code example for configuring
the Luxon date adapter to parse dates as UTC:

```ts
providers: [provideLuxonDateAdapter(undefined, {useUtc: true})]
```

`provideLuxonDateAdapter` only accepts one parameter (date formats), not a
second options parameter. This pattern was incorrectly copied from
`provideMomentDateAdapter` which does support a second options parameter.

Closes #32935

## What is the new behavior?

The docs now show the correct approach using the
`MAT_LUXON_DATE_ADAPTER_OPTIONS` injection token:

```ts
providers: [
  provideLuxonDateAdapter(),
  {provide: MAT_LUXON_DATE_ADAPTER_OPTIONS, useValue: {useUtc: true}}
]
```

## Additional context

Note: PR #32936 proposes adding the options parameter to
`provideLuxonDateAdapter` to match the Moment adapter API. If that PR is
merged, the docs can be simplified back. This PR fixes the docs to match
the current API.