### PR TITLE
docs(material/tooltip): update tooltip-delay example layout styles

### DIFF
--- a/src/components-examples/material/tooltip/tooltip-delay/tooltip-delay-example.css
+++ b/src/components-examples/material/tooltip/tooltip-delay/tooltip-delay-example.css
@@ -1,4 +1,3 @@
-.mat-form-field + .mat-form-field,
-.mat-raised-button {
-  margin-left: 8px;
+.example-user-input {
+  margin: 0 8px 8px 0;
 }


### PR DESCRIPTION
fixes a layout issue where elements were crowded together without horizontal or vertical space between them

Before:

<img width="685" height="397" alt="image" src="https://github.com/user-attachments/assets/ce4db9da-6f0d-43de-acf3-d4fe1e7f6eae" />

After:

<img width="685" height="393" alt="image" src="https://github.com/user-attachments/assets/a85ef49e-601c-4bae-bbb0-e822687fc3f1" />

