### PR TITLE
fix(material/list): remove pointer cursor from disabled selection controls

### DIFF
--- a/src/material/list/list.scss
+++ b/src/material/list/list.scss
@@ -39,6 +39,7 @@ $fallbacks: m3-list.get-tokens();
   .mdc-radio,
   .mdc-checkbox {
     opacity: token-utils.slot(list-list-item-disabled-label-text-opacity, $fallbacks);
+    cursor: default;
   }
 }
 


### PR DESCRIPTION
Fixes #31937.

This updates disabled list option styling so the radio/checkbox indicator uses the default cursor instead of a pointer cursor when the selection list item is disabled.