### PR TITLE
docs(material/tree): fixed typo in `cdkTreeNodeTypeaheadLabel` …

### DIFF
--- a/src/cdk/tree/tree.ts
+++ b/src/cdk/tree/tree.ts
@@ -1261,7 +1261,7 @@ export class CdkTreeNode<T, K = T> implements OnDestroy, OnInit, TreeKeyManagerI
 
   /**
    * The text used to locate this item during typeahead. If not specified, the `textContent` will
-   * will be used.
+   * be used.
    */
   @Input('cdkTreeNodeTypeaheadLabel') typeaheadLabel: string | null = null;
 


### PR DESCRIPTION
Fixes a typo in the description of `cdkTreeNodeTypeaheadLabel` input in `src/cdk/tree/tree.ts`.
