### PR TITLE
docs(material/form-field): fix incorrect chip component reference

### DIFF
--- a/src/material/form-field/form-field.md
+++ b/src/material/form-field/form-field.md
@@ -11,7 +11,9 @@ The following Angular Material components are designed to work inside a `<mat-fo
 - [`<input matNativeControl>` &amp; `<textarea matNativeControl>`](https://material.angular.dev/components/input/overview)
 - [`<select matNativeControl>`](https://material.angular.dev/components/select/overview)
 - [`<mat-select>`](https://material.angular.dev/components/select/overview)
-- [`<mat-chip-set>`](https://material.angular.dev/components/chips/overview)
+- [`<mat-chip-grid>`](https://material.angular.dev/components/chips/overview)
+
+Note: `<mat-form-field>` requires a child component that implements `MatFormFieldControl`. Among the chips components, only `<mat-chip-grid>` supports this integration.
 
 <!-- example(form-field-overview) -->
 


### PR DESCRIPTION
## Fix incorrect chips component in mat-form-field documentation

The documentation currently lists `mat-chip-set` as compatible with `mat-form-field`, but it does not implement `MatFormFieldControl` and results in the error:

> "mat-form-field must contain a MatFormFieldControl"

This PR updates the documentation to use `mat-chip-grid`, which correctly implements the required interface.

Additionally, a note was added to clarify that `mat-form-field` requires a component implementing `MatFormFieldControl`.

Closes #33035