### PR TITLE
fix(cdk/stepper): linear updates not reflected in the DOM

### DIFF
--- a/goldens/cdk/stepper/index.api.md
+++ b/goldens/cdk/stepper/index.api.md
@@ -106,7 +106,8 @@ export class CdkStepper implements AfterContentInit, AfterViewInit, OnDestroy {
     _getFocusIndex(): number | null;
     _getStepContentId(i: number): string;
     _getStepLabelId(i: number): string;
-    linear: boolean;
+    get linear(): boolean;
+    set linear(value: boolean);
     next(): void;
     // (undocumented)
     static ngAcceptInputType_linear: unknown;

--- a/src/cdk/stepper/stepper.ts
+++ b/src/cdk/stepper/stepper.ts
@@ -341,7 +341,14 @@ export class CdkStepper implements AfterContentInit, AfterViewInit, OnDestroy {
   private _sortedHeaders = new QueryList<CdkStepHeader>();
 
   /** Whether the validity of previous steps should be checked or not. */
-  @Input({transform: booleanAttribute}) linear: boolean = false;
+  @Input({transform: booleanAttribute})
+  get linear(): boolean {
+    return this._linear();
+  }
+  set linear(value: boolean) {
+    this._linear.set(value);
+  }
+  private _linear = signal(false);
 
   /** The index of the selected step. */
   @Input({transform: numberAttribute})


### PR DESCRIPTION
In #31208 I converted a bunch of the shared stepper state to signals in order to resolve "changed after checked errors". I didn't do it for `linear` which ends up being used in a `computed` and results in the DOM sometimes being out of sync. These changes update `linear` to use signals under the hood.

Fixes #32964.