### PR TITLE
docs: release notes for the v21.2.11 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+<a name="21.2.11"></a>
+# 21.2.11 "crystal ball" (2026-05-13)
+No user facing changes in this release
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="22.0.0-next.8"></a>
 # 22.0.0-next.8 "plastic-wallaby" (2026-05-06)
 ## Breaking Changes


### PR DESCRIPTION
Cherry-picks the changelog from the "21.2.x" branch to the next branch (main).