### PR TITLE
docs(material/tooltip): fix tooltip-position-at-origin example overflow

### DIFF
--- a/src/components-examples/material/tooltip/tooltip-position-at-origin/tooltip-position-at-origin-example.css
+++ b/src/components-examples/material/tooltip/tooltip-position-at-origin/tooltip-position-at-origin-example.css
@@ -1,8 +1,5 @@
 button.demo-button {
-  width: 500px;
-  height: 500px;
-}
-
-.example-enabled-checkbox {
-  margin-left: 8px;
+  width: 200px;
+  height: 200px;
+  margin: 0 8px 8px 0;
 }


### PR DESCRIPTION
Reduces the demo button size from 500×500px to 200×200px to prevent the example from overflowing on small screens.

Before:

<img width="449" height="832" alt="Screenshot 2026-05-06 at 6 54 38 PM" src="https://github.com/user-attachments/assets/b891d802-9491-4f63-a39f-ab5a9b26e896" />

After:

<img width="392" height="613" alt="Screenshot 2026-05-06 at 7 32 36 PM" src="https://github.com/user-attachments/assets/692e27b0-4534-43c3-b6a5-ad3041db75c8" />

