### PR TITLE
fix(material/select): open handler invoked twice

### DIFF
--- a/goldens/material/select/index.api.md
+++ b/goldens/material/select/index.api.md
@@ -361,6 +361,8 @@ export class MatSelect implements AfterContentInit, OnChanges, OnDestroy, OnInit
     tabIndex: number;
     toggle(): void;
     trigger: ElementRef;
+    // (undocumented)
+    protected _triggerClicked(): void;
     get triggerValue(): string;
     typeaheadDebounceInterval: number;
     updateErrorState(): void;

--- a/src/material/select/select.html
+++ b/src/material/select/select.html
@@ -1,7 +1,7 @@
 <div
   cdk-overlay-origin
   class="mat-mdc-select-trigger"
-  (click)="open()"
+  (click)="_triggerClicked()"
   #fallbackOverlayOrigin="cdkOverlayOrigin"
   #trigger
 >

--- a/src/material/select/select.ts
+++ b/src/material/select/select.ts
@@ -1018,6 +1018,13 @@ export class MatSelect
     return !this._selectionModel || this._selectionModel.isEmpty();
   }
 
+  protected _triggerClicked() {
+    // If a parent form field is present, it'll pick up this click so we don't need to handle it.
+    if (!this._parentFormField) {
+      this.open();
+    }
+  }
+
   private _initializeSelection(): void {
     // Defer setting the value in order to avoid the "Expression
     // has changed after it was checked" errors from Angular.


### PR DESCRIPTION
Fixes that the select's `open` handler was being called twice: once from the trigger's `click` handler and once from the `onContainerClick` callback when the event propagates.

Fixes #33116.