### PR TITLE
fix(material/sort): deprecate MatSortHeaderIntl and hide from docs

### DIFF
--- a/goldens/material/sort/index.api.md
+++ b/goldens/material/sort/index.api.md
@@ -114,7 +114,7 @@ export class MatSortHeader implements MatSortable, OnDestroy, OnInit, AfterViewI
     static ɵfac: i0.ɵɵFactoryDeclaration<MatSortHeader, never>;
 }
 
-// @public
+// @public @deprecated
 export class MatSortHeaderIntl {
     readonly changes: Subject<void>;
     // (undocumented)

--- a/src/material/sort/sort-header-intl.ts
+++ b/src/material/sort/sort-header-intl.ts
@@ -12,6 +12,10 @@ import {Subject} from 'rxjs';
 /**
  * To modify the labels and text displayed, create a new instance of MatSortHeaderIntl and
  * include it in a custom provider.
+ *
+ * @deprecated No longer used, will be removed.
+ * @breaking-change 23.0.0
+ * @docs-private
  */
 @Injectable({providedIn: 'root'})
 export class MatSortHeaderIntl {


### PR DESCRIPTION
`MatSortHeaderIntl` hasn't been used for a while. These changes deprecate it and it from the docs.

Fixes #33083.