### PR TITLE
docs(material/datepicker): fixed typo in ssrSafeIsHTMLTextAreaElement…

### DIFF
--- a/src/material/datepicker/aria-accessible-name.ts
+++ b/src/material/datepicker/aria-accessible-name.ts
@@ -79,7 +79,7 @@ function ssrSafeIsHTMLInputElement(node: Node): node is HTMLInputElement {
 
 /**
  * Determine if argument node is an HTMLTextAreaElement based on `nodeName` property. This
- * funciton is safe to use with server-side rendering.
+ * function is safe to use with server-side rendering.
  */
 function ssrSafeIsHTMLTextAreaElement(node: Node): node is HTMLTextAreaElement {
   return node.nodeName === 'TEXTAREA';


### PR DESCRIPTION
Fixes a typo in the description of `ssrSafeIsHTMLTextAreaElement` function in `src\material\datepicker\aria-accessible-name.ts`.