### PR TITLE
fix(material/datepicker): improve color distinction in comparison ran…

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -25,7 +25,6 @@
     "https://bcr.bazel.build/modules/aspect_rules_js/2.0.0/MODULE.bazel": "b45b507574aa60a92796e3e13c195cd5744b3b8aff516a9c0cb5ae6a048161c5",
     "https://bcr.bazel.build/modules/aspect_rules_js/3.0.3/MODULE.bazel": "28a30e8fc33bf64a67835d64d124f6e05a7d59648dcb27b110fb3502f761e503",
     "https://bcr.bazel.build/modules/aspect_rules_js/3.0.3/source.json": "bb8fff9a304452e1042af9522ad1d54d6f1d1fdf71c5127deadb6fd156654193",
-    "https://bcr.bazel.build/modules/aspect_rules_ts/3.8.7/MODULE.bazel": "830f8a53bb9f1139c24006a90ddc0230481326d69fa847eb00daf8eaae118724",
     "https://bcr.bazel.build/modules/aspect_rules_ts/3.8.8/MODULE.bazel": "b52b929a948438665809d49af610f58d1b14f63d6d21ab748f47b6050be4c1f6",
     "https://bcr.bazel.build/modules/aspect_rules_ts/3.8.8/source.json": "5414530b761a45ab7ca6c49f0a2a9cf8dc0da772f5037cf05ca18aaa64bb1b19",
     "https://bcr.bazel.build/modules/aspect_tools_telemetry/0.2.6/MODULE.bazel": "cafb8781ad591bc57cc765dca5fefab08cf9f65af363d162b79d49205c7f8af7",
@@ -196,7 +195,6 @@
     "https://bcr.bazel.build/modules/tar.bzl/0.2.1/MODULE.bazel": "52d1c00a80a8cc67acbd01649e83d8dd6a9dc426a6c0b754a04fe8c219c76468",
     "https://bcr.bazel.build/modules/tar.bzl/0.5.1/MODULE.bazel": "7c2eb3dcfc53b0f3d6f9acdfd911ca803eaf92aadf54f8ca6e4c1f3aee288351",
     "https://bcr.bazel.build/modules/tar.bzl/0.6.0/MODULE.bazel": "a3584b4edcfafcabd9b0ef9819808f05b372957bbdff41601429d5fd0aac2e7c",
-    "https://bcr.bazel.build/modules/tar.bzl/0.9.0/MODULE.bazel": "452a22d7f02b1c9d7a22ab25edf20f46f3e1101f0f67dc4bfbf9a474ddf02445",
     "https://bcr.bazel.build/modules/upb/0.0.0-20220923-a547704/MODULE.bazel": "7298990c00040a0e2f121f6c32544bab27d4452f80d9ce51349b1a28f3005c43",
     "https://bcr.bazel.build/modules/yq.bzl/0.1.1/MODULE.bazel": "9039681f9bcb8958ee2c87ffc74bdafba9f4369096a2b5634b88abc0eaefa072",
     "https://bcr.bazel.build/modules/yq.bzl/0.3.2/MODULE.bazel": "0384efa70e8033d842ea73aa4b7199fa099709e236a7264345c03937166670b6",
@@ -559,7 +557,7 @@
     },
     "@@rules_angular+//setup:extensions.bzl%rules_angular": {
       "general": {
-        "bzlTransitiveDigest": "fkaH7HMicL3g7/NDaFzlq39kcLopMyQ3KdbDn+5CRzA=",
+        "bzlTransitiveDigest": "USMahNi8icO2j7UqTdxSDobK9vXKMkMTdrZM1RILdh4=",
         "usagesDigest": "vp6WM1d49Yy4dgDwfmS8JwvPVN+C7d2LE2X0l4Goke4=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -592,7 +590,7 @@
     },
     "@@rules_browsers+//browsers:extensions.bzl%browsers": {
       "general": {
-        "bzlTransitiveDigest": "Bm6fiKpWy96aLohOlLCP36ARVxRLZm/R+smhsb2HzmI=",
+        "bzlTransitiveDigest": "eC73J3huWBHXDgd/j+zYZ6PiUN0uIx4EhQ1QREKVpUs=",
         "usagesDigest": "FmXYJVoVJlnfUU8x8gObSvu4qWcco/9Faw61aC/wBF0=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -4111,7 +4109,7 @@
     },
     "@@rules_sass+//src/toolchain:extensions.bzl%sass": {
       "general": {
-        "bzlTransitiveDigest": "mOfuR8PsNuUWEq7JZ4MpIRbwyAGAqrCvkXXGaRNnlPQ=",
+        "bzlTransitiveDigest": "Gfwqh4WQIb7kmT5RjszNYIIVtHQNaNimdY89DHIC+yU=",
         "usagesDigest": "R0KshhzIouLWuexMUCrl4HY+FUDwlVVgF9Z7UnwyUWA=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/package.json
+++ b/package.json
@@ -203,6 +203,17 @@
           "@nginfra/angular-linking": "1.0.11"
         }
       }
-    }
+    },
+    "ignoredBuiltDependencies": [
+      "@firebase/util",
+      "@parcel/watcher",
+      "bufferutil",
+      "esbuild",
+      "lmdb",
+      "msgpackr-extract",
+      "protobufjs",
+      "re2",
+      "utf-8-validate"
+    ]
   }
 }

--- a/src/components-examples/material/datepicker/date-range-picker-comparison/date-range-picker-comparison-example.css
+++ b/src/components-examples/material/datepicker/date-range-picker-comparison/date-range-picker-comparison-example.css
@@ -2,7 +2,6 @@
   margin: 0 8px 16px 0;
 }
 
-/* Selected range (user selection) */
 date-range-picker-comparison-example .mat-calendar-body-in-range:not(.mat-calendar-body-comparison) {
   background-color: #3f51b5;
   color: white;

--- a/src/components-examples/material/datepicker/date-range-picker-comparison/date-range-picker-comparison-example.css
+++ b/src/components-examples/material/datepicker/date-range-picker-comparison/date-range-picker-comparison-example.css
@@ -1,3 +1,19 @@
 .example-form-field {
   margin: 0 8px 16px 0;
 }
+
+/* Selected range (user selection) */
+date-range-picker-comparison-example .mat-calendar-body-in-range:not(.mat-calendar-body-comparison) {
+  background-color: #3f51b5;
+  color: white;
+}
+
+date-range-picker-comparison-example .mat-calendar-body-comparison {
+  background-color: #ff9800;
+  color: black;
+}
+
+date-range-picker-comparison-example .mat-calendar-body-in-range.mat-calendar-body-comparison {
+  background-color: #4caf50;
+  color: white;
+}


### PR DESCRIPTION
Fixes Issue #31663
Fixes the issue with poor visual distinction between selected and comparison ranges in the datepicker documentation example.
The default Material 3 themes do not provide sufficient contrast, making the example difficult to understand.
This change adds scoped CSS overrides to improve visibility and ensure the example remains clear and useful across themes.
This change is limited to the example and does not affect global styles.