### PR TITLE
test(multiple): check for incorrect usage of Angular Aria directives and log violations

### DIFF
--- a/goldens/aria/accordion/index.api.md
+++ b/goldens/aria/accordion/index.api.md
@@ -50,13 +50,14 @@ export class AccordionPanel {
     toggle(): void;
     readonly visible: _angular_core.Signal<boolean>;
     // (undocumented)
-    static ɵdir: _angular_core.ɵɵDirectiveDeclaration<AccordionPanel, "[ngAccordionPanel]", ["ngAccordionPanel"], { "id": { "alias": "id"; "required": false; "isSignal": true; }; }, {}, never, never, true, [{ directive: typeof DeferredContentAware; inputs: { "preserveContent": "preserveContent"; }; outputs: {}; }]>;
+    static ɵdir: _angular_core.ɵɵDirectiveDeclaration<AccordionPanel, "[ngAccordionPanel]", ["ngAccordionPanel"], { "id": { "alias": "id"; "required": false; "isSignal": true; }; }, {}, ["_accordionContent"], never, true, [{ directive: typeof DeferredContentAware; inputs: { "preserveContent": "preserveContent"; }; outputs: {}; }]>;
     // (undocumented)
     static ɵfac: _angular_core.ɵɵFactoryDeclaration<AccordionPanel, never>;
 }
 
 // @public
 export class AccordionTrigger implements OnInit, OnDestroy {
+    constructor();
     readonly active: _angular_core.Signal<boolean>;
     collapse(): void;
     readonly disabled: _angular_core.InputSignalWithTransform<boolean, unknown>;

--- a/goldens/aria/private/index.api.md
+++ b/goldens/aria/private/index.api.md
@@ -32,6 +32,7 @@ export class AccordionGroupPattern {
     onKeydown(event: KeyboardEvent): void;
     readonly prevKey: SignalLike<"ArrowUp" | "ArrowRight" | "ArrowLeft">;
     toggle(): void;
+    validate(): string[];
 }
 
 // @public
@@ -271,6 +272,7 @@ export class GridPattern {
     restoreFocusEffect(): void;
     setDefaultStateEffect(): void;
     readonly tabIndex: SignalLike<0 | -1>;
+    validate(): string[];
 }
 
 // @public
@@ -461,6 +463,7 @@ export class MenuPattern<V> {
     readonly tabIndex: () => 0 | -1;
     trigger(): void;
     readonly typeaheadRegexp: RegExp;
+    validate(): string[];
     readonly visible: SignalLike<boolean>;
 }
 
@@ -519,6 +522,9 @@ export class OptionPattern<V> {
     readonly tabIndex: SignalLike<0 | -1 | undefined>;
     readonly value: SignalLike<V>;
 }
+
+// @public
+export function reportViolations(violations: string[], element: Element): void;
 
 // @public
 export function resolveElement<T = HTMLElement>(resolver: ElementResolver<T>, context: HTMLElement): T | undefined;
@@ -652,6 +658,7 @@ export class ToolbarPattern<V> {
     setDefaultStateEffect(): void;
     readonly softDisabled: SignalLike<boolean>;
     readonly tabIndex: SignalLike<0 | -1>;
+    validate(): string[];
 }
 
 // @public

--- a/goldens/aria/tabs/index.api.md
+++ b/goldens/aria/tabs/index.api.md
@@ -13,6 +13,7 @@ import { WritableSignal } from '@angular/core';
 
 // @public
 export class Tab implements HasElement, OnInit, OnDestroy {
+    constructor();
     readonly active: _angular_core.Signal<boolean>;
     readonly disabled: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly element: HTMLElement;
@@ -81,7 +82,7 @@ export class TabPanel implements OnInit, OnDestroy {
     readonly value: _angular_core.InputSignal<string>;
     readonly visible: _angular_core.Signal<boolean>;
     // (undocumented)
-    static ɵdir: _angular_core.ɵɵDirectiveDeclaration<TabPanel, "[ngTabPanel]", ["ngTabPanel"], { "id": { "alias": "id"; "required": false; "isSignal": true; }; "value": { "alias": "value"; "required": true; "isSignal": true; }; }, {}, never, never, true, [{ directive: typeof DeferredContentAware; inputs: { "preserveContent": "preserveContent"; }; outputs: {}; }]>;
+    static ɵdir: _angular_core.ɵɵDirectiveDeclaration<TabPanel, "[ngTabPanel]", ["ngTabPanel"], { "id": { "alias": "id"; "required": false; "isSignal": true; }; "value": { "alias": "value"; "required": true; "isSignal": true; }; }, {}, ["_tabContent"], never, true, [{ directive: typeof DeferredContentAware; inputs: { "preserveContent": "preserveContent"; }; outputs: {}; }]>;
     // (undocumented)
     static ɵfac: _angular_core.ɵɵFactoryDeclaration<TabPanel, never>;
 }

--- a/goldens/aria/toolbar/index.api.md
+++ b/goldens/aria/toolbar/index.api.md
@@ -55,6 +55,7 @@ export class ToolbarWidget<V> implements OnInit, OnDestroy {
 
 // @public
 export class ToolbarWidgetGroup<V> {
+    constructor();
     readonly disabled: _angular_core.InputSignalWithTransform<boolean, unknown>;
     readonly element: HTMLElement;
     readonly multi: _angular_core.InputSignalWithTransform<boolean, unknown>;

--- a/src/aria/accordion/accordion-group.ts
+++ b/src/aria/accordion/accordion-group.ts
@@ -15,6 +15,7 @@ import {
   input,
   signal,
   afterNextRender,
+  afterRenderEffect,
   OnDestroy,
 } from '@angular/core';
 import {Directionality} from '@angular/cdk/bidi';
@@ -113,6 +114,18 @@ export class AccordionGroup implements OnDestroy {
     afterNextRender(() => {
       this._collection.startObserving(this.element);
     });
+
+    // Check for any violations after the DOM has been updated.
+    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+      afterRenderEffect({
+        read: () => {
+          const violations = this._pattern.validate();
+          for (const violation of violations) {
+            console.error(violation);
+          }
+        },
+      });
+    }
   }
 
   ngOnDestroy() {

--- a/src/aria/accordion/accordion-group.ts
+++ b/src/aria/accordion/accordion-group.ts
@@ -19,7 +19,7 @@ import {
   OnDestroy,
 } from '@angular/core';
 import {Directionality} from '@angular/cdk/bidi';
-import {AccordionGroupPattern, SortedCollection} from '../private';
+import {AccordionGroupPattern, SortedCollection, reportViolations} from '../private';
 import {ACCORDION_GROUP} from './accordion-tokens';
 import {AccordionTrigger} from './accordion-trigger';
 
@@ -119,10 +119,7 @@ export class AccordionGroup implements OnDestroy {
     if (typeof ngDevMode === 'undefined' || ngDevMode) {
       afterRenderEffect({
         read: () => {
-          const violations = this._pattern.validate();
-          for (const violation of violations) {
-            console.error(violation);
-          }
+          reportViolations(this._pattern.validate(), this.element);
         },
       });
     }

--- a/src/aria/accordion/accordion-panel.ts
+++ b/src/aria/accordion/accordion-panel.ts
@@ -6,9 +6,18 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Directive, ElementRef, afterRenderEffect, computed, inject, input} from '@angular/core';
+import {
+  Directive,
+  ElementRef,
+  afterRenderEffect,
+  computed,
+  contentChild,
+  inject,
+  input,
+} from '@angular/core';
 import {_IdGenerator} from '@angular/cdk/a11y';
 import {DeferredContentAware, AccordionTriggerPattern} from '../private';
+import {AccordionContent} from './accordion-content';
 
 /**
  * The content panel of an accordion item that is conditionally visible.
@@ -56,6 +65,8 @@ export class AccordionPanel {
   /** The DeferredContentAware host directive. */
   private readonly _deferredContentAware = inject(DeferredContentAware);
 
+  private readonly _accordionContent = contentChild(AccordionContent);
+
   /** A global unique identifier for the panel. */
   readonly id = input(inject(_IdGenerator).getId('ng-accordion-panel-', true));
 
@@ -76,6 +87,26 @@ export class AccordionPanel {
         this._deferredContentAware.contentVisible.set(this.visible());
       },
     });
+
+    // Check for any violations after the DOM has been updated.
+    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+      afterRenderEffect({
+        read: () => {
+          const violations: string[] = [];
+
+          if (!this._accordionContent()) {
+            violations.push('ngAccordionPanel must have an ngAccordionContent to render.');
+          }
+          if (!this._pattern) {
+            violations.push('ngAccordionPanel must have an ngAccordionTrigger to control it.');
+          }
+
+          for (const violation of violations) {
+            console.error(violation);
+          }
+        },
+      });
+    }
   }
 
   /** Expands this item. */

--- a/src/aria/accordion/accordion-panel.ts
+++ b/src/aria/accordion/accordion-panel.ts
@@ -16,7 +16,7 @@ import {
   input,
 } from '@angular/core';
 import {_IdGenerator} from '@angular/cdk/a11y';
-import {DeferredContentAware, AccordionTriggerPattern} from '../private';
+import {DeferredContentAware, AccordionTriggerPattern, reportViolations} from '../private';
 import {AccordionContent} from './accordion-content';
 
 /**
@@ -101,9 +101,7 @@ export class AccordionPanel {
             violations.push('ngAccordionPanel must have an ngAccordionTrigger to control it.');
           }
 
-          for (const violation of violations) {
-            console.error(violation);
-          }
+          reportViolations(violations, this.element);
         },
       });
     }

--- a/src/aria/accordion/accordion-trigger.ts
+++ b/src/aria/accordion/accordion-trigger.ts
@@ -19,7 +19,7 @@ import {
   afterRenderEffect,
 } from '@angular/core';
 import {_IdGenerator} from '@angular/cdk/a11y';
-import {AccordionTriggerPattern} from '../private';
+import {AccordionTriggerPattern, reportViolations} from '../private';
 import {ACCORDION_GROUP} from './accordion-tokens';
 import {AccordionPanel} from './accordion-panel';
 
@@ -103,9 +103,7 @@ export class AccordionTrigger implements OnInit, OnDestroy {
             );
           }
 
-          for (const violation of violations) {
-            console.error(violation);
-          }
+          reportViolations(violations, this.element);
         },
       });
     }

--- a/src/aria/accordion/accordion-trigger.ts
+++ b/src/aria/accordion/accordion-trigger.ts
@@ -16,6 +16,7 @@ import {
   inject,
   input,
   model,
+  afterRenderEffect,
 } from '@angular/core';
 import {_IdGenerator} from '@angular/cdk/a11y';
 import {AccordionTriggerPattern} from '../private';
@@ -83,6 +84,32 @@ export class AccordionTrigger implements OnInit, OnDestroy {
 
   /** The UI pattern instance for this trigger. */
   _pattern!: AccordionTriggerPattern;
+
+  constructor() {
+    // Check for any violations after the DOM has been updated.
+    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+      afterRenderEffect({
+        read: () => {
+          const violations: string[] = [];
+
+          if (this.panel() && this.panel().element.contains(this.element)) {
+            violations.push(
+              'ngAccordionTrigger must not be nested inside its controlled ngAccordionPanel, otherwise it will become unreachable when collapsed.',
+            );
+          }
+          if (this.panel() && (this.panel() as any)._pattern !== this._pattern) {
+            violations.push(
+              'ngAccordionPanel is already controlled by another ngAccordionTrigger.',
+            );
+          }
+
+          for (const violation of violations) {
+            console.error(violation);
+          }
+        },
+      });
+    }
+  }
 
   ngOnInit() {
     this._pattern = new AccordionTriggerPattern({

--- a/src/aria/accordion/accordion.spec.ts
+++ b/src/aria/accordion/accordion.spec.ts
@@ -480,6 +480,89 @@ describe('AccordionGroup', () => {
       });
     });
   });
+
+  describe('structural validations', () => {
+    let consoleSpy: jasmine.Spy;
+
+    beforeEach(() => {
+      consoleSpy = spyOn(console, 'error');
+    });
+
+    afterEach(() => {
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        imports: [AccordionGroupWithLoop],
+        providers: [provideFakeDirectionality('ltr'), _IdGenerator],
+      });
+      fixture = TestBed.createComponent(AccordionGroupWithLoop);
+      setupAccordionGroup();
+    });
+
+    it('should warn when multiple triggers control the same panel', () => {
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        imports: [AccordionWithDuplicateTriggers],
+      });
+      const duplicateFixture = TestBed.createComponent(AccordionWithDuplicateTriggers);
+      duplicateFixture.detectChanges();
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        'ngAccordionPanel is already controlled by another ngAccordionTrigger.',
+      );
+    });
+
+    it('should warn when trigger is nested inside its controlled panel', () => {
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        imports: [AccordionWithNestedTrigger],
+      });
+      const nestedFixture = TestBed.createComponent(AccordionWithNestedTrigger);
+      nestedFixture.detectChanges();
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        'ngAccordionTrigger must not be nested inside its controlled ngAccordionPanel, otherwise it will become unreachable when collapsed.',
+      );
+    });
+
+    it('should warn when ngAccordionPanel is missing ngAccordionContent', () => {
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        imports: [AccordionPanelWithoutContent],
+      });
+      const noContentFixture = TestBed.createComponent(AccordionPanelWithoutContent);
+      noContentFixture.detectChanges();
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        'ngAccordionPanel must have an ngAccordionContent to render.',
+      );
+    });
+
+    it('should warn when ngAccordionPanel is missing controlling trigger', () => {
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        imports: [AccordionPanelWithoutTrigger],
+      });
+      const noTriggerFixture = TestBed.createComponent(AccordionPanelWithoutTrigger);
+      noTriggerFixture.detectChanges();
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        'ngAccordionPanel must have an ngAccordionTrigger to control it.',
+      );
+    });
+
+    it('should warn when multiple items are expanded in single-expand mode', () => {
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        imports: [AccordionWithMultipleExpandedItems],
+      });
+      const multipleExpandedFixture = TestBed.createComponent(AccordionWithMultipleExpandedItems);
+      multipleExpandedFixture.detectChanges();
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        'ngAccordionGroup has multiExpandable set to false, but multiple ngAccordionTrigger panels are initially expanded.',
+      );
+    });
+  });
 });
 
 @Component({
@@ -606,3 +689,81 @@ class AccordionGroupWithIfs extends AccordionGroupWithLoop {
   includeSecond = signal(true);
   includeThird = signal(true);
 }
+
+@Component({
+  template: `
+    <div ngAccordionGroup>
+      <button ngAccordionTrigger [panel]="panel1">Trigger 1</button>
+      <button ngAccordionTrigger [panel]="panel1">Trigger 2</button>
+      <div ngAccordionPanel #panel1="ngAccordionPanel">
+        <ng-template ngAccordionContent>Content</ng-template>
+      </div>
+    </div>
+  `,
+  imports: [AccordionGroup, AccordionTrigger, AccordionPanel, AccordionContent],
+  changeDetection: ChangeDetectionStrategy.Eager,
+})
+class AccordionWithDuplicateTriggers {}
+
+@Component({
+  template: `
+    <div ngAccordionGroup>
+      <div ngAccordionPanel #panel1="ngAccordionPanel">
+        <button ngAccordionTrigger [panel]="panel1">Nested Trigger</button>
+        <ng-template ngAccordionContent>Content</ng-template>
+      </div>
+    </div>
+  `,
+  imports: [AccordionGroup, AccordionTrigger, AccordionPanel, AccordionContent],
+  changeDetection: ChangeDetectionStrategy.Eager,
+})
+class AccordionWithNestedTrigger {}
+
+@Component({
+  template: `
+    <div ngAccordionGroup>
+      <button ngAccordionTrigger [panel]="panel1">Trigger</button>
+      <div ngAccordionPanel #panel1="ngAccordionPanel">
+        Content
+      </div>
+    </div>
+  `,
+  imports: [AccordionGroup, AccordionTrigger, AccordionPanel],
+  changeDetection: ChangeDetectionStrategy.Eager,
+})
+class AccordionPanelWithoutContent {}
+
+@Component({
+  template: `
+    <div ngAccordionGroup>
+      <div ngAccordionPanel>
+        <ng-template ngAccordionContent>Content</ng-template>
+      </div>
+    </div>
+  `,
+  imports: [AccordionGroup, AccordionPanel, AccordionContent],
+  changeDetection: ChangeDetectionStrategy.Eager,
+})
+class AccordionPanelWithoutTrigger {}
+
+@Component({
+  template: `
+    <div ngAccordionGroup [multiExpandable]="false">
+      <div>
+        <button ngAccordionTrigger [panel]="panel1" [expanded]="true">Trigger 1</button>
+        <div ngAccordionPanel #panel1="ngAccordionPanel">
+          <ng-template ngAccordionContent>Content 1</ng-template>
+        </div>
+      </div>
+      <div>
+        <button ngAccordionTrigger [panel]="panel2" [expanded]="true">Trigger 2</button>
+        <div ngAccordionPanel #panel2="ngAccordionPanel">
+          <ng-template ngAccordionContent>Content 2</ng-template>
+        </div>
+      </div>
+    </div>
+  `,
+  imports: [AccordionGroup, AccordionTrigger, AccordionPanel, AccordionContent],
+  changeDetection: ChangeDetectionStrategy.Eager,
+})
+class AccordionWithMultipleExpandedItems {}

--- a/src/aria/accordion/accordion.spec.ts
+++ b/src/aria/accordion/accordion.spec.ts
@@ -485,7 +485,7 @@ describe('AccordionGroup', () => {
     let consoleSpy: jasmine.Spy;
 
     beforeEach(() => {
-      consoleSpy = spyOn(console, 'error');
+      consoleSpy = spyOn(console, 'warn');
     });
 
     afterEach(() => {

--- a/src/aria/grid/grid.spec.ts
+++ b/src/aria/grid/grid.spec.ts
@@ -1065,7 +1065,7 @@ describe('Grid directives', () => {
     let consoleSpy: jasmine.Spy;
 
     beforeEach(() => {
-      consoleSpy = spyOn(console, 'error');
+      consoleSpy = spyOn(console, 'warn');
     });
 
     afterEach(() => {

--- a/src/aria/grid/grid.spec.ts
+++ b/src/aria/grid/grid.spec.ts
@@ -1060,6 +1060,30 @@ describe('Grid directives', () => {
       });
     });
   });
+
+  describe('structural validations', () => {
+    let consoleSpy: jasmine.Spy;
+
+    beforeEach(() => {
+      consoleSpy = spyOn(console, 'error');
+    });
+
+    afterEach(() => {
+      TestBed.resetTestingModule();
+      setupGrid();
+    });
+
+    it('should warn when ngGridRow contains no cells', () => {
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        imports: [GridRowWithoutCells],
+      });
+      const noCellsFixture = TestBed.createComponent(GridRowWithoutCells);
+      noCellsFixture.detectChanges();
+
+      expect(consoleSpy).toHaveBeenCalledWith('ngGridRow must contain at least one ngGridCell.');
+    });
+  });
 });
 
 @Component({
@@ -1136,3 +1160,14 @@ class GridTestComponent {
   onActivated = jasmine.createSpy('activated');
   onDeactivated = jasmine.createSpy('deactivated');
 }
+
+@Component({
+  template: `
+    <table ngGrid>
+      <tr ngGridRow></tr>
+    </table>
+  `,
+  imports: [Grid, GridRow],
+  changeDetection: ChangeDetectionStrategy.Eager,
+})
+class GridRowWithoutCells {}

--- a/src/aria/grid/grid.ts
+++ b/src/aria/grid/grid.ts
@@ -25,6 +25,7 @@ import {
   GridRowPattern,
   SortedCollection,
   tabIndexTransform,
+  reportViolations,
 } from '../private';
 import {GridRow} from './grid-row';
 import {GRID} from './grid-tokens';
@@ -158,10 +159,7 @@ export class Grid implements OnDestroy {
     if (typeof ngDevMode === 'undefined' || ngDevMode) {
       afterRenderEffect({
         read: () => {
-          const violations = this._pattern.validate();
-          for (const violation of violations) {
-            console.error(violation);
-          }
+          reportViolations(this._pattern.validate(), this.element);
         },
       });
     }

--- a/src/aria/grid/grid.ts
+++ b/src/aria/grid/grid.ts
@@ -154,6 +154,18 @@ export class Grid implements OnDestroy {
     afterRenderEffect({write: () => this._pattern.restoreFocusEffect()});
     afterRenderEffect({write: () => this._pattern.focusEffect()});
 
+    // Check for any violations after the DOM has been updated.
+    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+      afterRenderEffect({
+        read: () => {
+          const violations = this._pattern.validate();
+          for (const violation of violations) {
+            console.error(violation);
+          }
+        },
+      });
+    }
+
     afterNextRender(() => {
       this._collection.startObserving(this.element);
     });

--- a/src/aria/listbox/listbox.spec.ts
+++ b/src/aria/listbox/listbox.spec.ts
@@ -454,6 +454,58 @@ describe('Listbox', () => {
       });
     });
 
+    describe('structural validations', () => {
+      let consoleSpy: jasmine.Spy;
+
+      beforeEach(() => {
+        consoleSpy = spyOn(console, 'error');
+      });
+
+      afterEach(() => {
+        TestBed.resetTestingModule();
+        setupListbox();
+      });
+
+      it('should warn when duplicate option values are detected inside ngListbox', () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+          imports: [ListboxWithDuplicateValues],
+        });
+        const duplicateFixture = TestBed.createComponent(ListboxWithDuplicateValues);
+        duplicateFixture.detectChanges();
+
+        expect(consoleSpy).toHaveBeenCalledWith(
+          "Duplicate option value 'item0' detected inside ngListbox.",
+        );
+      });
+
+      it('should warn when duplicate option IDs are detected inside ngListbox', () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+          imports: [ListboxWithDuplicateIds],
+        });
+        const duplicateFixture = TestBed.createComponent(ListboxWithDuplicateIds);
+        duplicateFixture.detectChanges();
+
+        expect(consoleSpy).toHaveBeenCalledWith(
+          "Duplicate option ID 'option0' detected inside ngListbox.",
+        );
+      });
+
+      it('should warn when single-select listbox has multiple selected options', () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+          imports: [SingleSelectListboxWithMultipleValues],
+        });
+        const singleSelectFixture = TestBed.createComponent(SingleSelectListboxWithMultipleValues);
+        singleSelectFixture.detectChanges();
+
+        expect(consoleSpy).toHaveBeenCalledWith(
+          'A single-select listbox should not have multiple selected options. Selected options: item0, item1',
+        );
+      });
+    });
+
     describe('keyboard interactions', () => {
       describe('single select', () => {
         describe('selection follows focus', () => {
@@ -905,3 +957,39 @@ class ListboxExample {
   changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DefaultListboxExample {}
+
+@Component({
+  template: `
+    <ul ngListbox>
+      <li ngOption value="item0">Item 0</li>
+      <li ngOption value="item0">Item 0 Copy</li>
+    </ul>
+  `,
+  imports: [Listbox, Option],
+  changeDetection: ChangeDetectionStrategy.Eager,
+})
+class ListboxWithDuplicateValues {}
+
+@Component({
+  template: `
+    <ul ngListbox>
+      <li ngOption value="item0" id="option0">Item 0</li>
+      <li ngOption value="item1" id="option0">Item 1</li>
+    </ul>
+  `,
+  imports: [Listbox, Option],
+  changeDetection: ChangeDetectionStrategy.Eager,
+})
+class ListboxWithDuplicateIds {}
+
+@Component({
+  template: `
+    <ul ngListbox [multi]="false" [value]="['item0', 'item1']">
+      <li ngOption value="item0">Item 0</li>
+      <li ngOption value="item1">Item 1</li>
+    </ul>
+  `,
+  imports: [Listbox, Option],
+  changeDetection: ChangeDetectionStrategy.Eager,
+})
+class SingleSelectListboxWithMultipleValues {}

--- a/src/aria/listbox/listbox.spec.ts
+++ b/src/aria/listbox/listbox.spec.ts
@@ -458,7 +458,7 @@ describe('Listbox', () => {
       let consoleSpy: jasmine.Spy;
 
       beforeEach(() => {
-        consoleSpy = spyOn(console, 'error');
+        consoleSpy = spyOn(console, 'warn');
       });
 
       afterEach(() => {

--- a/src/aria/listbox/listbox.ts
+++ b/src/aria/listbox/listbox.ts
@@ -159,17 +159,18 @@ export class Listbox<V> implements OnDestroy {
       this._collection.startObserving(this.element);
     });
 
-    // Check for any violationns after the DOM has been updated.
-    afterRenderEffect({
-      read: () => {
-        if (typeof ngDevMode === 'undefined' || ngDevMode) {
+    // Check for any violations after the DOM has been updated.
+    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+      afterRenderEffect({
+        read: () => {
           const violations = this._pattern.validate();
+
           for (const violation of violations) {
             console.error(violation);
           }
-        }
-      },
-    });
+        },
+      });
+    }
 
     afterRenderEffect({write: () => this._pattern.setDefaultStateEffect()});
 

--- a/src/aria/listbox/listbox.ts
+++ b/src/aria/listbox/listbox.ts
@@ -23,7 +23,7 @@ import {
 } from '@angular/core';
 import {Directionality} from '@angular/cdk/bidi';
 import {_IdGenerator} from '@angular/cdk/a11y';
-import {ListboxPattern, SortedCollection, tabIndexTransform} from '../private';
+import {ListboxPattern, SortedCollection, tabIndexTransform, reportViolations} from '../private';
 import {Option} from './option';
 import {LISTBOX} from './tokens';
 
@@ -163,11 +163,7 @@ export class Listbox<V> implements OnDestroy {
     if (typeof ngDevMode === 'undefined' || ngDevMode) {
       afterRenderEffect({
         read: () => {
-          const violations = this._pattern.validate();
-
-          for (const violation of violations) {
-            console.error(violation);
-          }
+          reportViolations(this._pattern.validate(), this.element);
         },
       });
     }

--- a/src/aria/menu/menu-item.ts
+++ b/src/aria/menu/menu-item.ts
@@ -16,6 +16,7 @@ import {
   model,
   OnDestroy,
   OnInit,
+  afterRenderEffect,
 } from '@angular/core';
 import {MenuItemPattern} from '../private';
 import {_IdGenerator} from '@angular/cdk/a11y';
@@ -100,6 +101,17 @@ export class MenuItem<V> implements OnInit, OnDestroy {
 
   constructor() {
     effect(() => this.submenu()?.parent.set(this));
+
+    // Check for any violations after the DOM has been updated.
+    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+      afterRenderEffect({
+        read: () => {
+          if (!this.parent) {
+            console.error('ngMenuItem must be placed inside an ngMenu or ngMenuBar container.');
+          }
+        },
+      });
+    }
   }
 
   ngOnInit() {

--- a/src/aria/menu/menu-item.ts
+++ b/src/aria/menu/menu-item.ts
@@ -18,7 +18,7 @@ import {
   OnInit,
   afterRenderEffect,
 } from '@angular/core';
-import {MenuItemPattern} from '../private';
+import {MenuItemPattern, reportViolations} from '../private';
 import {_IdGenerator} from '@angular/cdk/a11y';
 import {MENU_COMPONENT} from './menu-tokens';
 import type {Menu} from './menu';
@@ -106,9 +106,11 @@ export class MenuItem<V> implements OnInit, OnDestroy {
     if (typeof ngDevMode === 'undefined' || ngDevMode) {
       afterRenderEffect({
         read: () => {
+          const violations: string[] = [];
           if (!this.parent) {
-            console.error('ngMenuItem must be placed inside an ngMenu or ngMenuBar container.');
+            violations.push('ngMenuItem must be placed inside an ngMenu or ngMenuBar container.');
           }
+          reportViolations(violations, this.element);
         },
       });
     }

--- a/src/aria/menu/menu.spec.ts
+++ b/src/aria/menu/menu.spec.ts
@@ -497,6 +497,43 @@ describe('Standalone Menu Pattern', () => {
     fixture.detectChanges();
     expect(item?.getAttribute('aria-label')).toBe('Apple item label');
   });
+
+  describe('structural validations', () => {
+    let consoleSpy: jasmine.Spy;
+
+    beforeEach(() => {
+      consoleSpy = spyOn(console, 'error');
+    });
+
+    afterEach(() => {
+      TestBed.resetTestingModule();
+      setupMenu();
+    });
+
+    it('should warn when duplicate values are detected inside ngMenu', () => {
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        imports: [MenuWithDuplicateValues],
+      });
+      const duplicateFixture = TestBed.createComponent(MenuWithDuplicateValues);
+      duplicateFixture.detectChanges();
+
+      expect(consoleSpy).toHaveBeenCalledWith("Duplicate value 'item0' detected inside ngMenu.");
+    });
+
+    it('should warn when ngMenuItem is outside ngMenu or ngMenuBar', () => {
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        imports: [MenuItemOutsideMenu],
+      });
+      const noMenuFixture = TestBed.createComponent(MenuItemOutsideMenu);
+      noMenuFixture.detectChanges();
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        'ngMenuItem must be placed inside an ngMenu or ngMenuBar container.',
+      );
+    });
+  });
 });
 
 describe('Menu Trigger Pattern', () => {
@@ -1167,3 +1204,26 @@ class ShuffledMenuExample {
 class ShuffledMenuBarExample {
   items = signal([{value: 'File'}, {value: 'Edit'}, {value: 'View'}]);
 }
+
+@Component({
+  template: `
+    <div ngMenu>
+      <ng-template ngMenuContent>
+        <div ngMenuItem value="item0">Item 0</div>
+        <div ngMenuItem value="item0">Item 0 Copy</div>
+      </ng-template>
+    </div>
+  `,
+  imports: [Menu, MenuItem, MenuContent],
+  changeDetection: ChangeDetectionStrategy.Eager,
+})
+class MenuWithDuplicateValues {}
+
+@Component({
+  template: `
+    <div ngMenuItem value="item0">Item 0</div>
+  `,
+  imports: [MenuItem],
+  changeDetection: ChangeDetectionStrategy.Eager,
+})
+class MenuItemOutsideMenu {}

--- a/src/aria/menu/menu.spec.ts
+++ b/src/aria/menu/menu.spec.ts
@@ -502,7 +502,7 @@ describe('Standalone Menu Pattern', () => {
     let consoleSpy: jasmine.Spy;
 
     beforeEach(() => {
-      consoleSpy = spyOn(console, 'error');
+      consoleSpy = spyOn(console, 'warn');
     });
 
     afterEach(() => {

--- a/src/aria/menu/menu.ts
+++ b/src/aria/menu/menu.ts
@@ -21,7 +21,7 @@ import {
   signal,
   untracked,
 } from '@angular/core';
-import {MenuPattern, DeferredContentAware, SortedCollection} from '../private';
+import {MenuPattern, DeferredContentAware, SortedCollection, reportViolations} from '../private';
 import {_IdGenerator} from '@angular/cdk/a11y';
 import {Directionality} from '@angular/cdk/bidi';
 import {MenuTrigger} from './menu-trigger';
@@ -192,10 +192,7 @@ export class Menu<V> implements OnDestroy {
     if (typeof ngDevMode === 'undefined' || ngDevMode) {
       afterRenderEffect({
         read: () => {
-          const violations = this._pattern.validate();
-          for (const violation of violations) {
-            console.error(violation);
-          }
+          reportViolations(this._pattern.validate(), this.element);
         },
       });
     }

--- a/src/aria/menu/menu.ts
+++ b/src/aria/menu/menu.ts
@@ -188,6 +188,18 @@ export class Menu<V> implements OnDestroy {
 
     afterRenderEffect({write: () => this._pattern.setDefaultStateEffect()});
 
+    // Check for any violations after the DOM has been updated.
+    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+      afterRenderEffect({
+        read: () => {
+          const violations = this._pattern.validate();
+          for (const violation of violations) {
+            console.error(violation);
+          }
+        },
+      });
+    }
+
     afterNextRender(() => {
       this._collection.startObserving(this.element);
     });

--- a/src/aria/private/accordion/accordion.ts
+++ b/src/aria/private/accordion/accordion.ts
@@ -126,6 +126,22 @@ export class AccordionGroupPattern {
     this.expansionBehavior.closeAll();
   }
 
+  /** Returns a set of violations */
+  validate(): string[] {
+    const violations: string[] = [];
+
+    if (!this.inputs.multiExpandable()) {
+      const expandedCount = this.inputs.items().filter(t => t.expanded()).length;
+      if (expandedCount > 1) {
+        violations.push(
+          'ngAccordionGroup has multiExpandable set to false, but multiple ngAccordionTrigger panels are initially expanded.',
+        );
+      }
+    }
+
+    return violations;
+  }
+
   /** Finds the trigger pattern for a given element. */
   private _findTriggerPattern(
     element: Element | null | undefined,

--- a/src/aria/private/grid/grid.ts
+++ b/src/aria/private/grid/grid.ts
@@ -196,6 +196,20 @@ export class GridPattern {
     });
   }
 
+  /** Returns a set of violations */
+  validate(): string[] {
+    const violations: string[] = [];
+
+    const rows = this.inputs.rows();
+    for (const row of rows) {
+      if (row.inputs.cells().length === 0) {
+        violations.push('ngGridRow must contain at least one ngGridCell.');
+      }
+    }
+
+    return violations;
+  }
+
   /** Handles keydown events on the grid. */
   onKeydown(event: KeyboardEvent) {
     if (this.disabled()) return;

--- a/src/aria/private/listbox/listbox.ts
+++ b/src/aria/private/listbox/listbox.ts
@@ -215,6 +215,18 @@ export class ListboxPattern<V> {
       );
     }
 
+    const values = this.inputs.items().map(o => o.value());
+    const duplicates = values.filter((val, idx) => values.indexOf(val) !== idx);
+    if (duplicates.length > 0) {
+      violations.push(`Duplicate option value '${duplicates[0]}' detected inside ngListbox.`);
+    }
+
+    const ids = this.inputs.items().map(o => o.id());
+    const duplicateIds = ids.filter((id, idx) => ids.indexOf(id) !== idx);
+    if (duplicateIds.length > 0) {
+      violations.push(`Duplicate option ID '${duplicateIds[0]}' detected inside ngListbox.`);
+    }
+
     return violations;
   }
 

--- a/src/aria/private/menu/menu.ts
+++ b/src/aria/private/menu/menu.ts
@@ -181,6 +181,19 @@ export class MenuPattern<V> {
     });
   }
 
+  /** Returns a set of violations */
+  validate(): string[] {
+    const violations: string[] = [];
+
+    const values = this.inputs.items().map(i => i.value());
+    const duplicates = values.filter((val, idx) => values.indexOf(val) !== idx);
+    if (duplicates.length > 0) {
+      violations.push(`Duplicate value '${duplicates[0]}' detected inside ngMenu.`);
+    }
+
+    return violations;
+  }
+
   /** Sets the default state for the menu. */
   setDefaultState() {
     if (!this.inputs.parent()) {

--- a/src/aria/private/public-api.ts
+++ b/src/aria/private/public-api.ts
@@ -26,4 +26,5 @@ export * from './utils/collection';
 export * from './utils/element';
 export * from './utils/element-resolver';
 export * from './utils/transforms';
+export * from './utils/violations';
 export * from './combobox/combobox';

--- a/src/aria/private/toolbar/toolbar.ts
+++ b/src/aria/private/toolbar/toolbar.ts
@@ -170,6 +170,19 @@ export class ToolbarPattern<V> {
     });
   }
 
+  /** Returns a set of violations */
+  validate(): string[] {
+    const violations: string[] = [];
+
+    const values = this.inputs.items().map(w => w.value());
+    const duplicates = values.filter((val, idx) => values.indexOf(val) !== idx);
+    if (duplicates.length > 0) {
+      violations.push(`Duplicate value '${duplicates[0]}' detected inside ngToolbar.`);
+    }
+
+    return violations;
+  }
+
   /** Handles keydown events for the toolbar. */
   onKeydown(event: KeyboardEvent) {
     if (this.disabled()) return;

--- a/src/aria/private/tree/tree.ts
+++ b/src/aria/private/tree/tree.ts
@@ -383,6 +383,12 @@ export class TreePattern<V> implements TreeInputs<V> {
       );
     }
 
+    const values = this.inputs.items().map(t => t.value());
+    const duplicates = values.filter((val, idx) => values.indexOf(val) !== idx);
+    if (duplicates.length > 0) {
+      violations.push(`Duplicate tree item value '${duplicates[0]}' detected inside ngTree.`);
+    }
+
     return violations;
   }
 

--- a/src/aria/private/utils/BUILD.bazel
+++ b/src/aria/private/utils/BUILD.bazel
@@ -9,6 +9,7 @@ ts_project(
         "element.ts",
         "element-resolver.ts",
         "transforms.ts",
+        "violations.ts",
     ],
     deps = [
         "//:node_modules/@angular/core",

--- a/src/aria/private/utils/violations.ts
+++ b/src/aria/private/utils/violations.ts
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+/** Logs each of the violations to the console as errors, optionally with the host element context. */
+export function reportViolations(violations: string[], element: Element): void {
+  if (violations.length) {
+    console.warn('Violations found on element: %o:', element);
+    violations.forEach(violation => {
+      console.warn(violation);
+    });
+  }
+}

--- a/src/aria/tabs/tab-list.ts
+++ b/src/aria/tabs/tab-list.ts
@@ -147,6 +147,19 @@ export class TabList implements OnInit, OnDestroy {
         this.selectedTab.set(tab?.value());
       },
     });
+
+    // Check for any violations after the DOM has been updated.
+    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+      afterRenderEffect({
+        read: () => {
+          const values = this._collection.orderedItems().map(t => t.value());
+          const duplicates = values.filter((item, index) => values.indexOf(item) !== index);
+          if (duplicates.length > 0) {
+            console.error(`Duplicate value '${duplicates[0]}' detected inside ngTabList.`);
+          }
+        },
+      });
+    }
   }
 
   ngOnInit() {

--- a/src/aria/tabs/tab-list.ts
+++ b/src/aria/tabs/tab-list.ts
@@ -23,7 +23,7 @@ import {
   linkedSignal,
   WritableSignal,
 } from '@angular/core';
-import {SortedCollection, TabListPattern, TabPattern} from '../private';
+import {SortedCollection, TabListPattern, TabPattern, reportViolations} from '../private';
 import {TABS, TAB_LIST} from './tab-tokens';
 import type {Tab} from './tab';
 
@@ -152,11 +152,15 @@ export class TabList implements OnInit, OnDestroy {
     if (typeof ngDevMode === 'undefined' || ngDevMode) {
       afterRenderEffect({
         read: () => {
+          const violations: string[] = [];
+
           const values = this._collection.orderedItems().map(t => t.value());
           const duplicates = values.filter((item, index) => values.indexOf(item) !== index);
           if (duplicates.length > 0) {
-            console.error(`Duplicate value '${duplicates[0]}' detected inside ngTabList.`);
+            violations.push(`Duplicate value '${duplicates[0]}' detected inside ngTabList.`);
           }
+
+          reportViolations(violations, this.element);
         },
       });
     }

--- a/src/aria/tabs/tab-panel.ts
+++ b/src/aria/tabs/tab-panel.ts
@@ -18,7 +18,7 @@ import {
   OnInit,
   OnDestroy,
 } from '@angular/core';
-import {TabPanelPattern, DeferredContentAware} from '../private';
+import {TabPanelPattern, DeferredContentAware, reportViolations} from '../private';
 import {TABS} from './tab-tokens';
 import {TabContent} from './tab-content';
 
@@ -114,9 +114,7 @@ export class TabPanel implements OnInit, OnDestroy {
             );
           }
 
-          for (const violation of violations) {
-            console.error(violation);
-          }
+          reportViolations(violations, this.element);
         },
       });
     }

--- a/src/aria/tabs/tab-panel.ts
+++ b/src/aria/tabs/tab-panel.ts
@@ -14,11 +14,13 @@ import {
   inject,
   input,
   afterRenderEffect,
+  contentChild,
   OnInit,
   OnDestroy,
 } from '@angular/core';
 import {TabPanelPattern, DeferredContentAware} from '../private';
 import {TABS} from './tab-tokens';
+import {TabContent} from './tab-content';
 
 /**
  * A TabPanel container for the resources of layered content associated with a tab.
@@ -87,8 +89,37 @@ export class TabPanel implements OnInit, OnDestroy {
     tab: this._tabPattern,
   });
 
+  private readonly _tabContent = contentChild(TabContent);
+
   constructor() {
-    afterRenderEffect(() => this._deferredContentAware.contentVisible.set(this.visible()));
+    // Connect the panel's hidden state to the DeferredContentAware's visibility.
+    afterRenderEffect({
+      write: () => {
+        this._deferredContentAware.contentVisible.set(this.visible());
+      },
+    });
+
+    // Check for any violations after the DOM has been updated.
+    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+      afterRenderEffect({
+        read: () => {
+          const violations: string[] = [];
+
+          if (!this._tabContent()) {
+            violations.push('ngTabPanel must have an ngTabContent structural directive to render.');
+          }
+          if (!this._tabs._tabMap().has(this.value())) {
+            violations.push(
+              `ngTabPanel with value '${this.value()}' does not have a corresponding ngTab.`,
+            );
+          }
+
+          for (const violation of violations) {
+            console.error(violation);
+          }
+        },
+      });
+    }
   }
 
   ngOnInit() {

--- a/src/aria/tabs/tab.ts
+++ b/src/aria/tabs/tab.ts
@@ -16,6 +16,7 @@ import {
   computed,
   inject,
   input,
+  afterRenderEffect,
 } from '@angular/core';
 import {TabPattern, HasElement} from '../private';
 import {TAB_LIST} from './tab-tokens';
@@ -88,6 +89,22 @@ export class Tab implements HasElement, OnInit, OnDestroy {
   /** Opens this tab panel. */
   open() {
     this._pattern.open();
+  }
+
+  constructor() {
+    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+      afterRenderEffect({
+        read: () => {
+          if (this._tabList && this._tabList._tabsParent) {
+            if (!this._tabList._tabsParent._panelMap().has(this.value())) {
+              console.error(
+                `ngTab with value '${this.value()}' does not have a corresponding ngTabPanel.`,
+              );
+            }
+          }
+        },
+      });
+    }
   }
 
   ngOnInit() {

--- a/src/aria/tabs/tab.ts
+++ b/src/aria/tabs/tab.ts
@@ -18,7 +18,7 @@ import {
   input,
   afterRenderEffect,
 } from '@angular/core';
-import {TabPattern, HasElement} from '../private';
+import {TabPattern, HasElement, reportViolations} from '../private';
 import {TAB_LIST} from './tab-tokens';
 
 /**
@@ -95,13 +95,15 @@ export class Tab implements HasElement, OnInit, OnDestroy {
     if (typeof ngDevMode === 'undefined' || ngDevMode) {
       afterRenderEffect({
         read: () => {
+          const violations: string[] = [];
           if (this._tabList && this._tabList._tabsParent) {
             if (!this._tabList._tabsParent._panelMap().has(this.value())) {
-              console.error(
+              violations.push(
                 `ngTab with value '${this.value()}' does not have a corresponding ngTabPanel.`,
               );
             }
           }
+          reportViolations(violations, this.element);
         },
       });
     }

--- a/src/aria/tabs/tabs.spec.ts
+++ b/src/aria/tabs/tabs.spec.ts
@@ -806,6 +806,69 @@ describe('Tabs', () => {
       expect(panelEl.getAttribute('aria-labelledby')).toBe('custom-tab-id');
     });
   });
+
+  describe('structural validations', () => {
+    let consoleSpy: jasmine.Spy;
+
+    beforeEach(() => {
+      consoleSpy = spyOn(console, 'error');
+    });
+
+    afterEach(() => {
+      TestBed.resetTestingModule();
+      setupTestTabs();
+    });
+
+    it('should warn when ngTab is missing its corresponding ngTabPanel', () => {
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        imports: [TabWithoutPanelComponent],
+      });
+      const noPanelFixture = TestBed.createComponent(TabWithoutPanelComponent);
+      noPanelFixture.detectChanges();
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        "ngTab with value 'tab1' does not have a corresponding ngTabPanel.",
+      );
+    });
+
+    it('should warn when ngTabPanel is missing its corresponding ngTab', () => {
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        imports: [PanelWithoutTabComponent],
+      });
+      const noTabFixture = TestBed.createComponent(PanelWithoutTabComponent);
+      noTabFixture.detectChanges();
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        "ngTabPanel with value 'tab1' does not have a corresponding ngTab.",
+      );
+    });
+
+    it('should warn when ngTabPanel is missing ngTabContent structural directive', () => {
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        imports: [PanelWithoutContentComponent],
+      });
+      const noContentFixture = TestBed.createComponent(PanelWithoutContentComponent);
+      noContentFixture.detectChanges();
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        'ngTabPanel must have an ngTabContent structural directive to render.',
+      );
+    });
+
+    it('should warn when duplicate values are detected inside ngTabList', () => {
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        imports: [DuplicateTabValuesComponent],
+      });
+      const duplicateFixture = TestBed.createComponent(DuplicateTabValuesComponent);
+      duplicateFixture.detectChanges();
+
+      expect(consoleSpy).toHaveBeenCalledWith("Duplicate value 'tab1' detected inside ngTabList.");
+    });
+  });
 });
 
 @Component({
@@ -882,3 +945,62 @@ class TestTabsComponent {
 class TestTabsCustomIdComponent {
   selectedTab = signal('tab1');
 }
+
+@Component({
+  template: `
+    <div ngTabs>
+      <ul ngTabList>
+        <li ngTab value="tab1">Tab 1</li>
+      </ul>
+    </div>
+  `,
+  imports: [Tabs, TabList, Tab],
+  changeDetection: ChangeDetectionStrategy.Eager,
+})
+class TabWithoutPanelComponent {}
+
+@Component({
+  template: `
+    <div ngTabs>
+      <div ngTabPanel value="tab1">
+        <ng-template ngTabContent>Content 1</ng-template>
+      </div>
+    </div>
+  `,
+  imports: [Tabs, TabPanel, TabContent],
+  changeDetection: ChangeDetectionStrategy.Eager,
+})
+class PanelWithoutTabComponent {}
+
+@Component({
+  template: `
+    <div ngTabs>
+      <ul ngTabList>
+        <li ngTab value="tab1">Tab 1</li>
+      </ul>
+      <div ngTabPanel value="tab1">
+        Content 1
+      </div>
+    </div>
+  `,
+  imports: [Tabs, TabList, Tab, TabPanel],
+  changeDetection: ChangeDetectionStrategy.Eager,
+})
+class PanelWithoutContentComponent {}
+
+@Component({
+  template: `
+    <div ngTabs>
+      <ul ngTabList>
+        <li ngTab value="tab1">Tab 1</li>
+        <li ngTab value="tab1">Tab 1 Copy</li>
+      </ul>
+      <div ngTabPanel value="tab1">
+        <ng-template ngTabContent>Content 1</ng-template>
+      </div>
+    </div>
+  `,
+  imports: [Tabs, TabList, Tab, TabPanel, TabContent],
+  changeDetection: ChangeDetectionStrategy.Eager,
+})
+class DuplicateTabValuesComponent {}

--- a/src/aria/tabs/tabs.spec.ts
+++ b/src/aria/tabs/tabs.spec.ts
@@ -811,7 +811,7 @@ describe('Tabs', () => {
     let consoleSpy: jasmine.Spy;
 
     beforeEach(() => {
-      consoleSpy = spyOn(console, 'error');
+      consoleSpy = spyOn(console, 'warn');
     });
 
     afterEach(() => {

--- a/src/aria/toolbar/toolbar-widget-group.ts
+++ b/src/aria/toolbar/toolbar-widget-group.ts
@@ -16,7 +16,7 @@ import {
   contentChildren,
   afterRenderEffect,
 } from '@angular/core';
-import {ToolbarWidgetPattern, ToolbarWidgetGroupPattern} from '../private';
+import {ToolbarWidgetPattern, ToolbarWidgetGroupPattern, reportViolations} from '../private';
 import {Toolbar} from './toolbar';
 import {ToolbarWidget} from './toolbar-widget';
 import {TOOLBAR_WIDGET_GROUP} from './toolbar-tokens';
@@ -69,9 +69,11 @@ export class ToolbarWidgetGroup<V> {
     if (typeof ngDevMode === 'undefined' || ngDevMode) {
       afterRenderEffect({
         read: () => {
+          const violations: string[] = [];
           if (!this._toolbar) {
-            console.error('ngToolbarWidgetGroup must be placed inside an ngToolbar container.');
+            violations.push('ngToolbarWidgetGroup must be placed inside an ngToolbar container.');
           }
+          reportViolations(violations, this.element);
         },
       });
     }

--- a/src/aria/toolbar/toolbar-widget-group.ts
+++ b/src/aria/toolbar/toolbar-widget-group.ts
@@ -14,6 +14,7 @@ import {
   input,
   booleanAttribute,
   contentChildren,
+  afterRenderEffect,
 } from '@angular/core';
 import {ToolbarWidgetPattern, ToolbarWidgetGroupPattern} from '../private';
 import {Toolbar} from './toolbar';
@@ -62,4 +63,17 @@ export class ToolbarWidgetGroup<V> {
     items: this._itemPatterns,
     toolbar: this._toolbarPattern,
   });
+
+  constructor() {
+    // Check for any violations after the DOM has been updated.
+    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+      afterRenderEffect({
+        read: () => {
+          if (!this._toolbar) {
+            console.error('ngToolbarWidgetGroup must be placed inside an ngToolbar container.');
+          }
+        },
+      });
+    }
+  }
 }

--- a/src/aria/toolbar/toolbar.spec.ts
+++ b/src/aria/toolbar/toolbar.spec.ts
@@ -703,6 +703,43 @@ describe('Toolbar', () => {
       expect(widgets[0].getAttribute('disabled')).toBe('true');
     });
   });
+
+  describe('structural validations', () => {
+    let consoleSpy: jasmine.Spy;
+
+    beforeEach(() => {
+      consoleSpy = spyOn(console, 'error');
+    });
+
+    afterEach(() => {
+      TestBed.resetTestingModule();
+      setupToolbar();
+    });
+
+    it('should warn when duplicate values are detected inside ngToolbar', () => {
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        imports: [ToolbarWithDuplicateValues],
+      });
+      const duplicateFixture = TestBed.createComponent(ToolbarWithDuplicateValues);
+      duplicateFixture.detectChanges();
+
+      expect(consoleSpy).toHaveBeenCalledWith("Duplicate value 'item0' detected inside ngToolbar.");
+    });
+
+    it('should warn when ngToolbarWidgetGroup is outside ngToolbar', () => {
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        imports: [ToolbarGroupOutsideToolbar],
+      });
+      const noToolbarFixture = TestBed.createComponent(ToolbarGroupOutsideToolbar);
+      noToolbarFixture.detectChanges();
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        'ngToolbarWidgetGroup must be placed inside an ngToolbar container.',
+      );
+    });
+  });
 });
 
 @Component({
@@ -816,3 +853,26 @@ class WrappedToolbarExample {}
 class ShuffledToolbarExample {
   items = signal([{value: 'item 0'}, {value: 'item 1'}, {value: 'item 2'}]);
 }
+
+@Component({
+  template: `
+    <div ngToolbar>
+      <button ngToolbarWidget value="item0">Item 0</button>
+      <button ngToolbarWidget value="item0">Item 0 Copy</button>
+    </div>
+  `,
+  imports: [Toolbar, ToolbarWidget],
+  changeDetection: ChangeDetectionStrategy.Eager,
+})
+class ToolbarWithDuplicateValues {}
+
+@Component({
+  template: `
+    <div ngToolbarWidgetGroup>
+      Widget Group Content
+    </div>
+  `,
+  imports: [ToolbarWidgetGroup],
+  changeDetection: ChangeDetectionStrategy.Eager,
+})
+class ToolbarGroupOutsideToolbar {}

--- a/src/aria/toolbar/toolbar.spec.ts
+++ b/src/aria/toolbar/toolbar.spec.ts
@@ -708,7 +708,7 @@ describe('Toolbar', () => {
     let consoleSpy: jasmine.Spy;
 
     beforeEach(() => {
-      consoleSpy = spyOn(console, 'error');
+      consoleSpy = spyOn(console, 'warn');
     });
 
     afterEach(() => {

--- a/src/aria/toolbar/toolbar.ts
+++ b/src/aria/toolbar/toolbar.ts
@@ -107,6 +107,18 @@ export class Toolbar<V> implements OnDestroy {
   constructor() {
     afterRenderEffect({write: () => this._pattern.setDefaultStateEffect()});
 
+    // Check for any violations after the DOM has been updated.
+    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+      afterRenderEffect({
+        read: () => {
+          const violations = this._pattern.validate();
+          for (const violation of violations) {
+            console.error(violation);
+          }
+        },
+      });
+    }
+
     afterNextRender(() => {
       this._collection.startObserving(this.element);
     });

--- a/src/aria/toolbar/toolbar.ts
+++ b/src/aria/toolbar/toolbar.ts
@@ -19,7 +19,7 @@ import {
   OnDestroy,
   signal,
 } from '@angular/core';
-import {ToolbarPattern, ToolbarWidgetPattern, SortedCollection} from '../private';
+import {ToolbarPattern, ToolbarWidgetPattern, SortedCollection, reportViolations} from '../private';
 import {Directionality} from '@angular/cdk/bidi';
 import type {ToolbarWidget} from './toolbar-widget';
 
@@ -111,10 +111,7 @@ export class Toolbar<V> implements OnDestroy {
     if (typeof ngDevMode === 'undefined' || ngDevMode) {
       afterRenderEffect({
         read: () => {
-          const violations = this._pattern.validate();
-          for (const violation of violations) {
-            console.error(violation);
-          }
+          reportViolations(this._pattern.validate(), this.element);
         },
       });
     }

--- a/src/aria/tree/tree.spec.ts
+++ b/src/aria/tree/tree.spec.ts
@@ -195,7 +195,7 @@ describe('Tree', () => {
     let consoleSpy: jasmine.Spy;
 
     beforeEach(() => {
-      consoleSpy = spyOn(console, 'error');
+      consoleSpy = spyOn(console, 'warn');
     });
 
     afterEach(() => {

--- a/src/aria/tree/tree.spec.ts
+++ b/src/aria/tree/tree.spec.ts
@@ -191,6 +191,45 @@ describe('Tree', () => {
     });
   });
 
+  describe('structural validations', () => {
+    let consoleSpy: jasmine.Spy;
+
+    beforeEach(() => {
+      consoleSpy = spyOn(console, 'error');
+    });
+
+    afterEach(() => {
+      TestBed.resetTestingModule();
+      setupTestTree();
+    });
+
+    it('should warn when duplicate values are detected inside ngTree', () => {
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        imports: [TreeWithDuplicateValues],
+      });
+      const duplicateFixture = TestBed.createComponent(TreeWithDuplicateValues);
+      duplicateFixture.detectChanges();
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        "Duplicate tree item value 'item0' detected inside ngTree.",
+      );
+    });
+
+    it('should warn when single-select tree has multiple selected values', () => {
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        imports: [SingleSelectTreeWithMultipleValues],
+      });
+      const singleSelectFixture = TestBed.createComponent(SingleSelectTreeWithMultipleValues);
+      singleSelectFixture.detectChanges();
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        'A single-select tree should not have multiple selected options. Selected options: item0, item1',
+      );
+    });
+  });
+
   describe('ARIA attributes and roles', () => {
     describe('default configuration', () => {
       beforeEach(() => {
@@ -1680,3 +1719,27 @@ class TestTreeComponent {
   currentType = signal('page' as 'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false');
   tabIndex = signal<number | undefined>(undefined);
 }
+
+@Component({
+  template: `
+    <ul ngTree #tree="ngTree">
+      <li ngTreeItem [parent]="tree" value="item0">Item 0</li>
+      <li ngTreeItem [parent]="tree" value="item0">Item 0 Copy</li>
+    </ul>
+  `,
+  imports: [Tree, TreeItem],
+  changeDetection: ChangeDetectionStrategy.Eager,
+})
+class TreeWithDuplicateValues {}
+
+@Component({
+  template: `
+    <ul ngTree [multi]="false" [value]="['item0', 'item1']" #tree="ngTree">
+      <li ngTreeItem [parent]="tree" value="item0">Item 0</li>
+      <li ngTreeItem [parent]="tree" value="item1">Item 1</li>
+    </ul>
+  `,
+  imports: [Tree, TreeItem],
+  changeDetection: ChangeDetectionStrategy.Eager,
+})
+class SingleSelectTreeWithMultipleValues {}

--- a/src/aria/tree/tree.ts
+++ b/src/aria/tree/tree.ts
@@ -23,7 +23,13 @@ import {
 } from '@angular/core';
 import {_IdGenerator} from '@angular/cdk/a11y';
 import {Directionality} from '@angular/cdk/bidi';
-import {SortedCollection, tabIndexTransform, TreeItemPattern, TreePattern} from '../private';
+import {
+  SortedCollection,
+  tabIndexTransform,
+  TreeItemPattern,
+  TreePattern,
+  reportViolations,
+} from '../private';
 import type {TreeItem} from './tree-item';
 
 /**
@@ -174,11 +180,7 @@ export class Tree<V> implements OnDestroy {
     if (typeof ngDevMode === 'undefined' || ngDevMode) {
       afterRenderEffect({
         read: () => {
-          const violations = this._pattern.validate();
-
-          for (const violation of violations) {
-            console.error(violation);
-          }
+          reportViolations(this._pattern.validate(), this.element);
         },
       });
     }

--- a/src/aria/tree/tree.ts
+++ b/src/aria/tree/tree.ts
@@ -171,16 +171,17 @@ export class Tree<V> implements OnDestroy {
     });
 
     // Check for any violations after the DOM has been updated.
-    afterRenderEffect({
-      read: () => {
-        if (typeof ngDevMode === 'undefined' || ngDevMode) {
+    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+      afterRenderEffect({
+        read: () => {
           const violations = this._pattern.validate();
+
           for (const violation of violations) {
             console.error(violation);
           }
-        }
-      },
-    });
+        },
+      });
+    }
 
     // Resets default focus based on selection state until interacted.
     afterRenderEffect({write: () => this._pattern.setDefaultStateEffect()});


### PR DESCRIPTION
Used gemini to go through all of the components and generate additional violation checks for possible issues with how each set of angular aria directives are used together. Also generated specs for the new and previously existing violations.

Final commit adds a utility method to report the violations which does the console.error but also takes in an element to help in location where the issue is coming from.