### PR TITLE
feat(material): layer shipped CSS for predictable app overrides

### DIFF
--- a/guides/theming.md
+++ b/guides/theming.md
@@ -50,58 +50,70 @@ html {
 
 ### CSS cascade layers
 
-You can place `mat.theme` output in a
-[CSS cascade layer](https://www.w3.org/TR/css-cascade-5/#layering) so normalization,
-Angular CDK/Material, and app overrides stay predictable. For background, see
+Angular Material ships all component CSS inside the `angular-material`
+[cascade layer](https://www.w3.org/TR/css-cascade-5/#layering). This lets
+applications control where Material sits in the cascade relative to resets,
+CDK styles, and utility frameworks such as Tailwind — without resorting to
+extra specificity or `!important`. See also
 [MDN: Cascade layers](https://developer.mozilla.org/en-US/docs/Web/CSS/@layer).
 
-**Layer order.** Declare the order of named layers (including
-[from CDK](https://github.com/angular/components/blob/main/src/cdk/overlay/_index.scss)
-`cdk-overlay` and `cdk-resets` when you use those packages) before other rules, for example:
+Component styles are layered automatically at build time — no action is
+needed for component CSS. Prebuilt themes are also shipped pre-layered.
 
-```scss
-@layer reset, cdk-resets, cdk-overlay, angular-material, overrides;
-```
-
-**Default is unlayered.** `mat.theme` does not use a layer unless you opt in.
-
-Use either the optional third argument:
+**Layer order.** In Sass, `@use` must come before any other rules. After your
+`@use` lines, declare the order of named layers:
 
 ```scss
 @use '@angular/material' as mat;
 
-html {
-  @include mat.theme(
-    (
+@layer base, cdk-resets, cdk-overlay, angular-material, components, utilities;
+```
+
+If your app uses CDK overlay or drag-drop resets, include their published
+layer names (`cdk-overlay`, `cdk-resets`) so their priority is predictable.
+
+**Tailwind CSS.** Placing `angular-material` before `utilities` allows
+Tailwind utility classes to override Material styles at equal specificity.
+Put Material `@use` and your layer prelude before Tailwind’s `@tailwind`
+directives (Tailwind’s own docs describe layer setup for your stack):
+
+```scss
+@use '@angular/material' as mat;
+
+@layer base, cdk-resets, cdk-overlay, angular-material, components, utilities;
+
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+```
+
+**Theme output.** Wrap `mat.theme` in `mat.theme-layer` so the generated
+CSS custom properties land in the same `angular-material` layer as the
+component styles. You can also use the same mixin around other Angular
+Material theme output such as `all-component-themes` or individual
+component theme mixins:
+
+```scss
+@use '@angular/material' as mat;
+
+@layer base, cdk-resets, cdk-overlay, angular-material, components, utilities;
+
+@include mat.theme-layer {
+  html {
+    @include mat.theme((
       color: mat.$violet-palette,
       typography: Roboto,
       density: 0,
-    ),
-    (),
-    mat.$default-cascade-layer-name
-  );
+    ));
+  }
 }
 ```
 
-or wrap the mixin with `with-cascade-layer` and a custom name:
-
-```scss
-@include mat.with-cascade-layer(custom-material) {
-  @include mat.theme((
-    color: mat.$violet-palette,
-    typography: Roboto,
-    density: 0,
-  ));
-}
-```
-
-**Cascade note.** In the CSS Cascade Level 5 model, unlayered author declarations participate in an
-implicit outer layer with higher priority than explicit named layers. Unlayered rules can therefore
-override layered Material at equal specificity. Overrides that live in named layers must appear after
-your Material layer in the prelude `@layer` list (or use higher specificity / `!important` as usual).
-
-Per-component styles from Angular Material are emitted in separate stylesheets and are not placed
-in this layer by default; this feature applies to the system variables emitted by `mat.theme`.
+**Cascade note.** In the CSS Cascade Level 5 model, unlayered author
+styles have higher priority than any named layer. Plain CSS rules can
+therefore override layered Material at equal specificity. Overrides that
+live inside named layers must appear after `angular-material` in the
+`@layer` order list, or use higher specificity / `!important` as usual.
 
 You can use the following styles to apply the theme’s surface background and
 on-surface text colors as a default across your application:

--- a/src/cdk/overlay/overlay-structure.scss
+++ b/src/cdk/overlay/overlay-structure.scss
@@ -2,9 +2,6 @@
 
 // We don't emit the layer internally, because all the breaking changes
 // have been resolved already and the `@layer` seems to break some targets.
-// Published CSS still uses `@layer cdk-overlay`. Apps combining CDK with
-// Material can prelude layer order alongside `mat.with-cascade-layer` /
-// `mat.theme(..., $cascade-layer: ...)` (see `guides/theming.md`).
 $_is-external-build: true;
 
 @include overlay.private-overlay-structure($_is-external-build);

--- a/src/e2e-app/BUILD.bazel
+++ b/src/e2e-app/BUILD.bazel
@@ -43,6 +43,7 @@ ng_project(
         "//src/cdk/scrolling",
         "//src/cdk/testing/tests:test_components",
         "//src/components-examples/private",
+        "//src/material/button",
         "//src/material/core",
         "//src/material/slider",
     ],

--- a/src/e2e-app/components/e2e-app/e2e-app.ts
+++ b/src/e2e-app/components/e2e-app/e2e-app.ts
@@ -16,6 +16,7 @@ export class E2eApp {
     {path: 'block-scroll-strategy', title: 'Block Scroll Strategy'},
     {path: 'component-harness', title: 'Component Harness'},
     {path: 'slider', title: 'Slider'},
+    {path: 'tailwind-layer', title: 'Tailwind Layer'},
     {path: 'virtual-scroll', title: 'Virtual Scroll'},
   ];
 }

--- a/src/e2e-app/components/tailwind-layer-e2e.ts
+++ b/src/e2e-app/components/tailwind-layer-e2e.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {ChangeDetectionStrategy, Component} from '@angular/core';
+import {MatButtonModule} from '@angular/material/button';
+
+@Component({
+  selector: 'tailwind-layer-e2e',
+  template: `
+    <button
+      id="tailwind-utility-button"
+      class="tw-bg-lime-500"
+      mat-flat-button>
+      Tailwind utility should win
+    </button>
+    <button
+      id="unlayered-utility-button"
+      class="tw-bg-fuchsia-unlayered"
+      mat-flat-button>
+      Unlayered utility control
+    </button>
+  `,
+  imports: [MatButtonModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
+})
+export class TailwindLayerE2e {}

--- a/src/e2e-app/main.ts
+++ b/src/e2e-app/main.ts
@@ -7,6 +7,7 @@ import {ComponentHarnessE2e} from './components/component-harness-e2e';
 import {E2eApp} from './components/e2e-app/e2e-app';
 import {Home} from './components/home';
 import {SliderE2e} from './components/slider-e2e';
+import {TailwindLayerE2e} from './components/tailwind-layer-e2e';
 import {VirtualScrollE2E} from './components/virtual-scroll/virtual-scroll-e2e';
 
 enableProdMode();
@@ -19,6 +20,7 @@ bootstrapApplication(E2eApp, {
       {path: 'block-scroll-strategy', component: BlockScrollStrategyE2E},
       {path: 'component-harness', component: ComponentHarnessE2e},
       {path: 'slider', component: SliderE2e},
+      {path: 'tailwind-layer', component: TailwindLayerE2e},
       {path: 'virtual-scroll', component: VirtualScrollE2E},
     ]),
     provideZoneChangeDetection(),

--- a/src/e2e-app/theme.scss
+++ b/src/e2e-app/theme.scss
@@ -1,5 +1,7 @@
 @use '@angular/material' as mat;
 
+@layer base, angular-material, utilities;
+
 $theme: mat.define-theme((
   color: (
     theme-type: light,
@@ -11,8 +13,21 @@ $theme: mat.define-theme((
   )
 ));
 
-html {
-  @include mat.all-component-themes($theme);
+@include mat.theme-layer {
+  html {
+    @include mat.all-component-themes($theme);
+  }
+
+  @include mat.typography-hierarchy($theme);
 }
 
-@include mat.typography-hierarchy($theme);
+@layer utilities {
+  .tw-bg-lime-500 {
+    background-color: rgb(132, 204, 22);
+  }
+}
+
+// Control utility that is intentionally unlayered.
+.tw-bg-fuchsia-unlayered {
+  background-color: rgb(217, 70, 239);
+}

--- a/src/material-experimental/menubar/BUILD.bazel
+++ b/src/material-experimental/menubar/BUILD.bazel
@@ -32,11 +32,13 @@ sass_library(
 sass_binary(
     name = "menubar_scss",
     src = "menubar.scss",
+    layer = "angular-material",
 )
 
 sass_binary(
     name = "menubar_item_scss",
     src = "menubar-item.scss",
+    layer = "angular-material",
 )
 
 ng_project(

--- a/src/material-experimental/selection/BUILD.bazel
+++ b/src/material-experimental/selection/BUILD.bazel
@@ -27,4 +27,5 @@ sass_library(
 sass_binary(
     name = "selection_column_scss",
     src = "selection-column.scss",
+    layer = "angular-material",
 )

--- a/src/material/_index.scss
+++ b/src/material/_index.scss
@@ -33,8 +33,7 @@
   $private-ease-in-out-curve-function, $private-swift-ease-out-duration, $private-xsmall;
 @forward './core/style/sass-utils' as private-*;
 @forward './core/style/validation' as private-*;
-@forward './core/style/cascade-layers' show $default-cascade-layer-name,
-  with-cascade-layer;
+@forward './core/style/cascade-layers' show theme-layer;
 
 // Structural
 @forward './core/core' show core, app-background, elevation-classes;

--- a/src/material/autocomplete/BUILD.bazel
+++ b/src/material/autocomplete/BUILD.bazel
@@ -53,6 +53,7 @@ sass_library(
 sass_binary(
     name = "css",
     src = "autocomplete.scss",
+    layer = "angular-material",
     deps = [
         ":m2",
         ":m3",

--- a/src/material/badge/BUILD.bazel
+++ b/src/material/badge/BUILD.bazel
@@ -53,6 +53,7 @@ sass_library(
 sass_binary(
     name = "badge_css",
     src = "badge.scss",
+    layer = "angular-material",
     deps = [
         ":m2",
         "//src/cdk:sass_lib",

--- a/src/material/bottom-sheet/BUILD.bazel
+++ b/src/material/bottom-sheet/BUILD.bazel
@@ -53,6 +53,7 @@ sass_library(
 sass_binary(
     name = "css",
     src = "bottom-sheet-container.scss",
+    layer = "angular-material",
     deps = [
         ":m2",
         "//src/cdk:sass_lib",

--- a/src/material/button-toggle/BUILD.bazel
+++ b/src/material/button-toggle/BUILD.bazel
@@ -53,6 +53,7 @@ sass_library(
 sass_binary(
     name = "css",
     src = "button-toggle.scss",
+    layer = "angular-material",
     deps = [
         ":m2",
         "//src/cdk:sass_lib",

--- a/src/material/button/BUILD.bazel
+++ b/src/material/button/BUILD.bazel
@@ -84,6 +84,7 @@ sass_library(
 sass_binary(
     name = "icon_button_css",
     src = "icon-button.scss",
+    layer = "angular-material",
     deps = [
         ":base_lib",
         ":m2",
@@ -96,6 +97,7 @@ sass_binary(
 sass_binary(
     name = "fab_css",
     src = "fab.scss",
+    layer = "angular-material",
     deps = [
         ":base_lib",
         ":m2",
@@ -109,6 +111,7 @@ sass_binary(
 sass_binary(
     name = "button_high_contrast",
     src = "button-high-contrast.scss",
+    layer = "angular-material",
     deps = [
         "//src/cdk:sass_lib",
     ],
@@ -128,6 +131,7 @@ sass_library(
 sass_binary(
     name = "css",
     src = "button.scss",
+    layer = "angular-material",
     deps = [
         ":base_lib",
         ":m2",

--- a/src/material/card/BUILD.bazel
+++ b/src/material/card/BUILD.bazel
@@ -53,6 +53,7 @@ sass_library(
 sass_binary(
     name = "css",
     src = "card.scss",
+    layer = "angular-material",
     deps = [
         ":m2",
         "//src/material/core/tokens:token_utils",

--- a/src/material/checkbox/BUILD.bazel
+++ b/src/material/checkbox/BUILD.bazel
@@ -64,6 +64,7 @@ sass_library(
 sass_binary(
     name = "css",
     src = "checkbox.scss",
+    layer = "angular-material",
     deps = [
         ":checkbox_common",
         ":m2",

--- a/src/material/chips/BUILD.bazel
+++ b/src/material/chips/BUILD.bazel
@@ -52,6 +52,7 @@ sass_library(
 sass_binary(
     name = "chip_css",
     src = "chip.scss",
+    layer = "angular-material",
     deps = [
         ":m2",
         "//src/cdk:sass_lib",
@@ -65,6 +66,7 @@ sass_binary(
 sass_binary(
     name = "chip_set_css",
     src = "chip-set.scss",
+    layer = "angular-material",
     deps = ["//src/material/core/style:vendor_prefixes"],
 )
 

--- a/src/material/core/BUILD.bazel
+++ b/src/material/core/BUILD.bazel
@@ -203,6 +203,7 @@ sass_library(
 sass_binary(
     name = "ripple_structure",
     src = "ripple/ripple-structure.scss",
+    layer = "angular-material",
     deps = [
         ":ripple_sass",
     ],

--- a/src/material/core/focus-indicators/BUILD.bazel
+++ b/src/material/core/focus-indicators/BUILD.bazel
@@ -25,5 +25,6 @@ ng_project(
 sass_binary(
     name = "structural_styles_css",
     src = "structural-styles.scss",
+    layer = "angular-material",
     deps = [":focus-indicators"],
 )

--- a/src/material/core/internal-form-field/BUILD.bazel
+++ b/src/material/core/internal-form-field/BUILD.bazel
@@ -16,5 +16,6 @@ ng_project(
 sass_binary(
     name = "internal_form_field_css",
     src = "internal-form-field.scss",
+    layer = "angular-material",
     deps = ["//src/material/core/style:vendor_prefixes"],
 )

--- a/src/material/core/option/BUILD.bazel
+++ b/src/material/core/option/BUILD.bazel
@@ -77,6 +77,7 @@ ng_project(
 sass_binary(
     name = "option_css",
     src = "option.scss",
+    layer = "angular-material",
     deps = [
         "//src/cdk:sass_lib",
         "//src/material/core/style:layout_common",
@@ -88,6 +89,7 @@ sass_binary(
 sass_binary(
     name = "optgroup_css",
     src = "optgroup.scss",
+    layer = "angular-material",
     deps = [
         "//src/material/core/tokens:token_utils",
     ],

--- a/src/material/core/selection/pseudo-checkbox/BUILD.bazel
+++ b/src/material/core/selection/pseudo-checkbox/BUILD.bazel
@@ -66,6 +66,7 @@ sass_library(
 sass_binary(
     name = "css",
     src = "pseudo-checkbox.scss",
+    layer = "angular-material",
     deps = [
         ":_pseudo_checkbox_common",
         "//src/material/core/style:checkbox_common",

--- a/src/material/core/style/_cascade-layers.scss
+++ b/src/material/core/style/_cascade-layers.scss
@@ -1,21 +1,14 @@
-// Cascade layers for Angular Material (CSS Cascade Module Level 5).
-// Compose with app-authored @layer ordering. CDK also uses layers in published CSS
-// (`cdk-overlay` for overlay structural styles, `cdk-resets` for drag-drop); declare
-// layer order once, e.g. @layer reset, cdk-resets, cdk-overlay, angular-material,
-// overrides;
+// Angular Material uses a fixed layer name so shipped component CSS and Sass-emitted theme
+// output can participate in the same app-authored @layer ordering.
+$private-layer-name: angular-material;
 
-/// Default layer name for Material theme output when using cascade-layer helpers.
-$default-cascade-layer-name: angular-material !default;
-
-/// Wraps emitted CSS in a named cascade [@layer](https://www.w3.org/TR/css-cascade-5/#layering).
+/// Wraps emitted CSS in Angular Material's cascade layer.
 ///
-/// Unlayered author styles sort after explicit layers in the cascade, so they can override
-/// rules inside this layer without higher specificity. For overrides in named layers, declare
-/// those layers after `angular-material` (or your chosen name) in a prelude `@layer` rule.
-///
-/// @param {String} $name Layer name (may use nested syntax such as `app.material`).
-@mixin with-cascade-layer($name: $default-cascade-layer-name) {
-  @layer #{$name} {
+/// Use this around Angular Material theme mixins such as `mat.theme`,
+/// `mat.all-component-themes`, or individual component theme mixins when you want their
+/// output to align with the layer used by Angular Material's shipped component CSS.
+@mixin theme-layer {
+  @layer #{$private-layer-name} {
     @content;
   }
 }

--- a/src/material/core/theming/prebuilt/BUILD.bazel
+++ b/src/material/core/theming/prebuilt/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 sass_binary(
     name = "indigo-pink-theme",
     src = "indigo-pink.scss",
+    layer = "angular-material",
     deps = [
         "//src/material/core:core_sass",
         "//src/material/core/m2:m2_sass",
@@ -16,6 +17,7 @@ sass_binary(
 sass_binary(
     name = "deeppurple-amber-theme",
     src = "deeppurple-amber.scss",
+    layer = "angular-material",
     deps = [
         "//src/material/core:core_sass",
         "//src/material/core/m2:m2_sass",
@@ -27,6 +29,7 @@ sass_binary(
 sass_binary(
     name = "pink-bluegrey-theme",
     src = "pink-bluegrey.scss",
+    layer = "angular-material",
     deps = [
         "//src/material/core:core_sass",
         "//src/material/core/m2:m2_sass",
@@ -38,6 +41,7 @@ sass_binary(
 sass_binary(
     name = "purple-green-theme",
     src = "purple-green.scss",
+    layer = "angular-material",
     deps = [
         "//src/material/core:core_sass",
         "//src/material/core/m2:m2_sass",
@@ -49,6 +53,7 @@ sass_binary(
 sass_binary(
     name = "rose_red",
     src = "rose-red.scss",
+    layer = "angular-material",
     deps = [
         "//src/material/core/theming:_palettes",
         "//src/material/core/tokens:system",
@@ -58,6 +63,7 @@ sass_binary(
 sass_binary(
     name = "azure_blue",
     src = "azure-blue.scss",
+    layer = "angular-material",
     deps = [
         "//src/material/core/theming:_palettes",
         "//src/material/core/tokens:system",
@@ -67,6 +73,7 @@ sass_binary(
 sass_binary(
     name = "cyan_orange",
     src = "cyan-orange.scss",
+    layer = "angular-material",
     deps = [
         "//src/material/core/theming:_palettes",
         "//src/material/core/tokens:system",
@@ -76,6 +83,7 @@ sass_binary(
 sass_binary(
     name = "magenta_violet",
     src = "magenta-violet.scss",
+    layer = "angular-material",
     deps = [
         "//src/material/core/theming:_palettes",
         "//src/material/core/tokens:system",

--- a/src/material/core/theming/tests/BUILD.bazel
+++ b/src/material/core/theming/tests/BUILD.bazel
@@ -91,6 +91,8 @@ jasmine_test(
         ":unit_test_lib",
         "//src/material:sass_lib",
         "//src/material-experimental:sass_lib",
+        "//src/material/button:css",
+        "//src/material/prebuilt-themes:azure-blue",
     ],
     no_copy_to_bin = [
         "//src/material:sass_lib",

--- a/src/material/core/theming/tests/cascade-layers.spec.ts
+++ b/src/material/core/theming/tests/cascade-layers.spec.ts
@@ -1,4 +1,5 @@
 import {runfiles} from '@bazel/runfiles';
+import * as fs from 'fs';
 import * as path from 'path';
 import {compileString} from 'sass';
 
@@ -25,27 +26,25 @@ function transpile(content: string) {
 }
 
 describe('CSS cascade layers', () => {
-  it('wraps mat.theme in @layer when third argument is set', () => {
+  it('wraps mat.theme with mat.theme-layer', () => {
     const css = transpile(`
-      html {
-        @include mat.theme(
-          (
+      @include mat.theme-layer {
+        html {
+          @include mat.theme((
             color: (
               theme-type: light,
               primary: mat.$violet-palette,
             ),
             typography: Roboto,
             density: 0,
-          ),
-          (),
-          mat.$default-cascade-layer-name
-        );
+          ));
+        }
       }
     `);
     expect(css).toContain('@layer angular-material');
   });
 
-  it('does not emit @layer when third argument is omitted', () => {
+  it('does not emit @layer when theme-layer is omitted', () => {
     const css = transpile(`
       html {
         @include mat.theme((
@@ -58,24 +57,23 @@ describe('CSS cascade layers', () => {
         ));
       }
     `);
-    expect(css).not.toContain('@layer');
+    expect(css).not.toContain('@layer angular-material');
   });
 
-  it('wraps output for with-cascade-layer', () => {
-    const css = transpile(`
-      html {
-        @include mat.with-cascade-layer(custom-layer) {
-          @include mat.theme((
-            color: (
-              theme-type: light,
-              primary: mat.$violet-palette,
-            ),
-            typography: Roboto,
-            density: 0,
-          ));
-        }
-      }
-    `);
-    expect(css).toContain('@layer custom-layer');
+  it('wraps compiled component CSS in the angular-material layer', () => {
+    const css = fs.readFileSync(
+      runfiles.resolveWorkspaceRelative('src/material/button/button.css'),
+      'utf8',
+    );
+    expect(css).toMatch(/^@layer angular-material \{/);
+    expect(css).toContain('.mat-mdc-button-base');
+  });
+
+  it('wraps prebuilt theme CSS in the angular-material layer', () => {
+    const css = fs.readFileSync(
+      runfiles.resolveWorkspaceRelative('src/material/prebuilt-themes/azure-blue.css'),
+      'utf8',
+    );
+    expect(css).toMatch(/^@layer angular-material \{/);
   });
 });

--- a/src/material/core/theming/tests/test-cascade-layers.scss
+++ b/src/material/core/theming/tests/test-cascade-layers.scss
@@ -2,17 +2,15 @@
 
 $theme: mat.define-theme();
 
-html {
-  @include mat.theme(
-    (
+@include mat.theme-layer {
+  html {
+    @include mat.theme((
       color: (
         theme-type: light,
         primary: mat.$violet-palette,
       ),
       typography: Roboto,
       density: 0,
-    ),
-    (),
-    mat.$default-cascade-layer-name
-  );
+    ));
+  }
 }

--- a/src/material/core/tokens/BUILD.bazel
+++ b/src/material/core/tokens/BUILD.bazel
@@ -24,7 +24,6 @@ sass_library(
     srcs = ["_system.scss"],
     deps = [
         ":m3_tokens",
-        "//src/material/core/style:cascade_layers",
         "//src/material/core/style:elevation",
         "//src/material/core/style:sass_utils",
         "//src/material/core/theming:_config_validation",

--- a/src/material/core/tokens/_system.scss
+++ b/src/material/core/tokens/_system.scss
@@ -15,7 +15,6 @@
 @use '../../tabs/m3-tabs';
 @use '../../toolbar/m3-toolbar';
 @use '../../tree/m3-tree';
-@use '../style/cascade-layers' as cascade-layers;
 @use '../style/elevation';
 @use '../theming/config-validation';
 @use '../theming/definition';
@@ -55,18 +54,7 @@
 /// e.g. --mat-sys-surface: #E5E5E5
 ///
 /// @param {Map} $config The color configuration with optional keys color, typography, or density.
-/// @param {String | null} $cascade-layer When non-null, wraps output in [@layer](https://www.w3.org/TR/css-cascade-5/#layering).
-@mixin theme($config, $overrides: (), $cascade-layer: null) {
-  @if ($cascade-layer == null) {
-    @include _theme-impl($config, $overrides);
-  } @else {
-    @include cascade-layers.with-cascade-layer($cascade-layer) {
-      @include _theme-impl($config, $overrides);
-    }
-  }
-}
-
-@mixin _theme-impl($config, $overrides: ()) {
+@mixin theme($config, $overrides: ()) {
   $color: map.get($config, color);
   $color-config: null;
   @if ($color) {

--- a/src/material/datepicker/BUILD.bazel
+++ b/src/material/datepicker/BUILD.bazel
@@ -63,6 +63,7 @@ sass_library(
 sass_binary(
     name = "datepicker_content_css",
     src = "datepicker-content.scss",
+    layer = "angular-material",
     deps = [
         ":m2",
         "//src/material/core/tokens:token_utils",
@@ -72,6 +73,7 @@ sass_binary(
 sass_binary(
     name = "calendar_css",
     src = "calendar.scss",
+    layer = "angular-material",
     deps = [
         ":m2",
         "//src/cdk:sass_lib",
@@ -83,6 +85,7 @@ sass_binary(
 sass_binary(
     name = "calendar_body_css",
     src = "calendar-body.scss",
+    layer = "angular-material",
     deps = [
         ":m2",
         "//src/cdk:sass_lib",
@@ -94,6 +97,7 @@ sass_binary(
 sass_binary(
     name = "datepicker_toggle_css",
     src = "datepicker-toggle.scss",
+    layer = "angular-material",
     deps = [
         ":m2",
         "//src/cdk:sass_lib",
@@ -104,11 +108,13 @@ sass_binary(
 sass_binary(
     name = "datepicker_actions_css",
     src = "datepicker-actions.scss",
+    layer = "angular-material",
 )
 
 sass_binary(
     name = "date_range_input_css",
     src = "date-range-input.scss",
+    layer = "angular-material",
     deps = [
         ":m2",
         "//src/cdk:sass_lib",

--- a/src/material/dialog/BUILD.bazel
+++ b/src/material/dialog/BUILD.bazel
@@ -60,6 +60,7 @@ sass_library(
 sass_binary(
     name = "css",
     src = "dialog.scss",
+    layer = "angular-material",
     deps = [
         ":m2",
         "//src/cdk:sass_lib",

--- a/src/material/divider/BUILD.bazel
+++ b/src/material/divider/BUILD.bazel
@@ -55,6 +55,7 @@ sass_library(
 sass_binary(
     name = "css",
     src = "divider.scss",
+    layer = "angular-material",
     deps = [
         ":m2",
         "//src/material/core/tokens:token_utils",

--- a/src/material/expansion/BUILD.bazel
+++ b/src/material/expansion/BUILD.bazel
@@ -53,6 +53,7 @@ sass_library(
 sass_binary(
     name = "css",
     src = "expansion-panel.scss",
+    layer = "angular-material",
     deps = [
         ":m2",
         "//src/cdk:sass_lib",
@@ -65,6 +66,7 @@ sass_binary(
 sass_binary(
     name = "header_css",
     src = "expansion-panel-header.scss",
+    layer = "angular-material",
     deps = [
         ":m2",
         ":variables",

--- a/src/material/form-field/BUILD.bazel
+++ b/src/material/form-field/BUILD.bazel
@@ -52,6 +52,7 @@ sass_library(
 sass_binary(
     name = "css",
     src = "form-field.scss",
+    layer = "angular-material",
     deps = [
         ":form_field_partials",
         "//src/material/core/style:vendor_prefixes",

--- a/src/material/grid-list/BUILD.bazel
+++ b/src/material/grid-list/BUILD.bazel
@@ -53,6 +53,7 @@ sass_library(
 sass_binary(
     name = "css",
     src = "grid-list.scss",
+    layer = "angular-material",
     deps = [
         ":m2",
         "//src/material/core/style:layout_common",

--- a/src/material/icon/BUILD.bazel
+++ b/src/material/icon/BUILD.bazel
@@ -52,6 +52,7 @@ sass_library(
 sass_binary(
     name = "css",
     src = "icon.scss",
+    layer = "angular-material",
     deps = [
         ":m2",
         "//src/material/core/style:vendor_prefixes",

--- a/src/material/list/BUILD.bazel
+++ b/src/material/list/BUILD.bazel
@@ -55,6 +55,7 @@ sass_library(
 sass_binary(
     name = "css",
     src = "list.scss",
+    layer = "angular-material",
     deps = [
         ":list_inherited_structure",
         ":list_item_hcm_indicator",
@@ -83,6 +84,7 @@ sass_library(
 sass_binary(
     name = "option_css",
     src = "list-option.scss",
+    layer = "angular-material",
     deps = [
         ":list_item_hcm_indicator",
         "//src/material/checkbox:checkbox_common",

--- a/src/material/menu/BUILD.bazel
+++ b/src/material/menu/BUILD.bazel
@@ -53,6 +53,7 @@ sass_library(
 sass_binary(
     name = "css",
     src = "menu.scss",
+    layer = "angular-material",
     deps = [
         ":m2",
         "//src/cdk:sass_lib",

--- a/src/material/paginator/BUILD.bazel
+++ b/src/material/paginator/BUILD.bazel
@@ -53,6 +53,7 @@ sass_library(
 sass_binary(
     name = "css",
     src = "paginator.scss",
+    layer = "angular-material",
     deps = [
         ":m2",
         "//src/cdk:sass_lib",

--- a/src/material/progress-bar/BUILD.bazel
+++ b/src/material/progress-bar/BUILD.bazel
@@ -52,6 +52,7 @@ sass_library(
 sass_binary(
     name = "css",
     src = "progress-bar.scss",
+    layer = "angular-material",
     deps = [
         ":m2",
         "//src/cdk:sass_lib",

--- a/src/material/progress-spinner/BUILD.bazel
+++ b/src/material/progress-spinner/BUILD.bazel
@@ -52,6 +52,7 @@ sass_library(
 sass_binary(
     name = "css",
     src = "progress-spinner.scss",
+    layer = "angular-material",
     deps = [
         ":m2",
         "//src/cdk:sass_lib",

--- a/src/material/radio/BUILD.bazel
+++ b/src/material/radio/BUILD.bazel
@@ -63,6 +63,7 @@ sass_library(
 sass_binary(
     name = "css",
     src = "radio.scss",
+    layer = "angular-material",
     deps = [
         ":m2",
         ":radio_common",

--- a/src/material/schematics/ng-add/index.spec.ts
+++ b/src/material/schematics/ng-add/index.spec.ts
@@ -107,6 +107,8 @@ describe('ng-add schematic', () => {
 
     expect(themeContent).toContain(`@use '@angular/material' as mat;`);
     expect(themeContent).toContain(`@include mat.theme((`);
+    expect(themeContent).toContain(`@layer base, cdk-resets, cdk-overlay, angular-material`);
+    expect(themeContent).toContain(`@include mat.theme-layer`);
   });
 
   it('should create a custom theme file if no SCSS file could be found', async () => {

--- a/src/material/schematics/ng-add/theming/create-theme.ts
+++ b/src/material/schematics/ng-add/theming/create-theme.ts
@@ -16,22 +16,29 @@ export function createTheme(userPaletteChoice: string): string {
   ]);
   return `
 // Include theming for Angular Material with \`mat.theme()\`.
-// This Sass mixin will define CSS variables that are used for styling Angular Material
-// components according to the Material 3 design spec.
-// Learn more about theming and how to use it for your application's
-// custom components at https://material.angular.dev/guide/theming
+// \`@use\` must come before any other rules (including \`@layer\`).
 @use '@angular/material' as mat;
 
-html {
-  height: 100%;
-  @include mat.theme((
-    color: (
-      primary: mat.$${colorPalettes.get(userPaletteChoice)!.primary}-palette,
-      tertiary: mat.$${colorPalettes.get(userPaletteChoice)!.tertiary}-palette,
-    ),
-    typography: Roboto,
-    density: 0,
-  ));
+// Cascade layer ordering. Angular Material component styles ship in the
+// \`angular-material\` layer. Declaring layer order here makes overrides
+// predictable alongside CDK styles and utility frameworks.
+// Learn more: https://material.angular.dev/guide/theming#css-cascade-layers
+@layer base, cdk-resets, cdk-overlay, angular-material, components, utilities;
+
+// Wrapping \`mat.theme()\` in \`mat.theme-layer\` places generated CSS
+// custom properties in the same \`angular-material\` layer as component styles.
+@include mat.theme-layer {
+  html {
+    height: 100%;
+    @include mat.theme((
+      color: (
+        primary: mat.$${colorPalettes.get(userPaletteChoice)!.primary}-palette,
+        tertiary: mat.$${colorPalettes.get(userPaletteChoice)!.tertiary}-palette,
+      ),
+      typography: Roboto,
+      density: 0,
+    ));
+  }
 }
 
 body {

--- a/src/material/select/BUILD.bazel
+++ b/src/material/select/BUILD.bazel
@@ -53,6 +53,7 @@ sass_library(
 sass_binary(
     name = "css",
     src = "select.scss",
+    layer = "angular-material",
     deps = [
         ":m2",
         "//src/cdk:sass_lib",

--- a/src/material/sidenav/BUILD.bazel
+++ b/src/material/sidenav/BUILD.bazel
@@ -52,6 +52,7 @@ sass_library(
 sass_binary(
     name = "css",
     src = "drawer.scss",
+    layer = "angular-material",
     deps = [
         ":m2",
         "//src/cdk:sass_lib",

--- a/src/material/slide-toggle/BUILD.bazel
+++ b/src/material/slide-toggle/BUILD.bazel
@@ -53,6 +53,7 @@ sass_library(
 sass_binary(
     name = "css",
     src = "slide-toggle.scss",
+    layer = "angular-material",
     deps = [
         ":m2",
         "//src/cdk:sass_lib",

--- a/src/material/slider/BUILD.bazel
+++ b/src/material/slider/BUILD.bazel
@@ -55,6 +55,7 @@ sass_library(
 sass_binary(
     name = "slider-css",
     src = "slider.scss",
+    layer = "angular-material",
     deps = [
         ":m2",
         "//src/cdk:sass_lib",
@@ -66,6 +67,7 @@ sass_binary(
 sass_binary(
     name = "slider-thumb-css",
     src = "slider-thumb.scss",
+    layer = "angular-material",
 )
 
 ng_project(

--- a/src/material/slider/tailwind-layer.e2e.spec.ts
+++ b/src/material/slider/tailwind-layer.e2e.spec.ts
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {browser, by, element} from 'protractor';
+
+describe('Tailwind layer + Angular Material E2E', () => {
+  beforeEach(async () => await browser.get('/tailwind-layer'));
+
+  it('allows utility layer styles to override Angular Material styles', async () => {
+    const button = element(by.id('tailwind-utility-button'));
+    const backgroundColor = await browser.executeScript<string>(
+      'return getComputedStyle(arguments[0]).backgroundColor;',
+      button.getWebElement(),
+    );
+
+    // Tailwind's lime-500 utility value.
+    expect(backgroundColor).toBe('rgb(132, 204, 22)');
+  });
+
+  it('also allows unlayered utility styles to override layered Material styles', async () => {
+    const button = element(by.id('unlayered-utility-button'));
+    const backgroundColor = await browser.executeScript<string>(
+      'return getComputedStyle(arguments[0]).backgroundColor;',
+      button.getWebElement(),
+    );
+
+    // Unlayered author styles outrank named layers in Cascade 5.
+    expect(backgroundColor).toBe('rgb(217, 70, 239)');
+  });
+});

--- a/src/material/snack-bar/BUILD.bazel
+++ b/src/material/snack-bar/BUILD.bazel
@@ -53,6 +53,7 @@ sass_library(
 sass_binary(
     name = "container_css",
     src = "snack-bar-container.scss",
+    layer = "angular-material",
     deps = [
         ":m2",
         "//src/cdk:sass_lib",
@@ -64,6 +65,7 @@ sass_binary(
 sass_binary(
     name = "css",
     src = "simple-snack-bar.scss",
+    layer = "angular-material",
 )
 
 ng_project(

--- a/src/material/sort/BUILD.bazel
+++ b/src/material/sort/BUILD.bazel
@@ -53,6 +53,7 @@ sass_library(
 sass_binary(
     name = "css",
     src = "sort-header.scss",
+    layer = "angular-material",
     deps = [
         ":m2",
         "//src/material/core/focus-indicators",

--- a/src/material/stepper/BUILD.bazel
+++ b/src/material/stepper/BUILD.bazel
@@ -53,6 +53,7 @@ sass_library(
 sass_binary(
     name = "css",
     src = "stepper.scss",
+    layer = "angular-material",
     deps = [
         ":m2",
         ":variables",
@@ -64,6 +65,7 @@ sass_binary(
 sass_binary(
     name = "header_css",
     src = "step-header.scss",
+    layer = "angular-material",
     deps = [
         ":m2",
         ":variables",

--- a/src/material/table/BUILD.bazel
+++ b/src/material/table/BUILD.bazel
@@ -60,6 +60,7 @@ sass_library(
 sass_binary(
     name = "css",
     src = "table.scss",
+    layer = "angular-material",
     deps = [
         ":flex_sass",
         ":m2",

--- a/src/material/tabs/BUILD.bazel
+++ b/src/material/tabs/BUILD.bazel
@@ -65,6 +65,7 @@ sass_library(
 sass_binary(
     name = "tab_group_css",
     src = "tab-group.scss",
+    layer = "angular-material",
     deps = [
         ":m2",
         ":sass",
@@ -76,6 +77,7 @@ sass_binary(
 sass_binary(
     name = "tab_nav_bar_css",
     src = "tab-nav-bar/tab-nav-bar.scss",
+    layer = "angular-material",
     deps = [
         ":sass",
     ],
@@ -84,6 +86,7 @@ sass_binary(
 sass_binary(
     name = "tab_link_css",
     src = "tab-nav-bar/tab-link.scss",
+    layer = "angular-material",
     deps = [
         ":sass",
         "//src/material/core/style:variables",
@@ -93,6 +96,7 @@ sass_binary(
 sass_binary(
     name = "tab_header_css",
     src = "tab-header.scss",
+    layer = "angular-material",
     deps = [
         ":sass",
         "//src/cdk:sass_lib",
@@ -102,6 +106,7 @@ sass_binary(
 sass_binary(
     name = "tab_body_css",
     src = "tab-body.scss",
+    layer = "angular-material",
     deps = ["//src/material/core/style:layout_common"],
 )
 

--- a/src/material/timepicker/BUILD.bazel
+++ b/src/material/timepicker/BUILD.bazel
@@ -53,6 +53,7 @@ sass_library(
 sass_binary(
     name = "timepicker_css",
     src = "timepicker.scss",
+    layer = "angular-material",
     deps = [
         ":m2",
         "//src/cdk:sass_lib",

--- a/src/material/toolbar/BUILD.bazel
+++ b/src/material/toolbar/BUILD.bazel
@@ -53,6 +53,7 @@ sass_library(
 sass_binary(
     name = "css",
     src = "toolbar.scss",
+    layer = "angular-material",
     deps = [
         ":m2",
         "//src/cdk:sass_lib",

--- a/src/material/tooltip/BUILD.bazel
+++ b/src/material/tooltip/BUILD.bazel
@@ -53,6 +53,7 @@ sass_library(
 sass_binary(
     name = "css",
     src = "tooltip.scss",
+    layer = "angular-material",
     deps = [
         ":m2",
         "//src/material/core/tokens:token_utils",

--- a/src/material/tree/BUILD.bazel
+++ b/src/material/tree/BUILD.bazel
@@ -53,6 +53,7 @@ sass_library(
 sass_binary(
     name = "css",
     src = "tree.scss",
+    layer = "angular-material",
     deps = [
         ":m2",
         "//src/material/core/tokens:token_utils",

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -29,17 +29,61 @@ spec_bundle = _spec_bundle
 http_server = _http_server
 ng_examples_db = _ng_examples_db
 
-def sass_binary(sourcemap = False, include_paths = [], **kwargs):
-    _sass_binary(
-        sourcemap = sourcemap,
-        include_paths = include_paths,
-        module_mappings = {
-            "@angular/cdk": "/".join([".."] * (native.package_name().count("/") + 1)) + "/src/cdk",
-            "@angular/material": "/".join([".."] * (native.package_name().count("/") + 1)) + "/src/material",
-            "@angular/material-experimental": "/".join([".."] * (native.package_name().count("/") + 1)) + "/src/material-experimental",
-        },
-        **kwargs
-    )
+def sass_binary(sourcemap = False, include_paths = [], layer = None, **kwargs):
+    _module_mappings = {
+        "@angular/cdk": "/".join([".."] * (native.package_name().count("/") + 1)) + "/src/cdk",
+        "@angular/material": "/".join([".."] * (native.package_name().count("/") + 1)) + "/src/material",
+        "@angular/material-experimental": "/".join([".."] * (native.package_name().count("/") + 1)) + "/src/material-experimental",
+    }
+
+    if layer:
+        if sourcemap:
+            fail("sass_binary(layer=...) does not support sourcemap because wrapping the CSS in @layer invalidates the generated mappings.")
+        if kwargs.get("output_name") or kwargs.get("output_dir"):
+            fail("sass_binary(layer=...) does not support output_name or output_dir.")
+
+        name = kwargs.pop("name")
+        visibility = kwargs.pop("visibility", None)
+        testonly = kwargs.get("testonly", False)
+        src = kwargs.get("src", "")
+        out_css = src.rsplit(".", 1)[0] + ".css"
+
+        # Prefix only the filename to avoid creating spurious directories.
+        if "/" in out_css:
+            out_dir, out_file = out_css.rsplit("/", 1)
+            raw_css = out_dir + "/_layer_" + out_file
+        else:
+            raw_css = "_layer_" + out_css
+
+        # Compile to an intermediate CSS file, then wrap the compiled output in a named @layer
+        # while preserving the final filename expected by component `styleUrl`s.
+        _sass_binary(
+            name = name + "_pre_layer",
+            sourcemap = False,
+            include_paths = include_paths,
+            output_name = raw_css,
+            module_mappings = _module_mappings,
+            visibility = ["//visibility:private"],
+            **kwargs
+        )
+
+        native.genrule(
+            name = name,
+            srcs = [":" + name + "_pre_layer"],
+            outs = [out_css],
+            cmd = ("printf '@layer %s {\\n' > $@ " +
+                   "&& cat $< >> $@ " +
+                   "&& printf '\\n}\\n' >> $@") % layer,
+            testonly = testonly,
+            visibility = visibility,
+        )
+    else:
+        _sass_binary(
+            sourcemap = sourcemap,
+            include_paths = include_paths,
+            module_mappings = _module_mappings,
+            **kwargs
+        )
 
 def sass_library(**kwargs):
     _sass_library(**kwargs)


### PR DESCRIPTION
## Summary
- wrap compiled Angular Material component and prebuilt theme CSS in the fixed `angular-material` cascade layer
- add `mat.theme-layer` so app-authored theme output can participate in the same layer ordering
- document Tailwind/cascade-layer usage and add tests, including an E2E proof that utility styles override Material predictably

Closes angular/components#26451.

## Test plan
- [x] `pnpm exec bazel test //src/material/core/theming/tests:unit_tests`
- [x] `pnpm exec bazel test //src/material/schematics:unit_tests`
- [x] `pnpm exec bazel test //src/material/slider:e2e_tests`
- [x] `pnpm exec bazel build //src/material/tabs:tabs //src/material-experimental/menubar:menubar //src/material/prebuilt-themes:azure-blue`