### PR TITLE
fix(material/chips): hide input placeholder when chip grid is disabled

### DIFF
--- a/src/material/chips/chip-input.ts
+++ b/src/material/chips/chip-input.ts
@@ -58,7 +58,7 @@ export interface MatChipInputEvent {
     '(input)': '_onInput()',
     '[id]': 'id',
     '[attr.disabled]': 'disabled && !disabledInteractive ? "" : null',
-    '[attr.placeholder]': 'placeholder || null',
+    '[attr.placeholder]': '!disabled ? (placeholder || null) : null',
     '[attr.aria-invalid]': '_chipGrid && _chipGrid.ngControl ? _chipGrid.ngControl.invalid : null',
     '[attr.aria-required]': '_chipGrid && _chipGrid.required || null',
     '[attr.aria-disabled]': 'disabled && disabledInteractive ? "true" : null',


### PR DESCRIPTION
## Summary
- Hides the input placeholder text when the chip grid is disabled
- When a `mat-chip-grid` is disabled, the associated `matChipInput` now removes its placeholder attribute, preventing misleading placeholder text on a non-interactive input

## Changes
- Updated `chip-input.ts` host binding: `[attr.placeholder]` now checks the `disabled` state before rendering the placeholder

## Test plan
- [ ] Verify placeholder is visible when chip grid is enabled
- [ ] Verify placeholder is hidden when chip grid is disabled
- [ ] Run `pnpm test chips` to confirm existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)