### PR TITLE
fix(multiple): prevent form submissions in aria directives

### DIFF
--- a/src/aria/accordion/accordion-trigger.ts
+++ b/src/aria/accordion/accordion-trigger.ts
@@ -86,6 +86,11 @@ export class AccordionTrigger implements OnInit, OnDestroy {
   _pattern!: AccordionTriggerPattern;
 
   constructor() {
+    // Automatically prevent form submission.
+    if (this.element.tagName === 'BUTTON' && !this.element.hasAttribute('type')) {
+      this.element.setAttribute('type', 'button');
+    }
+
     // Check for any violations after the DOM has been updated.
     if (typeof ngDevMode === 'undefined' || ngDevMode) {
       afterRenderEffect({

--- a/src/aria/accordion/accordion.spec.ts
+++ b/src/aria/accordion/accordion.spec.ts
@@ -87,6 +87,12 @@ describe('AccordionGroup', () => {
           expect(getTriggerAttribute(2, 'role')).toBe('button');
         });
 
+        it('should set type="button" by default on buttons', () => {
+          expect(getTriggerAttribute(0, 'type')).toBe('button');
+          expect(getTriggerAttribute(1, 'type')).toBe('button');
+          expect(getTriggerAttribute(2, 'type')).toBe('button');
+        });
+
         it('should have aria-expanded="false" when collapsed', () => {
           expect(getTriggerAttribute(0, 'aria-expanded')).toBe('false');
           expect(getTriggerAttribute(1, 'aria-expanded')).toBe('false');

--- a/src/aria/menu/menu-trigger.ts
+++ b/src/aria/menu/menu-trigger.ts
@@ -90,6 +90,11 @@ export class MenuTrigger<V> {
   constructor() {
     effect(() => this.menu()?.parent.set(this));
     effect(() => this._pattern.pendingFocusEffect());
+
+    // Automatically prevent form submission.
+    if (this.element.tagName === 'BUTTON' && !this.element.hasAttribute('type')) {
+      this.element.setAttribute('type', 'button');
+    }
   }
 
   /** Opens the menu focusing on the first menu item. */

--- a/src/aria/menu/menu.spec.ts
+++ b/src/aria/menu/menu.spec.ts
@@ -861,6 +861,10 @@ describe('CDK Overlay Menu Pattern', () => {
     await keydown(trigger, 'Enter');
     expect(document.activeElement).toBe(getItem('Apple'));
   });
+
+  it('should set type="button" by default on button triggers', () => {
+    expect(getTrigger().getAttribute('type')).toBe('button');
+  });
 });
 
 describe('Menu Bar Pattern', () => {

--- a/src/aria/tabs/tab.ts
+++ b/src/aria/tabs/tab.ts
@@ -92,6 +92,11 @@ export class Tab implements HasElement, OnInit, OnDestroy {
   }
 
   constructor() {
+    // Automatically prevent form submission.
+    if (this.element.tagName === 'BUTTON' && !this.element.hasAttribute('type')) {
+      this.element.setAttribute('type', 'button');
+    }
+
     if (typeof ngDevMode === 'undefined' || ngDevMode) {
       afterRenderEffect({
         read: () => {


### PR DESCRIPTION
Updates a few of the Aria directives that are likely to be placed on buttons to have `type="button"` by default. This prevents them from accidentally submitting forms.