### PR TITLE
refactor(aria/tabs): remove unnecessary LabelControl usage

### DIFF
--- a/goldens/aria/private/index.api.md
+++ b/goldens/aria/private/index.api.md
@@ -707,7 +707,7 @@ export class TabListPattern {
 }
 
 // @public
-export interface TabPanelInputs extends LabelControlOptionalInputs {
+export interface TabPanelInputs {
     id: SignalLike<string>;
     readonly tab: SignalLike<TabPattern | undefined>;
 }
@@ -720,7 +720,6 @@ export class TabPanelPattern {
     // (undocumented)
     readonly inputs: TabPanelInputs;
     readonly labelledBy: SignalLike<string | undefined>;
-    readonly labelManager: LabelControl;
     readonly tabIndex: SignalLike<-1 | 0>;
 }
 

--- a/src/aria/private/tabs/tabs.ts
+++ b/src/aria/private/tabs/tabs.ts
@@ -15,7 +15,6 @@ import {
   linkedSignal,
   signal,
 } from '../behaviors/signal-like/signal-like';
-import {LabelControl, LabelControlOptionalInputs} from '../behaviors/label/label';
 import {ListFocus} from '../behaviors/list-focus/list-focus';
 import {
   ListNavigation,
@@ -81,7 +80,7 @@ export class TabPattern {
 }
 
 /** The required inputs for the tabpanel. */
-export interface TabPanelInputs extends LabelControlOptionalInputs {
+export interface TabPanelInputs {
   /** A global unique identifier for the tabpanel. */
   id: SignalLike<string>;
 
@@ -94,9 +93,6 @@ export class TabPanelPattern {
   /** A global unique identifier for the tabpanel. */
   readonly id: SignalLike<string>; // set from inputs
 
-  /** Controls label for this tabpanel. */
-  readonly labelManager: LabelControl;
-
   /** Whether the tabpanel is hidden. */
   readonly hidden = computed(() => this.inputs.tab()?.expanded() === false);
 
@@ -104,19 +100,10 @@ export class TabPanelPattern {
   readonly tabIndex = computed(() => (this.hidden() ? -1 : 0));
 
   /** The aria-labelledby value for this tabpanel. */
-  readonly labelledBy = computed(() =>
-    this.labelManager.labelledBy().length > 0
-      ? this.labelManager.labelledBy().join(' ')
-      : undefined,
-  );
+  readonly labelledBy = computed(() => this.inputs.tab()?.id());
 
   constructor(readonly inputs: TabPanelInputs) {
     this.id = inputs.id;
-
-    this.labelManager = new LabelControl({
-      ...inputs,
-      defaultLabelledBy: computed(() => (this.inputs.tab() ? [this.inputs.tab()!.id()] : [])),
-    });
   }
 }
 


### PR DESCRIPTION
Remove unnecessary usage of LabelControl in Tab pattern. It doesn't help if just used for setting aria-labelledby as just a lot of redirection to accomplish the same thing.

See https://github.com/angular/components/pull/33146 for subsequent work to make LabelControl easier to use, and then to actually use it for the full usage allowing users of the directives to supply custom aria-labelledby or aria-label.