### PR TITLE
refactor(material/bottom-sheet): switch tests away from fakeAsync

### DIFF
--- a/src/material/bottom-sheet/bottom-sheet.spec.ts
+++ b/src/material/bottom-sheet/bottom-sheet.spec.ts
@@ -26,14 +26,7 @@ import {
   inject,
   ChangeDetectionStrategy,
 } from '@angular/core';
-import {
-  ComponentFixture,
-  TestBed,
-  fakeAsync,
-  flush,
-  flushMicrotasks,
-  tick,
-} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
 import {MAT_BOTTOM_SHEET_DEFAULT_OPTIONS, MatBottomSheet} from './bottom-sheet';
@@ -51,7 +44,7 @@ describe('MatBottomSheet', () => {
   let viewContainerFixture: ComponentFixture<ComponentWithChildViewContainer>;
   let mockLocation: SpyLocation;
 
-  beforeEach(fakeAsync(() => {
+  beforeEach(async () => {
     TestBed.configureTestingModule({
       providers: [
         {provide: Location, useClass: SpyLocation},
@@ -66,7 +59,7 @@ describe('MatBottomSheet', () => {
     viewContainerFixture = TestBed.createComponent(ComponentWithChildViewContainer);
     viewContainerFixture.detectChanges();
     testViewContainerRef = viewContainerFixture.componentInstance.childViewContainer;
-  }));
+  });
 
   it('should open a bottom sheet with a component', () => {
     const bottomSheetRef = bottomSheet.open(PizzaMsg, {viewContainerRef: testViewContainerRef});
@@ -109,7 +102,7 @@ describe('MatBottomSheet', () => {
     );
   });
 
-  it('should emit when the bottom sheet opening animation is complete', fakeAsync(() => {
+  it('should emit when the bottom sheet opening animation is complete', async () => {
     const bottomSheetRef = bottomSheet.open(PizzaMsg, {viewContainerRef: testViewContainerRef});
     const spy = jasmine.createSpy('afterOpened spy');
 
@@ -119,9 +112,10 @@ describe('MatBottomSheet', () => {
     // callback should not be called before animation is complete
     expect(spy).not.toHaveBeenCalled();
 
-    flush();
+    await wait(0);
+    viewContainerFixture.detectChanges();
     expect(spy).toHaveBeenCalled();
-  }));
+  });
 
   it('should use the correct injector', () => {
     const bottomSheetRef = bottomSheet.open(PizzaMsg, {viewContainerRef: testViewContainerRef});
@@ -162,30 +156,31 @@ describe('MatBottomSheet', () => {
     expect(container.getAttribute('aria-modal')).toBe('true');
   });
 
-  it('should close a bottom sheet via the escape key', fakeAsync(() => {
+  it('should close a bottom sheet via the escape key', async () => {
     bottomSheet.open(PizzaMsg, {viewContainerRef: testViewContainerRef});
 
     const event = dispatchKeyboardEvent(document.body, 'keydown', ESCAPE);
     viewContainerFixture.detectChanges();
-    flush();
+    await wait(0);
+    viewContainerFixture.detectChanges();
 
     expect(overlayContainerElement.querySelector('mat-bottom-sheet-container')).toBeNull();
     expect(event.defaultPrevented).toBe(true);
-  }));
+  });
 
-  it('should not close a bottom sheet via the escape key with a modifier', fakeAsync(() => {
+  it('should not close a bottom sheet via the escape key with a modifier', async () => {
     bottomSheet.open(PizzaMsg, {viewContainerRef: testViewContainerRef});
 
     const event = createKeyboardEvent('keydown', ESCAPE, undefined, {alt: true});
     dispatchEvent(document.body, event);
     viewContainerFixture.detectChanges();
-    flush();
+    await viewContainerFixture.whenStable();
 
     expect(overlayContainerElement.querySelector('mat-bottom-sheet-container')).toBeTruthy();
     expect(event.defaultPrevented).toBe(false);
-  }));
+  });
 
-  it('should close when clicking on the overlay backdrop', fakeAsync(() => {
+  it('should close when clicking on the overlay backdrop', async () => {
     bottomSheet.open(PizzaMsg, {
       viewContainerRef: testViewContainerRef,
     });
@@ -196,23 +191,24 @@ describe('MatBottomSheet', () => {
 
     backdrop.click();
     viewContainerFixture.detectChanges();
-    flush();
+    await wait(0);
+    viewContainerFixture.detectChanges();
 
     expect(overlayContainerElement.querySelector('mat-bottom-sheet-container')).toBeFalsy();
-  }));
+  });
 
-  it('should dispose of bottom sheet if view container is destroyed while animating', fakeAsync(() => {
+  it('should dispose of bottom sheet if view container is destroyed while animating', async () => {
     const bottomSheetRef = bottomSheet.open(PizzaMsg, {viewContainerRef: testViewContainerRef});
 
     bottomSheetRef.dismiss();
     viewContainerFixture.detectChanges();
     viewContainerFixture.destroy();
-    flush();
+    await viewContainerFixture.whenStable();
 
     expect(overlayContainerElement.querySelector('mat-dialog-container')).toBeNull();
-  }));
+  });
 
-  it('should emit the backdropClick stream when clicking on the overlay backdrop', fakeAsync(() => {
+  it('should emit the backdropClick stream when clicking on the overlay backdrop', async () => {
     const bottomSheetRef = bottomSheet.open(PizzaMsg, {viewContainerRef: testViewContainerRef});
     const spy = jasmine.createSpy('backdropClick spy');
 
@@ -225,20 +221,20 @@ describe('MatBottomSheet', () => {
     expect(spy).toHaveBeenCalledTimes(1);
 
     viewContainerFixture.detectChanges();
-    flush();
+    await viewContainerFixture.whenStable();
 
     // Additional clicks after the bottom sheet was closed should not be emitted
     backdrop.click();
     expect(spy).toHaveBeenCalledTimes(1);
-  }));
+  });
 
-  it('should emit the keyboardEvent stream when key events target the overlay', fakeAsync(() => {
+  it('should emit the keyboardEvent stream when key events target the overlay', async () => {
     const bottomSheetRef = bottomSheet.open(PizzaMsg, {viewContainerRef: testViewContainerRef});
     const spy = jasmine.createSpy('keyboardEvent spy');
 
     bottomSheetRef.keydownEvents().subscribe(spy);
     viewContainerFixture.detectChanges();
-    flush();
+    await viewContainerFixture.whenStable();
 
     const backdrop = overlayContainerElement.querySelector('.cdk-overlay-backdrop') as HTMLElement;
     const container = overlayContainerElement.querySelector(
@@ -249,7 +245,7 @@ describe('MatBottomSheet', () => {
     dispatchKeyboardEvent(container, 'keydown', A);
 
     expect(spy).toHaveBeenCalledTimes(3);
-  }));
+  });
 
   it('should allow setting the layout direction', () => {
     bottomSheet.open(PizzaMsg, {direction: 'rtl'});
@@ -299,31 +295,33 @@ describe('MatBottomSheet', () => {
     expect(container.getAttribute('aria-label')).toBe('Hello there');
   });
 
-  it('should be able to get dismissed through the service', fakeAsync(() => {
+  it('should be able to get dismissed through the service', async () => {
     bottomSheet.open(PizzaMsg);
     viewContainerFixture.detectChanges();
     expect(overlayContainerElement.childElementCount).toBeGreaterThan(0);
 
     bottomSheet.dismiss();
     viewContainerFixture.detectChanges();
-    flush();
+    await wait(0);
+    viewContainerFixture.detectChanges();
 
     expect(overlayContainerElement.childElementCount).toBe(0);
-  }));
+  });
 
-  it('should dismiss the bottom sheet when the service is destroyed', fakeAsync(() => {
+  it('should dismiss the bottom sheet when the service is destroyed', async () => {
     bottomSheet.open(PizzaMsg);
     viewContainerFixture.detectChanges();
     expect(overlayContainerElement.childElementCount).toBeGreaterThan(0);
 
     bottomSheet.ngOnDestroy();
     viewContainerFixture.detectChanges();
-    flush();
+    await wait(0);
+    viewContainerFixture.detectChanges();
 
     expect(overlayContainerElement.childElementCount).toBe(0);
-  }));
+  });
 
-  it('should open a new bottom sheet after dismissing a previous sheet', fakeAsync(() => {
+  it('should open a new bottom sheet after dismissing a previous sheet', async () => {
     const config: MatBottomSheetConfig = {viewContainerRef: testViewContainerRef};
     let bottomSheetRef: MatBottomSheetRef<any> = bottomSheet.open(PizzaMsg, config);
 
@@ -333,52 +331,51 @@ describe('MatBottomSheet', () => {
     viewContainerFixture.detectChanges();
 
     // Wait for the dismiss animation to finish.
-    flush();
+    await wait(0);
+    viewContainerFixture.detectChanges();
     bottomSheetRef = bottomSheet.open(TacoMsg, config);
     viewContainerFixture.detectChanges();
 
     // Wait for the open animation to finish.
-    flush();
+    await wait(0);
+    viewContainerFixture.detectChanges();
     expect(bottomSheetRef.containerInstance._animationState)
       .withContext(`Expected the animation state would be 'visible'.`)
       .toBe('visible');
-  }));
+  });
 
-  it('should remove past bottom sheets when opening new ones', fakeAsync(() => {
+  it('should remove past bottom sheets when opening new ones', async () => {
     bottomSheet.open(PizzaMsg);
     viewContainerFixture.detectChanges();
 
     bottomSheet.open(TacoMsg);
     viewContainerFixture.detectChanges();
-    flush();
+    await viewContainerFixture.whenStable();
 
     expect(overlayContainerElement.textContent).toContain('Taco');
-  }));
+  });
 
-  it('should not throw when opening multiple bottom sheet in quick succession', fakeAsync(() => {
-    expect(() => {
-      for (let i = 0; i < 3; i++) {
-        bottomSheet.open(PizzaMsg);
-        viewContainerFixture.detectChanges();
-      }
+  it('should not throw when opening multiple bottom sheet in quick succession', async () => {
+    for (let i = 0; i < 3; i++) {
+      bottomSheet.open(PizzaMsg);
+      viewContainerFixture.detectChanges();
+    }
 
-      flush();
-    }).not.toThrow();
-  }));
+    await viewContainerFixture.whenStable();
+  });
 
-  it('should remove bottom sheet if another is shown while its still animating open', fakeAsync(() => {
+  it('should remove bottom sheet if another is shown while its still animating open', async () => {
     bottomSheet.open(PizzaMsg);
     viewContainerFixture.detectChanges();
 
     bottomSheet.open(TacoMsg);
     viewContainerFixture.detectChanges();
 
-    tick();
+    await viewContainerFixture.whenStable();
     expect(overlayContainerElement.textContent).toContain('Taco');
-    tick(500);
-  }));
+  });
 
-  it('should emit after being dismissed', fakeAsync(() => {
+  it('should emit after being dismissed', async () => {
     const bottomSheetRef = bottomSheet.open(PizzaMsg);
     const spy = jasmine.createSpy('afterDismissed spy');
 
@@ -387,12 +384,13 @@ describe('MatBottomSheet', () => {
 
     bottomSheetRef.dismiss();
     viewContainerFixture.detectChanges();
-    flush();
+    await wait(0);
+    viewContainerFixture.detectChanges();
 
     expect(spy).toHaveBeenCalledTimes(1);
-  }));
+  });
 
-  it('should be able to pass a result back to the dismissed stream', fakeAsync(() => {
+  it('should be able to pass a result back to the dismissed stream', async () => {
     const bottomSheetRef = bottomSheet.open<PizzaMsg, any, number>(PizzaMsg);
     const spy = jasmine.createSpy('afterDismissed spy');
 
@@ -401,12 +399,13 @@ describe('MatBottomSheet', () => {
 
     bottomSheetRef.dismiss(1337);
     viewContainerFixture.detectChanges();
-    flush();
+    await wait(0);
+    viewContainerFixture.detectChanges();
 
     expect(spy).toHaveBeenCalledWith(1337);
-  }));
+  });
 
-  it('should be able to pass data when dismissing through the service', fakeAsync(() => {
+  it('should be able to pass data when dismissing through the service', async () => {
     const bottomSheetRef = bottomSheet.open<PizzaMsg, any, number>(PizzaMsg);
     const spy = jasmine.createSpy('afterDismissed spy');
 
@@ -415,46 +414,47 @@ describe('MatBottomSheet', () => {
 
     bottomSheet.dismiss(1337);
     viewContainerFixture.detectChanges();
-    flush();
+    await wait(0);
+    viewContainerFixture.detectChanges();
 
     expect(spy).toHaveBeenCalledWith(1337);
-  }));
+  });
 
-  it('should close the bottom sheet when going forwards/backwards in history', fakeAsync(() => {
+  it('should close the bottom sheet when going forwards/backwards in history', async () => {
     bottomSheet.open(PizzaMsg);
 
     expect(overlayContainerElement.querySelector('mat-bottom-sheet-container')).toBeTruthy();
 
     mockLocation.simulateUrlPop('');
     viewContainerFixture.detectChanges();
-    flush();
+    await viewContainerFixture.whenStable();
 
     expect(overlayContainerElement.querySelector('mat-bottom-sheet-container')).toBeFalsy();
-  }));
+  });
 
-  it('should close the bottom sheet when the location hash changes', fakeAsync(() => {
+  it('should close the bottom sheet when the location hash changes', async () => {
     bottomSheet.open(PizzaMsg);
 
     expect(overlayContainerElement.querySelector('mat-bottom-sheet-container')).toBeTruthy();
 
     mockLocation.simulateHashChange('');
     viewContainerFixture.detectChanges();
-    flush();
+    await viewContainerFixture.whenStable();
 
     expect(overlayContainerElement.querySelector('mat-bottom-sheet-container')).toBeFalsy();
-  }));
+  });
 
-  it('should allow the consumer to disable closing a bottom sheet on navigation', fakeAsync(() => {
+  it('should allow the consumer to disable closing a bottom sheet on navigation', async () => {
     bottomSheet.open(PizzaMsg, {closeOnNavigation: false});
 
     expect(overlayContainerElement.querySelector('mat-bottom-sheet-container')).toBeTruthy();
 
     mockLocation.simulateUrlPop('');
     viewContainerFixture.detectChanges();
-    flush();
+    await viewContainerFixture.whenStable();
 
     expect(overlayContainerElement.querySelector('mat-bottom-sheet-container')).toBeTruthy();
-  }));
+  });
 
   it('should be able to attach a custom scroll strategy', () => {
     const scrollStrategy: ScrollStrategy = {
@@ -509,7 +509,7 @@ describe('MatBottomSheet', () => {
   });
 
   describe('disableClose option', () => {
-    it('should prevent closing via clicks on the backdrop', fakeAsync(() => {
+    it('should prevent closing via clicks on the backdrop', async () => {
       bottomSheet.open(PizzaMsg, {
         disableClose: true,
         viewContainerRef: testViewContainerRef,
@@ -522,12 +522,12 @@ describe('MatBottomSheet', () => {
       ) as HTMLElement;
       backdrop.click();
       viewContainerFixture.detectChanges();
-      flush();
+      await viewContainerFixture.whenStable();
 
       expect(overlayContainerElement.querySelector('mat-bottom-sheet-container')).toBeTruthy();
-    }));
+    });
 
-    it('should prevent closing via the escape key', fakeAsync(() => {
+    it('should prevent closing via the escape key', async () => {
       bottomSheet.open(PizzaMsg, {
         disableClose: true,
         viewContainerRef: testViewContainerRef,
@@ -536,12 +536,12 @@ describe('MatBottomSheet', () => {
       viewContainerFixture.detectChanges();
       dispatchKeyboardEvent(document.body, 'keydown', ESCAPE);
       viewContainerFixture.detectChanges();
-      flush();
+      await viewContainerFixture.whenStable();
 
       expect(overlayContainerElement.querySelector('mat-bottom-sheet-container')).toBeTruthy();
-    }));
+    });
 
-    it('should allow for the disableClose option to be updated while open', fakeAsync(() => {
+    it('should allow for the disableClose option to be updated while open', async () => {
       const bottomSheetRef = bottomSheet.open(PizzaMsg, {
         disableClose: true,
         viewContainerRef: testViewContainerRef,
@@ -559,10 +559,11 @@ describe('MatBottomSheet', () => {
       bottomSheetRef.disableClose = false;
       backdrop.click();
       viewContainerFixture.detectChanges();
-      flush();
+      await wait(0);
+      viewContainerFixture.detectChanges();
 
       expect(overlayContainerElement.querySelector('mat-bottom-sheet-container')).toBeFalsy();
-    }));
+    });
   });
 
   describe('hasBackdrop option', () => {
@@ -618,31 +619,31 @@ describe('MatBottomSheet', () => {
     beforeEach(() => document.body.appendChild(overlayContainerElement));
     afterEach(() => overlayContainerElement.remove());
 
-    it('should focus the first tabbable element by default', fakeAsync(() => {
+    it('should focus the first tabbable element by default', async () => {
       bottomSheet.open(PizzaMsg, {
         viewContainerRef: testViewContainerRef,
       });
 
       viewContainerFixture.detectChanges();
-      flush();
+      await viewContainerFixture.whenStable();
       viewContainerFixture.detectChanges();
 
       expect(document.activeElement!.tagName).toBe('INPUT');
-    }));
+    });
 
-    it('should create a focus trap if autoFocus is disabled', fakeAsync(() => {
+    it('should create a focus trap if autoFocus is disabled', async () => {
       bottomSheet.open(PizzaMsg, {
         viewContainerRef: testViewContainerRef,
         autoFocus: false,
       });
 
       viewContainerFixture.detectChanges();
-      flush();
+      await viewContainerFixture.whenStable();
 
       const focusTrapAnchors = overlayContainerElement.querySelectorAll('.cdk-focus-trap-anchor');
 
       expect(focusTrapAnchors.length).toBeGreaterThan(0);
-    }));
+    });
 
     it('should focus the first tabbable element of the bottom sheet on open when autoFocus is set to "first-tabbable"', () => {
       bottomSheet.open(PizzaMsg, {
@@ -657,14 +658,14 @@ describe('MatBottomSheet', () => {
         .toBe('INPUT');
     });
 
-    it('should focus the bottom sheet element on open when autoFocus is set to "dialog"', fakeAsync(() => {
+    it('should focus the bottom sheet element on open when autoFocus is set to "dialog"', async () => {
       bottomSheet.open(PizzaMsg, {
         viewContainerRef: testViewContainerRef,
         autoFocus: 'dialog',
       });
 
       viewContainerFixture.detectChanges();
-      flush();
+      await viewContainerFixture.whenStable();
       viewContainerFixture.detectChanges();
 
       let container = overlayContainerElement.querySelector(
@@ -674,16 +675,16 @@ describe('MatBottomSheet', () => {
       expect(document.activeElement)
         .withContext('Expected container to be focused on open')
         .toBe(container);
-    }));
+    });
 
-    it('should focus the bottom sheet element on open when autoFocus is set to "first-heading"', fakeAsync(() => {
+    it('should focus the bottom sheet element on open when autoFocus is set to "first-heading"', async () => {
       bottomSheet.open(ContentElementDialog, {
         viewContainerRef: testViewContainerRef,
         autoFocus: 'first-heading',
       });
 
       viewContainerFixture.detectChanges();
-      flush();
+      await viewContainerFixture.whenStable();
       viewContainerFixture.detectChanges();
 
       let firstHeader = overlayContainerElement.querySelector(
@@ -693,16 +694,16 @@ describe('MatBottomSheet', () => {
       expect(document.activeElement)
         .withContext('Expected first header to be focused on open')
         .toBe(firstHeader);
-    }));
+    });
 
-    it('should focus the first element that matches the css selector on open when autoFocus is set to a css selector', fakeAsync(() => {
+    it('should focus the first element that matches the css selector on open when autoFocus is set to a css selector', async () => {
       bottomSheet.open(ContentElementDialog, {
         viewContainerRef: testViewContainerRef,
         autoFocus: 'p',
       });
 
       viewContainerFixture.detectChanges();
-      flush();
+      await viewContainerFixture.whenStable();
       viewContainerFixture.detectChanges();
 
       let firstParagraph = overlayContainerElement.querySelector(
@@ -712,9 +713,9 @@ describe('MatBottomSheet', () => {
       expect(document.activeElement)
         .withContext('Expected first paragraph to be focused on open')
         .toBe(firstParagraph);
-    }));
+    });
 
-    it('should re-focus trigger element when bottom sheet closes', fakeAsync(() => {
+    it('should re-focus trigger element when bottom sheet closes', async () => {
       const button = document.createElement('button');
       button.id = 'bottom-sheet-trigger';
       document.body.appendChild(button);
@@ -722,9 +723,7 @@ describe('MatBottomSheet', () => {
 
       const bottomSheetRef = bottomSheet.open(PizzaMsg, {viewContainerRef: testViewContainerRef});
 
-      flush();
-      viewContainerFixture.detectChanges();
-      flush();
+      await wait(0);
       viewContainerFixture.detectChanges();
 
       expect(document.activeElement!.id).not.toBe(
@@ -738,18 +737,17 @@ describe('MatBottomSheet', () => {
         'Expcted the focus not to have changed before the animation finishes.',
       );
 
-      flush();
+      await wait(0);
       viewContainerFixture.detectChanges();
-      tick(500);
 
       expect(document.activeElement!.id)
         .withContext('Expected that the trigger was refocused after the sheet is closed.')
         .toBe('bottom-sheet-trigger');
 
       button.remove();
-    }));
+    });
 
-    it('should be able to disable focus restoration', fakeAsync(() => {
+    it('should be able to disable focus restoration', async () => {
       const button = document.createElement('button');
       button.id = 'bottom-sheet-trigger';
       document.body.appendChild(button);
@@ -760,9 +758,7 @@ describe('MatBottomSheet', () => {
         restoreFocus: false,
       });
 
-      flush();
-      viewContainerFixture.detectChanges();
-      flush();
+      await wait(0);
       viewContainerFixture.detectChanges();
 
       expect(document.activeElement!.id).not.toBe(
@@ -776,9 +772,8 @@ describe('MatBottomSheet', () => {
         'Expcted the focus not to have changed before the animation finishes.',
       );
 
-      flush();
+      await wait(0);
       viewContainerFixture.detectChanges();
-      tick(500);
 
       expect(document.activeElement!.id).not.toBe(
         'bottom-sheet-trigger',
@@ -786,9 +781,9 @@ describe('MatBottomSheet', () => {
       );
 
       button.remove();
-    }));
+    });
 
-    it('should not move focus if it was moved outside the sheet while animating', fakeAsync(() => {
+    it('should not move focus if it was moved outside the sheet while animating', async () => {
       // Create a element that has focus before the bottom sheet is opened.
       const button = document.createElement('button');
       const otherButton = document.createElement('button');
@@ -801,9 +796,7 @@ describe('MatBottomSheet', () => {
 
       const bottomSheetRef = bottomSheet.open(PizzaMsg, {viewContainerRef: testViewContainerRef});
 
-      flush();
-      viewContainerFixture.detectChanges();
-      flush();
+      await wait(0);
       viewContainerFixture.detectChanges();
 
       expect(document.activeElement!.id).not.toBe(
@@ -819,9 +812,8 @@ describe('MatBottomSheet', () => {
         .withContext('Expected focus to be on the alternate button.')
         .toBe('other-button');
 
-      flushMicrotasks();
+      await wait(0);
       viewContainerFixture.detectChanges();
-      flush();
 
       expect(document.activeElement!.id)
         .withContext('Expected focus to stay on the alternate button.')
@@ -829,9 +821,9 @@ describe('MatBottomSheet', () => {
 
       button.remove();
       otherButton.remove();
-    }));
+    });
 
-    it('should re-focus trigger element inside the shadow DOM when the bottom sheet is dismissed', fakeAsync(() => {
+    it('should re-focus trigger element inside the shadow DOM when the bottom sheet is dismissed', async () => {
       if (!_supportsShadowDom()) {
         return;
       }
@@ -844,18 +836,16 @@ describe('MatBottomSheet', () => {
       button.focus();
 
       const ref = bottomSheet.open(PizzaMsg);
-      flushMicrotasks();
+      await wait(0);
       fixture.detectChanges();
-      flushMicrotasks();
 
       const spy = spyOn(button, 'focus').and.callThrough();
       ref.dismiss();
-      flushMicrotasks();
+      await wait(0);
       fixture.detectChanges();
-      tick(500);
 
       expect(spy).toHaveBeenCalled();
-    }));
+    });
   });
 });
 
@@ -865,7 +855,7 @@ describe('MatBottomSheet with parent MatBottomSheet', () => {
   let overlayContainerElement: HTMLElement;
   let fixture: ComponentFixture<ComponentThatProvidesMatBottomSheet>;
 
-  beforeEach(fakeAsync(() => {
+  beforeEach(async () => {
     TestBed.configureTestingModule({
       providers: [{provide: MATERIAL_ANIMATIONS, useValue: {animationsDisabled: true}}],
     });
@@ -875,12 +865,13 @@ describe('MatBottomSheet with parent MatBottomSheet', () => {
     fixture = TestBed.createComponent(ComponentThatProvidesMatBottomSheet);
     childBottomSheet = fixture.componentInstance.bottomSheet;
     fixture.detectChanges();
-  }));
+  });
 
-  it('should close bottom sheets opened by parent when opening from child', fakeAsync(() => {
+  it('should close bottom sheets opened by parent when opening from child', async () => {
     parentBottomSheet.open(PizzaMsg);
     fixture.detectChanges();
-    tick(1000);
+    await wait(0);
+    fixture.detectChanges();
 
     expect(overlayContainerElement.textContent)
       .withContext('Expected a bottom sheet to be opened')
@@ -888,17 +879,19 @@ describe('MatBottomSheet with parent MatBottomSheet', () => {
 
     childBottomSheet.open(TacoMsg);
     fixture.detectChanges();
-    tick(1000);
+    await wait(0);
+    fixture.detectChanges();
 
     expect(overlayContainerElement.textContent)
       .withContext('Expected parent bottom sheet to be dismissed by opening from child')
       .toContain('Taco');
-  }));
+  });
 
-  it('should close bottom sheets opened by child when opening from parent', fakeAsync(() => {
+  it('should close bottom sheets opened by child when opening from parent', async () => {
     childBottomSheet.open(PizzaMsg);
     fixture.detectChanges();
-    tick(1000);
+    await wait(0);
+    fixture.detectChanges();
 
     expect(overlayContainerElement.textContent)
       .withContext('Expected a bottom sheet to be opened')
@@ -906,17 +899,19 @@ describe('MatBottomSheet with parent MatBottomSheet', () => {
 
     parentBottomSheet.open(TacoMsg);
     fixture.detectChanges();
-    tick(1000);
+    await wait(0);
+    fixture.detectChanges();
 
     expect(overlayContainerElement.textContent)
       .withContext('Expected child bottom sheet to be dismissed by opening from parent')
       .toContain('Taco');
-  }));
+  });
 
-  it('should not close parent bottom sheet when child is destroyed', fakeAsync(() => {
+  it('should not close parent bottom sheet when child is destroyed', async () => {
     parentBottomSheet.open(PizzaMsg);
     fixture.detectChanges();
-    tick(1000);
+    await wait(0);
+    fixture.detectChanges();
 
     expect(overlayContainerElement.textContent)
       .withContext('Expected a bottom sheet to be opened')
@@ -924,12 +919,13 @@ describe('MatBottomSheet with parent MatBottomSheet', () => {
 
     childBottomSheet.ngOnDestroy();
     fixture.detectChanges();
-    tick(1000);
+    await wait(0);
+    fixture.detectChanges();
 
     expect(overlayContainerElement.textContent)
       .withContext('Expected a bottom sheet to stay open')
       .toContain('Pizza');
-  }));
+  });
 });
 
 describe('MatBottomSheet with default options', () => {
@@ -939,7 +935,7 @@ describe('MatBottomSheet with default options', () => {
   let testViewContainerRef: ViewContainerRef;
   let viewContainerFixture: ComponentFixture<ComponentWithChildViewContainer>;
 
-  beforeEach(fakeAsync(() => {
+  beforeEach(async () => {
     const defaultConfig: MatBottomSheetConfig = {
       hasBackdrop: false,
       disableClose: true,
@@ -958,7 +954,7 @@ describe('MatBottomSheet with default options', () => {
     viewContainerFixture = TestBed.createComponent(ComponentWithChildViewContainer);
     viewContainerFixture.detectChanges();
     testViewContainerRef = viewContainerFixture.componentInstance.childViewContainer;
-  }));
+  });
 
   it('should use the provided defaults', () => {
     bottomSheet.open(PizzaMsg, {viewContainerRef: testViewContainerRef});
@@ -973,7 +969,7 @@ describe('MatBottomSheet with default options', () => {
     expect(document.activeElement!.tagName).not.toBe('INPUT');
   });
 
-  it('should be overridable by open() options', fakeAsync(() => {
+  it('should be overridable by open() options', async () => {
     bottomSheet.open(PizzaMsg, {
       hasBackdrop: true,
       disableClose: false,
@@ -986,20 +982,21 @@ describe('MatBottomSheet with default options', () => {
 
     dispatchKeyboardEvent(document.body, 'keydown', ESCAPE);
     viewContainerFixture.detectChanges();
-    flush();
+    await wait(0);
+    viewContainerFixture.detectChanges();
 
     expect(overlayContainerElement.querySelector('mat-bottom-sheet-container')).toBeFalsy();
-  }));
+  });
 });
 
 describe('MatBottomSheet with explicit injector provided', () => {
   let overlayContainerElement: HTMLElement;
   let fixture: ComponentFixture<ModuleBoundBottomSheetParentComponent>;
 
-  beforeEach(fakeAsync(() => {
+  beforeEach(async () => {
     overlayContainerElement = TestBed.inject(OverlayContainer).getContainerElement();
     fixture = TestBed.createComponent(ModuleBoundBottomSheetParentComponent);
-  }));
+  });
 
   it('should use the standalone injector and render the bottom sheet successfully', () => {
     fixture.componentInstance.openBottomSheet();
@@ -1010,6 +1007,10 @@ describe('MatBottomSheet with explicit injector provided', () => {
     ).toEqual('<p>Pasta</p>');
   });
 });
+
+function wait(milliseconds: number) {
+  return new Promise(resolve => setTimeout(resolve, milliseconds));
+}
 
 @Directive({
   selector: 'dir-with-view-container',


### PR DESCRIPTION
Reworks the bottom sheet tests not to depend on `fakeAsync` anymore.