### PR TITLE
feat(material/autocomplete): add MatAutocompleteSelectedTrigger for c…

### DIFF
--- a/goldens/material/autocomplete/index.api.md
+++ b/goldens/material/autocomplete/index.api.md
@@ -39,6 +39,9 @@ export const MAT_AUTOCOMPLETE_DEFAULT_OPTIONS: InjectionToken<MatAutocompleteDef
 export const MAT_AUTOCOMPLETE_SCROLL_STRATEGY: InjectionToken<() => ScrollStrategy>;
 
 // @public
+export const MAT_AUTOCOMPLETE_SELECTED_TRIGGER: InjectionToken<MatAutocompleteSelectedTrigger>;
+
+// @public
 export const MAT_AUTOCOMPLETE_VALUE_ACCESSOR: any;
 
 // @public
@@ -55,6 +58,7 @@ export class MatAutocomplete implements AfterContentInit, OnDestroy {
     _classList: string | string[];
     readonly closed: EventEmitter<void>;
     protected _color: ThemePalette;
+    customTrigger: MatAutocompleteSelectedTrigger | undefined;
     // (undocumented)
     protected _defaults: MatAutocompleteDefaultOptions;
     disableRipple: boolean;
@@ -102,7 +106,7 @@ export class MatAutocomplete implements AfterContentInit, OnDestroy {
     _syncParentProperties(): void;
     template: TemplateRef<any>;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<MatAutocomplete, "mat-autocomplete", ["matAutocomplete"], { "ariaLabel": { "alias": "aria-label"; "required": false; }; "ariaLabelledby": { "alias": "aria-labelledby"; "required": false; }; "displayWith": { "alias": "displayWith"; "required": false; }; "autoActiveFirstOption": { "alias": "autoActiveFirstOption"; "required": false; }; "autoSelectActiveOption": { "alias": "autoSelectActiveOption"; "required": false; }; "requireSelection": { "alias": "requireSelection"; "required": false; }; "panelWidth": { "alias": "panelWidth"; "required": false; }; "disableRipple": { "alias": "disableRipple"; "required": false; }; "classList": { "alias": "class"; "required": false; }; "hideSingleSelectionIndicator": { "alias": "hideSingleSelectionIndicator"; "required": false; }; }, { "optionSelected": "optionSelected"; "opened": "opened"; "closed": "closed"; "optionActivated": "optionActivated"; }, ["options", "optionGroups"], ["*"], true, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MatAutocomplete, "mat-autocomplete", ["matAutocomplete"], { "ariaLabel": { "alias": "aria-label"; "required": false; }; "ariaLabelledby": { "alias": "aria-labelledby"; "required": false; }; "displayWith": { "alias": "displayWith"; "required": false; }; "autoActiveFirstOption": { "alias": "autoActiveFirstOption"; "required": false; }; "autoSelectActiveOption": { "alias": "autoSelectActiveOption"; "required": false; }; "requireSelection": { "alias": "requireSelection"; "required": false; }; "panelWidth": { "alias": "panelWidth"; "required": false; }; "disableRipple": { "alias": "disableRipple"; "required": false; }; "classList": { "alias": "class"; "required": false; }; "hideSingleSelectionIndicator": { "alias": "hideSingleSelectionIndicator"; "required": false; }; }, { "optionSelected": "optionSelected"; "opened": "opened"; "closed": "closed"; "optionActivated": "optionActivated"; }, ["customTrigger", "options", "optionGroups"], ["*"], true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatAutocomplete, never>;
 }
@@ -131,7 +135,7 @@ export class MatAutocompleteModule {
     // (undocumented)
     static ɵinj: i0.ɵɵInjectorDeclaration<MatAutocompleteModule>;
     // (undocumented)
-    static ɵmod: i0.ɵɵNgModuleDeclaration<MatAutocompleteModule, never, [typeof i2.OverlayModule, typeof MatOptionModule, typeof MatAutocomplete, typeof MatAutocompleteTrigger, typeof MatAutocompleteOrigin], [typeof i1.CdkScrollableModule, typeof MatAutocomplete, typeof MatOptionModule, typeof i2$1.BidiModule, typeof MatAutocompleteTrigger, typeof MatAutocompleteOrigin]>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<MatAutocompleteModule, never, [typeof i2.OverlayModule, typeof MatOptionModule, typeof MatAutocomplete, typeof MatAutocompleteTrigger, typeof MatAutocompleteOrigin, typeof MatAutocompleteSelectedTrigger], [typeof i1.CdkScrollableModule, typeof MatAutocomplete, typeof MatOptionModule, typeof i2$1.BidiModule, typeof MatAutocompleteTrigger, typeof MatAutocompleteOrigin, typeof MatAutocompleteSelectedTrigger]>;
 }
 
 // @public
@@ -155,6 +159,16 @@ export class MatAutocompleteSelectedEvent {
 }
 
 // @public
+export class MatAutocompleteSelectedTrigger {
+    // (undocumented)
+    readonly templateRef: TemplateRef<any>;
+    // (undocumented)
+    static ɵdir: i0.ɵɵDirectiveDeclaration<MatAutocompleteSelectedTrigger, "ng-template[matAutocompleteSelectedTrigger]", never, {}, {}, never, never, true, never>;
+    // (undocumented)
+    static ɵfac: i0.ɵɵFactoryDeclaration<MatAutocompleteSelectedTrigger, never>;
+}
+
+// @public
 export class MatAutocompleteTrigger implements ControlValueAccessor, AfterViewInit, OnChanges, OnDestroy {
     constructor(...args: unknown[]);
     get activeOption(): MatOption | null;
@@ -163,6 +177,8 @@ export class MatAutocompleteTrigger implements ControlValueAccessor, AfterViewIn
     autocompleteDisabled: boolean;
     closePanel(): void;
     connectedTo: MatAutocompleteOrigin;
+    // (undocumented)
+    _handleBlur(): void;
     // (undocumented)
     _handleClick(): void;
     // (undocumented)

--- a/src/components-examples/material/autocomplete/autocomplete-custom-trigger/autocomplete-custom-trigger-example.css
+++ b/src/components-examples/material/autocomplete/autocomplete-custom-trigger/autocomplete-custom-trigger-example.css
@@ -1,0 +1,23 @@
+.example-form {
+  min-width: 150px;
+  max-width: 500px;
+  width: 100%;
+}
+
+.example-full-width {
+  width: 100%;
+}
+
+.example-option-img {
+  vertical-align: middle;
+  margin-right: 8px;
+}
+
+.example-trigger-flag {
+  vertical-align: middle;
+  margin-right: 4px;
+}
+
+.mat-autocomplete-selected-trigger {
+  top: 15px;
+}

--- a/src/components-examples/material/autocomplete/autocomplete-custom-trigger/autocomplete-custom-trigger-example.html
+++ b/src/components-examples/material/autocomplete/autocomplete-custom-trigger/autocomplete-custom-trigger-example.html
@@ -1,0 +1,36 @@
+<form class="example-form">
+  <mat-form-field class="example-full-width">
+    <mat-label>State</mat-label>
+    <input
+      matInput
+      aria-label="State"
+      [matAutocomplete]="auto"
+      [formControl]="stateCtrl" />
+    <mat-autocomplete #auto="matAutocomplete" [displayWith]="displayFn">
+      <!--
+        matAutocompleteSelectedTrigger replaces the plain text with a custom HTML template
+        after an option is selected. The let-state binding exposes the raw selected value.
+        Click the field or start typing to clear the display and re-open the panel.
+      -->
+      <ng-template matAutocompleteSelectedTrigger let-state>
+        <img class="example-trigger-flag" [src]="state?.flag" [alt]="state?.name" height="20" />
+        {{ state?.name }}
+      </ng-template>
+      @for (state of filteredStates | async; track state.name) {
+        <mat-option [value]="state">
+          <img alt="" class="example-option-img" [src]="state.flag" height="25" />
+          <span>{{ state.name }}</span> |
+          <small>Population: {{ state.population }}</small>
+        </mat-option>
+      }
+    </mat-autocomplete>
+  </mat-form-field>
+
+  <br />
+
+  <mat-slide-toggle
+    [checked]="stateCtrl.disabled"
+    (change)="stateCtrl.disabled ? stateCtrl.enable() : stateCtrl.disable()">
+    Disable Input?
+  </mat-slide-toggle>
+</form>

--- a/src/components-examples/material/autocomplete/autocomplete-custom-trigger/autocomplete-custom-trigger-example.ts
+++ b/src/components-examples/material/autocomplete/autocomplete-custom-trigger/autocomplete-custom-trigger-example.ts
@@ -1,0 +1,83 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {AsyncPipe} from '@angular/common';
+import {Component} from '@angular/core';
+import {FormControl, ReactiveFormsModule} from '@angular/forms';
+import {MatAutocompleteModule} from '@angular/material/autocomplete';
+import {MatFormFieldModule} from '@angular/material/form-field';
+import {MatInputModule} from '@angular/material/input';
+import {MatSlideToggleModule} from '@angular/material/slide-toggle';
+import {map, startWith} from 'rxjs/operators';
+
+export interface State {
+  flag: string;
+  name: string;
+  population: string;
+}
+
+/** @title Autocomplete with custom selected-value template */
+@Component({
+  selector: 'autocomplete-custom-trigger-example',
+  templateUrl: 'autocomplete-custom-trigger-example.html',
+  styleUrl: 'autocomplete-custom-trigger-example.css',
+  imports: [
+    AsyncPipe,
+    MatAutocompleteModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSlideToggleModule,
+    ReactiveFormsModule,
+  ],
+})
+export class AutocompleteCustomTriggerExample {
+  stateCtrl = new FormControl<State | string | null>(null);
+  filteredStates = this.stateCtrl.valueChanges.pipe(
+    startWith(null),
+    map(value => {
+      const name = typeof value === 'string' ? value : (value?.name ?? '');
+      return name ? this._filterStates(name) : this.states.slice();
+    }),
+  );
+
+  states: State[] = [
+    {
+      name: 'Arkansas',
+      population: '2.978M',
+      // https://commons.wikimedia.org/wiki/File:Flag_of_Arkansas.svg
+      flag: 'https://upload.wikimedia.org/wikipedia/commons/9/9d/Flag_of_Arkansas.svg',
+    },
+    {
+      name: 'California',
+      population: '39.14M',
+      // https://commons.wikimedia.org/wiki/File:Flag_of_California.svg
+      flag: 'https://upload.wikimedia.org/wikipedia/commons/0/01/Flag_of_California.svg',
+    },
+    {
+      name: 'Florida',
+      population: '20.27M',
+      // https://commons.wikimedia.org/wiki/File:Flag_of_Florida.svg
+      flag: 'https://upload.wikimedia.org/wikipedia/commons/f/f7/Flag_of_Florida.svg',
+    },
+    {
+      name: 'Texas',
+      population: '27.47M',
+      // https://commons.wikimedia.org/wiki/File:Flag_of_Texas.svg
+      flag: 'https://upload.wikimedia.org/wikipedia/commons/f/f7/Flag_of_Texas.svg',
+    },
+  ];
+
+  displayFn(state: State | null): string {
+    return state?.name ?? '';
+  }
+
+  private _filterStates(value: string): State[] {
+    const filterValue = value.toLowerCase();
+    return this.states.filter(state => state.name.toLowerCase().includes(filterValue));
+  }
+}

--- a/src/components-examples/material/autocomplete/index.ts
+++ b/src/components-examples/material/autocomplete/index.ts
@@ -1,4 +1,5 @@
 export {AutocompleteAutoActiveFirstOptionExample} from './autocomplete-auto-active-first-option/autocomplete-auto-active-first-option-example';
+export {AutocompleteCustomTriggerExample} from './autocomplete-custom-trigger/autocomplete-custom-trigger-example';
 export {AutocompleteDisplayExample} from './autocomplete-display/autocomplete-display-example';
 export {AutocompleteFilterExample} from './autocomplete-filter/autocomplete-filter-example';
 export {AutocompleteOptgroupExample} from './autocomplete-optgroup/autocomplete-optgroup-example';

--- a/src/material/autocomplete/BUILD.bazel
+++ b/src/material/autocomplete/BUILD.bazel
@@ -67,6 +67,7 @@ ng_project(
         "autocomplete.ts",
         "autocomplete-module.ts",
         "autocomplete-origin.ts",
+        "autocomplete-selected-trigger.ts",
         "autocomplete-trigger.ts",
         "index.ts",
         "public-api.ts",

--- a/src/material/autocomplete/autocomplete-module.ts
+++ b/src/material/autocomplete/autocomplete-module.ts
@@ -12,6 +12,7 @@ import {BidiModule} from '@angular/cdk/bidi';
 import {CdkScrollableModule} from '@angular/cdk/scrolling';
 import {OverlayModule} from '@angular/cdk/overlay';
 import {MatAutocomplete} from './autocomplete';
+import {MatAutocompleteSelectedTrigger} from './autocomplete-selected-trigger';
 import {MatAutocompleteTrigger} from './autocomplete-trigger';
 import {MatAutocompleteOrigin} from './autocomplete-origin';
 
@@ -22,6 +23,7 @@ import {MatAutocompleteOrigin} from './autocomplete-origin';
     MatAutocomplete,
     MatAutocompleteTrigger,
     MatAutocompleteOrigin,
+    MatAutocompleteSelectedTrigger,
   ],
   exports: [
     CdkScrollableModule,
@@ -30,6 +32,7 @@ import {MatAutocompleteOrigin} from './autocomplete-origin';
     BidiModule,
     MatAutocompleteTrigger,
     MatAutocompleteOrigin,
+    MatAutocompleteSelectedTrigger,
   ],
 })
 export class MatAutocompleteModule {}

--- a/src/material/autocomplete/autocomplete-selected-trigger.ts
+++ b/src/material/autocomplete/autocomplete-selected-trigger.ts
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Directive, InjectionToken, TemplateRef, inject} from '@angular/core';
+
+/**
+ * Injection token that references the `MatAutocompleteSelectedTrigger`.
+ * @docs-private
+ */
+export const MAT_AUTOCOMPLETE_SELECTED_TRIGGER = new InjectionToken<MatAutocompleteSelectedTrigger>(
+  'MatAutocompleteSelectedTrigger',
+);
+
+/**
+ * Used to provide a custom template for the selected option display in `mat-autocomplete`,
+ * similar to `mat-select-trigger` for `mat-select`. Place inside `<mat-autocomplete>`:
+ *
+ * ```html
+ * <mat-autocomplete>
+ *   <ng-template matAutocompleteSelectedTrigger let-value>{{ value }}</ng-template>
+ * </mat-autocomplete>
+ * ```
+ *
+ * The `$implicit` template context variable is the raw selected value.
+ */
+@Directive({
+  selector: 'ng-template[matAutocompleteSelectedTrigger]',
+  providers: [
+    {provide: MAT_AUTOCOMPLETE_SELECTED_TRIGGER, useExisting: MatAutocompleteSelectedTrigger},
+  ],
+})
+export class MatAutocompleteSelectedTrigger {
+  readonly templateRef = inject(TemplateRef);
+}

--- a/src/material/autocomplete/autocomplete-trigger.ts
+++ b/src/material/autocomplete/autocomplete-trigger.ts
@@ -29,6 +29,7 @@ import {
   ChangeDetectorRef,
   Directive,
   ElementRef,
+  EmbeddedViewRef,
   EnvironmentInjector,
   InjectionToken,
   Injector,
@@ -112,7 +113,7 @@ export const MAT_AUTOCOMPLETE_SCROLL_STRATEGY = new InjectionToken<() => ScrollS
     // Note: we use `focusin`, as opposed to `focus`, in order to open the panel
     // a little earlier. This avoids issues where IE delays the focusing of the input.
     '(focusin)': '_handleFocus()',
-    '(blur)': '_onTouched()',
+    '(blur)': '_handleBlur()',
     '(input)': '_handleInput($event)',
     '(keydown)': '_handleKeydown($event)',
     '(click)': '_handleClick()',
@@ -188,6 +189,12 @@ export class MatAutocompleteTrigger
    * but which hasn't been propagated to the model value yet.
    */
   private _pendingAutoselectedOption: MatOption | null = null;
+
+  /** Embedded view rendered by the custom `mat-autocomplete-trigger` template, if any. */
+  private _customTriggerView: EmbeddedViewRef<unknown> | null = null;
+  private _customTriggerWrapper: HTMLElement | null = null;
+  /** The last value passed to _syncCustomTrigger so it can be restored after a no-op blur. */
+  private _customTriggerValue: any = null;
 
   /** Stream of keyboard events that can close the panel. */
   private readonly _closeKeyEventStream = new Subject<void>();
@@ -273,6 +280,7 @@ export class MatAutocompleteTrigger
     this._destroyPanel();
     this._closeKeyEventStream.complete();
     this._clearFromModal();
+    this._clearCustomTrigger();
   }
 
   /** Whether or not the autocomplete panel is open. */
@@ -434,7 +442,14 @@ export class MatAutocompleteTrigger
 
   // Implemented as part of ControlValueAccessor.
   writeValue(value: any): void {
-    Promise.resolve(null).then(() => this._assignOptionValue(value));
+    Promise.resolve(null).then(() => {
+      if (this._componentDestroyed) {
+        return;
+      }
+
+      this._assignOptionValue(value);
+      this._syncCustomTrigger(value);
+    });
   }
 
   // Implemented as part of ControlValueAccessor.
@@ -513,6 +528,7 @@ export class MatAutocompleteTrigger
     if (this._previousValue !== value) {
       this._previousValue = value;
       this._pendingAutoselectedOption = null;
+      this._clearCustomTrigger();
 
       // If selection is required we don't write to the CVA while the user is typing.
       // At the end of the selection either the user will have picked something
@@ -522,6 +538,7 @@ export class MatAutocompleteTrigger
       }
 
       if (!value) {
+        this._customTriggerValue = null;
         this._clearPreviousSelectedOption(null, false);
       } else if (this.panelOpen && !this.autocomplete.requireSelection) {
         // Note that we don't reset this when `requireSelection` is enabled,
@@ -551,6 +568,10 @@ export class MatAutocompleteTrigger
   }
 
   _handleFocus(): void {
+    // Always clear the custom trigger on focus so the user can edit the value,
+    // regardless of whether the panel is about to open. _clearCustomTrigger is a no-op
+    // when no custom trigger is active, so this is safe to call unconditionally.
+    this._clearCustomTrigger();
     if (!this._canOpenOnNextFocus) {
       this._canOpenOnNextFocus = true;
     } else if (this._canOpen()) {
@@ -560,7 +581,31 @@ export class MatAutocompleteTrigger
     }
   }
 
+  _handleBlur(): void {
+    this._onTouched();
+    // If the user focused and blurred without making a new selection, restore the custom trigger.
+    // Defer so any pending option-selection events (mousedown → click on option) run first:
+    // if a new value was selected, _syncCustomTrigger will have already set _customTriggerWrapper
+    // before this callback runs, and we skip the restore.
+    if (this._customTriggerValue != null && this._customTriggerValue !== '') {
+      Promise.resolve().then(() => {
+        if (!this._componentDestroyed && !this._customTriggerWrapper) {
+          // Only restore the trigger if the input still shows the selected value's display text.
+          // If the user typed something different and blurred, don't restore.
+          const currentInput = this._element.nativeElement.value;
+          const displayValue = String(this._getDisplayValue(this._customTriggerValue) ?? '');
+          if (currentInput === displayValue) {
+            this._syncCustomTrigger(this._customTriggerValue);
+          }
+        }
+      });
+    }
+  }
+
   _handleClick(): void {
+    // Clear the custom trigger on click so the user can immediately start editing,
+    // even when the input is already focused (focusin would not fire in that case).
+    this._clearCustomTrigger();
     if (this._canOpen() && !this.panelOpen) {
       this._openPanelInternal();
     }
@@ -689,6 +734,62 @@ export class MatAutocompleteTrigger
     return autocomplete && autocomplete.displayWith ? autocomplete.displayWith(value) : value;
   }
 
+  /**
+   * Renders the custom trigger template as an overlay over the input when a value is selected.
+   * All template root nodes are wrapped in a single library-created div so that:
+   * - Templates with multiple root nodes (e.g. `<img>` + text) are handled correctly.
+   * - `display: flex; align-items: center` works regardless of root node types.
+   * The input text is hidden via inline `color: transparent` which has higher specificity
+   * than any MDC class selector. Hides the overlay and restores the input when value is null.
+   */
+  private _syncCustomTrigger(value: any): void {
+    const customTrigger = this.autocomplete?.customTrigger;
+    if (!customTrigger) return;
+
+    // Only show the custom trigger for a real selected value — not for null or empty string,
+    // which both represent "no selection" (e.g. initial FormControl('') or after clearing).
+    if (value != null && value !== '') {
+      this._customTriggerValue = value;
+      this._clearCustomTrigger();
+      this._customTriggerView = this._viewContainerRef.createEmbeddedView(
+        customTrigger.templateRef,
+        {$implicit: value},
+      );
+      this._customTriggerView.detectChanges();
+
+      // Wrap all root nodes in a single div so positioning and flex layout work correctly
+      // regardless of how many root nodes the template has or what types they are.
+      this._customTriggerWrapper = this._renderer.createElement('div') as HTMLElement;
+      this._renderer.addClass(this._customTriggerWrapper, 'mat-autocomplete-selected-trigger');
+      for (const node of this._customTriggerView.rootNodes) {
+        this._renderer.appendChild(this._customTriggerWrapper, node);
+      }
+
+      const input = this._element.nativeElement;
+      const parent = input.parentNode;
+      if (parent) {
+        this._renderer.insertBefore(parent, this._customTriggerWrapper, input.nextSibling);
+        // Use inline styles to override MDC's higher-specificity color rules.
+        this._renderer.setStyle(input, 'color', 'transparent');
+        this._renderer.setStyle(input, 'caret-color', 'transparent');
+      }
+    } else {
+      this._customTriggerValue = null;
+      this._clearCustomTrigger();
+    }
+  }
+
+  /** Destroys the custom trigger overlay and restores normal input text rendering. */
+  private _clearCustomTrigger(): void {
+    this._customTriggerView?.destroy();
+    this._customTriggerView = null;
+    this._customTriggerWrapper?.remove();
+    this._customTriggerWrapper = null;
+    const input = this._element.nativeElement;
+    this._renderer.removeStyle(input, 'color');
+    this._renderer.removeStyle(input, 'caret-color');
+  }
+
   private _assignOptionValue(value: any): void {
     const toDisplay = this._getDisplayValue(value);
 
@@ -721,6 +822,7 @@ export class MatAutocompleteTrigger
   private _setValueAndClose(event: MatOptionSelectionChange | null): void {
     const panel = this.autocomplete;
     const toSelect = event ? event.source : this._pendingAutoselectedOption;
+    let didChange = false;
 
     if (toSelect) {
       this._clearPreviousSelectedOption(toSelect);
@@ -731,6 +833,7 @@ export class MatAutocompleteTrigger
       this._onChange(toSelect.value);
       panel._emitSelectEvent(toSelect);
       this._element.nativeElement.focus();
+      didChange = true;
     } else if (
       panel.requireSelection &&
       this._element.nativeElement.value !== this._valueOnAttach
@@ -738,9 +841,15 @@ export class MatAutocompleteTrigger
       this._clearPreviousSelectedOption(null);
       this._assignOptionValue(null);
       this._onChange(null);
+      didChange = true;
     }
 
     this.closePanel();
+
+    // After the panel closes, sync the custom trigger overlay if the value changed.
+    if (didChange) {
+      this._syncCustomTrigger(toSelect ? toSelect.value : null);
+    }
   }
 
   /**

--- a/src/material/autocomplete/autocomplete.scss
+++ b/src/material/autocomplete/autocomplete.scss
@@ -74,3 +74,24 @@ div.mat-mdc-autocomplete-panel.mat-mdc-autocomplete-hidden,
 mat-autocomplete {
   display: none;
 }
+
+// Applied to the library-created wrapper div that holds the `mat-autocomplete-trigger` template
+// content when an option is selected. Positions it absolutely within the form-field infix
+// (which has `position: relative`) so it overlays the input whose text is hidden via inline
+// `color: transparent`.
+.mat-autocomplete-selected-trigger {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  // Allow clicks to fall through to the underlying input so the user can re-focus and retype.
+  pointer-events: none;
+
+  // Mirror the disabled appearance of the underlying input.
+  input:disabled + & {
+    opacity: 0.38; // the canonical Material Design disabled-state opacity
+  }
+}

--- a/src/material/autocomplete/autocomplete.spec.ts
+++ b/src/material/autocomplete/autocomplete.spec.ts
@@ -57,6 +57,7 @@ import {
   MatAutocompleteDefaultOptions,
   MatAutocompleteOrigin,
   MatAutocompleteSelectedEvent,
+  MatAutocompleteSelectedTrigger,
   MatAutocompleteTrigger,
   getMatAutocompleteMissingPanelError,
 } from './index';
@@ -3998,6 +3999,183 @@ describe('MatAutocomplete', () => {
         .toContain(panelId);
     });
   });
+
+  describe('custom selected-value trigger (mat-autocomplete-trigger)', () => {
+    let fixture: ComponentFixture<AutocompleteWithCustomTrigger>;
+    let input: HTMLInputElement;
+
+    beforeEach(() => {
+      fixture = createComponent(AutocompleteWithCustomTrigger);
+      fixture.detectChanges();
+      input = fixture.debugElement.query(By.css('input'))!.nativeElement;
+    });
+
+    it('should render the custom trigger template after an option is selected', waitForAsync(async () => {
+      fixture.componentInstance.trigger.openPanel();
+      fixture.detectChanges();
+      await new Promise(r => setTimeout(r));
+
+      const option = getOverlayHost(fixture)!.querySelector('mat-option') as HTMLElement;
+      option.click();
+      fixture.detectChanges();
+      await new Promise(r => setTimeout(r));
+      fixture.detectChanges();
+
+      const customTrigger = fixture.nativeElement.querySelector('.custom-trigger-display');
+      expect(customTrigger).toBeTruthy('Expected custom trigger element to be in the DOM.');
+    }));
+
+    it('should expose the selected value as $implicit template context', waitForAsync(async () => {
+      fixture.componentInstance.trigger.openPanel();
+      fixture.detectChanges();
+      await new Promise(r => setTimeout(r));
+
+      const option = getOverlayHost(fixture)!.querySelector('mat-option') as HTMLElement;
+      option.click();
+      fixture.detectChanges();
+      await new Promise(r => setTimeout(r));
+      fixture.detectChanges();
+
+      const customTrigger = fixture.nativeElement.querySelector('.custom-trigger-display');
+      expect(customTrigger.textContent.trim()).toBe('Alabama');
+    }));
+
+    it('should hide the custom trigger overlay when the user starts typing', waitForAsync(async () => {
+      fixture.componentInstance.trigger.openPanel();
+      fixture.detectChanges();
+      await new Promise(r => setTimeout(r));
+
+      const option = getOverlayHost(fixture)!.querySelector('mat-option') as HTMLElement;
+      option.click();
+      fixture.detectChanges();
+      await new Promise(r => setTimeout(r));
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.querySelector('.custom-trigger-display')).toBeTruthy();
+
+      typeInElement(input, 'A');
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.querySelector('.custom-trigger-display'))
+        .withContext('Expected custom trigger to be removed after typing.')
+        .toBeFalsy();
+    }));
+
+    it('should set color: transparent on the input when the custom trigger is active', waitForAsync(async () => {
+      fixture.componentInstance.trigger.openPanel();
+      fixture.detectChanges();
+      await new Promise(r => setTimeout(r));
+
+      const option = getOverlayHost(fixture)!.querySelector('mat-option') as HTMLElement;
+      option.click();
+      fixture.detectChanges();
+      await new Promise(r => setTimeout(r));
+      fixture.detectChanges();
+
+      expect(input.style.color).toBe('transparent');
+    }));
+
+    it('should restore input color when typing after a selection', waitForAsync(async () => {
+      fixture.componentInstance.trigger.openPanel();
+      fixture.detectChanges();
+      await new Promise(r => setTimeout(r));
+
+      const option = getOverlayHost(fixture)!.querySelector('mat-option') as HTMLElement;
+      option.click();
+      fixture.detectChanges();
+      await new Promise(r => setTimeout(r));
+      fixture.detectChanges();
+
+      typeInElement(input, 'A');
+      fixture.detectChanges();
+
+      expect(input.style.color).not.toBe('transparent');
+    }));
+
+    it('should show the custom trigger when value is set programmatically via writeValue', fakeAsync(() => {
+      fixture.componentInstance.trigger.writeValue('Alabama');
+      tick();
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.querySelector('.custom-trigger-display')).toBeTruthy();
+      expect(input.style.color).toBe('transparent');
+    }));
+
+    it('should clear the custom trigger when value is set to null programmatically', fakeAsync(() => {
+      fixture.componentInstance.trigger.writeValue('Alabama');
+      tick();
+      fixture.detectChanges();
+
+      fixture.componentInstance.trigger.writeValue(null);
+      tick();
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.querySelector('.custom-trigger-display')).toBeFalsy();
+      expect(input.style.color).not.toBe('transparent');
+    }));
+
+    it('should not show the custom trigger while the panel is still open during navigation', fakeAsync(() => {
+      fixture.componentInstance.trigger.openPanel();
+      fixture.detectChanges();
+      flush();
+
+      // Keyboard navigate to first option; with autoSelectActiveOption this calls _assignOptionValue.
+      dispatchKeyboardEvent(input, 'keydown', DOWN_ARROW);
+      fixture.detectChanges();
+
+      // Panel is still open — custom trigger must not be visible yet.
+      expect(fixture.nativeElement.querySelector('.custom-trigger-display'))
+        .withContext('Expected custom trigger to stay hidden while panel is open.')
+        .toBeFalsy();
+    }));
+
+    it('should restore the custom trigger on blur when input still shows the selected display value', waitForAsync(async () => {
+      // Select an option so the custom trigger appears.
+      fixture.componentInstance.trigger.openPanel();
+      fixture.detectChanges();
+      const options = fixture.debugElement.queryAll(By.css('mat-option'));
+      options[0].nativeElement.click();
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expect(input.style.color).toBe('transparent');
+
+      // Click input to clear the custom trigger for editing.
+      input.click();
+      fixture.detectChanges();
+
+      expect(input.style.color).not.toBe('transparent');
+
+      // Blur without typing (input still holds the selected option's display text).
+      input.dispatchEvent(new Event('blur'));
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expect(input.style.color)
+        .withContext(
+          'Expected custom trigger to be restored after blur with matching display value.',
+        )
+        .toBe('transparent');
+    }));
+
+    it('should clean up the custom trigger wrapper when the component is destroyed', waitForAsync(async () => {
+      // Select an option so a wrapper div is inserted into the DOM.
+      fixture.componentInstance.trigger.openPanel();
+      fixture.detectChanges();
+      const options = fixture.debugElement.queryAll(By.css('mat-option'));
+      options[0].nativeElement.click();
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expect(fixture.nativeElement.querySelector('.custom-trigger-display')).toBeTruthy();
+
+      // Destroying the fixture must not throw and must remove the wrapper from the DOM.
+      expect(() => fixture.destroy()).not.toThrow();
+      expect(document.querySelector('.custom-trigger-display'))
+        .withContext('Expected wrapper to be removed from DOM after destroy.')
+        .toBeFalsy();
+    }));
+  });
 });
 
 const SIMPLE_AUTOCOMPLETE_TEMPLATE = `
@@ -4604,4 +4782,33 @@ class AutocompleteInsideAModal {
 })
 class AutocompleteWithoutOptions {
   @ViewChild(MatAutocompleteTrigger, {static: true}) trigger!: MatAutocompleteTrigger;
+}
+
+@Component({
+  template: `
+    <mat-form-field>
+      <input matInput [matAutocomplete]="auto">
+    </mat-form-field>
+
+    <mat-autocomplete #auto="matAutocomplete">
+      <ng-template matAutocompleteSelectedTrigger let-val>
+        <span class="custom-trigger-display">{{ val }}</span>
+      </ng-template>
+      @for (state of states; track state) {
+        <mat-option [value]="state">{{ state }}</mat-option>
+      }
+    </mat-autocomplete>
+  `,
+  imports: [
+    MatAutocomplete,
+    MatAutocompleteTrigger,
+    MatAutocompleteSelectedTrigger,
+    MatInputModule,
+    MatOption,
+  ],
+  changeDetection: ChangeDetectionStrategy.Eager,
+})
+class AutocompleteWithCustomTrigger {
+  @ViewChild(MatAutocompleteTrigger, {static: true}) trigger!: MatAutocompleteTrigger;
+  states = ['Alabama', 'California', 'Florida'];
 }

--- a/src/material/autocomplete/autocomplete.ts
+++ b/src/material/autocomplete/autocomplete.ts
@@ -11,6 +11,7 @@ import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
+  ContentChild,
   ContentChildren,
   ElementRef,
   EventEmitter,
@@ -25,6 +26,9 @@ import {
   booleanAttribute,
   inject,
 } from '@angular/core';
+import {_IdGenerator, ActiveDescendantKeyManager} from '@angular/cdk/a11y';
+import {Platform} from '@angular/cdk/platform';
+import {Subscription} from 'rxjs';
 import {
   _animationsDisabled,
   MAT_OPTGROUP,
@@ -33,9 +37,10 @@ import {
   MatOption,
   ThemePalette,
 } from '../core';
-import {_IdGenerator, ActiveDescendantKeyManager} from '@angular/cdk/a11y';
-import {Platform} from '@angular/cdk/platform';
-import {Subscription} from 'rxjs';
+import {
+  MAT_AUTOCOMPLETE_SELECTED_TRIGGER,
+  MatAutocompleteSelectedTrigger,
+} from './autocomplete-selected-trigger';
 
 /** Event object that is emitted when an autocomplete option is selected. */
 export class MatAutocompleteSelectedEvent {
@@ -156,6 +161,10 @@ export class MatAutocomplete implements AfterContentInit, OnDestroy {
 
   /** Reference to all option groups within the autocomplete. */
   @ContentChildren(MAT_OPTGROUP, {descendants: true}) optionGroups!: QueryList<MatOptgroup>;
+
+  /** Custom template for rendering the selected option in the trigger area. */
+  @ContentChild(MAT_AUTOCOMPLETE_SELECTED_TRIGGER)
+  customTrigger: MatAutocompleteSelectedTrigger | undefined;
 
   /** Aria label of the autocomplete. */
   @Input('aria-label') ariaLabel!: string;

--- a/src/material/autocomplete/public-api.ts
+++ b/src/material/autocomplete/public-api.ts
@@ -9,6 +9,7 @@
 export * from './autocomplete-module';
 export * from './autocomplete';
 export * from './autocomplete-origin';
+export * from './autocomplete-selected-trigger';
 export * from './autocomplete-trigger';
 
 // Re-export these since they're required to be used together with `mat-autocomplete`.


### PR DESCRIPTION
Add an `ng-template[matAutocompleteSelectedTrigger]` directive that let consumers render arbitrary HTML in the trigger area after an option is selected, analogous to `mat-select-trigger` for `mat-select`. Since autocomplete writes to a native `<input>`, the implementation creates an Angular embedded view and inserts a wrapper `<div>` as a DOM sibling, hiding the input text via inline `color: transparent`. Clearing occurs on focus/click; the trigger is restored on blur when the input still contains the selected value's display text.

close #32931