### PR TITLE
fix(material/select): stop event propagation on keyboard close in inl…

### DIFF
--- a/src/material/select/select.ts
+++ b/src/material/select/select.ts
@@ -942,6 +942,11 @@ export class MatSelect
     if (isArrowKey && event.altKey) {
       // Close the select on ALT + arrow key to match the native <select>
       event.preventDefault();
+      // Stop propagation so the event doesn't bubble to the host element and trigger
+      // _handleClosedKeydown, which would re-open the panel immediately.
+      event.stopPropagation();
+      // Restore focus to the trigger before closing so focus isn't lost when the overlay detaches.
+      this.focus();
       this.close();
       // Don't do anything in this case if the user is typing,
       // because the typing sequence can include the space key.
@@ -952,6 +957,9 @@ export class MatSelect
       !hasModifierKey(event)
     ) {
       event.preventDefault();
+      // Stop propagation so the event doesn't bubble to the host element and trigger
+      // _handleClosedKeydown, which would re-open the panel immediately.
+      event.stopPropagation();
       manager.activeItem._selectViaInteraction();
     } else if (!isTyping && this._multiple && keyCode === A && event.ctrlKey) {
       event.preventDefault();


### PR DESCRIPTION
…ine popover mode

When mat-select uses inline popover positioning (the default), the CDK overlay host is inserted inside the mat-select host element. This caused keydown events (ENTER, SPACE, ALT+Arrow) handled by the open panel to bubble up to the host element's listener, which then ran _handleClosedKeydown and immediately re-opened the panel.

Fixed by calling event.stopPropagation() in _handleOpenKeydown for the ENTER/SPACE selection and ALT+Arrow close branches. Also added a focus() call before close() in the ALT+Arrow branch so focus is explicitly restored to the trigger before the overlay detaches, consistent with the Tab and ENTER paths.

This bug was particularly noticeable with screen readers since the panel would re-open immediately after selection, causing aria-expanded to toggle true→false→true in a single frame and confusing the a11y tree.