### PR TITLE
fix(material/datepicker): replace aria-pressed with aria-selected on …

### DIFF
--- a/src/material/datepicker/calendar-body.html
+++ b/src/material/datepicker/calendar-body.html
@@ -33,7 +33,7 @@
     }
     <!--
       Each gridcell in the calendar contains a button, which signals to assistive technology that the
-      cell is interactable, as well as the selection state via `aria-pressed`. See #23476 for
+      cell is interactable, as well as the selection state via `aria-selected`. See #23476 for
       background.
     -->
     @for (item of row; track item.id; let colIndex = $index) {
@@ -66,7 +66,7 @@
             [class.mat-calendar-body-in-preview]="_isInPreview(item.compareValue)"
             [attr.aria-label]="item.ariaLabel"
             [attr.aria-disabled]="!item.enabled || null"
-            [attr.aria-pressed]="_isSelected(item.compareValue)"
+            [attr.aria-selected]="_isSelected(item.compareValue)"
             [attr.aria-current]="todayValue === item.compareValue ? 'date' : null"
             [attr.aria-describedby]="_getDescribedby(item.compareValue)"
             (click)="_cellClicked(item, $event)"

--- a/src/material/datepicker/calendar-body.spec.ts
+++ b/src/material/datepicker/calendar-body.spec.ts
@@ -88,13 +88,13 @@ describe('MatCalendarBody', () => {
       expect(selectedCell.innerHTML.trim()).toBe('4');
     });
 
-    it('should set aria-pressed correctly', () => {
-      const pressedCells = cellEls.filter(c => c.getAttribute('aria-pressed') === 'true');
-      const depressedCells = cellEls.filter(c => c.getAttribute('aria-pressed') === 'false');
+    it('should set aria-selected correctly', () => {
+      const selectedCells = cellEls.filter(c => c.getAttribute('aria-selected') === 'true');
+      const deselectedCells = cellEls.filter(c => c.getAttribute('aria-selected') === 'false');
 
-      expect(pressedCells.length).withContext('Expected one cell to be marked as pressed.').toBe(1);
-      expect(depressedCells.length)
-        .withContext('Expected remaining cells to be marked as not pressed.')
+      expect(selectedCells.length).withContext('Expected one cell to be marked as selected.').toBe(1);
+      expect(deselectedCells.length)
+        .withContext('Expected remaining cells to be marked as not selected.')
         .toBe(cellEls.length - 1);
     });
 

--- a/src/material/datepicker/testing/calendar-cell-harness.ts
+++ b/src/material/datepicker/testing/calendar-cell-harness.ts
@@ -69,7 +69,7 @@ export class MatCalendarCellHarness extends ComponentHarness {
   /** Whether the cell is selected. */
   async isSelected(): Promise<boolean> {
     const host = await this.host();
-    return (await host.getAttribute('aria-pressed')) === 'true';
+    return (await host.getAttribute('aria-selected')) === 'true';
   }
 
   /** Whether the cell is disabled. */


### PR DESCRIPTION
## Description
                                                                                                                                          
  Calendar date cells in `mat-calendar-body` bind `[attr.aria-pressed]` to                                                                
  indicate selection state. This is incorrect:                                                                                            
                                                                                                                                          
  - `aria-pressed` is semantically for toggle buttons — it implies the user                                                               
    can press again to deselect
  - mat-datepicker does not allow deselection by re-clicking a selected date                                                              
  - Screen readers announce cells as "toggle button, pressed" rather than                                                                 
    "selected", misleading users about the actual interaction                                                                             
                                                                                                                                          
  Per WAI-ARIA 1.2 §6.6.4 and WCAG 2.1 SC 4.1.2 (Name, Role, Value),                                                                      
  `aria-selected` is the correct attribute for selection state within a    
  grid widget.                                                                                                                            
                                                                           
  Fixes #30190                                                                                                                            
                                                                           
  ## Changes                                                                                                                              
                                                                           
  - `calendar-body.html`: `[attr.aria-pressed]` → `[attr.aria-selected]`; updated inline comment                                          
  - `calendar-cell-harness.ts`: `isSelected()` reads `aria-selected`
  - `calendar-body.spec.ts`: test name and assertions updated to match                                                                    
                                                                                                                                          
  ## Testing
                                                                                                                                          
  Existing test updated — no behavior changes, only the ARIA attribute name.