### PR TITLE
docs(aria/menu): fix menubar example highlight styling

### DIFF
--- a/src/components-examples/aria/menu/menu-example.css
+++ b/src/components-examples/aria/menu/menu-example.css
@@ -77,7 +77,9 @@
 
 .example-menu-trigger:hover,
 .example-menu-item[data-active='true'],
-.example-menu-bar-item[data-active='true'] {
+.example-menu-bar-item:hover,
+.example-menu-bar-item:focus-within,
+.example-menu-bar-item[aria-expanded='true'] {
   background: color-mix(
     in srgb,
     var(--mat-sys-on-surface) calc(var(--mat-sys-hover-state-layer-opacity) * 100%),

--- a/src/components-examples/aria/menubar/menubar.css
+++ b/src/components-examples/aria/menubar/menubar.css
@@ -47,7 +47,13 @@
   opacity: 0.5;
 }
 
-[ngMenuItem][data-active='true'] {
+[ngMenu] [ngMenuItem][data-active='true'] {
+  background: color-mix(in srgb, var(--mat-sys-outline) 20%, transparent);
+}
+
+[ngMenuBar] > [ngMenuItem]:hover,
+[ngMenuBar] > [ngMenuItem]:focus-within,
+[ngMenuBar] > [ngMenuItem][aria-expanded='true'] {
   background: color-mix(in srgb, var(--mat-sys-outline) 20%, transparent);
 }
 


### PR DESCRIPTION
## Summary

Updates the menubar example styles so items highlight only while the user is interacting: `:hover`, `:focus-within`, and `[aria-expanded='true']` (for when the submenu is open and focus is in the overlay). Items inside an open menu keep their `[data-active]` highlight.

## Test plan

- [x] Verified in dev-app (`pnpm dev-app`, Aria Menubar): nothing highlighted at rest, hover/focus highlight the right item, clears on leave.
