### PR TITLE
fix(multiple): remove developer preview tag from aria

### DIFF
--- a/src/aria/accordion/accordion-content.ts
+++ b/src/aria/accordion/accordion-content.ts
@@ -25,7 +25,6 @@ import {DeferredContent} from '../private';
  * </div>
  * ```
  *
- * @developerPreview 21.0
  * @see [Accordion](guide/aria/accordion)
  */
 @Directive({

--- a/src/aria/accordion/accordion-group.ts
+++ b/src/aria/accordion/accordion-group.ts
@@ -55,7 +55,6 @@ import {AccordionTrigger} from './accordion-trigger';
  * </div>
  * ```
  *
- * @developerPreview 21.0
  * @see [Accordion](guide/aria/accordion)
  */
 @Directive({

--- a/src/aria/accordion/accordion-panel.ts
+++ b/src/aria/accordion/accordion-panel.ts
@@ -28,7 +28,6 @@ import {DeferredContentAware, AccordionTriggerPattern} from '../private';
  * </div>
  * ```
  *
- * @developerPreview 21.0
  * @see [Accordion](guide/aria/accordion)
  */
 @Directive({

--- a/src/aria/accordion/accordion-trigger.ts
+++ b/src/aria/accordion/accordion-trigger.ts
@@ -37,7 +37,6 @@ import {AccordionPanel} from './accordion-panel';
  * </button>
  * ```
  *
- * @developerPreview 21.0
  * @see [Accordion](guide/aria/accordion)
  */
 @Directive({

--- a/src/aria/grid/grid-cell-widget.ts
+++ b/src/aria/grid/grid-cell-widget.ts
@@ -35,8 +35,6 @@ import {GRID_CELL} from './grid-tokens';
  * </td>
  * ```
  *
- * @developerPreview 21.0
- *
  * @see [Grid](guide/aria/grid)
  */
 @Directive({

--- a/src/aria/grid/grid-cell.ts
+++ b/src/aria/grid/grid-cell.ts
@@ -38,8 +38,6 @@ import {GRID_CELL, GRID_ROW} from './grid-tokens';
  * </td>
  * ```
  *
- * @developerPreview 21.0
- *
  * @see [Grid](guide/aria/grid)
  */
 @Directive({

--- a/src/aria/grid/grid-row.ts
+++ b/src/aria/grid/grid-row.ts
@@ -30,8 +30,6 @@ import {GridCell} from './grid-cell';
  * </tr>
  * ```
  *
- * @developerPreview 21.0
- *
  * @see [Grid](guide/aria/grid)
  */
 @Directive({

--- a/src/aria/grid/grid.ts
+++ b/src/aria/grid/grid.ts
@@ -48,8 +48,6 @@ import {GRID} from './grid-tokens';
  * </table>
  * ```
  *
- * @developerPreview 21.0
- *
  * @see [Grid](guide/aria/grid)
  */
 @Directive({

--- a/src/aria/listbox/listbox.ts
+++ b/src/aria/listbox/listbox.ts
@@ -44,8 +44,6 @@ import {LISTBOX} from './tokens';
  * </ul>
  * ```
  *
- * @developerPreview 21.0
- *
  * @see [Listbox](guide/aria/listbox)
  * @see [Autocomplete](guide/aria/autocomplete)
  * @see [Select](guide/aria/select)

--- a/src/aria/listbox/option.ts
+++ b/src/aria/listbox/option.ts
@@ -33,8 +33,6 @@ import {LISTBOX} from './tokens';
  * </li>
  * ```
  *
- * @developerPreview 21.0
- *
  * @see [Listbox](guide/aria/listbox)
  * @see [Autocomplete](guide/aria/autocomplete)
  * @see [Select](guide/aria/select)

--- a/src/aria/menu/menu-bar.ts
+++ b/src/aria/menu/menu-bar.ts
@@ -49,8 +49,6 @@ import {MENU_COMPONENT} from './menu-tokens';
  * </div>
  * ```
  *
- * @developerPreview 21.0
- *
  * @see [Menu](guide/aria/menu)
  * @see [MenuBar](guide/aria/menubar)
  */

--- a/src/aria/menu/menu-content.ts
+++ b/src/aria/menu/menu-content.ts
@@ -24,8 +24,6 @@ import {DeferredContent} from '../private';
  * </div>
  * ```
  *
- * @developerPreview 21.0
- *
  * @see [Menu](guide/aria/menu)
  * @see [MenuBar](guide/aria/menubar)
  */

--- a/src/aria/menu/menu-item.ts
+++ b/src/aria/menu/menu-item.ts
@@ -36,8 +36,6 @@ import type {MenuBar} from './menu-bar';
  * </div>
  * ```
  *
- * @developerPreview 21.0
- *
  * @see [Menu](guide/aria/menu)
  * @see [MenuBar](guide/aria/menubar)
  */

--- a/src/aria/menu/menu-trigger.ts
+++ b/src/aria/menu/menu-trigger.ts
@@ -35,8 +35,6 @@ import type {Menu} from './menu';
  * </div>
  * ```
  *
- * @developerPreview 21.0
- *
  * @see [Menu](guide/aria/menu)
  * @see [MenuBar](guide/aria/menubar)
  */

--- a/src/aria/menu/menu.ts
+++ b/src/aria/menu/menu.ts
@@ -51,8 +51,6 @@ import {MENU_COMPONENT} from './menu-tokens';
  * </div>
  * ```
  *
- * @developerPreview 21.0
- *
  * @see [Menu](guide/aria/menu)
  * @see [MenuBar](guide/aria/menubar)
  */

--- a/src/aria/tabs/tab-content.ts
+++ b/src/aria/tabs/tab-content.ts
@@ -24,8 +24,6 @@ import {DeferredContent} from '../private';
  * </div>
  * ```
  *
- * @developerPreview 21.0
- *
  * @see [Tabs](guide/aria/tabs)
  */
 @Directive({

--- a/src/aria/tabs/tab-list.ts
+++ b/src/aria/tabs/tab-list.ts
@@ -41,8 +41,6 @@ import type {Tab} from './tab';
  * </ul>
  * ```
  *
- * @developerPreview 21.0
- *
  * @see [Tabs](guide/aria/tabs)
  */
 @Directive({

--- a/src/aria/tabs/tab-panel.ts
+++ b/src/aria/tabs/tab-panel.ts
@@ -35,8 +35,6 @@ import {TABS} from './tab-tokens';
  * </div>
  * ```
  *
- * @developerPreview 21.0
- *
  * @see [Tabs](guide/aria/tabs)
  */
 @Directive({

--- a/src/aria/tabs/tab.ts
+++ b/src/aria/tabs/tab.ts
@@ -32,8 +32,6 @@ import {TAB_LIST} from './tab-tokens';
  * </li>
  * ```
  *
- * @developerPreview 21.0
- *
  * @see [Tabs](guide/aria/tabs)
  */
 @Directive({

--- a/src/aria/tabs/tabs.ts
+++ b/src/aria/tabs/tabs.ts
@@ -47,8 +47,6 @@ import {SortedCollection, TabPanelPattern, TabPattern} from '../private';
  * </div>
  * ```
  *
- * @developerPreview 21.0
- *
  * @see [Tabs](guide/aria/tabs)
  */
 @Directive({

--- a/src/aria/toolbar/toolbar-widget-group.ts
+++ b/src/aria/toolbar/toolbar-widget-group.ts
@@ -24,8 +24,6 @@ import {TOOLBAR_WIDGET_GROUP} from './toolbar-tokens';
  * A directive that groups toolbar widgets, used for more complex widgets like radio groups
  * that have their own internal navigation.
  *
- * @developerPreview 21.0
- *
  * @see [Toolbar](guide/aria/toolbar)
  */
 @Directive({

--- a/src/aria/toolbar/toolbar-widget.ts
+++ b/src/aria/toolbar/toolbar-widget.ts
@@ -40,8 +40,6 @@ import type {ToolbarWidgetGroup} from './toolbar-widget-group';
  * </button>
  * ```
  *
- * @developerPreview 21.0
- *
  * @see [Toolbar](guide/aria/toolbar)
  */
 @Directive({

--- a/src/aria/toolbar/toolbar.ts
+++ b/src/aria/toolbar/toolbar.ts
@@ -41,8 +41,6 @@ import type {ToolbarWidget} from './toolbar-widget';
  * </div>
  * ```
  *
- * @developerPreview 21.0
- *
  * @see [Toolbar](guide/aria/toolbar)
  */
 @Directive({

--- a/src/aria/tree/tree-item-group.ts
+++ b/src/aria/tree/tree-item-group.ts
@@ -37,8 +37,6 @@ import type {TreeItem} from './tree-item';
  * </li>
  * ```
  *
- * @developerPreview 21.0
- *
  * @see [Tree](guide/aria/tree)
  */
 @Directive({

--- a/src/aria/tree/tree-item.ts
+++ b/src/aria/tree/tree-item.ts
@@ -37,8 +37,6 @@ import {TreeItemGroup} from './tree-item-group';
  *   Item Label
  * </li>
  * ```
- *
- * @developerPreview 21.0
  */
 @Directive({
   selector: '[ngTreeItem]',

--- a/src/aria/tree/tree.ts
+++ b/src/aria/tree/tree.ts
@@ -58,8 +58,6 @@ import type {TreeItem} from './tree-item';
  * </ng-template>
  * ```
  *
- * @developerPreview 21.0
- *
  * @see [Tree](guide/aria/tree)
  */
 @Directive({


### PR DESCRIPTION
Removes the developer preview tag since we're stabilizing in v22.