### PR TITLE
test(multiple): generate additional tests for angular-aria directives, harness and patterns

### DIFF
--- a/goldens/aria/grid/testing/index.api.md
+++ b/goldens/aria/grid/testing/index.api.md
@@ -17,7 +17,9 @@ export class GridCellHarness extends ContentContainerComponentHarness {
     getText(): Promise<string>;
     // (undocumented)
     static hostSelector: string;
+    isActive(): Promise<boolean>;
     isDisabled(): Promise<boolean>;
+    isFocused(): Promise<boolean>;
     isSelected(): Promise<boolean>;
     static with(options?: GridCellHarnessFilters): HarnessPredicate<GridCellHarness>;
 }

--- a/goldens/aria/listbox/testing/index.api.md
+++ b/goldens/aria/listbox/testing/index.api.md
@@ -8,22 +8,17 @@ import { BaseHarnessFilters } from '@angular/cdk/testing';
 import { ComponentHarness } from '@angular/cdk/testing';
 import { HarnessPredicate } from '@angular/cdk/testing';
 
-// @public (undocumented)
+// @public
 export class ListboxHarness extends ComponentHarness {
     blur(): Promise<void>;
-    // (undocumented)
     focus(): Promise<void>;
-    // (undocumented)
+    getActiveDescendantId(): Promise<string | null>;
     getOptions(filters?: ListboxOptionHarnessFilters): Promise<ListboxOptionHarness[]>;
-    // (undocumented)
     getOrientation(): Promise<'vertical' | 'horizontal'>;
     // (undocumented)
     static hostSelector: string;
-    // (undocumented)
     isDisabled(): Promise<boolean>;
-    // (undocumented)
     isMulti(): Promise<boolean>;
-    // (undocumented)
     static with(options?: ListboxHarnessFilters): HarnessPredicate<ListboxHarness>;
 }
 
@@ -32,19 +27,14 @@ export interface ListboxHarnessFilters extends BaseHarnessFilters {
     disabled?: boolean;
 }
 
-// @public (undocumented)
+// @public
 export class ListboxOptionHarness extends ComponentHarness {
-    // (undocumented)
     click(): Promise<void>;
-    // (undocumented)
     getText(): Promise<string>;
     // (undocumented)
     static hostSelector: string;
-    // (undocumented)
     isDisabled(): Promise<boolean>;
-    // (undocumented)
     isSelected(): Promise<boolean>;
-    // (undocumented)
     static with(options?: ListboxOptionHarnessFilters): HarnessPredicate<ListboxOptionHarness>;
 }
 

--- a/goldens/aria/menu/testing/index.api.md
+++ b/goldens/aria/menu/testing/index.api.md
@@ -16,6 +16,7 @@ export class MenuHarness extends ComponentHarness {
     _getTrigger(): Promise<TestElement | null>;
     // (undocumented)
     static hostSelector: string;
+    isMenuBar(): Promise<boolean>;
     isOpen(): Promise<boolean>;
     open(): Promise<void>;
     // (undocumented)
@@ -32,10 +33,12 @@ export class MenuItemHarness extends ComponentHarness {
     click(): Promise<void>;
     getSubmenu(): Promise<MenuHarness | null>;
     getText(): Promise<string>;
+    hasSubmenu(): Promise<boolean>;
     // (undocumented)
     static hostSelector: string;
     isDisabled(): Promise<boolean>;
     isExpanded(): Promise<boolean>;
+    isFocused(): Promise<boolean>;
     // (undocumented)
     static with(options?: MenuItemHarnessFilters): HarnessPredicate<MenuItemHarness>;
 }

--- a/goldens/aria/toolbar/testing/index.api.md
+++ b/goldens/aria/toolbar/testing/index.api.md
@@ -44,12 +44,14 @@ export class ToolbarWidgetHarness extends ContentContainerComponentHarness<strin
     static hostSelector: string;
     isActive(): Promise<boolean>;
     isDisabled(): Promise<boolean>;
+    isSelected(): Promise<boolean>;
     static with(options?: ToolbarWidgetHarnessFilters): HarnessPredicate<ToolbarWidgetHarness>;
 }
 
 // @public
 export interface ToolbarWidgetHarnessFilters extends BaseHarnessFilters {
     active?: boolean;
+    selected?: boolean;
     text?: string | RegExp;
 }
 

--- a/goldens/aria/tree/testing/index.api.md
+++ b/goldens/aria/tree/testing/index.api.md
@@ -32,13 +32,17 @@ export interface TreeHarnessFilters extends BaseHarnessFilters {
 
 // @public
 export class TreeItemHarness extends ContentContainerComponentHarness<string> {
+    blur(): Promise<void>;
     click(): Promise<void>;
+    focus(): Promise<void>;
     getLevel(): Promise<number>;
     getText(): Promise<string>;
     // (undocumented)
     static hostSelector: string;
+    isActive(): Promise<boolean>;
     isDisabled(): Promise<boolean>;
     isExpanded(): Promise<boolean>;
+    isFocused(): Promise<boolean>;
     isSelected(): Promise<boolean>;
     static with(options?: TreeItemHarnessFilters): HarnessPredicate<TreeItemHarness>;
 }

--- a/src/aria/accordion/accordion.spec.ts
+++ b/src/aria/accordion/accordion.spec.ts
@@ -293,23 +293,23 @@ describe('AccordionGroup', () => {
       });
 
       it('should update collection order when items are shuffled', async () => {
-        const groupDebugElement = fixture.debugElement.query(By.directive(AccordionGroup));
-        const groupDirective = groupDebugElement.injector.get(AccordionGroup);
+        // Verify initial DOM order
+        expect(triggerElements.length).toBe(3);
+        expect(triggerElements[0].textContent?.trim()).toBe('Item 1 Header');
+        expect(triggerElements[2].textContent?.trim()).toBe('Item 3 Header');
 
-        let orderedItems = groupDirective._collection.orderedItems();
-        expect(orderedItems.length).toBe(3);
-        expect(orderedItems[0].element.textContent?.trim()).toBe('Item 1 Header');
-        expect(orderedItems[2].element.textContent?.trim()).toBe('Item 3 Header');
-
+        // Shuffle (reverse) data
         const items = testComponent.items().reverse();
         testComponent.items.set([...items]);
         fixture.detectChanges();
         await waitForMicrotasks();
 
-        orderedItems = groupDirective._collection.orderedItems();
-        expect(orderedItems.length).toBe(3);
-        expect(orderedItems[0].element.textContent?.trim()).toBe('Item 3 Header');
-        expect(orderedItems[2].element.textContent?.trim()).toBe('Item 1 Header');
+        // Re-query elements to check new DOM order
+        setupTriggerAndPanels();
+
+        expect(triggerElements.length).toBe(3);
+        expect(triggerElements[0].textContent?.trim()).toBe('Item 3 Header');
+        expect(triggerElements[2].textContent?.trim()).toBe('Item 1 Header');
       });
 
       describe('wrap behavior', () => {

--- a/src/aria/grid/testing/grid-harness.spec.ts
+++ b/src/aria/grid/testing/grid-harness.spec.ts
@@ -97,6 +97,19 @@ describe('Grid Harness', () => {
     const rows = await loader.getAllHarnesses(GridRowHarness);
     expect(await rows[0].getCellTextByIndex()).toEqual(['Cell 1.1', 'Cell 1.2']);
   });
+
+  it('reports the active state of a cell', async () => {
+    const cell = await loader.getHarness(GridCellHarness.with({text: 'Cell 1.1'}));
+    expect(await cell.isActive()).toBeTrue();
+  });
+
+  it('reports the focused state of a cell', async () => {
+    const cell = await loader.getHarness(GridCellHarness.with({text: 'Cell 1.1'}));
+    expect(await cell.isFocused()).toBeFalse();
+
+    await cell.focus();
+    expect(await cell.isFocused()).toBeTrue();
+  });
 });
 
 @Component({

--- a/src/aria/grid/testing/grid-harness.ts
+++ b/src/aria/grid/testing/grid-harness.ts
@@ -79,6 +79,18 @@ export class GridCellHarness extends ContentContainerComponentHarness {
     const host = await this.host();
     return host.blur();
   }
+
+  /** Whether the cell is active. */
+  async isActive(): Promise<boolean> {
+    const host = await this.host();
+    return (await host.getAttribute('data-active')) === 'true';
+  }
+
+  /** Whether the cell is focused. */
+  async isFocused(): Promise<boolean> {
+    const host = await this.host();
+    return host.isFocused();
+  }
 }
 
 /** Harness for interacting with a standard ngGridRow in tests. */

--- a/src/aria/listbox/listbox.spec.ts
+++ b/src/aria/listbox/listbox.spec.ts
@@ -434,10 +434,10 @@ describe('Listbox', () => {
           ],
         });
 
-        let orderedItems = listboxInstance._collection.orderedItems();
-        expect(orderedItems.length).toBe(3);
-        expect(orderedItems[0].element.textContent?.trim()).toBe('Item 1');
-        expect(orderedItems[2].element.textContent?.trim()).toBe('Item 3');
+        // Verify initial DOM order
+        expect(optionElements.length).toBe(3);
+        expect(optionElements[0].textContent?.trim()).toBe('Item 1');
+        expect(optionElements[2].textContent?.trim()).toBe('Item 3');
 
         const testComponent = fixture.componentInstance as ListboxExample;
         const items = testComponent.options().reverse();
@@ -445,10 +445,12 @@ describe('Listbox', () => {
         fixture.detectChanges();
         await waitForMicrotasks();
 
-        orderedItems = listboxInstance._collection.orderedItems();
-        expect(orderedItems.length).toBe(3);
-        expect(orderedItems[0].element.textContent?.trim()).toBe('Item 3');
-        expect(orderedItems[2].element.textContent?.trim()).toBe('Item 1');
+        // Re-query elements to check new DOM order
+        defineTestVariables(fixture);
+
+        expect(optionElements.length).toBe(3);
+        expect(optionElements[0].textContent?.trim()).toBe('Item 3');
+        expect(optionElements[2].textContent?.trim()).toBe('Item 1');
       });
     });
 

--- a/src/aria/listbox/testing/listbox-harness.spec.ts
+++ b/src/aria/listbox/testing/listbox-harness.spec.ts
@@ -83,6 +83,22 @@ describe('Listbox Harness', () => {
     expect(orientation).toBe('horizontal');
   });
 
+  it('gets the active descendant ID', async () => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [ListboxActiveDescendantTestComponent],
+    });
+    const customFixture = TestBed.createComponent(ListboxActiveDescendantTestComponent);
+    customFixture.detectChanges();
+    const customLoader = TestbedHarnessEnvironment.loader(customFixture);
+
+    const listbox = await customLoader.getHarness(ListboxHarness);
+    const options = await listbox.getOptions();
+
+    await options[0].click();
+    expect(await listbox.getActiveDescendantId()).toBe('apple-id');
+  });
+
   it('clicks an option inside the listbox', async () => {
     const option = await loader.getHarness(ListboxOptionHarness.with({text: 'Apple'}));
 
@@ -91,3 +107,14 @@ describe('Listbox Harness', () => {
     expect(await option.isSelected()).toBeTrue();
   });
 });
+
+@Component({
+  imports: [Listbox, Option],
+  template: `
+    <ul ngListbox focusMode="activedescendant">
+      <li ngOption [value]="1" id="apple-id">Apple</li>
+      <li ngOption [value]="2" id="banana-id">Banana</li>
+    </ul>
+  `,
+})
+class ListboxActiveDescendantTestComponent {}

--- a/src/aria/listbox/testing/listbox-harness.ts
+++ b/src/aria/listbox/testing/listbox-harness.ts
@@ -9,9 +9,16 @@
 import {ComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
 import {ListboxHarnessFilters, ListboxOptionHarnessFilters} from './listbox-harness-filters';
 
+/** Harness for interacting with a standard ngOption in tests. */
 export class ListboxOptionHarness extends ComponentHarness {
   static hostSelector = '[ngOption]';
 
+  /**
+   * Gets a `HarnessPredicate` that can be used to search for an option
+   * with specific attributes.
+   * @param options Options for filtering which option instances are considered a match.
+   * @return a `HarnessPredicate` configured with the given options.
+   */
   static with(options: ListboxOptionHarnessFilters = {}): HarnessPredicate<ListboxOptionHarness> {
     return new HarnessPredicate(ListboxOptionHarness, options)
       .addOption('text', options.text, (harness, text) =>
@@ -29,11 +36,13 @@ export class ListboxOptionHarness extends ComponentHarness {
       );
   }
 
+  /** Whether the option is selected. */
   async isSelected(): Promise<boolean> {
     const host = await this.host();
     return (await host.getAttribute('aria-selected')) === 'true';
   }
 
+  /** Whether the option is disabled. */
   async isDisabled(): Promise<boolean> {
     const host = await this.host();
     return (
@@ -42,20 +51,29 @@ export class ListboxOptionHarness extends ComponentHarness {
     );
   }
 
+  /** Gets the option's text. */
   async getText(): Promise<string> {
     const host = await this.host();
     return host.text();
   }
 
+  /** Clicks the option to toggle its selected state. */
   async click(): Promise<void> {
     const host = await this.host();
     return host.click();
   }
 }
 
+/** Harness for interacting with a standard ngListbox in tests. */
 export class ListboxHarness extends ComponentHarness {
   static hostSelector = '[ngListbox]';
 
+  /**
+   * Gets a `HarnessPredicate` that can be used to search for a listbox
+   * with specific attributes.
+   * @param options Options for filtering which listbox instances are considered a match.
+   * @return a `HarnessPredicate` configured with the given options.
+   */
   static with(options: ListboxHarnessFilters = {}): HarnessPredicate<ListboxHarness> {
     return new HarnessPredicate(ListboxHarness, options).addOption(
       'disabled',
@@ -64,26 +82,31 @@ export class ListboxHarness extends ComponentHarness {
     );
   }
 
+  /** Gets the orientation of the listbox. */
   async getOrientation(): Promise<'vertical' | 'horizontal'> {
     const host = await this.host();
     const orientation = await host.getAttribute('aria-orientation');
     return orientation === 'horizontal' ? 'horizontal' : 'vertical';
   }
 
+  /** Whether the listbox is multiselectable. */
   async isMulti(): Promise<boolean> {
     const host = await this.host();
     return (await host.getAttribute('aria-multiselectable')) === 'true';
   }
 
+  /** Whether the listbox is disabled. */
   async isDisabled(): Promise<boolean> {
     const host = await this.host();
     return (await host.getAttribute('aria-disabled')) === 'true';
   }
 
+  /** Gets the options inside the listbox. */
   async getOptions(filters: ListboxOptionHarnessFilters = {}): Promise<ListboxOptionHarness[]> {
     return this.locatorForAll(ListboxOptionHarness.with(filters))();
   }
 
+  /** Focuses the listbox container. */
   async focus(): Promise<void> {
     await (await this.host()).focus();
   }
@@ -91,5 +114,11 @@ export class ListboxHarness extends ComponentHarness {
   /** Blurs the listbox container. */
   async blur(): Promise<void> {
     await (await this.host()).blur();
+  }
+
+  /** Gets the ID of the active option. */
+  async getActiveDescendantId(): Promise<string | null> {
+    const host = await this.host();
+    return host.getAttribute('aria-activedescendant');
   }
 }

--- a/src/aria/menu/testing/menu-harness.spec.ts
+++ b/src/aria/menu/testing/menu-harness.spec.ts
@@ -117,6 +117,36 @@ describe('Aria Menu Harness', () => {
     expect(await items[0].getText()).toBe('File');
     expect(await items[1].getText()).toBe('Edit');
   });
+
+  it('should be able to get whether a menu item is focused', async () => {
+    const menu = await loader.getHarness(MenuHarness.with({triggerText: 'Open Menu'}));
+    await menu.open();
+    const items = await menu.getItems();
+
+    const itemHost = await items[0].host();
+    await itemHost.focus();
+    fixture.detectChanges();
+
+    expect(await items[0].isFocused()).toBe(true);
+    expect(await items[1].isFocused()).toBe(false);
+  });
+
+  it('should be able to get whether a menu item has a submenu', async () => {
+    const menu = await loader.getHarness(MenuHarness.with({triggerText: 'Open Menu'}));
+    await menu.open();
+    const items = await menu.getItems();
+
+    expect(await items[0].hasSubmenu()).toBe(false);
+    expect(await items[2].hasSubmenu()).toBe(true);
+  });
+
+  it('should be able to get whether a menu is a menu bar', async () => {
+    const menubar = await loader.getHarness(MenuHarness.with({selector: '[ngMenuBar]'}));
+    expect(await menubar.isMenuBar()).toBe(true);
+
+    const menu = await loader.getHarness(MenuHarness.with({triggerText: 'Open Menu'}));
+    expect(await menu.isMenuBar()).toBe(false);
+  });
 });
 
 @Component({

--- a/src/aria/menu/testing/menu-harness.ts
+++ b/src/aria/menu/testing/menu-harness.ts
@@ -62,6 +62,20 @@ export class MenuItemHarness extends ComponentHarness {
     }
     return null;
   }
+
+  /** Whether the menu item has focus. */
+  async isFocused(): Promise<boolean> {
+    return (await this.host()).isFocused();
+  }
+
+  /** Whether the menu item acts as a submenu trigger. */
+  async hasSubmenu(): Promise<boolean> {
+    const host = await this.host();
+    return (
+      (await host.getAttribute('aria-haspopup')) === 'true' ||
+      !!(await host.getAttribute('aria-controls'))
+    );
+  }
 }
 
 /** Harness for interacting with a standard ngMenu or ngMenuBar in tests. */
@@ -95,6 +109,12 @@ export class MenuHarness extends ComponentHarness {
       return true;
     }
     return (await host.getAttribute('data-visible')) === 'true';
+  }
+
+  /** Whether the menu is a menu bar. */
+  async isMenuBar(): Promise<boolean> {
+    const host = await this.host();
+    return host.matchesSelector('[ngMenuBar]');
   }
 
   /** Opens the menu if it is currently closed. */

--- a/src/aria/private/accordion/accordion.spec.ts
+++ b/src/aria/private/accordion/accordion.spec.ts
@@ -322,5 +322,49 @@ describe('Accordion Pattern', () => {
         expect(triggerPatterns[1].expanded()).toBeTrue();
       });
     });
+
+    describe('AccordionTriggerPattern methods', () => {
+      it('should expand via open()', () => {
+        expect(triggerPatterns[0].expanded()).toBeFalse();
+        triggerPatterns[0].open();
+        expect(triggerPatterns[0].expanded()).toBeTrue();
+      });
+
+      it('should collapse via close()', () => {
+        triggerPatterns[0].expanded.set(true);
+        expect(triggerPatterns[0].expanded()).toBeTrue();
+        triggerPatterns[0].close();
+        expect(triggerPatterns[0].expanded()).toBeFalse();
+      });
+
+      it('should toggle via toggle()', () => {
+        expect(triggerPatterns[0].expanded()).toBeFalse();
+        triggerPatterns[0].toggle();
+        expect(triggerPatterns[0].expanded()).toBeTrue();
+
+        triggerPatterns[0].toggle();
+        expect(triggerPatterns[0].expanded()).toBeFalse();
+      });
+    });
+
+    describe('softDisabled behavior', () => {
+      it('should compute hardDisabled as true when disabled=true and softDisabled=false', () => {
+        triggerInputs[0].disabled.set(true);
+        groupInputs.softDisabled.set(false);
+        expect(triggerPatterns[0].hardDisabled()).toBeTrue();
+      });
+
+      it('should compute hardDisabled as false when disabled=true and softDisabled=true', () => {
+        triggerInputs[0].disabled.set(true);
+        groupInputs.softDisabled.set(true);
+        expect(triggerPatterns[0].hardDisabled()).toBeFalse();
+      });
+
+      it('should compute hardDisabled as false when disabled=false', () => {
+        triggerInputs[0].disabled.set(false);
+        groupInputs.softDisabled.set(false);
+        expect(triggerPatterns[0].hardDisabled()).toBeFalse();
+      });
+    });
   });
 });

--- a/src/aria/private/listbox/listbox.spec.ts
+++ b/src/aria/private/listbox/listbox.spec.ts
@@ -90,6 +90,26 @@ describe('Listbox Pattern', () => {
     );
   }
 
+  describe('Tabindex', () => {
+    it('should expose tabIndex signals on listbox and options', () => {
+      const {listbox, options} = getDefaultPatterns();
+
+      expect(listbox.tabIndex()).toBe(-1);
+      expect(options[0].tabIndex()).toBe(0);
+      expect(options[1].tabIndex()).toBe(-1);
+
+      listbox.onKeydown(down());
+
+      expect(options[0].tabIndex()).toBe(-1);
+      expect(options[1].tabIndex()).toBe(0);
+    });
+
+    it('should set tabindex 0 for listbox in activedescendant mode', () => {
+      const {listbox} = getDefaultPatterns({focusMode: signal('activedescendant')});
+      expect(listbox.tabIndex()).toBe(0);
+    });
+  });
+
   describe('Keyboard Navigation', () => {
     it('should navigate next on ArrowDown', () => {
       const {listbox} = getDefaultPatterns();

--- a/src/aria/private/tabs/tabs.spec.ts
+++ b/src/aria/private/tabs/tabs.spec.ts
@@ -420,4 +420,21 @@ describe('Tabs Pattern', () => {
       expect(tabPanelPatterns[2].labelledBy()).toBe('tab-3-id');
     });
   });
+
+  describe('ActiveDescendant mode', () => {
+    beforeEach(() => {
+      tabListInputs.focusMode.set('activedescendant');
+      tabListPattern.setDefaultState();
+    });
+
+    it('should update activeDescendant when navigating', () => {
+      expect(tabListPattern.activeDescendant()).toBe('tab-1-id');
+
+      tabListPattern.onKeydown(right());
+      expect(tabListPattern.activeDescendant()).toBe('tab-2-id');
+
+      tabListPattern.onKeydown(right());
+      expect(tabListPattern.activeDescendant()).toBe('tab-3-id');
+    });
+  });
 });

--- a/src/aria/private/toolbar/toolbar.spec.ts
+++ b/src/aria/private/toolbar/toolbar.spec.ts
@@ -163,6 +163,20 @@ describe('Toolbar Pattern', () => {
     return toolbar.inputs.items().find(item => item.value() === value)!;
   }
 
+  describe('Tabindex', () => {
+    it('should expose tabIndex signals', () => {
+      const {toolbar, items} = getPatterns();
+
+      expect(items[0].tabIndex()).toBe(0);
+      expect(items[1].tabIndex()).toBe(-1);
+
+      toolbar.onKeydown(right()); // Move focus to item 1
+
+      expect(items[0].tabIndex()).toBe(-1);
+      expect(items[1].tabIndex()).toBe(0);
+    });
+  });
+
   describe('Navigation', () => {
     describe('with horizontal orientation', () => {
       it('should navigate on click (horizontal, ltr)', () => {

--- a/src/aria/tabs/tabs.spec.ts
+++ b/src/aria/tabs/tabs.spec.ts
@@ -495,23 +495,23 @@ describe('Tabs', () => {
         ],
       });
 
-      const tabsDebugElement = fixture.debugElement.query(By.directive(Tabs));
-      const tabsDirective = tabsDebugElement.injector.get(Tabs);
+      // Verify initial DOM order
+      expect(tabElements.length).toBe(3);
+      expect(tabElements[0].textContent?.trim()).toBe('Tab 1');
+      expect(tabElements[2].textContent?.trim()).toBe('Tab 3');
 
-      let orderedItems = tabsDirective._collection.orderedItems();
-      expect(orderedItems.length).toBe(3);
-      expect(orderedItems[0].value()).toBe('tab1');
-      expect(orderedItems[2].value()).toBe('tab3');
-
+      // Shuffle (reverse) data
       const items = testComponent.tabsData().reverse();
       testComponent.tabsData.set([...items]);
       fixture.detectChanges();
       await waitForMicrotasks();
 
-      orderedItems = tabsDirective._collection.orderedItems();
-      expect(orderedItems.length).toBe(3);
-      expect(orderedItems[0].value()).toBe('tab3');
-      expect(orderedItems[2].value()).toBe('tab1');
+      // Re-query elements to check new DOM order
+      defineTestVariables();
+
+      expect(tabElements.length).toBe(3);
+      expect(tabElements[0].textContent?.trim()).toBe('Tab 3');
+      expect(tabElements[2].textContent?.trim()).toBe('Tab 1');
     });
   });
 
@@ -740,6 +740,72 @@ describe('Tabs', () => {
       expect(tabPanelElements[2].hasAttribute('inert')).toBe(true);
     });
   });
+
+  describe('Dynamic tabs', () => {
+    beforeEach(() => {
+      setupTestTabs();
+      updateTabs({
+        initialTabs: [
+          {value: 'tab1', label: 'Tab 1', content: 'Content 1'},
+          {value: 'tab2', label: 'Tab 2', content: 'Content 2'},
+          {value: 'tab3', label: 'Tab 3', content: 'Content 3'},
+        ],
+        selectedTab: 'tab2',
+      });
+    });
+
+    it('should update selection when active tab is removed', () => {
+      expect(testComponent.selectedTab()).toBe('tab2');
+
+      testComponent.tabsData.set([
+        {value: 'tab1', label: 'Tab 1', content: 'Content 1'},
+        {value: 'tab3', label: 'Tab 3', content: 'Content 3'},
+      ]);
+      fixture.detectChanges();
+      defineTestVariables();
+
+      expect(testComponent.selectedTab()).toBeUndefined();
+    });
+
+    it('should maintain selection when a new tab is added', () => {
+      expect(testComponent.selectedTab()).toBe('tab2');
+
+      testComponent.tabsData.set([
+        {value: 'tab1', label: 'Tab 1', content: 'Content 1'},
+        {value: 'tab2', label: 'Tab 2', content: 'Content 2'},
+        {value: 'tab3', label: 'Tab 3', content: 'Content 3'},
+        {value: 'tab4', label: 'Tab 4', content: 'Content 4'},
+      ]);
+      fixture.detectChanges();
+      defineTestVariables();
+
+      expect(testComponent.selectedTab()).toBe('tab2');
+    });
+  });
+
+  describe('Custom IDs', () => {
+    let customIdFixture: ComponentFixture<TestTabsCustomIdComponent>;
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        providers: [provideFakeDirectionality('ltr')],
+      });
+      customIdFixture = TestBed.createComponent(TestTabsCustomIdComponent);
+      fixture = customIdFixture as any;
+      customIdFixture.detectChanges();
+    });
+
+    it('should use custom ID for tab and link to panel', async () => {
+      const tabEl = customIdFixture.nativeElement.querySelector('#custom-tab-id');
+      const panelEl = customIdFixture.nativeElement.querySelector('#custom-panel-id');
+
+      expect(tabEl).toBeTruthy();
+      expect(panelEl).toBeTruthy();
+
+      expect(tabEl.getAttribute('aria-controls')).toBe('custom-panel-id');
+      expect(panelEl.getAttribute('aria-labelledby')).toBe('custom-tab-id');
+    });
+  });
 });
 
 @Component({
@@ -797,4 +863,22 @@ class TestTabsComponent {
   softDisabled = signal(true);
   focusMode = signal<'roving' | 'activedescendant'>('roving');
   selectionMode = signal<'follow' | 'explicit'>('follow');
+}
+
+@Component({
+  template: `
+    <div ngTabs>
+      <ul ngTabList [(selectedTab)]="selectedTab">
+        <li ngTab value="tab1" id="custom-tab-id">Tab 1</li>
+      </ul>
+      <div ngTabPanel value="tab1" id="custom-panel-id">
+        <ng-template ngTabContent>Content 1</ng-template>
+      </div>
+    </div>
+  `,
+  imports: [Tabs, TabList, Tab, TabPanel, TabContent],
+  changeDetection: ChangeDetectionStrategy.Eager,
+})
+class TestTabsCustomIdComponent {
+  selectedTab = signal('tab1');
 }

--- a/src/aria/tabs/testing/tabs-harness.spec.ts
+++ b/src/aria/tabs/testing/tabs-harness.spec.ts
@@ -137,7 +137,6 @@ describe('TabsHarness', () => {
         <li ngTab value="tab3" [disabled]="true">Tab 3</li>
       </ul>
 
-
       <div ngTabPanel value="tab1">
         <ng-template ngTabContent>
           <div class="test-content">Content 1</div>

--- a/src/aria/toolbar/testing/toolbar-harness-filters.ts
+++ b/src/aria/toolbar/testing/toolbar-harness-filters.ts
@@ -21,4 +21,7 @@ export interface ToolbarWidgetHarnessFilters extends BaseHarnessFilters {
 
   /** Active state that the widget should match. */
   active?: boolean;
+
+  /** Selected state that the widget should match. */
+  selected?: boolean;
 }

--- a/src/aria/toolbar/testing/toolbar-harness.spec.ts
+++ b/src/aria/toolbar/testing/toolbar-harness.spec.ts
@@ -93,12 +93,20 @@ describe('ToolbarHarness', () => {
     fixture.componentInstance.undoDisabled.set(true);
     expect(await widget.isDisabled()).toBe(true);
   });
+
+  it('should be able to get whether a widget is selected', async () => {
+    const widget = await loader.getHarness(ToolbarWidgetHarness.with({text: 'Undo'}));
+    expect(await widget.isSelected()).toBe(false);
+
+    await widget.click();
+    expect(await widget.isSelected()).toBe(true);
+  });
 });
 
 @Component({
   template: `
     <div ngToolbar [orientation]="orientation()" [disabled]="toolbarDisabled()">
-      <button ngToolbarWidget value="undo" [disabled]="undoDisabled()">Undo</button>
+      <button ngToolbarWidget #u="ngToolbarWidget" value="undo" [disabled]="undoDisabled()" [aria-pressed]="u.selected()">Undo</button>
       <button ngToolbarWidget value="redo">Redo</button>
 
       <div ngToolbarWidgetGroup>

--- a/src/aria/toolbar/testing/toolbar-widget-harness.ts
+++ b/src/aria/toolbar/testing/toolbar-widget-harness.ts
@@ -28,6 +28,11 @@ export class ToolbarWidgetHarness extends ContentContainerComponentHarness<strin
         'active',
         options.active,
         async (harness, active) => (await harness.isActive()) === active,
+      )
+      .addOption(
+        'selected',
+        options.selected,
+        async (harness, selected) => (await harness.isSelected()) === selected,
       );
   }
 
@@ -51,5 +56,11 @@ export class ToolbarWidgetHarness extends ContentContainerComponentHarness<strin
   async isDisabled(): Promise<boolean> {
     const host = await this.host();
     return (await host.getAttribute('aria-disabled')) === 'true';
+  }
+
+  /** Gets whether the widget is selected. */
+  async isSelected(): Promise<boolean> {
+    const host = await this.host();
+    return (await host.getAttribute('aria-pressed')) === 'true';
   }
 }

--- a/src/aria/toolbar/toolbar.spec.ts
+++ b/src/aria/toolbar/toolbar.spec.ts
@@ -626,6 +626,55 @@ describe('Toolbar', () => {
       expect(item2.getAttribute('aria-pressed')).toBe('false');
     });
   });
+
+  describe('ARIA attributes and roles', () => {
+    beforeEach(() => setupToolbar());
+
+    it('should have role="toolbar"', () => {
+      expect(toolbarElement.getAttribute('role')).toBe('toolbar');
+    });
+
+    it('should set aria-orientation based on input', () => {
+      expect(toolbarElement.getAttribute('aria-orientation')).toBe('horizontal');
+      fixture.componentInstance.orientation.set('vertical');
+      fixture.detectChanges();
+      expect(toolbarElement.getAttribute('aria-orientation')).toBe('vertical');
+    });
+
+    it('should set aria-disabled based on input', () => {
+      expect(toolbarElement.getAttribute('aria-disabled')).toBe('false');
+      fixture.componentInstance.disabled.set(true);
+      fixture.detectChanges();
+      expect(toolbarElement.getAttribute('aria-disabled')).toBe('true');
+    });
+  });
+
+  describe('Focus management', () => {
+    beforeEach(() => setupToolbar());
+
+    it('should have tabindex on widgets set by active state', () => {
+      const widgets = getWidgetEls();
+      expect(widgets[0].getAttribute('tabindex')).toBe('0');
+      expect(widgets[1].getAttribute('tabindex')).toBe('-1');
+
+      click(widgets[1]);
+      expect(widgets[0].getAttribute('tabindex')).toBe('-1');
+      expect(widgets[1].getAttribute('tabindex')).toBe('0');
+    });
+  });
+
+  describe('Hard disabled state attributes', () => {
+    beforeEach(() => setupToolbar({softDisabled: false}));
+
+    it('should set inert and disabled attributes on hard-disabled widgets', () => {
+      fixture.componentInstance.widgets[0].disabled.set(true);
+      fixture.detectChanges();
+
+      const widgets = getWidgetEls();
+      expect(widgets[0].hasAttribute('inert')).toBe(true);
+      expect(widgets[0].getAttribute('disabled')).toBe('true');
+    });
+  });
 });
 
 @Component({

--- a/src/aria/tree/testing/item-harness.ts
+++ b/src/aria/tree/testing/item-harness.ts
@@ -76,6 +76,26 @@ export class TreeItemHarness extends ContentContainerComponentHarness<string> {
     return (await this.host()).click();
   }
 
+  /** Focuses the tree item. */
+  async focus(): Promise<void> {
+    return (await this.host()).focus();
+  }
+
+  /** Blurs the tree item. */
+  async blur(): Promise<void> {
+    return (await this.host()).blur();
+  }
+
+  /** Whether the tree item is active. */
+  async isActive(): Promise<boolean> {
+    return (await this._getHostAttribute('data-active')) === 'true';
+  }
+
+  /** Whether the tree item has focus. */
+  async isFocused(): Promise<boolean> {
+    return (await this.host()).isFocused();
+  }
+
   private async _getHostAttribute(attributeName: string): Promise<string | null> {
     return (await this.host()).getAttribute(attributeName);
   }

--- a/src/aria/tree/testing/tree-harness.spec.ts
+++ b/src/aria/tree/testing/tree-harness.spec.ts
@@ -109,6 +109,26 @@ describe('TreeHarness', () => {
       ],
     });
   });
+
+  it('should be able to get whether a tree item has focus', async () => {
+    const tree = await loader.getHarness(TreeHarness);
+    const item = (await tree.getItems({text: 'angular.json'}))[0];
+
+    expect(await item.isFocused()).toBeFalse();
+
+    await item.focus();
+    expect(await item.isFocused()).toBeTrue();
+
+    await item.blur();
+    expect(await item.isFocused()).toBeFalse();
+  });
+
+  it('should be able to get whether a tree item is active', async () => {
+    const tree = await loader.getHarness(TreeHarness);
+    const item = (await tree.getItems({text: 'public'}))[0];
+
+    expect(await item.isActive()).toBeTrue();
+  });
 });
 
 interface TreeNode {


### PR DESCRIPTION
Used Gemini to go through the Angular Aria components, harnesses and patterns to fill in a few additional harness methods and specs.

Of note is switching the shuffled tests back to test at the directive level instead of at the lower collection level (already tested in SortedCollection unit tests).