### PR TITLE
fix(material/sidenav): handle mixed sidenav and drawer

### DIFF
--- a/goldens/material/sidenav/index.api.md
+++ b/goldens/material/sidenav/index.api.md
@@ -112,7 +112,7 @@ export class MatDrawerContainer implements AfterContentInit, DoCheck, OnDestroy 
     // (undocumented)
     _userContent: MatDrawerContent;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<MatDrawerContainer, "mat-drawer-container", ["matDrawerContainer"], { "autosize": { "alias": "autosize"; "required": false; }; "hasBackdrop": { "alias": "hasBackdrop"; "required": false; }; }, { "backdropClick": "backdropClick"; }, ["_content", "_allDrawers"], ["mat-drawer", "mat-drawer-content", "*"], true, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MatDrawerContainer, "mat-drawer-container", ["matDrawerContainer"], { "autosize": { "alias": "autosize"; "required": false; }; "hasBackdrop": { "alias": "hasBackdrop"; "required": false; }; }, { "backdropClick": "backdropClick"; }, ["_content", "_allDrawers"], ["mat-drawer, mat-sidenav", "mat-drawer-content, mat-sidenav-content", "*"], true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatDrawerContainer, never>;
 }
@@ -159,7 +159,7 @@ export class MatSidenavContainer extends MatDrawerContainer {
     // (undocumented)
     _content: MatSidenavContent;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<MatSidenavContainer, "mat-sidenav-container", ["matSidenavContainer"], {}, {}, ["_content", "_allDrawers"], ["mat-sidenav", "mat-sidenav-content", "*"], true, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MatSidenavContainer, "mat-sidenav-container", ["matSidenavContainer"], {}, {}, ["_content", "_allDrawers"], ["mat-drawer, mat-sidenav", "mat-drawer-content, mat-sidenav-content", "*"], true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatSidenavContainer, never>;
 }

--- a/src/material/sidenav/drawer-container.html
+++ b/src/material/sidenav/drawer-container.html
@@ -3,13 +3,11 @@
        [class.mat-drawer-shown]="_isShowingBackdrop()"></div>
 }
 
-<ng-content select="mat-drawer"></ng-content>
-
-<ng-content select="mat-drawer-content">
-</ng-content>
+<ng-content select="mat-drawer, mat-sidenav"/>
+<ng-content select="mat-drawer-content, mat-sidenav-content"/>
 
 @if (!_content) {
   <mat-drawer-content>
-    <ng-content></ng-content>
+    <ng-content/>
   </mat-drawer-content>
 }

--- a/src/material/sidenav/sidenav-container.html
+++ b/src/material/sidenav/sidenav-container.html
@@ -3,13 +3,11 @@
        [class.mat-drawer-shown]="_isShowingBackdrop()"></div>
 }
 
-<ng-content select="mat-sidenav"></ng-content>
-
-<ng-content select="mat-sidenav-content">
-</ng-content>
+<ng-content select="mat-drawer, mat-sidenav"/>
+<ng-content select="mat-drawer-content, mat-sidenav-content"/>
 
 @if (!_content) {
   <mat-sidenav-content>
-    <ng-content></ng-content>
+    <ng-content/>
   </mat-sidenav-content>
 }


### PR DESCRIPTION
Fixes that if we mix something like `mat-drawer-container` and `mat-sidenav`, the navigation ends up in the wrong slot and gets caught by the `inert` attribute when it's opened.