### PR TITLE
docs: release notes for the v21.2.8 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+<a name="21.2.8"></a>
+# 21.2.8 "v21-2-8" (2026-04-22)
+No user facing changes in this release
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="22.0.0-next.5"></a>
 # 22.0.0-next.5 "carbon-steel" (2026-04-16)
 ### aria


### PR DESCRIPTION
Cherry-picks the changelog from the "21.2.x" branch to the next branch (main).