### PR TITLE
docs(material/bottom-sheet): clarify panelClass target

### DIFF
--- a/src/material/bottom-sheet/bottom-sheet-config.ts
+++ b/src/material/bottom-sheet/bottom-sheet-config.ts
@@ -30,7 +30,7 @@ export class MatBottomSheetConfig<D = any> {
    */
   injector?: Injector;
 
-  /** Extra CSS classes to be added to the bottom sheet container. */
+  /** Extra CSS classes to be added to the bottom sheet's overlay pane. */
   panelClass?: string | string[];
 
   /** Text layout direction for the bottom sheet. */


### PR DESCRIPTION
Fixes #33103.

`MatBottomSheetConfig.panelClass` is forwarded through CDK Dialog/Overlay, where it applies to the overlay pane. This updates the config comment so the API docs describe the current behavior instead of saying the class is added to the bottom sheet container.

Tested:
- `git diff --check -- src/material/bottom-sheet/bottom-sheet-config.ts`