### PR TITLE
ci: fix pnpm install and snapshot script for scheduled ci

### DIFF
--- a/.github/workflows/scheduled-ci.yml
+++ b/.github/workflows/scheduled-ci.yml
@@ -31,7 +31,7 @@ jobs:
         # updates the lock file as expected with the changes
         run: node ./scripts/circleci/setup-angular-snapshots.js main
       - name: Install node modules
-        run: pnpm install
+        run: pnpm install --no-frozen-lockfile
       - name: Run Browser tests
         run: pnpm bazel test --build_tag_filters=-e2e --test_tag_filters=-e2e --build_tests_only -- src/...
 
@@ -51,7 +51,7 @@ jobs:
         # updates the lock files as expected with the changes
         run: node ./scripts/circleci/setup-angular-snapshots.js main
       - name: Install node modules
-        run: pnpm install
+        run: pnpm install --no-frozen-lockfile
       - name: Run linker tests using AOT
         run: pnpm test-linker-aot
       - name: Run linker tests using JIT

--- a/scripts/circleci/setup-angular-snapshots.js
+++ b/scripts/circleci/setup-angular-snapshots.js
@@ -75,11 +75,11 @@ packagesToUpdate.forEach(({name, repoName}) => {
 
   // Since the resolutions only cover the version of all nested installs, we also need
   // to explicitly set the version for the package listed in the project "package.json".
-  packageJson.dependencies[name] = buildsUrl;
-
-  // In case this dependency was previously a dev dependency, just remove it because we
-  // re-added it as a normal dependency for simplicity.
-  delete packageJson.devDependencies[name];
+  if (packageJson.devDependencies && packageJson.devDependencies[name]) {
+    packageJson.devDependencies[name] = buildsUrl;
+  } else {
+    packageJson.dependencies[name] = buildsUrl;
+  }
 });
 
 // Write changes to the "packageJson", so that we can install the new versions afterwards.


### PR DESCRIPTION
Fixes the failure in Scheduled CI by adding `--no-frozen-lockfile` to `pnpm install` when running snapshot builds, and updating the snapshot script to avoid moving packages from `devDependencies` to `dependencies`.