### PR TITLE
refactor(multiple): Clean up afterRenderEffect usage across angular aria

### DIFF
--- a/goldens/aria/combobox/index.api.md
+++ b/goldens/aria/combobox/index.api.md
@@ -36,11 +36,12 @@ export class ComboboxDialog {
     // (undocumented)
     close(): void;
     readonly combobox: Combobox<any>;
-    readonly element: HTMLElement;
+    readonly element: HTMLDialogElement;
+    readonly id: _angular_core.InputSignal<string>;
     // (undocumented)
     readonly _pattern: ComboboxDialogPattern;
     // (undocumented)
-    static ɵdir: _angular_core.ɵɵDirectiveDeclaration<ComboboxDialog, "dialog[ngComboboxDialog]", ["ngComboboxDialog"], {}, {}, never, never, true, [{ directive: typeof ComboboxPopup; inputs: {}; outputs: {}; }]>;
+    static ɵdir: _angular_core.ɵɵDirectiveDeclaration<ComboboxDialog, "dialog[ngComboboxDialog]", ["ngComboboxDialog"], { "id": { "alias": "id"; "required": false; "isSignal": true; }; }, {}, never, never, true, [{ directive: typeof ComboboxPopup; inputs: {}; outputs: {}; }]>;
     // (undocumented)
     static ɵfac: _angular_core.ɵɵFactoryDeclaration<ComboboxDialog, never>;
 }

--- a/src/aria/accordion/accordion-panel.ts
+++ b/src/aria/accordion/accordion-panel.ts
@@ -72,8 +72,10 @@ export class AccordionPanel {
 
   constructor() {
     // Connect the panel's hidden state to the DeferredContentAware's visibility.
-    afterRenderEffect(() => {
-      this._deferredContentAware.contentVisible.set(this.visible());
+    afterRenderEffect({
+      write: () => {
+        this._deferredContentAware.contentVisible.set(this.visible());
+      },
     });
   }
 

--- a/src/aria/combobox/BUILD.bazel
+++ b/src/aria/combobox/BUILD.bazel
@@ -11,6 +11,7 @@ ng_project(
     deps = [
         "//:node_modules/@angular/core",
         "//src/aria/private",
+        "//src/cdk/a11y",
         "//src/cdk/bidi",
     ],
 )

--- a/src/aria/combobox/combobox-dialog.ts
+++ b/src/aria/combobox/combobox-dialog.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {afterRenderEffect, Directive, ElementRef, inject} from '@angular/core';
+import {afterRenderEffect, Directive, ElementRef, inject, input} from '@angular/core';
+import {_IdGenerator} from '@angular/cdk/a11y';
 import {ComboboxDialogPattern} from '../private';
 import {Combobox} from './combobox';
 import {ComboboxPopup} from './combobox-popup';
@@ -46,35 +47,34 @@ export class ComboboxDialog {
   private readonly _elementRef = inject(ElementRef<HTMLDialogElement>);
 
   /** A reference to the dialog element. */
-  readonly element = this._elementRef.nativeElement as HTMLElement;
+  readonly element = this._elementRef.nativeElement as HTMLDialogElement;
 
   /** The combobox that the dialog belongs to. */
   readonly combobox = inject(Combobox);
+
+  /** The unique identifier for the trigger. */
+  readonly id = input(inject(_IdGenerator).getId('ng-combobox-dialog-', true));
 
   /** A reference to the parent combobox popup, if one exists. */
   private readonly _popup = inject<ComboboxPopup<unknown>>(ComboboxPopup, {
     optional: true,
   });
 
-  readonly _pattern: ComboboxDialogPattern;
+  readonly _pattern: ComboboxDialogPattern = new ComboboxDialogPattern({
+    id: this.id,
+    element: () => this.element,
+    combobox: this.combobox._pattern,
+  });
 
   constructor() {
-    this._pattern = new ComboboxDialogPattern({
-      id: () => '',
-      element: () => this._elementRef.nativeElement,
-      combobox: this.combobox._pattern,
-    });
-
     if (this._popup) {
       this._popup._controls.set(this._pattern);
     }
 
-    afterRenderEffect(() => {
-      if (this._elementRef) {
-        this.combobox._pattern.expanded()
-          ? this._elementRef.nativeElement.showModal()
-          : this._elementRef.nativeElement.close();
-      }
+    afterRenderEffect({
+      write: () => {
+        this.combobox._pattern.expanded() ? this.element.showModal() : this.element.close();
+      },
     });
   }
 

--- a/src/aria/combobox/combobox-input.ts
+++ b/src/aria/combobox/combobox-input.ts
@@ -81,10 +81,12 @@ export class ComboboxInput {
     }
 
     /** Focuses & selects the first item in the combobox if the user changes the input value. */
-    afterRenderEffect(() => {
-      this.value();
-      controls?.items();
-      untracked(() => this.combobox._pattern.onFilter());
+    afterRenderEffect({
+      write: () => {
+        this.value();
+        controls?.items();
+        untracked(() => this.combobox._pattern.onFilter());
+      },
     });
   }
 }

--- a/src/aria/combobox/combobox.ts
+++ b/src/aria/combobox/combobox.ts
@@ -140,13 +140,15 @@ export class Combobox<V> {
       }
     });
 
-    afterRenderEffect(() => {
-      if (
-        !this._deferredContentAware?.contentVisible() &&
-        (this._pattern.isFocused() || this.alwaysExpanded())
-      ) {
-        this._deferredContentAware?.contentVisible.set(true);
-      }
+    afterRenderEffect({
+      write: () => {
+        if (
+          !this._deferredContentAware?.contentVisible() &&
+          (this._pattern.isFocused() || this.alwaysExpanded())
+        ) {
+          this._deferredContentAware?.contentVisible.set(true);
+        }
+      },
     });
   }
 

--- a/src/aria/grid/grid-cell-widget.ts
+++ b/src/aria/grid/grid-cell-widget.ts
@@ -104,19 +104,23 @@ export class GridCellWidget {
   }
 
   constructor() {
-    afterRenderEffect(() => {
-      if (this._pattern.isActivated()) {
-        const activateEvent = this._pattern.lastActivateEvent();
-        this.activated.emit(activateEvent);
-        this._pattern.focus();
-      }
+    afterRenderEffect({
+      read: () => {
+        if (this._pattern.isActivated()) {
+          const activateEvent = this._pattern.lastActivateEvent();
+          this.activated.emit(activateEvent);
+          this._pattern.focus();
+        }
+      },
     });
 
-    afterRenderEffect(() => {
-      const deactivateEvent = this._pattern.lastDeactivateEvent();
-      if (deactivateEvent) {
-        this.deactivated.emit(deactivateEvent);
-      }
+    afterRenderEffect({
+      read: () => {
+        const deactivateEvent = this._pattern.lastDeactivateEvent();
+        if (deactivateEvent) {
+          this.deactivated.emit(deactivateEvent);
+        }
+      },
     });
   }
 

--- a/src/aria/grid/grid.ts
+++ b/src/aria/grid/grid.ts
@@ -129,11 +129,12 @@ export class Grid {
   });
 
   constructor() {
-    afterRenderEffect(() => this._pattern.setDefaultStateEffect());
-    afterRenderEffect(() => this._pattern.resetStateEffect());
-    afterRenderEffect(() => this._pattern.resetFocusEffect());
-    afterRenderEffect(() => this._pattern.restoreFocusEffect());
-    afterRenderEffect(() => this._pattern.focusEffect());
+    // Use Write mode for all direct DOM focus management actions.
+    afterRenderEffect({write: () => this._pattern.setDefaultStateEffect()});
+    afterRenderEffect({write: () => this._pattern.resetStateEffect()});
+    afterRenderEffect({write: () => this._pattern.resetFocusEffect()});
+    afterRenderEffect({write: () => this._pattern.restoreFocusEffect()});
+    afterRenderEffect({write: () => this._pattern.focusEffect()});
   }
 
   /** Gets the cell pattern for a given element. */

--- a/src/aria/listbox/listbox.ts
+++ b/src/aria/listbox/listbox.ts
@@ -158,36 +158,44 @@ export class Listbox<V> {
       this._popup._controls.set(this._pattern as ComboboxListboxPattern<V>);
     }
 
-    afterRenderEffect(() => {
-      if (typeof ngDevMode === 'undefined' || ngDevMode) {
-        const violations = this._pattern.validate();
-        for (const violation of violations) {
-          console.error(violation);
+    // Check for any violationns after the DOM has been updated.
+    afterRenderEffect({
+      read: () => {
+        if (typeof ngDevMode === 'undefined' || ngDevMode) {
+          const violations = this._pattern.validate();
+          for (const violation of violations) {
+            console.error(violation);
+          }
         }
-      }
+      },
     });
 
     afterRenderEffect({write: () => this._pattern.setDefaultStateEffect()});
 
     // Ensure that if the active item is removed from
     // the list, the listbox updates it's focus state.
-    afterRenderEffect(() => {
-      const items = inputs.items();
-      const activeItem = untracked(() => inputs.activeItem());
+    afterRenderEffect({
+      write: () => {
+        const items = inputs.items();
+        const activeItem = untracked(() => inputs.activeItem());
 
-      if (!items.some(i => i === activeItem) && activeItem) {
-        this._pattern.listBehavior.unfocus();
-      }
+        if (!items.some(i => i === activeItem) && activeItem) {
+          this._pattern.listBehavior.unfocus();
+        }
+      },
     });
 
     // Ensure that the value is always in sync with the available options.
-    afterRenderEffect(() => {
-      const items = inputs.items();
-      const value = untracked(() => this.value());
+    // This needs to be after the render for the value to always be available.
+    afterRenderEffect({
+      write: () => {
+        const items = inputs.items();
+        const value = untracked(() => this.value());
 
-      if (items && value.some(v => !items.some(i => i.value() === v))) {
-        this.value.set(value.filter(v => items.some(i => i.value() === v)));
-      }
+        if (items && value.some(v => !items.some(i => i.value() === v))) {
+          this.value.set(value.filter(v => items.some(i => i.value() === v)));
+        }
+      },
     });
   }
 

--- a/src/aria/listbox/listbox.ts
+++ b/src/aria/listbox/listbox.ts
@@ -167,9 +167,7 @@ export class Listbox<V> {
       }
     });
 
-    afterRenderEffect(() => {
-      this._pattern.setDefaultStateEffect();
-    });
+    afterRenderEffect({write: () => this._pattern.setDefaultStateEffect()});
 
     // Ensure that if the active item is removed from
     // the list, the listbox updates it's focus state.

--- a/src/aria/menu/menu-bar.ts
+++ b/src/aria/menu/menu-bar.ts
@@ -104,7 +104,7 @@ export class MenuBar<V> {
   readonly _pattern: MenuBarPattern<V>;
 
   /** The menu items as a writable signal. */
-  private readonly _itemPatterns = signal<any[]>([]);
+  private readonly _itemPatterns = computed(() => this._items().map(i => i._pattern));
 
   /** A callback function triggered when a menu item is selected. */
   readonly itemSelected = output<V>();
@@ -121,10 +121,6 @@ export class MenuBar<V> {
       itemSelected: (value: V) => this.itemSelected.emit(value),
       activeItem: signal(undefined),
       element: computed(() => this._elementRef.nativeElement),
-    });
-
-    afterRenderEffect(() => {
-      this._itemPatterns.set(this._items().map(i => i._pattern));
     });
 
     afterRenderEffect(() => {

--- a/src/aria/menu/menu-bar.ts
+++ b/src/aria/menu/menu-bar.ts
@@ -123,9 +123,7 @@ export class MenuBar<V> {
       element: computed(() => this._elementRef.nativeElement),
     });
 
-    afterRenderEffect(() => {
-      this._pattern.setDefaultStateEffect();
-    });
+    afterRenderEffect({write: () => this._pattern.setDefaultStateEffect()});
   }
 
   /** Closes the menubar. */

--- a/src/aria/menu/menu.ts
+++ b/src/aria/menu/menu.ts
@@ -187,9 +187,7 @@ export class Menu<V> {
       },
     });
 
-    afterRenderEffect(() => {
-      this._pattern.setDefaultStateEffect();
-    });
+    afterRenderEffect({write: () => this._pattern.setDefaultStateEffect()});
   }
 
   /** Closes the menu. */

--- a/src/aria/menu/menu.ts
+++ b/src/aria/menu/menu.ts
@@ -162,15 +162,17 @@ export class Menu<V> {
       itemSelected: (value: V) => this.itemSelected.emit(value),
     });
 
-    afterRenderEffect(() => {
-      const parent = this.parent();
-      if (parent instanceof MenuItem && parent.parent instanceof MenuBar) {
-        this._deferredContentAware?.contentVisible.set(true);
-      } else {
-        this._deferredContentAware?.contentVisible.set(
-          this._pattern.visible() || !!this.parent()?._pattern.hasBeenInteracted(),
-        );
-      }
+    afterRenderEffect({
+      write: () => {
+        const parent = this.parent();
+        if (parent instanceof MenuItem && parent.parent instanceof MenuBar) {
+          this._deferredContentAware?.contentVisible.set(true);
+        } else {
+          this._deferredContentAware?.contentVisible.set(
+            this._pattern.visible() || !!this.parent()?._pattern.hasBeenInteracted(),
+          );
+        }
+      },
     });
 
     // Focuses an active menu item when the menu becomes visible. This is needed to

--- a/src/aria/menu/menu.ts
+++ b/src/aria/menu/menu.ts
@@ -176,11 +176,13 @@ export class Menu<V> {
     // Focuses an active menu item when the menu becomes visible. This is needed to
     // properly restore focus to the active item when returning to a menu, and to
     // focus the first item when navigating into a submenu with hover.
-    afterRenderEffect(() => {
-      if (this._pattern.visible()) {
-        const activeItem = untracked(() => this._pattern.inputs.activeItem());
-        this._pattern.listBehavior.goto(activeItem!);
-      }
+    afterRenderEffect({
+      write: () => {
+        if (this.visible()) {
+          const activeItem = untracked(() => this._pattern.inputs.activeItem());
+          this._pattern.listBehavior.goto(activeItem!);
+        }
+      },
     });
 
     afterRenderEffect(() => {

--- a/src/aria/private/deferred-content/deferred-content.ts
+++ b/src/aria/private/deferred-content/deferred-content.ts
@@ -53,17 +53,19 @@ export class DeferredContent implements OnDestroy {
   readonly deferredContentAware = signal(this._deferredContentAware);
 
   constructor() {
-    afterRenderEffect(() => {
-      if (this.deferredContentAware()?.contentVisible()) {
-        if (!this._isRendered) {
+    afterRenderEffect({
+      write: () => {
+        if (this.deferredContentAware()?.contentVisible()) {
+          if (!this._isRendered) {
+            this._destroyContent();
+            this._currentViewRef = this._viewContainerRef.createEmbeddedView(this._templateRef);
+            this._isRendered = true;
+          }
+        } else if (!this.deferredContentAware()?.preserveContent()) {
           this._destroyContent();
-          this._currentViewRef = this._viewContainerRef.createEmbeddedView(this._templateRef);
-          this._isRendered = true;
+          this._isRendered = false;
         }
-      } else if (!this.deferredContentAware()?.preserveContent()) {
-        this._destroyContent();
-        this._isRendered = false;
-      }
+      },
     });
   }
 

--- a/src/aria/tabs/tab-panel.ts
+++ b/src/aria/tabs/tab-panel.ts
@@ -90,7 +90,11 @@ export class TabPanel implements OnInit, OnDestroy {
   });
 
   constructor() {
-    afterRenderEffect(() => this._deferredContentAware.contentVisible.set(this.visible()));
+    afterRenderEffect({
+      write: () => {
+        this._deferredContentAware.contentVisible.set(this.visible());
+      },
+    });
   }
 
   ngOnInit() {

--- a/src/aria/toolbar/toolbar.ts
+++ b/src/aria/toolbar/toolbar.ts
@@ -105,9 +105,7 @@ export class Toolbar<V> {
   });
 
   constructor() {
-    afterRenderEffect(() => {
-      this._pattern.setDefaultStateEffect();
-    });
+    afterRenderEffect({write: () => this._pattern.setDefaultStateEffect()});
   }
 
   _register(widget: ToolbarWidget<V>) {

--- a/src/aria/tree/tree-item.ts
+++ b/src/aria/tree/tree-item.ts
@@ -128,10 +128,12 @@ export class TreeItem<V> extends DeferredContentAware implements OnInit, OnDestr
       }
     });
     // Connect the group's hidden state to the DeferredContentAware's visibility.
-    afterRenderEffect(() => {
-      this.tree()._pattern instanceof ComboboxTreePattern
-        ? this.contentVisible.set(true)
-        : this.contentVisible.set(this._pattern.expanded());
+    afterRenderEffect({
+      write: () => {
+        this.tree()._pattern instanceof ComboboxTreePattern
+          ? this.contentVisible.set(true)
+          : this.contentVisible.set(this._pattern.expanded());
+      },
     });
   }
 

--- a/src/aria/tree/tree.ts
+++ b/src/aria/tree/tree.ts
@@ -170,36 +170,43 @@ export class Tree<V> {
       this._popup?._controls?.set(this._pattern as ComboboxTreePattern<V>);
     }
 
-    afterRenderEffect(() => {
-      if (typeof ngDevMode === 'undefined' || ngDevMode) {
-        const violations = this._pattern.validate();
-        for (const violation of violations) {
-          console.error(violation);
+    // Check for any violationns after the DOM has been updated.
+    afterRenderEffect({
+      read: () => {
+        if (typeof ngDevMode === 'undefined' || ngDevMode) {
+          const violations = this._pattern.validate();
+          for (const violation of violations) {
+            console.error(violation);
+          }
         }
-      }
+      },
     });
 
     // Resets default focus based on selection state until interacted.
     afterRenderEffect({write: () => this._pattern.setDefaultStateEffect()});
 
-    afterRenderEffect(() => {
-      const items = inputs.items();
-      const activeItem = untracked(() => inputs.activeItem());
+    afterRenderEffect({
+      write: () => {
+        const items = inputs.items();
+        const activeItem = untracked(() => inputs.activeItem());
 
-      if (!items.some(i => i === activeItem) && activeItem) {
-        this._pattern.treeBehavior.unfocus();
-      }
+        if (!items.some(i => i === activeItem) && activeItem) {
+          this._pattern.treeBehavior.unfocus();
+        }
+      },
     });
 
-    afterRenderEffect(() => {
-      if (!(this._pattern instanceof ComboboxTreePattern)) return;
+    afterRenderEffect({
+      write: () => {
+        if (!(this._pattern instanceof ComboboxTreePattern)) return;
 
-      const items = inputs.items();
-      const value = untracked(() => this.value());
+        const items = inputs.items();
+        const value = untracked(() => this.value());
 
-      if (items && value.some(v => !items.some(i => i.value() === v))) {
-        this.value.set(value.filter(v => items.some(i => i.value() === v)));
-      }
+        if (items && value.some(v => !items.some(i => i.value() === v))) {
+          this.value.set(value.filter(v => items.some(i => i.value() === v)));
+        }
+      },
     });
   }
 

--- a/src/aria/tree/tree.ts
+++ b/src/aria/tree/tree.ts
@@ -179,9 +179,8 @@ export class Tree<V> {
       }
     });
 
-    afterRenderEffect(() => {
-      this._pattern.setDefaultStateEffect();
-    });
+    // Resets default focus based on selection state until interacted.
+    afterRenderEffect({write: () => this._pattern.setDefaultStateEffect()});
 
     afterRenderEffect(() => {
       const items = inputs.items();


### PR DESCRIPTION
Across angular-aria afterRenderEffect was being used as a general-purpose synching hook. Also, a phase was not specified so it always was defaulting to the mixedReadWrite phase which is not as performant and unnecessary in all the cases.

This PR cleans up the usage by:
- Swapping to effect when only internal state is being updated
- Using write mode whenever necessary to write to the DOM (primarily focus updates)
- Using read mode when not necessary to write but need to update state post render
- Other as appropriate clean up to use computed instead of an effect

See https://angular.dev/guide/signals/effect#render-phases for background.

