### PR TITLE
refactor(cdk/schematics): clean up TypeScript 6 workaround

### DIFF
--- a/src/cdk/schematics/utils/ast.ts
+++ b/src/cdk/schematics/utils/ast.ts
@@ -16,13 +16,6 @@ import {getAppModulePath} from '@schematics/angular/utility/ng-ast-utils';
 import * as ts from 'typescript';
 import {getProjectMainFile} from './project-main-file';
 
-/**
- * Temporary type until the CLI starts bundling TS6.
- *
- * TODO(crisbeto): clean this up eventually.
- */
-export type AnyDuringTs6Migration = any;
-
 /** Reads file given path and returns TypeScript source file. */
 export function parseSourceFile(host: Tree, path: string): ts.SourceFile {
   const buffer = host.read(path);
@@ -62,12 +55,7 @@ export function addModuleImportToModule(
     throw new SchematicsException(`Module not found: ${modulePath}`);
   }
 
-  const changes = addImportToModule(
-    moduleSource as AnyDuringTs6Migration,
-    modulePath,
-    moduleName,
-    src,
-  );
+  const changes = addImportToModule(moduleSource, modulePath, moduleName, src);
   const recorder = host.beginUpdate(modulePath);
 
   changes.forEach(change => {

--- a/src/cdk/schematics/utils/build-component.ts
+++ b/src/cdk/schematics/utils/build-component.ts
@@ -36,7 +36,6 @@ import {dirname, join, resolve} from 'path';
 import * as ts from 'typescript';
 import {getProjectFromWorkspace} from './get-project';
 import {getDefaultComponentOptions, isStandaloneSchematic} from './schematic-options';
-import {AnyDuringTs6Migration} from './ast';
 
 /**
  * Build a default project path for generating.
@@ -84,7 +83,7 @@ function addDeclarationToNgModule(options: ComponentOptions): Rule {
     const classifiedName = strings.classify(`${options.name}Component`);
 
     const declarationChanges = addDeclarationToModule(
-      source as AnyDuringTs6Migration,
+      source,
       modulePath,
       classifiedName,
       relativePath,
@@ -104,7 +103,7 @@ function addDeclarationToNgModule(options: ComponentOptions): Rule {
 
       const exportRecorder = host.beginUpdate(modulePath);
       const exportChanges = addExportToModule(
-        source as AnyDuringTs6Migration,
+        source,
         modulePath,
         strings.classify(`${options.name}Component`),
         relativePath,


### PR DESCRIPTION
Removes a workaround that was put in place to unblock the TypeScript 6 upgrade.