### PR TITLE
fix(material/tooltip): tooltip inside sidenav hides after text update

### DIFF
--- a/src/material/tooltip/tooltip.spec.ts
+++ b/src/material/tooltip/tooltip.spec.ts
@@ -1214,6 +1214,29 @@ describe('MatTooltip', () => {
         .withContext('Expected tooltip hidden when scrolled out of view, after throttle limit')
         .toBe(false);
     }));
+
+    it('should not hide tooltip when message is updated inside a scrollable container', fakeAsync(() => {
+      assertTooltipInstance(tooltipDirective, false);
+
+      // Show the tooltip and tick for the show delay (default is 0)
+      tooltipDirective.show();
+      fixture.detectChanges();
+      tick(0);
+
+      expect(tooltipDirective._isTooltipVisible())
+        .withContext('Expected tooltip to be initially visible')
+        .toBe(true);
+
+      // Update the tooltip message while visible
+      fixture.componentInstance.message = 'updated message';
+      fixture.detectChanges();
+      tick(0);
+
+      // The tooltip should remain visible after the message update
+      expect(tooltipDirective._isTooltipVisible())
+        .withContext('Expected tooltip to remain visible after message update')
+        .toBe(true);
+    }));
   });
 
   describe('with OnPush', () => {

--- a/src/material/tooltip/tooltip.ts
+++ b/src/material/tooltip/tooltip.ts
@@ -221,6 +221,7 @@ export class MatTooltip implements OnDestroy, AfterViewInit {
   private readonly _tooltipComponent = TooltipComponent;
   private _viewportMargin = 8;
   private _currentPosition!: TooltipPosition;
+  private _isRepositioningForMessage = false;
   private readonly _cssClassPrefix: string = 'mat-mdc';
   private _ariaDescriptionPending = false;
   private _dirSubscribed = false;
@@ -529,7 +530,11 @@ export class MatTooltip implements OnDestroy, AfterViewInit {
       this._updateCurrentPositionClass(change.connectionPair);
 
       if (this._tooltipInstance) {
-        if (change.scrollableViewProperties.isOverlayClipped && this._tooltipInstance.isVisible()) {
+        if (
+          change.scrollableViewProperties.isOverlayClipped &&
+          this._tooltipInstance.isVisible() &&
+          !this._isRepositioningForMessage
+        ) {
           // After position changes occur and the overlay is clipped by
           // a parent scrollable then close the tooltip.
           this._ngZone.run(() => this.hide(0));
@@ -703,7 +708,9 @@ export class MatTooltip implements OnDestroy, AfterViewInit {
       afterNextRender(
         () => {
           if (this._tooltipInstance) {
+            this._isRepositioningForMessage = true;
             this._overlayRef!.updatePosition();
+            this._isRepositioningForMessage = false;
           }
         },
         {


### PR DESCRIPTION
## Summary
- Fixes tooltip inside `mat-sidenav` hiding when its text content is updated dynamically
- When the tooltip overflows the sidenav (a scrollable ancestor) and its message is updated, `updatePosition()` triggers the overlay clip check which incorrectly detects the tooltip as clipped and hides it
- Added `_isRepositioningForMessage` flag to skip the clip check during message-driven repositioning

## Root Cause
1. `mat-sidenav` content extends `CdkScrollable`, making it a registered scrollable ancestor
2. Updating tooltip message triggers `_updateTooltipMessage()` → `updatePosition()` → `positionChanges` emission
3. The `positionChanges` subscriber checks `isOverlayClipped` against scrollable ancestors
4. Since the tooltip overlay (in the global overlay container) extends beyond the sidenav bounds, it's detected as "clipped" and hidden

## Test plan
- [x] Added unit test verifying tooltip stays visible when message is updated inside a scrollable container
- [ ] CI validates existing tooltip scroll-hide tests still pass
- [ ] Manual verification with reproduction from issue

Fixes #27782

🤖 Generated with [Claude Code](https://claude.com/claude-code)