### PR TITLE
build: skip branch manager job on forked repositories

### DIFF
--- a/.github/workflows/assistant-to-the-branch-manager.yml
+++ b/.github/workflows/assistant-to-the-branch-manager.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   assistant_to_the_branch_manager:
     runs-on: ubuntu-latest
+    if: github.event.repository.fork == false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
Currently when a commit is pushed to a branch in a forked angular/components repository it kicks off the `assistant_to_the_branch_manager` which fails because the user does not have the angular robot key in their Github environment. This change prevents the `assistant_to_the_branch_manager` job from running on forked repositories.

It is identical to the approach uses by angular/angular. See [here](https://github.com/angular/angular/blob/main/.github/workflows/assistant-to-the-branch-manager.yml#L15)

After making this commit and pushing to my branch I saw the following (which is the desired behavior).

<img width="1118" height="565" alt="image" src="https://github.com/user-attachments/assets/9939757a-cbc2-4a81-bc6b-4d7def80abad" />

Resolves #33221