### PR TITLE
refactor(aria/combobox): make input readonly when disabled

### DIFF
--- a/src/aria/simple-combobox/simple-combobox.spec.ts
+++ b/src/aria/simple-combobox/simple-combobox.spec.ts
@@ -547,6 +547,13 @@ describe('Combobox', () => {
         expect(inputElement.getAttribute('aria-disabled')).toBe('true');
       });
 
+      it('should make the input read-only when disabled and softDisabled is true', () => {
+        fixture.componentInstance.disabled.set(true);
+        fixture.detectChanges();
+
+        expect(inputElement.getAttribute('readonly')).toBe('');
+      });
+
       it('should block interactions when disabled', () => {
         fixture.componentInstance.disabled.set(true);
         fixture.detectChanges();

--- a/src/aria/simple-combobox/simple-combobox.ts
+++ b/src/aria/simple-combobox/simple-combobox.ts
@@ -53,6 +53,7 @@ import type {ComboboxPopup} from './simple-combobox-popup';
     '[attr.aria-haspopup]': '_pattern.popupType()',
     '[attr.tabindex]': 'disabled() && !softDisabled() ? -1 : null',
     '[attr.disabled]': 'disabled() && !softDisabled() ? "" : null',
+    '[attr.readonly]': 'disabled() && _pattern.isEditable() ? "" : null',
     '(keydown)': '_pattern.onKeydown($event)',
     '(focusin)': '_pattern.onFocusin()',
     '(focusout)': '_pattern.onFocusout($event)',

--- a/src/components-examples/aria/simple-combobox/simple-combobox-autocomplete-disabled/simple-combobox-autocomplete-disabled-example.ts
+++ b/src/components-examples/aria/simple-combobox/simple-combobox-autocomplete-disabled/simple-combobox-autocomplete-disabled-example.ts
@@ -34,7 +34,7 @@ export class SimpleComboboxAutocompleteDisabledExample {
   readonly combobox = viewChild(Combobox);
 
   popupExpanded = signal(false);
-  searchString = signal('United States of America');
+  searchString = signal('Select a country');
   selectedOption = signal<string[]>([]);
 
   /** The query string used to filter the list of countries. */


### PR DESCRIPTION
- issues when we have simple-combobox and softDisabled 
- need the input or textarea element to still be readable without marking it disabled since it would block the focus on it (preventing soft disabled)