### PR TITLE
fix(material/stepper): ensure sufficient contrast of step icon in M2

### DIFF
--- a/src/material/stepper/_m2-stepper.scss
+++ b/src/material/stepper/_m2-stepper.scss
@@ -23,6 +23,7 @@
       stepper-header-optional-label-text-color: map.get($system, on-surface-variant),
       stepper-header-selected-state-label-text-color: map.get($system, on-surface),
       stepper-header-error-state-label-text-color: map.get($system, error),
+      stepper-header-icon-foreground-color: map.get($system, surface),
       stepper-header-icon-background-color: map.get($system, on-surface-variant),
       stepper-header-error-state-icon-foreground-color: map.get($system, error),
       stepper-header-error-state-icon-background-color: transparent)
@@ -54,7 +55,6 @@
   $system: m3-utils.replace-colors-with-variant($system, primary, $color-variant);
 
   @return (
-    stepper-header-icon-foreground-color: map.get($system, on-primary),
     stepper-header-selected-state-icon-background-color: map.get($system, primary),
     stepper-header-selected-state-icon-foreground-color: map.get($system, on-primary),
     stepper-header-done-state-icon-background-color: map.get($system, primary),


### PR DESCRIPTION
Currently, the step icon M2 theming does not work correctly. The foreground color uses the contrast color of the primary color, but this does not necessarily provide enough contrast to the background. With this changes, the default foreground color is adjusted to ensure sufficient contrast to the background, regardless of the primary contrast color.

Fixes #29518