### PR TITLE
fix(aria/combobox): increases autocomplete demo's  placeholder text c…

### DIFF
--- a/src/components-examples/aria/autocomplete/autocomplete.css
+++ b/src/components-examples/aria/autocomplete/autocomplete.css
@@ -117,3 +117,7 @@
 .example-check-icon {
   font-size: 0.9rem;
 }
+
+::placeholder {
+  color: var(--mat-sys-on-surface-variant);
+}

--- a/src/components-examples/aria/autocomplete/autocomplete.css
+++ b/src/components-examples/aria/autocomplete/autocomplete.css
@@ -118,6 +118,12 @@
   font-size: 0.9rem;
 }
 
+/* stylelint-disable material/no-prefixes -- Provides all prefixes for ::placeholder */
+input::-webkit-input-placeholder,
+input::-moz-placeholder, /* Firefox 19+ */
+input:-ms-input-placeholder, /* IE 10+ */
+input:-moz-placeholder, /* Firefox 18- */
 input::placeholder {
   color: var(--mat-sys-on-surface-variant);
 }
+/* stylelint-enable material/no-prefixes */

--- a/src/components-examples/aria/autocomplete/autocomplete.css
+++ b/src/components-examples/aria/autocomplete/autocomplete.css
@@ -118,6 +118,6 @@
   font-size: 0.9rem;
 }
 
-::placeholder {
+input::placeholder {
   color: var(--mat-sys-on-surface-variant);
 }


### PR DESCRIPTION
…ontrast

Fixes a bug in Angular Aria combo box's autocomplete demo example where the input's placeholder text is failing text contrast at 4.4 and does not meet the a11y required 4.5:1 contrast ratio. This provides a color variable to ::placeholder to meet the ratio at 8.89:1.

* BEFORE color contrast ratio: Foreground: #747676  |  Background: #fafafc  |  Ratio: 4.38
* AFTER color contrast ratio: Foreground: #43484b  | Background: #fafafc  |  Ratio: 8.89

Fixes b/477617379