### PR TITLE
fix(material/toolbar): heading styles not taking precedence over mat-typography

### DIFF
--- a/src/material/toolbar/toolbar.scss
+++ b/src/material/toolbar/toolbar.scss
@@ -14,14 +14,20 @@ $height-mobile-portrait: 56px !default;
 .mat-toolbar {
   background: token-utils.slot(toolbar-container-background-color, $fallbacks);
   color: token-utils.slot(toolbar-container-text-color, $fallbacks);
+  font-family: token-utils.slot(toolbar-title-text-font, $fallbacks);
+  font-size: token-utils.slot(toolbar-title-text-size, $fallbacks);
+  line-height: token-utils.slot(toolbar-title-text-line-height, $fallbacks);
+  font-weight: token-utils.slot(toolbar-title-text-weight, $fallbacks);
+  letter-spacing: token-utils.slot(toolbar-title-text-tracking, $fallbacks);
 
-  &, h1, h2, h3, h4, h5, h6 {
-    font-family: token-utils.slot(toolbar-title-text-font, $fallbacks);
-    font-size: token-utils.slot(toolbar-title-text-size, $fallbacks);
-    line-height: token-utils.slot(toolbar-title-text-line-height, $fallbacks);
-    font-weight: token-utils.slot(toolbar-title-text-weight, $fallbacks);
-    letter-spacing: token-utils.slot(toolbar-title-text-tracking, $fallbacks);
-    margin: 0;
+  // Use doubled class selector (specificity 0-2-1) to ensure heading styles
+  // take precedence over .mat-typography heading styles (specificity 0-1-1).
+  &.mat-toolbar {
+    h1, h2, h3, h4, h5, h6 {
+      font: inherit;
+      letter-spacing: inherit;
+      margin: 0;
+    }
   }
 
   @include cdk.high-contrast {


### PR DESCRIPTION
## Summary
- Fixes heading elements (h1-h6) inside `mat-toolbar` getting overridden by `.mat-typography` heading styles
- Both `.mat-toolbar h1` and `.mat-typography h1` had equal specificity (0-1-1), causing load-order-dependent behavior
- Uses a doubled class selector `.mat-toolbar.mat-toolbar` (specificity 0-2-1) to ensure toolbar heading styles always win

## Changes
- Moved font properties directly onto `.mat-toolbar` (no behavior change)
- Heading styles (h1-h6) now use `font: inherit; letter-spacing: inherit; margin: 0` under the higher-specificity `.mat-toolbar.mat-toolbar` selector

## Test plan
- [ ] Apply `mat-typography` class to a parent element and verify h1/h2 inside `mat-toolbar` use toolbar typography
- [ ] Verify toolbar headings show correct font-size, font-weight, and `margin: 0`
- [ ] CI validates existing toolbar tests pass

Fixes #26261

🤖 Generated with [Claude Code](https://claude.com/claude-code)