### PR TITLE
docs(aria/combobox): bind cdkConnectedOverlayOpen to popupExpanded in simple-combobox examples

### DIFF
--- a/src/components-examples/aria/aria-toolbar-simple-combobox/simple-toolbar.ts
+++ b/src/components-examples/aria/aria-toolbar-simple-combobox/simple-toolbar.ts
@@ -82,7 +82,7 @@ export class SimpleToolbarRadioButton {
         >
       </div>
 
-      <ng-template [cdkConnectedOverlay]="{origin, usePopover: 'inline', matchWidth: true}" [cdkConnectedOverlayOpen]="true"
+      <ng-template [cdkConnectedOverlay]="{origin, usePopover: 'inline', matchWidth: true}" [cdkConnectedOverlayOpen]="popupExpanded()"
         [cdkConnectedOverlayDisableClose]="true">
         <ng-template ngComboboxPopup [combobox]="combobox">
           <div ngListbox ngComboboxWidget [(value)]="selectedOption" class="example-listbox example-popup" focusMode="activedescendant"

--- a/src/components-examples/aria/simple-combobox/simple-combobox-auto-select/simple-combobox-auto-select-example.html
+++ b/src/components-examples/aria/simple-combobox/simple-combobox-auto-select/simple-combobox-auto-select-example.html
@@ -9,7 +9,7 @@
     {{options().length === 0 ? 'No results found for ' + searchString() : ''}}
   </div>
 
-  <ng-template [cdkConnectedOverlay]="{origin, usePopover: 'inline', matchWidth: true}" [cdkConnectedOverlayOpen]="true"
+  <ng-template [cdkConnectedOverlay]="{origin, usePopover: 'inline', matchWidth: true}" [cdkConnectedOverlayOpen]="popupExpanded()"
     [cdkConnectedOverlayDisableClose]="true">
     <ng-template ngComboboxPopup [combobox]="combobox">
       <div class="example-popup">

--- a/src/components-examples/aria/simple-combobox/simple-combobox-autocomplete-auto-select/simple-combobox-autocomplete-auto-select-example.html
+++ b/src/components-examples/aria/simple-combobox/simple-combobox-autocomplete-auto-select/simple-combobox-autocomplete-auto-select-example.html
@@ -24,7 +24,7 @@
     {{countries().length === 0 ? 'No results found for ' + query() : ''}}
   </div>
 
-  <ng-template [cdkConnectedOverlay]="{origin, usePopover: 'inline', matchWidth: true}" [cdkConnectedOverlayOpen]="true">
+  <ng-template [cdkConnectedOverlay]="{origin, usePopover: 'inline', matchWidth: true}" [cdkConnectedOverlayOpen]="popupExpanded()">
     <ng-template ngComboboxPopup [combobox]="combobox">
       <div class="example-popup">
         @if (countries().length === 0) {

--- a/src/components-examples/aria/simple-combobox/simple-combobox-autocomplete-disabled/simple-combobox-autocomplete-disabled-example.html
+++ b/src/components-examples/aria/simple-combobox/simple-combobox-autocomplete-disabled/simple-combobox-autocomplete-disabled-example.html
@@ -13,7 +13,7 @@
     />
   </div>
 
-  <ng-template [cdkConnectedOverlay]="{origin, usePopover: 'inline', matchWidth: true}" [cdkConnectedOverlayOpen]="true">
+  <ng-template [cdkConnectedOverlay]="{origin, usePopover: 'inline', matchWidth: true}" [cdkConnectedOverlayOpen]="popupExpanded()">
     <ng-template ngComboboxPopup [combobox]="combobox">
       <div class="example-popup">
         @if (countries().length === 0) {

--- a/src/components-examples/aria/simple-combobox/simple-combobox-autocomplete-highlight/simple-combobox-autocomplete-highlight-example.html
+++ b/src/components-examples/aria/simple-combobox/simple-combobox-autocomplete-highlight/simple-combobox-autocomplete-highlight-example.html
@@ -15,7 +15,7 @@
   </div>
 
   <ng-template [cdkConnectedOverlay]="{origin, usePopover: 'inline', matchWidth: true}"
-    [cdkConnectedOverlayOpen]="true">
+    [cdkConnectedOverlayOpen]="popupExpanded()">
     <ng-template ngComboboxPopup [combobox]="combobox">
       <div class="example-popup">
         @if (countries().length === 0) {

--- a/src/components-examples/aria/simple-combobox/simple-combobox-autocomplete-manual/simple-combobox-autocomplete-manual-example.html
+++ b/src/components-examples/aria/simple-combobox/simple-combobox-autocomplete-manual/simple-combobox-autocomplete-manual-example.html
@@ -13,7 +13,7 @@
   </div>
 
   <ng-template [cdkConnectedOverlay]="{origin, usePopover: 'inline', matchWidth: true}"
-    [cdkConnectedOverlayOpen]="true">
+    [cdkConnectedOverlayOpen]="popupExpanded()">
     <ng-template ngComboboxPopup [combobox]="combobox">
       <div class="example-popup">
         @if (countries().length === 0) {

--- a/src/components-examples/aria/simple-combobox/simple-combobox-grid/simple-combobox-grid-example.html
+++ b/src/components-examples/aria/simple-combobox/simple-combobox-grid/simple-combobox-grid-example.html
@@ -9,7 +9,7 @@
     {{filteredItems().length === 0 ? 'No results found for ' + searchString() : ''}}
   </div>
 
-  <ng-template [cdkConnectedOverlay]="{origin, usePopover: 'inline', matchWidth: true}" [cdkConnectedOverlayOpen]="true"
+  <ng-template [cdkConnectedOverlay]="{origin, usePopover: 'inline', matchWidth: true}" [cdkConnectedOverlayOpen]="popupExpanded()"
     [cdkConnectedOverlayDisableClose]="true">
     <ng-template ngComboboxPopup [combobox]="combobox">
       <div class="example-popup">

--- a/src/components-examples/aria/simple-combobox/simple-combobox-highlight/simple-combobox-highlight-example.html
+++ b/src/components-examples/aria/simple-combobox/simple-combobox-highlight/simple-combobox-highlight-example.html
@@ -11,7 +11,7 @@
     {{options().length === 0 ? 'No results found for ' + searchString() : ''}}
   </div>
 
-  <ng-template [cdkConnectedOverlay]="{origin, usePopover: 'inline', matchWidth: true}" [cdkConnectedOverlayOpen]="true"
+  <ng-template [cdkConnectedOverlay]="{origin, usePopover: 'inline', matchWidth: true}" [cdkConnectedOverlayOpen]="popupExpanded()"
     [cdkConnectedOverlayDisableClose]="true">
     <ng-template ngComboboxPopup [combobox]="combobox">
       <div class="example-popup">

--- a/src/components-examples/aria/simple-combobox/simple-combobox-listbox/simple-combobox-listbox-example.html
+++ b/src/components-examples/aria/simple-combobox/simple-combobox-listbox/simple-combobox-listbox-example.html
@@ -9,7 +9,7 @@
     {{options().length === 0 ? 'No results found for ' + searchString() : ''}}
   </div>
 
-  <ng-template [cdkConnectedOverlay]="{origin, usePopover: 'inline', matchWidth: true}" [cdkConnectedOverlayOpen]="true"
+  <ng-template [cdkConnectedOverlay]="{origin, usePopover: 'inline', matchWidth: true}" [cdkConnectedOverlayOpen]="popupExpanded()"
     [cdkConnectedOverlayDisableClose]="true">
     <ng-template ngComboboxPopup [combobox]="combobox">
       <div class="example-popup">

--- a/src/components-examples/aria/simple-combobox/simple-combobox-readonly-disabled/simple-combobox-readonly-disabled-example.html
+++ b/src/components-examples/aria/simple-combobox/simple-combobox-readonly-disabled/simple-combobox-readonly-disabled-example.html
@@ -4,7 +4,7 @@
 </div>
 
 <ng-template [cdkConnectedOverlay]="{origin: combobox.element, usePopover: 'inline', matchWidth: true}"
-  [cdkConnectedOverlayOpen]="true" [cdkConnectedOverlayDisableClose]="true">
+  [cdkConnectedOverlayOpen]="popupExpanded()" [cdkConnectedOverlayDisableClose]="true">
   <ng-template ngComboboxPopup [combobox]="combobox">
     <div class="example-popup-container">
       <div #listbox="ngListbox" ngListbox tabindex="-1" ngComboboxWidget focusMode="activedescendant"

--- a/src/components-examples/aria/simple-combobox/simple-combobox-readonly-multiselect/simple-combobox-readonly-multiselect-example.html
+++ b/src/components-examples/aria/simple-combobox/simple-combobox-readonly-multiselect/simple-combobox-readonly-multiselect-example.html
@@ -4,7 +4,7 @@
 </div>
 
 <ng-template [cdkConnectedOverlay]="{origin: combobox.element, usePopover: 'inline', matchWidth: true}"
-  [cdkConnectedOverlayOpen]="true" [cdkConnectedOverlayDisableClose]="true">
+  [cdkConnectedOverlayOpen]="popupExpanded()" [cdkConnectedOverlayDisableClose]="true">
   <ng-template ngComboboxPopup [combobox]="combobox">
     <div class="example-popup-container">
       <div #listbox="ngListbox" ngListbox [multi]="true" ngComboboxWidget focusMode="activedescendant" [tabindex]="-1"

--- a/src/components-examples/aria/simple-combobox/simple-combobox-select/simple-combobox-select-example.html
+++ b/src/components-examples/aria/simple-combobox/simple-combobox-select/simple-combobox-select-example.html
@@ -4,7 +4,7 @@
 </div>
 
 <ng-template [cdkConnectedOverlay]="{origin: combobox.element, usePopover: 'inline', matchWidth: true}"
-  [cdkConnectedOverlayOpen]="true" [cdkConnectedOverlayDisableClose]="true">
+  [cdkConnectedOverlayOpen]="popupExpanded()" [cdkConnectedOverlayDisableClose]="true">
   <ng-template ngComboboxPopup [combobox]="combobox">
     <div class="example-popup-container">
       <div #listbox="ngListbox" ngListbox ngComboboxWidget focusMode="activedescendant"

--- a/src/components-examples/aria/simple-combobox/simple-combobox-tree-auto-select/simple-combobox-tree-auto-select-example.html
+++ b/src/components-examples/aria/simple-combobox/simple-combobox-tree-auto-select/simple-combobox-tree-auto-select-example.html
@@ -16,7 +16,7 @@
         @if (filteredGroups().length === 0) {
         <div class="example-no-results">No results found</div>
         }
-        <ul ngTree ngComboboxWidget class="example-tree" focusMode="activedescendant" [tabindex="-1"
+        <ul ngTree ngComboboxWidget class="example-tree" focusMode="activedescendant" [tabindex]="-1"
           selectionMode="follow" [(value)]="selectedValues" (click)="onCommit()" (keydown.enter)="onCommit()"
           #tree="ngTree" [activeDescendant]="tree.activeDescendant()"
           [class.example-empty]="filteredGroups().length === 0">

--- a/src/components-examples/aria/simple-combobox/simple-combobox-tree-highlight/simple-combobox-tree-highlight-example.html
+++ b/src/components-examples/aria/simple-combobox/simple-combobox-tree-highlight/simple-combobox-tree-highlight-example.html
@@ -11,7 +11,7 @@
     {{filteredGroups().length === 0 ? 'No results found for ' + searchString() : ''}}
   </div>
 
-  <ng-template [cdkConnectedOverlay]="{origin, usePopover: 'inline', matchWidth: true}" [cdkConnectedOverlayOpen]="true"
+  <ng-template [cdkConnectedOverlay]="{origin, usePopover: 'inline', matchWidth: true}" [cdkConnectedOverlayOpen]="popupExpanded()"
     [cdkConnectedOverlayDisableClose]="true">
     <ng-template ngComboboxPopup [combobox]="combobox" popupType="tree">
       <div class="example-popup">


### PR DESCRIPTION
Updates all `SimpleCombobox` component examples to bind the overlay's `cdkConnectedOverlayOpen` property directly to the reactive `popupExpanded` signal.

Fixes angular/components#32678