### PR TITLE
fix(multiple): remove empty constructors

### DIFF
--- a/goldens/cdk/a11y/index.api.md
+++ b/goldens/cdk/a11y/index.api.md
@@ -46,7 +46,7 @@ export function addAriaReferencedId(el: Element, attr: `aria-${string}`, id: str
 
 // @public
 export class AriaDescriber implements OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     describe(hostElement: Element, message: string, role?: string): void;
     describe(hostElement: Element, message: HTMLElement): void;
     ngOnDestroy(): void;
@@ -69,7 +69,7 @@ export const CDK_DESCRIBEDBY_ID_PREFIX = "cdk-describedby-message";
 
 // @public
 export class CdkAriaLive implements OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     duration: number;
     // (undocumented)
     ngOnDestroy(): void;
@@ -83,7 +83,6 @@ export class CdkAriaLive implements OnDestroy {
 
 // @public
 export class CdkMonitorFocus implements AfterViewInit, OnDestroy {
-    constructor(...args: unknown[]);
     // (undocumented)
     readonly cdkFocusChange: EventEmitter<FocusOrigin>;
     // (undocumented)
@@ -100,7 +99,7 @@ export class CdkMonitorFocus implements AfterViewInit, OnDestroy {
 
 // @public
 export class CdkTrapFocus implements OnDestroy, AfterContentInit, OnChanges, DoCheck {
-    constructor(...args: unknown[]);
+    constructor();
     autoCapture: boolean;
     get enabled(): boolean;
     set enabled(value: boolean);
@@ -140,7 +139,7 @@ export interface ConfigurableFocusTrapConfig {
 
 // @public
 export class ConfigurableFocusTrapFactory {
-    constructor(...args: unknown[]);
+    constructor();
     create(element: HTMLElement, config?: ConfigurableFocusTrapConfig): ConfigurableFocusTrap;
     // @deprecated (undocumented)
     create(element: HTMLElement, deferCaptureElements: boolean): ConfigurableFocusTrap;
@@ -177,7 +176,7 @@ export class FocusKeyManager<T> extends ListKeyManager<FocusableOption & T> {
 
 // @public
 export class FocusMonitor implements OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     protected _document: Document;
     focusVia(element: HTMLElement, origin: FocusOrigin, options?: FocusOptions_2): void;
     focusVia(element: ElementRef<HTMLElement>, origin: FocusOrigin, options?: FocusOptions_2): void;
@@ -248,7 +247,7 @@ export class FocusTrap {
 
 // @public
 export class FocusTrapFactory {
-    constructor(...args: unknown[]);
+    constructor();
     create(element: HTMLElement, deferCaptureElements?: boolean): FocusTrap;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<FocusTrapFactory, never>;
@@ -277,7 +276,7 @@ export enum HighContrastMode {
 
 // @public
 export class HighContrastModeDetector implements OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     _applyBodyHighContrastModeCssClasses(): void;
     getHighContrastMode(): HighContrastMode;
     // (undocumented)
@@ -314,7 +313,7 @@ export type InputModality = 'keyboard' | 'mouse' | 'touch' | null;
 
 // @public
 export class InputModalityDetector implements OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     readonly modalityChanged: Observable<InputModality>;
     readonly modalityDetected: Observable<InputModality>;
     get mostRecentModality(): InputModality;
@@ -334,7 +333,6 @@ export interface InputModalityDetectorOptions {
 
 // @public
 export class InteractivityChecker {
-    constructor(...args: unknown[]);
     isDisabled(element: HTMLElement): boolean;
     isFocusable(element: HTMLElement, config?: IsFocusableConfig): boolean;
     isTabbable(element: HTMLElement): boolean;
@@ -404,7 +402,7 @@ export const LIVE_ANNOUNCER_ELEMENT_TOKEN: InjectionToken<HTMLElement | null>;
 
 // @public (undocumented)
 export class LiveAnnouncer implements OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     announce(message: LiveAnnouncerMessage): Promise<void>;
     announce(message: LiveAnnouncerMessage, politeness?: AriaLivePoliteness): Promise<void>;
     announce(message: LiveAnnouncerMessage, duration?: number): Promise<void>;

--- a/goldens/cdk/accordion/index.api.md
+++ b/goldens/cdk/accordion/index.api.md
@@ -38,7 +38,6 @@ export class CdkAccordion implements OnDestroy, OnChanges {
 
 // @public
 export class CdkAccordionItem implements OnInit, OnDestroy {
-    constructor(...args: unknown[]);
     // (undocumented)
     accordion: CdkAccordion;
     close(): void;

--- a/goldens/cdk/bidi/index.api.md
+++ b/goldens/cdk/bidi/index.api.md
@@ -46,7 +46,7 @@ export type Direction = 'ltr' | 'rtl';
 
 // @public
 export class Directionality implements OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     readonly change: EventEmitter<Direction>;
     // (undocumented)
     ngOnDestroy(): void;

--- a/goldens/cdk/clipboard/index.api.md
+++ b/goldens/cdk/clipboard/index.api.md
@@ -14,7 +14,7 @@ export const CDK_COPY_TO_CLIPBOARD_CONFIG: InjectionToken<CdkCopyToClipboardConf
 
 // @public
 export class CdkCopyToClipboard implements OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     attempts: number;
     readonly copied: EventEmitter<boolean>;
     copy(attempts?: number): void;
@@ -34,7 +34,6 @@ export interface CdkCopyToClipboardConfig {
 
 // @public
 class Clipboard_2 {
-    constructor(...args: unknown[]);
     beginCopy(text: string): PendingCopy;
     copy(text: string): boolean;
     // (undocumented)

--- a/goldens/cdk/dialog/index.api.md
+++ b/goldens/cdk/dialog/index.api.md
@@ -40,7 +40,7 @@ export type AutoFocusTarget = 'dialog' | 'first-tabbable' | 'first-heading';
 
 // @public
 export class CdkDialogContainer<C extends DialogConfig = DialogConfig> extends BasePortalOutlet implements DialogContainer, OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     // (undocumented)
     _addAriaLabelledBy(id: string): void;
     _ariaLabelledByQueue: string[];
@@ -84,7 +84,6 @@ export const DEFAULT_DIALOG_CONFIG: InjectionToken<DialogConfig<unknown, unknown
 
 // @public (undocumented)
 export class Dialog implements OnDestroy {
-    constructor(...args: unknown[]);
     readonly afterAllClosed: Observable<void>;
     get afterOpened(): Subject<DialogRef<any, any>>;
     closeAll(): void;

--- a/goldens/cdk/drag-drop/index.api.md
+++ b/goldens/cdk/drag-drop/index.api.md
@@ -45,7 +45,7 @@ export const CDK_DROP_LIST_GROUP: InjectionToken<CdkDropListGroup<CdkDropList<an
 
 // @public
 export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     // (undocumented)
     _addHandle(handle: CdkDragHandle): void;
     boundaryElement: string | ElementRef<HTMLElement> | HTMLElement;
@@ -152,7 +152,7 @@ export interface CdkDragExit<T = any, I = T> {
 
 // @public
 export class CdkDragHandle implements AfterViewInit, OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     get disabled(): boolean;
     set disabled(value: boolean);
     // (undocumented)
@@ -190,7 +190,7 @@ export interface CdkDragMove<T = any> {
 
 // @public
 export class CdkDragPlaceholder<T = any> implements OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     data: T;
     // (undocumented)
     ngOnDestroy(): void;
@@ -204,7 +204,7 @@ export class CdkDragPlaceholder<T = any> implements OnDestroy {
 
 // @public
 export class CdkDragPreview<T = any> implements OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     data: T;
     matchSize: boolean;
     // (undocumented)
@@ -241,7 +241,7 @@ export interface CdkDragStart<T = any> {
 
 // @public
 export class CdkDropList<T = any> implements OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     addItem(item: CdkDrag): void;
     autoScrollDisabled: boolean;
     autoScrollStep: NumberInput;
@@ -313,7 +313,6 @@ export type DragConstrainPosition = (userPointerPosition: Point, dragRef: DragRe
 
 // @public @deprecated
 export class DragDrop {
-    constructor(...args: unknown[]);
     // @deprecated
     createDrag<T = any>(element: ElementRef<HTMLElement> | HTMLElement, config?: DragRefConfig): DragRef<T>;
     // @deprecated
@@ -364,7 +363,6 @@ export class DragDropModule {
 
 // @public
 export class DragDropRegistry implements OnDestroy {
-    constructor(...args: unknown[]);
     getDragDirectiveForNode(node: Node): CdkDrag | null;
     isDragging(drag: DragRef): boolean;
     // (undocumented)

--- a/goldens/cdk/layout/index.api.md
+++ b/goldens/cdk/layout/index.api.md
@@ -10,7 +10,6 @@ import { OnDestroy } from '@angular/core';
 
 // @public
 export class BreakpointObserver implements OnDestroy {
-    constructor(...args: unknown[]);
     isMatched(value: string | readonly string[]): boolean;
     ngOnDestroy(): void;
     observe(value: string | readonly string[]): Observable<BreakpointState>;
@@ -58,7 +57,7 @@ export class LayoutModule {
 
 // @public
 export class MediaMatcher {
-    constructor(...args: unknown[]);
+    constructor();
     matchMedia(query: string): MediaQueryList;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MediaMatcher, never>;

--- a/goldens/cdk/observers/index.api.md
+++ b/goldens/cdk/observers/index.api.md
@@ -13,7 +13,6 @@ import { OnDestroy } from '@angular/core';
 
 // @public
 export class CdkObserveContent implements AfterContentInit, OnDestroy {
-    constructor(...args: unknown[]);
     get debounce(): number;
     set debounce(value: NumberInput);
     get disabled(): boolean;
@@ -33,7 +32,6 @@ export class CdkObserveContent implements AfterContentInit, OnDestroy {
 
 // @public
 export class ContentObserver implements OnDestroy {
-    constructor(...args: unknown[]);
     // (undocumented)
     ngOnDestroy(): void;
     observe(element: Element): Observable<MutationRecord[]>;

--- a/goldens/cdk/overlay/index.api.md
+++ b/goldens/cdk/overlay/index.api.md
@@ -44,7 +44,7 @@ export const CDK_CONNECTED_OVERLAY_DEFAULT_CONFIG: InjectionToken<CdkConnectedOv
 
 // @public
 export class CdkConnectedOverlay implements OnDestroy, OnChanges {
-    constructor(...args: unknown[]);
+    constructor();
     readonly attach: EventEmitter<void>;
     attachOverlay(): void;
     backdropClass: string | string[];
@@ -158,7 +158,6 @@ export interface CdkConnectedOverlayConfig {
 
 // @public
 export class CdkOverlayOrigin {
-    constructor(...args: unknown[]);
     // (undocumented)
     elementRef: ElementRef<any>;
     // (undocumented)
@@ -169,7 +168,6 @@ export class CdkOverlayOrigin {
 
 // @public
 export class CdkScrollable implements OnInit, OnDestroy {
-    constructor(...args: unknown[]);
     // (undocumented)
     protected readonly _destroyed: Subject<void>;
     // (undocumented)
@@ -322,7 +320,6 @@ export type FlexibleOverlayPopoverLocation = 'global' | 'inline' | {
 
 // @public
 export class FullscreenOverlayContainer extends OverlayContainer implements OnDestroy {
-    constructor(...args: unknown[]);
     // (undocumented)
     protected _createContainer(): void;
     getFullscreenElement(): Element;
@@ -374,7 +371,6 @@ export interface OriginConnectionPosition {
 
 // @public
 export class Overlay {
-    constructor(...args: unknown[]);
     create(config?: OverlayConfig): OverlayRef;
     position(): OverlayPositionBuilder;
     // (undocumented)
@@ -419,7 +415,6 @@ export interface OverlayConnectionPosition {
 
 // @public
 export class OverlayContainer implements OnDestroy {
-    constructor(...args: unknown[]);
     // (undocumented)
     protected _containerElement: HTMLElement | undefined;
     protected _createContainer(): void;
@@ -477,7 +472,6 @@ export class OverlayOutsideClickDispatcher extends BaseOverlayDispatcher {
 
 // @public
 export class OverlayPositionBuilder {
-    constructor(...args: unknown[]);
     flexibleConnectedTo(origin: FlexibleConnectedPositionStrategyOrigin): FlexibleConnectedPositionStrategy;
     global(): GlobalPositionStrategy;
     // (undocumented)
@@ -567,7 +561,6 @@ export interface RepositionScrollStrategyConfig {
 
 // @public
 export class ScrollDispatcher implements OnDestroy {
-    constructor(...args: unknown[]);
     ancestorScrolled(elementOrElementRef: ElementRef | HTMLElement, auditTimeInMs?: number): Observable<CdkScrollable | void>;
     deregister(scrollable: CdkScrollable): void;
     getAncestorScrollContainers(elementOrElementRef: ElementRef | HTMLElement): CdkScrollable[];
@@ -604,7 +597,6 @@ export interface ScrollStrategy {
 
 // @public
 export class ScrollStrategyOptions {
-    constructor(...args: unknown[]);
     block: () => BlockScrollStrategy;
     close: (config?: CloseScrollStrategyConfig) => CloseScrollStrategy;
     noop: () => NoopScrollStrategy;
@@ -640,7 +632,7 @@ export type ViewportMargin = number | {
 
 // @public
 export class ViewportRuler implements OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     change(throttleTime?: number): Observable<Event>;
     protected _document: Document;
     getViewportRect(): {

--- a/goldens/cdk/platform/index.api.md
+++ b/goldens/cdk/platform/index.api.md
@@ -29,7 +29,6 @@ export function normalizePassiveListenerOptions(options: AddEventListenerOptions
 
 // @public
 export class Platform {
-    constructor(..._args: unknown[]);
     ANDROID: boolean;
     BLINK: boolean;
     EDGE: boolean;

--- a/goldens/cdk/portal/index.api.md
+++ b/goldens/cdk/portal/index.api.md
@@ -40,7 +40,7 @@ export abstract class BasePortalOutlet implements PortalOutlet {
 
 // @public
 export class CdkPortal extends TemplatePortal {
-    constructor(...args: unknown[]);
+    constructor();
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<CdkPortal, "[cdkPortal]", ["cdkPortal"], {}, {}, never, never, true, never>;
     // (undocumented)
@@ -49,7 +49,6 @@ export class CdkPortal extends TemplatePortal {
 
 // @public
 export class CdkPortalOutlet extends BasePortalOutlet implements OnInit, OnDestroy {
-    constructor(...args: unknown[]);
     attachComponentPortal<T>(portal: ComponentPortal<T>): ComponentRef<T>;
     // @deprecated
     attachDomPortal: (portal: DomPortal) => void;

--- a/goldens/cdk/scrolling/index.api.md
+++ b/goldens/cdk/scrolling/index.api.md
@@ -54,7 +54,6 @@ export class CdkFixedSizeVirtualScroll implements OnChanges {
 
 // @public
 export class CdkScrollable implements OnInit, OnDestroy {
-    constructor(...args: unknown[]);
     // (undocumented)
     protected readonly _destroyed: Subject<void>;
     // (undocumented)
@@ -93,7 +92,7 @@ export class CdkScrollableModule {
 
 // @public
 export class CdkVirtualForOf<T> implements CdkVirtualScrollRepeater<T>, CollectionViewer, DoCheck, OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     get cdkVirtualForOf(): DataSource<T> | Observable<T[]> | NgIterable<T> | null | undefined;
     set cdkVirtualForOf(value: DataSource<T> | Observable<T[]> | NgIterable<T> | null | undefined);
     // (undocumented)
@@ -132,7 +131,6 @@ export type CdkVirtualForOfContext<T> = {
 
 // @public
 export abstract class CdkVirtualScrollable extends CdkScrollable {
-    constructor(...args: unknown[]);
     abstract measureBoundingClientRectWithScrollOffset(from: 'left' | 'top' | 'right' | 'bottom'): number;
     measureViewportSize(orientation: 'horizontal' | 'vertical'): number;
     // (undocumented)
@@ -143,7 +141,6 @@ export abstract class CdkVirtualScrollable extends CdkScrollable {
 
 // @public
 export class CdkVirtualScrollableElement extends CdkVirtualScrollable {
-    constructor(...args: unknown[]);
     // (undocumented)
     measureBoundingClientRectWithScrollOffset(from: 'left' | 'top' | 'right' | 'bottom'): number;
     // (undocumented)
@@ -154,7 +151,7 @@ export class CdkVirtualScrollableElement extends CdkVirtualScrollable {
 
 // @public
 export class CdkVirtualScrollableWindow extends CdkVirtualScrollable {
-    constructor(...args: unknown[]);
+    constructor();
     // (undocumented)
     measureBoundingClientRectWithScrollOffset(from: 'left' | 'top' | 'right' | 'bottom'): number;
     // (undocumented)
@@ -173,7 +170,7 @@ export interface CdkVirtualScrollRepeater<T> {
 
 // @public
 export class CdkVirtualScrollViewport extends CdkVirtualScrollable implements OnInit, OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     appendOnly: boolean;
     attach(forOf: CdkVirtualScrollRepeater<any>): void;
     checkViewportSize(): void;
@@ -260,7 +257,6 @@ export type _Right = {
 
 // @public
 export class ScrollDispatcher implements OnDestroy {
-    constructor(...args: unknown[]);
     ancestorScrolled(elementOrElementRef: ElementRef | HTMLElement, auditTimeInMs?: number): Observable<CdkScrollable | void>;
     deregister(scrollable: CdkScrollable): void;
     getAncestorScrollContainers(elementOrElementRef: ElementRef | HTMLElement): CdkScrollable[];
@@ -297,7 +293,7 @@ export type _Top = {
 
 // @public
 export class ViewportRuler implements OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     change(throttleTime?: number): Observable<Event>;
     protected _document: Document;
     getViewportRect(): {

--- a/goldens/cdk/stepper/index.api.md
+++ b/goldens/cdk/stepper/index.api.md
@@ -21,7 +21,7 @@ import { TemplateRef } from '@angular/core';
 
 // @public (undocumented)
 export class CdkStep implements OnChanges {
-    constructor(...args: unknown[]);
+    constructor();
     ariaLabel: string;
     ariaLabelledby: string;
     protected _childForms: QueryList<Partial<NgForm | FormGroupDirective>> | undefined;
@@ -75,7 +75,6 @@ export class CdkStep implements OnChanges {
 
 // @public (undocumented)
 export class CdkStepHeader implements FocusableOption {
-    constructor(...args: unknown[]);
     // (undocumented)
     _elementRef: ElementRef<HTMLElement>;
     focus(): void;
@@ -87,7 +86,6 @@ export class CdkStepHeader implements FocusableOption {
 
 // @public (undocumented)
 export class CdkStepLabel {
-    constructor(...args: unknown[]);
     // (undocumented)
     template: TemplateRef<any>;
     // (undocumented)
@@ -98,7 +96,6 @@ export class CdkStepLabel {
 
 // @public (undocumented)
 export class CdkStepper implements AfterContentInit, AfterViewInit, OnDestroy {
-    constructor(...args: unknown[]);
     protected readonly _destroyed: Subject<void>;
     // (undocumented)
     protected _elementRef: ElementRef<HTMLElement>;
@@ -153,7 +150,6 @@ export class CdkStepperModule {
 
 // @public
 export class CdkStepperNext {
-    constructor(...args: unknown[]);
     // (undocumented)
     _stepper: CdkStepper;
     type: string;
@@ -165,7 +161,6 @@ export class CdkStepperNext {
 
 // @public
 export class CdkStepperPrevious {
-    constructor(...args: unknown[]);
     // (undocumented)
     _stepper: CdkStepper;
     type: string;

--- a/goldens/cdk/table/index.api.md
+++ b/goldens/cdk/table/index.api.md
@@ -38,7 +38,6 @@ export class BaseCdkCell {
 
 // @public
 export abstract class BaseRowDef implements OnChanges {
-    constructor(...args: unknown[]);
     columns: Iterable<string>;
     protected _columnsDiffer: IterableDiffer<any>;
     // (undocumented)
@@ -63,7 +62,7 @@ export const CDK_TABLE: InjectionToken<any>;
 
 // @public
 export class CdkCell extends BaseCdkCell {
-    constructor(...args: unknown[]);
+    constructor();
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<CdkCell, "cdk-cell, td[cdk-cell]", never, {}, {}, never, never, true, never>;
     // (undocumented)
@@ -72,7 +71,6 @@ export class CdkCell extends BaseCdkCell {
 
 // @public
 export class CdkCellDef implements CellDef {
-    constructor(...args: unknown[]);
     template: TemplateRef<any>;
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<CdkCellDef, "[cdkCellDef]", never, {}, {}, never, never, true, never>;
@@ -82,7 +80,7 @@ export class CdkCellDef implements CellDef {
 
 // @public
 export class CdkCellOutlet implements OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     cells: CdkCellDef[];
     context: any;
     static mostRecentCellOutlet: CdkCellOutlet | null;
@@ -121,7 +119,6 @@ export interface CdkCellOutletRowContext<T> {
 
 // @public
 export class CdkColumnDef implements CanStick {
-    constructor(...args: unknown[]);
     cell: CdkCellDef;
     _columnCssClassName: string[];
     cssClassFriendlyName: string;
@@ -155,7 +152,7 @@ export class CdkColumnDef implements CanStick {
 
 // @public
 export class CdkFooterCell extends BaseCdkCell {
-    constructor(...args: unknown[]);
+    constructor();
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<CdkFooterCell, "cdk-footer-cell, td[cdk-footer-cell]", never, {}, {}, never, never, true, never>;
     // (undocumented)
@@ -164,7 +161,6 @@ export class CdkFooterCell extends BaseCdkCell {
 
 // @public
 export class CdkFooterCellDef implements CellDef {
-    constructor(...args: unknown[]);
     template: TemplateRef<any>;
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<CdkFooterCellDef, "[cdkFooterCellDef]", never, {}, {}, never, never, true, never>;
@@ -182,7 +178,6 @@ export class CdkFooterRow {
 
 // @public
 export class CdkFooterRowDef extends BaseRowDef implements CanStick, OnChanges {
-    constructor(...args: unknown[]);
     hasStickyChanged(): boolean;
     // (undocumented)
     static ngAcceptInputType_sticky: unknown;
@@ -201,7 +196,7 @@ export class CdkFooterRowDef extends BaseRowDef implements CanStick, OnChanges {
 
 // @public
 export class CdkHeaderCell extends BaseCdkCell {
-    constructor(...args: unknown[]);
+    constructor();
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<CdkHeaderCell, "cdk-header-cell, th[cdk-header-cell]", never, {}, {}, never, never, true, never>;
     // (undocumented)
@@ -210,7 +205,6 @@ export class CdkHeaderCell extends BaseCdkCell {
 
 // @public
 export class CdkHeaderCellDef implements CellDef {
-    constructor(...args: unknown[]);
     template: TemplateRef<any>;
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<CdkHeaderCellDef, "[cdkHeaderCellDef]", never, {}, {}, never, never, true, never>;
@@ -228,7 +222,6 @@ export class CdkHeaderRow {
 
 // @public
 export class CdkHeaderRowDef extends BaseRowDef implements CanStick, OnChanges {
-    constructor(...args: unknown[]);
     hasStickyChanged(): boolean;
     // (undocumented)
     static ngAcceptInputType_sticky: unknown;
@@ -247,7 +240,6 @@ export class CdkHeaderRowDef extends BaseRowDef implements CanStick, OnChanges {
 
 // @public
 export class CdkNoDataRow {
-    constructor(...args: unknown[]);
     // (undocumented)
     _cellClassNames: string[];
     // (undocumented)
@@ -280,7 +272,6 @@ export class CdkRow {
 
 // @public
 export class CdkRowDef<T> extends BaseRowDef {
-    constructor(...args: unknown[]);
     // (undocumented)
     _table?: any;
     when: (index: number, rowData: T) => boolean;
@@ -292,7 +283,7 @@ export class CdkRowDef<T> extends BaseRowDef {
 
 // @public
 export class CdkTable<T> implements AfterContentInit, AfterContentChecked, CollectionViewer, OnDestroy, OnInit, StickyPositioningListener {
-    constructor(...args: unknown[]);
+    constructor();
     addColumnDef(columnDef: CdkColumnDef): void;
     addFooterRowDef(footerRowDef: CdkFooterRowDef): void;
     addHeaderRowDef(headerRowDef: CdkHeaderRowDef): void;
@@ -393,7 +384,7 @@ export class CdkTableModule {
 
 // @public
 export class CdkTextColumn<T> implements OnDestroy, OnInit {
-    constructor(...args: unknown[]);
+    constructor();
     cell: CdkCellDef;
     columnDef: CdkColumnDef;
     _createDefaultHeaderText(): string;
@@ -423,7 +414,7 @@ export interface CellDef {
 
 // @public
 export class DataRowOutlet implements RowOutlet {
-    constructor(...args: unknown[]);
+    constructor();
     // (undocumented)
     elementRef: ElementRef<any>;
     // (undocumented)
@@ -442,7 +433,7 @@ export abstract class DataSource<T> {
 
 // @public
 export class FooterRowOutlet implements RowOutlet {
-    constructor(...args: unknown[]);
+    constructor();
     // (undocumented)
     elementRef: ElementRef<any>;
     // (undocumented)
@@ -455,7 +446,7 @@ export class FooterRowOutlet implements RowOutlet {
 
 // @public
 export class HeaderRowOutlet implements RowOutlet {
-    constructor(...args: unknown[]);
+    constructor();
     // (undocumented)
     elementRef: ElementRef<any>;
     // (undocumented)
@@ -468,7 +459,7 @@ export class HeaderRowOutlet implements RowOutlet {
 
 // @public
 export class NoDataRowOutlet implements RowOutlet {
-    constructor(...args: unknown[]);
+    constructor();
     // (undocumented)
     elementRef: ElementRef<any>;
     // (undocumented)

--- a/goldens/cdk/text-field/index.api.md
+++ b/goldens/cdk/text-field/index.api.md
@@ -21,7 +21,6 @@ export type AutofillEvent = {
 
 // @public
 export class AutofillMonitor implements OnDestroy {
-    constructor(...args: unknown[]);
     monitor(element: Element): Observable<AutofillEvent>;
     monitor(element: ElementRef<Element>): Observable<AutofillEvent>;
     // (undocumented)
@@ -36,7 +35,6 @@ export class AutofillMonitor implements OnDestroy {
 
 // @public
 export class CdkAutofill implements OnDestroy, OnInit {
-    constructor(...args: unknown[]);
     readonly cdkAutofill: EventEmitter<AutofillEvent>;
     // (undocumented)
     ngOnDestroy(): void;
@@ -50,7 +48,7 @@ export class CdkAutofill implements OnDestroy, OnInit {
 
 // @public
 export class CdkTextareaAutosize implements AfterViewInit, DoCheck, OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     protected _document: Document;
     get enabled(): boolean;
     set enabled(value: boolean);

--- a/goldens/cdk/tree/index.api.md
+++ b/goldens/cdk/tree/index.api.md
@@ -50,7 +50,6 @@ export const CDK_TREE_NODE_OUTLET_NODE: InjectionToken<{}>;
 
 // @public
 export class CdkNestedTreeNode<T, K = T> extends CdkTreeNode<T, K> implements AfterContentInit, OnDestroy {
-    constructor(...args: unknown[]);
     protected _children: T[];
     protected _clear(): void;
     // (undocumented)
@@ -71,7 +70,6 @@ export class CdkNestedTreeNode<T, K = T> extends CdkTreeNode<T, K> implements Af
 
 // @public
 export class CdkTree<T, K = T> implements AfterContentChecked, AfterContentInit, AfterViewInit, CollectionViewer, OnDestroy, OnInit {
-    constructor(...args: unknown[]);
     childrenAccessor?: (dataNode: T) => T[] | Observable<T[]>;
     collapse(dataNode: T): void;
     collapseAll(): void;
@@ -142,7 +140,7 @@ export class CdkTreeModule {
 
 // @public
 export class CdkTreeNode<T, K = T> implements OnDestroy, OnInit, TreeKeyManagerItem {
-    constructor(...args: unknown[]);
+    constructor();
     activate(): void;
     readonly activation: EventEmitter<T>;
     collapse(): void;
@@ -212,7 +210,6 @@ export class CdkTreeNode<T, K = T> implements OnDestroy, OnInit, TreeKeyManagerI
 
 // @public
 export class CdkTreeNodeDef<T> {
-    constructor(...args: unknown[]);
     template: TemplateRef<any>;
     when: (index: number, nodeData: T) => boolean;
     // (undocumented)
@@ -223,7 +220,6 @@ export class CdkTreeNodeDef<T> {
 
 // @public
 export class CdkTreeNodeOutlet {
-    constructor(...args: unknown[]);
     // (undocumented)
     _node?: {} | null | undefined;
     // (undocumented)
@@ -245,7 +241,7 @@ export class CdkTreeNodeOutletContext<T> {
 
 // @public
 export class CdkTreeNodePadding<T, K = T> implements OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     get indent(): number | string;
     set indent(indent: number | string);
     // (undocumented)
@@ -272,7 +268,6 @@ export class CdkTreeNodePadding<T, K = T> implements OnDestroy {
 
 // @public
 export class CdkTreeNodeToggle<T, K = T> {
-    constructor(...args: unknown[]);
     // (undocumented)
     static ngAcceptInputType_recursive: unknown;
     recursive: boolean;

--- a/goldens/google-maps/index.api.md
+++ b/goldens/google-maps/index.api.md
@@ -131,7 +131,6 @@ export const defaultOnClusterClickHandler: onClusterClickHandler;
 
 // @public @deprecated
 export class DeprecatedMapMarkerClusterer implements OnInit, AfterContentInit, OnChanges, OnDestroy {
-    constructor(...args: unknown[]);
     // (undocumented)
     ariaLabelFn: AriaLabelFn;
     // (undocumented)
@@ -233,7 +232,7 @@ export class DeprecatedMapMarkerClusterer implements OnInit, AfterContentInit, O
 
 // @public
 export class GoogleMap implements OnChanges, OnInit, OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     readonly authFailure: EventEmitter<void>;
     readonly boundsChanged: Observable<void>;
     // (undocumented)
@@ -311,7 +310,6 @@ export type HeatmapData = google.maps.MVCArray<google.maps.LatLng | google.maps.
 
 // @public
 export class MapAdvancedMarker implements OnInit, OnChanges, OnDestroy, MapAnchorPoint, MarkerDirective {
-    constructor(...args: unknown[]);
     advancedMarker: google.maps.marker.AdvancedMarkerElement;
     set content(content: Node | google.maps.marker.PinElement | null);
     // (undocumented)
@@ -352,7 +350,6 @@ export interface MapAnchorPoint {
 
 // @public (undocumented)
 export class MapBaseLayer implements OnInit, OnDestroy {
-    constructor(...args: unknown[]);
     // (undocumented)
     protected _initializeObject(): void;
     // (undocumented)
@@ -389,7 +386,6 @@ export class MapBicyclingLayer implements OnInit, OnDestroy {
 
 // @public
 export class MapCircle implements OnInit, OnDestroy {
-    constructor(...args: unknown[]);
     // (undocumented)
     set center(center: google.maps.LatLng | google.maps.LatLngLiteral);
     // (undocumented)
@@ -448,7 +444,6 @@ export class MapCircle implements OnInit, OnDestroy {
 
 // @public
 export class MapDirectionsRenderer implements OnInit, OnChanges, OnDestroy {
-    constructor(...args: unknown[]);
     set directions(directions: google.maps.DirectionsResult);
     readonly directionsChanged: Observable<void>;
     directionsRenderer?: google.maps.DirectionsRenderer;
@@ -479,7 +474,6 @@ export interface MapDirectionsResponse {
 
 // @public
 export class MapDirectionsService {
-    constructor(...args: unknown[]);
     route(request: google.maps.DirectionsRequest): Observable<MapDirectionsResponse>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MapDirectionsService, never>;
@@ -497,7 +491,6 @@ export class MapEventManager {
 
 // @public
 export class MapGeocoder {
-    constructor(...args: unknown[]);
     geocode(request: google.maps.GeocoderRequest): Observable<MapGeocoderResponse>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MapGeocoder, never>;
@@ -515,7 +508,6 @@ export interface MapGeocoderResponse {
 
 // @public
 export class MapGroundOverlay implements OnInit, OnDestroy {
-    constructor(...args: unknown[]);
     get bounds(): google.maps.LatLngBounds | google.maps.LatLngBoundsLiteral;
     set bounds(bounds: google.maps.LatLngBounds | google.maps.LatLngBoundsLiteral);
     clickable: boolean;
@@ -540,7 +532,6 @@ export class MapGroundOverlay implements OnInit, OnDestroy {
 
 // @public
 export class MapHeatmapLayer implements OnInit, OnChanges, OnDestroy {
-    constructor(...args: unknown[]);
     set data(data: HeatmapData);
     getData(): HeatmapData;
     heatmap?: google.maps.visualization.HeatmapLayer;
@@ -560,7 +551,6 @@ export class MapHeatmapLayer implements OnInit, OnChanges, OnDestroy {
 
 // @public
 export class MapInfoWindow implements OnInit, OnDestroy {
-    constructor(...args: unknown[]);
     close(): void;
     readonly closeclick: Observable<void>;
     readonly contentChanged: Observable<void>;
@@ -591,7 +581,6 @@ export class MapInfoWindow implements OnInit, OnDestroy {
 
 // @public
 export class MapKmlLayer implements OnInit, OnDestroy {
-    constructor(...args: unknown[]);
     readonly defaultviewportChanged: Observable<void>;
     getDefaultViewport(): google.maps.LatLngBounds | null;
     getMetadata(): google.maps.KmlLayerMetadata | null;
@@ -618,7 +607,6 @@ export class MapKmlLayer implements OnInit, OnDestroy {
 
 // @public
 export class MapMarker implements OnInit, OnChanges, OnDestroy, MapAnchorPoint, MarkerDirective {
-    constructor(...args: unknown[]);
     readonly animationChanged: Observable<void>;
     set clickable(clickable: boolean);
     readonly clickableChanged: Observable<void>;
@@ -700,7 +688,6 @@ export class MapMarkerClusterer implements OnInit, OnChanges, OnDestroy {
 
 // @public
 export class MapPolygon implements OnInit, OnDestroy {
-    constructor(...args: unknown[]);
     getDraggable(): boolean;
     getEditable(): boolean;
     getPath(): google.maps.MVCArray<google.maps.LatLng>;
@@ -735,7 +722,6 @@ export class MapPolygon implements OnInit, OnDestroy {
 
 // @public
 export class MapPolyline implements OnInit, OnDestroy {
-    constructor(...args: unknown[]);
     getDraggable(): boolean;
     getEditable(): boolean;
     getPath(): google.maps.MVCArray<google.maps.LatLng>;
@@ -769,7 +755,6 @@ export class MapPolyline implements OnInit, OnDestroy {
 
 // @public
 export class MapRectangle implements OnInit, OnDestroy {
-    constructor(...args: unknown[]);
     // (undocumented)
     set bounds(bounds: google.maps.LatLngBounds | google.maps.LatLngBoundsLiteral);
     readonly boundsChanged: Observable<void>;
@@ -804,7 +789,6 @@ export class MapRectangle implements OnInit, OnDestroy {
 
 // @public
 export class MapTrafficLayer implements OnInit, OnDestroy {
-    constructor(...args: unknown[]);
     set autoRefresh(autoRefresh: boolean);
     // (undocumented)
     ngOnDestroy(): void;

--- a/goldens/material/autocomplete/index.api.md
+++ b/goldens/material/autocomplete/index.api.md
@@ -43,7 +43,7 @@ export const MAT_AUTOCOMPLETE_VALUE_ACCESSOR: any;
 
 // @public
 export class MatAutocomplete implements AfterContentInit, OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     // (undocumented)
     protected _animationsDisabled: boolean;
     ariaLabel: string;
@@ -136,7 +136,6 @@ export class MatAutocompleteModule {
 
 // @public
 export class MatAutocompleteOrigin {
-    constructor(...args: unknown[]);
     // (undocumented)
     elementRef: ElementRef<HTMLElement>;
     // (undocumented)
@@ -156,7 +155,6 @@ export class MatAutocompleteSelectedEvent {
 
 // @public
 export class MatAutocompleteTrigger implements ControlValueAccessor, AfterViewInit, OnChanges, OnDestroy {
-    constructor(...args: unknown[]);
     get activeOption(): MatOption | null;
     autocomplete: MatAutocomplete;
     autocompleteAttribute: string;
@@ -204,7 +202,7 @@ export class MatAutocompleteTrigger implements ControlValueAccessor, AfterViewIn
 
 // @public
 export class MatOptgroup {
-    constructor(...args: unknown[]);
+    constructor();
     disabled: boolean;
     _inert: boolean;
     label: string;
@@ -219,7 +217,7 @@ export class MatOptgroup {
 
 // @public
 export class MatOption<T = any> implements FocusableOption, AfterViewChecked, OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     get active(): boolean;
     // (undocumented)
     _changeDetectorRef: ChangeDetectorRef;

--- a/goldens/material/badge/index.api.md
+++ b/goldens/material/badge/index.api.md
@@ -13,7 +13,7 @@ import { OnInit } from '@angular/core';
 
 // @public
 export class MatBadge implements OnInit, AfterViewInit, OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     get color(): ThemePalette;
     set color(value: ThemePalette);
     get content(): string | number | undefined | null;

--- a/goldens/material/bottom-sheet/index.api.md
+++ b/goldens/material/bottom-sheet/index.api.md
@@ -34,7 +34,6 @@ export const MAT_BOTTOM_SHEET_DEFAULT_OPTIONS: InjectionToken<MatBottomSheetConf
 
 // @public
 export class MatBottomSheet implements OnDestroy {
-    constructor(...args: unknown[]);
     dismiss<R = any>(result?: R): void;
     // (undocumented)
     ngOnDestroy(): void;
@@ -71,7 +70,7 @@ export class MatBottomSheetConfig<D = any> {
 
 // @public
 export class MatBottomSheetContainer extends CdkDialogContainer implements OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     // (undocumented)
     protected _animationsDisabled: boolean;
     _animationState: 'void' | 'visible' | 'hidden';

--- a/goldens/material/button-toggle/index.api.md
+++ b/goldens/material/button-toggle/index.api.md
@@ -28,7 +28,7 @@ export const MAT_BUTTON_TOGGLE_GROUP_VALUE_ACCESSOR: any;
 
 // @public
 export class MatButtonToggle implements OnInit, AfterViewInit, OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     get appearance(): MatButtonToggleAppearance;
     set appearance(value: MatButtonToggleAppearance);
     ariaLabel: string;
@@ -96,7 +96,7 @@ export interface MatButtonToggleDefaultOptions {
 
 // @public
 export class MatButtonToggleGroup implements ControlValueAccessor, OnInit, AfterContentInit {
-    constructor(...args: unknown[]);
+    constructor();
     appearance: MatButtonToggleAppearance;
     _buttonToggles: QueryList<MatButtonToggle>;
     readonly change: EventEmitter<MatButtonToggleChange>;

--- a/goldens/material/button/index.api.md
+++ b/goldens/material/button/index.api.md
@@ -28,7 +28,7 @@ export type MatAnchor = MatButton;
 
 // @public
 export class MatButton extends MatButtonBase {
-    constructor(...args: unknown[]);
+    constructor();
     get appearance(): MatButtonAppearance | null;
     set appearance(value: MatButtonAppearance | '');
     setAppearance(appearance: MatButtonAppearance): void;
@@ -66,7 +66,7 @@ export type MatFabAnchor = MatFabButton;
 
 // @public
 export class MatFabButton extends MatButtonBase {
-    constructor(...args: unknown[]);
+    constructor();
     // (undocumented)
     extended: boolean;
     // (undocumented)
@@ -92,7 +92,7 @@ export type MatIconAnchor = MatIconButton;
 
 // @public
 export class MatIconButton extends MatButtonBase {
-    constructor(...args: unknown[]);
+    constructor();
     // (undocumented)
     static ɵcmp: i0.ɵɵComponentDeclaration<MatIconButton, "button[mat-icon-button], a[mat-icon-button], button[matIconButton], a[matIconButton]", ["matButton", "matAnchor"], {}, {}, never, ["*", "[progressIndicator]"], true, never>;
     // (undocumented)
@@ -107,7 +107,7 @@ export type MatMiniFabAnchor = MatMiniFabButton;
 
 // @public
 export class MatMiniFabButton extends MatButtonBase {
-    constructor(...args: unknown[]);
+    constructor();
     // (undocumented)
     _isFab: boolean;
     // (undocumented)

--- a/goldens/material/card/index.api.md
+++ b/goldens/material/card/index.api.md
@@ -13,7 +13,7 @@ export const MAT_CARD_CONFIG: InjectionToken<MatCardConfig>;
 
 // @public
 export class MatCard {
-    constructor(...args: unknown[]);
+    constructor();
     // (undocumented)
     appearance: MatCardAppearance;
     // (undocumented)

--- a/goldens/material/checkbox/index.api.md
+++ b/goldens/material/checkbox/index.api.md
@@ -23,7 +23,7 @@ export const MAT_CHECKBOX_DEFAULT_OPTIONS: InjectionToken<MatCheckboxDefaultOpti
 
 // @public (undocumented)
 export class MatCheckbox implements AfterViewInit, OnChanges, ControlValueAccessor, Validator, FocusableOption {
-    constructor(...args: unknown[]);
+    constructor();
     protected _animationClasses: {
         uncheckedToChecked: string;
         uncheckedToIndeterminate: string;

--- a/goldens/material/chips/index.api.md
+++ b/goldens/material/chips/index.api.md
@@ -53,7 +53,7 @@ export const MAT_CHIPS_DEFAULT_OPTIONS: InjectionToken<MatChipsDefaultOptions>;
 
 // @public
 export class MatChip implements OnInit, AfterViewInit, AfterContentInit, DoCheck, OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     protected _allEditIcons: QueryList<MatChipEdit>;
     protected _allLeadingIcons: QueryList<MatChipAvatar>;
     protected _allRemoveIcons: QueryList<MatChipRemove>;
@@ -163,7 +163,6 @@ export interface MatChipEditedEvent extends MatChipEvent {
 
 // @public
 export class MatChipEditInput {
-    constructor(...args: unknown[]);
     // (undocumented)
     getNativeElement(): HTMLElement;
     // (undocumented)
@@ -185,7 +184,7 @@ export interface MatChipEvent {
 
 // @public
 export class MatChipGrid extends MatChipSet implements AfterContentInit, AfterViewInit, ControlValueAccessor, DoCheck, MatFormFieldControl<any>, OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     protected _allowFocusEscape(): void;
     _blur(): void;
     readonly change: EventEmitter<MatChipGridChange>;
@@ -264,7 +263,7 @@ export class MatChipGridChange {
 
 // @public
 export class MatChipInput implements MatChipTextControl, OnChanges, OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     addOnBlur: boolean;
     _blur(): void;
     readonly chipEnd: EventEmitter<MatChipInputEvent>;
@@ -436,7 +435,7 @@ export class MatChipRemove extends MatChipAction {
 
 // @public
 export class MatChipRow extends MatChip implements AfterViewInit, OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     // (undocumented)
     protected basicChipAttrName: string;
     contentEditInput?: MatChipEditInput;
@@ -491,7 +490,6 @@ export class MatChipSelectionChange {
 
 // @public
 export class MatChipSet implements AfterViewInit, OnDestroy {
-    constructor(...args: unknown[]);
     protected _allowFocusEscape(): void;
     // (undocumented)
     protected _changeDetectorRef: ChangeDetectorRef;

--- a/goldens/material/core/index.api.md
+++ b/goldens/material/core/index.api.md
@@ -193,7 +193,7 @@ export class MatNativeDateModule {
 
 // @public
 export class MatOptgroup {
-    constructor(...args: unknown[]);
+    constructor();
     disabled: boolean;
     _inert: boolean;
     label: string;
@@ -208,7 +208,7 @@ export class MatOptgroup {
 
 // @public
 export class MatOption<T = any> implements FocusableOption, AfterViewChecked, OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     get active(): boolean;
     // (undocumented)
     _changeDetectorRef: ChangeDetectorRef;
@@ -281,7 +281,6 @@ export class MatOptionSelectionChange<T = any> {
 
 // @public
 export class MatPseudoCheckbox {
-    constructor(...args: unknown[]);
     // (undocumented)
     _animationsDisabled: boolean;
     appearance: 'minimal' | 'full';
@@ -308,7 +307,7 @@ export type MatPseudoCheckboxState = 'unchecked' | 'checked' | 'indeterminate';
 
 // @public (undocumented)
 export class MatRipple implements OnInit, OnDestroy, RippleTarget {
-    constructor(...args: unknown[]);
+    constructor();
     animation: RippleAnimationConfig;
     centered: boolean;
     color: string;
@@ -366,7 +365,7 @@ export class MatRippleModule {
 
 // @public
 export class NativeDateAdapter extends DateAdapter<Date> {
-    constructor(...args: unknown[]);
+    constructor();
     // (undocumented)
     addCalendarDays(date: Date, days: number): Date;
     // (undocumented)

--- a/goldens/material/datepicker/index.api.md
+++ b/goldens/material/datepicker/index.api.md
@@ -99,7 +99,7 @@ export const MAT_DATEPICKER_VALUE_ACCESSOR: any;
 
 // @public
 export class MatCalendar<D> implements AfterContentInit, AfterViewChecked, OnDestroy, OnChanges {
-    constructor(...args: unknown[]);
+    constructor();
     get activeDate(): D;
     set activeDate(value: D);
     protected _activeDrag: MatCalendarUserEvent<D> | null;
@@ -156,7 +156,7 @@ export class MatCalendar<D> implements AfterContentInit, AfterViewChecked, OnDes
 
 // @public
 export class MatCalendarBody<D = any> implements OnChanges, OnDestroy, AfterViewChecked {
-    constructor(...args: unknown[]);
+    constructor();
     activeCell: number;
     // (undocumented)
     readonly activeDateChange: EventEmitter<MatCalendarUserEvent<number>>;
@@ -250,7 +250,7 @@ export type MatCalendarCellCssClasses = string | string[] | Set<string> | Record
 
 // @public
 export class MatCalendarHeader<D> {
-    constructor(...args: unknown[]);
+    constructor();
     // (undocumented)
     calendar: MatCalendar<D>;
     currentPeriodClicked(): void;
@@ -292,7 +292,6 @@ export class MatDatepicker<D> extends MatDatepickerBase<MatDatepickerControl<D>,
 
 // @public
 export class MatDatepickerActions implements AfterViewInit, OnDestroy {
-    constructor(...args: unknown[]);
     // (undocumented)
     ngAfterViewInit(): void;
     // (undocumented)
@@ -307,7 +306,6 @@ export class MatDatepickerActions implements AfterViewInit, OnDestroy {
 
 // @public
 export class MatDatepickerApply {
-    constructor(...args: unknown[]);
     // (undocumented)
     _applySelection(): void;
     // (undocumented)
@@ -318,7 +316,6 @@ export class MatDatepickerApply {
 
 // @public
 export class MatDatepickerCancel {
-    constructor(...args: unknown[]);
     // (undocumented)
     _datepicker: MatDatepickerBase<MatDatepickerControl<any>, unknown, {}>;
     // (undocumented)
@@ -329,7 +326,7 @@ export class MatDatepickerCancel {
 
 // @public
 export class MatDatepickerContent<S, D = ExtractDateTypeFromSelection<S>> implements AfterViewInit, OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     _actionsPortal: TemplatePortal | null;
     readonly _animationDone: Subject<void>;
     // (undocumented)
@@ -392,7 +389,7 @@ export interface MatDatepickerControl<D> {
 
 // @public
 export class MatDatepickerInput<D> extends MatDatepickerInputBase<D | null, D> implements MatDatepickerControl<D | null>, OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     protected _ariaOwns: i0.WritableSignal<string | null>;
     // (undocumented)
     protected _assignValueToModel(value: D | null): void;
@@ -489,7 +486,7 @@ export interface MatDatepickerPanel<C extends MatDatepickerControl<D>, S, D = Ex
 
 // @public (undocumented)
 export class MatDatepickerToggle<D> implements AfterContentInit, OnChanges, OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     ariaLabel: string;
     _button: MatButton;
     _customIcon: MatDatepickerToggleIcon;
@@ -526,7 +523,7 @@ export class MatDatepickerToggleIcon {
 
 // @public (undocumented)
 export class MatDateRangeInput<D> implements MatFormFieldControl<DateRange<D>>, MatDatepickerControl<D>, MatDateRangePickerInput<D>, AfterContentInit, OnChanges, OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     _ariaDescribedBy: string | null;
     _ariaOwns: i0.WritableSignal<string | null>;
     comparisonEnd: D | null;
@@ -657,7 +654,7 @@ export class MatEndDate<D> extends MatDateRangeInputPartBase<D> {
 
 // @public
 export class MatMonthView<D> implements AfterContentInit, OnChanges, OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     get activeDate(): D;
     set activeDate(value: D);
     readonly activeDateChange: EventEmitter<D>;
@@ -722,7 +719,7 @@ export class MatMonthView<D> implements AfterContentInit, OnChanges, OnDestroy {
 
 // @public
 export class MatMultiYearView<D> implements AfterContentInit, OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     get activeDate(): D;
     set activeDate(value: D);
     readonly activeDateChange: EventEmitter<D>;
@@ -809,7 +806,7 @@ export class MatStartDate<D> extends MatDateRangeInputPartBase<D> {
 
 // @public
 export class MatYearView<D> implements AfterContentInit, OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     get activeDate(): D;
     set activeDate(value: D);
     readonly activeDateChange: EventEmitter<D>;

--- a/goldens/material/dialog/index.api.md
+++ b/goldens/material/dialog/index.api.md
@@ -61,7 +61,7 @@ export const MAT_DIALOG_SCROLL_STRATEGY: InjectionToken<() => ScrollStrategy>;
 
 // @public
 export class MatDialog implements OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     readonly afterAllClosed: Observable<void>;
     get afterOpened(): Subject<MatDialogRef<any>>;
     closeAll(): void;
@@ -98,7 +98,6 @@ export class MatDialogActions extends MatDialogLayoutSection {
 
 // @public
 export class MatDialogClose implements OnInit, OnChanges {
-    constructor(...args: unknown[]);
     ariaLabel: string;
     // (undocumented)
     dialogRef: MatDialogRef<any, any>;

--- a/goldens/material/dialog/testing/index.api.md
+++ b/goldens/material/dialog/testing/index.api.md
@@ -66,7 +66,7 @@ export enum MatDialogSection {
 
 // @public
 export class MatTestDialogOpener<T = unknown, R = unknown> implements OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     closedResult: R | undefined;
     protected static component: ComponentType<unknown> | undefined;
     protected static config: MatDialogConfig | undefined;

--- a/goldens/material/expansion/index.api.md
+++ b/goldens/material/expansion/index.api.md
@@ -82,7 +82,7 @@ export class MatExpansionModule {
 
 // @public
 export class MatExpansionPanel extends CdkAccordionItem implements AfterContentInit, OnChanges, OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     accordion: MatAccordionBase;
     readonly afterCollapse: EventEmitter<void>;
     readonly afterExpand: EventEmitter<void>;
@@ -156,7 +156,6 @@ export class MatExpansionPanelActionRow {
 
 // @public
 export class MatExpansionPanelContent {
-    constructor(...args: unknown[]);
     // (undocumented)
     _expansionPanel: MatExpansionPanelBase | null;
     // (undocumented)
@@ -184,7 +183,7 @@ export class MatExpansionPanelDescription {
 
 // @public
 export class MatExpansionPanelHeader implements AfterViewInit, OnDestroy, FocusableOption {
-    constructor(...args: unknown[]);
+    constructor();
     collapsedHeight: string;
     get disabled(): boolean;
     expandedHeight: string;

--- a/goldens/material/form-field/index.api.md
+++ b/goldens/material/form-field/index.api.md
@@ -48,7 +48,6 @@ export const MAT_SUFFIX: InjectionToken<MatSuffix>;
 
 // @public
 export class MatError {
-    constructor(...args: unknown[]);
     // (undocumented)
     id: string;
     // (undocumented)
@@ -59,7 +58,7 @@ export class MatError {
 
 // @public
 export class MatFormField implements FloatingLabelParent, AfterContentInit, AfterContentChecked, AfterViewInit, OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     _animateAndLockLabel(): void;
     // (undocumented)
     protected readonly _animationsDisabled: boolean;

--- a/goldens/material/grid-list/index.api.md
+++ b/goldens/material/grid-list/index.api.md
@@ -22,7 +22,6 @@ export class MatGridAvatarCssMatStyler {
 
 // @public (undocumented)
 export class MatGridList implements MatGridListBase, OnInit, AfterContentChecked, TileStyleTarget {
-    constructor(...args: unknown[]);
     get cols(): number;
     set cols(value: NumberInput);
     get gutterSize(): string;
@@ -52,7 +51,6 @@ export class MatGridListModule {
 
 // @public (undocumented)
 export class MatGridTile {
-    constructor(...args: unknown[]);
     get colspan(): number;
     set colspan(value: NumberInput);
     // (undocumented)
@@ -88,7 +86,6 @@ export class MatGridTileHeaderCssMatStyler {
 
 // @public (undocumented)
 export class MatGridTileText implements AfterContentInit {
-    constructor(...args: unknown[]);
     // (undocumented)
     _lines: QueryList<MatLine>;
     // (undocumented)

--- a/goldens/material/icon/index.api.md
+++ b/goldens/material/icon/index.api.md
@@ -47,7 +47,7 @@ export const MAT_ICON_LOCATION: InjectionToken<MatIconLocation>;
 
 // @public
 export class MatIcon implements OnInit, AfterViewChecked, OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     get color(): string | null | undefined;
     set color(value: string | null | undefined);
     // (undocumented)

--- a/goldens/material/input/index.api.md
+++ b/goldens/material/input/index.api.md
@@ -41,7 +41,6 @@ export const MAT_INPUT_VALUE_ACCESSOR: InjectionToken<{
 
 // @public
 export class MatError {
-    constructor(...args: unknown[]);
     // (undocumented)
     id: string;
     // (undocumented)
@@ -52,7 +51,7 @@ export class MatError {
 
 // @public
 export class MatFormField implements FloatingLabelParent, AfterContentInit, AfterContentChecked, AfterViewInit, OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     _animateAndLockLabel(): void;
     // (undocumented)
     protected readonly _animationsDisabled: boolean;
@@ -149,7 +148,7 @@ export class MatHint {
 
 // @public (undocumented)
 export class MatInput implements MatFormFieldControl_2<any>, OnChanges, OnDestroy, AfterViewInit, DoCheck {
-    constructor(...args: unknown[]);
+    constructor();
     autofilled: boolean;
     controlType: string;
     get describedByIds(): string[];

--- a/goldens/material/list/index.api.md
+++ b/goldens/material/list/index.api.md
@@ -103,7 +103,6 @@ export class MatListItemAvatar extends _MatListItemGraphicBase {
 
 // @public
 export class _MatListItemGraphicBase {
-    constructor(...args: unknown[]);
     // (undocumented)
     _isAlignedAtStart(): boolean;
     // (undocumented)
@@ -124,7 +123,6 @@ export class MatListItemIcon extends _MatListItemGraphicBase {
 
 // @public
 export class MatListItemLine {
-    constructor(...args: unknown[]);
     // (undocumented)
     _elementRef: ElementRef<HTMLElement>;
     // (undocumented)
@@ -143,7 +141,6 @@ export class MatListItemMeta {
 
 // @public
 export class MatListItemTitle {
-    constructor(...args: unknown[]);
     // (undocumented)
     _elementRef: ElementRef<HTMLElement>;
     // (undocumented)
@@ -234,7 +231,7 @@ export class MatNavList extends MatListBase {
 
 // @public (undocumented)
 export class MatSelectionList extends MatListBase implements SelectionList, ControlValueAccessor, AfterViewInit, OnChanges, OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     color: ThemePalette;
     compareWith: (o1: any, o2: any) => boolean;
     deselectAll(): MatListOption[];

--- a/goldens/material/menu/index.api.md
+++ b/goldens/material/menu/index.api.md
@@ -75,7 +75,7 @@ export class MatContextMenuTrigger extends MatMenuTriggerBase implements OnDestr
 
 // @public (undocumented)
 export class MatMenu implements AfterContentInit, MatMenuPanel<MatMenuItem>, OnInit, OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     // (undocumented)
     addItem(_item: MatMenuItem): void;
     _allItems: QueryList<MatMenuItem>;
@@ -145,7 +145,6 @@ export class MatMenu implements AfterContentInit, MatMenuPanel<MatMenuItem>, OnI
 
 // @public
 export class MatMenuContent implements OnDestroy {
-    constructor(...args: unknown[]);
     attach(context?: any): void;
     readonly _attached: Subject<void>;
     detach(): void;
@@ -169,7 +168,7 @@ export interface MatMenuDefaultOptions {
 
 // @public
 export class MatMenuItem implements FocusableOption, AfterViewInit, OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     _checkDisabled(event: Event): void;
     disabled: boolean;
     disableRipple: boolean;
@@ -257,7 +256,7 @@ export interface MatMenuPanel<T = any> {
 
 // @public
 export class MatMenuTrigger extends MatMenuTriggerBase implements AfterContentInit, OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     closeMenu(): void;
     // @deprecated (undocumented)
     get _deprecatedMatMenuTriggerFor(): MatMenuPanel | null;

--- a/goldens/material/paginator/index.api.md
+++ b/goldens/material/paginator/index.api.md
@@ -55,7 +55,7 @@ export const MAT_PAGINATOR_DEFAULT_OPTIONS: InjectionToken<MatPaginatorDefaultOp
 
 // @public
 export class MatPaginator implements OnInit, OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     protected _buttonClicked(targetIndex: number, isDisabled: boolean): void;
     _changePageSize(pageSize: number): void;
     color: ThemePalette;

--- a/goldens/material/progress-bar/index.api.md
+++ b/goldens/material/progress-bar/index.api.md
@@ -20,7 +20,7 @@ export const MAT_PROGRESS_BAR_LOCATION: InjectionToken<MatProgressBarLocation>;
 
 // @public (undocumented)
 export class MatProgressBar implements AfterViewInit, OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     readonly animationEnd: EventEmitter<ProgressAnimationEnd>;
     get bufferValue(): number;
     set bufferValue(v: number);

--- a/goldens/material/progress-spinner/index.api.md
+++ b/goldens/material/progress-spinner/index.api.md
@@ -14,7 +14,7 @@ export const MAT_PROGRESS_SPINNER_DEFAULT_OPTIONS: InjectionToken<MatProgressSpi
 
 // @public (undocumented)
 export class MatProgressSpinner {
-    constructor(...args: unknown[]);
+    constructor();
     _circleRadius(): number;
     _circleStrokeWidth(): number;
     get color(): string | null | undefined;

--- a/goldens/material/radio/index.api.md
+++ b/goldens/material/radio/index.api.md
@@ -29,7 +29,7 @@ export const MAT_RADIO_GROUP_CONTROL_VALUE_ACCESSOR: any;
 
 // @public (undocumented)
 export class MatRadioButton implements OnInit, AfterViewInit, DoCheck, OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     ariaDescribedby: string | null;
     ariaLabel: string | null;
     ariaLabelledby: string | null;
@@ -109,7 +109,6 @@ export interface MatRadioDefaultOptions {
 
 // @public
 export class MatRadioGroup implements AfterContentInit, OnDestroy, ControlValueAccessor {
-    constructor(...args: unknown[]);
     readonly change: EventEmitter<MatRadioChange>;
     // (undocumented)
     _checkSelectedRadioButton(): void;

--- a/goldens/material/select/index.api.md
+++ b/goldens/material/select/index.api.md
@@ -54,7 +54,6 @@ export const MAT_SELECT_TRIGGER: InjectionToken<MatSelectTrigger>;
 
 // @public
 export class MatError {
-    constructor(...args: unknown[]);
     // (undocumented)
     id: string;
     // (undocumented)
@@ -65,7 +64,7 @@ export class MatError {
 
 // @public
 export class MatFormField implements FloatingLabelParent, AfterContentInit, AfterContentChecked, AfterViewInit, OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     _animateAndLockLabel(): void;
     // (undocumented)
     protected readonly _animationsDisabled: boolean;
@@ -170,7 +169,7 @@ export class MatLabel {
 
 // @public
 export class MatOptgroup {
-    constructor(...args: unknown[]);
+    constructor();
     disabled: boolean;
     _inert: boolean;
     label: string;
@@ -185,7 +184,7 @@ export class MatOptgroup {
 
 // @public
 export class MatOption<T = any> implements FocusableOption, AfterViewChecked, OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     get active(): boolean;
     // (undocumented)
     _changeDetectorRef: ChangeDetectorRef;
@@ -239,7 +238,7 @@ export class MatPrefix {
 
 // @public (undocumented)
 export class MatSelect implements AfterContentInit, OnChanges, OnDestroy, OnInit, DoCheck, ControlValueAccessor, MatFormFieldControl_2<any> {
-    constructor(...args: unknown[]);
+    constructor();
     // (undocumented)
     protected _animationsDisabled: boolean;
     ariaLabel: string;

--- a/goldens/material/sidenav/index.api.md
+++ b/goldens/material/sidenav/index.api.md
@@ -27,7 +27,7 @@ export const MAT_DRAWER_DEFAULT_AUTOSIZE: InjectionToken<boolean>;
 
 // @public
 export class MatDrawer implements AfterViewInit, OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     readonly _animationEnd: Subject<unknown>;
     readonly _animationStarted: Subject<unknown>;
     get autoFocus(): AutoFocusTarget | string | boolean;
@@ -68,7 +68,7 @@ export class MatDrawer implements AfterViewInit, OnDestroy {
 
 // @public
 export class MatDrawerContainer implements AfterContentInit, DoCheck, OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     _allDrawers: QueryList<MatDrawer>;
     get autosize(): boolean;
     set autosize(value: BooleanInput);
@@ -119,7 +119,6 @@ export class MatDrawerContainer implements AfterContentInit, DoCheck, OnDestroy 
 
 // @public (undocumented)
 export class MatDrawerContent extends CdkScrollable implements AfterContentInit {
-    constructor(...args: unknown[]);
     // (undocumented)
     _container: MatDrawerContainer;
     // (undocumented)

--- a/goldens/material/slide-toggle/index.api.md
+++ b/goldens/material/slide-toggle/index.api.md
@@ -25,7 +25,7 @@ export const MAT_SLIDE_TOGGLE_DEFAULT_OPTIONS: InjectionToken<MatSlideToggleDefa
 
 // @public (undocumented)
 export class MatSlideToggle implements OnDestroy, AfterContentInit, OnChanges, ControlValueAccessor, Validator {
-    constructor(...args: unknown[]);
+    constructor();
     ariaDescribedby: string;
     ariaLabel: string | null;
     ariaLabelledby: string | null;

--- a/goldens/material/slider/index.api.md
+++ b/goldens/material/slider/index.api.md
@@ -22,7 +22,7 @@ import { WritableSignal } from '@angular/core';
 
 // @public
 export class MatSlider implements AfterViewInit, OnDestroy, _MatSlider {
-    constructor(...args: unknown[]);
+    constructor();
     // (undocumented)
     _cachedLeft: number;
     // (undocumented)
@@ -152,7 +152,7 @@ export class MatSliderModule {
 
 // @public (undocumented)
 export class MatSliderRangeThumb extends MatSliderThumb implements _MatSliderRangeThumb {
-    constructor(...args: unknown[]);
+    constructor();
     // (undocumented)
     readonly _cdr: ChangeDetectorRef;
     // (undocumented)
@@ -197,7 +197,7 @@ export class MatSliderRangeThumb extends MatSliderThumb implements _MatSliderRan
 
 // @public
 export class MatSliderThumb implements _MatSliderThumb, OnDestroy, ControlValueAccessor {
-    constructor(...args: unknown[]);
+    constructor();
     // (undocumented)
     blur(): void;
     // (undocumented)
@@ -301,7 +301,6 @@ export class MatSliderThumb implements _MatSliderThumb, OnDestroy, ControlValueA
 
 // @public
 export class MatSliderVisualThumb implements _MatSliderVisualThumb, AfterViewInit, OnDestroy {
-    constructor(...args: unknown[]);
     // (undocumented)
     readonly _cdr: ChangeDetectorRef;
     discrete: boolean;

--- a/goldens/material/snack-bar/index.api.md
+++ b/goldens/material/snack-bar/index.api.md
@@ -39,7 +39,6 @@ export const MAT_SNACK_BAR_DEFAULT_OPTIONS: InjectionToken<MatSnackBarConfig<any
 
 // @public
 export class MatSnackBar implements OnDestroy {
-    constructor(...args: unknown[]);
     dismiss(): void;
     handsetCssClass: string;
     // (undocumented)
@@ -88,7 +87,7 @@ export class MatSnackBarConfig<D = any> {
 
 // @public
 export class MatSnackBarContainer extends BasePortalOutlet implements OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     // (undocumented)
     protected _animationsDisabled: boolean;
     _animationState: string;
@@ -165,7 +164,6 @@ export type MatSnackBarVerticalPosition = 'top' | 'bottom';
 
 // @public (undocumented)
 export class SimpleSnackBar implements TextOnlySnackBar {
-    constructor(...args: unknown[]);
     action(): void;
     // (undocumented)
     data: any;

--- a/goldens/material/sort/index.api.md
+++ b/goldens/material/sort/index.api.md
@@ -77,7 +77,7 @@ export interface MatSortDefaultOptions {
 
 // @public
 export class MatSortHeader implements MatSortable, OnDestroy, OnInit, AfterViewInit {
-    constructor(...args: unknown[]);
+    constructor();
     // (undocumented)
     protected _animationsDisabled: boolean;
     arrowPosition: SortHeaderArrowPosition;

--- a/goldens/material/stepper/index.api.md
+++ b/goldens/material/stepper/index.api.md
@@ -51,7 +51,6 @@ export class MatStep extends CdkStep implements ErrorStateMatcher, AfterContentI
 
 // @public
 export class MatStepContent<C = unknown> {
-    constructor(...args: unknown[]);
     // (undocumented)
     _template: TemplateRef<C>;
     // (undocumented)
@@ -62,7 +61,7 @@ export class MatStepContent<C = unknown> {
 
 // @public (undocumented)
 export class MatStepHeader extends CdkStepHeader implements AfterViewInit, OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     active: boolean;
     color: ThemePalette;
     disableRipple: boolean;
@@ -109,7 +108,7 @@ export class MatStepLabel extends CdkStepLabel {
 
 // @public (undocumented)
 export class MatStepper extends CdkStepper implements AfterViewInit, AfterContentInit, OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     _animatedContainers: QueryList<ElementRef>;
     readonly animationDone: EventEmitter<void>;
     get animationDuration(): string;
@@ -143,7 +142,6 @@ export class MatStepper extends CdkStepper implements AfterViewInit, AfterConten
 
 // @public
 export class MatStepperIcon {
-    constructor(...args: unknown[]);
     name: StepState;
     // (undocumented)
     templateRef: TemplateRef<MatStepperIconContext>;

--- a/goldens/material/tabs/index.api.md
+++ b/goldens/material/tabs/index.api.md
@@ -65,7 +65,7 @@ export interface _MatInkBarPositioner {
 
 // @public
 export abstract class MatPaginatedTabHeader implements AfterContentChecked, AfterContentInit, AfterViewInit, OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     _alignInkBarToSelectedTab(): void;
     // (undocumented)
     _animationsDisabled: boolean;
@@ -143,7 +143,7 @@ export abstract class MatPaginatedTabHeader implements AfterContentChecked, Afte
 
 // @public (undocumented)
 export class MatTab implements OnInit, OnChanges, OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     ariaLabel: string;
     ariaLabelledby: string;
     bodyClass: string | string[];
@@ -177,7 +177,7 @@ export class MatTab implements OnInit, OnChanges, OnDestroy {
 
 // @public
 export class MatTabBody implements OnInit, OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     readonly _afterLeavingCenter: EventEmitter<void>;
     animationDuration: string;
     readonly _beforeCentering: EventEmitter<boolean>;
@@ -208,7 +208,6 @@ export type MatTabBodyOriginState = 'left' | 'right';
 
 // @public
 export class MatTabBodyPortal extends CdkPortalOutlet implements OnInit, OnDestroy {
-    constructor(...args: unknown[]);
     ngOnDestroy(): void;
     ngOnInit(): void;
     // (undocumented)
@@ -228,7 +227,6 @@ export class MatTabChangeEvent {
 
 // @public
 export class MatTabContent {
-    constructor(...args: unknown[]);
     // (undocumented)
     template: TemplateRef<any>;
     // (undocumented)
@@ -239,7 +237,7 @@ export class MatTabContent {
 
 // @public
 export class MatTabGroup implements AfterViewInit, AfterContentInit, AfterContentChecked, OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     alignTabs: string | null;
     _allTabs: QueryList<MatTab>;
     readonly animationDone: EventEmitter<void>;
@@ -398,7 +396,7 @@ export class MatTabLabelWrapper extends InkBarItem {
 
 // @public
 export class MatTabLink extends InkBarItem implements AfterViewInit, OnDestroy, RippleTarget, FocusableOption {
-    constructor(...args: unknown[]);
+    constructor();
     get active(): boolean;
     set active(value: boolean);
     disabled: boolean;
@@ -447,7 +445,7 @@ export class MatTabLink extends InkBarItem implements AfterViewInit, OnDestroy, 
 
 // @public
 export class MatTabNav extends MatPaginatedTabHeader implements AfterContentInit, AfterViewInit {
-    constructor(...args: unknown[]);
+    constructor();
     // (undocumented)
     get animationDuration(): string;
     set animationDuration(value: string | number);

--- a/goldens/material/toolbar/index.api.md
+++ b/goldens/material/toolbar/index.api.md
@@ -12,7 +12,6 @@ import { QueryList } from '@angular/core';
 
 // @public (undocumented)
 export class MatToolbar implements AfterViewInit {
-    constructor(...args: unknown[]);
     color?: string | null;
     // (undocumented)
     protected _elementRef: ElementRef<any>;

--- a/goldens/material/tooltip/index.api.md
+++ b/goldens/material/tooltip/index.api.md
@@ -34,7 +34,7 @@ export const MAT_TOOLTIP_SCROLL_STRATEGY: InjectionToken<() => ScrollStrategy>;
 
 // @public
 export class MatTooltip implements OnDestroy, AfterViewInit {
-    constructor(...args: unknown[]);
+    constructor();
     protected _addOffset(position: ConnectedPosition): ConnectedPosition;
     // (undocumented)
     protected _dir: Directionality;
@@ -122,7 +122,6 @@ export const TOOLTIP_PANEL_CLASS = "mat-mdc-tooltip-panel";
 
 // @public
 export class TooltipComponent implements OnDestroy {
-    constructor(...args: unknown[]);
     afterHidden(): Observable<void>;
     _cancelPendingAnimations(): void;
     // (undocumented)

--- a/goldens/material/tree/index.api.md
+++ b/goldens/material/tree/index.api.md
@@ -112,7 +112,7 @@ export class MatTreeNestedDataSource<T> extends DataSource<T> {
 
 // @public
 export class MatTreeNode<T, K = T> extends CdkTreeNode<T, K> implements OnInit, OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     // @deprecated
     defaultTabIndex: number;
     // @deprecated

--- a/goldens/youtube-player/index.api.md
+++ b/goldens/youtube-player/index.api.md
@@ -23,7 +23,7 @@ export const YOUTUBE_PLAYER_CONFIG: InjectionToken<YouTubePlayerConfig>;
 
 // @public
 export class YouTubePlayer implements AfterViewInit, OnChanges, OnDestroy {
-    constructor(...args: unknown[]);
+    constructor();
     readonly apiChange: Observable<YT.PlayerEvent>;
     disableCookies: boolean;
     disablePlaceholder: boolean;

--- a/src/cdk-experimental/column-resize/coalesced-style-scheduler.ts
+++ b/src/cdk-experimental/column-resize/coalesced-style-scheduler.ts
@@ -33,9 +33,6 @@ export class _CoalescedStyleScheduler {
   private _currentSchedule: _Schedule | null = null;
   private _ngZone = inject(NgZone);
 
-  constructor(...args: unknown[]);
-  constructor() {}
-
   /**
    * Schedules the specified task to run at the end of the current VM turn.
    */

--- a/src/cdk/a11y/aria-describer/aria-describer.ts
+++ b/src/cdk/a11y/aria-describer/aria-describer.ts
@@ -66,8 +66,6 @@ export class AriaDescriber implements OnDestroy {
   /** Unique ID for the service. */
   private readonly _id = `${nextId++}`;
 
-  constructor(...args: unknown[]);
-
   constructor() {
     inject(_CdkPrivateStyleLoader).load(_VisuallyHiddenLoader);
     this._id = inject(APP_ID) + '-' + nextId++;

--- a/src/cdk/a11y/focus-monitor/focus-monitor.ts
+++ b/src/cdk/a11y/focus-monitor/focus-monitor.ts
@@ -147,8 +147,6 @@ export class FocusMonitor implements OnDestroy {
   /** Subject for stopping our InputModalityDetector subscription. */
   private readonly _stopInputModalityDetector = new Subject<void>();
 
-  constructor(...args: unknown[]);
-
   constructor() {
     const options = inject<FocusMonitorOptions | null>(FOCUS_MONITOR_DEFAULT_OPTIONS, {
       optional: true,
@@ -621,9 +619,6 @@ export class CdkMonitorFocus implements AfterViewInit, OnDestroy {
   private _focusOrigin: FocusOrigin = null;
 
   @Output() readonly cdkFocusChange = new EventEmitter<FocusOrigin>();
-
-  constructor(...args: unknown[]);
-  constructor() {}
 
   get focusOrigin(): FocusOrigin {
     return this._focusOrigin;

--- a/src/cdk/a11y/focus-trap/configurable-focus-trap-factory.ts
+++ b/src/cdk/a11y/focus-trap/configurable-focus-trap-factory.ts
@@ -26,8 +26,6 @@ export class ConfigurableFocusTrapFactory {
 
   private readonly _injector = inject(Injector);
 
-  constructor(...args: unknown[]);
-
   constructor() {
     const inertStrategy = inject(FOCUS_TRAP_INERT_STRATEGY, {optional: true});
 

--- a/src/cdk/a11y/focus-trap/focus-trap.ts
+++ b/src/cdk/a11y/focus-trap/focus-trap.ts
@@ -379,7 +379,6 @@ export class FocusTrapFactory {
   private _document = inject(DOCUMENT);
   private _injector = inject(Injector);
 
-  constructor(...args: unknown[]);
   constructor() {
     inject(_CdkPrivateStyleLoader).load(_VisuallyHiddenLoader);
   }
@@ -435,8 +434,6 @@ export class CdkTrapFocus implements OnDestroy, AfterContentInit, OnChanges, DoC
    */
   @Input({alias: 'cdkTrapFocusAutoCapture', transform: booleanAttribute})
   autoCapture: boolean = false;
-
-  constructor(...args: unknown[]);
 
   constructor() {
     const platform = inject(Platform);

--- a/src/cdk/a11y/high-contrast-mode/high-contrast-mode-detector.ts
+++ b/src/cdk/a11y/high-contrast-mode/high-contrast-mode-detector.ts
@@ -51,8 +51,6 @@ export class HighContrastModeDetector implements OnDestroy {
   private _document = inject(DOCUMENT);
   private _breakpointSubscription: Subscription;
 
-  constructor(...args: unknown[]);
-
   constructor() {
     this._breakpointSubscription = inject(BreakpointObserver)
       .observe('(forced-colors: active)')

--- a/src/cdk/a11y/input-modality/input-modality-detector.ts
+++ b/src/cdk/a11y/input-modality/input-modality-detector.ts
@@ -183,8 +183,6 @@ export class InputModalityDetector implements OnDestroy {
     this._mostRecentTarget = _getEventTarget(event);
   };
 
-  constructor(...args: unknown[]);
-
   constructor() {
     const ngZone = inject(NgZone);
     const document = inject<Document>(DOCUMENT);

--- a/src/cdk/a11y/interactivity-checker/interactivity-checker.ts
+++ b/src/cdk/a11y/interactivity-checker/interactivity-checker.ts
@@ -31,9 +31,6 @@ export class IsFocusableConfig {
 export class InteractivityChecker {
   private _platform = inject(Platform);
 
-  constructor(...args: unknown[]);
-  constructor() {}
-
   /**
    * Gets whether an element is disabled.
    *

--- a/src/cdk/a11y/live-announcer/live-announcer.ts
+++ b/src/cdk/a11y/live-announcer/live-announcer.ts
@@ -47,8 +47,6 @@ export class LiveAnnouncer implements OnDestroy {
   private _currentPromise: Promise<void> | undefined;
   private _currentResolve: (() => void) | undefined;
 
-  constructor(...args: unknown[]);
-
   constructor() {
     const elementToken = inject(LIVE_ANNOUNCER_ELEMENT_TOKEN, {optional: true});
     this._liveElement = elementToken || this._createLiveElement();
@@ -275,8 +273,6 @@ export class CdkAriaLive implements OnDestroy {
 
   private _previousAnnouncedText?: string;
   private _subscription: Subscription | undefined;
-
-  constructor(...args: unknown[]);
 
   constructor() {
     inject(_CdkPrivateStyleLoader).load(_VisuallyHiddenLoader);

--- a/src/cdk/accordion/accordion-item.ts
+++ b/src/cdk/accordion/accordion-item.ts
@@ -103,9 +103,6 @@ export class CdkAccordionItem implements OnInit, OnDestroy {
   /** Unregister function for _expansionDispatcher. */
   private _removeUniqueSelectionListener: () => void = () => {};
 
-  constructor(...args: unknown[]);
-  constructor() {}
-
   ngOnInit() {
     this._removeUniqueSelectionListener = this._expansionDispatcher.listen(
       (id: string, accordionId: string) => {

--- a/src/cdk/bidi/directionality.ts
+++ b/src/cdk/bidi/directionality.ts
@@ -45,8 +45,6 @@ export class Directionality implements OnDestroy {
   /** Stream that emits whenever the 'ltr' / 'rtl' state changes. */
   readonly change = new EventEmitter<Direction>();
 
-  constructor(...args: unknown[]);
-
   constructor() {
     const _document = inject(DIR_DOCUMENT, {optional: true});
 

--- a/src/cdk/clipboard/clipboard.ts
+++ b/src/cdk/clipboard/clipboard.ts
@@ -16,9 +16,6 @@ import {PendingCopy} from './pending-copy';
 export class Clipboard {
   private readonly _document = inject(DOCUMENT);
 
-  constructor(...args: unknown[]);
-  constructor() {}
-
   /**
    * Copies the provided text into the user's clipboard.
    *

--- a/src/cdk/clipboard/copy-to-clipboard.ts
+++ b/src/cdk/clipboard/copy-to-clipboard.ts
@@ -68,8 +68,6 @@ export class CdkCopyToClipboard implements OnDestroy {
   /** Timeout for the current copy attempt. */
   private _currentTimeout: any;
 
-  constructor(...args: unknown[]);
-
   constructor() {
     const config = inject(CDK_COPY_TO_CLIPBOARD_CONFIG, {optional: true});
 

--- a/src/cdk/dialog/dialog-container.ts
+++ b/src/cdk/dialog/dialog-container.ts
@@ -114,8 +114,6 @@ export class CdkDialogContainer<C extends DialogConfig = DialogConfig>
 
   private _isDestroyed = false;
 
-  constructor(...args: unknown[]);
-
   constructor() {
     super();
 

--- a/src/cdk/dialog/dialog.ts
+++ b/src/cdk/dialog/dialog.ts
@@ -86,10 +86,6 @@ export class Dialog implements OnDestroy {
       : this._getAfterAllClosed().pipe(startWith(undefined)),
   );
 
-  constructor(...args: unknown[]);
-
-  constructor() {}
-
   /**
    * Opens a modal dialog containing the given component.
    * @param component Type of the component to load into the dialog.

--- a/src/cdk/drag-drop/directives/drag-handle.ts
+++ b/src/cdk/drag-drop/directives/drag-handle.ts
@@ -57,8 +57,6 @@ export class CdkDragHandle implements AfterViewInit, OnDestroy {
   }
   private _disabled = false;
 
-  constructor(...args: unknown[]);
-
   constructor() {
     if (typeof ngDevMode === 'undefined' || ngDevMode) {
       assertElementNode(this.element.nativeElement, 'cdkDragHandle');

--- a/src/cdk/drag-drop/directives/drag-placeholder.ts
+++ b/src/cdk/drag-drop/directives/drag-placeholder.ts
@@ -32,8 +32,6 @@ export class CdkDragPlaceholder<T = any> implements OnDestroy {
   /** Context data to be added to the placeholder template instance. */
   @Input() data!: T;
 
-  constructor(...args: unknown[]);
-
   constructor() {
     this._drag?._setPlaceholderTemplate(this);
   }

--- a/src/cdk/drag-drop/directives/drag-preview.ts
+++ b/src/cdk/drag-drop/directives/drag-preview.ts
@@ -43,8 +43,6 @@ export class CdkDragPreview<T = any> implements OnDestroy {
   /** Whether the preview should preserve the same size as the item that is being dragged. */
   @Input({transform: booleanAttribute}) matchSize: boolean = false;
 
-  constructor(...args: unknown[]);
-
   constructor() {
     this._drag?._setPreviewTemplate(this);
   }

--- a/src/cdk/drag-drop/directives/drag.ts
+++ b/src/cdk/drag-drop/directives/drag.ts
@@ -216,8 +216,6 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
 
   private _injector = inject(Injector);
 
-  constructor(...args: unknown[]);
-
   constructor() {
     const dropContainer = this.dropContainer;
     const config = inject<DragDropConfig>(CDK_DRAG_CONFIG, {optional: true});

--- a/src/cdk/drag-drop/directives/drop-list-shared.spec.ts
+++ b/src/cdk/drag-drop/directives/drop-list-shared.spec.ts
@@ -5035,10 +5035,6 @@ export function getHorizontalFixtures(listOrientation: Exclude<DropListOrientati
       moveItemInArray(this.items, event.previousIndex, event.currentIndex);
     });
 
-    constructor(...args: unknown[]);
-
-    constructor() {}
-
     ngAfterViewInit() {
       // Firefox preserves the `scrollLeft` value from previous similar containers. This
       // could throw off test assertions and result in flaky results.

--- a/src/cdk/drag-drop/directives/drop-list.ts
+++ b/src/cdk/drag-drop/directives/drop-list.ts
@@ -194,8 +194,6 @@ export class CdkDropList<T = any> implements OnDestroy {
    */
   private _unsortedItems = new Set<CdkDrag>();
 
-  constructor(...args: unknown[]);
-
   constructor() {
     const config = inject<DragDropConfig>(CDK_DRAG_CONFIG, {optional: true});
     const injector = inject(Injector);

--- a/src/cdk/drag-drop/drag-drop-registry.ts
+++ b/src/cdk/drag-drop/drag-drop-registry.ts
@@ -102,9 +102,6 @@ export class DragDropRegistry implements OnDestroy {
    */
   readonly pointerUp: Subject<TouchEvent | MouseEvent> = new Subject<TouchEvent | MouseEvent>();
 
-  constructor(...args: unknown[]);
-  constructor() {}
-
   /** Adds a drop container to the registry. */
   registerDropContainer(drop: DropListRef) {
     if (!this._dropInstances.has(drop)) {

--- a/src/cdk/drag-drop/drag-drop.ts
+++ b/src/cdk/drag-drop/drag-drop.ts
@@ -20,9 +20,6 @@ import {createDropListRef, DropListRef} from './drop-list-ref';
 export class DragDrop {
   private _injector = inject(Injector);
 
-  constructor(...args: unknown[]);
-  constructor() {}
-
   /**
    * Turns an element into a draggable item.
    * @param element Element to which to attach the dragging functionality.

--- a/src/cdk/layout/breakpoints-observer.ts
+++ b/src/cdk/layout/breakpoints-observer.ts
@@ -49,9 +49,6 @@ export class BreakpointObserver implements OnDestroy {
   /** A subject for all other observables to takeUntil based on. */
   private readonly _destroySubject = new Subject<void>();
 
-  constructor(...args: unknown[]);
-  constructor() {}
-
   /** Completes the active subject, signalling to all other observables to complete. */
   ngOnDestroy() {
     this._destroySubject.next();

--- a/src/cdk/layout/media-matcher.ts
+++ b/src/cdk/layout/media-matcher.ts
@@ -23,8 +23,6 @@ export class MediaMatcher {
   /** The internal matchMedia method to return back a MediaQueryList like object. */
   private _matchMedia: (query: string) => MediaQueryList;
 
-  constructor(...args: unknown[]);
-
   constructor() {
     this._matchMedia =
       this._platform.isBrowser && window.matchMedia

--- a/src/cdk/observers/observe-content.ts
+++ b/src/cdk/observers/observe-content.ts
@@ -79,9 +79,6 @@ export class ContentObserver implements OnDestroy {
 
   private _ngZone = inject(NgZone);
 
-  constructor(...args: unknown[]);
-  constructor() {}
-
   ngOnDestroy() {
     this._observedElements.forEach((_, element) => this._cleanupObserver(element));
   }
@@ -212,9 +209,6 @@ export class CdkObserveContent implements AfterContentInit, OnDestroy {
   private _debounce: number | undefined;
 
   private _currentSubscription: Subscription | null = null;
-
-  constructor(...args: unknown[]);
-  constructor() {}
 
   ngAfterContentInit() {
     if (!this._currentSubscription && !this.disabled) {

--- a/src/cdk/overlay/dispatchers/base-overlay-dispatcher.ts
+++ b/src/cdk/overlay/dispatchers/base-overlay-dispatcher.ts
@@ -23,10 +23,6 @@ export abstract class BaseOverlayDispatcher implements OnDestroy {
   protected _document = inject(DOCUMENT);
   protected _isAttached = false;
 
-  constructor(...args: unknown[]);
-
-  constructor() {}
-
   ngOnDestroy(): void {
     this.detach();
   }

--- a/src/cdk/overlay/fullscreen-overlay-container.ts
+++ b/src/cdk/overlay/fullscreen-overlay-container.ts
@@ -22,12 +22,6 @@ export class FullscreenOverlayContainer extends OverlayContainer implements OnDe
   private _fullScreenEventName: string | undefined;
   private _cleanupFullScreenListener: (() => void) | undefined;
 
-  constructor(...args: unknown[]);
-
-  constructor() {
-    super();
-  }
-
   override ngOnDestroy() {
     super.ngOnDestroy();
     this._cleanupFullScreenListener?.();

--- a/src/cdk/overlay/overlay-container.ts
+++ b/src/cdk/overlay/overlay-container.ts
@@ -36,9 +36,6 @@ export class OverlayContainer implements OnDestroy {
   protected _document = inject(DOCUMENT);
   protected _styleLoader = inject(_CdkPrivateStyleLoader);
 
-  constructor(...args: unknown[]);
-  constructor() {}
-
   ngOnDestroy() {
     this._containerElement?.remove();
   }

--- a/src/cdk/overlay/overlay-directives.ts
+++ b/src/cdk/overlay/overlay-directives.ts
@@ -92,9 +92,6 @@ export const CDK_CONNECTED_OVERLAY_SCROLL_STRATEGY = new InjectionToken<() => Sc
 })
 export class CdkOverlayOrigin {
   elementRef = inject(ElementRef);
-
-  constructor(...args: unknown[]);
-  constructor() {}
 }
 
 /**
@@ -285,8 +282,6 @@ export class CdkConnectedOverlay implements OnDestroy, OnChanges {
 
   /** Emits when there are mouse outside click events that are targeted at the overlay. */
   @Output() readonly overlayOutsideClick = new EventEmitter<MouseEvent>();
-
-  constructor(...args: unknown[]);
 
   // TODO(jelbourn): inputs for size, scroll behavior, animation, etc.
 

--- a/src/cdk/overlay/overlay.ts
+++ b/src/cdk/overlay/overlay.ts
@@ -128,9 +128,6 @@ export class Overlay {
   private _positionBuilder = inject(OverlayPositionBuilder);
   private _injector = inject(Injector);
 
-  constructor(...args: unknown[]);
-  constructor() {}
-
   /**
    * Creates an overlay.
    * @param config Configuration applied to the overlay.

--- a/src/cdk/overlay/position/overlay-position-builder.ts
+++ b/src/cdk/overlay/position/overlay-position-builder.ts
@@ -19,9 +19,6 @@ import {createGlobalPositionStrategy, GlobalPositionStrategy} from './global-pos
 export class OverlayPositionBuilder {
   private _injector = inject(Injector);
 
-  constructor(...args: unknown[]);
-  constructor() {}
-
   /**
    * Creates a global position strategy.
    */

--- a/src/cdk/overlay/scroll/scroll-strategy-options.ts
+++ b/src/cdk/overlay/scroll/scroll-strategy-options.ts
@@ -25,9 +25,6 @@ import {
 export class ScrollStrategyOptions {
   private _injector = inject(Injector);
 
-  constructor(...args: unknown[]);
-  constructor() {}
-
   /** Do nothing on scroll. */
   noop = () => new NoopScrollStrategy();
 

--- a/src/cdk/platform/platform.ts
+++ b/src/cdk/platform/platform.ts
@@ -85,9 +85,4 @@ export class Platform {
   // Safari browser should also use Webkit as its layout engine.
   /** Whether the current browser is Safari. */
   SAFARI: boolean = this.isBrowser && /safari/i.test(navigator.userAgent) && this.WEBKIT;
-
-  /** Backwards-compatible constructor. */
-  constructor(..._args: unknown[]);
-
-  constructor() {}
 }

--- a/src/cdk/portal/portal-directives.ts
+++ b/src/cdk/portal/portal-directives.ts
@@ -34,8 +34,6 @@ import {BasePortalOutlet, ComponentPortal, Portal, TemplatePortal, DomPortal} fr
   exportAs: 'cdkPortal',
 })
 export class CdkPortal extends TemplatePortal {
-  constructor(...args: unknown[]);
-
   constructor() {
     const templateRef = inject<TemplateRef<any>>(TemplateRef);
     const viewContainerRef = inject(ViewContainerRef);
@@ -70,12 +68,6 @@ export class CdkPortalOutlet extends BasePortalOutlet implements OnInit, OnDestr
 
   /** Reference to the currently-attached component/view ref. */
   private _attachedRef: CdkPortalOutletAttachedRef = null;
-
-  constructor(...args: unknown[]);
-
-  constructor() {
-    super();
-  }
 
   /** Portal associated with the Portal outlet. */
   @Input('cdkPortalOutlet')

--- a/src/cdk/scrolling/scroll-dispatcher.ts
+++ b/src/cdk/scrolling/scroll-dispatcher.ts
@@ -27,9 +27,6 @@ export class ScrollDispatcher implements OnDestroy {
   private _renderer = inject(RendererFactory2).createRenderer(null, null);
   private _cleanupGlobalListener: (() => void) | undefined;
 
-  constructor(...args: unknown[]);
-  constructor() {}
-
   /** Subject for notifying that a registered scrollable reference element has been scrolled. */
   private readonly _scrolled = new Subject<CdkScrollable | void>();
 

--- a/src/cdk/scrolling/scrollable.ts
+++ b/src/cdk/scrolling/scrollable.ts
@@ -50,9 +50,6 @@ export class CdkScrollable implements OnInit, OnDestroy {
   private _cleanupScroll: (() => void) | undefined;
   private _elementScrolled = new Subject<Event>();
 
-  constructor(...args: unknown[]);
-  constructor() {}
-
   ngOnInit() {
     this._cleanupScroll = this.ngZone.runOutsideAngular(() =>
       this._renderer.listen(this._scrollElement, 'scroll', event =>

--- a/src/cdk/scrolling/viewport-ruler.ts
+++ b/src/cdk/scrolling/viewport-ruler.ts
@@ -38,8 +38,6 @@ export class ViewportRuler implements OnDestroy {
   /** Used to reference correct document/window */
   protected _document = inject(DOCUMENT);
 
-  constructor(...args: unknown[]);
-
   constructor() {
     const ngZone = inject(NgZone);
     const renderer = inject(RendererFactory2).createRenderer(null, null);

--- a/src/cdk/scrolling/virtual-for-of.ts
+++ b/src/cdk/scrolling/virtual-for-of.ts
@@ -182,8 +182,6 @@ export class CdkVirtualForOf<T>
 
   private readonly _destroyed = new Subject<void>();
 
-  constructor(...args: unknown[]);
-
   constructor() {
     const ngZone = inject(NgZone);
 

--- a/src/cdk/scrolling/virtual-scroll-viewport.ts
+++ b/src/cdk/scrolling/virtual-scroll-viewport.ts
@@ -200,8 +200,6 @@ export class CdkVirtualScrollViewport extends CdkVirtualScrollable implements On
 
   private _isDestroyed = false;
 
-  constructor(...args: unknown[]);
-
   constructor() {
     super();
     const viewportRuler = inject(ViewportRuler);

--- a/src/cdk/scrolling/virtual-scrollable-element.ts
+++ b/src/cdk/scrolling/virtual-scrollable-element.ts
@@ -20,12 +20,6 @@ import {CdkVirtualScrollable, VIRTUAL_SCROLLABLE} from './virtual-scrollable';
   },
 })
 export class CdkVirtualScrollableElement extends CdkVirtualScrollable {
-  constructor(...args: unknown[]);
-
-  constructor() {
-    super();
-  }
-
   override measureBoundingClientRectWithScrollOffset(
     from: 'left' | 'top' | 'right' | 'bottom',
   ): number {

--- a/src/cdk/scrolling/virtual-scrollable-window.ts
+++ b/src/cdk/scrolling/virtual-scrollable-window.ts
@@ -18,8 +18,6 @@ import {CdkVirtualScrollable, VIRTUAL_SCROLLABLE} from './virtual-scrollable';
   providers: [{provide: VIRTUAL_SCROLLABLE, useExisting: CdkVirtualScrollableWindow}],
 })
 export class CdkVirtualScrollableWindow extends CdkVirtualScrollable {
-  constructor(...args: unknown[]);
-
   constructor() {
     super();
     const document = inject(DOCUMENT);

--- a/src/cdk/scrolling/virtual-scrollable.ts
+++ b/src/cdk/scrolling/virtual-scrollable.ts
@@ -16,11 +16,6 @@ export const VIRTUAL_SCROLLABLE = new InjectionToken<CdkVirtualScrollable>('VIRT
  */
 @Directive()
 export abstract class CdkVirtualScrollable extends CdkScrollable {
-  constructor(...args: unknown[]);
-  constructor() {
-    super();
-  }
-
   /**
    * Measure the viewport size for the provided orientation.
    *

--- a/src/cdk/stepper/step-header.ts
+++ b/src/cdk/stepper/step-header.ts
@@ -18,9 +18,6 @@ import {FocusableOption} from '../a11y';
 export class CdkStepHeader implements FocusableOption {
   _elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
 
-  constructor(...args: unknown[]);
-  constructor() {}
-
   /** Focuses the step header. */
   focus() {
     this._elementRef.nativeElement.focus();

--- a/src/cdk/stepper/step-label.ts
+++ b/src/cdk/stepper/step-label.ts
@@ -13,7 +13,4 @@ import {Directive, TemplateRef, inject} from '@angular/core';
 })
 export class CdkStepLabel {
   template = inject<TemplateRef<any>>(TemplateRef);
-
-  constructor(...args: unknown[]);
-  constructor() {}
 }

--- a/src/cdk/stepper/stepper-button.ts
+++ b/src/cdk/stepper/stepper-button.ts
@@ -23,9 +23,6 @@ export class CdkStepperNext {
 
   /** Type of the next button. Defaults to "submit" if not specified. */
   @Input() type: string = 'submit';
-
-  constructor(...args: unknown[]);
-  constructor() {}
 }
 
 /** Button that moves to the previous step in a stepper workflow. */
@@ -41,7 +38,4 @@ export class CdkStepperPrevious {
 
   /** Type of the previous button. Defaults to "button" if not specified. */
   @Input() type: string = 'button';
-
-  constructor(...args: unknown[]);
-  constructor() {}
 }

--- a/src/cdk/stepper/stepper.ts
+++ b/src/cdk/stepper/stepper.ts
@@ -258,8 +258,6 @@ export class CdkStep implements OnChanges {
     return this.interacted && !!this.stepControl?.invalid;
   }
 
-  constructor(...args: unknown[]);
-
   constructor() {
     const stepperOptions = inject<StepperOptions>(STEPPER_GLOBAL_OPTIONS, {optional: true});
     this._stepperOptions = stepperOptions ? stepperOptions : {};
@@ -410,9 +408,6 @@ export class CdkStepper implements AfterContentInit, AfterViewInit, OnDestroy {
     }
   }
   private _orientation: StepperOrientation = 'horizontal';
-
-  constructor(...args: unknown[]);
-  constructor() {}
 
   ngAfterContentInit() {
     this._steps.changes

--- a/src/cdk/table/cell.ts
+++ b/src/cdk/table/cell.ts
@@ -33,9 +33,6 @@ export interface CellDef {
 export class CdkCellDef implements CellDef {
   /** @docs-private */
   template = inject<TemplateRef<any>>(TemplateRef);
-
-  constructor(...args: unknown[]);
-  constructor() {}
 }
 
 /**
@@ -48,9 +45,6 @@ export class CdkCellDef implements CellDef {
 export class CdkHeaderCellDef implements CellDef {
   /** @docs-private */
   template = inject<TemplateRef<any>>(TemplateRef);
-
-  constructor(...args: unknown[]);
-  constructor() {}
 }
 
 /**
@@ -63,9 +57,6 @@ export class CdkHeaderCellDef implements CellDef {
 export class CdkFooterCellDef implements CellDef {
   /** @docs-private */
   template = inject<TemplateRef<any>>(TemplateRef);
-
-  constructor(...args: unknown[]);
-  constructor() {}
 }
 
 /**
@@ -140,9 +131,6 @@ export class CdkColumnDef implements CanStick {
    */
   _columnCssClassName!: string[];
 
-  constructor(...args: unknown[]);
-  constructor() {}
-
   /** Whether the sticky state has changed. */
   hasStickyChanged(): boolean {
     const hasStickyChanged = this._hasStickyChanged;
@@ -199,8 +187,6 @@ export class BaseCdkCell {
   },
 })
 export class CdkHeaderCell extends BaseCdkCell {
-  constructor(...args: unknown[]);
-
   constructor() {
     super(inject(CdkColumnDef), inject(ElementRef));
   }
@@ -214,8 +200,6 @@ export class CdkHeaderCell extends BaseCdkCell {
   },
 })
 export class CdkFooterCell extends BaseCdkCell {
-  constructor(...args: unknown[]);
-
   constructor() {
     const columnDef = inject(CdkColumnDef);
     const elementRef = inject(ElementRef);
@@ -237,8 +221,6 @@ export class CdkFooterCell extends BaseCdkCell {
   },
 })
 export class CdkCell extends BaseCdkCell {
-  constructor(...args: unknown[]);
-
   constructor() {
     const columnDef = inject(CdkColumnDef);
     const elementRef = inject(ElementRef);

--- a/src/cdk/table/row.ts
+++ b/src/cdk/table/row.ts
@@ -48,9 +48,6 @@ export abstract class BaseRowDef implements OnChanges {
   /** Differ used to check if any changes were made to the columns. */
   protected _columnsDiffer!: IterableDiffer<any>;
 
-  constructor(...args: unknown[]);
-  constructor() {}
-
   ngOnChanges(changes: SimpleChanges<this>): void {
     // Create a new columns differ if one does not yet exist. Initialize it based on initial value
     // of the columns property or an empty array if none is provided.
@@ -108,12 +105,6 @@ export class CdkHeaderRowDef extends BaseRowDef implements CanStick, OnChanges {
   }
   private _sticky = false;
 
-  constructor(...args: unknown[]);
-
-  constructor() {
-    super(inject<TemplateRef<any>>(TemplateRef), inject(IterableDiffers));
-  }
-
   // Prerender fails to recognize that ngOnChanges in a part of this class through inheritance.
   // Explicitly define it so that the method is called as part of the Angular lifecycle.
   override ngOnChanges(changes: SimpleChanges<this>): void {
@@ -159,12 +150,6 @@ export class CdkFooterRowDef extends BaseRowDef implements CanStick, OnChanges {
   }
   private _sticky = false;
 
-  constructor(...args: unknown[]);
-
-  constructor() {
-    super(inject<TemplateRef<any>>(TemplateRef), inject(IterableDiffers));
-  }
-
   // Prerender fails to recognize that ngOnChanges in a part of this class through inheritance.
   // Explicitly define it so that the method is called as part of the Angular lifecycle.
   override ngOnChanges(changes: SimpleChanges<this>): void {
@@ -199,6 +184,9 @@ export class CdkFooterRowDef extends BaseRowDef implements CanStick, OnChanges {
 export class CdkRowDef<T> extends BaseRowDef {
   _table? = inject(CDK_TABLE, {optional: true});
 
+  // TODO(andrewseguin): Add an input for providing a switch function to determine
+  //   if this template should be used.
+
   /**
    * Function that should return true if this row template should be used for the provided index
    * and row data. If left undefined, this row will be considered the default row template to use
@@ -206,14 +194,6 @@ export class CdkRowDef<T> extends BaseRowDef {
    * For every row, there must be at least one when function that passes or an undefined to default.
    */
   when!: (index: number, rowData: T) => boolean;
-
-  constructor(...args: unknown[]);
-
-  constructor() {
-    // TODO(andrewseguin): Add an input for providing a switch function to determine
-    //   if this template should be used.
-    super(inject<TemplateRef<any>>(TemplateRef), inject(IterableDiffers));
-  }
 }
 
 /** Context provided to the row cells when `multiTemplateDataRows` is false */
@@ -296,8 +276,6 @@ export class CdkCellOutlet implements OnDestroy {
    */
   static mostRecentCellOutlet: CdkCellOutlet | null = null;
 
-  constructor(...args: unknown[]);
-
   constructor() {
     CdkCellOutlet.mostRecentCellOutlet = this;
   }
@@ -369,7 +347,4 @@ export class CdkNoDataRow {
   _contentClassNames = ['cdk-no-data-row', 'cdk-row'];
   _cellClassNames = ['cdk-cell', 'cdk-no-data-cell'];
   _cellSelector = 'td, cdk-cell, [cdk-cell], .cdk-cell';
-
-  constructor(...args: unknown[]);
-  constructor() {}
 }

--- a/src/cdk/table/table.ts
+++ b/src/cdk/table/table.ts
@@ -124,8 +124,6 @@ export class DataRowOutlet implements RowOutlet {
   viewContainer = inject(ViewContainerRef);
   elementRef = inject(ElementRef);
 
-  constructor(...args: unknown[]);
-
   constructor() {
     const table = inject<CdkTable<unknown>>(CDK_TABLE);
     table._rowOutlet = this;
@@ -143,8 +141,6 @@ export class DataRowOutlet implements RowOutlet {
 export class HeaderRowOutlet implements RowOutlet {
   viewContainer = inject(ViewContainerRef);
   elementRef = inject(ElementRef);
-
-  constructor(...args: unknown[]);
 
   constructor() {
     const table = inject<CdkTable<unknown>>(CDK_TABLE);
@@ -164,8 +160,6 @@ export class FooterRowOutlet implements RowOutlet {
   viewContainer = inject(ViewContainerRef);
   elementRef = inject(ElementRef);
 
-  constructor(...args: unknown[]);
-
   constructor() {
     const table = inject<CdkTable<unknown>>(CDK_TABLE);
     table._footerRowOutlet = this;
@@ -184,8 +178,6 @@ export class FooterRowOutlet implements RowOutlet {
 export class NoDataRowOutlet implements RowOutlet {
   viewContainer = inject(ViewContainerRef);
   elementRef = inject(ElementRef);
-
-  constructor(...args: unknown[]);
 
   constructor() {
     const table = inject<CdkTable<unknown>>(CDK_TABLE);
@@ -641,8 +633,6 @@ export class CdkTable<T>
 
   /** Row definition that will only be rendered if there's no data in the table. */
   @ContentChild(CdkNoDataRow) _noDataRow!: CdkNoDataRow;
-
-  constructor(...args: unknown[]);
 
   constructor() {
     const role = inject(new HostAttributeToken('role'), {optional: true});

--- a/src/cdk/table/text-column.ts
+++ b/src/cdk/table/text-column.ts
@@ -111,8 +111,6 @@ export class CdkTextColumn<T> implements OnDestroy, OnInit {
    */
   @ViewChild(CdkHeaderCellDef, {static: true}) headerCell!: CdkHeaderCellDef;
 
-  constructor(...args: unknown[]);
-
   constructor() {
     this._options = this._options || {};
   }

--- a/src/cdk/text-field/autofill.ts
+++ b/src/cdk/text-field/autofill.ts
@@ -55,9 +55,6 @@ export class AutofillMonitor implements OnDestroy {
   private _styleLoader = inject(_CdkPrivateStyleLoader);
   private _monitoredElements = new Map<Element, MonitoredElementInfo>();
 
-  constructor(...args: unknown[]);
-  constructor() {}
-
   /**
    * Monitor for changes in the autofill state of the given input element.
    * @param element The element to monitor.
@@ -158,9 +155,6 @@ export class CdkAutofill implements OnDestroy, OnInit {
 
   /** Emits when the autofill state of the element changes. */
   @Output() readonly cdkAutofill = new EventEmitter<AutofillEvent>();
-
-  constructor(...args: unknown[]);
-  constructor() {}
 
   ngOnInit() {
     this._autofillMonitor

--- a/src/cdk/text-field/autosize.ts
+++ b/src/cdk/text-field/autosize.ts
@@ -126,8 +126,6 @@ export class CdkTextareaAutosize implements AfterViewInit, DoCheck, OnDestroy {
 
   private _isViewInited = false;
 
-  constructor(...args: unknown[]);
-
   constructor() {
     const styleLoader = inject(_CdkPrivateStyleLoader);
     styleLoader.load(_CdkTextFieldStyleLoader);

--- a/src/cdk/tree/nested-node.ts
+++ b/src/cdk/tree/nested-node.ts
@@ -58,12 +58,6 @@ export class CdkNestedTreeNode<T, K = T>
   })
   nodeOutlet!: QueryList<CdkTreeNodeOutlet>;
 
-  constructor(...args: unknown[]);
-
-  constructor() {
-    super();
-  }
-
   ngAfterContentInit() {
     this._dataDiffer = this._differs.find([]).create(this._tree.trackBy);
     this._tree

--- a/src/cdk/tree/node.ts
+++ b/src/cdk/tree/node.ts
@@ -47,7 +47,4 @@ export class CdkTreeNodeDef<T> {
    * default.
    */
   when!: (index: number, nodeData: T) => boolean;
-
-  constructor(...args: unknown[]);
-  constructor() {}
 }

--- a/src/cdk/tree/outlet.ts
+++ b/src/cdk/tree/outlet.ts
@@ -24,7 +24,4 @@ export const CDK_TREE_NODE_OUTLET_NODE = new InjectionToken<{}>('CDK_TREE_NODE_O
 export class CdkTreeNodeOutlet {
   viewContainer = inject(ViewContainerRef);
   _node? = inject(CDK_TREE_NODE_OUTLET_NODE, {optional: true});
-
-  constructor(...args: unknown[]);
-  constructor() {}
 }

--- a/src/cdk/tree/padding.ts
+++ b/src/cdk/tree/padding.ts
@@ -60,8 +60,6 @@ export class CdkTreeNodePadding<T, K = T> implements OnDestroy {
   }
   _indent: number = 40;
 
-  constructor(...args: unknown[]);
-
   constructor() {
     this._setPadding();
     this._dir?.change.pipe(takeUntil(this._destroyed)).subscribe(() => this._setPadding(true));

--- a/src/cdk/tree/toggle.ts
+++ b/src/cdk/tree/toggle.ts
@@ -30,9 +30,6 @@ export class CdkTreeNodeToggle<T, K = T> {
   @Input({alias: 'cdkTreeNodeToggleRecursive', transform: booleanAttribute})
   recursive: boolean = false;
 
-  constructor(...args: unknown[]);
-  constructor() {}
-
   // Toggle the expanded or collapsed state of this node.
   //
   // Focus this node with expanding or collapsing it. This ensures that the active node will always

--- a/src/cdk/tree/tree.ts
+++ b/src/cdk/tree/tree.ts
@@ -267,9 +267,6 @@ export class CdkTree<T, K = T>
   _keyManager!: TreeKeyManagerStrategy<CdkTreeNode<T, K>>;
   private _viewInit = false;
 
-  constructor(...args: unknown[]);
-  constructor() {}
-
   ngAfterContentInit() {
     this._initializeKeyManager();
   }
@@ -1387,8 +1384,6 @@ export class CdkTreeNode<T, K = T> implements OnDestroy, OnInit, TreeKeyManagerI
   }
 
   private _changeDetectorRef = inject(ChangeDetectorRef);
-
-  constructor(...args: unknown[]);
 
   constructor() {
     CdkTreeNode.mostRecentTreeNode = this as CdkTreeNode<T, K>;

--- a/src/components-examples/aria/grid/grid-table/grid-table-example.ts
+++ b/src/components-examples/aria/grid/grid-table/grid-table-example.ts
@@ -59,8 +59,6 @@ export class GridTableExample {
 
   readonly tasks: WritableSignal<TaskRow[]> = signal(this._createRows());
 
-  constructor() {}
-
   startEdit(
     event: KeyboardEvent | FocusEvent | undefined,
     task: TaskRow,

--- a/src/google-maps/deprecated-map-marker-clusterer/deprecated-map-marker-clusterer.ts
+++ b/src/google-maps/deprecated-map-marker-clusterer/deprecated-map-marker-clusterer.ts
@@ -216,9 +216,6 @@ export class DeprecatedMapMarkerClusterer
   @Output() readonly markerClustererInitialized: EventEmitter<MarkerClustererInstance> =
     new EventEmitter<MarkerClustererInstance>();
 
-  constructor(...args: unknown[]);
-  constructor() {}
-
   ngOnInit() {
     if (this._canInitialize) {
       this._ngZone.runOutsideAngular(() => {

--- a/src/google-maps/google-map/google-map.ts
+++ b/src/google-maps/google-map/google-map.ts
@@ -247,8 +247,6 @@ export class GoogleMap implements OnChanges, OnInit, OnDestroy {
   @Output() readonly zoomChanged: Observable<void> =
     this._eventManager.getLazyEmitter<void>('zoom_changed');
 
-  constructor(...args: unknown[]);
-
   constructor() {
     const platformId = inject<Object>(PLATFORM_ID);
     this._isBrowser = isPlatformBrowser(platformId);

--- a/src/google-maps/map-advanced-marker/map-advanced-marker.ts
+++ b/src/google-maps/map-advanced-marker/map-advanced-marker.ts
@@ -194,9 +194,6 @@ export class MapAdvancedMarker
    */
   advancedMarker!: google.maps.marker.AdvancedMarkerElement;
 
-  constructor(...args: unknown[]);
-  constructor() {}
-
   ngOnInit() {
     if (!this._googleMap._isBrowser) {
       return;

--- a/src/google-maps/map-base-layer.ts
+++ b/src/google-maps/map-base-layer.ts
@@ -18,9 +18,6 @@ export class MapBaseLayer implements OnInit, OnDestroy {
   protected readonly _map = inject(GoogleMap);
   protected readonly _ngZone = inject(NgZone);
 
-  constructor(...args: unknown[]);
-  constructor() {}
-
   ngOnInit() {
     if (this._map._isBrowser) {
       this._ngZone.runOutsideAngular(() => {

--- a/src/google-maps/map-circle/map-circle.ts
+++ b/src/google-maps/map-circle/map-circle.ts
@@ -158,9 +158,6 @@ export class MapCircle implements OnInit, OnDestroy {
   @Output() readonly circleInitialized: EventEmitter<google.maps.Circle> =
     new EventEmitter<google.maps.Circle>();
 
-  constructor(...args: unknown[]);
-  constructor() {}
-
   ngOnInit() {
     if (!this._map._isBrowser) {
       return;

--- a/src/google-maps/map-directions-renderer/map-directions-renderer.ts
+++ b/src/google-maps/map-directions-renderer/map-directions-renderer.ts
@@ -72,9 +72,6 @@ export class MapDirectionsRenderer implements OnInit, OnChanges, OnDestroy {
   /** The underlying google.maps.DirectionsRenderer object. */
   directionsRenderer?: google.maps.DirectionsRenderer;
 
-  constructor(...args: unknown[]);
-  constructor() {}
-
   ngOnInit() {
     if (this._googleMap._isBrowser) {
       if (google.maps.DirectionsRenderer && this._googleMap.googleMap) {

--- a/src/google-maps/map-directions-renderer/map-directions-service.ts
+++ b/src/google-maps/map-directions-renderer/map-directions-service.ts
@@ -25,9 +25,6 @@ export class MapDirectionsService {
   private readonly _ngZone = inject(NgZone);
   private _directionsService: google.maps.DirectionsService | undefined;
 
-  constructor(...args: unknown[]);
-  constructor() {}
-
   /**
    * See
    * developers.google.com/maps/documentation/javascript/reference/directions

--- a/src/google-maps/map-geocoder/map-geocoder.ts
+++ b/src/google-maps/map-geocoder/map-geocoder.ts
@@ -23,9 +23,6 @@ export class MapGeocoder {
   private readonly _ngZone = inject(NgZone);
   private _geocoder: google.maps.Geocoder | undefined;
 
-  constructor(...args: unknown[]);
-  constructor() {}
-
   /**
    * See developers.google.com/maps/documentation/javascript/reference/geocoder#Geocoder.geocode
    */

--- a/src/google-maps/map-ground-overlay/map-ground-overlay.ts
+++ b/src/google-maps/map-ground-overlay/map-ground-overlay.ts
@@ -93,9 +93,6 @@ export class MapGroundOverlay implements OnInit, OnDestroy {
   @Output() readonly groundOverlayInitialized: EventEmitter<google.maps.GroundOverlay> =
     new EventEmitter<google.maps.GroundOverlay>();
 
-  constructor(...args: unknown[]);
-  constructor() {}
-
   ngOnInit() {
     if (this._map._isBrowser) {
       // The ground overlay setup is slightly different from the other Google Maps objects in that

--- a/src/google-maps/map-heatmap-layer/map-heatmap-layer.ts
+++ b/src/google-maps/map-heatmap-layer/map-heatmap-layer.ts
@@ -72,9 +72,6 @@ export class MapHeatmapLayer implements OnInit, OnChanges, OnDestroy {
   @Output() readonly heatmapInitialized: EventEmitter<google.maps.visualization.HeatmapLayer> =
     new EventEmitter<google.maps.visualization.HeatmapLayer>();
 
-  constructor(...args: unknown[]);
-  constructor() {}
-
   ngOnInit() {
     if (this._googleMap._isBrowser) {
       if (

--- a/src/google-maps/map-info-window/map-info-window.ts
+++ b/src/google-maps/map-info-window/map-info-window.ts
@@ -104,9 +104,6 @@ export class MapInfoWindow implements OnInit, OnDestroy {
   @Output() readonly infoWindowInitialized: EventEmitter<google.maps.InfoWindow> =
     new EventEmitter<google.maps.InfoWindow>();
 
-  constructor(...args: unknown[]);
-  constructor() {}
-
   ngOnInit() {
     if (this._googleMap._isBrowser) {
       this._combineOptions()

--- a/src/google-maps/map-kml-layer/map-kml-layer.ts
+++ b/src/google-maps/map-kml-layer/map-kml-layer.ts
@@ -81,9 +81,6 @@ export class MapKmlLayer implements OnInit, OnDestroy {
   @Output() readonly kmlLayerInitialized: EventEmitter<google.maps.KmlLayer> =
     new EventEmitter<google.maps.KmlLayer>();
 
-  constructor(...args: unknown[]);
-  constructor() {}
-
   ngOnInit() {
     if (this._map._isBrowser) {
       this._combineOptions()

--- a/src/google-maps/map-marker/map-marker.ts
+++ b/src/google-maps/map-marker/map-marker.ts
@@ -282,9 +282,6 @@ export class MapMarker implements OnInit, OnChanges, OnDestroy, MapAnchorPoint, 
    */
   marker?: google.maps.Marker;
 
-  constructor(...args: unknown[]);
-  constructor() {}
-
   ngOnInit() {
     if (!this._googleMap._isBrowser) {
       return;

--- a/src/google-maps/map-polygon/map-polygon.ts
+++ b/src/google-maps/map-polygon/map-polygon.ts
@@ -139,9 +139,6 @@ export class MapPolygon implements OnInit, OnDestroy {
   @Output() readonly polygonInitialized: EventEmitter<google.maps.Polygon> =
     new EventEmitter<google.maps.Polygon>();
 
-  constructor(...args: unknown[]);
-  constructor() {}
-
   ngOnInit() {
     if (this._map._isBrowser) {
       this._combineOptions()

--- a/src/google-maps/map-polyline/map-polyline.ts
+++ b/src/google-maps/map-polyline/map-polyline.ts
@@ -137,9 +137,6 @@ export class MapPolyline implements OnInit, OnDestroy {
   @Output() readonly polylineInitialized: EventEmitter<google.maps.Polyline> =
     new EventEmitter<google.maps.Polyline>();
 
-  constructor(...args: unknown[]);
-  constructor() {}
-
   ngOnInit() {
     if (this._map._isBrowser) {
       this._combineOptions()

--- a/src/google-maps/map-rectangle/map-rectangle.ts
+++ b/src/google-maps/map-rectangle/map-rectangle.ts
@@ -146,9 +146,6 @@ export class MapRectangle implements OnInit, OnDestroy {
   @Output() readonly rectangleInitialized: EventEmitter<google.maps.Rectangle> =
     new EventEmitter<google.maps.Rectangle>();
 
-  constructor(...args: unknown[]);
-  constructor() {}
-
   ngOnInit() {
     if (this._map._isBrowser) {
       this._combineOptions()

--- a/src/google-maps/map-traffic-layer/map-traffic-layer.ts
+++ b/src/google-maps/map-traffic-layer/map-traffic-layer.ts
@@ -55,9 +55,6 @@ export class MapTrafficLayer implements OnInit, OnDestroy {
   @Output() readonly trafficLayerInitialized: EventEmitter<google.maps.TrafficLayer> =
     new EventEmitter<google.maps.TrafficLayer>();
 
-  constructor(...args: unknown[]);
-  constructor() {}
-
   ngOnInit() {
     if (this._map._isBrowser) {
       this._combineOptions()

--- a/src/material-date-fns-adapter/adapter/date-fns-adapter.ts
+++ b/src/material-date-fns-adapter/adapter/date-fns-adapter.ts
@@ -57,8 +57,6 @@ const DAY_OF_WEEK_FORMATS = {
 /** Adds date-fns support to Angular Material. */
 @Injectable()
 export class DateFnsAdapter extends DateAdapter<Date, Locale> {
-  constructor(...args: unknown[]);
-
   constructor() {
     super();
     const matDateLocale = inject(MAT_DATE_LOCALE, {optional: true});

--- a/src/material-luxon-adapter/adapter/luxon-date-adapter.ts
+++ b/src/material-luxon-adapter/adapter/luxon-date-adapter.ts
@@ -64,8 +64,6 @@ export class LuxonDateAdapter extends DateAdapter<LuxonDateTime> {
   private _firstDayOfWeek: number | undefined;
   private _defaultOutputCalendar: LuxonCalendarSystem;
 
-  constructor(...args: unknown[]);
-
   constructor() {
     super();
 

--- a/src/material-moment-adapter/adapter/moment-date-adapter.ts
+++ b/src/material-moment-adapter/adapter/moment-date-adapter.ts
@@ -75,8 +75,6 @@ export class MomentDateAdapter extends DateAdapter<Moment> {
     narrowDaysOfWeek: string[];
   };
 
-  constructor(...args: unknown[]);
-
   constructor() {
     super();
     const dateLocale = inject<string>(MAT_DATE_LOCALE, {optional: true});

--- a/src/material/autocomplete/autocomplete-origin.ts
+++ b/src/material/autocomplete/autocomplete-origin.ts
@@ -18,7 +18,4 @@ import {Directive, ElementRef, inject} from '@angular/core';
 })
 export class MatAutocompleteOrigin {
   elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
-
-  constructor(...args: unknown[]);
-  constructor() {}
 }

--- a/src/material/autocomplete/autocomplete-trigger.ts
+++ b/src/material/autocomplete/autocomplete-trigger.ts
@@ -243,9 +243,6 @@ export class MatAutocompleteTrigger
   @Input({alias: 'matAutocompleteDisabled', transform: booleanAttribute})
   autocompleteDisabled: boolean = false;
 
-  constructor(...args: unknown[]);
-  constructor() {}
-
   /** Class to apply to the panel when it's above the input. */
   private _aboveClass = 'mat-mdc-autocomplete-panel-above';
 

--- a/src/material/autocomplete/autocomplete.ts
+++ b/src/material/autocomplete/autocomplete.ts
@@ -246,8 +246,6 @@ export class MatAutocomplete implements AfterContentInit, OnDestroy {
    */
   readonly inertGroups: boolean;
 
-  constructor(...args: unknown[]);
-
   constructor() {
     const platform = inject(Platform);
 

--- a/src/material/badge/badge.ts
+++ b/src/material/badge/badge.ts
@@ -149,8 +149,6 @@ export class MatBadge implements OnInit, AfterViewInit, OnDestroy {
 
   private _document = inject(DOCUMENT);
 
-  constructor(...args: unknown[]);
-
   constructor() {
     const styleLoader = inject(_CdkPrivateStyleLoader);
     styleLoader.load(_MatBadgeStyleLoader);

--- a/src/material/bottom-sheet/bottom-sheet-container.ts
+++ b/src/material/bottom-sheet/bottom-sheet-container.ts
@@ -68,8 +68,6 @@ export class MatBottomSheetContainer extends CdkDialogContainer implements OnDes
   /** Whether the component has been destroyed. */
   private _destroyed = false;
 
-  constructor(...args: unknown[]);
-
   constructor() {
     super();
 

--- a/src/material/bottom-sheet/bottom-sheet.ts
+++ b/src/material/bottom-sheet/bottom-sheet.ts
@@ -49,9 +49,6 @@ export class MatBottomSheet implements OnDestroy {
     }
   }
 
-  constructor(...args: unknown[]);
-  constructor() {}
-
   /**
    * Opens a bottom sheet containing the given component.
    * @param component Type of the component to load into the bottom sheet.

--- a/src/material/button-toggle/button-toggle.ts
+++ b/src/material/button-toggle/button-toggle.ts
@@ -279,8 +279,6 @@ export class MatButtonToggleGroup implements ControlValueAccessor, OnInit, After
   }
   private _hideMultipleSelectionIndicator: boolean;
 
-  constructor(...args: unknown[]);
-
   constructor() {
     const defaultOptions = inject<MatButtonToggleDefaultOptions>(
       MAT_BUTTON_TOGGLE_DEFAULT_OPTIONS,
@@ -676,8 +674,6 @@ export class MatButtonToggle implements OnInit, AfterViewInit, OnDestroy {
   /** Event emitted when the group value changes. */
   @Output() readonly change: EventEmitter<MatButtonToggleChange> =
     new EventEmitter<MatButtonToggleChange>();
-
-  constructor(...args: unknown[]);
 
   constructor() {
     inject(_CdkPrivateStyleLoader).load(_StructuralStylesLoader);

--- a/src/material/button/button-base.ts
+++ b/src/material/button/button-base.ts
@@ -155,8 +155,6 @@ export class MatButtonBase implements AfterViewInit, OnDestroy {
   /** Whether the button is showing a progress indicator. */
   readonly showProgress = input(false, {transform: booleanAttribute});
 
-  constructor(...args: unknown[]);
-
   constructor() {
     inject(_CdkPrivateStyleLoader).load(_StructuralStylesLoader);
     const element = this._elementRef.nativeElement;

--- a/src/material/button/button.ts
+++ b/src/material/button/button.ts
@@ -53,8 +53,6 @@ export class MatButton extends MatButtonBase {
   }
   private _appearance: MatButtonAppearance | null = null;
 
-  constructor(...args: unknown[]);
-
   constructor() {
     super();
     const inferredAppearance = _inferAppearance(this._elementRef.nativeElement);

--- a/src/material/button/fab.ts
+++ b/src/material/button/fab.ts
@@ -73,8 +73,6 @@ export class MatFabButton extends MatButtonBase {
 
   @Input({transform: booleanAttribute}) extended: boolean = false;
 
-  constructor(...args: unknown[]);
-
   constructor() {
     super();
     this._options = this._options || defaults;
@@ -102,8 +100,6 @@ export class MatMiniFabButton extends MatButtonBase {
   private _options = inject<MatFabDefaultOptions>(MAT_FAB_DEFAULT_OPTIONS, {optional: true});
 
   override _isFab = true;
-
-  constructor(...args: unknown[]);
 
   constructor() {
     super();

--- a/src/material/button/icon-button.ts
+++ b/src/material/button/icon-button.ts
@@ -26,8 +26,6 @@ import {MatButtonBase} from './button-base';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MatIconButton extends MatButtonBase {
-  constructor(...args: unknown[]);
-
   constructor() {
     super();
     this._rippleLoader.configureRipple(this._elementRef.nativeElement, {centered: true});

--- a/src/material/card/card.ts
+++ b/src/material/card/card.ts
@@ -51,8 +51,6 @@ export const MAT_CARD_CONFIG = new InjectionToken<MatCardConfig>('MAT_CARD_CONFI
 export class MatCard {
   @Input() appearance: MatCardAppearance;
 
-  constructor(...args: unknown[]);
-
   constructor() {
     const config = inject<MatCardConfig>(MAT_CARD_CONFIG, {optional: true});
     this.appearance = config?.appearance || 'raised';

--- a/src/material/checkbox/checkbox.ts
+++ b/src/material/checkbox/checkbox.ts
@@ -240,8 +240,6 @@ export class MatCheckbox
   private _controlValueAccessorChangeFn: (value: any) => void = () => {};
   private _validatorChangeFn = () => {};
 
-  constructor(...args: unknown[]);
-
   constructor() {
     inject(_CdkPrivateStyleLoader).load(_StructuralStylesLoader);
     const tabIndex = inject(new HostAttributeToken('tabindex'), {optional: true});

--- a/src/material/chips/chip-action.ts
+++ b/src/material/chips/chip-action.ts
@@ -82,8 +82,6 @@ export class MatChipContent {
     return this.disabled && !this._allowFocusWhenDisabled ? '' : null;
   }
 
-  constructor(...args: unknown[]);
-
   constructor() {
     inject(_CdkPrivateStyleLoader).load(_StructuralStylesLoader);
     if (this._elementRef.nativeElement.nodeName === 'BUTTON') {

--- a/src/material/chips/chip-edit-input.ts
+++ b/src/material/chips/chip-edit-input.ts
@@ -25,9 +25,6 @@ export class MatChipEditInput {
   private readonly _elementRef = inject(ElementRef);
   private readonly _document = inject(DOCUMENT);
 
-  constructor(...args: unknown[]);
-  constructor() {}
-
   initialize(initialValue: string) {
     this.getNativeElement().focus();
     this.setValue(initialValue);

--- a/src/material/chips/chip-grid.ts
+++ b/src/material/chips/chip-grid.ts
@@ -254,8 +254,6 @@ export class MatChipGrid
     this._errorStateTracker.errorState = value;
   }
 
-  constructor(...args: unknown[]);
-
   constructor() {
     super();
 

--- a/src/material/chips/chip-input.ts
+++ b/src/material/chips/chip-input.ts
@@ -135,8 +135,6 @@ export class MatChipInput implements MatChipTextControl, OnChanges, OnDestroy {
   /** The native input element to which this directive is attached. */
   readonly inputElement!: HTMLInputElement;
 
-  constructor(...args: unknown[]);
-
   constructor() {
     const defaultOptions = inject<MatChipsDefaultOptions>(MAT_CHIPS_DEFAULT_OPTIONS);
     const formField = inject<MatFormField>(MAT_FORM_FIELD, {optional: true});

--- a/src/material/chips/chip-row.ts
+++ b/src/material/chips/chip-row.ts
@@ -110,8 +110,6 @@ export class MatChipRow extends MatChip implements AfterViewInit, OnDestroy {
 
   _isEditing = false;
 
-  constructor(...args: unknown[]);
-
   constructor() {
     super();
 

--- a/src/material/chips/chip-set.ts
+++ b/src/material/chips/chip-set.ts
@@ -134,9 +134,6 @@ export class MatChipSet implements AfterViewInit, OnDestroy {
   /** Flat list of all the actions contained within the chips. */
   _chipActions = new QueryList<MatChipAction>();
 
-  constructor(...args: unknown[]);
-  constructor() {}
-
   ngAfterViewInit() {
     this._setUpFocusManagement();
     this._trackChipSetChanges();

--- a/src/material/chips/chip.ts
+++ b/src/material/chips/chip.ts
@@ -255,8 +255,6 @@ export class MatChip implements OnInit, AfterViewInit, AfterContentInit, DoCheck
 
   protected _injector = inject(Injector);
 
-  constructor(...args: unknown[]);
-
   constructor() {
     const styleLoader = inject(_CdkPrivateStyleLoader);
     styleLoader.load(_StructuralStylesLoader);

--- a/src/material/core/datetime/native-date-adapter.ts
+++ b/src/material/core/datetime/native-date-adapter.ts
@@ -45,8 +45,6 @@ export class NativeDateAdapter extends DateAdapter<Date> {
   /** The injected locale. */
   private readonly _matDateLocale = inject(MAT_DATE_LOCALE, {optional: true});
 
-  constructor(...args: unknown[]);
-
   constructor() {
     super();
 

--- a/src/material/core/option/optgroup.ts
+++ b/src/material/core/option/optgroup.ts
@@ -76,8 +76,6 @@ export class MatOptgroup {
   /** Whether the group is in inert a11y mode. */
   _inert: boolean;
 
-  constructor(...args: unknown[]);
-
   constructor() {
     const parent = inject<MatOptionParentComponent>(MAT_OPTION_PARENT_COMPONENT, {optional: true});
     this._inert = parent?.inertGroups ?? false;

--- a/src/material/core/option/option.ts
+++ b/src/material/core/option/option.ts
@@ -138,7 +138,6 @@ export class MatOption<T = any> implements FocusableOption, AfterViewChecked, On
   /** Emits when the state of the option changes and any parents have to be notified. */
   readonly _stateChanges = new Subject<void>();
 
-  constructor(...args: unknown[]);
   constructor() {
     const styleLoader = inject(_CdkPrivateStyleLoader);
     styleLoader.load(_StructuralStylesLoader);

--- a/src/material/core/ripple/ripple.ts
+++ b/src/material/core/ripple/ripple.ts
@@ -133,8 +133,6 @@ export class MatRipple implements OnInit, OnDestroy, RippleTarget {
   /** @docs-private Whether ripple directive is initialized and the input bindings are set. */
   _isInitialized: boolean = false;
 
-  constructor(...args: unknown[]);
-
   constructor() {
     const ngZone = inject(NgZone);
     const platform = inject(Platform);

--- a/src/material/core/selection/pseudo-checkbox/pseudo-checkbox.ts
+++ b/src/material/core/selection/pseudo-checkbox/pseudo-checkbox.ts
@@ -58,7 +58,4 @@ export class MatPseudoCheckbox {
    * indicator inside a square box. 'minimal' appearance only renders the checkmark/mixedmark.
    */
   @Input() appearance: 'minimal' | 'full' = 'full';
-
-  constructor(...args: unknown[]);
-  constructor() {}
 }

--- a/src/material/datepicker/calendar-body.ts
+++ b/src/material/datepicker/calendar-body.ts
@@ -224,8 +224,6 @@ export class MatCalendarBody<D = any> implements OnChanges, OnDestroy, AfterView
    */
   _trackRow = (row: MatCalendarCell[]) => row;
 
-  constructor(...args: unknown[]);
-
   constructor() {
     const renderer = inject(Renderer2);
     const idGenerator = inject(_IdGenerator);

--- a/src/material/datepicker/calendar.ts
+++ b/src/material/datepicker/calendar.ts
@@ -71,8 +71,6 @@ export class MatCalendarHeader<D> {
   private _prevButtonLabel!: string;
   private _nextButtonLabel!: string;
 
-  constructor(...args: unknown[]);
-
   constructor() {
     inject(_CdkPrivateStyleLoader).load(_VisuallyHiddenLoader);
     const changeDetectorRef = inject(ChangeDetectorRef);
@@ -419,8 +417,6 @@ export class MatCalendar<D> implements AfterContentInit, AfterViewChecked, OnDes
    * Emits whenever there is a state change that the header may need to respond to.
    */
   readonly stateChanges = new Subject<void>();
-
-  constructor(...args: unknown[]);
 
   constructor() {
     if (typeof ngDevMode === 'undefined' || ngDevMode) {

--- a/src/material/datepicker/date-range-input-parts.ts
+++ b/src/material/datepicker/date-range-input-parts.ts
@@ -82,8 +82,6 @@ abstract class MatDateRangeInputPartBase<D>
     this._errorStateTracker.errorState = value;
   }
 
-  constructor(...args: unknown[]);
-
   constructor() {
     super();
 

--- a/src/material/datepicker/date-range-input.ts
+++ b/src/material/datepicker/date-range-input.ts
@@ -263,8 +263,6 @@ export class MatDateRangeInput<D>
    */
   readonly disableAutomaticLabeling = true;
 
-  constructor(...args: unknown[]);
-
   constructor() {
     if (!this._dateAdapter && (typeof ngDevMode === 'undefined' || ngDevMode)) {
       throw createMissingDateImplError('DateAdapter');

--- a/src/material/datepicker/datepicker-actions.ts
+++ b/src/material/datepicker/datepicker-actions.ts
@@ -30,10 +30,6 @@ export class MatDatepickerApply {
   private _datepicker =
     inject<MatDatepickerBase<MatDatepickerControl<any>, unknown>>(MatDatepickerBase);
 
-  constructor(...args: unknown[]);
-
-  constructor() {}
-
   _applySelection() {
     this._datepicker._applyPendingSelection();
     this._datepicker.close();
@@ -47,9 +43,6 @@ export class MatDatepickerApply {
 })
 export class MatDatepickerCancel {
   _datepicker = inject<MatDatepickerBase<MatDatepickerControl<any>, unknown>>(MatDatepickerBase);
-
-  constructor(...args: unknown[]);
-  constructor() {}
 }
 
 /**
@@ -76,9 +69,6 @@ export class MatDatepickerActions implements AfterViewInit, OnDestroy {
 
   @ViewChild(TemplateRef) _template!: TemplateRef<unknown>;
   private _portal!: TemplatePortal;
-
-  constructor(...args: unknown[]);
-  constructor() {}
 
   ngAfterViewInit() {
     this._portal = new TemplatePortal(this._template, this._viewContainerRef);

--- a/src/material/datepicker/datepicker-base.ts
+++ b/src/material/datepicker/datepicker-base.ts
@@ -187,8 +187,6 @@ export class MatDatepickerContent<S, D = ExtractDateTypeFromSelection<S>>
   /** Id of the label for the `role="dialog"` element. */
   _dialogLabelId: string | null = null;
 
-  constructor(...args: unknown[]);
-
   constructor() {
     inject(_CdkPrivateStyleLoader).load(_VisuallyHiddenLoader);
     this._closeButtonText = inject(MatDatepickerIntl).closeCalendarLabel;
@@ -550,8 +548,6 @@ export abstract class MatDatepickerBase<
   readonly stateChanges = new Subject<void>();
 
   private readonly _changeDetectorRef = inject(ChangeDetectorRef);
-
-  constructor(...args: unknown[]);
 
   constructor() {
     if (!this._dateAdapter && (typeof ngDevMode === 'undefined' || ngDevMode)) {

--- a/src/material/datepicker/datepicker-input-base.ts
+++ b/src/material/datepicker/datepicker-input-base.ts
@@ -245,8 +245,6 @@ export abstract class MatDatepickerInputBase<S, D = ExtractDateTypeFromSelection
   /** Whether the last value set on the input was valid. */
   protected _lastValueValid = false;
 
-  constructor(...args: unknown[]);
-
   constructor() {
     if (typeof ngDevMode === 'undefined' || ngDevMode) {
       if (!this._dateAdapter) {

--- a/src/material/datepicker/datepicker-input.ts
+++ b/src/material/datepicker/datepicker-input.ts
@@ -132,8 +132,6 @@ export class MatDatepickerInput<D>
   /** The combined form control validator for this input. */
   protected _validator: ValidatorFn | null = null;
 
-  constructor(...args: unknown[]);
-
   constructor() {
     super();
     this._validator = Validators.compose(super._getValidators());

--- a/src/material/datepicker/datepicker-toggle.ts
+++ b/src/material/datepicker/datepicker-toggle.ts
@@ -93,8 +93,6 @@ export class MatDatepickerToggle<D> implements AfterContentInit, OnChanges, OnDe
   /** Underlying button element. */
   @ViewChild('button') _button!: MatButton;
 
-  constructor(...args: unknown[]);
-
   constructor() {
     const defaultTabIndex = inject(new HostAttributeToken('tabindex'), {optional: true});
     const parsedTabIndex = Number(defaultTabIndex);

--- a/src/material/datepicker/month-view.ts
+++ b/src/material/datepicker/month-view.ts
@@ -219,8 +219,6 @@ export class MatMonthView<D> implements AfterContentInit, OnChanges, OnDestroy {
   /** The names of the weekdays. */
   _weekdays = signal<{long: string; narrow: string; id: number}[]>([]);
 
-  constructor(...args: unknown[]);
-
   constructor() {
     inject(_CdkPrivateStyleLoader).load(_VisuallyHiddenLoader);
     if (typeof ngDevMode === 'undefined' || ngDevMode) {

--- a/src/material/datepicker/multi-year-view.ts
+++ b/src/material/datepicker/multi-year-view.ts
@@ -159,8 +159,6 @@ export class MatMultiYearView<D> implements AfterContentInit, OnDestroy {
   /** The year of the selected date. Null if the selected date is null. */
   _selectedYear = signal<number | null>(null);
 
-  constructor(...args: unknown[]);
-
   constructor() {
     if (!this._dateAdapter && (typeof ngDevMode === 'undefined' || ngDevMode)) {
       throw createMissingDateImplError('DateAdapter');

--- a/src/material/datepicker/year-view.ts
+++ b/src/material/datepicker/year-view.ts
@@ -154,8 +154,6 @@ export class MatYearView<D> implements AfterContentInit, OnDestroy {
    */
   _selectedMonth = signal<number | null>(null);
 
-  constructor(...args: unknown[]);
-
   constructor() {
     if (typeof ngDevMode === 'undefined' || ngDevMode) {
       if (!this._dateAdapter) {

--- a/src/material/dialog/dialog-content-directives.ts
+++ b/src/material/dialog/dialog-content-directives.ts
@@ -50,9 +50,6 @@ export class MatDialogClose implements OnInit, OnChanges {
 
   @Input('matDialogClose') _matDialogClose: any;
 
-  constructor(...args: unknown[]);
-  constructor() {}
-
   ngOnInit() {
     if (!this.dialogRef) {
       // When this directive is included in a dialog via TemplateRef (rather than being
@@ -90,10 +87,6 @@ export abstract class MatDialogLayoutSection implements OnInit, OnDestroy {
   protected _dialogRef = inject<MatDialogRef<any>>(MatDialogRef, {optional: true})!;
   private _elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
   private _dialog = inject(MatDialog);
-
-  constructor(...args: unknown[]);
-
-  constructor() {}
 
   protected abstract _onAdd(): void;
   protected abstract _onRemove(): void;

--- a/src/material/dialog/dialog.ts
+++ b/src/material/dialog/dialog.ts
@@ -98,8 +98,6 @@ export class MatDialog implements OnDestroy {
       : this._getAfterAllClosed().pipe(startWith(undefined)),
   ) as Observable<any>;
 
-  constructor(...args: unknown[]);
-
   constructor() {
     this._dialogRefConstructor = MatDialogRef;
     this._dialogContainerType = MatDialogContainer;

--- a/src/material/dialog/testing/dialog-opener.ts
+++ b/src/material/dialog/testing/dialog-opener.ts
@@ -56,8 +56,6 @@ export class MatTestDialogOpener<T = unknown, R = unknown> implements OnDestroy 
     return MatTestDialogOpener as ComponentType<MatTestDialogOpener<T, R>>;
   }
 
-  constructor(...args: unknown[]);
-
   constructor() {
     if (!MatTestDialogOpener.component) {
       throw new Error(`MatTestDialogOpener does not have a component provided.`);

--- a/src/material/expansion/expansion-panel-content.ts
+++ b/src/material/expansion/expansion-panel-content.ts
@@ -19,7 +19,4 @@ import {MAT_EXPANSION_PANEL, MatExpansionPanelBase} from './expansion-panel-base
 export class MatExpansionPanelContent {
   _template = inject<TemplateRef<any>>(TemplateRef);
   _expansionPanel = inject<MatExpansionPanelBase>(MAT_EXPANSION_PANEL, {optional: true});
-
-  constructor(...args: unknown[]);
-  constructor() {}
 }

--- a/src/material/expansion/expansion-panel-header.ts
+++ b/src/material/expansion/expansion-panel-header.ts
@@ -66,8 +66,6 @@ export class MatExpansionPanelHeader implements AfterViewInit, OnDestroy, Focusa
 
   private _parentChangeSubscription = Subscription.EMPTY;
 
-  constructor(...args: unknown[]);
-
   constructor() {
     inject(_CdkPrivateStyleLoader).load(_StructuralStylesLoader);
     const panel = this.panel;

--- a/src/material/expansion/expansion-panel.ts
+++ b/src/material/expansion/expansion-panel.ts
@@ -150,8 +150,6 @@ export class MatExpansionPanel
   /** ID for the associated header element. Used for a11y labelling. */
   _headerId: string = inject(_IdGenerator).getId('mat-expansion-panel-header-');
 
-  constructor(...args: unknown[]);
-
   constructor() {
     super();
 

--- a/src/material/form-field/directives/error.ts
+++ b/src/material/form-field/directives/error.ts
@@ -27,8 +27,4 @@ export const MAT_ERROR = new InjectionToken<MatError>('MatError');
 })
 export class MatError {
   @Input() id: string = inject(_IdGenerator).getId('mat-mdc-error-');
-
-  constructor(...args: unknown[]);
-
-  constructor() {}
 }

--- a/src/material/form-field/directives/floating-label.ts
+++ b/src/material/form-field/directives/floating-label.ts
@@ -89,9 +89,6 @@ export class MatFormFieldFloatingLabel implements OnDestroy {
   /** The current resize event subscription. */
   private _resizeSubscription = new Subscription();
 
-  constructor(...args: unknown[]);
-  constructor() {}
-
   ngOnDestroy() {
     this._resizeSubscription.unsubscribe();
   }

--- a/src/material/form-field/directives/line-ripple.ts
+++ b/src/material/form-field/directives/line-ripple.ts
@@ -32,8 +32,6 @@ export class MatFormFieldLineRipple implements OnDestroy {
   private _elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
   private _cleanupTransitionEnd!: () => void;
 
-  constructor(...args: unknown[]);
-
   constructor() {
     const ngZone = inject(NgZone);
     const renderer = inject(Renderer2);

--- a/src/material/form-field/form-field.ts
+++ b/src/material/form-field/form-field.ts
@@ -343,8 +343,6 @@ export class MatFormField
   private _outlineLabelOffsetResizeObserver: ResizeObserver | null = null;
   protected readonly _animationsDisabled = _animationsDisabled();
 
-  constructor(...args: unknown[]);
-
   constructor() {
     const defaults = this._defaults;
     const dir = inject(Directionality);

--- a/src/material/grid-list/grid-list.ts
+++ b/src/material/grid-list/grid-list.ts
@@ -84,9 +84,6 @@ export class MatGridList implements MatGridListBase, OnInit, AfterContentChecked
   /** Query list of tiles that are being rendered. */
   @ContentChildren(MatGridTile, {descendants: true}) _tiles!: QueryList<MatGridTile>;
 
-  constructor(...args: unknown[]);
-  constructor() {}
-
   /** Amount of columns in the grid list. */
   @Input()
   get cols(): number {

--- a/src/material/grid-list/grid-tile.ts
+++ b/src/material/grid-list/grid-tile.ts
@@ -44,9 +44,6 @@ export class MatGridTile {
   _rowspan: number = 1;
   _colspan: number = 1;
 
-  constructor(...args: unknown[]);
-  constructor() {}
-
   /** Amount of rows that the grid tile takes up. */
   @Input()
   get rowspan(): number {
@@ -84,9 +81,6 @@ export class MatGridTileText implements AfterContentInit {
   private _element = inject<ElementRef<HTMLElement>>(ElementRef);
 
   @ContentChildren(MatLine, {descendants: true}) _lines!: QueryList<MatLine>;
-
-  constructor(...args: unknown[]);
-  constructor() {}
 
   ngAfterContentInit() {
     setLines(this._lines, this._element);

--- a/src/material/icon/icon.ts
+++ b/src/material/icon/icon.ts
@@ -239,8 +239,6 @@ export class MatIcon implements OnInit, AfterViewChecked, OnDestroy {
   /** Subscription to the current in-progress SVG icon request. */
   private _currentIconFetch = Subscription.EMPTY;
 
-  constructor(...args: unknown[]);
-
   constructor() {
     const ariaHidden = inject(new HostAttributeToken('aria-hidden'), {optional: true});
     const defaults = inject<MatIconDefaultOptions>(MAT_ICON_DEFAULT_OPTIONS, {optional: true});

--- a/src/material/input/input.ts
+++ b/src/material/input/input.ts
@@ -294,8 +294,6 @@ export class MatInput
     'week',
   ].filter(t => getSupportedInputTypes().has(t));
 
-  constructor(...args: unknown[]);
-
   constructor() {
     const parentForm = inject(NgForm, {optional: true});
     const parentFormGroup = inject(FormGroupDirective, {optional: true});

--- a/src/material/list/list-base.ts
+++ b/src/material/list/list-base.ts
@@ -177,8 +177,6 @@ export abstract class MatListItemBase implements AfterViewInit, OnDestroy, Rippl
     return this.disableRipple || !!this.rippleConfig.disabled;
   }
 
-  constructor(...args: unknown[]);
-
   constructor() {
     inject(_CdkPrivateStyleLoader).load(_StructuralStylesLoader);
     const globalRippleOptions = inject<RippleGlobalOptions>(MAT_RIPPLE_GLOBAL_OPTIONS, {

--- a/src/material/list/list-item-sections.ts
+++ b/src/material/list/list-item-sections.ts
@@ -21,9 +21,6 @@ import {LIST_OPTION, ListOption} from './list-option-types';
 })
 export class MatListItemTitle {
   _elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
-
-  constructor(...args: unknown[]);
-  constructor() {}
 }
 
 /**
@@ -38,9 +35,6 @@ export class MatListItemTitle {
 })
 export class MatListItemLine {
   _elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
-
-  constructor(...args: unknown[]);
-  constructor() {}
 }
 
 /**
@@ -75,9 +69,6 @@ export class MatListItemMeta {}
 })
 export class _MatListItemGraphicBase {
   _listOption = inject<ListOption>(LIST_OPTION, {optional: true});
-
-  constructor(...args: unknown[]);
-  constructor() {}
 
   _isAlignedAtStart() {
     // By default, in all list items the graphic is aligned at start. In list options,

--- a/src/material/list/selection-list.ts
+++ b/src/material/list/selection-list.ts
@@ -161,8 +161,6 @@ export class MatSelectionList
 
   private readonly _changeDetectorRef = inject(ChangeDetectorRef);
 
-  constructor(...args: unknown[]);
-
   constructor() {
     super();
     this._isNonInteractive = false;

--- a/src/material/menu/menu-content.ts
+++ b/src/material/menu/menu-content.ts
@@ -48,10 +48,6 @@ export class MatMenuContent implements OnDestroy {
   /** Emits when the menu content has been attached. */
   readonly _attached = new Subject<void>();
 
-  constructor(...args: unknown[]);
-
-  constructor() {}
-
   /**
    * Attaches the content with a particular context.
    * @docs-private

--- a/src/material/menu/menu-item.ts
+++ b/src/material/menu/menu-item.ts
@@ -76,8 +76,6 @@ export class MatMenuItem implements FocusableOption, AfterViewInit, OnDestroy {
   /** Whether the menu item acts as a trigger for a sub-menu. */
   _triggersSubmenu: boolean = false;
 
-  constructor(...args: unknown[]);
-
   constructor() {
     inject(_CdkPrivateStyleLoader).load(_StructuralStylesLoader);
     this._parentMenu?.addItem?.(this);

--- a/src/material/menu/menu-trigger.ts
+++ b/src/material/menu/menu-trigger.ts
@@ -97,8 +97,6 @@ export class MatMenuTrigger extends MatMenuTriggerBase implements AfterContentIn
   // tslint:disable-next-line:no-output-on-prefix
   @Output() readonly onMenuClose: EventEmitter<void> = this.menuClosed;
 
-  constructor(...args: unknown[]);
-
   constructor() {
     super(true);
 

--- a/src/material/menu/menu.ts
+++ b/src/material/menu/menu.ts
@@ -272,8 +272,6 @@ export class MatMenu implements AfterContentInit, MatMenuPanel<MatMenuItem>, OnI
 
   readonly panelId: string = inject(_IdGenerator).getId('mat-menu-panel-');
 
-  constructor(...args: unknown[]);
-
   constructor() {
     const defaultOptions = inject<MatMenuDefaultOptions>(MAT_MENU_DEFAULT_OPTIONS);
     this.overlayPanelClass = defaultOptions.overlayPanelClass || '';

--- a/src/material/paginator/paginator.ts
+++ b/src/material/paginator/paginator.ts
@@ -200,8 +200,6 @@ export class MatPaginator implements OnInit, OnDestroy {
   initialized: Observable<void> = this._initializedStream;
 
   /** Inserted by Angular inject() migration for backwards compatibility */
-  constructor(...args: unknown[]);
-
   constructor() {
     const _intl = this._intl;
     const defaults = inject<MatPaginatorDefaultOptions>(MAT_PAGINATOR_DEFAULT_OPTIONS, {

--- a/src/material/progress-bar/progress-bar.ts
+++ b/src/material/progress-bar/progress-bar.ts
@@ -114,8 +114,6 @@ export class MatProgressBar implements AfterViewInit, OnDestroy {
   private _renderer = inject(Renderer2);
   private _cleanupTransitionEnd: (() => void) | undefined;
 
-  constructor(...args: unknown[]);
-
   constructor() {
     const animationsState = _getAnimationsState();
 

--- a/src/material/progress-spinner/progress-spinner.ts
+++ b/src/material/progress-spinner/progress-spinner.ts
@@ -115,8 +115,6 @@ export class MatProgressSpinner {
   /** The element of the determinate spinner. */
   @ViewChild('determinateSpinner') _determinateCircle!: ElementRef<HTMLElement>;
 
-  constructor(...args: unknown[]);
-
   constructor() {
     const defaults = inject<MatProgressSpinnerDefaultOptions>(MAT_PROGRESS_SPINNER_DEFAULT_OPTIONS);
     const animationsState = _getAnimationsState();

--- a/src/material/radio/radio.ts
+++ b/src/material/radio/radio.ts
@@ -263,10 +263,6 @@ export class MatRadioGroup implements AfterContentInit, OnDestroy, ControlValueA
   }
   private _disabledInteractive = false;
 
-  constructor(...args: unknown[]);
-
-  constructor() {}
-
   /**
    * Initialize properties once content children are available.
    * This allows us to propagate relevant attributes to associated buttons.
@@ -599,8 +595,6 @@ export class MatRadioButton implements OnInit, AfterViewInit, DoCheck, OnDestroy
   _noopAnimations = _animationsDisabled();
 
   private _injector = inject(Injector);
-
-  constructor(...args: unknown[]);
 
   constructor() {
     inject(_CdkPrivateStyleLoader).load(_StructuralStylesLoader);

--- a/src/material/select/select.ts
+++ b/src/material/select/select.ts
@@ -597,8 +597,6 @@ export class MatSelect
    */
   @Output() readonly valueChange: EventEmitter<any> = new EventEmitter<any>();
 
-  constructor(...args: unknown[]);
-
   constructor() {
     const defaultErrorStateMatcher = inject(ErrorStateMatcher);
     const parentForm = inject(NgForm, {optional: true});

--- a/src/material/sidenav/drawer.ts
+++ b/src/material/sidenav/drawer.ts
@@ -16,7 +16,7 @@ import {Directionality} from '@angular/cdk/bidi';
 import {BooleanInput, coerceBooleanProperty} from '@angular/cdk/coercion';
 import {ESCAPE, hasModifierKey} from '@angular/cdk/keycodes';
 import {Platform} from '@angular/cdk/platform';
-import {CdkScrollable, ScrollDispatcher, ViewportRuler} from '@angular/cdk/scrolling';
+import {CdkScrollable, ViewportRuler} from '@angular/cdk/scrolling';
 
 import {
   AfterContentInit,
@@ -102,16 +102,6 @@ export class MatDrawerContent extends CdkScrollable implements AfterContentInit 
   private _platform = inject(Platform);
   private _changeDetectorRef = inject(ChangeDetectorRef);
   _container = inject(MatDrawerContainer);
-
-  constructor(...args: unknown[]);
-
-  constructor() {
-    const elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
-    const scrollDispatcher = inject(ScrollDispatcher);
-    const ngZone = inject(NgZone);
-
-    super(elementRef, scrollDispatcher, ngZone);
-  }
 
   ngAfterContentInit() {
     this._container._contentMarginChanges.subscribe(() => {
@@ -332,8 +322,6 @@ export class MatDrawer implements AfterViewInit, OnDestroy {
 
   private _injector = inject(Injector);
   private _changeDetectorRef = inject(ChangeDetectorRef);
-
-  constructor(...args: unknown[]);
 
   constructor() {
     this.openedChange.pipe(takeUntil(this._destroyed)).subscribe((opened: boolean) => {
@@ -787,8 +775,6 @@ export class MatDrawerContainer implements AfterContentInit, DoCheck, OnDestroy 
   }
 
   private _injector = inject(Injector);
-
-  constructor(...args: unknown[]);
 
   constructor() {
     const platform = inject(Platform);

--- a/src/material/slide-toggle/slide-toggle.ts
+++ b/src/material/slide-toggle/slide-toggle.ts
@@ -204,8 +204,6 @@ export class MatSlideToggle
     return `${this.id || this._uniqueId}-input`;
   }
 
-  constructor(...args: unknown[]);
-
   constructor() {
     inject(_CdkPrivateStyleLoader).load(_StructuralStylesLoader);
     const tabIndex = inject(new HostAttributeToken('tabindex'), {optional: true});

--- a/src/material/slider/slider-input.ts
+++ b/src/material/slider/slider-input.ts
@@ -281,8 +281,6 @@ export class MatSliderThumb implements _MatSliderThumb, OnDestroy, ControlValueA
    */
   protected _isControlInitialized = false;
 
-  constructor(...args: unknown[]);
-
   constructor() {
     const renderer = inject(Renderer2);
 
@@ -660,8 +658,6 @@ export class MatSliderRangeThumb extends MatSliderThumb implements _MatSliderRan
 
   /** Whether this slider corresponds to the input with greater value. */
   _isEndThumb = false;
-
-  constructor(...args: unknown[]);
 
   constructor() {
     super();

--- a/src/material/slider/slider-thumb.ts
+++ b/src/material/slider/slider-thumb.ts
@@ -105,9 +105,6 @@ export class MatSliderVisualThumb implements _MatSliderVisualThumb, AfterViewIni
 
   private _platform = inject(Platform);
 
-  constructor(...args: unknown[]);
-  constructor() {}
-
   ngAfterViewInit() {
     const sliderInput = this._slider._getInput(this.thumbPosition);
 

--- a/src/material/slider/slider.ts
+++ b/src/material/slider/slider.ts
@@ -415,8 +415,6 @@ export class MatSlider implements AfterViewInit, OnDestroy, _MatSlider {
 
   private _platform = inject(Platform);
 
-  constructor(...args: unknown[]);
-
   constructor() {
     inject(_CdkPrivateStyleLoader).load(_StructuralStylesLoader);
 

--- a/src/material/snack-bar/simple-snack-bar.ts
+++ b/src/material/snack-bar/simple-snack-bar.ts
@@ -38,9 +38,6 @@ export class SimpleSnackBar implements TextOnlySnackBar {
   snackBarRef = inject<MatSnackBarRef<SimpleSnackBar>>(MatSnackBarRef);
   data = inject(MAT_SNACK_BAR_DATA);
 
-  constructor(...args: unknown[]);
-  constructor() {}
-
   /** Performs the action on the snack bar. */
   action(): void {
     this.snackBarRef.dismissWithAction();

--- a/src/material/snack-bar/snack-bar-container.ts
+++ b/src/material/snack-bar/snack-bar-container.ts
@@ -120,8 +120,6 @@ export class MatSnackBarContainer extends BasePortalOutlet implements OnDestroy 
   /** Unique ID of the aria-live element. */
   readonly _liveElementId = inject(_IdGenerator).getId('mat-snack-bar-container-live-');
 
-  constructor(...args: unknown[]);
-
   constructor() {
     super();
     const config = this.snackBarConfig;

--- a/src/material/snack-bar/snack-bar.ts
+++ b/src/material/snack-bar/snack-bar.ts
@@ -84,9 +84,6 @@ export class MatSnackBar implements OnDestroy {
     }
   }
 
-  constructor(...args: unknown[]);
-  constructor() {}
-
   /**
    * Creates and dispatches a snack bar with a custom component for the content, removing any
    * currently opened snack bars.

--- a/src/material/sort/sort-header.ts
+++ b/src/material/sort/sort-header.ts
@@ -143,8 +143,6 @@ export class MatSortHeader implements MatSortable, OnDestroy, OnInit, AfterViewI
   @Input({transform: booleanAttribute})
   disableClear!: boolean;
 
-  constructor(...args: unknown[]);
-
   constructor() {
     inject(_CdkPrivateStyleLoader).load(_StructuralStylesLoader);
     const defaultOptions = inject<MatSortDefaultOptions>(MAT_SORT_DEFAULT_OPTIONS, {

--- a/src/material/stepper/step-content.ts
+++ b/src/material/stepper/step-content.ts
@@ -16,7 +16,4 @@ import {Directive, TemplateRef, inject} from '@angular/core';
 })
 export class MatStepContent<C = unknown> {
   _template = inject<TemplateRef<C>>(TemplateRef);
-
-  constructor(...args: unknown[]);
-  constructor() {}
 }

--- a/src/material/stepper/step-header.ts
+++ b/src/material/stepper/step-header.ts
@@ -84,8 +84,6 @@ export class MatStepHeader extends CdkStepHeader implements AfterViewInit, OnDes
    */
   @Input() color!: ThemePalette;
 
-  constructor(...args: unknown[]);
-
   constructor() {
     super();
 

--- a/src/material/stepper/stepper-icon.ts
+++ b/src/material/stepper/stepper-icon.ts
@@ -30,7 +30,4 @@ export class MatStepperIcon {
 
   /** Name of the icon to be overridden. */
   @Input('matStepperIcon') name!: StepState;
-
-  constructor(...args: unknown[]);
-  constructor() {}
 }

--- a/src/material/stepper/stepper.ts
+++ b/src/material/stepper/stepper.ts
@@ -207,8 +207,6 @@ export class MatStepper extends CdkStepper implements AfterViewInit, AfterConten
   /** Whether the stepper is rendering on the server. */
   protected _isServer: boolean = !inject(Platform).isBrowser;
 
-  constructor(...args: unknown[]);
-
   constructor() {
     super();
 

--- a/src/material/tabs/paginated-tab-header.ts
+++ b/src/material/tabs/paginated-tab-header.ts
@@ -159,8 +159,6 @@ export abstract class MatPaginatedTabHeader
   /** Event emitted when a label is focused. */
   @Output() readonly indexFocused: EventEmitter<number> = new EventEmitter<number>();
 
-  constructor(...args: unknown[]);
-
   constructor() {
     // Bind the `mouseleave` event on the outside since it doesn't change anything in the view.
     this._eventCleanups = this._ngZone.runOutsideAngular(() => [

--- a/src/material/tabs/tab-body.ts
+++ b/src/material/tabs/tab-body.ts
@@ -46,12 +46,6 @@ export class MatTabBodyPortal extends CdkPortalOutlet implements OnInit, OnDestr
   /** Subscription to events for when the tab body finishes leaving from center position. */
   private _leavingSub = Subscription.EMPTY;
 
-  constructor(...args: unknown[]);
-
-  constructor() {
-    super();
-  }
-
   /** Set initial visibility or set up subscription for changing visibility. */
   override ngOnInit(): void {
     super.ngOnInit();
@@ -191,8 +185,6 @@ export class MatTabBody implements OnInit, OnDestroy {
     this._positionIndex = position;
     this._computePositionAnimationState();
   }
-
-  constructor(...args: unknown[]);
 
   constructor() {
     if (this._dir) {

--- a/src/material/tabs/tab-content.ts
+++ b/src/material/tabs/tab-content.ts
@@ -22,7 +22,4 @@ export const MAT_TAB_CONTENT = new InjectionToken<MatTabContent>('MatTabContent'
 })
 export class MatTabContent {
   template = inject<TemplateRef<any>>(TemplateRef);
-
-  constructor(...args: unknown[]);
-  constructor() {}
 }

--- a/src/material/tabs/tab-group.ts
+++ b/src/material/tabs/tab-group.ts
@@ -288,8 +288,6 @@ export class MatTabGroup
   /** Whether the tab group is rendered on the server. */
   protected _isServer: boolean = !inject(Platform).isBrowser;
 
-  constructor(...args: unknown[]);
-
   constructor() {
     const defaultConfig = inject<MatTabsConfig>(MAT_TABS_CONFIG, {optional: true});
 

--- a/src/material/tabs/tab-nav-bar/tab-nav-bar.ts
+++ b/src/material/tabs/tab-nav-bar/tab-nav-bar.ts
@@ -163,8 +163,6 @@ export class MatTabNav extends MatPaginatedTabHeader implements AfterContentInit
   @ViewChild('previousPaginator') _previousPaginator!: ElementRef<HTMLElement>;
   _inkBar!: MatInkBar;
 
-  constructor(...args: unknown[]);
-
   constructor() {
     const defaultConfig = inject<MatTabsConfig>(MAT_TABS_CONFIG, {optional: true});
 
@@ -340,8 +338,6 @@ export class MatTabLink
 
   /** Unique id for the tab. */
   @Input() id: string = inject(_IdGenerator).getId('mat-tab-link-');
-
-  constructor(...args: unknown[]);
 
   constructor() {
     super();

--- a/src/material/tabs/tab.ts
+++ b/src/material/tabs/tab.ts
@@ -137,7 +137,6 @@ export class MatTab implements OnInit, OnChanges, OnDestroy {
    */
   isActive = false;
 
-  constructor(...args: unknown[]);
   constructor() {
     inject(_CdkPrivateStyleLoader).load(_StructuralStylesLoader);
   }

--- a/src/material/toolbar/toolbar.ts
+++ b/src/material/toolbar/toolbar.ts
@@ -61,9 +61,6 @@ export class MatToolbar implements AfterViewInit {
   /** Reference to all toolbar row elements that have been projected. */
   @ContentChildren(MatToolbarRow, {descendants: true}) _toolbarRows!: QueryList<MatToolbarRow>;
 
-  constructor(...args: unknown[]);
-  constructor() {}
-
   ngAfterViewInit() {
     if (this._platform.isBrowser) {
       this._checkToolbarMixedModes();

--- a/src/material/tooltip/tooltip.ts
+++ b/src/material/tooltip/tooltip.ts
@@ -378,8 +378,6 @@ export class MatTooltip implements OnDestroy, AfterViewInit {
   /** Whether ngOnDestroyed has been called. */
   private _isDestroyed = false;
 
-  constructor(...args: unknown[]);
-
   constructor() {
     const defaultOptions = this._defaultOptions;
 
@@ -1019,10 +1017,6 @@ export class TooltipComponent implements OnDestroy {
 
   /** Name of the hide animation and the class that toggles it. */
   private readonly _hideAnimation = 'mat-mdc-tooltip-hide';
-
-  constructor(...args: unknown[]);
-
-  constructor() {}
 
   /**
    * Shows the tooltip with an animation originating from the provided origin

--- a/src/material/tree/node.ts
+++ b/src/material/tree/node.ts
@@ -105,8 +105,6 @@ export class MatTreeNode<T, K = T> extends CdkTreeNode<T, K> implements OnInit, 
     this.isDisabled = value;
   }
 
-  constructor(...args: unknown[]);
-
   constructor() {
     super();
 

--- a/src/youtube-player/youtube-player.ts
+++ b/src/youtube-player/youtube-player.ts
@@ -250,8 +250,6 @@ export class YouTubePlayer implements AfterViewInit, OnChanges, OnDestroy {
   @ViewChild('youtubeContainer', {static: true})
   youtubeContainer!: ElementRef<HTMLElement>;
 
-  constructor(...args: unknown[]);
-
   constructor() {
     const platformId = inject<Object>(PLATFORM_ID);
     const config = inject(YOUTUBE_PLAYER_CONFIG, {optional: true});


### PR DESCRIPTION
When we made the transition to `inject`, we added some constructors for backwards compatibility. These changes remove them since they weren't used for anything.

BREAKING CHANGE:
* A bunch of constructors that with rest arguments have been removed. If you were extending Material/CDK components, you may have to update your `super` calls accordingly.