### PR TITLE
fix(cdk/clipboard): let `Clipboard.copy` refocus prior focus without …

### DIFF
--- a/src/cdk/clipboard/pending-copy.ts
+++ b/src/cdk/clipboard/pending-copy.ts
@@ -59,7 +59,7 @@ export class PendingCopy {
         successful = this._document.execCommand('copy');
 
         if (currentFocus) {
-          currentFocus.focus();
+          currentFocus.focus({preventScroll: true});
         }
       }
     } catch {


### PR DESCRIPTION
…initiating scoll

`ClipboardCopy.copy` and its underlying `PendingCopy.copy` insert a temporary textarea with the contents to copy, selecting all its text and thereby changing the focused element. The focus is restored upon completion, but this could initiate a scroll interaction to scroll the element into view. This commit avoids this behavior by passing `preventScroll: true`.