### PR TITLE
build: add explicit change detection to tests

### DIFF
--- a/src/aria/accordion/accordion.spec.ts
+++ b/src/aria/accordion/accordion.spec.ts
@@ -1,4 +1,4 @@
-import {Component, DebugElement, signal} from '@angular/core';
+import {Component, DebugElement, signal, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {provideFakeDirectionality, runAccessibilityChecks} from '@angular/cdk/testing/private';
@@ -404,6 +404,7 @@ describe('AccordionGroup', () => {
     </div>
   `,
   imports: [AccordionGroup, AccordionTrigger, AccordionPanel, AccordionContent],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class AccordionGroupExample {
   items = signal([

--- a/src/aria/combobox/combobox.spec.ts
+++ b/src/aria/combobox/combobox.spec.ts
@@ -1,4 +1,4 @@
-import {Component, computed, DebugElement, signal} from '@angular/core';
+import {Component, computed, DebugElement, signal, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {Combobox, ComboboxInput, ComboboxPopup, ComboboxPopupContainer} from '../combobox';
@@ -1126,6 +1126,7 @@ describe('Combobox', () => {
 </div>
   `,
   imports: [Combobox, ComboboxInput, ComboboxPopup, ComboboxPopupContainer, Listbox, Option],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ComboboxListboxExample {
   readonly = signal(false);
@@ -1196,6 +1197,7 @@ class ComboboxListboxExample {
     TreeItemGroup,
     NgTemplateOutlet,
   ],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ComboboxTreeExample {
   readonly = signal(false);

--- a/src/aria/grid/grid.spec.ts
+++ b/src/aria/grid/grid.spec.ts
@@ -1,4 +1,4 @@
-import {Component, DebugElement, signal} from '@angular/core';
+import {Component, DebugElement, signal, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {Grid} from './grid';
@@ -1056,6 +1056,7 @@ describe('Grid directives', () => {
     </table>
   `,
   imports: [Grid, GridRow, GridCell, GridCellWidget],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class GridTestComponent {
   readonly disabled = signal(false);

--- a/src/aria/listbox/listbox.spec.ts
+++ b/src/aria/listbox/listbox.spec.ts
@@ -1,4 +1,4 @@
-import {Component, DebugElement, signal} from '@angular/core';
+import {Component, DebugElement, signal, ChangeDetectionStrategy} from '@angular/core';
 import {Listbox} from './listbox';
 import {Option} from './option';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
@@ -799,6 +799,7 @@ interface TestOption {
     </ul>
   `,
   imports: [Listbox, Option],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ListboxExample {
   options = signal<TestOption[]>([
@@ -830,5 +831,6 @@ class ListboxExample {
     </ul>
   `,
   imports: [Listbox, Option],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DefaultListboxExample {}

--- a/src/aria/menu/menu.spec.ts
+++ b/src/aria/menu/menu.spec.ts
@@ -1,4 +1,4 @@
-import {Component, DebugElement} from '@angular/core';
+import {Component, DebugElement, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {provideFakeDirectionality} from '@angular/cdk/testing/private';
@@ -989,6 +989,7 @@ describe('Menu Bar Pattern', () => {
 </div>
   `,
   imports: [Menu, MenuItem, MenuContent],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class StandaloneMenuExample {
   itemSelected(value: string) {}
@@ -1017,6 +1018,7 @@ class StandaloneMenuExample {
 </div>
   `,
   imports: [Menu, MenuItem, MenuTrigger, MenuContent],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MenuTriggerExample {
   itemSelected(value: string) {}
@@ -1056,5 +1058,6 @@ class MenuTriggerExample {
 </div>
   `,
   imports: [Menu, MenuBar, MenuItem, MenuContent],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MenuBarExample {}

--- a/src/aria/private/deferred-content/deferred-content.spec.ts
+++ b/src/aria/private/deferred-content/deferred-content.spec.ts
@@ -1,4 +1,12 @@
-import {Component, DebugElement, Directive, effect, inject, signal} from '@angular/core';
+import {
+  Component,
+  DebugElement,
+  Directive,
+  effect,
+  inject,
+  signal,
+  ChangeDetectionStrategy,
+} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {DeferredContent, DeferredContentAware} from './deferred-content';
 import {By} from '@angular/platform-browser';
@@ -83,6 +91,7 @@ class CollapsibleContent {}
     </div>
     `,
   imports: [Collapsible, CollapsibleContent],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TestComponent {
   preserveContent = signal(false);

--- a/src/aria/tabs/tabs.spec.ts
+++ b/src/aria/tabs/tabs.spec.ts
@@ -1,4 +1,4 @@
-import {Component, DebugElement, signal} from '@angular/core';
+import {Component, DebugElement, signal, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {Direction} from '@angular/cdk/bidi';
@@ -733,6 +733,7 @@ describe('Tabs', () => {
     </div>
   `,
   imports: [Tabs, TabList, Tab, TabPanel, TabContent],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TestTabsComponent {
   tabsData = signal<TestTabDefinition[]>([

--- a/src/aria/toolbar/toolbar.spec.ts
+++ b/src/aria/toolbar/toolbar.spec.ts
@@ -1,4 +1,11 @@
-import {Component, DebugElement, Directive, inject, signal} from '@angular/core';
+import {
+  Component,
+  DebugElement,
+  Directive,
+  inject,
+  signal,
+  ChangeDetectionStrategy,
+} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {provideFakeDirectionality, runAccessibilityChecks} from '@angular/cdk/testing/private';
@@ -673,6 +680,7 @@ describe('Toolbar', () => {
     </div>
   `,
   imports: [Toolbar, ToolbarWidget, ToolbarWidgetGroup],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ToolbarExample {
   orientation = signal<'vertical' | 'horizontal'>('horizontal');
@@ -713,5 +721,6 @@ export class SimpleToolbarButton {
     </div>
   `,
   imports: [Toolbar, SimpleToolbarButton],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class WrappedToolbarExample {}

--- a/src/aria/tree/tree.spec.ts
+++ b/src/aria/tree/tree.spec.ts
@@ -1,4 +1,4 @@
-import {Component, signal} from '@angular/core';
+import {Component, signal, ChangeDetectionStrategy} from '@angular/core';
 import {NgTemplateOutlet} from '@angular/common';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
@@ -1579,6 +1579,7 @@ interface TestTreeNode<V = string> {
     </ng-template>
   `,
   imports: [Tree, TreeItem, TreeItemGroup, NgTemplateOutlet],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TestTreeComponent {
   nodes = signal<TestTreeNode[]>([

--- a/src/cdk-experimental/popover-edit/popover-edit.spec.ts
+++ b/src/cdk-experimental/popover-edit/popover-edit.spec.ts
@@ -10,6 +10,7 @@ import {
   ElementRef,
   ViewChild,
   inject,
+  ChangeDetectionStrategy,
 } from '@angular/core';
 import {ComponentFixture, TestBed, fakeAsync, flush, tick} from '@angular/core/testing';
 import {FormsModule, NgForm} from '@angular/forms';
@@ -858,6 +859,7 @@ abstract class BaseTestComponent {
   </table>
   `,
   imports: [CdkPopoverEditModule, FormsModule, CdkTableModule, BidiModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class VanillaTableOutOfCell extends BaseTestComponent {
   elements!: ChemicalElement[];
@@ -919,6 +921,7 @@ class VanillaTableOutOfCell extends BaseTestComponent {
   </table>
   `,
   imports: [CdkPopoverEditModule, FormsModule, CdkTableModule, BidiModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class VanillaTableInCell extends BaseTestComponent {
   elements!: ChemicalElement[];
@@ -1004,6 +1007,7 @@ class ElementDataSource extends DataSource<PeriodicElement> {
   </div>
   `,
   imports: [CdkPopoverEditModule, FormsModule, CdkTableModule, BidiModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class CdkFlexTableInCell extends BaseTestComponent {
   displayedColumns = ['before', 'name', 'weight'];
@@ -1078,6 +1082,7 @@ class CdkFlexTableInCell extends BaseTestComponent {
   <div>
   `,
   imports: [CdkPopoverEditModule, FormsModule, CdkTableModule, BidiModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class CdkTableInCell extends BaseTestComponent {
   displayedColumns = ['before', 'name', 'weight'];
@@ -1159,6 +1164,7 @@ class CdkTableInCell extends BaseTestComponent {
   <div>
   `,
   imports: [CdkPopoverEditModule, FormsModule, CdkTableModule, BidiModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class CdkTableWithSkipRows extends BaseTestComponent {
   displayedColumns = ['before', 'name', 'weight'];

--- a/src/cdk-experimental/scrolling/virtual-scroll-viewport.spec.ts
+++ b/src/cdk-experimental/scrolling/virtual-scroll-viewport.spec.ts
@@ -1,5 +1,5 @@
 import {CdkVirtualScrollViewport, ScrollingModule} from '@angular/cdk/scrolling';
-import {Component, ViewChild, ViewEncapsulation} from '@angular/core';
+import {Component, ViewChild, ViewEncapsulation, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed, fakeAsync, flush} from '@angular/core/testing';
 import {ScrollingModule as ExperimentalScrollingModule} from './scrolling-module';
 
@@ -90,6 +90,7 @@ function finishInit(fixture: ComponentFixture<any>) {
   `,
   encapsulation: ViewEncapsulation.None,
   imports: [ScrollingModule, ExperimentalScrollingModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class AutoSizeVirtualScroll {
   @ViewChild(CdkVirtualScrollViewport, {static: true}) viewport!: CdkVirtualScrollViewport;

--- a/src/cdk-experimental/selection/selection.spec.ts
+++ b/src/cdk-experimental/selection/selection.spec.ts
@@ -1,6 +1,13 @@
 import {AsyncPipe} from '@angular/common';
 import {CdkTableModule} from '@angular/cdk/table';
-import {ChangeDetectorRef, Component, ElementRef, ViewChild, inject} from '@angular/core';
+import {
+  ChangeDetectorRef,
+  Component,
+  ElementRef,
+  ViewChild,
+  inject,
+  ChangeDetectionStrategy,
+} from '@angular/core';
 import {ComponentFixture, fakeAsync, flush, TestBed} from '@angular/core/testing';
 
 import {CdkSelection} from './selection';
@@ -429,6 +436,7 @@ describe('cdkSelectionColumn with multiple = false', () => {
       }
     </ul>`,
   imports: [CdkSelectionModule, AsyncPipe],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ListWithMultiSelection {
   private readonly _elementRef = inject(ElementRef);
@@ -493,6 +501,7 @@ class ListWithMultiSelection {
       }
     </ul>`,
   imports: [CdkSelectionModule, AsyncPipe],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ListWithSingleSelection {
   private readonly _elementRef = inject(ElementRef);
@@ -534,6 +543,7 @@ class ListWithSingleSelection {
     </table>
     `,
   imports: [CdkSelectionModule, CdkTableModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MultiSelectTableWithSelectionColumn {
   readonly elementRef = inject(ElementRef);
@@ -601,6 +611,7 @@ class MultiSelectTableWithSelectionColumn {
     </table>
     `,
   imports: [CdkSelectionModule, CdkTableModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SingleSelectTableWithSelectionColumn {
   readonly elementRef = inject(ElementRef);

--- a/src/cdk-experimental/table-scroll-container/table-scroll-container.spec.ts
+++ b/src/cdk-experimental/table-scroll-container/table-scroll-container.spec.ts
@@ -1,7 +1,7 @@
 import {CollectionViewer, DataSource} from '@angular/cdk/collections';
 import {Platform} from '@angular/cdk/platform';
 import {CdkTable, CdkTableModule} from '@angular/cdk/table';
-import {Component, Type, ViewChild} from '@angular/core';
+import {Component, Type, ViewChild, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 import {BehaviorSubject, combineLatest} from 'rxjs';
 import {map} from 'rxjs/operators';
@@ -294,6 +294,7 @@ class FakeDataSource extends DataSource<TestData> {
       box-sizing: border-box;
     }
   `,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class StickyNativeLayoutCdkTableApp {
   dataSource: FakeDataSource = new FakeDataSource();

--- a/src/cdk/a11y/aria-describer/aria-describer.spec.ts
+++ b/src/cdk/a11y/aria-describer/aria-describer.spec.ts
@@ -1,7 +1,7 @@
 import {A11yModule, CDK_DESCRIBEDBY_HOST_ATTRIBUTE} from '../index';
 import {AriaDescriber} from './aria-describer';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
-import {Component, ElementRef, ViewChild, inject} from '@angular/core';
+import {Component, ElementRef, ViewChild, inject, ChangeDetectionStrategy} from '@angular/core';
 
 describe('AriaDescriber', () => {
   let ariaDescriber: AriaDescriber;
@@ -396,6 +396,7 @@ function expectMessage(el: Element, message: string) {
     <div description-without-id>Hey</div>
   `,
   imports: [A11yModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TestApp {
   ariaDescriber = inject(AriaDescriber);

--- a/src/cdk/a11y/focus-monitor/focus-monitor.spec.ts
+++ b/src/cdk/a11y/focus-monitor/focus-monitor.spec.ts
@@ -1,6 +1,6 @@
 import {TAB} from '../../keycodes';
 import {Platform} from '../../platform';
-import {Component, ViewChild, DOCUMENT} from '@angular/core';
+import {Component, ViewChild, DOCUMENT, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {
@@ -875,12 +875,14 @@ describe('FocusMonitor input label detection', () => {
 @Component({
   template: `<div class="parent"><button>focus me!</button></div>`,
   imports: [A11yModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class PlainButton {}
 
 @Component({
   template: `<button cdkMonitorElementFocus (cdkFocusChange)="focusChanged($event)"></button>`,
   imports: [A11yModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ButtonWithFocusClasses {
   focusChanged(_origin: FocusOrigin) {}
@@ -889,24 +891,28 @@ class ButtonWithFocusClasses {
 @Component({
   template: `<div tabindex="0" cdkMonitorElementFocus><button></button></div>`,
   imports: [A11yModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ComplexComponentWithMonitorElementFocus {}
 
 @Component({
   template: `<div tabindex="0" cdkMonitorSubtreeFocus><button></button></div>`,
   imports: [A11yModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ComplexComponentWithMonitorSubtreeFocus {}
 
 @Component({
   template: `<div cdkMonitorSubtreeFocus><button cdkMonitorElementFocus></button></div>`,
   imports: [A11yModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ComplexComponentWithMonitorSubtreeFocusAndMonitorElementFocus {}
 
 @Component({
   template: `<ng-container cdkMonitorElementFocus></ng-container>`,
   imports: [A11yModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class FocusMonitorOnCommentNode {}
 
@@ -916,12 +922,14 @@ class FocusMonitorOnCommentNode {}
     <input id="test-checkbox" type="checkbox">
   `,
   imports: [A11yModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class CheckboxWithLabel {}
 
 @Component({
   template: `<button cdkMonitorElementFocus #exportedDir="cdkMonitorFocus"></button>`,
   imports: [A11yModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ExportedFocusMonitor {
   @ViewChild('exportedDir') exportedDirRef!: CdkMonitorFocus;

--- a/src/cdk/a11y/focus-monitor/focus-monitor.zone.spec.ts
+++ b/src/cdk/a11y/focus-monitor/focus-monitor.zone.spec.ts
@@ -1,6 +1,11 @@
 import {Platform} from '../../platform';
 import {patchElementFocus} from '../../testing/private';
-import {Component, NgZone, provideZoneChangeDetection} from '@angular/core';
+import {
+  Component,
+  NgZone,
+  provideZoneChangeDetection,
+  ChangeDetectionStrategy,
+} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {A11yModule} from '../a11y-module';
 import {FocusMonitor} from './focus-monitor';
@@ -38,5 +43,6 @@ describe('FocusMonitor observable stream Zone.js integration', () => {
 @Component({
   template: `<div class="parent"><button>focus me!</button></div>`,
   imports: [A11yModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class PlainButton {}

--- a/src/cdk/a11y/focus-trap/configurable-focus-trap.spec.ts
+++ b/src/cdk/a11y/focus-trap/configurable-focus-trap.spec.ts
@@ -6,6 +6,7 @@ import {
   ViewChild,
   Provider,
   inject,
+  ChangeDetectionStrategy,
 } from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {
@@ -113,6 +114,7 @@ function createComponent<T>(
       <button>SAVE</button>
     </div>
   `,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SimpleFocusTrap implements AfterViewInit {
   private _focusTrapFactory = inject(ConfigurableFocusTrapFactory);

--- a/src/cdk/a11y/focus-trap/event-listener-inert-strategy.spec.ts
+++ b/src/cdk/a11y/focus-trap/event-listener-inert-strategy.spec.ts
@@ -6,6 +6,7 @@ import {
   Type,
   ViewChild,
   inject,
+  ChangeDetectionStrategy,
 } from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {patchElementFocus} from '../../testing/private';
@@ -82,6 +83,7 @@ function createComponent<T>(
       <button #secondFocusable>SAVE</button>
     </div>
   `,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SimpleFocusTrap implements AfterViewInit {
   private _focusTrapFactory = inject(ConfigurableFocusTrapFactory);

--- a/src/cdk/a11y/focus-trap/focus-trap.spec.ts
+++ b/src/cdk/a11y/focus-trap/focus-trap.spec.ts
@@ -7,6 +7,7 @@ import {
   ViewContainerRef,
   ViewEncapsulation,
   inject,
+  ChangeDetectionStrategy,
 } from '@angular/core';
 import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
@@ -323,6 +324,7 @@ function getActiveElement() {
     </div>
     `,
   imports: [A11yModule, PortalModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SimpleFocusTrap {
   @ViewChild(CdkTrapFocus) focusTrapDirective!: CdkTrapFocus;
@@ -341,6 +343,7 @@ const AUTO_FOCUS_TEMPLATE = `
 @Component({
   template: AUTO_FOCUS_TEMPLATE,
   imports: [A11yModule, PortalModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class FocusTrapWithAutoCapture {
   @ViewChild(CdkTrapFocus) focusTrapDirective!: CdkTrapFocus;
@@ -352,6 +355,7 @@ class FocusTrapWithAutoCapture {
   template: AUTO_FOCUS_TEMPLATE,
   encapsulation: ViewEncapsulation.ShadowDom,
   imports: [A11yModule, PortalModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class FocusTrapWithAutoCaptureInShadowDom extends FocusTrapWithAutoCapture {}
 
@@ -365,6 +369,7 @@ class FocusTrapWithAutoCaptureInShadowDom extends FocusTrapWithAutoCapture {}
     }
   `,
   imports: [A11yModule, PortalModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class FocusTrapWithBindings {
   @ViewChild(CdkTrapFocus) focusTrapDirective!: CdkTrapFocus;
@@ -385,6 +390,7 @@ class FocusTrapWithBindings {
     </div>
     `,
   imports: [A11yModule, PortalModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class FocusTrapTargets {
   @ViewChild(CdkTrapFocus) focusTrapDirective!: CdkTrapFocus;
@@ -397,6 +403,7 @@ class FocusTrapTargets {
     </div>
     `,
   imports: [A11yModule, PortalModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class FocusTrapUnfocusableTarget {
   @ViewChild(CdkTrapFocus) focusTrapDirective!: CdkTrapFocus;
@@ -411,6 +418,7 @@ class FocusTrapUnfocusableTarget {
     </div>
     `,
   imports: [A11yModule, PortalModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class FocusTrapWithSvg {
   @ViewChild(CdkTrapFocus) focusTrapDirective!: CdkTrapFocus;
@@ -423,6 +431,7 @@ class FocusTrapWithSvg {
     </div>
     `,
   imports: [A11yModule, PortalModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class FocusTrapWithoutFocusableElements {
   @ViewChild(CdkTrapFocus) focusTrapDirective!: CdkTrapFocus;
@@ -441,6 +450,7 @@ class FocusTrapWithoutFocusableElements {
   </ng-template>
   `,
   imports: [A11yModule, PortalModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class FocusTrapInsidePortal {
   viewContainerRef = inject(ViewContainerRef);

--- a/src/cdk/a11y/key-manager/list-key-manager.spec.ts
+++ b/src/cdk/a11y/key-manager/list-key-manager.spec.ts
@@ -1,6 +1,6 @@
 import {DOWN_ARROW, END, HOME, LEFT_ARROW, RIGHT_ARROW, TAB, UP_ARROW} from '../../keycodes';
 import {createKeyboardEvent} from '../../testing/private';
-import {Component, QueryList, signal} from '@angular/core';
+import {Component, QueryList, signal, ChangeDetectionStrategy} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {take} from 'rxjs/operators';
 import {FocusOrigin} from '../focus-monitor/focus-monitor';
@@ -113,7 +113,7 @@ describe('Key managers', () => {
     it('should maintain the active item when the signal-based items change', () => {
       keyManager.destroy();
 
-      @Component({template: ''})
+      @Component({template: '', changeDetection: ChangeDetectionStrategy.Eager})
       class App {}
 
       const fixture = TestBed.createComponent(App);

--- a/src/cdk/a11y/live-announcer/live-announcer.spec.ts
+++ b/src/cdk/a11y/live-announcer/live-announcer.spec.ts
@@ -1,6 +1,6 @@
 import {MutationObserverFactory} from '../../observers';
 import {ComponentPortal} from '../../portal';
-import {Component, inject, Injector} from '@angular/core';
+import {Component, inject, Injector, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By, DomSanitizer} from '@angular/platform-browser';
 import {A11yModule} from '../index';
@@ -397,6 +397,7 @@ function getLiveElement(): Element {
 @Component({
   template: `<button (click)="announce('Test')">Announce</button>`,
   imports: [A11yModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TestApp {
   live = inject(LiveAnnouncer);
@@ -410,6 +411,7 @@ class TestApp {
   template: '',
   host: {'[attr.aria-owns]': 'ariaOwns', 'aria-modal': 'true'},
   imports: [A11yModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TestModal {
   ariaOwns: string | null = null;
@@ -421,6 +423,7 @@ class TestModal {
       [cdkAriaLive]="politeness"
       [cdkAriaLiveDuration]="duration">{{content}}</div>`,
   imports: [A11yModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DivWithCdkAriaLive {
   politeness: AriaLivePoliteness = 'polite';

--- a/src/cdk/accordion/accordion-item.spec.ts
+++ b/src/cdk/accordion/accordion-item.spec.ts
@@ -1,5 +1,5 @@
 import {TestBed, ComponentFixture} from '@angular/core/testing';
-import {Component} from '@angular/core';
+import {Component, ChangeDetectionStrategy} from '@angular/core';
 import {By} from '@angular/platform-browser';
 import {CdkAccordionModule, CdkAccordionItem} from './public-api';
 
@@ -226,6 +226,7 @@ describe('CdkAccordionItem', () => {
 @Component({
   template: `<cdk-accordion-item #item1></cdk-accordion-item>`,
   imports: [CdkAccordionModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SingleItem {}
 
@@ -235,6 +236,7 @@ class SingleItem {}
     <cdk-accordion-item #item2></cdk-accordion-item>
   `,
   imports: [CdkAccordionModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ItemGroupWithoutAccordion {}
 
@@ -246,5 +248,6 @@ class ItemGroupWithoutAccordion {}
     </cdk-accordion>
   `,
   imports: [CdkAccordionModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ItemGroupWithAccordion {}

--- a/src/cdk/accordion/accordion.spec.ts
+++ b/src/cdk/accordion/accordion.spec.ts
@@ -1,5 +1,11 @@
 import {TestBed} from '@angular/core/testing';
-import {Component, QueryList, ViewChild, ViewChildren} from '@angular/core';
+import {
+  Component,
+  QueryList,
+  ViewChild,
+  ViewChildren,
+  ChangeDetectionStrategy,
+} from '@angular/core';
 import {By} from '@angular/platform-browser';
 import {CdkAccordion} from './accordion';
 import {CdkAccordionItem} from './accordion-item';
@@ -109,6 +115,7 @@ describe('CdkAccordion', () => {
     <cdk-accordion-item></cdk-accordion-item>
   </cdk-accordion>`,
   imports: [CdkAccordionModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SetOfItems {
   @ViewChild(CdkAccordion) accordion!: CdkAccordion;
@@ -124,6 +131,7 @@ class SetOfItems {
     </cdk-accordion-item>
   </cdk-accordion>`,
   imports: [CdkAccordionModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NestedItems {
   @ViewChild('outerItem') outerItem!: CdkAccordionItem;

--- a/src/cdk/bidi/directionality.spec.ts
+++ b/src/cdk/bidi/directionality.spec.ts
@@ -1,5 +1,5 @@
 import {waitForAsync, fakeAsync, TestBed, flush} from '@angular/core/testing';
-import {Component, ViewChild, signal, inject} from '@angular/core';
+import {Component, ViewChild, signal, inject, ChangeDetectionStrategy} from '@angular/core';
 import {By} from '@angular/platform-browser';
 import {BidiModule, Directionality, Dir, Direction, DIR_DOCUMENT} from './index';
 
@@ -156,6 +156,7 @@ describe('Directionality', () => {
   selector: 'injects-directionality',
   template: `<div></div>`,
   imports: [BidiModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class InjectsDirectionality {
   dir = inject(Directionality);
@@ -168,6 +169,7 @@ class InjectsDirectionality {
     </div>
   `,
   imports: [Dir, InjectsDirectionality],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ElementWithDir {
   @ViewChild(Dir) dir!: Dir;
@@ -178,6 +180,7 @@ class ElementWithDir {
 @Component({
   template: '<div dir="auto"></div>',
   imports: [Dir],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ElementWithPredefinedAutoDir {
   @ViewChild(Dir) dir!: Dir;
@@ -186,6 +189,7 @@ class ElementWithPredefinedAutoDir {
 @Component({
   template: '<div [dir]="$any(`RTL`)"></div>',
   imports: [Dir],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ElementWithPredefinedUppercaseDir {
   @ViewChild(Dir) dir!: Dir;

--- a/src/cdk/clipboard/copy-to-clipboard.spec.ts
+++ b/src/cdk/clipboard/copy-to-clipboard.spec.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import {Component, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed, fakeAsync, tick} from '@angular/core/testing';
 
 import {Clipboard} from './clipboard';
@@ -15,6 +15,7 @@ const COPY_CONTENT = 'copy content';
     [cdkCopyToClipboardAttempts]="attempts"
     (cdkCopyToClipboardCopied)="copied($event)"></button>`,
   imports: [ClipboardModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class CopyToClipboardHost {
   content = '';

--- a/src/cdk/dialog/dialog.spec.ts
+++ b/src/cdk/dialog/dialog.spec.ts
@@ -1412,6 +1412,7 @@ class ComponentWithOnPushViewContainer {
   selector: 'arbitrary-component',
   template: `<dir-with-view-container></dir-with-view-container>`,
   imports: [DirectiveWithViewContainer],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ComponentWithChildViewContainer {
   @ViewChild(DirectiveWithViewContainer) childWithViewContainer!: DirectiveWithViewContainer;
@@ -1426,6 +1427,7 @@ class ComponentWithChildViewContainer {
   template: `<ng-template let-data let-dialogRef="dialogRef">
       Cheese {{localValue}} {{data?.value}}{{setDialogRef(dialogRef)}}</ng-template>`,
   imports: [DialogModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ComponentWithTemplateRef {
   localValue = '';
@@ -1443,6 +1445,7 @@ class ComponentWithTemplateRef {
 @Component({
   template: '<p>Pizza</p> <input> <button>Close</button>',
   imports: [DialogModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class PizzaMsg {
   dialogRef = inject<DialogRef<PizzaMsg>>(DialogRef);
@@ -1459,6 +1462,7 @@ class PizzaMsg {
     // Avoids conflicting ID warning
     'id': 'content-element-dialog',
   },
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ContentElementDialog {
   closeButtonAriaLabel = '';
@@ -1468,6 +1472,7 @@ class ContentElementDialog {
   template: '',
   providers: [Dialog],
   imports: [DialogModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ComponentThatProvidesMatDialog {
   dialog = inject(Dialog);
@@ -1477,6 +1482,7 @@ class ComponentThatProvidesMatDialog {
 @Component({
   template: '',
   imports: [DialogModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DialogWithInjectedData {
   data = inject(DIALOG_DATA);
@@ -1489,12 +1495,14 @@ class DialogWithInjectedData {
     // Avoids conflicting ID warning
     'id': 'dialog-without-focusable',
   },
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DialogWithoutFocusableElements {}
 
 @Component({
   template: `<button>I'm a button</button>`,
   encapsulation: ViewEncapsulation.ShadowDom,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ShadowDomComponent {}
 
@@ -1519,6 +1527,7 @@ class TemplateInjectorInnerDirective {
     },
   ],
   imports: [TemplateInjectorInnerDirective],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TemplateInjectorParentComponent {
   @ViewChild(TemplateRef) templateRef!: TemplateRef<any>;

--- a/src/cdk/drag-drop/directives/drop-list-shared.spec.ts
+++ b/src/cdk/drag-drop/directives/drop-list-shared.spec.ts
@@ -5017,6 +5017,7 @@ export function getHorizontalFixtures(listOrientation: Exclude<DropListOrientati
     styles: HORIZONTAL_FIXTURE_STYLES,
     template: HORIZONTAL_FIXTURE_TEMPLATE,
     imports: [CdkDropList, CdkDrag],
+    changeDetection: ChangeDetectionStrategy.Eager,
   })
   class DraggableInHorizontalDropZone implements AfterViewInit {
     readonly _elementRef = inject(ElementRef);
@@ -5063,6 +5064,7 @@ export function getHorizontalFixtures(listOrientation: Exclude<DropListOrientati
         }
       `,
     ],
+    changeDetection: ChangeDetectionStrategy.Eager,
   })
   class DraggableInScrollableHorizontalDropZone extends DraggableInHorizontalDropZone {
     constructor() {
@@ -5102,6 +5104,7 @@ export function getHorizontalFixtures(listOrientation: Exclude<DropListOrientati
       </div>
     `,
     imports: [CdkDropList, CdkDrag, CdkDragPreview],
+    changeDetection: ChangeDetectionStrategy.Eager,
   })
   class DraggableInHorizontalFlexDropZoneWithMatchSizePreview {
     @ViewChildren(CdkDrag) dragItems!: QueryList<CdkDrag>;
@@ -5147,6 +5150,7 @@ const DROP_ZONE_FIXTURE_TEMPLATE = `
 @Component({
   template: DROP_ZONE_FIXTURE_TEMPLATE,
   imports: [CdkDropList, CdkDrag, NgFor],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 export class DraggableInDropZone implements AfterViewInit {
   protected _elementRef = inject(ElementRef);
@@ -5197,6 +5201,7 @@ class DraggableInOnPushDropZone extends DraggableInDropZone {}
     </div>
   `,
   imports: [CdkDropListGroup, DraggableInOnPushDropZone],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ConnectedDropListsInOnPush {}
 
@@ -5213,6 +5218,7 @@ class ConnectedDropListsInOnPush {}
     }
   `,
   imports: [CdkDropList, CdkDrag, NgFor],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 export class DraggableInScrollableVerticalDropZone extends DraggableInDropZone {
   constructor() {
@@ -5241,6 +5247,7 @@ export class DraggableInScrollableVerticalDropZone extends DraggableInDropZone {
     }
   `,
   imports: [CdkDropList, CdkDrag, NgFor, CdkScrollable],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DraggableInScrollableParentContainer extends DraggableInDropZone implements AfterViewInit {
   @ViewChild('scrollContainer') scrollContainer!: ElementRef<HTMLElement>;
@@ -5288,6 +5295,7 @@ class DraggableInScrollableParentContainer extends DraggableInDropZone implement
     </div>
   `,
   imports: [CdkDropList, CdkDrag],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DraggableInDropZoneWithContainer extends DraggableInDropZone {}
 
@@ -5318,6 +5326,7 @@ class DraggableInDropZoneWithContainer extends DraggableInDropZone {}
     </div>
   `,
   imports: [CdkDropList, CdkDrag, CdkDragPreview, NgIf],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DraggableInDropZoneWithCustomPreview {
   @ViewChild(CdkDropList) dropInstance!: CdkDropList;
@@ -5352,6 +5361,7 @@ class DraggableInDropZoneWithCustomPreview {
     </div>
   `,
   imports: [CdkDropList, CdkDrag, CdkDragPreview],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DraggableInDropZoneWithCustomTextOnlyPreview {
   @ViewChild(CdkDropList) dropInstance!: CdkDropList;
@@ -5374,6 +5384,7 @@ class DraggableInDropZoneWithCustomTextOnlyPreview {
     </div>
   `,
   imports: [CdkDropList, CdkDrag, CdkDragPreview],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DraggableInDropZoneWithCustomMultiNodePreview {
   @ViewChild(CdkDropList) dropInstance!: CdkDropList;
@@ -5406,6 +5417,7 @@ class DraggableInDropZoneWithCustomMultiNodePreview {
     }
   `,
   imports: [CdkDropList, CdkDrag, CdkDragPlaceholder],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DraggableInDropZoneWithCustomPlaceholder {
   @ViewChildren(CdkDrag) dragItems!: QueryList<CdkDrag>;
@@ -5427,6 +5439,7 @@ class DraggableInDropZoneWithCustomPlaceholder {
     </div>
   `,
   imports: [CdkDropList, CdkDrag, CdkDragPlaceholder],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DraggableInDropZoneWithCustomTextOnlyPlaceholder {
   @ViewChildren(CdkDrag) dragItems!: QueryList<CdkDrag>;
@@ -5448,6 +5461,7 @@ class DraggableInDropZoneWithCustomTextOnlyPlaceholder {
     </div>
   `,
   imports: [CdkDropList, CdkDrag, CdkDragPlaceholder],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DraggableInDropZoneWithCustomMultiNodePlaceholder {
   @ViewChildren(CdkDrag) dragItems!: QueryList<CdkDrag>;
@@ -5526,6 +5540,7 @@ const CONNECTED_DROP_ZONES_TEMPLATE = `
   styles: CONNECTED_DROP_ZONES_STYLES,
   template: CONNECTED_DROP_ZONES_TEMPLATE,
   imports: [CdkDropList, CdkDrag],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 export class ConnectedDropZones implements AfterViewInit {
   @ViewChildren(CdkDrag) rawDragItems!: QueryList<CdkDrag>;
@@ -5561,6 +5576,7 @@ export class ConnectedDropZones implements AfterViewInit {
   styles: CONNECTED_DROP_ZONES_STYLES,
   template: `@if (true) {${CONNECTED_DROP_ZONES_TEMPLATE}}`,
   imports: [CdkDropList, CdkDrag],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ConnectedDropZonesInsideShadowRootWithNgIf extends ConnectedDropZones {}
 
@@ -5602,6 +5618,7 @@ class ConnectedDropZonesInsideShadowRootWithNgIf extends ConnectedDropZones {}
     </div>
   `,
   imports: [CdkDropList, CdkDrag, CdkDropListGroup],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ConnectedDropZonesViaGroupDirective extends ConnectedDropZones {
   groupDisabled = false;
@@ -5641,6 +5658,7 @@ class ConnectedDropZonesViaGroupDirective extends ConnectedDropZones {
     </div>
   `,
   imports: [CdkDropList, CdkDrag],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ConnectedDropZonesWithSingleItems {
   @ViewChildren(CdkDrag) dragItems!: QueryList<CdkDrag>;
@@ -5661,6 +5679,7 @@ class ConnectedDropZonesWithSingleItems {
     </div>
   `,
   imports: [CdkDropList, CdkDropListGroup],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NestedDropListGroups {
   @ViewChild('group') group!: CdkDropListGroup<CdkDropList>;
@@ -5673,6 +5692,7 @@ class NestedDropListGroups {
     <ng-container cdkDropList></ng-container>
   `,
   imports: [CdkDropList],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DropListOnNgContainer {}
 
@@ -5741,6 +5761,7 @@ class WrappedDropContainerComponent {
     </div>
   `,
   imports: [CdkDropListGroup, WrappedDropContainerComponent],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ConnectedWrappedDropZones {
   todo = ['Zero', 'One', 'Two', 'Three'];
@@ -5771,6 +5792,7 @@ class ConnectedWrappedDropZones {
     </div>
   `,
   imports: [CdkDropList, CdkDrag],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DraggableWithCanvasInDropZone extends DraggableInDropZone implements AfterViewInit {
   override ngAfterViewInit() {
@@ -5812,6 +5834,7 @@ class DraggableWithCanvasInDropZone extends DraggableInDropZone implements After
     </div>
   `,
   imports: [CdkDropList, CdkDrag],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DraggableWithInvalidCanvasInDropZone extends DraggableInDropZone {}
 
@@ -5851,6 +5874,7 @@ class DraggableWithInvalidCanvasInDropZone extends DraggableInDropZone {}
       </div>
     </div>`,
   imports: [CdkDrag],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NestedDragsComponent {
   @ViewChild('container') container!: ElementRef;
@@ -5905,6 +5929,7 @@ class NestedDragsComponent {
     </ng-template>
   `,
   imports: [CdkDrag, NgTemplateOutlet],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NestedDragsThroughTemplate {
   @ViewChild('container') container!: ElementRef;
@@ -5930,6 +5955,7 @@ class NestedDragsThroughTemplate {
     </div>
   `,
   imports: [CdkDropList, CdkDrag],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NestedDropZones {
   @ViewChildren(CdkDrag) dragItems!: QueryList<CdkDrag>;
@@ -5941,6 +5967,7 @@ class NestedDropZones {
 @Component({
   template: `<div cdkDropList></div>`,
   imports: [CdkDropList],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class PlainStandaloneDropList {
   @ViewChild(CdkDropList) dropList!: CdkDropList;
@@ -5983,6 +6010,7 @@ class PlainStandaloneDropList {
     </div>
   `,
   imports: [CdkDropList, CdkDrag],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ConnectedDropZonesWithIntermediateSibling extends ConnectedDropZones {}
 
@@ -6015,6 +6043,7 @@ class ConnectedDropZonesWithIntermediateSibling extends ConnectedDropZones {}
     </div>
   `,
   imports: [CdkDropList, CdkDrag],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DraggableWithInputsInDropZone extends DraggableInDropZone {
   inputValue = 'hello';
@@ -6037,6 +6066,7 @@ class DraggableWithInputsInDropZone extends DraggableInDropZone {
     </div>
   `,
   imports: [CdkDropList, CdkDrag],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DraggableWithRadioInputsInDropZone {
   @ViewChildren(CdkDrag) dragItems!: QueryList<CdkDrag>;
@@ -6088,6 +6118,7 @@ class DraggableWithRadioInputsInDropZone {
     </div>
   `,
   imports: [CdkDropList, CdkDrag],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ConnectedDropZonesWithAlternateContainer extends ConnectedDropZones {
   override done: string[] = [];
@@ -6110,6 +6141,7 @@ class ConnectedDropZonesWithAlternateContainer extends ConnectedDropZones {
     </div>
   `,
   imports: [CdkDropList, CdkDrag],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DraggableWithInvalidAlternateContainer {
   @ViewChildren(CdkDrag) dragItems!: QueryList<CdkDrag>;
@@ -6132,6 +6164,7 @@ class DraggableWithInvalidAlternateContainer {
     </div>
   `,
   imports: [CdkDropList, CdkDrag],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DraggableWithMissingAlternateContainer {
   @ViewChildren(CdkDrag) dragItems!: QueryList<CdkDrag>;

--- a/src/cdk/drag-drop/directives/mixed-drop-list.spec.ts
+++ b/src/cdk/drag-drop/directives/mixed-drop-list.spec.ts
@@ -1,4 +1,10 @@
-import {Component, QueryList, ViewChild, ViewChildren} from '@angular/core';
+import {
+  Component,
+  QueryList,
+  ViewChild,
+  ViewChildren,
+  ChangeDetectionStrategy,
+} from '@angular/core';
 
 import {CdkDropList} from './drop-list';
 import {CdkDrag} from './drag';
@@ -132,6 +138,7 @@ function getSortedSiblings(item: Element) {
     </div>
   `,
   imports: [CdkDropList, CdkDrag],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DraggableInHorizontalWrappingDropZone {
   @ViewChildren(CdkDrag) dragItems!: QueryList<CdkDrag>;

--- a/src/cdk/drag-drop/directives/standalone-drag.spec.ts
+++ b/src/cdk/drag-drop/directives/standalone-drag.spec.ts
@@ -1872,6 +1872,7 @@ describe('Standalone CdkDrag', () => {
     </div>
   `,
   imports: [CdkDrag],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class StandaloneDraggable {
   @ViewChild('dragElement') dragElement!: ElementRef<HTMLElement>;
@@ -1915,6 +1916,7 @@ class StandaloneDraggableWithOnPush {
     </div>
   `,
   imports: [CdkDrag, CdkDragHandle],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class StandaloneDraggableWithHandle {
   @ViewChild('dragElement') dragElement!: ElementRef<HTMLElement>;
@@ -1936,6 +1938,7 @@ class StandaloneDraggableWithHandle {
     </div>
   `,
   imports: [CdkDrag, CdkDragHandle],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class StandaloneDraggableWithPreDisabledHandle {
   @ViewChild('dragElement') dragElement!: ElementRef<HTMLElement>;
@@ -1956,6 +1959,7 @@ class StandaloneDraggableWithPreDisabledHandle {
     </div>
   `,
   imports: [CdkDrag, CdkDragHandle],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class StandaloneDraggableWithDelayedHandle {
   @ViewChild('dragElement') dragElement!: ElementRef<HTMLElement>;
@@ -1970,6 +1974,7 @@ class StandaloneDraggableWithDelayedHandle {
 @Component({
   selector: 'passthrough-component',
   template: '<ng-content></ng-content>',
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class PassthroughComponent {}
 
@@ -1987,6 +1992,7 @@ class PassthroughComponent {}
     </div>
   `,
   imports: [CdkDrag, CdkDragHandle, PassthroughComponent],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class StandaloneDraggableWithIndirectHandle {
   @ViewChild('dragElement') dragElement!: ElementRef<HTMLElement>;
@@ -1997,6 +2003,7 @@ class StandaloneDraggableWithIndirectHandle {
   selector: 'shadow-wrapper',
   template: '<ng-content></ng-content>',
   encapsulation: ViewEncapsulation.ShadowDom,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ShadowWrapper {}
 
@@ -2011,6 +2018,7 @@ class ShadowWrapper {}
     </div>
   `,
   imports: [CdkDrag, CdkDragHandle, ShadowWrapper],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class StandaloneDraggableWithShadowInsideHandle {
   @ViewChild('dragElement') dragElement!: ElementRef<HTMLElement>;
@@ -2036,6 +2044,7 @@ class StandaloneDraggableWithShadowInsideHandle {
     </div>
   `,
   imports: [CdkDrag, CdkDragHandle],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class StandaloneDraggableWithMultipleHandles {
   @ViewChild('dragElement') dragElement!: ElementRef<HTMLElement>;
@@ -2053,6 +2062,7 @@ class StandaloneDraggableWithMultipleHandles {
     </div>
   `,
   imports: [CdkDrag],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DraggableWithAlternateRoot {
   @ViewChild('dragElement') dragElement!: ElementRef<HTMLElement>;
@@ -2066,6 +2076,7 @@ class DraggableWithAlternateRoot {
     <ng-container cdkDrag></ng-container>
   `,
   imports: [CdkDrag],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DraggableOnNgContainer {}
 
@@ -2076,6 +2087,7 @@ class DraggableOnNgContainer {}
     </div>
   `,
   imports: [CdkDrag, CdkDragHandle],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DragHandleOnNgContainer {}
 
@@ -2091,6 +2103,7 @@ class DragHandleOnNgContainer {}
     </div>
   `,
   imports: [CdkDrag, CdkDragHandle],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DraggableWithAlternateRootAndSelfHandle {
   @ViewChild('dragElement') dragElement!: ElementRef<HTMLElement>;
@@ -2107,6 +2120,7 @@ class DraggableWithAlternateRootAndSelfHandle {
     </div>
   `,
   imports: [CdkDrag],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DraggableNgContainerWithAlternateRoot {
   @ViewChild('dragRoot') dragRoot!: ElementRef<HTMLElement>;
@@ -2116,6 +2130,7 @@ class DraggableNgContainerWithAlternateRoot {
 @Component({
   template: `<div cdkDrag></div>`,
   imports: [CdkDrag],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class PlainStandaloneDraggable {
   @ViewChild(CdkDrag) dragInstance!: CdkDrag;
@@ -2133,6 +2148,7 @@ class PlainStandaloneDraggable {
     </ng-template>
   `,
   imports: [CdkDrag, CdkDragHandle, NgTemplateOutlet],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class StandaloneDraggableWithExternalTemplateHandle {
   @ViewChild('dragElement') dragElement!: ElementRef<HTMLElement>;
@@ -2147,6 +2163,7 @@ class StandaloneDraggableWithExternalTemplateHandle {
     </div>
   `,
   imports: [CdkDrag],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DragWithResizeableBoundary {
   @ViewChild('boundaryElement') boundaryElement!: ElementRef<HTMLElement>;

--- a/src/cdk/drag-drop/directives/standalone-drag.zone.spec.ts
+++ b/src/cdk/drag-drop/directives/standalone-drag.zone.spec.ts
@@ -5,6 +5,7 @@ import {
   Type,
   ViewChild,
   provideZoneChangeDetection,
+  ChangeDetectionStrategy,
 } from '@angular/core';
 import {Point} from '../drag-ref';
 import {CdkDrag} from './drag';
@@ -52,6 +53,7 @@ describe('Standalone CdkDrag Zone.js integration', () => {
     </div>
   `,
   imports: [CdkDrag],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class StandaloneDraggable {
   @ViewChild('dragElement') dragElement!: ElementRef<HTMLElement>;

--- a/src/cdk/drag-drop/drag-drop-registry.spec.ts
+++ b/src/cdk/drag-drop/drag-drop-registry.spec.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import {Component, ChangeDetectionStrategy} from '@angular/core';
 import {TestBed, ComponentFixture} from '@angular/core/testing';
 import {
   createMouseEvent,
@@ -261,6 +261,7 @@ describe('DragDropRegistry', () => {
   @Component({
     template: ``,
     imports: [DragDropModule],
+    changeDetection: ChangeDetectionStrategy.Eager,
   })
   class BlankComponent {}
 });

--- a/src/cdk/drag-drop/drag-drop.spec.ts
+++ b/src/cdk/drag-drop/drag-drop.spec.ts
@@ -1,4 +1,4 @@
-import {Component, ElementRef, inject} from '@angular/core';
+import {Component, ElementRef, inject, ChangeDetectionStrategy} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {DragDrop} from './drag-drop';
 import {DragRef} from './drag-ref';
@@ -30,6 +30,7 @@ describe('DragDrop', () => {
 
 @Component({
   template: '<div></div>',
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TestComponent {
   elementRef = inject<ElementRef<HTMLElement>>(ElementRef);

--- a/src/cdk/listbox/listbox.spec.ts
+++ b/src/cdk/listbox/listbox.spec.ts
@@ -1,5 +1,5 @@
 import {A, B, DOWN_ARROW, END, HOME, LEFT_ARROW, RIGHT_ARROW, SPACE, UP_ARROW} from '../keycodes';
-import {Component, Type, signal} from '@angular/core';
+import {Component, Type, signal, ChangeDetectionStrategy} from '@angular/core';
 import {TestBed, fakeAsync, tick} from '@angular/core/testing';
 import {FormControl, ReactiveFormsModule} from '@angular/forms';
 import {By} from '@angular/platform-browser';
@@ -983,6 +983,7 @@ describe('CdkOption and CdkListbox', () => {
     </div>
   `,
   imports: [CdkListbox, CdkOption],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ListboxWithOptions {
   changedOption: CdkOption<string> | null = null;
@@ -1009,6 +1010,7 @@ class ListboxWithOptions {
 @Component({
   template: `<div cdkListbox></div>`,
   imports: [CdkListbox],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ListboxWithNoOptions {}
 
@@ -1025,6 +1027,7 @@ class ListboxWithNoOptions {}
     </div>
   `,
   imports: [CdkListbox, CdkOption, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ListboxWithFormControl {
   formControl = new FormControl();
@@ -1041,6 +1044,7 @@ class ListboxWithFormControl {
     </div>
   `,
   imports: [CdkListbox, CdkOption, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ListboxWithPreselectedFormControl {
   options = ['a', 'b', 'c'];
@@ -1056,6 +1060,7 @@ class ListboxWithPreselectedFormControl {
     </div>
   `,
   imports: [CdkListbox, CdkOption, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ListboxWithInvalidPreselectedFormControl {
   options = ['a', 'b', 'c'];
@@ -1072,6 +1077,7 @@ class ListboxWithInvalidPreselectedFormControl {
     </ul>
   `,
   imports: [CdkListbox, CdkOption],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ListboxWithCustomTypeahead {}
 
@@ -1086,6 +1092,7 @@ class ListboxWithCustomTypeahead {}
     </div>
   `,
   imports: [CdkListbox, CdkOption],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ListboxWithBoundValue {
   value = ['banana'];
@@ -1103,6 +1110,7 @@ class ListboxWithBoundValue {
     </div>
   `,
   imports: [CdkListbox, CdkOption],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ListboxWithMultipleBoundValues {
   value = ['apple', 'banana'];
@@ -1117,6 +1125,7 @@ class ListboxWithMultipleBoundValues {
     </div>
   `,
   imports: [CdkListbox, CdkOption],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ListboxWithObjectValues {
   fruits = [{name: 'Apple'}, {name: 'Orange'}, {name: 'Banana'}, {name: 'Peach'}];

--- a/src/cdk/menu/context-menu-trigger.spec.ts
+++ b/src/cdk/menu/context-menu-trigger.spec.ts
@@ -1,4 +1,11 @@
-import {Component, ViewChild, ElementRef, ViewChildren, QueryList} from '@angular/core';
+import {
+  Component,
+  ViewChild,
+  ElementRef,
+  ViewChildren,
+  QueryList,
+  ChangeDetectionStrategy,
+} from '@angular/core';
 import {TestBed, ComponentFixture} from '@angular/core/testing';
 import {CdkMenu} from './menu';
 import {CdkContextMenuTrigger} from './context-menu-trigger';
@@ -421,6 +428,7 @@ describe('CdkContextMenuTrigger', () => {
     </ng-template>
   `,
   imports: [CdkContextMenuTrigger, CdkMenu, CdkMenuItem],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SimpleContextMenu {
   @ViewChild(CdkContextMenuTrigger) trigger!: CdkContextMenuTrigger;
@@ -450,6 +458,7 @@ class SimpleContextMenu {
     </ng-template>
   `,
   imports: [CdkContextMenuTrigger, CdkMenu],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NestedContextMenu {
   @ViewChild('cut_trigger', {read: ElementRef}) cutContext!: ElementRef<HTMLElement>;
@@ -476,6 +485,7 @@ class NestedContextMenu {
     </ng-template>
   `,
   imports: [CdkContextMenuTrigger, CdkMenuTrigger, CdkMenu, CdkMenuItem],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ContextMenuWithSubmenu {
   @ViewChild(CdkContextMenuTrigger, {read: ElementRef}) context!: ElementRef<HTMLElement>;
@@ -507,6 +517,7 @@ class ContextMenuWithSubmenu {
     </div>
   `,
   imports: [CdkContextMenuTrigger, CdkMenuTrigger, CdkMenu, CdkMenuItem, CdkMenuBar],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ContextMenuWithMenuBarAndInlineMenu {
   @ViewChild(CdkMenuBar, {read: ElementRef}) nativeMenuBar!: ElementRef;
@@ -536,6 +547,7 @@ class ContextMenuWithMenuBarAndInlineMenu {
     </ng-template>
   `,
   imports: [CdkMenuBar, CdkContextMenuTrigger, CdkMenu, CdkMenuItem, CdkMenuTrigger],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MenuBarAndContextTriggerShareMenu {
   @ViewChild(CdkMenuTrigger) menuBarTrigger!: CdkMenuTrigger;
@@ -552,6 +564,7 @@ class MenuBarAndContextTriggerShareMenu {
     </ng-template>
   `,
   imports: [CdkContextMenuTrigger, CdkMenu],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ContextTriggerWithData {
   @ViewChild(CdkContextMenuTrigger, {read: ElementRef}) triggerElement!: ElementRef<HTMLElement>;

--- a/src/cdk/menu/menu-bar.spec.ts
+++ b/src/cdk/menu/menu-bar.spec.ts
@@ -6,6 +6,7 @@ import {
   QueryList,
   ViewChild,
   ViewChildren,
+  ChangeDetectionStrategy,
 } from '@angular/core';
 import {By} from '@angular/platform-browser';
 import {
@@ -1077,6 +1078,7 @@ describe('MenuBar', () => {
     </ul>
   `,
   imports: [CdkMenuModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MenuBarRadioGroup {}
 
@@ -1112,6 +1114,7 @@ class MenuBarRadioGroup {}
     </div>
   `,
   imports: [CdkMenuModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MultiMenuWithSubmenu {
   clickEmitter = new EventEmitter<void>();
@@ -1138,6 +1141,7 @@ class MultiMenuWithSubmenu {
     </div>
   `,
   imports: [CdkMenuModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MenuWithCheckboxes {
   @ViewChild(CdkMenuBar, {read: ElementRef}) nativeMenuBar!: ElementRef;
@@ -1165,6 +1169,7 @@ class MenuWithCheckboxes {
     </div>
   `,
   imports: [CdkMenuModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MenuWithRadioButtons {
   @ViewChild(CdkMenuBar, {read: ElementRef}) nativeMenuBar!: ElementRef;
@@ -1198,6 +1203,7 @@ class MenuWithRadioButtons {
     </div>
   `,
   imports: [CdkMenuModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MenuBarWithMenusAndInlineMenu {
   @ViewChildren(CdkMenu) menus!: QueryList<CdkMenu>;

--- a/src/cdk/menu/menu-group.spec.ts
+++ b/src/cdk/menu/menu-group.spec.ts
@@ -1,4 +1,4 @@
-import {Component, ViewChild} from '@angular/core';
+import {Component, ViewChild, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {CdkMenuModule} from './menu-module';
@@ -96,6 +96,7 @@ describe('MenuGroup', () => {
     </ng-template>
   `,
   imports: [CdkMenuModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class CheckboxMenu {
   @ViewChild(CdkMenuItem) readonly trigger!: CdkMenuItem;
@@ -140,6 +141,7 @@ class CheckboxMenu {
     </ng-template>
   `,
   imports: [CdkMenuModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MenuWithMultipleRadioGroups {
   @ViewChild(CdkMenuItem) readonly trigger!: CdkMenuItem;

--- a/src/cdk/menu/menu-item-checkbox.spec.ts
+++ b/src/cdk/menu/menu-item-checkbox.spec.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import {Component, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {CdkMenuModule} from './menu-module';
@@ -90,5 +90,6 @@ describe('MenuItemCheckbox', () => {
     </div>
   `,
   imports: [CdkMenuModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SingleCheckboxButton {}

--- a/src/cdk/menu/menu-item-radio.spec.ts
+++ b/src/cdk/menu/menu-item-radio.spec.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import {Component, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {CdkMenuModule} from './menu-module';
@@ -80,5 +80,6 @@ describe('MenuItemRadio', () => {
     </div>
   `,
   imports: [CdkMenuModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SimpleRadioButton {}

--- a/src/cdk/menu/menu-item.spec.ts
+++ b/src/cdk/menu/menu-item.spec.ts
@@ -1,4 +1,4 @@
-import {Component, Type} from '@angular/core';
+import {Component, Type, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {dispatchFakeEvent, dispatchKeyboardEvent} from '../testing/private';
 import {By} from '@angular/platform-browser';
@@ -139,6 +139,7 @@ describe('MenuItem', () => {
 @Component({
   selector: 'mat-icon',
   template: '<ng-content></ng-content>',
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class FakeMatIcon {}
 
@@ -149,6 +150,7 @@ class FakeMatIcon {}
     </div>
   `,
   imports: [CdkMenuModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SingleMenuItem {}
 
@@ -162,6 +164,7 @@ class SingleMenuItem {}
     </div>
   `,
   imports: [CdkMenuModule, FakeMatIcon],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MenuItemWithIcon {
   typeahead: string | null = null;
@@ -177,6 +180,7 @@ class MenuItemWithIcon {
     </div>
   `,
   imports: [CdkMenuModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MenuItemWithIconClass {
   typeahead: string | null = null;
@@ -189,6 +193,7 @@ class MenuItemWithIconClass {
     </div>
   `,
   imports: [CdkMenuModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MenuItemWithBoldElement {}
 
@@ -208,6 +213,7 @@ class MenuItemWithBoldElement {}
     </div>
   `,
   imports: [CdkMenuModule, FakeMatIcon],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MenuItemWithMultipleNestings {
   typeahead = '';

--- a/src/cdk/menu/menu-stack.spec.ts
+++ b/src/cdk/menu/menu-stack.spec.ts
@@ -1,4 +1,10 @@
-import {QueryList, ViewChild, ViewChildren, Component} from '@angular/core';
+import {
+  QueryList,
+  ViewChild,
+  ViewChildren,
+  Component,
+  ChangeDetectionStrategy,
+} from '@angular/core';
 import {CdkMenu} from './menu';
 import {CdkMenuBar} from './menu-bar';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
@@ -95,6 +101,7 @@ describe('MenuStack', () => {
     </div>
   `,
   imports: [CdkMenuModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MultiMenuWithSubmenu {
   @ViewChild(CdkMenuBar) menuBar!: CdkMenuBar;

--- a/src/cdk/menu/menu-trigger.spec.ts
+++ b/src/cdk/menu/menu-trigger.spec.ts
@@ -1,5 +1,12 @@
 import {ENTER, SPACE, TAB} from '../keycodes';
-import {Component, ElementRef, QueryList, ViewChild, ViewChildren} from '@angular/core';
+import {
+  Component,
+  ElementRef,
+  QueryList,
+  ViewChild,
+  ViewChildren,
+  ChangeDetectionStrategy,
+} from '@angular/core';
 import {ComponentFixture, TestBed, fakeAsync, tick} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {dispatchKeyboardEvent} from '../../cdk/testing/private';
@@ -537,6 +544,7 @@ describe('MenuTrigger', () => {
     <ng-template #noop><div cdkMenu></div></ng-template>
   `,
   imports: [CdkMenuBar, CdkMenu, CdkMenuItem, CdkMenuTrigger],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TriggerForEmptyMenu {
   @ViewChild(CdkMenuTrigger) trigger!: CdkMenuTrigger;
@@ -562,6 +570,7 @@ class TriggerForEmptyMenu {
     </ng-template>
   `,
   imports: [CdkMenu, CdkMenuItem, CdkMenuTrigger, CdkMenuBar],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MenuBarWithNestedSubMenus {
   @ViewChildren(CdkMenu) menus!: QueryList<CdkMenu>;
@@ -589,6 +598,7 @@ class MenuBarWithNestedSubMenus {
     </ng-template>
   `,
   imports: [CdkMenu, CdkMenuItem, CdkMenuTrigger, CdkMenuBar],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TriggersWithSameMenuDifferentMenuBars {
   @ViewChildren(CdkMenuTrigger) triggers!: QueryList<CdkMenuTrigger>;
@@ -612,6 +622,7 @@ class TriggersWithSameMenuDifferentMenuBars {
     </ng-template>
   `,
   imports: [CdkMenu, CdkMenuItem, CdkMenuTrigger, CdkMenuBar],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TriggersWithSameMenuSameMenuBar {
   @ViewChildren(CdkMenuTrigger) triggers!: QueryList<CdkMenuTrigger>;
@@ -631,6 +642,7 @@ class TriggersWithSameMenuSameMenuBar {
     </ng-template>
   `,
   imports: [CdkMenu, CdkMenuItem, CdkMenuTrigger, CdkMenuBar],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TriggerOpensItsMenu {
   @ViewChildren(CdkMenuTrigger) triggers!: QueryList<CdkMenuTrigger>;
@@ -656,6 +668,7 @@ class TriggerOpensItsMenu {
     </div>
   `,
   imports: [CdkMenu, CdkMenuItem, CdkMenuTrigger],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class StandaloneTriggerWithInlineMenu {
   @ViewChild(CdkMenuItem, {read: ElementRef}) nativeTrigger!: ElementRef<HTMLElement>;
@@ -676,6 +689,7 @@ class StandaloneTriggerWithInlineMenu {
     </ng-template>
   `,
   imports: [CdkMenu, CdkMenuTrigger],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TriggerWithData {
   menuData: unknown;
@@ -686,6 +700,7 @@ class TriggerWithData {
     <button [cdkMenuTriggerFor]="null">First</button>
   `,
   imports: [CdkMenuTrigger],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TriggerWithNullValue {
   @ViewChild(CdkMenuTrigger, {static: true})

--- a/src/cdk/menu/menu.spec.ts
+++ b/src/cdk/menu/menu.spec.ts
@@ -1,5 +1,12 @@
 import {TAB} from '../keycodes';
-import {Component, ElementRef, QueryList, ViewChild, ViewChildren} from '@angular/core';
+import {
+  Component,
+  ElementRef,
+  QueryList,
+  ViewChild,
+  ViewChildren,
+  ChangeDetectionStrategy,
+} from '@angular/core';
 import {
   ComponentFixture,
   TestBed,
@@ -528,6 +535,7 @@ describe('Menu', () => {
     </ng-template>
   `,
   imports: [CdkMenuModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MenuCheckboxGroup {
   @ViewChild(CdkMenuItem) readonly trigger!: CdkMenuItem;
@@ -541,6 +549,7 @@ class MenuCheckboxGroup {
     </div>
   `,
   imports: [CdkMenuModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class InlineMenu {}
 
@@ -594,6 +603,7 @@ class InlineMenu {}
     </ng-template>
   `,
   imports: [CdkMenuModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class WithComplexNestedMenus {
   @ViewChild('file_trigger', {read: ElementRef}) nativeFileTrigger!: ElementRef<HTMLElement>;
@@ -654,6 +664,7 @@ class WithComplexNestedMenus {
     </ng-template>
   `,
   imports: [CdkMenuModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class WithComplexNestedMenusOnBottom {
   @ViewChild('file_trigger', {read: ElementRef}) nativeFileTrigger!: ElementRef<HTMLElement>;
@@ -673,6 +684,7 @@ class WithComplexNestedMenusOnBottom {
     </div>
   `,
   imports: [CdkMenuModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MenuWithActiveItem {
   @ViewChild(CdkMenu) menu!: CdkMenu;
@@ -692,6 +704,7 @@ class MenuWithActiveItem {
     </div>
   `,
   imports: [CdkMenuModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NestedMenuDefinition {
   @ViewChild('root', {read: CdkMenu}) root!: CdkMenu;

--- a/src/cdk/menu/pointer-focus-tracker.spec.ts
+++ b/src/cdk/menu/pointer-focus-tracker.spec.ts
@@ -6,6 +6,7 @@ import {
   AfterViewInit,
   inject,
   Renderer2,
+  ChangeDetectionStrategy,
 } from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {createMouseEvent, dispatchEvent} from '../../cdk/testing/private';
@@ -101,6 +102,7 @@ describe('FocusMouseManger', () => {
 @Component({
   selector: 'wrapper',
   template: `<ng-content></ng-content>`,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MockWrapper implements FocusableElement {
   readonly _elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
@@ -117,6 +119,7 @@ class MockWrapper implements FocusableElement {
     </div>
   `,
   imports: [MockWrapper],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MultiElementWithConditionalComponent implements AfterViewInit {
   private _renderer = inject(Renderer2);

--- a/src/cdk/observers/observe-content.spec.ts
+++ b/src/cdk/observers/observe-content.spec.ts
@@ -1,4 +1,4 @@
-import {Component, ElementRef, ViewChild} from '@angular/core';
+import {Component, ElementRef, ViewChild, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed, fakeAsync, tick, waitForAsync} from '@angular/core/testing';
 import {ContentObserver, MutationObserverFactory, ObserversModule} from './observe-content';
 
@@ -252,6 +252,7 @@ describe('ContentObserver injectable', () => {
       [cdkObserveContentDisabled]="disabled">{{text}}</div>
   `,
   imports: [ObserversModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ComponentWithTextContent {
   text = '';
@@ -262,6 +263,7 @@ class ComponentWithTextContent {
 @Component({
   template: `<div (cdkObserveContent)="doSomething()"><div>{{text}}</div></div>`,
   imports: [ObserversModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ComponentWithChildTextContent {
   text = '';
@@ -271,6 +273,7 @@ class ComponentWithChildTextContent {
 @Component({
   template: `<div (cdkObserveContent)="spy($event)" [debounce]="debounce">{{text}}</div>`,
   imports: [ObserversModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ComponentWithDebouncedListener {
   debounce = 500;
@@ -281,6 +284,7 @@ class ComponentWithDebouncedListener {
 @Component({
   template: `<div #contentEl>{{text}}</div>`,
   imports: [ObserversModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class UnobservedComponentWithTextContent {
   @ViewChild('contentEl') contentEl!: ElementRef<HTMLElement>;

--- a/src/cdk/observers/private/shared-resize-observer.spec.ts
+++ b/src/cdk/observers/private/shared-resize-observer.spec.ts
@@ -1,5 +1,5 @@
 import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
-import {Component, ElementRef, inject, ViewChild} from '@angular/core';
+import {Component, ElementRef, inject, ViewChild, ChangeDetectionStrategy} from '@angular/core';
 import {SharedResizeObserver} from './shared-resize-observer';
 
 describe('SharedResizeObserver', () => {
@@ -135,6 +135,7 @@ describe('SharedResizeObserver', () => {
     <div #el1></div>
     <div #el2></div>
   `,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 export class TestComponent {
   @ViewChild('el1') el1!: ElementRef<Element>;

--- a/src/cdk/overlay/dispatchers/overlay-keyboard-dispatcher.spec.ts
+++ b/src/cdk/overlay/dispatchers/overlay-keyboard-dispatcher.spec.ts
@@ -1,6 +1,6 @@
 import {ESCAPE} from '../../keycodes';
 import {ComponentPortal} from '../../portal';
-import {ApplicationRef, Component, Injector} from '@angular/core';
+import {ApplicationRef, Component, Injector, ChangeDetectionStrategy} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {dispatchKeyboardEvent} from '../../testing/private';
 import {createOverlayRef} from '../index';
@@ -209,5 +209,5 @@ describe('OverlayKeyboardDispatcher', () => {
   });
 });
 
-@Component({template: 'Hello'})
+@Component({template: 'Hello', changeDetection: ChangeDetectionStrategy.Eager})
 class TestComponent {}

--- a/src/cdk/overlay/dispatchers/overlay-outside-click-dispatcher.spec.ts
+++ b/src/cdk/overlay/dispatchers/overlay-outside-click-dispatcher.spec.ts
@@ -1,4 +1,4 @@
-import {ApplicationRef, Component, Injector} from '@angular/core';
+import {ApplicationRef, Component, Injector, ChangeDetectionStrategy} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {filter, take} from 'rxjs/operators';
 import {ComponentPortal} from '../../portal';
@@ -407,7 +407,7 @@ describe('OverlayOutsideClickDispatcher', () => {
 
     it('should run change detection if the click was made outside the overlay and there are `outsidePointerEvents` observers', async () => {
       let renders = 0;
-      @Component({template: '{{increment()}}'})
+      @Component({template: '{{increment()}}', changeDetection: ChangeDetectionStrategy.Eager})
       class Counter {
         increment() {
           renders++;
@@ -448,5 +448,5 @@ describe('OverlayOutsideClickDispatcher', () => {
   });
 });
 
-@Component({template: 'Hello'})
+@Component({template: 'Hello', changeDetection: ChangeDetectionStrategy.Eager})
 class TestComponent {}

--- a/src/cdk/overlay/fullscreen-overlay-container.spec.ts
+++ b/src/cdk/overlay/fullscreen-overlay-container.spec.ts
@@ -1,5 +1,13 @@
 import {waitForAsync, TestBed} from '@angular/core/testing';
-import {Component, ViewChild, ViewContainerRef, inject, DOCUMENT, Injector} from '@angular/core';
+import {
+  Component,
+  ViewChild,
+  ViewContainerRef,
+  inject,
+  DOCUMENT,
+  Injector,
+  ChangeDetectionStrategy,
+} from '@angular/core';
 import {CdkPortal} from '../portal';
 import {OverlayContainer, FullscreenOverlayContainer, createOverlayRef} from './index';
 
@@ -107,6 +115,7 @@ describe('FullscreenOverlayContainer', () => {
 @Component({
   template: `<ng-template cdkPortal>Cake</ng-template>`,
   imports: [CdkPortal],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TestComponentWithTemplatePortals {
   viewContainerRef = inject(ViewContainerRef);

--- a/src/cdk/overlay/overlay-container.spec.ts
+++ b/src/cdk/overlay/overlay-container.spec.ts
@@ -1,5 +1,12 @@
 import {waitForAsync, TestBed} from '@angular/core/testing';
-import {Component, Injector, ViewChild, ViewContainerRef, inject} from '@angular/core';
+import {
+  Component,
+  Injector,
+  ViewChild,
+  ViewContainerRef,
+  inject,
+  ChangeDetectionStrategy,
+} from '@angular/core';
 import {CdkPortal} from '../portal';
 import {createOverlayRef, OverlayContainer} from './index';
 
@@ -83,6 +90,7 @@ describe('OverlayContainer', () => {
 @Component({
   template: `<ng-template cdkPortal>Cake</ng-template>`,
   imports: [CdkPortal],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TestComponentWithTemplatePortals {
   viewContainerRef = inject(ViewContainerRef);

--- a/src/cdk/overlay/overlay-directives.spec.ts
+++ b/src/cdk/overlay/overlay-directives.spec.ts
@@ -1,4 +1,12 @@
-import {Component, ElementRef, Injector, signal, ViewChild, WritableSignal} from '@angular/core';
+import {
+  Component,
+  ElementRef,
+  Injector,
+  signal,
+  ViewChild,
+  WritableSignal,
+  ChangeDetectionStrategy,
+} from '@angular/core';
 import {ComponentFixture, fakeAsync, TestBed, tick, waitForAsync} from '@angular/core/testing';
 import {Subject} from 'rxjs';
 import {Direction} from '../bidi';
@@ -789,6 +797,7 @@ describe('Overlay directives', () => {
     <p>Menu content</p>
   </ng-template>`,
   imports: [OverlayModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ConnectedOverlayDirectiveTest {
   @ViewChild(CdkConnectedOverlay) connectedOverlayDirective!: CdkConnectedOverlay;
@@ -832,6 +841,7 @@ class ConnectedOverlayDirectiveTest {
     <ng-template cdk-connected-overlay>Menu content</ng-template>
   `,
   imports: [OverlayModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ConnectedOverlayPropertyInitOrder {
   @ViewChild(CdkConnectedOverlay) connectedOverlayDirective!: CdkConnectedOverlay;

--- a/src/cdk/overlay/overlay-directives.zone.spec.ts
+++ b/src/cdk/overlay/overlay-directives.zone.spec.ts
@@ -1,4 +1,11 @@
-import {Component, ElementRef, NgZone, ViewChild, provideZoneChangeDetection} from '@angular/core';
+import {
+  Component,
+  ElementRef,
+  NgZone,
+  ViewChild,
+  provideZoneChangeDetection,
+  ChangeDetectionStrategy,
+} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {CdkConnectedOverlay, CdkOverlayOrigin} from './overlay-directives';
 import {OverlayModule} from './overlay-module';
@@ -75,6 +82,7 @@ describe('Overlay directives Zone.js integration', () => {
       <p>Menu content</p>
     </ng-template>`,
   imports: [OverlayModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ConnectedOverlayDirectiveTest {
   @ViewChild(CdkConnectedOverlay) connectedOverlayDirective!: CdkConnectedOverlay;

--- a/src/cdk/overlay/overlay.spec.ts
+++ b/src/cdk/overlay/overlay.spec.ts
@@ -13,6 +13,7 @@ import {
   WritableSignal,
   inject,
   signal,
+  ChangeDetectionStrategy,
 } from '@angular/core';
 import {
   ComponentFixture,
@@ -1120,6 +1121,7 @@ describe('Overlay', () => {
 @Component({
   selector: 'pizza',
   template: '<p>Pizza</p>',
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class PizzaMsg {}
 
@@ -1127,6 +1129,7 @@ class PizzaMsg {}
 @Component({
   template: `<ng-template cdkPortal>Cake</ng-template>`,
   imports: [CdkPortal],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TestComponentWithTemplatePortals {
   viewContainerRef = inject(ViewContainerRef);

--- a/src/cdk/overlay/position/flexible-connected-position-strategy.spec.ts
+++ b/src/cdk/overlay/position/flexible-connected-position-strategy.spec.ts
@@ -9,6 +9,7 @@ import {
   Renderer2,
   RendererFactory2,
   runInInjectionContext,
+  ChangeDetectionStrategy,
 } from '@angular/core';
 import {fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {Subscription} from 'rxjs';
@@ -3073,5 +3074,6 @@ function createOverflowContainerElement() {
       style="width: ${DEFAULT_WIDTH}px; height: ${DEFAULT_HEIGHT}px;"></div>
   `,
   imports: [ScrollingModule, OverlayModule, PortalModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TestOverlay {}

--- a/src/cdk/overlay/position/global-position-strategy.spec.ts
+++ b/src/cdk/overlay/position/global-position-strategy.spec.ts
@@ -1,4 +1,4 @@
-import {Component, ApplicationRef, Injector} from '@angular/core';
+import {Component, ApplicationRef, Injector, ChangeDetectionStrategy} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {PortalModule, ComponentPortal} from '../../portal';
 import {
@@ -475,5 +475,6 @@ describe('GlobalPositonStrategy', () => {
 @Component({
   template: '',
   imports: [OverlayModule, PortalModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class BlankPortal {}

--- a/src/cdk/overlay/scroll/block-scroll-strategy.spec.ts
+++ b/src/cdk/overlay/scroll/block-scroll-strategy.spec.ts
@@ -1,4 +1,4 @@
-import {Component, Injector} from '@angular/core';
+import {Component, Injector, ChangeDetectionStrategy} from '@angular/core';
 import {waitForAsync, TestBed} from '@angular/core/testing';
 import {ComponentPortal, PortalModule} from '../../portal';
 import {Platform} from '../../platform';
@@ -264,5 +264,6 @@ describe('BlockScrollStrategy', () => {
 @Component({
   template: '<p>Focaccia</p>',
   imports: [OverlayModule, PortalModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class FocacciaMsg {}

--- a/src/cdk/overlay/scroll/close-scroll-strategy.spec.ts
+++ b/src/cdk/overlay/scroll/close-scroll-strategy.spec.ts
@@ -1,6 +1,6 @@
 import {ComponentPortal, PortalModule} from '../../portal';
 import {CdkScrollable, ScrollDispatcher, ViewportRuler} from '../../scrolling';
-import {Component, ElementRef, Injector} from '@angular/core';
+import {Component, ElementRef, Injector, ChangeDetectionStrategy} from '@angular/core';
 import {TestBed, fakeAsync} from '@angular/core/testing';
 import {Subject} from 'rxjs';
 import {
@@ -138,5 +138,6 @@ describe('CloseScrollStrategy', () => {
 @Component({
   template: '<p>Mozarella</p>',
   imports: [OverlayModule, PortalModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MozarellaMsg {}

--- a/src/cdk/overlay/scroll/close-scroll-strategy.zone.spec.ts
+++ b/src/cdk/overlay/scroll/close-scroll-strategy.zone.spec.ts
@@ -1,5 +1,11 @@
 import {ComponentPortal, PortalModule} from '../../portal';
-import {Component, Injector, NgZone, provideZoneChangeDetection} from '@angular/core';
+import {
+  Component,
+  Injector,
+  NgZone,
+  provideZoneChangeDetection,
+  ChangeDetectionStrategy,
+} from '@angular/core';
 import {TestBed, fakeAsync} from '@angular/core/testing';
 import {Subject} from 'rxjs';
 import {OverlayConfig} from '../overlay-config';
@@ -70,5 +76,6 @@ describe('CloseScrollStrategy Zone.js integration', () => {
 @Component({
   template: '<p>Mozarella</p>',
   imports: [OverlayModule, PortalModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MozarellaMsg {}

--- a/src/cdk/overlay/scroll/reposition-scroll-strategy.spec.ts
+++ b/src/cdk/overlay/scroll/reposition-scroll-strategy.spec.ts
@@ -1,5 +1,5 @@
 import {waitForAsync, TestBed} from '@angular/core/testing';
-import {Component, Injector} from '@angular/core';
+import {Component, Injector, ChangeDetectionStrategy} from '@angular/core';
 import {Subject} from 'rxjs';
 import {ComponentPortal, PortalModule} from '../../portal';
 import {
@@ -116,5 +116,6 @@ describe('RepositionScrollStrategy', () => {
 @Component({
   template: '<p>Pasta</p>',
   imports: [OverlayModule, PortalModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class PastaMsg {}

--- a/src/cdk/portal/portal.spec.ts
+++ b/src/cdk/portal/portal.spec.ts
@@ -17,6 +17,7 @@ import {
   createEnvironmentInjector,
   inject,
   inputBinding,
+  ChangeDetectionStrategy,
 } from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {DomPortalOutlet} from './dom-portal-outlet';
@@ -650,7 +651,7 @@ describe('Portals', () => {
         'Child environment',
       );
 
-      @Component({template: ''})
+      @Component({template: '', changeDetection: ChangeDetectionStrategy.Eager})
       class ChildComponent {}
 
       const component = createComponent(ChildComponent, {
@@ -773,6 +774,7 @@ class ChocolateInjector {
   selector: 'pizza-msg',
   template: '<p>Pizza</p><p>{{snack}}</p><ng-content></ng-content>',
   imports: [PortalModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class PizzaMsg {
   snack = inject(Chocolate, {optional: true});
@@ -808,6 +810,7 @@ class SaveParentNodeOnInit implements AfterViewInit {
     </ng-template>
   `,
   imports: [SaveParentNodeOnInit],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ArbitraryViewContainerRefComponent {
   viewContainerRef = inject(ViewContainerRef);
@@ -849,6 +852,7 @@ class ArbitraryViewContainerRefComponent {
   </div>
   `,
   imports: [CdkPortal, CdkPortalOutlet, PizzaMsg],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class PortalTestApp {
   viewContainerRef = inject(ViewContainerRef);
@@ -891,6 +895,7 @@ class PortalTestApp {
     </div>
   `,
   imports: [CdkPortalOutlet],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class UnboundPortalTestApp {
   @ViewChild(CdkPortalOutlet) portalOutlet!: CdkPortalOutlet;

--- a/src/cdk/scrolling/scroll-dispatcher.spec.ts
+++ b/src/cdk/scrolling/scroll-dispatcher.spec.ts
@@ -1,5 +1,5 @@
 import {TestBed, fakeAsync, ComponentFixture, tick} from '@angular/core/testing';
-import {Component, ViewChild, ElementRef} from '@angular/core';
+import {Component, ViewChild, ElementRef, ChangeDetectionStrategy} from '@angular/core';
 import {CdkScrollable, ScrollDispatcher, ScrollingModule} from './public-api';
 import {dispatchFakeEvent} from '../testing/private';
 
@@ -259,6 +259,7 @@ describe('ScrollDispatcher', () => {
 @Component({
   template: `<div #scrollingElement cdkScrollable style="height: 9999px"></div>`,
   imports: [ScrollingModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ScrollingComponent {
   @ViewChild(CdkScrollable) scrollable!: CdkScrollable;
@@ -277,6 +278,7 @@ class ScrollingComponent {
     <div id="scrollable-2" cdkScrollable></div>
   `,
   imports: [ScrollingModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NestedScrollingComponent {
   @ViewChild('interestingElement') interestingElement!: ElementRef<HTMLElement>;

--- a/src/cdk/scrolling/scroll-dispatcher.zone.spec.ts
+++ b/src/cdk/scrolling/scroll-dispatcher.zone.spec.ts
@@ -1,4 +1,10 @@
-import {Component, ElementRef, ViewChild, provideZoneChangeDetection} from '@angular/core';
+import {
+  Component,
+  ElementRef,
+  ViewChild,
+  provideZoneChangeDetection,
+  ChangeDetectionStrategy,
+} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {dispatchFakeEvent} from '../testing/private';
 import {ScrollDispatcher} from './scroll-dispatcher';
@@ -36,6 +42,7 @@ describe('ScrollDispatcher Zone.js integration', () => {
 @Component({
   template: `<div #scrollingElement cdkScrollable style="height: 9999px"></div>`,
   imports: [ScrollingModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ScrollingComponent {
   @ViewChild(CdkScrollable) scrollable!: CdkScrollable;

--- a/src/cdk/scrolling/scrollable.spec.ts
+++ b/src/cdk/scrolling/scrollable.spec.ts
@@ -1,6 +1,6 @@
 import {Direction} from '../bidi';
 import {CdkScrollable, ScrollingModule} from '../scrolling';
-import {Component, ElementRef, Input, ViewChild} from '@angular/core';
+import {Component, ElementRef, Input, ViewChild, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 
 function expectOverlapping(el1: ElementRef<Element>, el2: ElementRef<Element>, expected = true) {
@@ -241,6 +241,7 @@ describe('CdkScrollable', () => {
     }
   `,
   imports: [ScrollingModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ScrollableViewport {
   @Input() dir: Direction = 'ltr';

--- a/src/cdk/scrolling/virtual-scroll-viewport.spec.ts
+++ b/src/cdk/scrolling/virtual-scroll-viewport.spec.ts
@@ -14,6 +14,7 @@ import {
   ViewContainerRef,
   ViewEncapsulation,
   inject,
+  ChangeDetectionStrategy,
 } from '@angular/core';
 import {
   ComponentFixture,
@@ -1190,6 +1191,7 @@ function triggerScroll(viewport: CdkVirtualScrollViewport, offset?: number) {
   `,
   encapsulation: ViewEncapsulation.None,
   imports: [ScrollingModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class FixedSizeVirtualScroll {
   @ViewChild(CdkVirtualScrollViewport, {static: true}) viewport!: CdkVirtualScrollViewport;
@@ -1255,6 +1257,7 @@ class FixedSizeVirtualScroll {
   `,
   encapsulation: ViewEncapsulation.None,
   imports: [ScrollingModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class FixedSizeVirtualScrollWithRtlDirection {
   @ViewChild(CdkVirtualScrollViewport, {static: true}) viewport!: CdkVirtualScrollViewport;
@@ -1299,6 +1302,7 @@ class FixedSizeVirtualScrollWithRtlDirection {
     }
   `,
   imports: [ScrollingModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class VirtualScrollWithNoStrategy {
   items = [];
@@ -1338,6 +1342,7 @@ class InjectsViewContainer {
   `,
   encapsulation: ViewEncapsulation.None,
   imports: [InjectsViewContainer, ScrollingModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class VirtualScrollWithItemInjectingViewContainer {
   @ViewChild(CdkVirtualScrollViewport, {static: true}) viewport!: CdkVirtualScrollViewport;
@@ -1376,6 +1381,7 @@ class VirtualScrollWithItemInjectingViewContainer {
   `,
   encapsulation: ViewEncapsulation.None,
   imports: [ScrollingModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DelayedInitializationVirtualScroll {
   @ViewChild(CdkVirtualScrollViewport, {static: true}) viewport!: CdkVirtualScrollViewport;
@@ -1414,6 +1420,7 @@ class DelayedInitializationVirtualScroll {
   `,
   encapsulation: ViewEncapsulation.None,
   imports: [ScrollingModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class VirtualScrollWithAppendOnly {
   @ViewChild(CdkVirtualScrollViewport, {static: true}) viewport!: CdkVirtualScrollViewport;
@@ -1456,6 +1463,7 @@ class VirtualScrollWithAppendOnly {
     `,
   encapsulation: ViewEncapsulation.None,
   imports: [ScrollingModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class VirtualScrollWithCustomScrollingElement {
   @ViewChild(CdkVirtualScrollViewport, {static: true}) viewport!: CdkVirtualScrollViewport;
@@ -1497,6 +1505,7 @@ class VirtualScrollWithCustomScrollingElement {
     `,
   encapsulation: ViewEncapsulation.None,
   imports: [ScrollingModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class VirtualScrollWithScrollableWindow {
   @ViewChild(CdkVirtualScrollViewport, {static: true}) viewport!: CdkVirtualScrollViewport;
@@ -1509,6 +1518,7 @@ class VirtualScrollWithScrollableWindow {
 @Component({
   template: '<cdk-virtual-scroll-viewport itemSize="50"></cdk-virtual-scroll-viewport>',
   imports: [ScrollingModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class VirtualScrollableQuery {
   @ViewChild(CdkScrollable) scrollable!: CdkScrollable;

--- a/src/cdk/scrolling/virtual-scroll-viewport.zone.spec.ts
+++ b/src/cdk/scrolling/virtual-scroll-viewport.zone.spec.ts
@@ -7,6 +7,7 @@ import {
   ViewEncapsulation,
   afterNextRender,
   provideZoneChangeDetection,
+  ChangeDetectionStrategy,
 } from '@angular/core';
 import {ComponentFixture, TestBed, fakeAsync, flush} from '@angular/core/testing';
 import {animationFrameScheduler} from 'rxjs';
@@ -99,6 +100,7 @@ describe('CdkVirtualScrollViewport Zone.js intergation', () => {
     `,
   encapsulation: ViewEncapsulation.None,
   imports: [ScrollingModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class FixedSizeVirtualScroll {
   @ViewChild(CdkVirtualScrollViewport, {static: true}) viewport!: CdkVirtualScrollViewport;

--- a/src/cdk/table/table.spec.ts
+++ b/src/cdk/table/table.spec.ts
@@ -2223,6 +2223,7 @@ class BooleanDataSource extends DataSource<boolean> {
     </cdk-table>
   `,
   imports: [CdkTableModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SimpleCdkTableApp {
   dataSource = new FakeDataSource();
@@ -2255,6 +2256,7 @@ class SimpleCdkTableApp {
     </cdk-table>
   `,
   imports: [CdkTableModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class CdkTableWithDifferentDataInputsApp {
   dataSource: DataSource<TestData> | Observable<TestData[]> | TestData[] | any = null;
@@ -2276,6 +2278,7 @@ class CdkTableWithDifferentDataInputsApp {
     </cdk-table>
   `,
   imports: [CdkTableModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class BooleanRowCdkTableApp {
   dataSource = new BooleanDataSource();
@@ -2295,6 +2298,7 @@ class BooleanRowCdkTableApp {
     </cdk-table>
   `,
   imports: [CdkTableModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NullDataCdkTableApp {
   dataSource = observableOf<any>(null);
@@ -2327,6 +2331,7 @@ class NullDataCdkTableApp {
     </cdk-table>
   `,
   imports: [CdkTableModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MultipleHeaderFooterRowsCdkTableApp {}
 
@@ -2380,6 +2385,7 @@ class MultipleHeaderFooterRowsCdkTableApp {}
     </cdk-table>
   `,
   imports: [CdkTableModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class WhenRowCdkTableApp {
   multiTemplateDataRows = false;
@@ -2456,6 +2462,7 @@ class WhenRowCdkTableApp {
     </cdk-table>
   `,
   imports: [CdkTableModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class CoercedMultiTemplateDataRows extends WhenRowCdkTableApp {}
 
@@ -2493,6 +2500,7 @@ class CoercedMultiTemplateDataRows extends WhenRowCdkTableApp {}
     </cdk-table>
   `,
   imports: [CdkTableModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class WhenRowWithoutDefaultCdkTableApp {
   dataSource = new FakeDataSource();
@@ -2538,6 +2546,7 @@ class WhenRowWithoutDefaultCdkTableApp {
     </cdk-table>
   `,
   imports: [CdkTableModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class WhenRowMultipleDefaultsCdkTableApp {
   dataSource = new FakeDataSource();
@@ -2560,6 +2569,7 @@ class WhenRowMultipleDefaultsCdkTableApp {
     </cdk-table>
   `,
   imports: [CdkTableModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DynamicDataSourceCdkTableApp {
   dataSource!: FakeDataSource;
@@ -2586,6 +2596,7 @@ class DynamicDataSourceCdkTableApp {
     </cdk-table>
   `,
   imports: [CdkTableModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TrackByCdkTableApp {
   trackByStrategy: 'reference' | 'propertyA' | 'index' = 'reference';
@@ -2671,6 +2682,7 @@ class StickyPositioningListenerTest implements StickyPositioningListener {
   `,
   providers: [{provide: STICKY_POSITIONING_LISTENER, useExisting: StickyFlexLayoutCdkTableApp}],
   imports: [CdkTableModule, BidiModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class StickyFlexLayoutCdkTableApp extends StickyPositioningListenerTest {
   dataSource = new FakeDataSource();
@@ -2728,6 +2740,7 @@ class StickyFlexLayoutCdkTableApp extends StickyPositioningListenerTest {
   `,
   providers: [{provide: STICKY_POSITIONING_LISTENER, useExisting: StickyNativeLayoutCdkTableApp}],
   imports: [CdkTableModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class StickyNativeLayoutCdkTableApp extends StickyPositioningListenerTest {
   dataSource = new FakeDataSource();
@@ -2760,6 +2773,7 @@ class StickyNativeLayoutCdkTableApp extends StickyPositioningListenerTest {
     </cdk-table>
   `,
   imports: [CdkTableModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DynamicColumnDefinitionsCdkTableApp {
   dynamicColumns: any[] = [];
@@ -2781,6 +2795,7 @@ class DynamicColumnDefinitionsCdkTableApp {
     </cdk-table>
   `,
   imports: [CdkTableModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class CustomRoleCdkTableApp {
   dataSource = new FakeDataSource();
@@ -2802,6 +2817,7 @@ class CustomRoleCdkTableApp {
     </cdk-table>
   `,
   imports: [CdkTableModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class CrazyColumnNameCdkTableApp {
   dataSource = new FakeDataSource();
@@ -2828,6 +2844,7 @@ class CrazyColumnNameCdkTableApp {
     </cdk-table>
   `,
   imports: [CdkTableModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DuplicateColumnDefNameCdkTableApp {
   dataSource = new FakeDataSource();
@@ -2846,6 +2863,7 @@ class DuplicateColumnDefNameCdkTableApp {
     </cdk-table>
   `,
   imports: [CdkTableModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MissingColumnDefCdkTableApp {
   dataSource = new FakeDataSource();
@@ -2864,6 +2882,7 @@ class MissingColumnDefCdkTableApp {
     </cdk-table>
   `,
   imports: [CdkTableModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MissingColumnDefAfterRenderCdkTableApp implements AfterViewInit {
   dataSource!: FakeDataSource;
@@ -2888,6 +2907,7 @@ class MissingColumnDefAfterRenderCdkTableApp implements AfterViewInit {
     </cdk-table>
   `,
   imports: [CdkTableModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MissingAllRowDefsCdkTableApp {
   dataSource = new FakeDataSource();
@@ -2907,6 +2927,7 @@ class MissingAllRowDefsCdkTableApp {
     </cdk-table>
   `,
   imports: [CdkTableModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MissingHeaderRowDefCdkTableApp {
   dataSource = new FakeDataSource();
@@ -2926,6 +2947,7 @@ class MissingHeaderRowDefCdkTableApp {
     </cdk-table>
   `,
   imports: [CdkTableModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MissingRowDefCdkTableApp {
   dataSource = new FakeDataSource();
@@ -2945,6 +2967,7 @@ class MissingRowDefCdkTableApp {
     </cdk-table>
   `,
   imports: [CdkTableModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MissingFooterRowDefCdkTableApp {
   dataSource = new FakeDataSource();
@@ -2963,6 +2986,7 @@ class MissingFooterRowDefCdkTableApp {
     </cdk-table>
   `,
   imports: [CdkTableModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class UndefinedColumnsCdkTableApp {
   undefinedColumns: string[] | undefined;
@@ -2998,6 +3022,7 @@ class UndefinedColumnsCdkTableApp {
     </cdk-table>
   `,
   imports: [CdkTableModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class RowContextCdkTableApp {
   dataSource = new FakeDataSource();
@@ -3024,6 +3049,7 @@ class RowContextCdkTableApp {
     </cdk-table>
   `,
   imports: [CdkTableModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class WrapperCdkTableApp<T> implements AfterContentInit {
   @ContentChildren(CdkColumnDef, {descendants: false}) columnDefs!: QueryList<CdkColumnDef>;
@@ -3068,6 +3094,7 @@ class WrapperCdkTableApp<T> implements AfterContentInit {
     </wrapper-table>
   `,
   imports: [CdkTableModule, WrapperCdkTableApp],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class OuterTableApp {
   dataSource = new FakeDataSource();
@@ -3107,6 +3134,7 @@ class OuterTableApp {
     </table>
   `,
   imports: [CdkTableModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NativeHtmlTableApp {
   dataSource = new FakeDataSource();
@@ -3158,6 +3186,7 @@ class NativeHtmlTableApp {
     </table>
   `,
   imports: [CdkTableModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NestedHtmlTableApp {
   dataSource = new FakeDataSource();
@@ -3186,6 +3215,7 @@ class NestedHtmlTableApp {
     </table>
   `,
   imports: [CdkTableModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NativeTableWithNoHeaderOrFooterRows {
   dataSource = new FakeDataSource();
@@ -3208,6 +3238,7 @@ class NativeTableWithNoHeaderOrFooterRows {
     </table>
   `,
   imports: [CdkTableModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NativeHtmlTableWithCaptionApp {
   dataSource = new FakeDataSource();
@@ -3237,6 +3268,7 @@ class NativeHtmlTableWithCaptionApp {
     </table>
   `,
   imports: [CdkTableModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NativeHtmlTableWithColgroupAndCol {
   dataSource = new FakeDataSource();
@@ -3261,6 +3293,7 @@ class NativeHtmlTableWithColgroupAndCol {
     </cdk-table>
   `,
   imports: [CdkTableModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TableWithIndirectDescendantDefs {
   dataSource = new FakeDataSource();
@@ -3305,6 +3338,7 @@ class NativeHtmlTableAppOnPush {
     <cdk-table-change-detection-on-push [dataSource]="dataSource"></cdk-table-change-detection-on-push>
   `,
   imports: [NativeHtmlTableAppOnPush],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class WrapNativeHtmlTableAppOnPush {
   dataSource = new FakeDataSource();
@@ -3345,6 +3379,7 @@ class WrapNativeHtmlTableAppOnPush {
       overflow: auto;
     }
   `,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TableWithVirtualScroll {
   @ViewChild(CdkTable) table!: CdkTable<TestData>;
@@ -3372,6 +3407,7 @@ class TableWithVirtualScroll {
     </cdk-virtual-scroll-viewport>
   `,
   imports: [CdkTableModule, ScrollingModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TableWithVirtualScrollAndMultipleDefinitions extends TableWithVirtualScroll {
   predicate = () => true;

--- a/src/cdk/table/text-column.spec.ts
+++ b/src/cdk/table/text-column.spec.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import {Component, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 
 import {
@@ -149,6 +149,7 @@ interface TestData {
     </cdk-table>
   `,
   imports: [CdkTableModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class BasicTextColumnApp {
   displayedColumns = ['propertyA', 'propertyB', 'propertyC'];
@@ -168,6 +169,7 @@ class BasicTextColumnApp {
     <cdk-text-column name="column-a"></cdk-text-column>
   `,
   imports: [CdkTableModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MissingTableApp {}
 
@@ -181,5 +183,6 @@ class MissingTableApp {}
     </cdk-table>
   `,
   imports: [CdkTableModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TextColumnWithoutNameApp extends BasicTextColumnApp {}

--- a/src/cdk/text-field/autofill.spec.ts
+++ b/src/cdk/text-field/autofill.spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {normalizePassiveListenerOptions} from '../platform';
-import {Component, ElementRef, ViewChild} from '@angular/core';
+import {Component, ElementRef, ViewChild, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {EMPTY} from 'rxjs';
 import {AutofillEvent, AutofillMonitor} from './autofill';
@@ -193,6 +193,7 @@ describe('cdkAutofill', () => {
     <input #input3>
   `,
   imports: [TextFieldModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class Inputs {
   // Cast to `any` so we can stub out some methods in the tests.
@@ -204,6 +205,7 @@ class Inputs {
 @Component({
   template: `<input #input cdkAutofill>`,
   imports: [TextFieldModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class InputWithCdkAutofilled {
   // Cast to `any` so we can stub out some methods in the tests.

--- a/src/cdk/text-field/autofill.zone.spec.ts
+++ b/src/cdk/text-field/autofill.zone.spec.ts
@@ -1,4 +1,11 @@
-import {Component, ElementRef, NgZone, ViewChild, provideZoneChangeDetection} from '@angular/core';
+import {
+  Component,
+  ElementRef,
+  NgZone,
+  ViewChild,
+  provideZoneChangeDetection,
+  ChangeDetectionStrategy,
+} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {AutofillMonitor} from './autofill';
 import {TextFieldModule} from './text-field-module';
@@ -45,6 +52,7 @@ describe('AutofillMonitor Zone.js integration', () => {
       <input #input3>
     `,
   imports: [TextFieldModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class Inputs {
   // Cast to `any` so we can stub out some methods in the tests.

--- a/src/cdk/text-field/autosize.spec.ts
+++ b/src/cdk/text-field/autosize.spec.ts
@@ -1,4 +1,4 @@
-import {Component, ViewChild} from '@angular/core';
+import {Component, ViewChild, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed, fakeAsync, flush, tick} from '@angular/core/testing';
 import {FormsModule} from '@angular/forms';
 import {By} from '@angular/platform-browser';
@@ -388,6 +388,7 @@ const textareaStyleReset = `
         #autosize="cdkTextareaAutosize" [placeholder]="placeholder">{{content}}</textarea>`,
   styles: textareaStyleReset,
   imports: [FormsModule, TextFieldModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class AutosizeTextAreaWithContent {
   @ViewChild('autosize') autosize!: CdkTextareaAutosize;
@@ -401,6 +402,7 @@ class AutosizeTextAreaWithContent {
   template: `<textarea cdkTextareaAutosize [(ngModel)]="model"></textarea>`,
   styles: textareaStyleReset,
   imports: [FormsModule, TextFieldModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class AutosizeTextareaWithNgModel {
   model = '';
@@ -410,6 +412,7 @@ class AutosizeTextareaWithNgModel {
   template: `<textarea [cdkTextareaAutosize]="false">{{content}}</textarea>`,
   styles: textareaStyleReset,
   imports: [FormsModule, TextFieldModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class AutosizeTextareaWithoutAutosize {
   content: string = '';

--- a/src/cdk/tree/tree-using-legacy-key-manager.spec.ts
+++ b/src/cdk/tree/tree-using-legacy-key-manager.spec.ts
@@ -1,4 +1,11 @@
-import {Component, ElementRef, QueryList, ViewChild, ViewChildren} from '@angular/core';
+import {
+  Component,
+  ElementRef,
+  QueryList,
+  ViewChild,
+  ViewChildren,
+  ChangeDetectionStrategy,
+} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {of} from 'rxjs';
 import {CdkTreeModule} from './tree-module';
@@ -76,6 +83,7 @@ class MinimalTestData {
     </cdk-tree>
   `,
   imports: [CdkTreeModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SimpleCdkTreeApp {
   isExpandable = (node: MinimalTestData) => node.children.length > 0;

--- a/src/cdk/tree/tree-with-tree-control.spec.ts
+++ b/src/cdk/tree/tree-with-tree-control.spec.ts
@@ -14,6 +14,7 @@ import {
   ViewChildren,
   WritableSignal,
   ViewChild,
+  ChangeDetectionStrategy,
 } from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 
@@ -1442,6 +1443,7 @@ function expectNestedTreeToMatch(treeElement: Element, ...expectedTree: any[]) {
     </cdk-tree>
   `,
   imports: [CdkTreeModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SimpleCdkTreeApp {
   getLevel = (node: TestData) => node.level;
@@ -1468,6 +1470,7 @@ class SimpleCdkTreeApp {
     </cdk-tree>
   `,
   imports: [CdkTreeModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SimpleCdkTreeAppWithIndirectNodes extends SimpleCdkTreeApp {}
 
@@ -1481,6 +1484,7 @@ class SimpleCdkTreeAppWithIndirectNodes extends SimpleCdkTreeApp {}
     </cdk-tree>
   `,
   imports: [CdkTreeModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NestedCdkTreeApp {
   getChildren = (node: TestData) => node.observableChildren;
@@ -1505,6 +1509,7 @@ class NestedCdkTreeApp {
     </cdk-tree>
   `,
   imports: [CdkTreeModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class StaticNestedCdkTreeApp {
   getChildren = (node: TestData) => node.children;
@@ -1542,6 +1547,7 @@ class StaticNestedCdkTreeApp {
     </cdk-tree>
   `,
   imports: [CdkTreeModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class WhenNodeNestedCdkTreeApp {
   isSecondNode = (_: number, node: TestData) => node.pizzaBase.indexOf('2') > 0;
@@ -1566,6 +1572,7 @@ class WhenNodeNestedCdkTreeApp {
     </cdk-tree>
   `,
   imports: [CdkTreeModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class CdkTreeAppWithToggle {
   toggleRecursively: boolean = true;
@@ -1593,6 +1600,7 @@ class CdkTreeAppWithToggle {
     </cdk-tree>
   `,
   imports: [CdkTreeModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NestedCdkTreeAppWithToggle {
   toggleRecursively: boolean = true;
@@ -1623,6 +1631,7 @@ class NestedCdkTreeAppWithToggle {
     </cdk-tree>
   `,
   imports: [CdkTreeModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class WhenNodeCdkTreeApp {
   isOddNode = (_: number, node: TestData) => node.level % 2 === 1;
@@ -1647,6 +1656,7 @@ class WhenNodeCdkTreeApp {
     </cdk-tree>
   `,
   imports: [CdkTreeModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ArrayDataSourceCdkTreeApp {
   getLevel = (node: TestData) => node.level;
@@ -1674,6 +1684,7 @@ class ArrayDataSourceCdkTreeApp {
     </cdk-tree>
   `,
   imports: [CdkTreeModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ObservableDataSourceCdkTreeApp {
   getLevel = (node: TestData) => node.level;
@@ -1700,6 +1711,7 @@ class ObservableDataSourceCdkTreeApp {
     </cdk-tree>
   `,
   imports: [CdkTreeModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ArrayDataSourceNestedCdkTreeApp {
   getChildren = (node: TestData) => node.observableChildren;
@@ -1725,6 +1737,7 @@ class ArrayDataSourceNestedCdkTreeApp {
     </cdk-tree>
   `,
   imports: [CdkTreeModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ObservableDataSourceNestedCdkTreeApp {
   getChildren = (node: TestData) => node.observableChildren;
@@ -1751,6 +1764,7 @@ class ObservableDataSourceNestedCdkTreeApp {
     </cdk-tree>
   `,
   imports: [CdkTreeModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DepthNestedCdkTreeApp {
   getChildren = (node: TestData) => node.observableChildren;
@@ -1775,6 +1789,7 @@ class DepthNestedCdkTreeApp {
     </cdk-tree>
   `,
   imports: [CdkTreeModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class CdkTreeAppWithTrackBy {
   trackByStrategy: 'reference' | 'property' | 'index' = 'reference';
@@ -1809,6 +1824,7 @@ class CdkTreeAppWithTrackBy {
     </cdk-tree>
   `,
   imports: [CdkTreeModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NestedCdkTreeAppWithTrackBy {
   trackByStrategy: 'reference' | 'property' | 'index' = 'reference';

--- a/src/cdk/tree/tree.spec.ts
+++ b/src/cdk/tree/tree.spec.ts
@@ -17,6 +17,7 @@ import {
   WritableSignal,
   inject,
   signal,
+  ChangeDetectionStrategy,
 } from '@angular/core';
 import {ComponentFixture, TestBed, fakeAsync, tick} from '@angular/core/testing';
 import {AsyncPipe} from '@angular/common';
@@ -1700,6 +1701,7 @@ function expectNestedTreeToMatch(treeElement: Element, ...expectedTree: any[]) {
     </cdk-tree>
   `,
   imports: [CdkTreeModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SimpleCdkTreeApp {
   getLevel = (node: TestData) => node.level;
@@ -1728,6 +1730,7 @@ class SimpleCdkTreeApp {
     </cdk-tree>
   `,
   imports: [CdkTreeModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SimpleCdkTreeAppWithIndirectNodes extends SimpleCdkTreeApp {}
 
@@ -1742,6 +1745,7 @@ class SimpleCdkTreeAppWithIndirectNodes extends SimpleCdkTreeApp {}
     </cdk-tree>
   `,
   imports: [CdkTreeModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NestedCdkTreeApp {
   getChildren = (node: TestData) => node.observableChildren;
@@ -1766,6 +1770,7 @@ class NestedCdkTreeApp {
     </cdk-tree>
   `,
   imports: [CdkTreeModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class StaticNestedCdkTreeApp {
   getChildren = (node: TestData) => node.children;
@@ -1800,6 +1805,7 @@ class StaticNestedCdkTreeApp {
     </cdk-tree>
   `,
   imports: [CdkTreeModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class WhenNodeNestedCdkTreeApp {
   isSecondNode = (_: number, node: TestData) => node.pizzaBase.indexOf('2') > 0;
@@ -1824,6 +1830,7 @@ class WhenNodeNestedCdkTreeApp {
     </cdk-tree>
   `,
   imports: [CdkTreeModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class CdkTreeAppWithToggle {
   toggleRecursively: boolean = true;
@@ -1854,6 +1861,7 @@ class CdkTreeAppWithToggle {
     </cdk-tree>
   `,
   imports: [CdkTreeModule, AsyncPipe],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NestedCdkTreeAppWithToggle {
   toggleRecursively: boolean = true;
@@ -1886,6 +1894,7 @@ class NestedCdkTreeAppWithToggle {
     </cdk-tree>
   `,
   imports: [CdkTreeModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class WhenNodeCdkTreeApp {
   isOddNode = (_: number, node: TestData) => node.level % 2 === 1;
@@ -1910,6 +1919,7 @@ class WhenNodeCdkTreeApp {
     </cdk-tree>
   `,
   imports: [CdkTreeModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ArrayDataSourceCdkTreeApp {
   getLevel = (node: TestData) => node.level;
@@ -1945,6 +1955,7 @@ class ArrayDataSourceCdkTreeApp {
     </cdk-tree>
   `,
   imports: [CdkTreeModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ObservableDataSourceCdkTreeApp {
   getLevel = (node: TestData) => node.level;
@@ -1970,6 +1981,7 @@ class ObservableDataSourceCdkTreeApp {
     </cdk-tree>
   `,
   imports: [CdkTreeModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ArrayDataSourceNestedCdkTreeApp {
   getChildren = (node: TestData) => node.observableChildren;
@@ -1994,6 +2006,7 @@ class ArrayDataSourceNestedCdkTreeApp {
     </cdk-tree>
   `,
   imports: [CdkTreeModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ObservableDataSourceNestedCdkTreeApp {
   getChildren = (node: TestData) => node.observableChildren;
@@ -2019,6 +2032,7 @@ class ObservableDataSourceNestedCdkTreeApp {
     </cdk-tree>
   `,
   imports: [CdkTreeModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DepthNestedCdkTreeApp {
   getChildren = (node: TestData) => node.observableChildren;
@@ -2042,6 +2056,7 @@ class DepthNestedCdkTreeApp {
     </cdk-tree>
   `,
   imports: [CdkTreeModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class CdkTreeAppWithTrackBy {
   trackByStrategy: 'reference' | 'property' | 'index' = 'reference';
@@ -2076,6 +2091,7 @@ class CdkTreeAppWithTrackBy {
     </cdk-tree>
   `,
   imports: [CdkTreeModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NestedCdkTreeAppWithTrackBy {
   trackByStrategy: 'reference' | 'property' | 'index' = 'reference';
@@ -2120,6 +2136,7 @@ class MinimalTestData {
     </cdk-tree>
   `,
   imports: [CdkTreeModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TypeaheadLabelFlatTreeWithThreeNodes {
   isExpandable = (node: MinimalTestData) => node.children.length > 0;
@@ -2144,6 +2161,7 @@ class TypeaheadLabelFlatTreeWithThreeNodes {
     </cdk-tree>
   `,
   imports: [CdkTreeModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class FlatTreeWithThreeNodes {
   isExpandable = (node: MinimalTestData) => node.children.length > 0;
@@ -2171,6 +2189,7 @@ class FlatTreeWithThreeNodes {
     </cdk-tree>
   `,
   imports: [CdkTreeModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class IsExpandableOrderingTest {
   getChildren = (node: MinimalTestData) => node.children;

--- a/src/e2e-app/components/block-scroll-strategy/block-scroll-strategy-e2e.ts
+++ b/src/e2e-app/components/block-scroll-strategy/block-scroll-strategy-e2e.ts
@@ -1,4 +1,4 @@
-import {Component, inject, Injector} from '@angular/core';
+import {Component, inject, Injector, ChangeDetectionStrategy} from '@angular/core';
 import {createBlockScrollStrategy, OverlayContainer} from '@angular/cdk/overlay';
 import {ScrollingModule} from '@angular/cdk/scrolling';
 
@@ -7,6 +7,7 @@ import {ScrollingModule} from '@angular/cdk/scrolling';
   templateUrl: 'block-scroll-strategy-e2e.html',
   styleUrl: 'block-scroll-strategy-e2e.css',
   imports: [ScrollingModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 export class BlockScrollStrategyE2E {
   scrollStrategy = createBlockScrollStrategy(inject(Injector));

--- a/src/e2e-app/components/component-harness-e2e.ts
+++ b/src/e2e-app/components/component-harness-e2e.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import {Component, ChangeDetectionStrategy} from '@angular/core';
 import {TestMainComponent} from '@angular/cdk/testing/tests';
 
 @Component({
@@ -11,6 +11,7 @@ import {TestMainComponent} from '@angular/cdk/testing/tests';
     }
   `,
   imports: [TestMainComponent],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 export class ComponentHarnessE2e {
   protected isShown = true;

--- a/src/e2e-app/components/e2e-app/e2e-app.ts
+++ b/src/e2e-app/components/e2e-app/e2e-app.ts
@@ -1,4 +1,4 @@
-import {Component, ViewEncapsulation} from '@angular/core';
+import {Component, ViewEncapsulation, ChangeDetectionStrategy} from '@angular/core';
 import {MatListModule} from '@angular/material/list';
 import {RouterLink, RouterOutlet} from '@angular/router';
 
@@ -7,6 +7,7 @@ import {RouterLink, RouterOutlet} from '@angular/router';
   templateUrl: 'e2e-app.html',
   encapsulation: ViewEncapsulation.None,
   imports: [MatListModule, RouterLink, RouterOutlet],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 export class E2eApp {
   showLinks = false;

--- a/src/e2e-app/components/home.ts
+++ b/src/e2e-app/components/home.ts
@@ -1,7 +1,8 @@
-import {Component} from '@angular/core';
+import {Component, ChangeDetectionStrategy} from '@angular/core';
 
 @Component({
   selector: 'home',
   template: `<p>Welcome to the e2e tests app</p>`,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 export class Home {}

--- a/src/e2e-app/components/slider-e2e.ts
+++ b/src/e2e-app/components/slider-e2e.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component} from '@angular/core';
+import {Component, ChangeDetectionStrategy} from '@angular/core';
 import {MatSliderModule} from '@angular/material/slider';
 
 @Component({
@@ -27,5 +27,6 @@ import {MatSliderModule} from '@angular/material/slider';
     `,
   styles: '.mat-mdc-slider { width: 148px; }',
   imports: [MatSliderModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 export class SliderE2e {}

--- a/src/e2e-app/components/virtual-scroll/virtual-scroll-e2e.ts
+++ b/src/e2e-app/components/virtual-scroll/virtual-scroll-e2e.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import {Component, ChangeDetectionStrategy} from '@angular/core';
 import {ScrollingModule} from '@angular/cdk/scrolling';
 import {ScrollingModule as ExperimentalScrollingModule} from '@angular/cdk-experimental/scrolling';
 
@@ -9,6 +9,7 @@ const itemSizeSample = [100, 25, 50, 50, 100, 200, 75, 100, 50, 250];
   templateUrl: 'virtual-scroll-e2e.html',
   styleUrl: 'virtual-scroll-e2e.css',
   imports: [ScrollingModule, ExperimentalScrollingModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 export class VirtualScrollE2E {
   uniformItems = Array(1000).fill(50);

--- a/src/google-maps/deprecated-map-marker-clusterer/deprecated-map-marker-clusterer.spec.ts
+++ b/src/google-maps/deprecated-map-marker-clusterer/deprecated-map-marker-clusterer.spec.ts
@@ -1,4 +1,4 @@
-import {Component, ViewChild} from '@angular/core';
+import {Component, ViewChild, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed, fakeAsync, flush} from '@angular/core/testing';
 
 import {DEFAULT_OPTIONS, GoogleMap} from '../google-map/google-map';
@@ -343,6 +343,7 @@ describe('DeprecatedMapMarkerClusterer', () => {
     </google-map>
   `,
   imports: [GoogleMap, MapMarker, DeprecatedMapMarkerClusterer],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TestApp {
   @ViewChild(DeprecatedMapMarkerClusterer) markerClusterer!: DeprecatedMapMarkerClusterer;

--- a/src/google-maps/google-map/google-map.spec.ts
+++ b/src/google-maps/google-map/google-map.spec.ts
@@ -1,4 +1,4 @@
-import {Component, ViewChild} from '@angular/core';
+import {Component, ViewChild, ChangeDetectionStrategy} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
@@ -445,6 +445,7 @@ describe('GoogleMap', () => {
       (mapInitialized)="mapInitializedSpy($event)" />
   `,
   imports: [GoogleMap],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TestApp {
   @ViewChild(GoogleMap) map!: GoogleMap;

--- a/src/google-maps/map-advanced-marker/map-advanced-marker.spec.ts
+++ b/src/google-maps/map-advanced-marker/map-advanced-marker.spec.ts
@@ -1,4 +1,4 @@
-import {Component, ViewChild} from '@angular/core';
+import {Component, ViewChild, ChangeDetectionStrategy} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 
 import {DEFAULT_OPTIONS, GoogleMap} from '../google-map/google-map';
@@ -173,6 +173,7 @@ describe('MapAdvancedMarker', () => {
     </google-map>
   `,
   imports: [GoogleMap, MapAdvancedMarker],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TestApp {
   @ViewChild(MapAdvancedMarker) advancedMarker!: MapAdvancedMarker;

--- a/src/google-maps/map-bicycling-layer/map-bicycling-layer.spec.ts
+++ b/src/google-maps/map-bicycling-layer/map-bicycling-layer.spec.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import {Component, ChangeDetectionStrategy} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 
 import {DEFAULT_OPTIONS, GoogleMap} from '../google-map/google-map';
@@ -42,5 +42,6 @@ describe('MapBicyclingLayer', () => {
     </google-map>
   `,
   imports: [GoogleMap, MapBicyclingLayer],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TestApp {}

--- a/src/google-maps/map-circle/map-circle.spec.ts
+++ b/src/google-maps/map-circle/map-circle.spec.ts
@@ -1,4 +1,4 @@
-import {Component, ViewChild} from '@angular/core';
+import {Component, ViewChild, ChangeDetectionStrategy} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
@@ -161,6 +161,7 @@ describe('MapCircle', () => {
         (circleRightclick)="handleRightclick()" />
     </google-map>`,
   imports: [GoogleMap, MapCircle],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TestApp {
   @ViewChild(MapCircle) circle!: MapCircle;

--- a/src/google-maps/map-directions-renderer/map-directions-renderer.spec.ts
+++ b/src/google-maps/map-directions-renderer/map-directions-renderer.spec.ts
@@ -1,4 +1,4 @@
-import {Component, ViewChild} from '@angular/core';
+import {Component, ViewChild, ChangeDetectionStrategy} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {MapDirectionsRenderer} from './map-directions-renderer';
@@ -132,6 +132,7 @@ describe('MapDirectionsRenderer', () => {
     </google-map>
   `,
   imports: [GoogleMap, MapDirectionsRenderer],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TestApp {
   @ViewChild(MapDirectionsRenderer) directionsRenderer!: MapDirectionsRenderer;

--- a/src/google-maps/map-ground-overlay/map-ground-overlay.spec.ts
+++ b/src/google-maps/map-ground-overlay/map-ground-overlay.spec.ts
@@ -1,4 +1,4 @@
-import {Component, ViewChild} from '@angular/core';
+import {Component, ViewChild, ChangeDetectionStrategy} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
@@ -162,6 +162,7 @@ describe('MapGroundOverlay', () => {
     </google-map>
   `,
   imports: [GoogleMap, MapGroundOverlay],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TestApp {
   @ViewChild(MapGroundOverlay) groundOverlay!: MapGroundOverlay;

--- a/src/google-maps/map-heatmap-layer/map-heatmap-layer.spec.ts
+++ b/src/google-maps/map-heatmap-layer/map-heatmap-layer.spec.ts
@@ -1,4 +1,4 @@
-import {Component, ViewChild} from '@angular/core';
+import {Component, ViewChild, ChangeDetectionStrategy} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 
 import {DEFAULT_OPTIONS, GoogleMap} from '../google-map/google-map';
@@ -158,6 +158,7 @@ describe('MapHeatmapLayer', () => {
     </google-map>
   `,
   imports: [GoogleMap, MapHeatmapLayer],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TestApp {
   @ViewChild(MapHeatmapLayer) heatmap!: MapHeatmapLayer;

--- a/src/google-maps/map-info-window/map-info-window.spec.ts
+++ b/src/google-maps/map-info-window/map-info-window.spec.ts
@@ -1,4 +1,4 @@
-import {Component, ViewChild} from '@angular/core';
+import {Component, ViewChild, ChangeDetectionStrategy} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
@@ -249,6 +249,7 @@ describe('MapInfoWindow', () => {
     </google-map>
   `,
   imports: [GoogleMap, MapInfoWindow],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TestApp {
   @ViewChild(MapInfoWindow) infoWindow!: MapInfoWindow;

--- a/src/google-maps/map-kml-layer/map-kml-layer.spec.ts
+++ b/src/google-maps/map-kml-layer/map-kml-layer.spec.ts
@@ -1,4 +1,4 @@
-import {Component, ViewChild} from '@angular/core';
+import {Component, ViewChild, ChangeDetectionStrategy} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
@@ -149,6 +149,7 @@ describe('MapKmlLayer', () => {
     </google-map>
   `,
   imports: [GoogleMap, MapKmlLayer],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TestApp {
   @ViewChild(MapKmlLayer) kmlLayer!: MapKmlLayer;

--- a/src/google-maps/map-marker-clusterer/map-marker-clusterer.spec.ts
+++ b/src/google-maps/map-marker-clusterer/map-marker-clusterer.spec.ts
@@ -1,4 +1,4 @@
-import {Component, ViewChild} from '@angular/core';
+import {Component, ViewChild, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed, fakeAsync, flush} from '@angular/core/testing';
 import type {MarkerClusterer, Renderer, Algorithm} from './map-marker-clusterer-types';
 
@@ -197,6 +197,7 @@ describe('MapMarkerClusterer', () => {
       </map-marker-clusterer>
     </google-map>
   `,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TestApp {
   @ViewChild(MapMarkerClusterer) markerClusterer!: MapMarkerClusterer;

--- a/src/google-maps/map-marker/map-marker.spec.ts
+++ b/src/google-maps/map-marker/map-marker.spec.ts
@@ -1,4 +1,4 @@
-import {Component, ViewChild} from '@angular/core';
+import {Component, ViewChild, ChangeDetectionStrategy} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 
 import {DEFAULT_OPTIONS, GoogleMap} from '../google-map/google-map';
@@ -228,6 +228,7 @@ describe('MapMarker', () => {
     </google-map>
   `,
   imports: [GoogleMap, MapMarker],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TestApp {
   @ViewChild(MapMarker) marker!: MapMarker;

--- a/src/google-maps/map-polygon/map-polygon.spec.ts
+++ b/src/google-maps/map-polygon/map-polygon.spec.ts
@@ -1,4 +1,4 @@
-import {Component, ViewChild} from '@angular/core';
+import {Component, ViewChild, ChangeDetectionStrategy} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
@@ -152,6 +152,7 @@ describe('MapPolygon', () => {
     </google-map>
   `,
   imports: [GoogleMap, MapPolygon],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TestApp {
   @ViewChild(MapPolygon) polygon!: MapPolygon;

--- a/src/google-maps/map-polyline/map-polyline.spec.ts
+++ b/src/google-maps/map-polyline/map-polyline.spec.ts
@@ -1,4 +1,4 @@
-import {Component, ViewChild} from '@angular/core';
+import {Component, ViewChild, ChangeDetectionStrategy} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
@@ -152,6 +152,7 @@ describe('MapPolyline', () => {
     </google-map>
   `,
   imports: [GoogleMap, MapPolyline],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TestApp {
   @ViewChild(MapPolyline) polyline!: MapPolyline;

--- a/src/google-maps/map-rectangle/map-rectangle.spec.ts
+++ b/src/google-maps/map-rectangle/map-rectangle.spec.ts
@@ -1,4 +1,4 @@
-import {Component, ViewChild} from '@angular/core';
+import {Component, ViewChild, ChangeDetectionStrategy} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
@@ -146,6 +146,7 @@ describe('MapRectangle', () => {
     </google-map>
   `,
   imports: [GoogleMap, MapRectangle],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TestApp {
   @ViewChild(MapRectangle) rectangle!: MapRectangle;

--- a/src/google-maps/map-traffic-layer/map-traffic-layer.spec.ts
+++ b/src/google-maps/map-traffic-layer/map-traffic-layer.spec.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import {Component, ChangeDetectionStrategy} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 
 import {DEFAULT_OPTIONS, GoogleMap} from '../google-map/google-map';
@@ -44,6 +44,7 @@ describe('MapTrafficLayer', () => {
     </google-map>
   `,
   imports: [GoogleMap, MapTrafficLayer],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TestApp {
   autoRefresh = false;

--- a/src/google-maps/map-transit-layer/map-transit-layer.spec.ts
+++ b/src/google-maps/map-transit-layer/map-transit-layer.spec.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import {Component, ChangeDetectionStrategy} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 
 import {DEFAULT_OPTIONS, GoogleMap} from '../google-map/google-map';
@@ -43,5 +43,6 @@ describe('MapTransitLayer', () => {
     </google-map>
   `,
   imports: [GoogleMap, MapTransitLayer],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TestApp {}

--- a/src/material-experimental/column-resize/column-resize.spec.ts
+++ b/src/material-experimental/column-resize/column-resize.spec.ts
@@ -277,6 +277,7 @@ abstract class BaseTestComponentRtl extends BaseTestComponent {
 @Component({
   template: getTableTemplate(false),
   imports: [BidiModule, MatTableModule, MatColumnResizeModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatResizeTest extends BaseTestComponent {
   @ViewChild(MatColumnResize) columnResize!: AbstractMatColumnResize;
@@ -292,6 +293,7 @@ class MatResizeOnPushTest extends MatResizeTest {}
 @Component({
   template: getTableTemplate(true),
   imports: [BidiModule, MatTableModule, MatDefaultEnabledColumnResizeModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatResizeDefaultTest extends BaseTestComponent {
   @ViewChild(MatDefaultEnabledColumnResize) columnResize!: AbstractMatColumnResize;
@@ -300,6 +302,7 @@ class MatResizeDefaultTest extends BaseTestComponent {
 @Component({
   template: getTableTemplate(true),
   imports: [BidiModule, MatTableModule, MatDefaultEnabledColumnResizeModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatResizeDefaultRtlTest extends BaseTestComponentRtl {
   @ViewChild(MatDefaultEnabledColumnResize) columnResize!: AbstractMatColumnResize;
@@ -308,6 +311,7 @@ class MatResizeDefaultRtlTest extends BaseTestComponentRtl {
 @Component({
   template: getFlexTemplate(false),
   imports: [BidiModule, MatTableModule, MatColumnResizeModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatResizeFlexTest extends BaseTestComponent {
   @ViewChild(MatColumnResizeFlex) columnResize!: AbstractMatColumnResize;
@@ -316,6 +320,7 @@ class MatResizeFlexTest extends BaseTestComponent {
 @Component({
   template: getFlexTemplate(true),
   imports: [BidiModule, MatTableModule, MatDefaultEnabledColumnResizeModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatResizeDefaultFlexTest extends BaseTestComponent {
   @ViewChild(MatDefaultEnabledColumnResizeFlex)
@@ -325,6 +330,7 @@ class MatResizeDefaultFlexTest extends BaseTestComponent {
 @Component({
   template: getFlexTemplate(true),
   imports: [BidiModule, MatTableModule, MatDefaultEnabledColumnResizeModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatResizeDefaultFlexRtlTest extends BaseTestComponentRtl {
   @ViewChild(MatDefaultEnabledColumnResizeFlex)

--- a/src/material-experimental/menubar/menubar-item.spec.ts
+++ b/src/material-experimental/menubar/menubar-item.spec.ts
@@ -1,4 +1,4 @@
-import {Component, ElementRef, ViewChild} from '@angular/core';
+import {Component, ElementRef, ViewChild, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {CdkMenuItem, CdkMenuModule, CdkMenu} from '@angular/cdk/menu';
 import {MatMenuBarItem} from './menubar-item';
@@ -57,6 +57,7 @@ describe('MatMenuBarItem', () => {
     </ng-template>
   `,
   imports: [MatMenuBarModule, CdkMenuModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SimpleMenuBarItem {
   @ViewChild(CdkMenuItem) menubarItem!: MatMenuBarItem;

--- a/src/material-experimental/menubar/menubar.spec.ts
+++ b/src/material-experimental/menubar/menubar.spec.ts
@@ -1,4 +1,4 @@
-import {Component, ViewChild, ElementRef} from '@angular/core';
+import {Component, ViewChild, ElementRef, ChangeDetectionStrategy} from '@angular/core';
 import {RIGHT_ARROW} from '@angular/cdk/keycodes';
 import {CdkMenuBar} from '@angular/cdk/menu';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
@@ -50,6 +50,7 @@ describe('MatMenuBar', () => {
     </mat-menubar>
   `,
   imports: [MatMenuBarModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SimpleMatMenuBar {
   @ViewChild(CdkMenuBar) matMenubar!: MatMenuBar;

--- a/src/material-experimental/popover-edit/popover-edit.spec.ts
+++ b/src/material-experimental/popover-edit/popover-edit.spec.ts
@@ -1,6 +1,6 @@
 import {DataSource} from '@angular/cdk/collections';
 import {DOWN_ARROW, LEFT_ARROW, RIGHT_ARROW, TAB, UP_ARROW} from '@angular/cdk/keycodes';
-import {Component, Directive, ElementRef, ViewChild} from '@angular/core';
+import {Component, Directive, ElementRef, ViewChild, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed, fakeAsync, flush, tick} from '@angular/core/testing';
 import {FormsModule, NgForm} from '@angular/forms';
 import {MatTableModule} from '@angular/material/table';
@@ -230,6 +230,7 @@ class ElementDataSource extends DataSource<PeriodicElement> {
     }
   `,
   imports: [MatTableModule, MatPopoverEditModule, FormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatFlexTableInCell extends BaseTestComponent {
   displayedColumns = ['before', 'name', 'weight'];
@@ -282,6 +283,7 @@ class MatFlexTableInCell extends BaseTestComponent {
     }
   `,
   imports: [MatTableModule, MatPopoverEditModule, FormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatTableInCell extends BaseTestComponent {
   displayedColumns = ['before', 'name', 'weight'];

--- a/src/material/autocomplete/autocomplete.spec.ts
+++ b/src/material/autocomplete/autocomplete.spec.ts
@@ -4043,6 +4043,7 @@ const SIMPLE_AUTOCOMPLETE_TEMPLATE = `
     MatInputModule,
     ReactiveFormsModule,
   ],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SimpleAutocomplete implements OnDestroy {
   stateCtrl = new FormControl<{name: string; code: string} | string | null>(null);
@@ -4109,6 +4110,7 @@ class SimpleAutocomplete implements OnDestroy {
     MatInputModule,
     ReactiveFormsModule,
   ],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SimpleAutocompleteShadowDom extends SimpleAutocomplete {}
 
@@ -4136,6 +4138,7 @@ class SimpleAutocompleteShadowDom extends SimpleAutocomplete {}
     ReactiveFormsModule,
     AsyncPipe,
   ],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NgIfAutocomplete {
   optionCtrl = new FormControl('');
@@ -4174,6 +4177,7 @@ class NgIfAutocomplete {
     </mat-autocomplete>
   `,
   imports: [MatAutocomplete, MatAutocompleteTrigger, MatOption, MatInputModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class AutocompleteWithoutForms {
   filteredStates!: any[];
@@ -4204,6 +4208,7 @@ class AutocompleteWithoutForms {
     </mat-autocomplete>
   `,
   imports: [MatAutocomplete, MatAutocompleteTrigger, MatOption, MatInputModule, FormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class AutocompleteWithNgModel {
   filteredStates!: any[];
@@ -4236,6 +4241,7 @@ class AutocompleteWithNgModel {
     </mat-autocomplete>
   `,
   imports: [MatAutocomplete, MatAutocompleteTrigger, MatOption, MatInputModule, FormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class AutocompleteWithNumbers {
   selectedNumber!: number;
@@ -4285,6 +4291,7 @@ class AutocompleteWithOnPushDelay implements OnInit {
     </mat-autocomplete>
   `,
   imports: [MatAutocomplete, MatAutocompleteTrigger, MatOption, ReactiveFormsModule, AsyncPipe],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class AutocompleteWithNativeInput {
   optionCtrl = new FormControl('');
@@ -4309,6 +4316,7 @@ class AutocompleteWithNativeInput {
 @Component({
   template: `<input placeholder="Choose" [matAutocomplete]="null!" [formControl]="control">`,
   imports: [MatAutocompleteTrigger, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class AutocompleteWithoutPanel {
   @ViewChild(MatAutocompleteTrigger) trigger!: MatAutocompleteTrigger;
@@ -4341,6 +4349,7 @@ class AutocompleteWithoutPanel {
     MatInputModule,
     FormsModule,
   ],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class AutocompleteWithGroups {
   @ViewChild(MatAutocompleteTrigger) trigger!: MatAutocompleteTrigger;
@@ -4389,6 +4398,7 @@ class AutocompleteWithGroups {
     MatInputModule,
     FormsModule,
   ],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class AutocompleteWithIndirectGroups extends AutocompleteWithGroups {}
 
@@ -4407,6 +4417,7 @@ class AutocompleteWithIndirectGroups extends AutocompleteWithGroups {}
     </mat-autocomplete>
   `,
   imports: [MatAutocomplete, MatAutocompleteTrigger, MatOption, MatInputModule, FormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class AutocompleteWithSelectEvent {
   selectedState!: string;
@@ -4423,6 +4434,7 @@ class AutocompleteWithSelectEvent {
     <mat-autocomplete #auto="matAutocomplete"></mat-autocomplete>
   `,
   imports: [MatAutocomplete, MatAutocompleteTrigger, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class PlainAutocompleteInputWithFormControl {
   formControl = new FormControl('');
@@ -4441,6 +4453,7 @@ class PlainAutocompleteInputWithFormControl {
     </mat-autocomplete>
   `,
   imports: [MatAutocomplete, MatAutocompleteTrigger, MatOption, MatInputModule, FormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class AutocompleteWithNumberInputAndNgModel {
   selectedValue!: number;
@@ -4481,6 +4494,7 @@ class AutocompleteWithNumberInputAndNgModel {
     MatInputModule,
     FormsModule,
   ],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class AutocompleteWithDifferentOrigin {
   @ViewChild(MatAutocompleteTrigger) trigger!: MatAutocompleteTrigger;
@@ -4496,6 +4510,7 @@ class AutocompleteWithDifferentOrigin {
     <mat-autocomplete #auto="matAutocomplete"></mat-autocomplete>
   `,
   imports: [MatAutocomplete, MatAutocompleteTrigger, FormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class AutocompleteWithNativeAutocompleteAttribute {
   value!: string;
@@ -4504,6 +4519,7 @@ class AutocompleteWithNativeAutocompleteAttribute {
 @Component({
   template: '<input [matAutocomplete]="null!" matAutocompleteDisabled>',
   imports: [MatAutocompleteTrigger],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class InputWithoutAutocompleteAndDisabled {}
 
@@ -4520,6 +4536,7 @@ class InputWithoutAutocompleteAndDisabled {}
     </mat-autocomplete>
   `,
   imports: [MatAutocomplete, MatAutocompleteTrigger, MatOption, MatInputModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class AutocompleteWithActivatedEvent {
   states = ['California', 'West Virginia', 'Florida'];
@@ -4556,6 +4573,7 @@ class AutocompleteWithActivatedEvent {
     ReactiveFormsModule,
     OverlayModule,
   ],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class AutocompleteInsideAModal {
   foods = [
@@ -4582,6 +4600,7 @@ class AutocompleteInsideAModal {
     </mat-autocomplete>
   `,
   imports: [MatAutocomplete, MatAutocompleteTrigger, MatInputModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class AutocompleteWithoutOptions {
   @ViewChild(MatAutocompleteTrigger, {static: true}) trigger!: MatAutocompleteTrigger;

--- a/src/material/autocomplete/autocomplete.zone.spec.ts
+++ b/src/material/autocomplete/autocomplete.zone.spec.ts
@@ -9,6 +9,7 @@ import {
   ViewChild,
   ViewChildren,
   provideZoneChangeDetection,
+  ChangeDetectionStrategy,
 } from '@angular/core';
 import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 import {FormControl, ReactiveFormsModule} from '@angular/forms';
@@ -116,6 +117,7 @@ describe('MatAutocomplete Zone.js integration', () => {
     </mat-autocomplete>
   `,
   imports: [MatAutocompleteModule, MatInputModule, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SimpleAutocomplete implements OnDestroy {
   stateCtrl = new FormControl<{name: string; code: string} | string | null>(null);

--- a/src/material/autocomplete/testing/autocomplete-harness.spec.ts
+++ b/src/material/autocomplete/testing/autocomplete-harness.spec.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import {Component, ChangeDetectionStrategy} from '@angular/core';
 import {MatAutocompleteModule} from '../autocomplete-module';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
@@ -172,6 +172,7 @@ describe('MatAutocompleteHarness', () => {
     <input id="grouped" [matAutocomplete]="groupedAutocomplete">
   `,
   imports: [MatAutocompleteModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class AutocompleteHarnessTest {
   states = [

--- a/src/material/badge/badge.spec.ts
+++ b/src/material/badge/badge.spec.ts
@@ -1,5 +1,12 @@
 import {ComponentFixture, TestBed} from '@angular/core/testing';
-import {Component, DebugElement, ViewEncapsulation, ViewChild, signal} from '@angular/core';
+import {
+  Component,
+  DebugElement,
+  ViewEncapsulation,
+  ViewChild,
+  signal,
+  ChangeDetectionStrategy,
+} from '@angular/core';
 import {By} from '@angular/platform-browser';
 import {MatBadge, MatBadgeModule, MatBadgePosition, MatBadgeSize} from './index';
 import {ThemePalette} from '../core';
@@ -278,6 +285,7 @@ describe('MatBadge', () => {
     </button>
   `,
   imports: [MatBadgeModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class BadgeOnInteractiveElement {
   @ViewChild(MatBadge) badgeInstance!: MatBadge;
@@ -294,6 +302,7 @@ class BadgeOnInteractiveElement {
 @Component({
   template: '<span matBadge="7" [matBadgeDescription]="description()">Hello</span>',
   imports: [MatBadgeModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class BadgeOnNonInteractiveElement {
   description = signal('');
@@ -307,6 +316,7 @@ class BadgeOnNonInteractiveElement {
     </span>
   `,
   imports: [MatBadgeModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class PreExistingBadge {}
 
@@ -318,6 +328,7 @@ class PreExistingBadge {}
     </span>
   `,
   imports: [MatBadgeModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NestedBadge {}
 
@@ -325,5 +336,6 @@ class NestedBadge {}
   template: `
     <ng-template matBadge="1">Notifications</ng-template>`,
   imports: [MatBadgeModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class BadgeOnTemplate {}

--- a/src/material/badge/testing/badge-harness.spec.ts
+++ b/src/material/badge/testing/badge-harness.spec.ts
@@ -1,6 +1,6 @@
 import {HarnessLoader} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
-import {Component} from '@angular/core';
+import {Component, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatBadgeModule, MatBadgePosition, MatBadgeSize} from '../../badge';
 import {MatBadgeHarness} from './badge-harness';
@@ -133,6 +133,7 @@ describe('MatBadgeHarness', () => {
       [matBadgeDisabled]="disabled">Disabled</button>
   `,
   imports: [MatBadgeModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class BadgeHarnessTest {
   simpleContent = 'Simple badge';

--- a/src/material/bottom-sheet/bottom-sheet.spec.ts
+++ b/src/material/bottom-sheet/bottom-sheet.spec.ts
@@ -24,6 +24,7 @@ import {
   ViewEncapsulation,
   forwardRef,
   inject,
+  ChangeDetectionStrategy,
 } from '@angular/core';
 import {
   ComponentFixture,
@@ -1020,6 +1021,7 @@ class DirectiveWithViewContainer {
 @Component({
   template: `<dir-with-view-container></dir-with-view-container>`,
   imports: [DirectiveWithViewContainer],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ComponentWithChildViewContainer {
   @ViewChild(DirectiveWithViewContainer) childWithViewContainer!: DirectiveWithViewContainer;
@@ -1033,6 +1035,7 @@ class ComponentWithChildViewContainer {
   selector: 'arbitrary-component-with-template-ref',
   template: `<ng-template let-data let-bottomSheetRef="bottomSheetRef">
       Cheese {{localValue}} {{data?.value}}{{setRef(bottomSheetRef)}}</ng-template>`,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ComponentWithTemplateRef {
   localValue!: string;
@@ -1048,6 +1051,7 @@ class ComponentWithTemplateRef {
 
 @Component({
   template: '<p>Pizza</p> <input> <button>Close</button>',
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class PizzaMsg {
   bottomSheetRef = inject<MatBottomSheetRef<PizzaMsg>>(MatBottomSheetRef);
@@ -1057,6 +1061,7 @@ class PizzaMsg {
 
 @Component({
   template: '<p>Taco</p>',
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TacoMsg {}
 
@@ -1065,6 +1070,7 @@ class TacoMsg {}
     <h1>This is the title</h1>
     <p>This is the paragraph</p>
   `,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ContentElementDialog {}
 
@@ -1072,6 +1078,7 @@ class ContentElementDialog {}
   template: '',
   providers: [MatBottomSheet],
   imports: [MatBottomSheetModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ComponentThatProvidesMatBottomSheet {
   bottomSheet = inject(MatBottomSheet);
@@ -1079,6 +1086,7 @@ class ComponentThatProvidesMatBottomSheet {
 
 @Component({
   template: '',
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class BottomSheetWithInjectedData {
   data = inject(MAT_BOTTOM_SHEET_DATA);
@@ -1087,11 +1095,13 @@ class BottomSheetWithInjectedData {
 @Component({
   template: `<button>I'm a button</button>`,
   encapsulation: ViewEncapsulation.ShadowDom,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ShadowDomComponent {}
 
 @Component({
   template: '',
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ModuleBoundBottomSheetParentComponent {
   private _injector = inject(Injector);
@@ -1116,12 +1126,14 @@ class ModuleBoundBottomSheetService {
   template:
     '<module-bound-bottom-sheet-child-component></module-bound-bottom-sheet-child-component>',
   imports: [forwardRef(() => ModuleBoundBottomSheetChildComponent)],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ModuleBoundBottomSheetComponent {}
 
 @Component({
   selector: 'module-bound-bottom-sheet-child-component',
   template: '<p>{{service.name}}</p>',
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ModuleBoundBottomSheetChildComponent {
   service = inject(ModuleBoundBottomSheetService);

--- a/src/material/bottom-sheet/testing/bottom-sheet-harness.spec.ts
+++ b/src/material/bottom-sheet/testing/bottom-sheet-harness.spec.ts
@@ -1,4 +1,4 @@
-import {Component, TemplateRef, ViewChild, inject} from '@angular/core';
+import {Component, TemplateRef, ViewChild, inject, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
@@ -46,6 +46,7 @@ describe('MatBottomSheetHarness', () => {
     </ng-template>
   `,
   imports: [MatBottomSheetModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class BottomSheetHarnessTest {
   readonly bottomSheet = inject(MatBottomSheet);

--- a/src/material/button-toggle/button-toggle.spec.ts
+++ b/src/material/button-toggle/button-toggle.spec.ts
@@ -1,6 +1,13 @@
 import {createKeyboardEvent, dispatchEvent, dispatchMouseEvent} from '@angular/cdk/testing/private';
 import {DOWN_ARROW, LEFT_ARROW, RIGHT_ARROW, UP_ARROW} from '@angular/cdk/keycodes';
-import {Component, DebugElement, QueryList, ViewChild, ViewChildren} from '@angular/core';
+import {
+  Component,
+  DebugElement,
+  QueryList,
+  ViewChild,
+  ViewChildren,
+  ChangeDetectionStrategy,
+} from '@angular/core';
 import {
   ComponentFixture,
   TestBed,
@@ -1166,6 +1173,7 @@ describe('MatButtonToggle without forms', () => {
   </mat-button-toggle-group>
   `,
   imports: [MatButtonToggleModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ButtonTogglesInsideButtonToggleGroup {
   isGroupDisabled: boolean = false;
@@ -1190,6 +1198,7 @@ class ButtonTogglesInsideButtonToggleGroup {
   </mat-button-toggle-group>
   `,
   imports: [MatButtonToggleModule, FormsModule, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ButtonToggleGroupWithNgModel {
   groupName = 'group-name';
@@ -1212,6 +1221,7 @@ class ButtonToggleGroupWithNgModel {
   </mat-button-toggle-group>
   `,
   imports: [MatButtonToggleModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ButtonTogglesInsideButtonToggleGroupMultiple {
   isGroupDisabled: boolean = false;
@@ -1228,6 +1238,7 @@ class ButtonTogglesInsideButtonToggleGroupMultiple {
   </mat-button-toggle-group>
   `,
   imports: [MatButtonToggleModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class FalsyButtonTogglesInsideButtonToggleGroupMultiple {
   value: ('' | number | null | undefined | boolean)[] = [0];
@@ -1239,6 +1250,7 @@ class FalsyButtonTogglesInsideButtonToggleGroupMultiple {
   <mat-button-toggle>Yes</mat-button-toggle>
   `,
   imports: [MatButtonToggleModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class StandaloneButtonToggle {}
 
@@ -1250,6 +1262,7 @@ class StandaloneButtonToggle {}
   </mat-button-toggle-group>
   `,
   imports: [MatButtonToggleModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ButtonToggleGroupWithInitialValue {
   lastEvent!: MatButtonToggleChange;
@@ -1264,6 +1277,7 @@ class ButtonToggleGroupWithInitialValue {
   </mat-button-toggle-group>
   `,
   imports: [MatButtonToggleModule, FormsModule, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ButtonToggleGroupWithFormControl {
   control = new FormControl('');
@@ -1281,6 +1295,7 @@ class ButtonToggleGroupWithFormControl {
     </mat-button-toggle-group>
   `,
   imports: [MatButtonToggleModule, FormsModule, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ButtonToggleGroupWithIndirectDescendantToggles {
   control = new FormControl('');
@@ -1290,6 +1305,7 @@ class ButtonToggleGroupWithIndirectDescendantToggles {
 @Component({
   template: `<mat-button-toggle aria-label="Super effective"></mat-button-toggle>`,
   imports: [MatButtonToggleModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ButtonToggleWithAriaLabel {}
 
@@ -1297,6 +1313,7 @@ class ButtonToggleWithAriaLabel {}
 @Component({
   template: `<mat-button-toggle aria-labelledby="some-id"></mat-button-toggle>`,
   imports: [MatButtonToggleModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ButtonToggleWithAriaLabelledby {}
 
@@ -1309,6 +1326,7 @@ class ButtonToggleWithAriaLabelledby {}
     </mat-button-toggle-group>
   `,
   imports: [MatButtonToggleModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class RepeatedButtonTogglesWithPreselectedValue {
   @ViewChild(MatButtonToggleGroup) toggleGroup!: MatButtonToggleGroup;
@@ -1321,12 +1339,14 @@ class RepeatedButtonTogglesWithPreselectedValue {
 @Component({
   template: `<mat-button-toggle tabindex="3"></mat-button-toggle>`,
   imports: [MatButtonToggleModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ButtonToggleWithTabindex {}
 
 @Component({
   template: `<mat-button-toggle name="custom-name"></mat-button-toggle>`,
   imports: [MatButtonToggleModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ButtonToggleWithStaticName {}
 
@@ -1338,6 +1358,7 @@ class ButtonToggleWithStaticName {}
     </mat-button-toggle-group>
   `,
   imports: [MatButtonToggleModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ButtonToggleWithStaticChecked {
   @ViewChild(MatButtonToggleGroup) group!: MatButtonToggleGroup;
@@ -1349,6 +1370,7 @@ class ButtonToggleWithStaticChecked {
     <mat-button-toggle aria-label="Toggle me" aria-labelledby="something"></mat-button-toggle>
   `,
   imports: [MatButtonToggleModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ButtonToggleWithStaticAriaAttributes {}
 
@@ -1361,6 +1383,7 @@ class ButtonToggleWithStaticAriaAttributes {}
   </mat-button-toggle-group>
   `,
   imports: [MatButtonToggleModule, FormsModule, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ButtonToggleGroupWithFormControlAndDynamicButtons {
   @ViewChildren(MatButtonToggle) toggles!: QueryList<MatButtonToggle>;
@@ -1377,6 +1400,7 @@ class ButtonToggleGroupWithFormControlAndDynamicButtons {
     </mat-button-toggle-group>
   `,
   imports: [MatButtonToggleModule, FormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ButtonToggleGroupWithNgModelAndStaticOptions {
   value = '';

--- a/src/material/button-toggle/testing/button-toggle-group.spec.ts
+++ b/src/material/button-toggle/testing/button-toggle-group.spec.ts
@@ -1,6 +1,6 @@
 import {HarnessLoader} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
-import {Component} from '@angular/core';
+import {Component, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatButtonToggleAppearance, MatButtonToggleModule} from '../../button-toggle';
 import {MatButtonToggleGroupHarness} from './button-toggle-group-harness';
@@ -82,6 +82,7 @@ describe('MatButtonToggleGroupHarness', () => {
     </mat-button-toggle-group>
   `,
   imports: [MatButtonToggleModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ButtonToggleGroupHarnessTest {
   disabled = false;

--- a/src/material/button-toggle/testing/button-toggle-harness.spec.ts
+++ b/src/material/button-toggle/testing/button-toggle-harness.spec.ts
@@ -1,6 +1,6 @@
 import {HarnessLoader} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
-import {Component} from '@angular/core';
+import {Component, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatButtonToggleModule} from '../../button-toggle';
 import {MatButtonToggleHarness} from './button-toggle-harness';
@@ -151,6 +151,7 @@ describe('MatButtonToggleHarness', () => {
       <span id="second-label">Second toggle</span>
   `,
   imports: [MatButtonToggleModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ButtonToggleHarnessTest {
   disabled = true;

--- a/src/material/button/button.spec.ts
+++ b/src/material/button/button.spec.ts
@@ -1,5 +1,5 @@
 import {createMouseEvent, dispatchEvent} from '@angular/cdk/testing/private';
-import {ApplicationRef, Component} from '@angular/core';
+import {ApplicationRef, Component, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {ThemePalette} from '../core';
 import {By} from '@angular/platform-browser';
@@ -400,6 +400,7 @@ describe('MatButton', () => {
     @Component({
       template: `<button mat-button>Click me</button>`,
       imports: [MatButtonModule],
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class ConfigTestApp {}
 
@@ -541,6 +542,7 @@ describe('MatFabDefaultOptions', () => {
     <button class="default-appearance" matButton>Dynamic button</button>
   `,
   imports: [MatButtonModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TestApp {
   clickCount = 0;

--- a/src/material/button/testing/button-harness.spec.ts
+++ b/src/material/button/testing/button-harness.spec.ts
@@ -1,4 +1,4 @@
-import {Component, signal} from '@angular/core';
+import {Component, signal, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {Platform} from '@angular/cdk/platform';
 import {HarnessLoader, parallel} from '@angular/cdk/testing';
@@ -273,6 +273,7 @@ describe('MatButtonHarness', () => {
     </a>
   `,
   imports: [MatButtonModule, MatIconModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ButtonHarnessTest {
   clicked = signal(false);

--- a/src/material/card/card.spec.ts
+++ b/src/material/card/card.spec.ts
@@ -1,5 +1,5 @@
 import {ComponentFixture, TestBed} from '@angular/core/testing';
-import {Component, Provider, Type, signal} from '@angular/core';
+import {Component, Provider, Type, signal, ChangeDetectionStrategy} from '@angular/core';
 import {MatCard, MAT_CARD_CONFIG, MatCardAppearance} from './card';
 
 describe('MatCard', () => {
@@ -44,6 +44,7 @@ describe('MatCard', () => {
 @Component({
   template: '<mat-card [appearance]="appearance()!"></mat-card>',
   imports: [MatCard],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class BasicCard {
   appearance = signal<MatCardAppearance | undefined>(undefined);
@@ -52,5 +53,6 @@ class BasicCard {
 @Component({
   template: '<mat-card></mat-card>',
   imports: [MatCard],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class BasicCardNoAppearance {}

--- a/src/material/card/testing/card-harness.spec.ts
+++ b/src/material/card/testing/card-harness.spec.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import {Component, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {ComponentHarness, HarnessLoader, parallel} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
@@ -120,6 +120,7 @@ describe('MatCardHarness', () => {
       </mat-card>
   `,
   imports: [MatCardModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class CardHarnessTest {}
 

--- a/src/material/checkbox/checkbox.spec.ts
+++ b/src/material/checkbox/checkbox.spec.ts
@@ -1186,6 +1186,7 @@ describe('MatCheckboxDefaultOptions', () => {
     </mat-checkbox>
   </div>`,
   imports: [MatCheckbox],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SingleCheckbox {
   labelPos: 'before' | 'after' = 'after';
@@ -1210,6 +1211,7 @@ class SingleCheckbox {
   template: `<mat-checkbox [required]="isRequired" [(ngModel)]="isGood"
                            [disabled]="isDisabled">Be good</mat-checkbox>`,
   imports: [MatCheckbox, FormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class CheckboxWithNgModel {
   isGood = false;
@@ -1231,6 +1233,7 @@ class CheckboxWithNgModelAndOnPush extends CheckboxWithNgModel {}
     <mat-checkbox>Option 2</mat-checkbox>
   `,
   imports: [MatCheckbox],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MultipleCheckboxes {}
 
@@ -1242,6 +1245,7 @@ class MultipleCheckboxes {}
         [disabled]="isDisabled">
     </mat-checkbox>`,
   imports: [MatCheckbox],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class CheckboxWithTabIndex {
   customTabIndex: number = 7;
@@ -1252,6 +1256,7 @@ class CheckboxWithTabIndex {
 @Component({
   template: `<mat-checkbox aria-label="Super effective"></mat-checkbox>`,
   imports: [MatCheckbox],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class CheckboxWithAriaLabel {}
 
@@ -1259,6 +1264,7 @@ class CheckboxWithAriaLabel {}
 @Component({
   template: `<mat-checkbox aria-labelledby="some-id"></mat-checkbox>`,
   imports: [MatCheckbox],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class CheckboxWithAriaLabelledby {}
 
@@ -1266,6 +1272,7 @@ class CheckboxWithAriaLabelledby {}
 @Component({
   template: `<mat-checkbox aria-describedby="some-id"></mat-checkbox>`,
   imports: [MatCheckbox],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class CheckboxWithAriaDescribedby {}
 
@@ -1273,6 +1280,7 @@ class CheckboxWithAriaDescribedby {}
 @Component({
   template: `<mat-checkbox aria-expanded="true"></mat-checkbox>`,
   imports: [MatCheckbox],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class CheckboxWithPositiveAriaExpanded {}
 
@@ -1280,6 +1288,7 @@ class CheckboxWithPositiveAriaExpanded {}
 @Component({
   template: `<mat-checkbox aria-expanded="false"></mat-checkbox>`,
   imports: [MatCheckbox],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class CheckboxWithNegativeAriaExpanded {}
 
@@ -1287,6 +1296,7 @@ class CheckboxWithNegativeAriaExpanded {}
 @Component({
   template: `<mat-checkbox aria-controls="some-id"></mat-checkbox>`,
   imports: [MatCheckbox],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class CheckboxWithAriaControls {}
 
@@ -1294,6 +1304,7 @@ class CheckboxWithAriaControls {}
 @Component({
   template: `<mat-checkbox aria-owns="some-id"></mat-checkbox>`,
   imports: [MatCheckbox],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class CheckboxWithAriaOwns {}
 
@@ -1301,6 +1312,7 @@ class CheckboxWithAriaOwns {}
 @Component({
   template: `<mat-checkbox name="test-name"></mat-checkbox>`,
   imports: [MatCheckbox],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class CheckboxWithNameAttribute {}
 
@@ -1308,6 +1320,7 @@ class CheckboxWithNameAttribute {}
 @Component({
   template: `<mat-checkbox (change)="lastEvent = $event"></mat-checkbox>`,
   imports: [MatCheckbox],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class CheckboxWithChangeEvent {
   lastEvent: MatCheckboxChange | undefined;
@@ -1317,6 +1330,7 @@ class CheckboxWithChangeEvent {
 @Component({
   template: `<mat-checkbox [formControl]="formControl"></mat-checkbox>`,
   imports: [MatCheckbox, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class CheckboxWithFormControl {
   formControl = new FormControl(false);
@@ -1326,6 +1340,7 @@ class CheckboxWithFormControl {
 @Component({
   template: `<mat-checkbox>{{ label }}</mat-checkbox>`,
   imports: [MatCheckbox],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class CheckboxWithoutLabel {
   label = '';
@@ -1335,11 +1350,13 @@ class CheckboxWithoutLabel {
 @Component({
   template: `<mat-checkbox tabindex="5"></mat-checkbox>`,
   imports: [MatCheckbox],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class CheckboxWithTabindexAttr {}
 
 @Component({
   template: `<mat-checkbox aria-label="Checkbox" aria-labelledby="something"></mat-checkbox>`,
   imports: [MatCheckbox],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class CheckboxWithStaticAriaAttributes {}

--- a/src/material/checkbox/testing/checkbox-harness.spec.ts
+++ b/src/material/checkbox/testing/checkbox-harness.spec.ts
@@ -1,4 +1,4 @@
-import {Component, signal} from '@angular/core';
+import {Component, signal, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
@@ -196,6 +196,7 @@ describe('MatCheckboxHarness', () => {
     <span id="second-label">Second checkbox</span>
   `,
   imports: [MatCheckboxModule, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class CheckboxHarnessTest {
   ctrl = new FormControl(true);

--- a/src/material/chips/chip-edit-input.spec.ts
+++ b/src/material/chips/chip-edit-input.spec.ts
@@ -1,4 +1,4 @@
-import {Component, DebugElement} from '@angular/core';
+import {Component, DebugElement, ChangeDetectionStrategy} from '@angular/core';
 import {waitForAsync, TestBed, ComponentFixture} from '@angular/core/testing';
 import {MatChipEditInput, MatChipsModule} from './index';
 import {By} from '@angular/platform-browser';
@@ -39,5 +39,6 @@ describe('MatChipEditInput', () => {
 @Component({
   template: `<mat-chip><span matChipEditInput></span></mat-chip>`,
   imports: [MatChipsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ChipEditInputContainer {}

--- a/src/material/chips/chip-grid.spec.ts
+++ b/src/material/chips/chip-grid.spec.ts
@@ -32,6 +32,7 @@ import {
   WritableSignal,
   inject,
   signal,
+  ChangeDetectionStrategy,
 } from '@angular/core';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 import {ComponentFixture, TestBed, fakeAsync, flush, tick} from '@angular/core/testing';
@@ -1129,6 +1130,7 @@ describe('MatChipGrid', () => {
     </mat-chip-grid>
     <input name="test" [matChipInputFor]="chipGrid"/>`,
   imports: [MatChipGrid, MatChipRow, MatChipInput],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class StandardChipGrid {
   name: string = 'Test';
@@ -1151,6 +1153,7 @@ class StandardChipGrid {
     </mat-form-field>
   `,
   imports: [MatChipGrid, MatChipRow, MatChipInput, MatFormField, MatLabel],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class FormFieldChipGrid {
   chips = ['Chip 0', 'Chip 1', 'Chip 2'];
@@ -1183,6 +1186,7 @@ class FormFieldChipGrid {
     </mat-form-field>
   `,
   imports: [MatChipGrid, MatChipRow, MatChipInput, MatFormField, MatLabel, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class InputChipGrid {
   foods: any[] = [
@@ -1252,6 +1256,7 @@ class InputChipGrid {
     ReactiveFormsModule,
     FormsModule,
   ],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ChipGridWithFormErrorMessages {
   foods: any[] = [
@@ -1288,6 +1293,7 @@ class ChipGridWithFormErrorMessages {
     </mat-form-field>
   `,
   imports: [MatChipGrid, MatChipRow, MatChipInput, MatFormField, MatChipRemove],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ChipGridWithRemove {
   chips = [0, 1, 2, 3, 4];
@@ -1310,6 +1316,7 @@ class ChipGridWithRemove {
     </mat-form-field>
   `,
   imports: [MatChipGrid, MatChipRow, MatFormField, MatLabel, MatHint],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ChipGridWithoutInput {
   chips = ['Pizza', 'Pasta', 'Tacos'];

--- a/src/material/chips/chip-input.spec.ts
+++ b/src/material/chips/chip-input.spec.ts
@@ -5,7 +5,7 @@ import {
   dispatchKeyboardEvent,
   provideFakeDirectionality,
 } from '@angular/cdk/testing/private';
-import {Component, DebugElement, ViewChild} from '@angular/core';
+import {Component, DebugElement, ViewChild, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, fakeAsync, flush, TestBed, waitForAsync} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {MATERIAL_ANIMATIONS} from '../core';
@@ -355,6 +355,7 @@ describe('MatChipInput', () => {
     </mat-form-field>
   `,
   imports: [MatFormField, MatChipGrid, MatChipRow, MatChipInput],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TestChipInput {
   @ViewChild(MatChipGrid) chipGridInstance!: MatChipGrid;

--- a/src/material/chips/chip-listbox.spec.ts
+++ b/src/material/chips/chip-listbox.spec.ts
@@ -15,6 +15,7 @@ import {
   ViewChild,
   ViewChildren,
   WritableSignal,
+  ChangeDetectionStrategy,
 } from '@angular/core';
 import {AsyncPipe} from '@angular/common';
 import {ComponentFixture, fakeAsync, flush, TestBed, tick} from '@angular/core/testing';
@@ -961,6 +962,7 @@ describe('MatChipListbox', () => {
       }
     </mat-chip-listbox>`,
   imports: [MatChipListbox, MatChipOption],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class StandardChipListbox {
   name: string = 'Test';
@@ -984,6 +986,7 @@ class StandardChipListbox {
     </mat-chip-listbox>
   `,
   imports: [MatChipListbox, MatChipOption, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class BasicChipListbox {
   foods: any[] = [
@@ -1018,6 +1021,7 @@ class BasicChipListbox {
     </mat-chip-listbox>
   `,
   imports: [MatChipListbox, MatChipOption, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MultiSelectionChipListbox {
   foods: any[] = [
@@ -1048,6 +1052,7 @@ class MultiSelectionChipListbox {
     </mat-chip-listbox>
   `,
   imports: [MatChipListbox, MatChipOption, AsyncPipe, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class AsyncMultiSelectionChipListbox {
   private _chipsSubject = new BehaviorSubject(['tutorial-1', 'tutorial-2', 'tutorial-3']);
@@ -1070,6 +1075,7 @@ class AsyncMultiSelectionChipListbox {
     </mat-chip-listbox>
   `,
   imports: [MatChipListbox, MatChipOption, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class FalsyValueChipListbox {
   foods: any[] = [
@@ -1091,6 +1097,7 @@ class FalsyValueChipListbox {
     </mat-chip-listbox>
   `,
   imports: [MatChipListbox, MatChipOption],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SelectedChipListbox {
   foods: any[] = [
@@ -1113,6 +1120,7 @@ class SelectedChipListbox {
     </mat-chip-listbox>
   `,
   imports: [MatChipListbox, MatChipOption, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class FalsyBasicChipListbox {
   foods: any[] = [
@@ -1144,6 +1152,7 @@ class FalsyBasicChipListbox {
     </form>
   `,
   imports: [MatChipListbox, MatChipOption, FormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class IndividuallyDisabledChipInsideForm {
   @ViewChild(MatChipOption) chip!: MatChipOption;

--- a/src/material/chips/chip-option.spec.ts
+++ b/src/material/chips/chip-option.spec.ts
@@ -4,7 +4,7 @@ import {
   dispatchKeyboardEvent,
   provideFakeDirectionality,
 } from '@angular/cdk/testing/private';
-import {Component, DebugElement, ViewChild} from '@angular/core';
+import {Component, DebugElement, ViewChild, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed, fakeAsync, flush, waitForAsync} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {MAT_RIPPLE_GLOBAL_OPTIONS, RippleGlobalOptions} from '../core';
@@ -403,6 +403,7 @@ describe('Option Chips', () => {
       }
     </mat-chip-listbox>`,
   imports: [MatChipListbox, MatChipOption, MatChipAvatar],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SingleChip {
   @ViewChild(MatChipListbox) chipList!: MatChipListbox;

--- a/src/material/chips/chip-remove.spec.ts
+++ b/src/material/chips/chip-remove.spec.ts
@@ -1,6 +1,6 @@
 import {ENTER, SPACE} from '@angular/cdk/keycodes';
 import {dispatchKeyboardEvent, dispatchMouseEvent} from '@angular/cdk/testing/private';
-import {Component} from '@angular/core';
+import {Component, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed, fakeAsync, flush, waitForAsync} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {MatChip, MatChipsModule} from './index';
@@ -111,6 +111,7 @@ describe('Chip Remove', () => {
     </mat-chip-set>
   `,
   imports: [MatChipsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TestChip {
   removable = false;

--- a/src/material/chips/chip-row.spec.ts
+++ b/src/material/chips/chip-row.spec.ts
@@ -7,7 +7,13 @@ import {
   dispatchMouseEvent,
   provideFakeDirectionality,
 } from '@angular/cdk/testing/private';
-import {Component, DebugElement, ElementRef, ViewChild} from '@angular/core';
+import {
+  Component,
+  DebugElement,
+  ElementRef,
+  ViewChild,
+  ChangeDetectionStrategy,
+} from '@angular/core';
 import {ComponentFixture, TestBed, fakeAsync, flush, waitForAsync} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {
@@ -530,6 +536,7 @@ describe('Row Chips', () => {
       }
     </mat-chip-grid>`,
   imports: [MatChipsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SingleChip {
   @ViewChild(MatChipGrid) chipList!: MatChipGrid;

--- a/src/material/chips/chip-set.spec.ts
+++ b/src/material/chips/chip-set.spec.ts
@@ -1,4 +1,4 @@
-import {Component, DebugElement, QueryList} from '@angular/core';
+import {Component, DebugElement, QueryList, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed, fakeAsync, tick} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {MatChip, MatChipSet, MatChipsModule} from './index';
@@ -110,6 +110,7 @@ describe('MatChipSet', () => {
       </mat-chip-set>
   `,
   imports: [MatChipsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class BasicChipSet {
   name: string = 'Test';
@@ -127,5 +128,6 @@ class BasicChipSet {
     </mat-chip-set>
   `,
   imports: [MatChipsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class IndirectDescendantsChipSet extends BasicChipSet {}

--- a/src/material/chips/chip.spec.ts
+++ b/src/material/chips/chip.spec.ts
@@ -1,5 +1,5 @@
 import {provideFakeDirectionality} from '@angular/cdk/testing/private';
-import {Component, DebugElement, ViewChild} from '@angular/core';
+import {Component, DebugElement, ViewChild, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {MatChip, MatChipEvent, MatChipSet, MatChipsModule} from './index';
@@ -158,6 +158,7 @@ describe('MatChip', () => {
       }
     </mat-chip-set>`,
   imports: [MatChipsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SingleChip {
   @ViewChild(MatChipSet) chipList!: MatChipSet;
@@ -176,18 +177,21 @@ class SingleChip {
 @Component({
   template: `<mat-basic-chip>Hello</mat-basic-chip>`,
   imports: [MatChipsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class BasicChip {}
 
 @Component({
   template: `<mat-basic-chip role="button" tabindex="3">Hello</mat-basic-chip>`,
   imports: [MatChipsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class BasicChipWithStaticTabindex {}
 
 @Component({
   template: `<mat-basic-chip role="button" [tabIndex]="tabindex">Hello</mat-basic-chip>`,
   imports: [MatChipsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class BasicChipWithBoundTabindex {
   tabindex = 12;

--- a/src/material/chips/testing/chip-grid-harness.spec.ts
+++ b/src/material/chips/testing/chip-grid-harness.spec.ts
@@ -1,6 +1,6 @@
 import {HarnessLoader, parallel} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
-import {Component} from '@angular/core';
+import {Component, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {FormControl, ReactiveFormsModule, Validators} from '@angular/forms';
 import {MatChipsModule} from '../index';
@@ -132,6 +132,7 @@ describe('MatChipGridHarness', () => {
     </mat-chip-grid>
   `,
   imports: [MatChipsModule, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ChipGridHarnessTest {
   control = new FormControl('value', [Validators.required]);

--- a/src/material/chips/testing/chip-harness.spec.ts
+++ b/src/material/chips/testing/chip-harness.spec.ts
@@ -1,6 +1,6 @@
 import {HarnessLoader, parallel} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
-import {Component} from '@angular/core';
+import {Component, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatIconModule} from '../../icon';
 import {MatIconHarness} from '../../icon/testing';
@@ -91,6 +91,7 @@ describe('MatChipHarness', () => {
     <mat-chip-row (removed)="removeChip()">Chip Row</mat-chip-row>
   `,
   imports: [MatChipsModule, MatIconModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ChipHarnessTest {
   removeChip() {}

--- a/src/material/chips/testing/chip-input-harness.spec.ts
+++ b/src/material/chips/testing/chip-input-harness.spec.ts
@@ -1,7 +1,7 @@
 import {COMMA} from '@angular/cdk/keycodes';
 import {HarnessLoader, TestKey} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
-import {Component} from '@angular/core';
+import {Component, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatChipsModule} from '../index';
 import {MatChipInputHarness} from './chip-input-harness';
@@ -102,6 +102,7 @@ describe('MatChipInputHarness', () => {
     </mat-chip-grid>
   `,
   imports: [MatChipsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ChipInputHarnessTest {
   required = false;

--- a/src/material/chips/testing/chip-listbox-harness.spec.ts
+++ b/src/material/chips/testing/chip-listbox-harness.spec.ts
@@ -1,6 +1,6 @@
 import {HarnessLoader, parallel} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
-import {Component} from '@angular/core';
+import {Component, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatChipsModule} from '../index';
 import {MatChipListboxHarness} from './chip-listbox-harness';
@@ -122,6 +122,7 @@ describe('MatChipListboxHarness', () => {
     </mat-chip-listbox>
   `,
   imports: [MatChipsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ChipListboxHarnessTest {
   isMultiple = false;

--- a/src/material/chips/testing/chip-option-harness.spec.ts
+++ b/src/material/chips/testing/chip-option-harness.spec.ts
@@ -1,6 +1,6 @@
 import {HarnessLoader} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
-import {Component} from '@angular/core';
+import {Component, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatChipsModule} from '../index';
 import {MatChipOptionHarness} from './chip-option-harness';
@@ -85,5 +85,6 @@ describe('MatChipOptionHarness', () => {
     </mat-chip-listbox>
   `,
   imports: [MatChipsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ChipOptionHarnessTest {}

--- a/src/material/chips/testing/chip-row-harness.spec.ts
+++ b/src/material/chips/testing/chip-row-harness.spec.ts
@@ -1,6 +1,6 @@
 import {HarnessLoader} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
-import {Component, signal} from '@angular/core';
+import {Component, signal, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatChipsModule} from '../index';
 import {MatChipRowHarness} from './chip-row-harness';
@@ -38,6 +38,7 @@ describe('MatChipRowHarness', () => {
     </mat-chip-grid>
   `,
   imports: [MatChipsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ChipRowHarnessTest {
   editable = signal(false);

--- a/src/material/chips/testing/chip-set-harness.spec.ts
+++ b/src/material/chips/testing/chip-set-harness.spec.ts
@@ -1,6 +1,6 @@
 import {HarnessLoader} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
-import {Component} from '@angular/core';
+import {Component, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatChipsModule} from '../index';
 import {MatChipSetHarness} from './chip-set-harness';
@@ -36,5 +36,6 @@ describe('MatChipSetHarness', () => {
     </mat-chip-set>
   `,
   imports: [MatChipsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ChipSetHarnessTest {}

--- a/src/material/core/option/option.spec.ts
+++ b/src/material/core/option/option.spec.ts
@@ -1,5 +1,5 @@
 import {waitForAsync, ComponentFixture, TestBed} from '@angular/core/testing';
-import {Component, DebugElement, signal} from '@angular/core';
+import {Component, DebugElement, signal, ChangeDetectionStrategy} from '@angular/core';
 import {By} from '@angular/platform-browser';
 import {
   dispatchFakeEvent,
@@ -237,6 +237,7 @@ describe('MatOption component', () => {
 @Component({
   template: `<mat-option [id]="id()" [disabled]="disabled()"></mat-option>`,
   imports: [MatOptionModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class BasicOption {
   disabled = signal(false);
@@ -250,5 +251,6 @@ class BasicOption {
     </mat-optgroup>
   `,
   imports: [MatOptionModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class InsideGroup {}

--- a/src/material/core/ripple/ripple.spec.ts
+++ b/src/material/core/ripple/ripple.spec.ts
@@ -7,7 +7,13 @@ import {
   dispatchMouseEvent,
   dispatchTouchEvent,
 } from '@angular/cdk/testing/private';
-import {Component, Provider, ViewChild, ViewEncapsulation} from '@angular/core';
+import {
+  Component,
+  Provider,
+  ViewChild,
+  ViewEncapsulation,
+  ChangeDetectionStrategy,
+} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {
   MAT_RIPPLE_GLOBAL_OPTIONS,
@@ -826,6 +832,7 @@ describe('MatRipple', () => {
     </div>
   `,
   imports: [MatRippleModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class BasicRippleContainer {
   @ViewChild('ripple') ripple!: MatRipple;
@@ -845,6 +852,7 @@ class BasicRippleContainer {
     <div class="alternateTrigger"></div>
   `,
   imports: [MatRippleModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class RippleContainerWithInputBindings {
   animationConfig!: RippleAnimationConfig;
@@ -859,12 +867,14 @@ class RippleContainerWithInputBindings {
 @Component({
   template: `<div id="container" #ripple="matRipple" matRipple></div>`,
   imports: [MatRippleModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class RippleContainerWithoutBindings {}
 
 @Component({
   template: `@if (!isDestroyed) {<div id="container" matRipple></div>}`,
   imports: [MatRippleModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class RippleContainerWithNgIf {
   @ViewChild(MatRipple) ripple!: MatRipple;
@@ -876,6 +886,7 @@ class RippleContainerWithNgIf {
   template: `<div id="container" matRipple></div>`,
   encapsulation: ViewEncapsulation.None,
   imports: [MatRippleModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class RippleCssTransitionNone {}
 
@@ -884,6 +895,7 @@ class RippleCssTransitionNone {}
   template: `<div id="container" matRipple></div>`,
   encapsulation: ViewEncapsulation.None,
   imports: [MatRippleModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class RippleCssTransitionDurationZero {}
 
@@ -894,6 +906,7 @@ class RippleCssTransitionDurationZero {}
     }
   `,
   imports: [MatRippleModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class RippleWithDomRemovalOnClick {
   show = true;

--- a/src/material/core/ripple/ripple.zone.spec.ts
+++ b/src/material/core/ripple/ripple.zone.spec.ts
@@ -1,5 +1,5 @@
 import {dispatchMouseEvent} from '@angular/cdk/testing/private';
-import {Component, ViewChild} from '@angular/core';
+import {Component, ViewChild, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatRippleModule} from '.';
 import {MatRipple} from './ripple';
@@ -47,6 +47,7 @@ describe('MatRipple Zone.js integration', () => {
       </div>
     `,
   imports: [MatRippleModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class BasicRippleContainer {
   @ViewChild('ripple') ripple!: MatRipple;

--- a/src/material/core/testing/optgroup-harness.spec.ts
+++ b/src/material/core/testing/optgroup-harness.spec.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import {Component, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {HarnessLoader, parallel} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
@@ -69,5 +69,6 @@ describe('MatOptgroupHarness', () => {
     </mat-optgroup>
   `,
   imports: [MatOptionModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class OptgroupHarnessTest {}

--- a/src/material/core/testing/option-harness.spec.ts
+++ b/src/material/core/testing/option-harness.spec.ts
@@ -1,6 +1,6 @@
 import {HarnessLoader, parallel} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
-import {Component, QueryList, ViewChildren, signal} from '@angular/core';
+import {Component, QueryList, ViewChildren, signal, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {
   MAT_OPTION_PARENT_COMPONENT,
@@ -109,6 +109,7 @@ describe('MatOptionHarness', () => {
     <mat-option disabled>Disabled option</mat-option>
   `,
   imports: [MatOptionModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class OptionHarnessTest implements MatOptionParentComponent {
   @ViewChildren(MatOption) options!: QueryList<{setActiveStyles(): void}>;

--- a/src/material/datepicker/calendar-body.spec.ts
+++ b/src/material/datepicker/calendar-body.spec.ts
@@ -3,7 +3,7 @@ import {
   dispatchMouseEvent,
   dispatchTouchEvent,
 } from '@angular/cdk/testing/private';
-import {Component} from '@angular/core';
+import {Component, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {MatCalendarBody, MatCalendarCell, MatCalendarUserEvent} from './calendar-body';
@@ -710,6 +710,7 @@ describe('MatCalendarBody', () => {
           (selectedValueChange)="onSelect($event)">
     </table>`,
   imports: [MatCalendarBody],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class StandardCalendarBody {
   label = 'Jan 2017';
@@ -742,6 +743,7 @@ class StandardCalendarBody {
           >
     </table>`,
   imports: [MatCalendarBody],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class RangeCalendarBody {
   rows = createCalendarCells(4);

--- a/src/material/datepicker/calendar-header.spec.ts
+++ b/src/material/datepicker/calendar-header.spec.ts
@@ -1,5 +1,5 @@
 import {provideFakeDirectionality} from '@angular/cdk/testing/private';
-import {Component} from '@angular/core';
+import {Component, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {DateAdapter, provideNativeDateAdapter} from '../core';
@@ -379,6 +379,7 @@ describe('MatCalendarHeader', () => {
         (monthSelected)="selectedMonth=$event">
     </mat-calendar>`,
   imports: [MatDatepickerModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class StandardCalendar {
   selected!: Date;
@@ -396,6 +397,7 @@ class StandardCalendar {
     </mat-calendar>
   `,
   imports: [MatDatepickerModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class CalendarWithMinMaxDate {
   startAt = new Date(2018, JAN, 1);

--- a/src/material/datepicker/calendar.spec.ts
+++ b/src/material/datepicker/calendar.spec.ts
@@ -5,7 +5,7 @@ import {
   dispatchMouseEvent,
   provideFakeDirectionality,
 } from '@angular/cdk/testing/private';
-import {Component} from '@angular/core';
+import {Component, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {DateAdapter, provideNativeDateAdapter} from '../core';
@@ -672,6 +672,7 @@ describe('MatCalendar', () => {
         (monthSelected)="selectedMonth=$event">
     </mat-calendar>`,
   imports: [MatCalendar],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class StandardCalendar {
   selected!: Date;
@@ -685,6 +686,7 @@ class StandardCalendar {
     <mat-calendar [startAt]="startAt" [minDate]="minDate" [maxDate]="maxDate"></mat-calendar>
   `,
   imports: [MatCalendar],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class CalendarWithMinMax {
   startAt!: Date;
@@ -698,6 +700,7 @@ class CalendarWithMinMax {
     </mat-calendar>
   `,
   imports: [MatCalendar],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class CalendarWithDateFilter {
   selected!: Date;
@@ -718,6 +721,7 @@ class CalendarWithDateFilter {
     </mat-calendar>
   `,
   imports: [MatCalendar],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class CalendarWithSelectableMinDate {
   startAt = new Date(2018, JUL, 0);

--- a/src/material/datepicker/date-range-input.spec.ts
+++ b/src/material/datepicker/date-range-input.spec.ts
@@ -6,7 +6,15 @@ import {
   dispatchKeyboardEvent,
   provideFakeDirectionality,
 } from '@angular/cdk/testing/private';
-import {Component, Directive, ElementRef, Provider, Type, ViewChild} from '@angular/core';
+import {
+  Component,
+  Directive,
+  ElementRef,
+  Provider,
+  Type,
+  ViewChild,
+  ChangeDetectionStrategy,
+} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {
   FormControl,
@@ -1149,6 +1157,7 @@ describe('MatDateRangeInput', () => {
     MatDateRangePicker,
     ReactiveFormsModule,
   ],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class StandardRangePicker {
   @ViewChild('start') start!: ElementRef<HTMLInputElement>;
@@ -1183,6 +1192,7 @@ class StandardRangePicker {
     </mat-form-field>
   `,
   imports: [MatDateRangeInput, MatEndDate, MatFormField, MatDateRangePicker],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class RangePickerNoStart {}
 
@@ -1197,6 +1207,7 @@ class RangePickerNoStart {}
     </mat-form-field>
   `,
   imports: [MatDateRangeInput, MatStartDate, MatFormField, MatDateRangePicker],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class RangePickerNoEnd {}
 
@@ -1219,6 +1230,7 @@ class RangePickerNoEnd {}
     MatDateRangePicker,
     FormsModule,
   ],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class RangePickerNgModel {
   @ViewChild(MatStartDate, {read: NgModel}) startModel!: NgModel;
@@ -1258,6 +1270,7 @@ class RangePickerNgModel {
     </mat-form-field>
   `,
   imports: [MatDateRangeInput, MatStartDate, MatEndDate, MatFormField, MatDateRangePicker],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class RangePickerNoLabel {
   @ViewChild('start') start!: ElementRef<HTMLInputElement>;
@@ -1298,6 +1311,7 @@ class CustomValidator implements Validator {
     CustomValidator,
     FormsModule,
   ],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class RangePickerWithCustomValidator {
   @ViewChild(CustomValidator) validator!: CustomValidator;
@@ -1319,6 +1333,7 @@ class RangePickerWithCustomValidator {
     </mat-form-field>
   `,
   imports: [MatDateRangeInput, MatStartDate, MatEndDate, MatFormField, MatDateRangePicker],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class RangePickerErrorStateMatcher {
   @ViewChild(MatStartDate) startInput!: MatStartDate<Date>;

--- a/src/material/datepicker/datepicker-actions.spec.ts
+++ b/src/material/datepicker/datepicker-actions.spec.ts
@@ -1,4 +1,4 @@
-import {Component, ElementRef, Type, ViewChild} from '@angular/core';
+import {Component, ElementRef, Type, ViewChild, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {FormControl, ReactiveFormsModule} from '@angular/forms';
 import {MATERIAL_ANIMATIONS, provideNativeDateAdapter} from '../core';
@@ -268,6 +268,7 @@ describe('MatDatepickerActions', () => {
     </mat-form-field>
   `,
   imports: [MatDatepickerModule, MatInputModule, MatButtonModule, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DatepickerWithActions {
   @ViewChild(MatDatepicker) datepicker!: MatDatepicker<Date>;

--- a/src/material/datepicker/datepicker.spec.ts
+++ b/src/material/datepicker/datepicker.spec.ts
@@ -30,6 +30,7 @@ import {
   ViewChild,
   ViewEncapsulation,
   signal,
+  ChangeDetectionStrategy,
 } from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {
@@ -2422,6 +2423,7 @@ const inputFixedWidthStyles = `
   `,
   styles: inputFixedWidthStyles,
   imports: [MatDatepickerInput, MatDatepicker],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class StandardDatepicker {
   opened = false;
@@ -2441,12 +2443,14 @@ class StandardDatepicker {
     <input [matDatepicker]="d"><input [matDatepicker]="d"><mat-datepicker #d></mat-datepicker>
   `,
   imports: [MatDatepickerInput, MatDatepicker],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MultiInputDatepicker {}
 
 @Component({
   template: `<mat-datepicker #d></mat-datepicker>`,
   imports: [MatDatepicker],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NoInputDatepicker {
   @ViewChild('d') datepicker!: MatDatepicker<Date>;
@@ -2458,6 +2462,7 @@ class NoInputDatepicker {
     <mat-datepicker #d [startAt]="startDate"></mat-datepicker>
   `,
   imports: [MatDatepickerInput, MatDatepicker],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DatepickerWithStartAt {
   date = new Date(2020, JAN, 1);
@@ -2471,6 +2476,7 @@ class DatepickerWithStartAt {
     <mat-datepicker #d startView="year" (monthSelected)="onYearSelection()"></mat-datepicker>
   `,
   imports: [MatDatepickerInput, MatDatepicker],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DatepickerWithStartViewYear {
   date = new Date(2020, JAN, 1);
@@ -2486,6 +2492,7 @@ class DatepickerWithStartViewYear {
         (yearSelected)="onMultiYearSelection()"></mat-datepicker>
   `,
   imports: [MatDatepickerInput, MatDatepicker],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DatepickerWithStartViewMultiYear {
   date = new Date(2020, JAN, 1);
@@ -2500,6 +2507,7 @@ class DatepickerWithStartViewMultiYear {
     <mat-datepicker #d></mat-datepicker>
   `,
   imports: [MatDatepickerInput, MatDatepicker, FormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DatepickerWithNgModel {
   selected: Date | null = null;
@@ -2514,6 +2522,7 @@ class DatepickerWithNgModel {
     <mat-datepicker #d></mat-datepicker>
   `,
   imports: [MatDatepickerInput, MatDatepicker, MatDatepickerToggle, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DatepickerWithFormControl {
   formControl = new FormControl<Date | null>(null);
@@ -2529,6 +2538,7 @@ class DatepickerWithFormControl {
     <mat-datepicker #d [touchUi]="touchUI" [restoreFocus]="restoreFocus"></mat-datepicker>
   `,
   imports: [MatDatepickerInput, MatDatepicker, MatDatepickerToggle],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DatepickerWithToggle {
   @ViewChild('d') datepicker!: MatDatepicker<Date>;
@@ -2546,6 +2556,7 @@ class DatepickerWithToggle {
     <mat-datepicker #d [touchUi]="touchUI" [restoreFocus]="restoreFocus"></mat-datepicker>
   `,
   imports: [MatDatepickerInput, MatDatepicker, MatDatepickerToggle],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DatepickerWithToggleInShadowDom extends DatepickerWithToggle {}
 
@@ -2558,6 +2569,7 @@ class DatepickerWithToggleInShadowDom extends DatepickerWithToggle {}
     <mat-datepicker #d></mat-datepicker>
   `,
   imports: [MatDatepickerInput, MatDatepicker, MatDatepickerToggle],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DatepickerWithCustomIcon {}
 
@@ -2570,6 +2582,7 @@ class DatepickerWithCustomIcon {}
     </mat-form-field>
   `,
   imports: [MatDatepickerInput, MatDatepicker, MatInputModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class FormFieldDatepicker {
   @ViewChild('d') datepicker!: MatDatepicker<Date>;
@@ -2584,6 +2597,7 @@ class FormFieldDatepicker {
     <mat-datepicker #d></mat-datepicker>
   `,
   imports: [MatDatepickerInput, MatDatepicker, MatDatepickerToggle, FormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DatepickerWithMinAndMaxValidation {
   @ViewChild('d') datepicker!: MatDatepicker<Date>;
@@ -2600,6 +2614,7 @@ class DatepickerWithMinAndMaxValidation {
     <mat-datepicker #d [touchUi]="true"></mat-datepicker>
   `,
   imports: [MatDatepickerInput, MatDatepicker, MatDatepickerToggle, FormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DatepickerWithFilterAndValidation {
   @ViewChild('d') datepicker!: MatDatepicker<Date>;
@@ -2615,6 +2630,7 @@ class DatepickerWithFilterAndValidation {
     <mat-datepicker #d [touchUi]="true"></mat-datepicker>
   `,
   imports: [MatDatepickerInput, MatDatepicker],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DatepickerWithChangeAndInputEvents {
   @ViewChild('d') datepicker!: MatDatepicker<Date>;
@@ -2631,6 +2647,7 @@ class DatepickerWithChangeAndInputEvents {
     <mat-datepicker #d></mat-datepicker>
   `,
   imports: [MatDatepickerInput, MatDatepicker, FormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DatepickerWithi18n {
   date: Date | null = new Date(2010, JAN, 1);
@@ -2644,6 +2661,7 @@ class DatepickerWithi18n {
     <mat-datepicker #d [startAt]="startAt"></mat-datepicker>
   `,
   imports: [MatDatepickerInput, MatDatepicker, FormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DatepickerWithISOStrings {
   value = new Date(2017, JUN, 1).toISOString();
@@ -2660,6 +2678,7 @@ class DatepickerWithISOStrings {
     <mat-datepicker (opened)="openedSpy()" (closed)="closedSpy()" #d></mat-datepicker>
   `,
   imports: [MatDatepickerInput, MatDatepicker, FormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DatepickerWithEvents {
   selected: Date | null = null;
@@ -2674,6 +2693,7 @@ class DatepickerWithEvents {
     <mat-datepicker #d="matDatepicker"></mat-datepicker>
   `,
   imports: [MatDatepickerInput, MatDatepicker],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DatepickerOpeningOnFocus {
   @ViewChild(MatDatepicker) datepicker!: MatDatepicker<Date>;
@@ -2685,6 +2705,7 @@ class DatepickerOpeningOnFocus {
     <mat-datepicker #ch [calendarHeaderComponent]="customHeaderForDatePicker"></mat-datepicker>
   `,
   imports: [MatDatepickerInput, MatDatepicker],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DatepickerWithCustomHeader {
   @ViewChild('ch') datepicker!: MatDatepicker<Date>;
@@ -2697,6 +2718,7 @@ class DatepickerWithCustomHeader {
     <mat-calendar-header></mat-calendar-header>
   `,
   imports: [MatCalendarHeader],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class CustomHeaderForDatepicker {}
 
@@ -2706,6 +2728,7 @@ class CustomHeaderForDatepicker {}
     <mat-datepicker #d [touchUi]="touch"></mat-datepicker>
   `,
   imports: [MatDatepickerInput, MatDatepicker],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DelayedDatepicker {
   @ViewChild('d') datepicker!: MatDatepicker<Date>;
@@ -2724,6 +2747,7 @@ class DelayedDatepicker {
     <mat-datepicker #d></mat-datepicker>
   `,
   imports: [MatDatepickerInput, MatDatepicker, MatDatepickerToggle, MatDatepickerToggleIcon],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DatepickerWithTabindexOnToggle {
   disabled = false;
@@ -2732,12 +2756,14 @@ class DatepickerWithTabindexOnToggle {
 @Component({
   template: `<mat-datepicker-toggle/>`,
   imports: [MatDatepickerToggle],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DatepickerToggleWithNoDatepicker {}
 
 @Component({
   template: `<input [matDatepicker]="null!">`,
   imports: [MatDatepickerInput],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DatepickerInputWithNoDatepicker {}
 
@@ -2761,6 +2787,7 @@ class CustomValidator implements Validator {
     <mat-datepicker #d></mat-datepicker>
   `,
   imports: [MatDatepickerInput, MatDatepicker, CustomValidator, FormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DatepickerInputWithCustomValidator {
   @ViewChild(CustomValidator) validator!: CustomValidator;
@@ -2775,6 +2802,7 @@ class DatepickerInputWithCustomValidator {
   <mat-datepicker [panelClass]="panelClass" touchUi #d></mat-datepicker>
   `,
   imports: [MatDatepickerInput, MatDatepicker],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class PanelClassDatepicker {
   date = new Date(0);

--- a/src/material/datepicker/month-view.spec.ts
+++ b/src/material/datepicker/month-view.spec.ts
@@ -20,7 +20,7 @@ import {
   dispatchMouseEvent,
   provideFakeDirectionality,
 } from '@angular/cdk/testing/private';
-import {Component, signal, WritableSignal} from '@angular/core';
+import {Component, signal, WritableSignal, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {MAT_DATE_FORMATS, provideNativeDateAdapter} from '../core';
@@ -846,6 +846,7 @@ describe('MatMonthView', () => {
       [activeDrag]="activeDrag"></mat-month-view>
       `,
   imports: [MatMonthView],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class StandardMonthView {
   date = new Date(2017, JAN, 5);
@@ -877,6 +878,7 @@ class StandardMonthView {
       [minDate]="minDate"
       [maxDate]="maxDate"></mat-month-view>`,
   imports: [MatMonthView],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MonthViewWithDateFilter {
   activeDate = new Date(2017, JAN, 1);
@@ -890,6 +892,7 @@ class MonthViewWithDateFilter {
 @Component({
   template: `<mat-month-view [activeDate]="activeDate" [dateClass]="dateClass"></mat-month-view>`,
   imports: [MatMonthView],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MonthViewWithDateClass {
   activeDate = new Date(2017, JAN, 1);

--- a/src/material/datepicker/multi-year-view.spec.ts
+++ b/src/material/datepicker/multi-year-view.spec.ts
@@ -14,7 +14,7 @@ import {
   dispatchKeyboardEvent,
   provideFakeDirectionality,
 } from '@angular/cdk/testing/private';
-import {Component, signal, ViewChild, WritableSignal} from '@angular/core';
+import {Component, signal, ViewChild, WritableSignal, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {provideNativeDateAdapter} from '../core';
@@ -398,6 +398,7 @@ describe('MatMultiYearView', () => {
     <mat-multi-year-view [(activeDate)]="date" [(selected)]="selected"
                          (yearSelected)="selectedYear=$event"></mat-multi-year-view>`,
   imports: [MatMultiYearView],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class StandardMultiYearView {
   date = new Date(2017, JAN, 1);
@@ -416,6 +417,7 @@ class StandardMultiYearView {
       [maxDate]="maxDate"></mat-multi-year-view>
     `,
   imports: [MatMultiYearView],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MultiYearViewWithDateFilter {
   activeDate = new Date(2017, JAN, 1);
@@ -432,6 +434,7 @@ class MultiYearViewWithDateFilter {
     </mat-multi-year-view>
     `,
   imports: [MatMultiYearView],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MultiYearViewWithMinMaxDate {
   activeDate = new Date(2019, JAN, 1);
@@ -444,6 +447,7 @@ class MultiYearViewWithMinMaxDate {
     <mat-multi-year-view [activeDate]="activeDate" [dateClass]="dateClass"></mat-multi-year-view>
   `,
   imports: [MatMultiYearView],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MultiYearViewWithDateClass {
   activeDate = new Date(2017, JAN, 1);

--- a/src/material/datepicker/testing/calendar-harness.spec.ts
+++ b/src/material/datepicker/testing/calendar-harness.spec.ts
@@ -1,6 +1,6 @@
 import {HarnessLoader, parallel} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
-import {Component} from '@angular/core';
+import {Component, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {provideNativeDateAdapter} from '../../core';
 import {
@@ -330,6 +330,7 @@ describe('MatCalendarHarness', () => {
       (selectedChange)="rangeChanged($event)"></mat-calendar>
   `,
   imports: [MatDatepickerModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class CalendarHarnessTest {
   // Start the datepickers off at a specific date so tests

--- a/src/material/datepicker/testing/date-range-input-harness.spec.ts
+++ b/src/material/datepicker/testing/date-range-input-harness.spec.ts
@@ -1,6 +1,6 @@
 import {HarnessLoader, parallel} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
-import {Component} from '@angular/core';
+import {Component, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {FormsModule} from '@angular/forms';
 import {MATERIAL_ANIMATIONS, provideNativeDateAdapter} from '../../core';
@@ -289,6 +289,7 @@ describe('matDateRangeInputHarness', () => {
     MatFormFieldModule,
     FormsModule,
   ],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DateRangeInputHarnessTest {
   startDate: Date | null = null;

--- a/src/material/datepicker/testing/datepicker-actions-harness.spec.ts
+++ b/src/material/datepicker/testing/datepicker-actions-harness.spec.ts
@@ -8,7 +8,7 @@
 
 import {HarnessLoader} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
-import {Component, signal} from '@angular/core';
+import {Component, signal, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatButtonModule} from '../../button';
 import {MATERIAL_ANIMATIONS, provideNativeDateAdapter} from '../../core';
@@ -71,6 +71,7 @@ describe('MatDatepickerActionsHarness', () => {
     </mat-datepicker>
   `,
   imports: [MatDatepickerModule, MatButtonModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DatepickerActionsHarnessTest {
   applied = signal(false);

--- a/src/material/datepicker/testing/datepicker-input-harness.spec.ts
+++ b/src/material/datepicker/testing/datepicker-input-harness.spec.ts
@@ -1,6 +1,6 @@
 import {HarnessLoader, parallel} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
-import {Component} from '@angular/core';
+import {Component, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {FormsModule} from '@angular/forms';
 import {DateAdapter, MATERIAL_ANIMATIONS, provideNativeDateAdapter} from '../../core';
@@ -217,6 +217,7 @@ describe('MatDatepickerInputHarness', () => {
     <input id="no-datepicker" [matDatepicker]="null!">
   `,
   imports: [MatDatepickerModule, MatFormFieldModule, MatInputModule, FormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DatepickerInputHarnessTest {
   date: Date | null = null;

--- a/src/material/datepicker/testing/datepicker-toggle-harness.spec.ts
+++ b/src/material/datepicker/testing/datepicker-toggle-harness.spec.ts
@@ -1,6 +1,6 @@
 import {HarnessLoader, parallel} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
-import {Component} from '@angular/core';
+import {Component, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {MATERIAL_ANIMATIONS, provideNativeDateAdapter} from '../../core';
 import {MatDatepickerModule} from '../../datepicker';
@@ -86,6 +86,7 @@ describe('MatDatepickerToggleHarness', () => {
     <mat-datepicker-toggle id="no-calendar"></mat-datepicker-toggle>
   `,
   imports: [MatDatepickerModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DatepickerToggleHarnessTest {
   touchUi = false;

--- a/src/material/datepicker/year-view.spec.ts
+++ b/src/material/datepicker/year-view.spec.ts
@@ -14,7 +14,7 @@ import {
   dispatchKeyboardEvent,
   provideFakeDirectionality,
 } from '@angular/cdk/testing/private';
-import {Component, signal, ViewChild, WritableSignal} from '@angular/core';
+import {Component, signal, ViewChild, WritableSignal, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {provideNativeDateAdapter} from '../core';
@@ -395,6 +395,7 @@ describe('MatYearView', () => {
     <mat-year-view [(activeDate)]="date" [(selected)]="selected"
                    (monthSelected)="selectedMonth=$event"></mat-year-view>`,
   imports: [MatYearView],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class StandardYearView {
   date = new Date(2017, JAN, 5);
@@ -412,6 +413,7 @@ class StandardYearView {
       [minDate]="minDate"
       [maxDate]="maxDate"></mat-year-view>`,
   imports: [MatYearView],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class YearViewWithDateFilter {
   activeDate = new Date(2017, JAN, 1);
@@ -431,6 +433,7 @@ class YearViewWithDateFilter {
 @Component({
   template: `<mat-year-view [activeDate]="activeDate" [dateClass]="dateClass"></mat-year-view>`,
   imports: [MatYearView],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class YearViewWithDateClass {
   activeDate = new Date(2017, JAN, 1);

--- a/src/material/dialog/dialog.spec.ts
+++ b/src/material/dialog/dialog.spec.ts
@@ -1757,6 +1757,7 @@ describe('MatDialog', () => {
       @Component({
         imports: [MatDialogTitle],
         template: `@if (showTitle()) { <h2 mat-dialog-title>This is the first title</h2> }`,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class DialogCmp {
         showTitle = signal(true);
@@ -1765,6 +1766,7 @@ describe('MatDialog', () => {
       @Component({
         template: '',
         selector: 'child',
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Child {
         readonly viewContainerRef = inject(ViewContainerRef);
@@ -2302,6 +2304,7 @@ class ComponentWithOnPushViewContainer {
   selector: 'arbitrary-component',
   template: `@if (showChildView) {<dir-with-view-container></dir-with-view-container>}`,
   imports: [DirectiveWithViewContainer],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ComponentWithChildViewContainer {
   showChildView = true;
@@ -2317,6 +2320,7 @@ class ComponentWithChildViewContainer {
   selector: 'arbitrary-component-with-template-ref',
   template: `<ng-template let-data let-dialogRef="dialogRef">
     Cheese {{localValue}} {{data?.value}}{{setDialogRef(dialogRef)}}</ng-template>`,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ComponentWithTemplateRef {
   localValue!: string;
@@ -2333,6 +2337,7 @@ class ComponentWithTemplateRef {
 /** Simple component for testing ComponentPortal. */
 @Component({
   template: '<p>Pizza</p> <input> <button>Close</button>',
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class PizzaMsg {
   dialogRef = inject<MatDialogRef<PizzaMsg>>(MatDialogRef);
@@ -2364,6 +2369,7 @@ class PizzaMsg {
     </mat-dialog-actions>
   `,
   imports: [MatDialogTitle, MatDialogContent, MatDialogActions, MatDialogClose],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ContentElementDialog {
   shownTitle: 'first' | 'second' | 'third' | 'all' = 'first';
@@ -2399,6 +2405,7 @@ class ContentElementDialog {
     </ng-template>
   `,
   imports: [MatDialogTitle, MatDialogContent, MatDialogActions, MatDialogClose],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ComponentWithContentElementTemplateRef {
   @ViewChild(TemplateRef) templateRef!: TemplateRef<any>;
@@ -2413,6 +2420,7 @@ class ComponentWithContentElementTemplateRef {
 @Component({
   template: '',
   providers: [MatDialog],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ComponentThatProvidesMatDialog {
   dialog = inject(MatDialog);
@@ -2421,6 +2429,7 @@ class ComponentThatProvidesMatDialog {
 /** Simple component for testing ComponentPortal. */
 @Component({
   template: '',
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DialogWithInjectedData {
   data = inject(MAT_DIALOG_DATA);
@@ -2428,17 +2437,20 @@ class DialogWithInjectedData {
 
 @Component({
   template: '<p>Pasta</p>',
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DialogWithoutFocusableElements {}
 
 @Component({
   template: `<button>I'm a button</button>`,
   encapsulation: ViewEncapsulation.ShadowDom,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ShadowDomComponent {}
 
 @Component({
   template: '',
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ModuleBoundDialogParentComponent {
   private _injector = inject(Injector);
@@ -2462,12 +2474,14 @@ class ModuleBoundDialogService {
 @Component({
   template: '<module-bound-dialog-child-component></module-bound-dialog-child-component>',
   imports: [forwardRef(() => ModuleBoundDialogChildComponent)],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ModuleBoundDialogComponent {}
 
 @Component({
   selector: 'module-bound-dialog-child-component',
   template: '<p>{{service.name}}</p>',
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ModuleBoundDialogChildComponent {
   service = inject(ModuleBoundDialogService);

--- a/src/material/dialog/dialog.zone.spec.ts
+++ b/src/material/dialog/dialog.zone.spec.ts
@@ -10,6 +10,7 @@ import {
   ViewContainerRef,
   provideZoneChangeDetection,
   inject,
+  ChangeDetectionStrategy,
 } from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatDialog, MatDialogRef} from '../dialog';
@@ -76,6 +77,7 @@ class DirectiveWithViewContainer {
   selector: 'arbitrary-component',
   template: `@if (showChildView) {<dir-with-view-container></dir-with-view-container>}`,
   imports: [DirectiveWithViewContainer],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ComponentWithChildViewContainer {
   showChildView = true;
@@ -90,6 +92,7 @@ class ComponentWithChildViewContainer {
 /** Simple component for testing ComponentPortal. */
 @Component({
   template: '<p>Pizza</p> <input> <button>Close</button>',
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class PizzaMsg {
   dialogRef = inject<MatDialogRef<PizzaMsg>>(MatDialogRef);

--- a/src/material/dialog/testing/dialog-harness.spec.ts
+++ b/src/material/dialog/testing/dialog-harness.spec.ts
@@ -1,4 +1,4 @@
-import {Component, TemplateRef, ViewChild, inject} from '@angular/core';
+import {Component, TemplateRef, ViewChild, inject, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
@@ -123,6 +123,7 @@ describe('MatDialogHarness', () => {
   </ng-template>
   `,
   imports: [MatDialogTitle, MatDialogContent, MatDialogActions],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DialogHarnessTest {
   readonly dialog = inject(MatDialog);

--- a/src/material/dialog/testing/dialog-opener.spec.ts
+++ b/src/material/dialog/testing/dialog-opener.spec.ts
@@ -1,4 +1,4 @@
-import {Component, inject} from '@angular/core';
+import {Component, inject, ChangeDetectionStrategy} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {MAT_DIALOG_DATA, MatDialogRef, MatDialogState} from '../../dialog';
 import {MatTestDialogOpener} from './dialog-opener';
@@ -55,6 +55,7 @@ interface ExampleDialogResult {
     Data: {{data}}
     <button id="close-btn" (click)="close()">Close</button>
   `,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ExampleComponent {
   dialogRef = inject<MatDialogRef<ExampleComponent, ExampleDialogResult>>(MatDialogRef);

--- a/src/material/divider/divider.spec.ts
+++ b/src/material/divider/divider.spec.ts
@@ -1,5 +1,5 @@
 import {ComponentFixture, TestBed} from '@angular/core/testing';
-import {Component} from '@angular/core';
+import {Component, ChangeDetectionStrategy} from '@angular/core';
 import {By} from '@angular/platform-browser';
 import {MatDividerModule} from './divider-module';
 
@@ -60,6 +60,7 @@ describe('MatDivider', () => {
 @Component({
   template: `<mat-divider [vertical]="vertical" [inset]="inset"></mat-divider>`,
   imports: [MatDividerModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatDividerTestComponent {
   vertical = false;

--- a/src/material/divider/testing/divider-harness.spec.ts
+++ b/src/material/divider/testing/divider-harness.spec.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import {Component, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
@@ -39,5 +39,6 @@ describe('MatLegacyButtonHarness', () => {
     <mat-divider inset vertical></mat-divider>
   `,
   imports: [MatDividerModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DividerHarnessTest {}

--- a/src/material/expansion/accordion.spec.ts
+++ b/src/material/expansion/accordion.spec.ts
@@ -5,7 +5,13 @@ import {
   dispatchEvent,
   dispatchKeyboardEvent,
 } from '@angular/cdk/testing/private';
-import {Component, QueryList, ViewChild, ViewChildren} from '@angular/core';
+import {
+  Component,
+  QueryList,
+  ViewChild,
+  ViewChildren,
+  ChangeDetectionStrategy,
+} from '@angular/core';
 import {TestBed, waitForAsync} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {
@@ -307,6 +313,7 @@ describe('MatAccordion', () => {
     }
   </mat-accordion>`,
   imports: [MatExpansionModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SetOfItems {
   @ViewChild(MatAccordion) accordion!: MatAccordion;
@@ -335,6 +342,7 @@ class SetOfItems {
     </mat-expansion-panel>
   </mat-accordion>`,
   imports: [MatExpansionModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NestedAccordions {
   @ViewChildren(MatExpansionPanelHeader) headers!: QueryList<MatExpansionPanelHeader>;
@@ -354,6 +362,7 @@ class NestedAccordions {
     </mat-expansion-panel>
   </mat-accordion>`,
   imports: [MatExpansionModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NestedPanel {
   @ViewChild('outerPanel') outerPanel!: MatExpansionPanel;
@@ -369,6 +378,7 @@ class NestedPanel {
     </mat-expansion-panel>
   </mat-accordion>`,
   imports: [MatExpansionModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class AccordionWithHideToggle {
   hideToggle = false;
@@ -383,6 +393,7 @@ class AccordionWithHideToggle {
     </mat-expansion-panel>
   </mat-accordion>`,
   imports: [MatExpansionModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class AccordionWithTogglePosition {
   togglePosition: MatAccordionTogglePosition = 'after';

--- a/src/material/expansion/expansion.spec.ts
+++ b/src/material/expansion/expansion.spec.ts
@@ -4,7 +4,7 @@ import {
   dispatchEvent,
   dispatchKeyboardEvent,
 } from '@angular/cdk/testing/private';
-import {Component, ViewChild} from '@angular/core';
+import {Component, ViewChild, ChangeDetectionStrategy} from '@angular/core';
 import {
   ComponentFixture,
   TestBed,
@@ -556,6 +556,7 @@ describe('MatExpansionPanel', () => {
     <button>I am a button</button>
   </mat-expansion-panel>`,
   imports: [MatExpansionModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class PanelWithContent {
   expanded = false;
@@ -577,6 +578,7 @@ class PanelWithContent {
     }
   `,
   imports: [MatExpansionModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class PanelWithContentInNgIf {
   expansionShown = true;
@@ -593,6 +595,7 @@ class PanelWithContentInNgIf {
     corrupti maxime voluptate accusamus impedit atque incidunt pariatur.
   </mat-expansion-panel>`,
   imports: [MatExpansionModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class PanelWithCustomMargin {
   expanded = false;
@@ -609,6 +612,7 @@ class PanelWithCustomMargin {
     </ng-template>
   </mat-expansion-panel>`,
   imports: [MatExpansionModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class LazyPanelWithContent {
   expanded = false;
@@ -624,6 +628,7 @@ class LazyPanelWithContent {
     </ng-template>
   </mat-expansion-panel>`,
   imports: [MatExpansionModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class LazyPanelOpenOnLoad {}
 
@@ -633,6 +638,7 @@ class LazyPanelOpenOnLoad {}
     <mat-expansion-panel-header>Panel Title</mat-expansion-panel-header>
   </mat-expansion-panel>`,
   imports: [MatExpansionModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class PanelWithTwoWayBinding {
   expanded = false;
@@ -644,6 +650,7 @@ class PanelWithTwoWayBinding {
     <mat-expansion-panel-header tabindex="7">Panel Title</mat-expansion-panel-header>
   </mat-expansion-panel>`,
   imports: [MatExpansionModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class PanelWithHeaderTabindex {}
 
@@ -658,6 +665,7 @@ class PanelWithHeaderTabindex {}
     </mat-expansion-panel>
   `,
   imports: [MatExpansionModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NestedLazyPanelWithContent {
   parentExpanded = false;

--- a/src/material/expansion/testing/expansion-harness.spec.ts
+++ b/src/material/expansion/testing/expansion-harness.spec.ts
@@ -1,6 +1,6 @@
 import {ComponentHarness, HarnessLoader, parallel} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
-import {Component} from '@angular/core';
+import {Component, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatAccordionTogglePosition, MatExpansionModule} from '../../expansion';
 import {MatAccordionHarness} from './accordion-harness';
@@ -324,6 +324,7 @@ function getActiveElementTag() {
     <div class="test-content-harness">Outside of expansion panel</div>
   `,
   imports: [MatExpansionModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ExpansionHarnessTestComponent {
   panel1Expanded = false;

--- a/src/material/form-field/testing/form-field-harness.spec.ts
+++ b/src/material/form-field/testing/form-field-harness.spec.ts
@@ -1,4 +1,4 @@
-import {Component, signal} from '@angular/core';
+import {Component, signal, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {ComponentHarness, HarnessLoader, HarnessPredicate, parallel} from '@angular/cdk/testing';
 import {createFakeEvent, dispatchFakeEvent} from '@angular/cdk/testing/private';
@@ -365,6 +365,7 @@ describe('MatFormFieldHarness', () => {
     MatSuffix,
     MatOption,
   ],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class FormFieldHarnessTest {
   requiredControl = new FormControl('Initial value', [Validators.required]);

--- a/src/material/grid-list/grid-list.spec.ts
+++ b/src/material/grid-list/grid-list.spec.ts
@@ -1,5 +1,5 @@
 import {provideFakeDirectionality} from '@angular/cdk/testing/private';
-import {Component, DebugElement, ViewChild} from '@angular/core';
+import {Component, DebugElement, ViewChild, ChangeDetectionStrategy} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {MatGridTile, MatGridTileText} from './grid-tile';
@@ -534,24 +534,31 @@ function getComputedLeft(element: DebugElement): number {
   return elementRect.left - bodyRect.left;
 }
 
-@Component({template: '<mat-grid-list></mat-grid-list>', imports: [MatGridListModule]})
+@Component({
+  template: '<mat-grid-list></mat-grid-list>',
+  imports: [MatGridListModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
+})
 class GridListWithoutCols {}
 
 @Component({
   template: '<mat-grid-list cols="4" rowHeight="4:3:2"></mat-grid-list>',
   imports: [MatGridListModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class GridListWithInvalidRowHeightRatio {}
 
 @Component({
   template: '<mat-grid-list cols="4"><mat-grid-tile colspan="5"></mat-grid-tile></mat-grid-list>',
   imports: [MatGridListModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class GridListWithTooWideColspan {}
 
 @Component({
   template: '<mat-grid-list [cols]="cols"></mat-grid-list>',
   imports: [MatGridListModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class GridListWithDynamicCols {
   @ViewChild(MatGridList) gridList!: MatGridList;
@@ -566,6 +573,7 @@ class GridListWithDynamicCols {
       </mat-grid-list>
     </div>`,
   imports: [MatGridListModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class GridListWithUnspecifiedRowHeight {}
 
@@ -577,6 +585,7 @@ class GridListWithUnspecifiedRowHeight {}
       </mat-grid-list>
     </div>`,
   imports: [MatGridListModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class GirdListWithRowHeightRatio {
   rowHeight!: string;
@@ -589,6 +598,7 @@ class GirdListWithRowHeightRatio {
       <mat-grid-tile></mat-grid-tile>
     </mat-grid-list>`,
   imports: [MatGridListModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class GridListWithFitRowHeightMode {
   totalHeight!: string;
@@ -600,6 +610,7 @@ class GridListWithFitRowHeightMode {
       <mat-grid-tile></mat-grid-tile>
     </mat-grid-list>`,
   imports: [MatGridListModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class GridListWithFixedRowHeightMode {
   rowHeight!: string;
@@ -611,6 +622,7 @@ class GridListWithFixedRowHeightMode {
       <mat-grid-tile></mat-grid-tile>
     </mat-grid-list>`,
   imports: [MatGridListModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class GridListWithUnitlessFixedRowHeight {
   rowHeight!: string;
@@ -626,6 +638,7 @@ class GridListWithUnitlessFixedRowHeight {
       </mat-grid-list>
     </div>`,
   imports: [MatGridListModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class GridListWithUnspecifiedGutterSize {}
 
@@ -639,6 +652,7 @@ class GridListWithUnspecifiedGutterSize {}
       </mat-grid-list>
     </div>`,
   imports: [MatGridListModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class GridListWithGutterSize {}
 
@@ -652,6 +666,7 @@ class GridListWithGutterSize {}
       </mat-grid-list>
     </div>`,
   imports: [MatGridListModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class GridListWithUnitlessGutterSize {}
 
@@ -664,6 +679,7 @@ class GridListWithUnitlessGutterSize {}
       </mat-grid-list>
     </div>`,
   imports: [MatGridListModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class GridListWithRatioHeightAndMulipleRows {}
 
@@ -674,6 +690,7 @@ class GridListWithRatioHeightAndMulipleRows {}
       <mat-grid-tile></mat-grid-tile>
     </mat-grid-list>`,
   imports: [MatGridListModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class GridListWithFixRowHeightAndMultipleRows {}
 
@@ -685,6 +702,7 @@ class GridListWithFixRowHeightAndMultipleRows {}
       </mat-grid-list>
     </div>`,
   imports: [MatGridListModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class GridListWithColspanBinding {
   colspan!: number;
@@ -696,6 +714,7 @@ class GridListWithColspanBinding {
       <mat-grid-tile [rowspan]="rowspan"></mat-grid-tile>
     </mat-grid-list>`,
   imports: [MatGridListModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class GridListWithRowspanBinding {
   rowspan!: number;
@@ -714,6 +733,7 @@ class GridListWithRowspanBinding {
       </mat-grid-list>
     </div>`,
   imports: [MatGridListModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class GridListWithComplexLayout {
   tiles!: any[];
@@ -731,6 +751,7 @@ class GridListWithComplexLayout {
     </mat-grid-list>
   </div>`,
   imports: [MatGridListModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class GridListWithLayout {}
 
@@ -745,6 +766,7 @@ class GridListWithLayout {}
     </mat-grid-list>
   </div>`,
   imports: [MatGridListModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class GridListWithSingleCellAtBeginning {}
 
@@ -758,6 +780,7 @@ class GridListWithSingleCellAtBeginning {}
       </mat-grid-tile>
     </mat-grid-list>`,
   imports: [MatGridListModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class GridListWithFootersWithoutLines {}
 
@@ -772,6 +795,7 @@ class GridListWithFootersWithoutLines {}
       </mat-grid-tile>
     </mat-grid-list>`,
   imports: [MatGridListModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class GridListWithFooterContainingTwoLines {}
 
@@ -790,6 +814,7 @@ class GridListWithFooterContainingTwoLines {}
       </mat-grid-tile>
     </mat-grid-list>`,
   imports: [MatGridListModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class GridListWithFooterContainingTwoIndirectDescendantLines {}
 
@@ -803,6 +828,7 @@ class GridListWithFooterContainingTwoIndirectDescendantLines {}
   </mat-grid-list>
 `,
   imports: [MatGridListModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class GridListWithoutMatchingGap {}
 
@@ -810,6 +836,7 @@ class GridListWithoutMatchingGap {}
   template: `<mat-grid-list cols="1"><mat-grid-tile>Hello</mat-grid-tile></mat-grid-list>`,
   providers: [provideFakeDirectionality('ltr')],
   imports: [MatGridListModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class GridListWithEmptyDirectionality {}
 
@@ -817,6 +844,7 @@ class GridListWithEmptyDirectionality {}
   template: `<mat-grid-list cols="1"><mat-grid-tile>Hello</mat-grid-tile></mat-grid-list>`,
   providers: [provideFakeDirectionality('rtl')],
   imports: [MatGridListModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class GridListWithRtl {}
 
@@ -832,6 +860,7 @@ class GridListWithRtl {}
     </div>
   `,
   imports: [MatGridListModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class GridListWithIndirectTileDescendants {}
 
@@ -850,5 +879,6 @@ class GridListWithIndirectTileDescendants {}
       </mat-grid-list>
     </div>`,
   imports: [MatGridListModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NestedGridList {}

--- a/src/material/grid-list/testing/grid-list-harness.spec.ts
+++ b/src/material/grid-list/testing/grid-list-harness.spec.ts
@@ -1,4 +1,4 @@
-import {Component, signal} from '@angular/core';
+import {Component, signal, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {HarnessLoader, parallel} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
@@ -178,6 +178,7 @@ describe('MatGridListHarness', () => {
     </mat-grid-list>
   `,
   imports: [MatGridListModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class GridListHarnessTest {
   firstTileText = signal('One');

--- a/src/material/icon/icon.spec.ts
+++ b/src/material/icon/icon.spec.ts
@@ -3,7 +3,14 @@ import {
   HttpTestingController,
   TestRequest,
 } from '@angular/common/http/testing';
-import {Component, ErrorHandler, Provider, Type, ViewChild} from '@angular/core';
+import {
+  Component,
+  ErrorHandler,
+  Provider,
+  Type,
+  ViewChild,
+  ChangeDetectionStrategy,
+} from '@angular/core';
 import {TestBed, fakeAsync, tick, waitForAsync} from '@angular/core/testing';
 import {DomSanitizer, SafeHtml, SafeResourceUrl} from '@angular/platform-browser';
 import {FAKE_SVGS} from './fake-svgs';
@@ -1411,6 +1418,7 @@ describe('MatIcon with default options', () => {
 @Component({
   template: `<mat-icon>{{iconName}}</mat-icon>`,
   imports: [MatIconModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class IconWithLigature {
   iconName = '';
@@ -1419,6 +1427,7 @@ class IconWithLigature {
 @Component({
   template: `<mat-icon [fontIcon]="iconName"></mat-icon>`,
   imports: [MatIconModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class IconWithLigatureByAttribute {
   iconName = '';
@@ -1427,6 +1436,7 @@ class IconWithLigatureByAttribute {
 @Component({
   template: `<mat-icon [color]="iconColor">{{iconName}}</mat-icon>`,
   imports: [MatIconModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class IconWithColor {
   iconName = '';
@@ -1436,6 +1446,7 @@ class IconWithColor {
 @Component({
   template: `<mat-icon [fontSet]="fontSet" [fontIcon]="fontIcon"></mat-icon>`,
   imports: [MatIconModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class IconWithCustomFontCss {
   fontSet = '';
@@ -1445,6 +1456,7 @@ class IconWithCustomFontCss {
 @Component({
   template: `<mat-icon [svgIcon]="iconName"></mat-icon>`,
   imports: [MatIconModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class IconFromSvgName {
   iconName = '';
@@ -1453,12 +1465,14 @@ class IconFromSvgName {
 @Component({
   template: '<mat-icon aria-hidden="false">face</mat-icon>',
   imports: [MatIconModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class IconWithAriaHiddenFalse {}
 
 @Component({
   template: `@if (showIcon) {<mat-icon [svgIcon]="iconName">{{iconName}}</mat-icon>}`,
   imports: [MatIconModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class IconWithBindingAndNgIf {
   iconName = 'fluffy';
@@ -1468,6 +1482,7 @@ class IconWithBindingAndNgIf {
 @Component({
   template: `<mat-icon [inline]="inline"></mat-icon>`,
   imports: [MatIconModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class InlineIcon {
   inline = false;
@@ -1476,6 +1491,7 @@ class InlineIcon {
 @Component({
   template: `<mat-icon [svgIcon]="iconName"><div>Hello</div></mat-icon>`,
   imports: [MatIconModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SvgIconWithUserContent {
   iconName = '';
@@ -1484,6 +1500,7 @@ class SvgIconWithUserContent {
 @Component({
   template: '<mat-icon [svgIcon]="iconName">house</mat-icon>',
   imports: [MatIconModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class IconWithLigatureAndSvgBinding {
   iconName!: string;
@@ -1492,6 +1509,7 @@ class IconWithLigatureAndSvgBinding {
 @Component({
   template: `<mat-icon></mat-icon>`,
   imports: [MatIconModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class BlankIcon {
   @ViewChild(MatIcon) icon!: MatIcon;

--- a/src/material/icon/testing/icon-harness.spec.ts
+++ b/src/material/icon/testing/icon-harness.spec.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import {Component, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {HarnessLoader, parallel} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
@@ -111,5 +111,6 @@ describe('MatIconHarness', () => {
     <mat-icon><span>ligature_icon_with_indirect_name</span></mat-icon>
   `,
   imports: [MatIconModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class IconHarnessTest {}

--- a/src/material/input/input.spec.ts
+++ b/src/material/input/input.spec.ts
@@ -1726,6 +1726,7 @@ describe('MatFormField without label', () => {
       <input matNativeControl id="test-id" placeholder="test">
     </mat-form-field>`,
   imports: [MatInputModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatInputWithId {
   floatLabel: 'always' | 'auto' = 'auto';
@@ -1738,6 +1739,7 @@ class MatInputWithId {
     </mat-form-field>
   `,
   imports: [MatInputModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatInputWithDisabled {
   disabled = false;
@@ -1747,6 +1749,7 @@ class MatInputWithDisabled {
 @Component({
   template: `<mat-form-field><input matInput [required]="required"></mat-form-field>`,
   imports: [MatInputModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatInputWithRequired {
   required = false;
@@ -1755,6 +1758,7 @@ class MatInputWithRequired {
 @Component({
   template: `<mat-form-field><input matInput [type]="type"></mat-form-field>`,
   imports: [MatInputModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatInputWithType {
   type!: string;
@@ -1767,6 +1771,7 @@ class MatInputWithType {
       <input matInput required [disabled]="disabled">
     </mat-form-field>`,
   imports: [MatInputModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatInputLabelRequiredTestComponent {
   hideRequiredMarker: boolean = false;
@@ -1779,6 +1784,7 @@ class MatInputLabelRequiredTestComponent {
       <input matInput placeholder="Hello" [formControl]="formControl">
     </mat-form-field>`,
   imports: [MatInputModule, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatInputWithFormControl {
   formControl = new FormControl('');
@@ -1787,6 +1793,7 @@ class MatInputWithFormControl {
 @Component({
   template: `<mat-form-field><input matInput><mat-hint>{{label}}</mat-hint></mat-form-field>`,
   imports: [MatInputModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatInputHintLabel2TestController {
   label: string = '';
@@ -1798,6 +1805,7 @@ class MatInputHintLabel2TestController {
       <input matInput aria-describedby="initial">
     </mat-form-field>`,
   imports: [MatInputModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatInputHintLabelTestController {
   label: string = '';
@@ -1812,6 +1820,7 @@ class MatInputHintLabelTestController {
       }
     </mat-form-field>`,
   imports: [MatInputModule, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatInputWithSubscriptAndAriaDescribedBy {
   label: string = '';
@@ -1823,6 +1832,7 @@ class MatInputWithSubscriptAndAriaDescribedBy {
 @Component({
   template: `<mat-form-field><input matInput [type]="t"></mat-form-field>`,
   imports: [MatInputModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatInputInvalidTypeTestController {
   t = 'file';
@@ -1835,6 +1845,7 @@ class MatInputInvalidTypeTestController {
       <mat-hint>World</mat-hint>
     </mat-form-field>`,
   imports: [MatInputModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatInputInvalidHint2TestController {}
 
@@ -1846,6 +1857,7 @@ class MatInputInvalidHint2TestController {}
       <mat-hint>World</mat-hint>
     </mat-form-field>`,
   imports: [MatInputModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatInputInvalidHintTestController {}
 
@@ -1857,6 +1869,7 @@ class MatInputInvalidHintTestController {}
       <mat-hint align="end" [id]="endId">World</mat-hint>
     </mat-form-field>`,
   imports: [MatInputModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatInputMultipleHintTestController {
   startId!: string;
@@ -1870,6 +1883,7 @@ class MatInputMultipleHintTestController {
       <mat-hint align="end">World</mat-hint>
     </mat-form-field>`,
   imports: [MatInputModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatInputMultipleHintMixedTestController {}
 
@@ -1879,6 +1893,7 @@ class MatInputMultipleHintMixedTestController {}
       <input matInput type="date" placeholder="Placeholder">
     </mat-form-field>`,
   imports: [MatInputModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatInputDateTestController {}
 
@@ -1894,6 +1909,7 @@ class MatInputDateTestController {}
         [disabledInteractive]="disabledInteractive">
     </mat-form-field>`,
   imports: [MatInputModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatInputTextTestController {
   disabled = false;
@@ -1906,6 +1922,7 @@ class MatInputTextTestController {
       <input matInput type="password" placeholder="Placeholder">
     </mat-form-field>`,
   imports: [MatInputModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatInputPasswordTestController {}
 
@@ -1915,6 +1932,7 @@ class MatInputPasswordTestController {}
       <input matInput type="number" placeholder="Placeholder">
     </mat-form-field>`,
   imports: [MatInputModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatInputNumberTestController {}
 
@@ -1924,6 +1942,7 @@ class MatInputNumberTestController {}
       <input matInput type="number" placeholder="Placeholder" [(ngModel)]="value">
     </mat-form-field>`,
   imports: [MatInputModule, FormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatInputZeroTestController {
   value = 0;
@@ -1935,6 +1954,7 @@ class MatInputZeroTestController {
       <input matInput placeholder="Label" [value]="value">
     </mat-form-field>`,
   imports: [MatInputModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatInputWithValueBinding {
   value: string = 'Initial';
@@ -1947,6 +1967,7 @@ class MatInputWithValueBinding {
     </mat-form-field>
   `,
   imports: [MatInputModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatInputWithStaticLabel {}
 
@@ -1961,6 +1982,7 @@ class MatInputWithStaticLabel {}
         [disabledInteractive]="disabledInteractive">
     </mat-form-field>`,
   imports: [MatInputModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatInputWithDynamicLabel {
   shouldFloat: 'always' | 'auto' = 'always';
@@ -1975,6 +1997,7 @@ class MatInputWithDynamicLabel {
     </mat-form-field>
   `,
   imports: [MatInputModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatInputWithoutDefinedLabel {}
 
@@ -1987,6 +2010,7 @@ class MatInputWithoutDefinedLabel {}
       <input matInput>
     </mat-form-field>`,
   imports: [MatInputModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatInputWithCondictionalLabel {
   hasLabel = true;
@@ -1999,6 +2023,7 @@ class MatInputWithCondictionalLabel {
       </textarea>
     </mat-form-field>`,
   imports: [MatInputModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatInputTextareaWithBindings {
   rows: number = 4;
@@ -2009,6 +2034,7 @@ class MatInputTextareaWithBindings {
 @Component({
   template: `<mat-form-field><input></mat-form-field>`,
   imports: [MatInputModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatInputMissingMatInputTestController {}
 
@@ -2025,6 +2051,7 @@ class MatInputMissingMatInputTestController {}
     </form>
   `,
   imports: [MatInputModule, ReactiveFormsModule, FormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatInputWithFormErrorMessages {
   @ViewChild('form') form!: NgForm;
@@ -2048,6 +2075,7 @@ class MatInputWithFormErrorMessages {
     </form>
   `,
   imports: [MatInputModule, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class InputInFormGroup {
   formGroup = new FormGroup({
@@ -2072,6 +2100,7 @@ class InputInFormGroup {
     </form>
   `,
   imports: [MatInputModule, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatInputWithFormGroupErrorMessages {
   @ViewChild(FormGroupDirective) formGroupDirective!: FormGroupDirective;
@@ -2091,6 +2120,7 @@ class MatInputWithFormGroupErrorMessages {
     </mat-form-field>
   `,
   imports: [MatInputModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatInputWithPrefixAndSuffix {}
 
@@ -2103,6 +2133,7 @@ class MatInputWithPrefixAndSuffix {}
     </mat-form-field>
   `,
   imports: [MatInputModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatInputWithNgIf {
   renderInput = true;
@@ -2130,6 +2161,7 @@ class MatInputOnPush {
     </mat-form-field>
   `,
   imports: [MatInputModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatInputWithLabel {}
 
@@ -2141,6 +2173,7 @@ class MatInputWithLabel {}
     </mat-form-field>
   `,
   imports: [MatInputModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatInputWithLabelAndPlaceholder {
   floatLabel!: FloatLabelType;
@@ -2155,6 +2188,7 @@ class MatInputWithLabelAndPlaceholder {
     </mat-form-field>
   `,
   imports: [MatInputModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatInputWithAppearance {
   @ViewChild(MatFormField) formField!: MatFormField;
@@ -2169,6 +2203,7 @@ class MatInputWithAppearance {
     </mat-form-field>
   `,
   imports: [MatInputModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatInputWithSubscriptSizing {
   @ViewChild(MatFormField) formField!: MatFormField;
@@ -2182,6 +2217,7 @@ class MatInputWithSubscriptSizing {
     </mat-form-field>
   `,
   imports: [MatInputModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatInputWithoutPlaceholder {}
 
@@ -2197,6 +2233,7 @@ class MatInputWithoutPlaceholder {}
       </select>
     </mat-form-field>`,
   imports: [MatInputModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatInputSelect {
   disabled: boolean = false;
@@ -2215,6 +2252,7 @@ class MatInputSelect {
       </select>
     </mat-form-field>`,
   imports: [MatInputModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatInputSelectWithNoLabelNoValue {}
 
@@ -2230,6 +2268,7 @@ class MatInputSelectWithNoLabelNoValue {}
       </select>
     </mat-form-field>`,
   imports: [MatInputModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatInputSelectWithLabel {}
 
@@ -2245,6 +2284,7 @@ class MatInputSelectWithLabel {}
       </select>
     </mat-form-field>`,
   imports: [MatInputModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatInputSelectWithInnerHtml {}
 
@@ -2272,6 +2312,7 @@ class CustomMatInputAccessor {
       <input matInput customInputAccessor placeholder="Placeholder">
     </mat-form-field>`,
   imports: [MatInputModule, CustomMatInputAccessor],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatInputWithCustomAccessor {}
 
@@ -2282,6 +2323,7 @@ class MatInputWithCustomAccessor {}
       </select>
     </mat-form-field>`,
   imports: [MatInputModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatInputSelectWithoutOptions {}
 
@@ -2291,6 +2333,7 @@ class MatInputSelectWithoutOptions {}
       <input matNativeControl>
     </mat-form-field>`,
   imports: [MatInputModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatInputWithColor {
   color!: ThemePalette;
@@ -2305,6 +2348,7 @@ class MatInputWithColor {
     <input class="outside" matNativeControl>
   `,
   imports: [MatInputModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatInputInsideOutsideFormField {}
 
@@ -2315,6 +2359,7 @@ class MatInputInsideOutsideFormField {}
       <input matInput [formControl]="formControl">
     </mat-form-field>`,
   imports: [MatInputModule, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatInputWithRequiredFormControl {
   formControl = new FormControl('', [Validators.required]);
@@ -2327,6 +2372,7 @@ class MatInputWithRequiredFormControl {
     </mat-form-field>
   `,
   imports: [MatInputModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatInputSimple {}
 
@@ -2341,6 +2387,7 @@ class MatInputSimple {}
     </mat-form-field>
   `,
   imports: [MatInputModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class InputWithNgContainerPrefixAndSuffix {}
 
@@ -2351,6 +2398,7 @@ class InputWithNgContainerPrefixAndSuffix {}
       <input matInput [formControl]="formControl">
     </mat-form-field>`,
   imports: [MatInputModule, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatInputWithRequiredAssignableFormControl {
   formControl = new FormControl('', [Validators.required]);

--- a/src/material/input/testing/input-harness.spec.ts
+++ b/src/material/input/testing/input-harness.spec.ts
@@ -1,4 +1,4 @@
-import {Component, signal} from '@angular/core';
+import {Component, signal, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
@@ -297,6 +297,7 @@ describe('MatInputHarness', () => {
     </mat-form-field>
   `,
   imports: [MatInputModule, FormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class InputHarnessTest {
   inputType = signal('number');

--- a/src/material/input/testing/native-select-harness.spec.ts
+++ b/src/material/input/testing/native-select-harness.spec.ts
@@ -1,4 +1,4 @@
-import {Component, signal} from '@angular/core';
+import {Component, signal, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {HarnessLoader, parallel} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
@@ -223,6 +223,7 @@ describe('MatNativeSelectHarness', () => {
     </mat-form-field>
   `,
   imports: [MatInputModule, FormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SelectHarnessTest {
   favoriteFood!: string;

--- a/src/material/list/list.spec.ts
+++ b/src/material/list/list.spec.ts
@@ -1,5 +1,11 @@
 import {dispatchFakeEvent, dispatchMouseEvent} from '@angular/cdk/testing/private';
-import {Component, QueryList, ViewChild, ViewChildren} from '@angular/core';
+import {
+  Component,
+  QueryList,
+  ViewChild,
+  ViewChildren,
+  ChangeDetectionStrategy,
+} from '@angular/core';
 import {TestBed, fakeAsync} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {MatListItem, MatListModule} from './index';
@@ -411,6 +417,7 @@ class BaseTestList {
     </a>
   </mat-list>`,
   imports: [MatListModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ListWithOneAnchorItem extends BaseTestList {
   // This needs to be declared directly on the class; if declared on the BaseTestList superclass,
@@ -426,6 +433,7 @@ class ListWithOneAnchorItem extends BaseTestList {
     </a>
   </mat-nav-list>`,
   imports: [MatListModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NavListWithOneAnchorItem extends BaseTestList {
   @ViewChildren(MatListItem) listItems!: QueryList<MatListItem>;
@@ -444,6 +452,7 @@ class NavListWithOneAnchorItem extends BaseTestList {
     }
   </mat-nav-list>`,
   imports: [MatListModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NavListWithActivatedItem extends BaseTestList {
   @ViewChildren(MatListItem) listItems!: QueryList<MatListItem>;
@@ -462,6 +471,7 @@ class NavListWithActivatedItem extends BaseTestList {
     </button>
   </mat-action-list>`,
   imports: [MatListModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ActionListWithoutType extends BaseTestList {
   @ViewChildren(MatListItem) listItems!: QueryList<MatListItem>;
@@ -477,6 +487,7 @@ class ActionListWithoutType extends BaseTestList {
     </button>
   </mat-action-list>`,
   imports: [MatListModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ActionListWithType extends BaseTestList {
   @ViewChildren(MatListItem) listItems!: QueryList<MatListItem>;
@@ -490,6 +501,7 @@ class ActionListWithType extends BaseTestList {
     }
   </mat-action-list>`,
   imports: [MatListModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ActionListWithDisabledList extends BaseTestList {
   disableList = true;
@@ -503,6 +515,7 @@ class ActionListWithDisabledList extends BaseTestList {
     </button>
   </mat-action-list>`,
   imports: [MatListModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ActionListWithDisabledItem extends BaseTestList {
   @ViewChild(MatListItem) buttonItem!: MatListItem;
@@ -517,6 +530,7 @@ class ActionListWithDisabledItem extends BaseTestList {
     </mat-list-item>
   </mat-list>`,
   imports: [MatListModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ListWithOneItem extends BaseTestList {}
 
@@ -532,6 +546,7 @@ class ListWithOneItem extends BaseTestList {}
     }
   </mat-list>`,
   imports: [MatListModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ListWithTwoLineItem extends BaseTestList {}
 
@@ -547,6 +562,7 @@ class ListWithTwoLineItem extends BaseTestList {}
     }
   </mat-list>`,
   imports: [MatListModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ListWithThreeLineItem extends BaseTestList {}
 
@@ -562,6 +578,7 @@ class ListWithThreeLineItem extends BaseTestList {}
     </mat-list-item>
   </mat-list>`,
   imports: [MatListModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ListWithAvatar extends BaseTestList {}
 
@@ -576,6 +593,7 @@ class ListWithAvatar extends BaseTestList {}
     }
   </mat-list>`,
   imports: [MatListModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ListWithItemWithCssClass extends BaseTestList {}
 
@@ -593,6 +611,7 @@ class ListWithItemWithCssClass extends BaseTestList {}
     }
   </mat-list>`,
   imports: [MatListModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ListWithDynamicNumberOfLines extends BaseTestList {}
 
@@ -604,6 +623,7 @@ class ListWithDynamicNumberOfLines extends BaseTestList {}
     }
   </mat-list>`,
   imports: [MatListModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ListWithMultipleItems extends BaseTestList {}
 
@@ -615,6 +635,7 @@ class ListWithMultipleItems extends BaseTestList {}
     <mat-list-item>Three</mat-list-item>
   </mat-list>`,
   imports: [MatListModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ListWithDisabledItems {
   firstItemDisabled = false;
@@ -624,5 +645,6 @@ class ListWithDisabledItems {
 @Component({
   template: `<mat-list-item></mat-list-item>`,
   imports: [MatListModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class StandaloneListItem {}

--- a/src/material/list/selection-list.spec.ts
+++ b/src/material/list/selection-list.spec.ts
@@ -1702,6 +1702,7 @@ describe('MatSelectionList with forms', () => {
     }
   </mat-selection-list>`,
   imports: [MatListModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SelectionListWithListOptions {
   showLastOption = true;
@@ -1730,6 +1731,7 @@ class SelectionListWithListOptions {
     </mat-list-option>
   </mat-selection-list>`,
   imports: [MatListModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SelectionListWithCheckboxPositionAfter {}
 
@@ -1750,6 +1752,7 @@ class SelectionListWithCheckboxPositionAfter {}
     </mat-list-option>
   </mat-selection-list>`,
   imports: [MatListModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SelectionListWithListDisabled {
   disabled: boolean = true;
@@ -1762,6 +1765,7 @@ class SelectionListWithListDisabled {
   </mat-selection-list>
   `,
   imports: [MatListModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SelectionListWithDisabledOption {
   disableItem: boolean = false;
@@ -1776,6 +1780,7 @@ class SelectionListWithDisabledOption {
     <mat-list-option>Not selected - Item #4</mat-list-option>
   </mat-selection-list>`,
   imports: [MatListModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SelectionListWithSelectedOption {}
 
@@ -1786,6 +1791,7 @@ class SelectionListWithSelectedOption {}
     <mat-list-option [selected]="true">Pre-selected - Item #2</mat-list-option>
   </mat-selection-list>`,
   imports: [MatListModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SingleSelectionListWithSelectedOption {}
 
@@ -1795,6 +1801,7 @@ class SingleSelectionListWithSelectedOption {}
     <mat-list-option [selected]="true" [value]="itemValue">Item</mat-list-option>
   </mat-selection-list>`,
   imports: [MatListModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SelectionListWithSelectedOptionAndValue {
   itemValue = 'item1';
@@ -1811,6 +1818,7 @@ class SelectionListWithSelectedOptionAndValue {
       }
     </mat-selection-list>`,
   imports: [MatListModule, FormsModule, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SelectionListWithModel {
   modelChangeSpy = jasmine.createSpy('model change spy');
@@ -1833,6 +1841,7 @@ class SelectionListWithModel {
     }
   `,
   imports: [MatListModule, FormsModule, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SelectionListWithFormControl {
   formControl = new FormControl([] as string[]);
@@ -1847,6 +1856,7 @@ class SelectionListWithFormControl {
       <mat-list-option value="opt2" selected>Option 2</mat-list-option>
     </mat-selection-list>`,
   imports: [MatListModule, FormsModule, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SelectionListWithPreselectedOption {
   selectedOptions!: string[];
@@ -1859,6 +1869,7 @@ class SelectionListWithPreselectedOption {
       <mat-list-option value="opt2" selected>Option 2</mat-list-option>
     </mat-selection-list>`,
   imports: [MatListModule, FormsModule, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SelectionListWithPreselectedOptionAndModel {
   selectedOptions = ['opt1'];
@@ -1888,6 +1899,7 @@ class SelectionListWithPreselectedFormControlOnPush {
       }
     </mat-selection-list>`,
   imports: [MatListModule, FormsModule, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SelectionListWithCustomComparator {
   @ViewChildren(MatListOption) optionInstances!: QueryList<MatListOption>;
@@ -1910,6 +1922,7 @@ class SelectionListWithCustomComparator {
     </mat-selection-list>
   `,
   imports: [MatListModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SelectionListWithAvatar {
   togglePosition!: MatListOptionTogglePosition;
@@ -1925,6 +1938,7 @@ class SelectionListWithAvatar {
     </mat-selection-list>
   `,
   imports: [MatListModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SelectionListWithIcon {
   togglePosition!: MatListOptionTogglePosition;
@@ -1940,6 +1954,7 @@ class SelectionListWithIcon {
       }
     </mat-selection-list>`,
   imports: [MatListModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SelectionListWithIndirectChildOptions {
   @ViewChildren(MatListOption) optionInstances!: QueryList<MatListOption>;
@@ -1952,6 +1967,7 @@ class SelectionListWithIndirectChildOptions {
   </mat-selection-list>
 `,
   imports: [MatListModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ListOptionWithTwoWayBinding {
   selected = false;

--- a/src/material/list/testing/list-harness.spec.ts
+++ b/src/material/list/testing/list-harness.spec.ts
@@ -6,7 +6,7 @@ import {
   parallel,
 } from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
-import {Component, Type, WritableSignal, signal} from '@angular/core';
+import {Component, Type, WritableSignal, signal, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatDividerHarness} from '../../divider/testing';
 import {MatListModule} from '../../list';
@@ -526,6 +526,7 @@ describe('MatSelectionListHarness', () => {
       <mat-list class="test-empty"></mat-list>
   `,
   imports: [MatListModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ListHarnessTest {
   disableThirdItem = signal(false);
@@ -566,6 +567,7 @@ class ListHarnessTest {
       <mat-action-list class="test-empty"></mat-action-list>
   `,
   imports: [MatListModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ActionListHarnessTest {
   lastClicked!: string;
@@ -608,6 +610,7 @@ class ActionListHarnessTest {
       <mat-nav-list class="test-empty"></mat-nav-list>
   `,
   imports: [MatListModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NavListHarnessTest {
   lastClicked!: string;
@@ -651,6 +654,7 @@ class NavListHarnessTest {
     <mat-selection-list class="test-empty" disabled></mat-selection-list>
   `,
   imports: [MatListModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SelectionListHarnessTest {
   disableThirdItem = signal(false);

--- a/src/material/menu/context-menu-trigger.spec.ts
+++ b/src/material/menu/context-menu-trigger.spec.ts
@@ -1,4 +1,4 @@
-import {Component, signal, ViewChild} from '@angular/core';
+import {Component, signal, ViewChild, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, fakeAsync, flush, TestBed} from '@angular/core/testing';
 import {MatContextMenuTrigger} from './context-menu-trigger';
 import {MatMenu} from './menu';
@@ -202,6 +202,7 @@ describe('context menu trigger', () => {
       outline: solid 1px;
     }
   `,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ContextMenuTest {
   @ViewChild(MatMenu) menuInstance!: MatMenu;

--- a/src/material/menu/menu.spec.ts
+++ b/src/material/menu/menu.spec.ts
@@ -2484,6 +2484,7 @@ const SIMPLE_MENU_TEMPLATE = `
 @Component({
   selector: 'mat-icon',
   template: '<ng-content/>',
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class FakeIcon {}
 
@@ -2491,6 +2492,7 @@ class FakeIcon {}
   template: SIMPLE_MENU_TEMPLATE,
   imports: [MatMenuTrigger, MatMenu, MatMenuItem, FakeIcon],
   selector: 'simple-menu',
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SimpleMenu {
   @ViewChild(MatMenuTrigger) trigger!: MatMenuTrigger;
@@ -2524,6 +2526,7 @@ class SimpleMenuOnPush extends SimpleMenu {}
     </mat-menu>
   `,
   imports: [MatButton, MatMenuTrigger, MatMenu, MatMenuItem],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DisabledMenu {
   @ViewChild('triggerEl', {read: ElementRef}) triggerEl!: ElementRef<HTMLElement>;
@@ -2537,6 +2540,7 @@ class DisabledMenu {
     </mat-menu>
   `,
   imports: [MatMenuTrigger, MatMenu, MatMenuItem],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class PositionedMenu {
   @ViewChild(MatMenuTrigger) trigger!: MatMenuTrigger;
@@ -2557,6 +2561,7 @@ interface TestableMenu {
     </mat-menu>
   `,
   imports: [MatMenuTrigger, MatMenu, MatMenuItem],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class OverlapMenu implements TestableMenu {
   @Input() overlapTrigger: boolean = false;
@@ -2573,6 +2578,7 @@ class OverlapMenu implements TestableMenu {
     </ng-template>
   `,
   exportAs: 'matCustomMenu',
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class CustomMenuPanel implements MatMenuPanel {
   direction!: Direction;
@@ -2596,6 +2602,7 @@ class CustomMenuPanel implements MatMenuPanel {
     </custom-menu>
   `,
   imports: [MatMenuTrigger, MatMenuItem, CustomMenuPanel],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class CustomMenu {
   @ViewChild(MatMenuTrigger) trigger!: MatMenuTrigger;
@@ -2649,6 +2656,7 @@ class CustomMenu {
     </mat-menu>
   `,
   imports: [MatMenuTrigger, MatMenu, MatMenuItem],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NestedMenu {
   @ViewChild('root') rootMenu!: MatMenu;
@@ -2691,6 +2699,7 @@ class NestedMenu {
     </mat-menu>
   `,
   imports: [MatMenuTrigger, MatMenu, MatMenuItem],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NestedMenuRepeater {
   @ViewChild('rootTriggerEl') rootTriggerEl!: ElementRef<HTMLElement>;
@@ -2712,6 +2721,7 @@ class NestedMenuRepeater {
     </mat-menu>
   `,
   imports: [MatMenuTrigger, MatMenu, MatMenuItem],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SubmenuDeclaredInsideParentMenu {
   @ViewChild('rootTriggerEl') rootTriggerEl!: ElementRef;
@@ -2741,6 +2751,7 @@ class DestroyChecker implements OnDestroy {
     </mat-menu>
   `,
   imports: [MatMenuTrigger, MatMenu, MatMenuItem, MatMenuContent, DestroyChecker],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SimpleLazyMenu {
   @ViewChild(MatMenuTrigger) trigger!: MatMenuTrigger;
@@ -2768,6 +2779,7 @@ class SimpleLazyMenu {
     </mat-menu>
   `,
   imports: [MatMenuTrigger, MatMenu, MatMenuItem, MatMenuContent],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class LazyMenuWithContext {
   @ViewChild('triggerOne') triggerOne!: MatMenuTrigger;
@@ -2786,6 +2798,7 @@ class LazyMenuWithContext {
     </mat-menu>
   `,
   imports: [MatMenuTrigger, MatMenu, MatMenuItem],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DynamicPanelMenu {
   @ViewChild(MatMenuTrigger) trigger!: MatMenuTrigger;
@@ -2803,6 +2816,7 @@ class DynamicPanelMenu {
     </mat-menu>
   `,
   imports: [MatMenuTrigger, MatMenu, MatMenuItem],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MenuWithCheckboxItems {
   @ViewChild(MatMenuTrigger) trigger!: MatMenuTrigger;
@@ -2818,6 +2832,7 @@ class MenuWithCheckboxItems {
     </mat-menu>
   `,
   imports: [MatMenuTrigger, MatMenu, MatMenuItem],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SimpleMenuWithRepeater {
   @ViewChild(MatMenuTrigger) trigger!: MatMenuTrigger;
@@ -2841,6 +2856,7 @@ class SimpleMenuWithRepeater {
     </mat-menu>
   `,
   imports: [MatMenuTrigger, MatMenu, MatMenuItem, MatMenuContent],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SimpleMenuWithRepeaterInLazyContent {
   @ViewChild(MatMenuTrigger) trigger!: MatMenuTrigger;
@@ -2882,24 +2898,28 @@ class LazyMenuWithOnPush {
     </mat-menu>
   `,
   imports: [MatMenuTrigger, MatMenu],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class InvalidRecursiveMenu {}
 
 @Component({
   template: '<mat-menu aria-label="label"></mat-menu>',
   imports: [MatMenu],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class StaticAriaLabelMenu {}
 
 @Component({
   template: '<mat-menu aria-labelledby="some-element"></mat-menu>',
   imports: [MatMenu],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class StaticAriaLabelledByMenu {}
 
 @Component({
   template: '<mat-menu aria-describedby="some-element"></mat-menu>',
   imports: [MatMenu],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class StaticAriaDescribedbyMenu {}
 
@@ -2913,6 +2933,7 @@ class StaticAriaDescribedbyMenu {}
     </mat-menu>
   `,
   imports: [MatMenuTrigger, MatMenu, MatMenuItem],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MenuWithRepeatedItems {
   @ViewChild(MatMenuTrigger, {static: false}) trigger!: MatMenuTrigger;

--- a/src/material/menu/testing/context-menu-harness.spec.ts
+++ b/src/material/menu/testing/context-menu-harness.spec.ts
@@ -1,4 +1,4 @@
-import {Component, signal} from '@angular/core';
+import {Component, signal, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
@@ -76,6 +76,7 @@ describe('MatContextMenuHarness', () => {
       outline: solid 1px;
     }
   `,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MenuHarnessTest {
   disabled = signal(false);

--- a/src/material/menu/testing/menu-harness.spec.ts
+++ b/src/material/menu/testing/menu-harness.spec.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import {Component, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
 import {MatIconModule} from '@angular/material/icon';
@@ -165,6 +165,7 @@ describe('MatMenuHarness', () => {
     </mat-menu>
   `,
   imports: [MatMenuModule, MatIconModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MenuHarnessTest {}
 
@@ -191,6 +192,7 @@ class MenuHarnessTest {}
     </mat-menu>
   `,
   imports: [MatMenuModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NestedMenuHarnessTest {
   lastClickedLeaf = 0;

--- a/src/material/paginator/paginator.spec.ts
+++ b/src/material/paginator/paginator.spec.ts
@@ -1,4 +1,12 @@
-import {ChangeDetectorRef, Component, Provider, Type, ViewChild, inject} from '@angular/core';
+import {
+  ChangeDetectorRef,
+  Component,
+  Provider,
+  Type,
+  ViewChild,
+  inject,
+  ChangeDetectionStrategy,
+} from '@angular/core';
 import {ComponentFixture, TestBed, fakeAsync, tick} from '@angular/core/testing';
 import {ThemePalette} from '../core';
 import {MatSelect} from '../select';
@@ -646,6 +654,7 @@ function getLastButton(fixture: ComponentFixture<any>): HTMLButtonElement {
     </mat-paginator>
   `,
   imports: [MatPaginator],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatPaginatorApp {
   pageIndex = 0;
@@ -672,6 +681,7 @@ class MatPaginatorApp {
 @Component({
   template: `<mat-paginator/>`,
   imports: [MatPaginator],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatPaginatorWithoutInputsApp {
   @ViewChild(MatPaginator) paginator!: MatPaginator;
@@ -680,6 +690,7 @@ class MatPaginatorWithoutInputsApp {
 @Component({
   template: `<mat-paginator [pageSizeOptions]="[10, 20, 30]"/>`,
   imports: [MatPaginator],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatPaginatorWithoutPageSizeApp {
   @ViewChild(MatPaginator) paginator!: MatPaginator;
@@ -688,6 +699,7 @@ class MatPaginatorWithoutPageSizeApp {
 @Component({
   template: `<mat-paginator [pageSize]="10"/>`,
   imports: [MatPaginator],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatPaginatorWithoutOptionsApp {
   @ViewChild(MatPaginator) paginator!: MatPaginator;
@@ -702,6 +714,7 @@ class MatPaginatorWithoutOptionsApp {
     </mat-paginator>
   `,
   imports: [MatPaginator],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatPaginatorWithStringValues {
   @ViewChild(MatPaginator) paginator!: MatPaginator;
@@ -710,6 +723,7 @@ class MatPaginatorWithStringValues {
 @Component({
   template: `<mat-paginator [pageSizeOptions]="pageSizeOptions"/>`,
   imports: [MatPaginator],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatPaginatorWithReadonlyOptions {
   @ViewChild(MatPaginator) paginator!: MatPaginator;

--- a/src/material/paginator/testing/paginator-harness.spec.ts
+++ b/src/material/paginator/testing/paginator-harness.spec.ts
@@ -1,4 +1,4 @@
-import {Component, signal} from '@angular/core';
+import {Component, signal, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
@@ -133,6 +133,7 @@ describe('MatPaginatorHarness', () => {
     </mat-paginator>
   `,
   imports: [MatPaginatorModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class PaginatorHarnessTest {
   length = 500;

--- a/src/material/progress-bar/progress-bar.spec.ts
+++ b/src/material/progress-bar/progress-bar.spec.ts
@@ -6,6 +6,7 @@ import {
   EnvironmentProviders,
   Provider,
   Type,
+  ChangeDetectionStrategy,
 } from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
@@ -333,11 +334,13 @@ describe('MatProgressBar', () => {
 @Component({
   template: '<mat-progress-bar></mat-progress-bar>',
   imports: [MatProgressBar],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class BasicProgressBar {}
 
 @Component({
   template: '<mat-progress-bar mode="buffer"></mat-progress-bar>',
   imports: [MatProgressBar],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class BufferProgressBar {}

--- a/src/material/progress-bar/testing/progress-bar-harness.spec.ts
+++ b/src/material/progress-bar/testing/progress-bar-harness.spec.ts
@@ -1,4 +1,4 @@
-import {Component, signal} from '@angular/core';
+import {Component, signal, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
@@ -41,6 +41,7 @@ describe('MatProgressBarHarness', () => {
     <mat-progress-bar mode="indeterminate"></mat-progress-bar>
   `,
   imports: [MatProgressBarModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ProgressBarHarnessTest {
   value = signal<number | undefined>(undefined);

--- a/src/material/progress-spinner/progress-spinner.spec.ts
+++ b/src/material/progress-spinner/progress-spinner.spec.ts
@@ -1,6 +1,6 @@
 import {TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
-import {Component, signal} from '@angular/core';
+import {Component, signal, ChangeDetectionStrategy} from '@angular/core';
 import {MatProgressSpinnerModule} from './progress-spinner-module';
 import {
   MatProgressSpinner,
@@ -381,12 +381,14 @@ describe('MatProgressSpinner', () => {
 @Component({
   template: '<mat-progress-spinner></mat-progress-spinner>',
   imports: [MatProgressSpinnerModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class BasicProgressSpinner {}
 
 @Component({
   template: '<mat-progress-spinner [strokeWidth]="strokeWidth"></mat-progress-spinner>',
   imports: [MatProgressSpinnerModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ProgressSpinnerCustomStrokeWidth {
   strokeWidth!: number;
@@ -395,6 +397,7 @@ class ProgressSpinnerCustomStrokeWidth {
 @Component({
   template: '<mat-progress-spinner [diameter]="diameter"></mat-progress-spinner>',
   imports: [MatProgressSpinnerModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ProgressSpinnerCustomDiameter {
   diameter!: number;
@@ -403,12 +406,14 @@ class ProgressSpinnerCustomDiameter {
 @Component({
   template: '<mat-progress-spinner mode="indeterminate"></mat-progress-spinner>',
   imports: [MatProgressSpinnerModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class IndeterminateProgressSpinner {}
 
 @Component({
   template: '<mat-progress-spinner [value]="value()" [mode]="mode()"></mat-progress-spinner>',
   imports: [MatProgressSpinnerModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ProgressSpinnerWithValueAndBoundMode {
   mode = signal<ProgressSpinnerMode>('indeterminate');
@@ -419,6 +424,7 @@ class ProgressSpinnerWithValueAndBoundMode {
   template: `
     <mat-spinner [color]="color()"></mat-spinner>`,
   imports: [MatProgressSpinnerModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SpinnerWithColor {
   color = signal('primary');
@@ -428,6 +434,7 @@ class SpinnerWithColor {
   template: `
     <mat-progress-spinner value="50" [color]="color()"></mat-progress-spinner>`,
   imports: [MatProgressSpinnerModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ProgressSpinnerWithColor {
   color = signal('primary');
@@ -438,11 +445,13 @@ class ProgressSpinnerWithColor {
     <mat-progress-spinner value="25" diameter="37" strokeWidth="11"></mat-progress-spinner>
   `,
   imports: [MatProgressSpinnerModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ProgressSpinnerWithStringValues {}
 
 @Component({
   template: '<mat-spinner mode="determinate"></mat-spinner>',
   imports: [MatProgressSpinnerModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SpinnerWithMode {}

--- a/src/material/progress-spinner/testing/progress-spinner-harness.spec.ts
+++ b/src/material/progress-spinner/testing/progress-spinner-harness.spec.ts
@@ -1,4 +1,4 @@
-import {Component, signal} from '@angular/core';
+import {Component, signal, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
@@ -45,6 +45,7 @@ describe('MatProgressSpinnerHarness', () => {
     <mat-spinner></mat-spinner>
   `,
   imports: [MatProgressSpinnerModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ProgressSpinnerHarnessTest {
   value = signal(0);

--- a/src/material/radio/radio.spec.ts
+++ b/src/material/radio/radio.spec.ts
@@ -1,5 +1,5 @@
 import {dispatchFakeEvent} from '@angular/cdk/testing/private';
-import {Component, DebugElement, ViewChild} from '@angular/core';
+import {Component, DebugElement, ViewChild, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed, fakeAsync, tick, waitForAsync} from '@angular/core/testing';
 import {FormControl, FormsModule, NgModel, ReactiveFormsModule} from '@angular/forms';
 import {By} from '@angular/platform-browser';
@@ -1080,6 +1080,7 @@ describe('MatRadioDefaultOverrides', () => {
   </mat-radio-group>
   `,
   imports: [MatRadioModule, FormsModule, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class RadiosInsideRadioGroup {
   labelPos!: 'before' | 'after';
@@ -1102,6 +1103,7 @@ class RadiosInsideRadioGroup {
   </mat-radio-group>
   `,
   imports: [MatRadioModule, FormsModule, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class RadiosInsidePreCheckedRadioGroup {}
 
@@ -1127,6 +1129,7 @@ class RadiosInsidePreCheckedRadioGroup {}
     <mat-radio-button id="nameless" value="no-name">No name</mat-radio-button>
   `,
   imports: [MatRadioModule, FormsModule, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class StandaloneRadioButtons {
   ariaLabel: string | null = 'Banana';
@@ -1143,6 +1146,7 @@ class StandaloneRadioButtons {
   </mat-radio-group>
   `,
   imports: [MatRadioModule, FormsModule, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class RadioGroupWithNgModel {
   modelValue!: string;
@@ -1161,6 +1165,7 @@ class RadioGroupWithNgModel {
       [disabled]="disabled"
       [disabledInteractive]="disabledInteractive">One</mat-radio-button>`,
   imports: [MatRadioModule, FormsModule, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DisableableRadioButton {
   disabled = false;
@@ -1177,6 +1182,7 @@ class DisableableRadioButton {
     </mat-radio-group>
   `,
   imports: [MatRadioModule, FormsModule, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class RadioGroupWithFormControl {
   @ViewChild(MatRadioGroup) group!: MatRadioGroup;
@@ -1186,6 +1192,7 @@ class RadioGroupWithFormControl {
 @Component({
   template: `<mat-radio-button [disabled]="disabled" [tabIndex]="tabIndex"></mat-radio-button>`,
   imports: [MatRadioModule, FormsModule, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class FocusableRadioButton {
   tabIndex!: number;
@@ -1198,6 +1205,7 @@ class FocusableRadioButton {
     <div><ng-content></ng-content></div>
   `,
   imports: [MatRadioModule, FormsModule, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TranscludingWrapper {}
 
@@ -1212,6 +1220,7 @@ class TranscludingWrapper {}
   </mat-radio-group>
   `,
   imports: [MatRadioModule, FormsModule, ReactiveFormsModule, TranscludingWrapper],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class InterleavedRadioGroup {
   modelValue = 'strawberry';
@@ -1225,18 +1234,21 @@ class InterleavedRadioGroup {
 @Component({
   template: `<mat-radio-button tabindex="5"></mat-radio-button>`,
   imports: [MatRadioModule, FormsModule, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class RadioButtonWithPredefinedTabindex {}
 
 @Component({
   template: `<mat-radio-button></mat-radio-button>`,
   imports: [MatRadioModule, FormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DefaultRadioButton {}
 
 @Component({
   template: `<mat-radio-button color="warn"></mat-radio-button>`,
   imports: [MatRadioModule, FormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class RadioButtonWithColorBinding {}
 
@@ -1247,6 +1259,7 @@ class RadioButtonWithColorBinding {}
       aria-describedby="something"
       aria-labelledby="something-else"></mat-radio-button>`,
   imports: [MatRadioModule, FormsModule, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class RadioButtonWithPredefinedAriaAttributes {}
 
@@ -1267,6 +1280,7 @@ class RadioButtonWithPredefinedAriaAttributes {}
     </mat-radio-group>
   `,
   imports: [MatRadioModule, FormsModule, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class PreselectedRadioWithStaticValueAndNgIf {
   @ViewChild('preselectedGroup', {read: MatRadioGroup}) preselectedGroup!: MatRadioGroup;

--- a/src/material/radio/testing/radio-harness.spec.ts
+++ b/src/material/radio/testing/radio-harness.spec.ts
@@ -1,6 +1,6 @@
 import {HarnessLoader} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
-import {Component} from '@angular/core';
+import {Component, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {ReactiveFormsModule} from '@angular/forms';
 import {MatRadioModule} from '../radio-module';
@@ -309,6 +309,7 @@ describe('radio harness', () => {
     </mat-radio-group>
   `,
   imports: [MatRadioModule, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MultipleRadioButtonsHarnessTest {
   values = ['opt1', 'opt2', 'opt3'];

--- a/src/material/select/select.spec.ts
+++ b/src/material/select/select.spec.ts
@@ -4506,6 +4506,7 @@ describe('MatSelect', () => {
     <div [style.height.px]="heightBelow"></div>
   `,
   imports: [MatSelect, MatOption, MatFormFieldModule, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class BasicSelect {
   foods: any[] = [
@@ -4549,6 +4550,7 @@ class BasicSelect {
     </mat-form-field>
   `,
   imports: [MatSelect, MatOption, MatFormFieldModule, FormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NgModelSelect {
   foods: any[] = [
@@ -4578,6 +4580,7 @@ class NgModelSelect {
     </mat-form-field>
   `,
   imports: [MatSelect, MatOption, MatFormFieldModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ManySelects {}
 
@@ -4596,6 +4599,7 @@ class ManySelects {}
     }
   `,
   imports: [MatSelect, MatOption, MatFormFieldModule, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NgIfSelect {
   isShowing = false;
@@ -4620,6 +4624,7 @@ class NgIfSelect {
     </mat-form-field>
   `,
   imports: [MatSelect, MatOption, MatFormFieldModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SelectWithChangeEvent {
   foods: string[] = [
@@ -4647,6 +4652,7 @@ class SelectWithChangeEvent {
     </mat-form-field>
   `,
   imports: [MatSelect, MatOption, MatFormFieldModule, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SelectInitWithoutOptions {
   foods!: any[];
@@ -4675,6 +4681,7 @@ class SelectInitWithoutOptions {
     },
   ],
   imports: [MatSelect, MatFormFieldModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class CustomSelectAccessor implements ControlValueAccessor {
   @ViewChild(MatSelect) select!: MatSelect;
@@ -4694,6 +4701,7 @@ class CustomSelectAccessor implements ControlValueAccessor {
     },
   ],
   imports: [CustomSelectAccessor, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class CompWithCustomSelect {
   ctrl = new FormControl('initial value');
@@ -4703,6 +4711,7 @@ class CompWithCustomSelect {
 @Component({
   template: '',
   selector: 'throws-error-on-init',
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ThrowsErrorOnInit implements OnInit {
   ngOnInit() {
@@ -4718,6 +4727,7 @@ class ThrowsErrorOnInit implements OnInit {
     <throws-error-on-init></throws-error-on-init>
   `,
   imports: [ThrowsErrorOnInit, MatSelect, MatFormFieldModule, FormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SelectWithErrorSibling {
   value!: string;
@@ -4780,6 +4790,7 @@ class BasicSelectOnPushPreselected {
     </mat-form-field>
     `,
   imports: [MatSelect, MatOption, MatFormFieldModule, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class FloatLabelSelect {
   floatLabel: FloatLabelType = 'auto';
@@ -4806,6 +4817,7 @@ class FloatLabelSelect {
     </mat-form-field>
   `,
   imports: [MatSelect, MatOption, MatFormFieldModule, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MultiSelect {
   foods: any[] = [
@@ -4828,6 +4840,7 @@ class MultiSelect {
 @Component({
   template: `<mat-form-field><mat-select tabindex="5"></mat-select></mat-form-field>`,
   imports: [MatSelect, MatFormFieldModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SelectWithPlainTabindex {}
 
@@ -4841,6 +4854,7 @@ class SelectWithPlainTabindex {}
     }
   `,
   imports: [MatSelect, MatFormFieldModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SelectEarlyAccessSibling {}
 
@@ -4853,6 +4867,7 @@ class SelectEarlyAccessSibling {}
     </mat-form-field>
   `,
   imports: [MatSelect, MatOption, MatFormFieldModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class BasicSelectInitiallyHidden {
   isVisible = false;
@@ -4867,6 +4882,7 @@ class BasicSelectInitiallyHidden {
     </mat-form-field>
   `,
   imports: [MatSelect, MatOption, MatFormFieldModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class BasicSelectNoPlaceholder {}
 
@@ -4880,6 +4896,7 @@ class BasicSelectNoPlaceholder {}
     </mat-form-field>
   `,
   imports: [MatSelect, MatOption, MatFormFieldModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class BasicSelectWithTheming {
   @ViewChild(MatSelect) select!: MatSelect;
@@ -4899,6 +4916,7 @@ class BasicSelectWithTheming {
     </mat-form-field>
   `,
   imports: [MatSelect, MatOption, MatFormFieldModule, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ResetValuesSelect {
   foods: any[] = [
@@ -4926,6 +4944,7 @@ class ResetValuesSelect {
     </mat-form-field>
   `,
   imports: [MatSelect, MatOption, MatFormFieldModule, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class FalsyValueSelect {
   foods: any[] = [
@@ -4952,6 +4971,7 @@ class FalsyValueSelect {
     </mat-form-field>
   `,
   imports: [MatSelect, MatOption, MatOptgroup, MatFormFieldModule, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SelectWithGroups {
   control = new FormControl('');
@@ -5009,6 +5029,7 @@ class SelectWithGroups {
     </mat-form-field>
   `,
   imports: [MatSelect, MatOption, MatOptgroup, MatFormFieldModule, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SelectWithGroupsAndNgContainer {
   control = new FormControl('');
@@ -5029,6 +5050,7 @@ class SelectWithGroupsAndNgContainer {
     </form>
   `,
   imports: [MatSelect, MatFormFieldModule, FormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class InvalidSelectInForm {
   value: any;
@@ -5050,6 +5072,7 @@ class InvalidSelectInForm {
     </form>
   `,
   imports: [MatSelect, MatOption, MatFormFieldModule, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SelectInsideFormGroup {
   @ViewChild(FormGroupDirective) formGroupDirective!: FormGroupDirective;
@@ -5075,6 +5098,7 @@ class SelectInsideFormGroup {
     </mat-form-field>
   `,
   imports: [MatSelect, MatOption, MatFormFieldModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class BasicSelectWithoutForms {
   selectedFood: string | null = null;
@@ -5098,6 +5122,7 @@ class BasicSelectWithoutForms {
     </mat-form-field>
   `,
   imports: [MatSelect, MatOption, MatFormFieldModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class BasicSelectWithoutFormsPreselected {
   selectedFood = 'pizza-1';
@@ -5120,6 +5145,7 @@ class BasicSelectWithoutFormsPreselected {
     </mat-form-field>
   `,
   imports: [MatSelect, MatOption, MatFormFieldModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class BasicSelectWithoutFormsMultiple {
   selectedFoods!: string[];
@@ -5146,6 +5172,7 @@ class BasicSelectWithoutFormsMultiple {
     </mat-form-field>
   `,
   imports: [MatSelect, MatSelectTrigger, MatOption, MatFormFieldModule, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SelectWithCustomTrigger {
   foods: any[] = [
@@ -5171,6 +5198,7 @@ class SelectWithCustomTrigger {
     </mat-form-field>
   `,
   imports: [MatSelect, MatOption, MatFormFieldModule, FormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NgModelCompareWithSelect {
   foods: {value: string; viewValue: string}[] = [
@@ -5218,6 +5246,7 @@ class NgModelCompareWithSelect {
     </mat-select>
   `,
   imports: [MatSelect, MatOption, MatFormFieldModule, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class CustomErrorBehaviorSelect {
   @ViewChild(MatSelect) select!: MatSelect;
@@ -5240,6 +5269,7 @@ class CustomErrorBehaviorSelect {
     </mat-form-field>
   `,
   imports: [MatSelect, MatOption, MatFormFieldModule, FormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SingleSelectWithPreselectedArrayValues {
   foods: any[] = [
@@ -5265,6 +5295,7 @@ class SingleSelectWithPreselectedArrayValues {
     </mat-form-field>
   `,
   imports: [MatSelect, MatOption, MatFormFieldModule, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SelectWithoutOptionCentering {
   foods: any[] = [
@@ -5295,6 +5326,7 @@ class SelectWithoutOptionCentering {
     </mat-form-field>
   `,
   imports: [MatSelect, MatOption, MatFormFieldModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SelectWithNgIfAndLabel {
   showSelect = true;
@@ -5311,6 +5343,7 @@ class SelectWithNgIfAndLabel {
     </mat-form-field>
   `,
   imports: [MatSelect, MatOption, MatFormFieldModule, FormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MultiSelectWithLotsOfOptions {
   items = new Array(100).fill(0).map((_, i) => i);
@@ -5337,6 +5370,7 @@ class MultiSelectWithLotsOfOptions {
     </mat-form-field>
   `,
   imports: [MatSelect, MatOption, MatFormFieldModule, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SelectWithResetOptionAndFormControl {
   @ViewChild(MatSelect) select!: MatSelect;
@@ -5357,6 +5391,7 @@ class SelectWithResetOptionAndFormControl {
     </mat-form-field>
   `,
   imports: [MatSelect, MatOption, MatFormFieldModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SelectInNgContainer {}
 
@@ -5371,6 +5406,7 @@ class SelectInNgContainer {}
     </form>
   `,
   imports: [MatSelect, MatOption, MatFormFieldModule, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SelectInsideDynamicFormGroup {
   private _formBuilder = inject(FormBuilder);
@@ -5416,6 +5452,7 @@ class SelectInsideDynamicFormGroup {
     <div [style.height.px]="heightBelow"></div>
   `,
   imports: [MatSelect, MatOption, MatFormFieldModule, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class BasicSelectWithFirstAndLastOptionDisabled {
   foods: any[] = [
@@ -5464,6 +5501,7 @@ class BasicSelectWithFirstAndLastOptionDisabled {
     </ng-template>
   `,
   imports: [MatSelect, MatOption, MatFormFieldModule, FormsModule, OverlayModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SelectInsideAModal {
   foods = [

--- a/src/material/select/testing/select-harness.spec.ts
+++ b/src/material/select/testing/select-harness.spec.ts
@@ -1,4 +1,4 @@
-import {Component, signal} from '@angular/core';
+import {Component, signal, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {OverlayContainer} from '@angular/cdk/overlay';
 import {HarnessLoader, parallel} from '@angular/cdk/testing';
@@ -304,6 +304,7 @@ describe('MatSelectHarness', () => {
     </mat-form-field>
   `,
   imports: [MatSelectModule, MatFormFieldModule, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SelectHarnessTest {
   formControl = new FormControl(undefined as string | undefined, [Validators.required]);

--- a/src/material/sidenav/drawer.spec.ts
+++ b/src/material/sidenav/drawer.spec.ts
@@ -7,7 +7,13 @@ import {
   dispatchEvent,
   dispatchKeyboardEvent,
 } from '@angular/cdk/testing/private';
-import {Component, ElementRef, ErrorHandler, ViewChild} from '@angular/core';
+import {
+  Component,
+  ElementRef,
+  ErrorHandler,
+  ViewChild,
+  ChangeDetectionStrategy,
+} from '@angular/core';
 import {
   ComponentFixture,
   TestBed,
@@ -1194,6 +1200,7 @@ describe('MatDrawerContainer', () => {
       <mat-drawer position="end"></mat-drawer>
     </mat-drawer-container>`,
   imports: [MatSidenavModule, A11yModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DrawerContainerTwoDrawerTestApp {
   @ViewChild(MatDrawerContainer) drawerContainer!: MatDrawerContainer;
@@ -1222,6 +1229,7 @@ class DrawerContainerTwoDrawerTestApp {
       </svg>
     </mat-drawer-container>`,
   imports: [MatSidenavModule, A11yModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class BasicTestApp {
   openCount = 0;
@@ -1267,6 +1275,7 @@ class BasicTestApp {
       </mat-drawer>
     </mat-drawer-container>`,
   imports: [MatSidenavModule, A11yModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DrawerSetToOpenedFalse {}
 
@@ -1278,6 +1287,7 @@ class DrawerSetToOpenedFalse {}
       </mat-drawer>
     </mat-drawer-container>`,
   imports: [MatSidenavModule, A11yModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DrawerSetToOpenedTrue {
   openCallback = jasmine.createSpy('open callback');
@@ -1291,6 +1301,7 @@ class DrawerSetToOpenedTrue {
       </mat-drawer>
     </mat-drawer-container>`,
   imports: [MatSidenavModule, A11yModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DrawerOpenBinding {
   isOpen = false;
@@ -1303,6 +1314,7 @@ class DrawerOpenBinding {
       <mat-drawer #drawer2 [position]="drawer2Position"></mat-drawer>
     </mat-drawer-container>`,
   imports: [MatSidenavModule, A11yModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DrawerDynamicPosition {
   drawer1Position: 'start' | 'end' = 'start';
@@ -1320,6 +1332,7 @@ class DrawerDynamicPosition {
       <input type="text" class="input2"/>
     </mat-drawer-container>`,
   imports: [MatSidenavModule, A11yModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DrawerWithFocusableElements {
   mode: MatDrawerMode = 'over';
@@ -1334,6 +1347,7 @@ class DrawerWithFocusableElements {
       </mat-drawer>
     </mat-drawer-container>`,
   imports: [MatSidenavModule, A11yModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DrawerWithoutFocusableElements {}
 
@@ -1346,6 +1360,7 @@ class DrawerWithoutFocusableElements {}
     </mat-drawer-container>
   `,
   imports: [MatSidenavModule, A11yModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DrawerDelayed {
   @ViewChild(MatDrawer) drawer!: MatDrawer;
@@ -1360,6 +1375,7 @@ class DrawerDelayed {
       }
     </mat-drawer-container>`,
   imports: [MatSidenavModule, A11yModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DrawerContainerStateChangesTestApp {
   @ViewChild(MatDrawer) drawer!: MatDrawer;
@@ -1379,6 +1395,7 @@ class DrawerContainerStateChangesTestApp {
       </mat-drawer>
     </mat-drawer-container>`,
   imports: [MatSidenavModule, A11yModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class AutosizeDrawer {
   @ViewChild(MatDrawer) drawer!: MatDrawer;
@@ -1394,6 +1411,7 @@ class AutosizeDrawer {
     </mat-drawer-container>
   `,
   imports: [MatSidenavModule, A11yModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DrawerContainerWithContent {
   @ViewChild(MatDrawerContainer) drawerContainer!: MatDrawerContainer;
@@ -1409,6 +1427,7 @@ class DrawerContainerWithContent {
       }
     </mat-drawer-container>`,
   imports: [MatSidenavModule, A11yModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class IndirectDescendantDrawer {
   @ViewChild('container') container!: MatDrawerContainer;
@@ -1427,6 +1446,7 @@ class IndirectDescendantDrawer {
     </mat-drawer-container>
   `,
   imports: [MatSidenavModule, A11yModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NestedDrawerContainers {
   @ViewChild('outerContainer') outerContainer!: MatDrawerContainer;
@@ -1445,5 +1465,6 @@ class NestedDrawerContainers {
     </mat-sidenav-container>
   `,
   imports: [MatSidenavModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DrawerWithSideAndHiddenBackdrop {}

--- a/src/material/sidenav/sidenav.spec.ts
+++ b/src/material/sidenav/sidenav.spec.ts
@@ -1,4 +1,4 @@
-import {Component, ViewChild} from '@angular/core';
+import {Component, ViewChild, ChangeDetectionStrategy} from '@angular/core';
 import {TestBed, fakeAsync, tick} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {MatSidenav, MatSidenavContainer, MatSidenavModule} from './index';
@@ -89,6 +89,7 @@ describe('MatSidenav', () => {
       </mat-sidenav-content>
     </mat-sidenav-container>`,
   imports: [MatSidenavModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SidenavWithFixedPosition {
   fixed = true;
@@ -107,6 +108,7 @@ class SidenavWithFixedPosition {
       <mat-sidenav-content>Some content.</mat-sidenav-content>
     </mat-sidenav-container>`,
   imports: [MatSidenavModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class IndirectDescendantSidenav {
   @ViewChild('container') container!: MatSidenavContainer;
@@ -125,6 +127,7 @@ class IndirectDescendantSidenav {
     </mat-sidenav-container>
   `,
   imports: [MatSidenavModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NestedSidenavContainers {
   @ViewChild('outerContainer') outerContainer!: MatSidenavContainer;

--- a/src/material/sidenav/testing/sidenav-harness.spec.ts
+++ b/src/material/sidenav/testing/sidenav-harness.spec.ts
@@ -1,4 +1,4 @@
-import {Component, signal} from '@angular/core';
+import {Component, signal, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {HarnessLoader, parallel} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
@@ -168,6 +168,7 @@ describe('MatSidenavHarness', () => {
     </mat-drawer-container>
   `,
   imports: [MatSidenavModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DrawerHarnessTest {
   threeOpened = signal(true);
@@ -187,5 +188,6 @@ class DrawerHarnessTest {
     </mat-sidenav-container>
   `,
   imports: [MatSidenavModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SidenavHarnessTest {}

--- a/src/material/slide-toggle/slide-toggle.spec.ts
+++ b/src/material/slide-toggle/slide-toggle.spec.ts
@@ -1,7 +1,7 @@
 import {FocusMonitor} from '@angular/cdk/a11y';
 import {BidiModule, Direction} from '@angular/cdk/bidi';
 import {dispatchFakeEvent} from '@angular/cdk/testing/private';
-import {Component} from '@angular/core';
+import {Component, ChangeDetectionStrategy} from '@angular/core';
 import {
   ComponentFixture,
   TestBed,
@@ -854,6 +854,7 @@ describe('MatSlideToggle with forms', () => {
       <span>Test Slide Toggle</span>
     </mat-slide-toggle>`,
   imports: [MatSlideToggleModule, BidiModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SlideToggleBasic {
   isDisabled = false;
@@ -888,6 +889,7 @@ class SlideToggleBasic {
       <button type="submit"></button>
     </form>`,
   imports: [MatSlideToggleModule, FormsModule, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SlideToggleWithForm {
   isSubmitted: boolean = false;
@@ -898,6 +900,7 @@ class SlideToggleWithForm {
   template: `<mat-slide-toggle [(ngModel)]="modelValue" [disabled]="isDisabled"
                                [checked]="isChecked"></mat-slide-toggle>`,
   imports: [MatSlideToggleModule, FormsModule, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SlideToggleWithModel {
   modelValue = false;
@@ -908,6 +911,7 @@ class SlideToggleWithModel {
 @Component({
   template: `<mat-slide-toggle checked disabled>Label</mat-slide-toggle>`,
   imports: [MatSlideToggleModule, BidiModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SlideToggleCheckedAndDisabledAttr {}
 
@@ -917,6 +921,7 @@ class SlideToggleCheckedAndDisabledAttr {}
       <span>Test Slide Toggle</span>
     </mat-slide-toggle>`,
   imports: [MatSlideToggleModule, FormsModule, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SlideToggleWithFormControl {
   formControl = new FormControl(false);
@@ -925,6 +930,7 @@ class SlideToggleWithFormControl {
 @Component({
   template: `<mat-slide-toggle tabindex="5" [disabled]="disabled"></mat-slide-toggle>`,
   imports: [MatSlideToggleModule, BidiModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SlideToggleWithTabindexAttr {
   disabled = false;
@@ -933,6 +939,7 @@ class SlideToggleWithTabindexAttr {
 @Component({
   template: `<mat-slide-toggle [(ngModel)]="checked" (change)="onChange()"></mat-slide-toggle>`,
   imports: [MatSlideToggleModule, FormsModule, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SlideToggleWithModelAndChangeEvent {
   checked = false;
@@ -944,5 +951,6 @@ class SlideToggleWithModelAndChangeEvent {
     <mat-slide-toggle aria-label="Slide toggle" aria-labelledby="something"></mat-slide-toggle>
   `,
   imports: [MatSlideToggleModule, BidiModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SlideToggleWithStaticAriaAttributes {}

--- a/src/material/slide-toggle/testing/slide-toggle-harness.spec.ts
+++ b/src/material/slide-toggle/testing/slide-toggle-harness.spec.ts
@@ -1,4 +1,4 @@
-import {Component, signal} from '@angular/core';
+import {Component, signal, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
@@ -187,6 +187,7 @@ describe('MatSlideToggleHarness', () => {
       <span id="second-label">Second slide-toggle</span>
   `,
   imports: [MatSlideToggleModule, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SlideToggleHarnessTest {
   ctrl = new FormControl(true);

--- a/src/material/slider/slider.spec.ts
+++ b/src/material/slider/slider.spec.ts
@@ -13,7 +13,15 @@ import {
   dispatchPointerEvent,
   provideFakeDirectionality,
 } from '@angular/cdk/testing/private';
-import {Component, Provider, QueryList, Type, ViewChild, ViewChildren} from '@angular/core';
+import {
+  Component,
+  Provider,
+  QueryList,
+  Type,
+  ViewChild,
+  ViewChildren,
+  ChangeDetectionStrategy,
+} from '@angular/core';
 import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 import {FormControl, FormGroup, FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {By} from '@angular/platform-browser';
@@ -1724,6 +1732,7 @@ const SLIDER_STYLES = ['.mat-mdc-slider { width: 300px; }'];
   `,
   styles: SLIDER_STYLES,
   imports: [MatSliderModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class StandardSlider {}
 
@@ -1736,6 +1745,7 @@ class StandardSlider {}
   `,
   styles: SLIDER_STYLES,
   imports: [MatSliderModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class StandardRangeSlider {}
 
@@ -1747,6 +1757,7 @@ class StandardRangeSlider {}
   `,
   styles: SLIDER_STYLES,
   imports: [MatSliderModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DisabledSlider {}
 
@@ -1759,6 +1770,7 @@ class DisabledSlider {}
   `,
   styles: SLIDER_STYLES,
   imports: [MatSliderModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DisabledRangeSlider {}
 
@@ -1770,6 +1782,7 @@ class DisabledRangeSlider {}
   `,
   styles: SLIDER_STYLES,
   imports: [MatSliderModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SliderWithMinAndMax {
   min = 25;
@@ -1785,6 +1798,7 @@ class SliderWithMinAndMax {
   `,
   styles: SLIDER_STYLES,
   imports: [MatSliderModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class RangeSliderWithMinAndMax {
   min = 25;
@@ -1799,6 +1813,7 @@ class RangeSliderWithMinAndMax {
   `,
   styles: SLIDER_STYLES,
   imports: [MatSliderModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SliderWithValue {}
 
@@ -1811,6 +1826,7 @@ class SliderWithValue {}
   `,
   styles: SLIDER_STYLES,
   imports: [MatSliderModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class RangeSliderWithValue {}
 
@@ -1822,6 +1838,7 @@ class RangeSliderWithValue {}
   `,
   styles: SLIDER_STYLES,
   imports: [MatSliderModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SliderWithStep {
   step = 25;
@@ -1836,6 +1853,7 @@ class SliderWithStep {
   `,
   styles: SLIDER_STYLES,
   imports: [MatSliderModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class RangeSliderWithStep {
   step = 25;
@@ -1849,6 +1867,7 @@ class RangeSliderWithStep {
   `,
   styles: SLIDER_STYLES,
   imports: [MatSliderModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DiscreteSliderWithDisplayWith {
   displayWith(v: number) {
@@ -1865,6 +1884,7 @@ class DiscreteSliderWithDisplayWith {
   `,
   styles: SLIDER_STYLES,
   imports: [MatSliderModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DiscreteRangeSliderWithDisplayWith {
   displayWith(v: number) {
@@ -1880,6 +1900,7 @@ class DiscreteRangeSliderWithDisplayWith {
   `,
   styles: SLIDER_STYLES,
   imports: [MatSliderModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SliderWithOneWayBinding {
   value = 50;
@@ -1894,6 +1915,7 @@ class SliderWithOneWayBinding {
   `,
   styles: SLIDER_STYLES,
   imports: [MatSliderModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class RangeSliderWithOneWayBinding {
   startValue = 25;
@@ -1908,6 +1930,7 @@ class RangeSliderWithOneWayBinding {
   `,
   styles: SLIDER_STYLES,
   imports: [MatSliderModule, FormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SliderWithNgModel {
   @ViewChild(MatSlider) slider!: MatSlider;
@@ -1923,6 +1946,7 @@ class SliderWithNgModel {
   `,
   styles: SLIDER_STYLES,
   imports: [MatSliderModule, FormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class RangeSliderWithNgModel {
   @ViewChild(MatSlider) slider!: MatSlider;
@@ -1940,6 +1964,7 @@ class RangeSliderWithNgModel {
 `,
   styles: SLIDER_STYLES,
   imports: [MatSliderModule, FormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class RangeSliderWithNgModelEdgeCase {
   @ViewChild(MatSlider) slider!: MatSlider;
@@ -1954,6 +1979,7 @@ class RangeSliderWithNgModelEdgeCase {
   </mat-slider>`,
   styles: SLIDER_STYLES,
   imports: [MatSliderModule, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SliderWithFormControl {
   control = new FormControl(0);
@@ -1967,6 +1993,7 @@ class SliderWithFormControl {
   </mat-slider>`,
   styles: SLIDER_STYLES,
   imports: [MatSliderModule, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class RangeSliderWithFormControl {
   startInputControl = new FormControl(0);
@@ -1981,6 +2008,7 @@ class RangeSliderWithFormControl {
   `,
   styles: SLIDER_STYLES,
   imports: [MatSliderModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SliderWithTwoWayBinding {
   value = 0;
@@ -1995,6 +2023,7 @@ class SliderWithTwoWayBinding {
   `,
   styles: SLIDER_STYLES,
   imports: [MatSliderModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class RangeSliderWithTwoWayBinding {
   @ViewChild(MatSlider) slider!: MatSlider;
@@ -2011,6 +2040,7 @@ class RangeSliderWithTwoWayBinding {
   `,
   styles: SLIDER_STYLES,
   imports: [MatSliderModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SliderWithTickMarks {
   @ViewChild(MatSlider) slider!: MatSlider;
@@ -2025,6 +2055,7 @@ class SliderWithTickMarks {
   `,
   styles: SLIDER_STYLES,
   imports: [MatSliderModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class RangeSliderWithTickMarks {
   @ViewChild(MatSlider) slider!: MatSlider;
@@ -2041,6 +2072,7 @@ class RangeSliderWithTickMarks {
   `,
   styles: SLIDER_STYLES,
   imports: [MatSliderModule, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SliderWithFormGroup {
   readonly MIN = 0;

--- a/src/material/slider/testing/slider-harness.spec.ts
+++ b/src/material/slider/testing/slider-harness.spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component, signal} from '@angular/core';
+import {Component, signal, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {HarnessLoader, parallel} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
@@ -199,6 +199,7 @@ describe('MatSliderHarness', () => {
     </mat-slider>
   `,
   imports: [MatSliderModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SliderHarnessTest {
   singleSliderDisabled = signal(false);

--- a/src/material/snack-bar/snack-bar.spec.ts
+++ b/src/material/snack-bar/snack-bar.spec.ts
@@ -995,6 +995,7 @@ class ComponentWithChildViewContainer {
       Fries {{localValue}} {{data?.value}}
     </ng-template>
   `,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ComponentWithTemplateRef {
   @ViewChild(TemplateRef) templateRef!: TemplateRef<any>;
@@ -1004,6 +1005,7 @@ class ComponentWithTemplateRef {
 /** Simple component for testing ComponentPortal. */
 @Component({
   template: '<p>Burritos are on the way.</p>',
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class BurritosNotification {
   snackBarRef = inject<MatSnackBarRef<BurritosNotification>>(MatSnackBarRef);
@@ -1013,6 +1015,7 @@ class BurritosNotification {
 @Component({
   template: '',
   providers: [MatSnackBar],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ComponentThatProvidesMatSnackBar {
   snackBar = inject(MatSnackBar);

--- a/src/material/snack-bar/testing/snack-bar-harness.spec.ts
+++ b/src/material/snack-bar/testing/snack-bar-harness.spec.ts
@@ -1,4 +1,4 @@
-import {Component, TemplateRef, ViewChild, inject} from '@angular/core';
+import {Component, TemplateRef, ViewChild, inject, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
@@ -172,6 +172,7 @@ describe('MatSnackBarHarness', () => {
     </ng-template>
   `,
   imports: [MatSnackBarLabel, MatSnackBarActions, MatSnackBarAction],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SnackbarHarnessTest {
   snackBar = inject(MatSnackBar);

--- a/src/material/sort/sort.spec.ts
+++ b/src/material/sort/sort.spec.ts
@@ -1,7 +1,7 @@
 import {CollectionViewer, DataSource} from '@angular/cdk/collections';
 import {CdkTableModule} from '@angular/cdk/table';
 import {dispatchMouseEvent, wrappedErrorMessage} from '@angular/cdk/testing/private';
-import {Component, ElementRef, ViewChild, inject} from '@angular/core';
+import {Component, ElementRef, ViewChild, inject, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed, fakeAsync, tick, waitForAsync} from '@angular/core/testing';
 import {MatTableModule} from '../table';
 import {By} from '@angular/platform-browser';
@@ -476,6 +476,7 @@ type SimpleMatSortAppColumnIds = 'defaultA' | 'defaultB' | 'overrideStart' | 'ov
     </div>
   `,
   imports: [MatSortModule, MatTableModule, CdkTableModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SimpleMatSortApp {
   elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
@@ -534,6 +535,7 @@ class FakeDataSource extends DataSource<never> {
     </cdk-table>
   `,
   imports: [MatSortModule, MatTableModule, CdkTableModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class CdkTableMatSortApp {
   @ViewChild(MatSort) matSort!: MatSort;
@@ -565,6 +567,7 @@ class CdkTableMatSortApp {
     </mat-table>
   `,
   imports: [MatSortModule, MatTableModule, CdkTableModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatTableMatSortApp {
   @ViewChild(MatSort) matSort!: MatSort;
@@ -576,6 +579,7 @@ class MatTableMatSortApp {
 @Component({
   template: `<div mat-sort-header="a"> A </div>`,
   imports: [MatSortModule, MatTableModule, CdkTableModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatSortHeaderMissingMatSortApp {}
 
@@ -587,6 +591,7 @@ class MatSortHeaderMissingMatSortApp {}
     </div>
   `,
   imports: [MatSortModule, MatTableModule, CdkTableModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatSortDuplicateMatSortableIdsApp {}
 
@@ -597,6 +602,7 @@ class MatSortDuplicateMatSortableIdsApp {}
     </div>
   `,
   imports: [MatSortModule, MatTableModule, CdkTableModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatSortableMissingIdApp {}
 
@@ -607,6 +613,7 @@ class MatSortableMissingIdApp {}
     </div>
   `,
   imports: [MatSortModule, MatTableModule, CdkTableModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatSortableInvalidDirection {}
 
@@ -622,6 +629,7 @@ class MatSortableInvalidDirection {}
     </div>
   `,
   imports: [MatSortModule, MatTableModule, CdkTableModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatSortWithoutExplicitInputs {
   elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
@@ -654,6 +662,7 @@ class MatSortWithoutExplicitInputs {
     </div>
   `,
   imports: [MatSortModule, MatTableModule, CdkTableModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatSortWithArrowPosition {
   arrowPosition!: 'before' | 'after';
@@ -674,6 +683,7 @@ class MatSortWithArrowPosition {
     </div>
   `,
   imports: [MatSortModule, MatTableModule, CdkTableModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatSortWithoutInputs {
   @ViewChild(MatSort) matSort!: MatSort;

--- a/src/material/sort/testing/sort-harness.spec.ts
+++ b/src/material/sort/testing/sort-harness.spec.ts
@@ -1,4 +1,4 @@
-import {Component, signal} from '@angular/core';
+import {Component, signal, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {HarnessLoader, parallel} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
@@ -133,6 +133,7 @@ describe('MatSortHarness', () => {
     </table>
   `,
   imports: [MatSortModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SortHarnessTest {
   disableThirdHeader = signal(false);

--- a/src/material/stepper/stepper.spec.ts
+++ b/src/material/stepper/stepper.spec.ts
@@ -34,6 +34,7 @@ import {
   WritableSignal,
   inject,
   signal,
+  ChangeDetectionStrategy,
 } from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {
@@ -1832,6 +1833,7 @@ function createComponent<T>(
   </form>
   `,
   imports: [MatStepperModule, MatInputModule, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatHorizontalStepperWithErrorsApp {
   private readonly _formBuilder = inject(FormBuilder);
@@ -1874,6 +1876,7 @@ class MatHorizontalStepperWithErrorsApp {
     </mat-stepper>
   `,
   imports: [MatStepperModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SimpleMatHorizontalStepperApp {
   @ViewChild(MatStepper) stepper!: MatStepper;
@@ -1915,6 +1918,7 @@ class SimpleMatHorizontalStepperApp {
     </mat-stepper>
   `,
   imports: [MatStepperModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SimpleMatVerticalStepperApp {
   @ViewChild(MatStepper) stepper!: MatStepper;
@@ -1964,6 +1968,7 @@ class SimpleMatVerticalStepperApp {
     </mat-stepper>
   `,
   imports: [ReactiveFormsModule, MatStepperModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class LinearMatVerticalStepperApp {
   validationTrigger = new Subject<void>();
@@ -1987,6 +1992,7 @@ class LinearMatVerticalStepperApp {
     </mat-stepper>
   `,
   imports: [MatStepperModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SimplePreselectedMatHorizontalStepperApp {
   @ViewChild(MatStepper) stepper!: MatStepper;
@@ -2032,6 +2038,7 @@ class SimplePreselectedMatHorizontalStepperApp {
     </mat-stepper>
   `,
   imports: [ReactiveFormsModule, MatStepperModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class LinearMatVerticalStepperAppForAlreadyFilledForm {
   @ViewChild(MatStepper) stepper!: MatStepper;
@@ -2057,6 +2064,7 @@ class LinearMatVerticalStepperAppForAlreadyFilledForm {
     </mat-stepper>
   `,
   imports: [MatStepperModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SimpleStepperWithoutStepControl {
   @ViewChild(MatStepper) stepper!: MatStepper;
@@ -2079,6 +2087,7 @@ class SimpleStepperWithoutStepControl {
     </mat-stepper>
   `,
   imports: [MatStepperModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SimpleStepperWithStepControlAndCompletedBinding {
   @ViewChild(MatStepper) stepper!: MatStepper;
@@ -2105,6 +2114,7 @@ class SimpleStepperWithStepControlAndCompletedBinding {
     </mat-stepper>
 `,
   imports: [MatStepperModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class IconOverridesStepper {
   @ViewChild(MatStepper) stepper!: MatStepper;
@@ -2143,6 +2153,7 @@ class IconOverridesStepper {
     </mat-stepper>
 `,
   imports: [MatStepperModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class IndirectDescendantIconOverridesStepper extends IconOverridesStepper {}
 
@@ -2155,6 +2166,7 @@ class IndirectDescendantIconOverridesStepper extends IconOverridesStepper {}
     </mat-stepper>
   `,
   imports: [MatStepperModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class LinearStepperWithValidOptionalStep {
   controls = [0, 0, 0].map(() => new FormControl(''));
@@ -2168,6 +2180,7 @@ class LinearStepperWithValidOptionalStep {
     </mat-stepper>
   `,
   imports: [MatStepperModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class StepperWithAriaInputs {
   ariaLabel = signal('');
@@ -2185,6 +2198,7 @@ class StepperWithAriaInputs {
     </mat-stepper>
   `,
   imports: [MatStepperModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class StepperWithIndirectDescendantSteps {
   @ViewChild(MatStepper) stepper!: MatStepper;
@@ -2205,6 +2219,7 @@ class StepperWithIndirectDescendantSteps {
     </mat-stepper>
   `,
   imports: [MatStepperModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class StepperWithNgIf {
   showStep2 = signal(false);
@@ -2224,6 +2239,7 @@ class StepperWithNgIf {
     </mat-stepper>
   `,
   imports: [MatStepperModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NestedSteppers {
   @ViewChildren(MatStepper) steppers!: QueryList<MatStepper>;
@@ -2238,6 +2254,7 @@ class NestedSteppers {
     </mat-stepper>
   `,
   imports: [MatStepperModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class StepperWithStaticOutOfBoundsIndex {
   @ViewChild(MatStepper) stepper!: MatStepper;
@@ -2261,6 +2278,7 @@ class StepperWithStaticOutOfBoundsIndex {
     </mat-stepper>
   `,
   imports: [MatStepperModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class StepperWithLazyContent {
   selectedIndex = signal(0);
@@ -2277,6 +2295,7 @@ class StepperWithLazyContent {
     </mat-stepper>
   `,
   imports: [MatStepperModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class HorizontalStepperWithDelayedStep {
   @ViewChild(MatStepper) stepper!: MatStepper;
@@ -2292,6 +2311,7 @@ class HorizontalStepperWithDelayedStep {
     </mat-stepper>
   `,
   imports: [MatStepperModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class StepperWithTwoWayBindingOnSelectedIndex {
   index: number = 0;
@@ -2310,6 +2330,7 @@ class StepperWithTwoWayBindingOnSelectedIndex {
     </ng-template>
   `,
   imports: [MatStepperModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class HorizontalStepperWithHeaderPrefix {
   @ViewChild(MatStepper) stepper!: MatStepper;
@@ -2328,6 +2349,7 @@ class HorizontalStepperWithHeaderPrefix {
     </ng-template>
   `,
   imports: [MatStepperModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class VerticalStepperWithHeaderPrefix {
   @ViewChild(MatStepper) stepper!: MatStepper;

--- a/src/material/stepper/testing/stepper-harness.spec.ts
+++ b/src/material/stepper/testing/stepper-harness.spec.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import {Component, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {ReactiveFormsModule, FormGroup, FormControl, Validators} from '@angular/forms';
 import {HarnessLoader, parallel} from '@angular/cdk/testing';
@@ -300,6 +300,7 @@ describe('MatStepperHarness', () => {
     </mat-stepper>
   `,
   imports: [MatStepperModule, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class StepperHarnessTest {
   oneGroup = new FormGroup({

--- a/src/material/table/table-data-source.spec.ts
+++ b/src/material/table/table-data-source.spec.ts
@@ -1,7 +1,7 @@
 import {MatTableDataSource} from './table-data-source';
 import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {MatSort, MatSortModule} from '@angular/material/sort';
-import {Component, ViewChild} from '@angular/core';
+import {Component, ViewChild, ChangeDetectionStrategy} from '@angular/core';
 
 describe('MatTableDataSource', () => {
   describe('sort', () => {
@@ -118,6 +118,7 @@ describe('MatTableDataSource', () => {
 @Component({
   template: `<div matSort matSortDirection="asc"></div>`,
   imports: [MatSortModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatSortApp {
   @ViewChild(MatSort, {static: true}) sort!: MatSort;

--- a/src/material/table/table.spec.ts
+++ b/src/material/table/table.spec.ts
@@ -1,4 +1,4 @@
-import {AfterViewInit, Component, OnInit, ViewChild} from '@angular/core';
+import {AfterViewInit, Component, OnInit, ViewChild, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, fakeAsync, flushMicrotasks, TestBed, tick} from '@angular/core/testing';
 import {MatTable, MatTableDataSource, MatTableModule} from './index';
 import {DataSource} from '@angular/cdk/table';
@@ -692,6 +692,7 @@ class FakeDataSource extends DataSource<TestData> {
     </table>
   `,
   imports: [MatTableModule, MatPaginatorModule, MatSortModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatTableApp {
   dataSource = new FakeDataSource();
@@ -727,6 +728,7 @@ class MatTableApp {
     </table>
   `,
   imports: [MatTableModule, MatPaginatorModule, MatSortModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NativeHtmlTableApp {
   dataSource = new FakeDataSource();
@@ -781,6 +783,7 @@ class NativeHtmlTableApp {
     </table>
   `,
   imports: [MatTableModule, MatPaginatorModule, MatSortModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NestedTableApp {
   dataSource = new FakeDataSource();
@@ -800,6 +803,7 @@ class NestedTableApp {
     </table>
   `,
   imports: [MatTableModule, MatPaginatorModule, MatSortModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class StickyTableApp {
   dataSource = new FakeDataSource();
@@ -828,6 +832,7 @@ class StickyTableApp {
     </table>
   `,
   imports: [MatTableModule, MatPaginatorModule, MatSortModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatTableWithWhenRowApp {
   multiTemplateDataRows = false;
@@ -866,6 +871,7 @@ class MatTableWithWhenRowApp {
     <mat-paginator [pageSize]="5"></mat-paginator>
   `,
   imports: [MatTableModule, MatPaginatorModule, MatSortModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ArrayDataSourceMatTableApp implements AfterViewInit {
   underlyingDataSource = new FakeDataSource();
@@ -919,6 +925,7 @@ class ArrayDataSourceMatTableApp implements AfterViewInit {
     </table>
   `,
   imports: [MatTableModule, MatPaginatorModule, MatSortModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatTableWithSortApp implements OnInit {
   underlyingDataSource = new FakeDataSource();
@@ -971,6 +978,7 @@ class MatTableWithSortApp implements OnInit {
     <mat-paginator [pageSize]="5"></mat-paginator>
   `,
   imports: [MatTableModule, MatPaginatorModule, MatSortModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatTableWithPaginatorApp implements OnInit {
   underlyingDataSource = new FakeDataSource();
@@ -1013,6 +1021,7 @@ class MatTableWithPaginatorApp implements OnInit {
     </table>
   `,
   imports: [MatTableModule, MatPaginatorModule, MatSortModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TableWithNgContainerRow {
   dataSource = new FakeDataSource();
@@ -1051,6 +1060,7 @@ class TableWithNgContainerRow {
     </mat-table>
   `,
   imports: [MatTableModule, MatPaginatorModule, MatSortModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatFlexTableApp {
   dataSource = new FakeDataSource();

--- a/src/material/table/testing/table-harness.spec.ts
+++ b/src/material/table/testing/table-harness.spec.ts
@@ -1,4 +1,4 @@
-import {Component, signal} from '@angular/core';
+import {Component, signal, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {HarnessLoader, parallel} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
@@ -228,6 +228,7 @@ describe('MatTableHarness', () => {
     </table>
   `,
   imports: [MatTableModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TableHarnessTest {
   displayedColumns: string[] = ['position', 'name', 'weight', 'symbol'];

--- a/src/material/tabs/tab-body.spec.ts
+++ b/src/material/tabs/tab-body.spec.ts
@@ -11,6 +11,7 @@ import {
   WritableSignal,
   inject,
   signal,
+  ChangeDetectionStrategy,
 } from '@angular/core';
 import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
@@ -136,6 +137,7 @@ describe('MatTabBody', () => {
     <mat-tab-body [content]="content()!" [position]="position"></mat-tab-body>
   `,
   imports: [PortalModule, MatRippleModule, MatTabBody],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SimpleTabBodyApp implements AfterViewInit {
   content = signal<TemplatePortal | undefined>(undefined);

--- a/src/material/tabs/tab-group.spec.ts
+++ b/src/material/tabs/tab-group.spec.ts
@@ -1,7 +1,15 @@
 import {LEFT_ARROW, RIGHT_ARROW} from '@angular/cdk/keycodes';
 import {dispatchFakeEvent, dispatchKeyboardEvent} from '@angular/cdk/testing/private';
 import {AsyncPipe} from '@angular/common';
-import {Component, DebugElement, OnInit, QueryList, ViewChild, ViewChildren} from '@angular/core';
+import {
+  Component,
+  DebugElement,
+  OnInit,
+  QueryList,
+  ViewChild,
+  ViewChildren,
+  ChangeDetectionStrategy,
+} from '@angular/core';
 import {
   ComponentFixture,
   TestBed,
@@ -1265,6 +1273,7 @@ describe('MatTabGroup labels aligned with a config', () => {
     </mat-tab-group>
   `,
   imports: [MatTabsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SimpleTabsTestApp {
   @ViewChild(MatTabGroup) tabGroup!: MatTabGroup;
@@ -1303,6 +1312,7 @@ class SimpleTabsTestApp {
     </mat-tab-group>
   `,
   imports: [MatTabsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SimpleDynamicTabsTestApp {
   tabs = [
@@ -1331,6 +1341,7 @@ class SimpleDynamicTabsTestApp {
     </mat-tab-group>
   `,
   imports: [MatTabsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class BindedTabsTestApp {
   tabs = [
@@ -1366,6 +1377,7 @@ class BindedTabsTestApp {
     </mat-tab-group>
   `,
   imports: [MatTabsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DisabledTabsTestApp {
   @ViewChildren(MatTab) tabs!: QueryList<MatTab>;
@@ -1384,6 +1396,7 @@ class DisabledTabsTestApp {
    </mat-tab-group>
   `,
   imports: [MatTabsModule, AsyncPipe],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class AsyncTabsTestApp implements OnInit {
   private _tabs = [
@@ -1411,6 +1424,7 @@ class AsyncTabsTestApp implements OnInit {
   </mat-tab-group>
   `,
   imports: [MatTabsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TabGroupWithSimpleApi {
   preserveContent = false;
@@ -1433,6 +1447,7 @@ class TabGroupWithSimpleApi {
     </mat-tab-group>
   `,
   imports: [MatTabsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NestedTabs {
   @ViewChildren(MatTabGroup) groups!: QueryList<MatTabGroup>;
@@ -1452,6 +1467,7 @@ class NestedTabs {
     </mat-tab-group>
   `,
   imports: [MatTabsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TemplateTabs {}
 
@@ -1462,6 +1478,7 @@ class TemplateTabs {}
   </mat-tab-group>
   `,
   imports: [MatTabsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TabGroupWithAriaInputs {
   ariaLabel!: string;
@@ -1480,6 +1497,7 @@ class TabGroupWithAriaInputs {
     }
   `,
   imports: [MatTabsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TabGroupWithIsActiveBinding {}
 
@@ -1491,6 +1509,7 @@ class TabGroupWithIsActiveBinding {}
     </mat-tab-group>
   `,
   imports: [MatTabsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TabsWithCustomAnimationDuration {}
 
@@ -1502,6 +1521,7 @@ class TabsWithCustomAnimationDuration {}
     </mat-tab-group>
   `,
   imports: [MatTabsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TabsWithObjectAnimationDuration {}
 
@@ -1515,6 +1535,7 @@ class TabsWithObjectAnimationDuration {}
     </mat-tab-group>
   `,
   imports: [MatTabsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TabGroupWithIndirectDescendantTabs {
   @ViewChild(MatTabGroup) tabGroup!: MatTabGroup;
@@ -1528,6 +1549,7 @@ class TabGroupWithIndirectDescendantTabs {
     </mat-tab-group>
   `,
   imports: [MatTabsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TabGroupWithInkBarFitToContent {
   fitInkBarToContent = true;
@@ -1550,6 +1572,7 @@ class TabGroupWithInkBarFitToContent {
     </mat-tab-group>
   `,
   imports: [MatTabsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TabGroupWithSpaceAbove {
   @ViewChild(MatTabGroup) tabGroup!: MatTabGroup;
@@ -1573,6 +1596,7 @@ class TabGroupWithSpaceAbove {
     </mat-tab-group>
   `,
   imports: [MatTabsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NestedTabGroupWithLabel {}
 
@@ -1589,6 +1613,7 @@ class NestedTabGroupWithLabel {}
     </mat-tab-group>
   `,
   imports: [MatTabsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TabsWithClassesTestApp {
   labelClassList!: string | string[];
@@ -1607,6 +1632,7 @@ class TabsWithClassesTestApp {
     </mat-tab-group>
   `,
   imports: [MatTabsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TabsWithAlignConfig {}
 
@@ -1622,5 +1648,6 @@ class TabsWithAlignConfig {}
     </mat-tab-group>
   `,
   imports: [MatTabsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TabsWithAlignCenter {}

--- a/src/material/tabs/tab-header.spec.ts
+++ b/src/material/tabs/tab-header.spec.ts
@@ -9,7 +9,13 @@ import {
   dispatchFakeEvent,
   dispatchKeyboardEvent,
 } from '@angular/cdk/testing/private';
-import {ChangeDetectorRef, Component, ViewChild, inject} from '@angular/core';
+import {
+  ChangeDetectorRef,
+  Component,
+  ViewChild,
+  inject,
+  ChangeDetectionStrategy,
+} from '@angular/core';
 import {
   ComponentFixture,
   TestBed,
@@ -739,6 +745,7 @@ interface Tab {
     }
   `,
   imports: [Dir, MatTabHeader, MatTabLabelWrapper],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SimpleTabHeaderApp {
   disableRipple: boolean = false;

--- a/src/material/tabs/tab-nav-bar/tab-nav-bar.spec.ts
+++ b/src/material/tabs/tab-nav-bar/tab-nav-bar.spec.ts
@@ -7,7 +7,15 @@ import {
   dispatchMouseEvent,
   provideFakeDirectionality,
 } from '@angular/cdk/testing/private';
-import {Component, QueryList, signal, ViewChild, ViewChildren, WritableSignal} from '@angular/core';
+import {
+  Component,
+  QueryList,
+  signal,
+  ViewChild,
+  ViewChildren,
+  WritableSignal,
+  ChangeDetectionStrategy,
+} from '@angular/core';
 import {ComponentFixture, fakeAsync, TestBed, tick, waitForAsync} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {Subject} from 'rxjs';
@@ -552,6 +560,7 @@ describe('MatTabNavBar with enabled animations', () => {
     <mat-tab-nav-panel #tabPanel id="tab-panel">Tab panel</mat-tab-nav-panel>
   `,
   imports: [MatTabsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SimpleTabNavBarTestApp {
   @ViewChild(MatTabNav) tabNavBar!: MatTabNav;
@@ -577,6 +586,7 @@ class SimpleTabNavBarTestApp {
     <mat-tab-nav-panel #tabPanel>Tab panel</mat-tab-nav-panel>
   `,
   imports: [MatTabsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TabLinkWithNgIf {
   isDestroyed = false;
@@ -592,6 +602,7 @@ class TabLinkWithNgIf {
     <mat-tab-nav-panel #tabPanel>Tab panel</mat-tab-nav-panel>
   `,
   imports: [MatTabsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TabBarWithInactiveTabsOnInit {
   tabs = [0, 1, 2];
@@ -607,6 +618,7 @@ class TabBarWithInactiveTabsOnInit {
   <mat-tab-nav-panel #tabPanel></mat-tab-nav-panel>,
   `,
   imports: [MatTabsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TabsWithCustomAnimationDuration {
   links = ['First', 'Second', 'Third'];
@@ -620,5 +632,6 @@ class TabsWithCustomAnimationDuration {
     <mat-tab-nav-panel #tabPanel>Tab panel</mat-tab-nav-panel>
   `,
   imports: [MatTabsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TabBarWithDisabledTabOnInit {}

--- a/src/material/tabs/testing/tab-group-harness.spec.ts
+++ b/src/material/tabs/testing/tab-group-harness.spec.ts
@@ -1,4 +1,4 @@
-import {Component, signal} from '@angular/core';
+import {Component, signal, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {ComponentHarness, HarnessLoader, parallel} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
@@ -170,6 +170,7 @@ describe('MatTabGroupHarness', () => {
     </mat-tab-group>
   `,
   imports: [MatTabsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TabGroupHarnessTest {
   isDisabled = signal(false);

--- a/src/material/tabs/testing/tab-nav-bar-harness.spec.ts
+++ b/src/material/tabs/testing/tab-nav-bar-harness.spec.ts
@@ -1,4 +1,4 @@
-import {Component, signal} from '@angular/core';
+import {Component, signal, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
@@ -107,6 +107,7 @@ describe('MatTabNavBarHarness', () => {
     </mat-tab-nav-panel>
   `,
   imports: [MatTabsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TabNavBarHarnessTest {
   activeLink = 0;

--- a/src/material/timepicker/testing/timepicker-harness.spec.ts
+++ b/src/material/timepicker/testing/timepicker-harness.spec.ts
@@ -1,4 +1,4 @@
-import {Component, signal} from '@angular/core';
+import {Component, signal, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {HarnessLoader, parallel} from '@angular/cdk/testing';
 import {DateAdapter, MATERIAL_ANIMATIONS, provideNativeDateAdapter} from '../../core';
@@ -75,6 +75,7 @@ describe('MatTimepickerHarness', () => {
     <mat-timepicker #twoPicker [interval]="interval()"/>
   `,
   imports: [MatTimepickerInput, MatTimepicker],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TimepickerHarnessTest {
   interval = signal('4h');

--- a/src/material/timepicker/testing/timepicker-input-harness.spec.ts
+++ b/src/material/timepicker/testing/timepicker-input-harness.spec.ts
@@ -1,6 +1,6 @@
 import {HarnessLoader, parallel} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
-import {Component, signal} from '@angular/core';
+import {Component, signal, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {DateAdapter, provideNativeDateAdapter} from '../../core';
 import {MatTimepicker, MatTimepickerInput} from '../../timepicker';
@@ -166,6 +166,7 @@ describe('MatTimepickerInputHarness', () => {
     <mat-timepicker #basicPicker/>
   `,
   imports: [MatTimepickerInput, MatTimepicker],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TimepickerInputHarnessTest {
   readonly value = signal<Date | null>(null);

--- a/src/material/timepicker/testing/timepicker-toggle-harness.spec.ts
+++ b/src/material/timepicker/testing/timepicker-toggle-harness.spec.ts
@@ -1,4 +1,4 @@
-import {Component, signal} from '@angular/core';
+import {Component, signal, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
 import {DateAdapter, provideNativeDateAdapter} from '../../core';
@@ -52,6 +52,7 @@ describe('MatTimepickerToggleHarness', () => {
     <mat-timepicker-toggle id="two" [for]="twoPicker" [disabled]="disabled()"/>
   `,
   imports: [MatTimepickerInput, MatTimepicker, MatTimepickerToggle],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TimepickerHarnessTest {
   disabled = signal(false);

--- a/src/material/timepicker/timepicker.spec.ts
+++ b/src/material/timepicker/timepicker.spec.ts
@@ -1,4 +1,12 @@
-import {Component, Injector, Provider, signal, ViewChild, ViewEncapsulation} from '@angular/core';
+import {
+  Component,
+  Injector,
+  Provider,
+  signal,
+  ViewChild,
+  ViewEncapsulation,
+  ChangeDetectionStrategy,
+} from '@angular/core';
 import {ComponentFixture, fakeAsync, flush, TestBed} from '@angular/core/testing';
 import {DateAdapter, MATERIAL_ANIMATIONS, provideNativeDateAdapter} from '../core';
 import {
@@ -1435,6 +1443,7 @@ describe('MatTimepicker', () => {
       [tabIndex]="toggleTabIndex()"/>
   `,
   imports: [MatTimepicker, MatTimepickerInput, MatTimepickerToggle],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class StandaloneTimepicker {
   @ViewChild(MatTimepickerInput) input!: MatTimepickerInput<Date>;
@@ -1475,6 +1484,7 @@ class StandaloneTimepicker {
     MatFormField,
     MatSuffix,
   ],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TimepickerInFormField {
   @ViewChild(MatTimepicker) timepicker!: MatTimepicker<Date>;
@@ -1487,6 +1497,7 @@ class TimepickerInFormField {
     <mat-timepicker #picker/>
   `,
   imports: [MatTimepicker, MatTimepickerInput],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TimepickerTwoWayBinding {
   @ViewChild(MatTimepickerInput) input!: MatTimepickerInput<Date>;
@@ -1503,6 +1514,7 @@ class TimepickerTwoWayBinding {
     <mat-timepicker #picker/>
   `,
   imports: [MatTimepicker, MatTimepickerInput, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TimepickerWithForms {
   @ViewChild(MatTimepickerInput) input!: MatTimepickerInput<Date>;
@@ -1519,12 +1531,14 @@ class TimepickerWithForms {
     <mat-timepicker #picker/>
   `,
   imports: [MatTimepicker, MatTimepickerInput],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TimepickerWithMultipleInputs {}
 
 @Component({
   template: '<mat-timepicker/>',
   imports: [MatTimepicker],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TimepickerWithoutInput {
   @ViewChild(MatTimepicker) timepicker!: MatTimepicker<Date>;
@@ -1537,5 +1551,6 @@ class TimepickerWithoutInput {
   `,
   imports: [MatTimepicker, MatTimepickerInput],
   encapsulation: ViewEncapsulation.ShadowDom,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TimepickerInShadowDom {}

--- a/src/material/toolbar/testing/toolbar-harness.spec.ts
+++ b/src/material/toolbar/testing/toolbar-harness.spec.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import {Component, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentHarness, HarnessLoader} from '@angular/cdk/testing';
 import {MatToolbarModule} from '../../toolbar';
 import {MatToolbarHarness, MatToolbarSection} from './toolbar-harness';
@@ -71,6 +71,7 @@ describe('MatToolbarHarness', () => {
     </mat-toolbar>
   `,
   imports: [MatToolbarModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ToolbarHarnessTest {}
 

--- a/src/material/toolbar/toolbar.spec.ts
+++ b/src/material/toolbar/toolbar.spec.ts
@@ -1,4 +1,4 @@
-import {Component, signal} from '@angular/core';
+import {Component, signal, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {MatToolbarModule} from './index';
@@ -77,6 +77,7 @@ describe('MatToolbar', () => {
     </mat-toolbar>
   `,
   imports: [MatToolbarModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ToolbarSingleRow {
   toolbarColor = signal('');
@@ -90,6 +91,7 @@ class ToolbarSingleRow {
     </mat-toolbar>
   `,
   imports: [MatToolbarModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ToolbarMultipleRows {}
 
@@ -103,6 +105,7 @@ class ToolbarMultipleRows {}
     </mat-toolbar>
   `,
   imports: [MatToolbarModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ToolbarMixedRowModes {
   showToolbarRow = signal(true);
@@ -121,5 +124,6 @@ class ToolbarMixedRowModes {
     </mat-toolbar>
   `,
   imports: [MatToolbarModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ToolbarMultipleIndirectRows {}

--- a/src/material/tooltip/testing/tooltip-harness.spec.ts
+++ b/src/material/tooltip/testing/tooltip-harness.spec.ts
@@ -1,4 +1,4 @@
-import {Component, provideZoneChangeDetection} from '@angular/core';
+import {Component, provideZoneChangeDetection, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
@@ -68,6 +68,7 @@ describe('MatTooltipHarness', () => {
     <button matTooltip='Disabled Tooltip' [matTooltipDisabled]='true' id='three'>Trigger 3</button>
   `,
   imports: [MatTooltipModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TooltipHarnessTest {
   message = 'Tooltip message';

--- a/src/material/tooltip/tooltip.spec.ts
+++ b/src/material/tooltip/tooltip.spec.ts
@@ -1575,6 +1575,7 @@ describe('MatTooltip', () => {
         [matTooltipDisabled]="tooltipDisabled">Button</button>
     }`,
   imports: [MatTooltipModule, OverlayModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class BasicTooltipDemo {
   position: TooltipPosition = 'below';
@@ -1598,6 +1599,7 @@ class BasicTooltipDemo {
       }
     </div>`,
   imports: [MatTooltipModule, OverlayModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ScrollableTooltipDemo {
   position: TooltipPosition = 'below';
@@ -1638,6 +1640,7 @@ class OnPushTooltipDemo {
     }
   `,
   imports: [MatTooltipModule, OverlayModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DynamicTooltipsDemo {
   tooltips: string[] = [];
@@ -1646,6 +1649,7 @@ class DynamicTooltipsDemo {
 @Component({
   template: `<button [matTooltip]="message" [attr.aria-label]="message">Click me</button>`,
   imports: [MatTooltipModule, OverlayModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DataBoundAriaLabelTooltip {
   message = 'Hello there';
@@ -1664,6 +1668,7 @@ class DataBoundAriaLabelTooltip {
       [matTooltipTouchGestures]="touchGestures"></textarea>
   `,
   imports: [MatTooltipModule, OverlayModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TooltipOnTextFields {
   @ViewChild('input') input!: ElementRef<HTMLInputElement>;
@@ -1680,6 +1685,7 @@ class TooltipOnTextFields {
       [matTooltipTouchGestures]="touchGestures"></button>
   `,
   imports: [MatTooltipModule, OverlayModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TooltipOnDraggableElement {
   @ViewChild('button') button!: ElementRef;
@@ -1689,6 +1695,7 @@ class TooltipOnDraggableElement {
 @Component({
   template: `<button #button [matTooltip]="message">Button</button>`,
   imports: [MatTooltip],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TooltipDemoWithoutPositionBinding {
   message: string = initialTooltipMessage;
@@ -1699,6 +1706,7 @@ class TooltipDemoWithoutPositionBinding {
 @Component({
   template: `<button #button [matTooltip]="message">Button</button>`,
   imports: [MatTooltip],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TooltipDemoWithoutTooltipClassBinding {
   message = initialTooltipMessage;
@@ -1711,6 +1719,7 @@ class TooltipDemoWithoutTooltipClassBinding {
     <button #button matTooltipClass="fixed-tooltip-class" [matTooltip]="message">Button</button>
   `,
   imports: [MatTooltip],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TooltipDemoWithTooltipClassBinding {
   message: string = initialTooltipMessage;
@@ -1722,6 +1731,7 @@ class TooltipDemoWithTooltipClassBinding {
   styles: `button { width: 500px; height: 500px; }`,
   template: `<button #button [matTooltip]="message">Button</button>`,
   imports: [MatTooltip],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class WideTooltipDemo {
   message = 'Test';

--- a/src/material/tooltip/tooltip.zone.spec.ts
+++ b/src/material/tooltip/tooltip.zone.spec.ts
@@ -6,6 +6,7 @@ import {
   NgZone,
   ViewChild,
   provideZoneChangeDetection,
+  ChangeDetectionStrategy,
 } from '@angular/core';
 import {ComponentFixture, TestBed, fakeAsync, tick, waitForAsync} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
@@ -66,6 +67,7 @@ describe('MatTooltip Zone.js integration', () => {
         }
       </div>`,
   imports: [MatTooltipModule, OverlayModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ScrollableTooltipDemo {
   position: TooltipPosition = 'below';

--- a/src/material/tree/testing/tree-harness.spec.ts
+++ b/src/material/tree/testing/tree-harness.spec.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import {Component, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {FlatTreeControl, NestedTreeControl} from '@angular/cdk/tree';
 import {
@@ -247,6 +247,7 @@ interface ExampleFlatNode {
     </mat-tree>
   `,
   imports: [MatTreeModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TreeHarnessTest {
   private _transformer = (node: Node, level: number) => {

--- a/src/material/tree/tree-using-legacy-key-manager.spec.ts
+++ b/src/material/tree/tree-using-legacy-key-manager.spec.ts
@@ -1,4 +1,11 @@
-import {Component, ElementRef, QueryList, ViewChild, ViewChildren} from '@angular/core';
+import {
+  Component,
+  ElementRef,
+  QueryList,
+  ViewChild,
+  ViewChildren,
+  ChangeDetectionStrategy,
+} from '@angular/core';
 import {of} from 'rxjs';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatTreeModule} from './tree-module';
@@ -94,6 +101,7 @@ class MinimalTestData {
     </mat-tree>
   `,
   imports: [MatTreeModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SimpleMatTreeApp {
   isExpandable = (node: MinimalTestData) => node.children.length > 0;

--- a/src/material/tree/tree-using-tree-control.spec.ts
+++ b/src/material/tree/tree-using-tree-control.spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 import {FlatTreeControl, NestedTreeControl, TreeControl} from '@angular/cdk/tree';
-import {Component, ViewChild} from '@angular/core';
+import {Component, ViewChild, ChangeDetectionStrategy} from '@angular/core';
 import {AsyncPipe} from '@angular/common';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {BehaviorSubject, Observable} from 'rxjs';
@@ -856,6 +856,7 @@ function expectNestedTreeToMatch(treeElement: Element, ...expectedTree: TreeCont
     </mat-tree>
   `,
   imports: [MatTreeModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SimpleMatTreeApp {
   getLevel = (node: TestData) => node.level;
@@ -934,6 +935,7 @@ const TREE_DATA: FoodNode[] = [
     </mat-tree>
   `,
   imports: [MatTreeModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatTreeWithNullOrUndefinedChild {
   private _transformer = (node: FoodNode, level: number) => {
@@ -971,6 +973,7 @@ class MatTreeWithNullOrUndefinedChild {
     </mat-tree>
   `,
   imports: [MatTreeModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatNestedTreeWithNullOrUndefinedChild {
   treeControl!: NestedTreeControl<FoodNode>;
@@ -997,6 +1000,7 @@ class MatNestedTreeWithNullOrUndefinedChild {
     </mat-tree>
   `,
   imports: [MatTreeModule, AsyncPipe],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NestedMatTreeApp {
   getChildren = (node: TestData) => node.observableChildren;
@@ -1034,6 +1038,7 @@ class NestedMatTreeApp {
     </mat-tree>
   `,
   imports: [MatTreeModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class WhenNodeNestedMatTreeApp {
   isSpecial = (_: number, node: TestData) => node.isSpecial;
@@ -1067,6 +1072,7 @@ class WhenNodeNestedMatTreeApp {
     </mat-tree>
   `,
   imports: [MatTreeModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatTreeAppWithToggle {
   toggleRecursively: boolean = true;
@@ -1116,6 +1122,7 @@ class MatTreeAppWithToggle {
     </mat-tree>
   `,
   imports: [MatTreeModule, AsyncPipe],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NestedMatTreeAppWithToggle {
   toggleRecursively: boolean = true;
@@ -1153,6 +1160,7 @@ class NestedMatTreeAppWithToggle {
     </mat-tree>
   `,
   imports: [MatTreeModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class WhenNodeMatTreeApp {
   isSpecial = (_: number, node: TestData) => node.isSpecial;

--- a/src/material/tree/tree.spec.ts
+++ b/src/material/tree/tree.spec.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.dev/license
  */
-import {Component, ViewChild} from '@angular/core';
+import {Component, ViewChild, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {AsyncPipe} from '@angular/common';
 import {BehaviorSubject, Observable} from 'rxjs';
@@ -859,6 +859,7 @@ function expectNestedTreeToMatch(treeElement: Element, ...expectedTree: TreeCont
     </mat-tree>
   `,
   imports: [MatTreeModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SimpleMatTreeApp {
   getLevel = (node: TestData) => node.level;
@@ -909,6 +910,7 @@ const TREE_DATA: FoodNode[] = [
     </mat-tree>
   `,
   imports: [MatTreeModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatTreeWithNullOrUndefinedChild {
   childrenAccessor = (node: FoodNode): FoodNode[] => node.children || [];
@@ -930,6 +932,7 @@ class MatTreeWithNullOrUndefinedChild {
     </mat-tree>
   `,
   imports: [MatTreeModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatNestedTreeWithNullOrUndefinedChild {
   childrenAccessor = (node: FoodNode): FoodNode[] => node.children || [];
@@ -953,6 +956,7 @@ class MatNestedTreeWithNullOrUndefinedChild {
     </mat-tree>
   `,
   imports: [MatTreeModule, AsyncPipe],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NestedMatTreeApp {
   childrenAccessor = (node: TestData) => node.observableChildren;
@@ -990,6 +994,7 @@ class NestedMatTreeApp {
     </mat-tree>
   `,
   imports: [MatTreeModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class WhenNodeNestedMatTreeApp {
   isSpecial = (_: number, node: TestData) => node.isSpecial;
@@ -1025,6 +1030,7 @@ class WhenNodeNestedMatTreeApp {
     </mat-tree>
   `,
   imports: [MatTreeModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MatTreeAppWithToggle {
   toggleRecursively: boolean = true;
@@ -1054,6 +1060,7 @@ class MatTreeAppWithToggle {
     </mat-tree>
   `,
   imports: [MatTreeModule, AsyncPipe],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NestedMatTreeAppWithToggle {
   toggleRecursively: boolean = true;
@@ -1087,6 +1094,7 @@ class NestedMatTreeAppWithToggle {
     </mat-tree>
   `,
   imports: [MatTreeModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class WhenNodeMatTreeApp {
   isSpecial = (_: number, node: TestData) => node.isSpecial;

--- a/src/youtube-player/youtube-player.spec.ts
+++ b/src/youtube-player/youtube-player.spec.ts
@@ -1,4 +1,10 @@
-import {Component, EnvironmentProviders, Provider, ViewChild} from '@angular/core';
+import {
+  Component,
+  EnvironmentProviders,
+  Provider,
+  ViewChild,
+  ChangeDetectionStrategy,
+} from '@angular/core';
 import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 import {Subscription} from 'rxjs';
 import {createFakeYtNamespace} from './fake-youtube-player';
@@ -804,6 +810,7 @@ describe('YoutubePlayer', () => {
         (apiChange)="onApiChange($event)"/>
     }
   `,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TestApp {
   videoId: string | undefined = VIDEO_ID;
@@ -832,6 +839,7 @@ class TestApp {
   template: `
     <youtube-player [videoId]="videoId" [startSeconds]="42" [endSeconds]="1337"/>
   `,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class StaticStartEndSecondsApp {
   videoId = VIDEO_ID;
@@ -840,6 +848,7 @@ class StaticStartEndSecondsApp {
 @Component({
   imports: [YouTubePlayer],
   template: `<youtube-player [videoId]="videoId"/>`,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NoEventsApp {
   @ViewChild(YouTubePlayer) player!: YouTubePlayer;


### PR DESCRIPTION
In the next pre-release version of Angular, components that don't specify a `changeDetection` will become `OnPush` by default. These changes add `ChangeDetectionStrategy.Eager` to all test components, because a lot of them will start to fail with the new behavior.