### PR TITLE
refactor(material/icon): switch tests away from fakeAsync

### DIFF
--- a/src/material/icon/icon.spec.ts
+++ b/src/material/icon/icon.spec.ts
@@ -11,7 +11,7 @@ import {
   ViewChild,
   ChangeDetectionStrategy,
 } from '@angular/core';
-import {TestBed, fakeAsync, tick, waitForAsync} from '@angular/core/testing';
+import {TestBed} from '@angular/core/testing';
 import {DomSanitizer, SafeHtml, SafeResourceUrl} from '@angular/platform-browser';
 import {FAKE_SVGS} from './fake-svgs';
 import {MatIcon} from './icon';
@@ -64,7 +64,7 @@ describe('MatIcon', () => {
   let sanitizer: DomSanitizer;
   let errorHandler: ErrorHandler;
 
-  beforeEach(waitForAsync(() => {
+  beforeEach(() => {
     // The $ prefix tells Karma not to try to process the
     // request so that we don't get warnings in our logs.
     fakePath = '/$fake-path';
@@ -83,7 +83,7 @@ describe('MatIcon', () => {
     http = TestBed.inject(HttpTestingController);
     sanitizer = TestBed.inject(DomSanitizer);
     errorHandler = TestBed.inject(ErrorHandler);
-  }));
+  });
 
   it('should apply the correct role', () => {
     const fixture = TestBed.createComponent(IconWithColor);
@@ -315,7 +315,7 @@ describe('MatIcon', () => {
   });
 
   describe('Icons from URLs', () => {
-    it('should register icon URLs by name', fakeAsync(() => {
+    it('should register icon URLs by name', () => {
       iconRegistry.addSvgIcon('fluffy', trustUrl('cat.svg'));
       iconRegistry.addSvgIcon('fido', trustUrl('dog.svg'));
       iconRegistry.addSvgIcon('felix', trustUrl('auth-cat.svg'), {withCredentials: true});
@@ -363,11 +363,9 @@ describe('MatIcon', () => {
       iconRegistry.getSvgIconFromUrl(trustUrl('cat.svg')).subscribe((element: SVGElement) => {
         verifyPathChildElement(element, 'meow');
       });
+    });
 
-      tick();
-    }));
-
-    it('should be able to set the viewBox when registering a single SVG icon', fakeAsync(() => {
+    it('should be able to set the viewBox when registering a single SVG icon', () => {
       iconRegistry.addSvgIcon('fluffy', trustUrl('cat.svg'), {viewBox: '0 0 27 27'});
       iconRegistry.addSvgIcon('fido', trustUrl('dog.svg'), {viewBox: '0 0 43 43'});
 
@@ -390,7 +388,7 @@ describe('MatIcon', () => {
       http.expectOne('cat.svg').flush(FAKE_SVGS.cat);
       svgElement = verifyAndGetSingleSvgChild(iconElement);
       expect(svgElement.getAttribute('viewBox')).toBe('0 0 27 27');
-    }));
+    });
 
     it('should throw an error when using an untrusted icon url', () => {
       iconRegistry.addSvgIcon('fluffy', 'farm-set-1.svg');
@@ -745,7 +743,7 @@ describe('MatIcon', () => {
       expect(icon.querySelector('svg')).toBeFalsy();
     });
 
-    it('should keep non-SVG user content inside the icon element', fakeAsync(() => {
+    it('should keep non-SVG user content inside the icon element', () => {
       iconRegistry.addSvgIcon('fido', trustUrl('dog.svg'));
 
       const fixture = TestBed.createComponent(SvgIconWithUserContent);
@@ -761,11 +759,9 @@ describe('MatIcon', () => {
 
       expect(userDiv).toBeTruthy();
       expect(iconElement.textContent.trim()).toContain('Hello');
+    });
 
-      tick();
-    }));
-
-    it('should cancel in-progress fetches if the icon changes', fakeAsync(() => {
+    it('should cancel in-progress fetches if the icon changes', () => {
       // Register an icon that will resolve immediately.
       iconRegistry.addSvgIconLiteral('fluffy', trustHtml(FAKE_SVGS.cat));
 
@@ -790,9 +786,9 @@ describe('MatIcon', () => {
 
       // Expect the last icon to have been assigned.
       verifyPathChildElement(verifyAndGetSingleSvgChild(iconElement), 'meow');
-    }));
+    });
 
-    it('should cancel in-progress fetches if the component is destroyed', fakeAsync(() => {
+    it('should cancel in-progress fetches if the component is destroyed', () => {
       iconRegistry.addSvgIcon('fido', trustUrl('dog.svg'));
 
       const fixture = TestBed.createComponent(IconFromSvgName);
@@ -802,11 +798,11 @@ describe('MatIcon', () => {
       fixture.destroy();
 
       expect(http.expectOne('dog.svg').cancelled).toBe(true);
-    }));
+    });
   });
 
   describe('Icons from HTML string', () => {
-    it('should register icon HTML strings by name', fakeAsync(() => {
+    it('should register icon HTML strings by name', () => {
       iconRegistry.addSvgIconLiteral('fluffy', trustHtml(FAKE_SVGS.cat));
       iconRegistry.addSvgIconLiteral('fido', trustHtml(FAKE_SVGS.dog));
 
@@ -831,11 +827,9 @@ describe('MatIcon', () => {
       iconRegistry.getNamedSvgIcon('fluffy').subscribe((element: SVGElement) => {
         verifyPathChildElement(element, 'meow');
       });
+    });
 
-      tick();
-    }));
-
-    it('should be able to configure the icon viewBox', fakeAsync(() => {
+    it('should be able to configure the icon viewBox', () => {
       iconRegistry.addSvgIconLiteral('fluffy', trustHtml(FAKE_SVGS.cat), {viewBox: '0 0 43 43'});
       iconRegistry.addSvgIconLiteral('fido', trustHtml(FAKE_SVGS.dog), {viewBox: '0 0 27 27'});
 
@@ -855,7 +849,7 @@ describe('MatIcon', () => {
       fixture.detectChanges();
       svgElement = verifyAndGetSingleSvgChild(iconElement);
       expect(svgElement.getAttribute('viewBox')).toBe('0 0 43 43');
-    }));
+    });
 
     it('should throw an error when using untrusted HTML', () => {
       // Stub out console.warn so we don't pollute our logs with Angular's warnings.
@@ -993,7 +987,7 @@ describe('MatIcon', () => {
       expect(svgElement.getAttribute('viewBox')).toBe('0 0 43 43');
     });
 
-    it('should prepend the current path to attributes with `url()` references', fakeAsync(() => {
+    it('should prepend the current path to attributes with `url()` references', () => {
       iconRegistry.addSvgIconLiteral(
         'fido',
         trustHtml(`
@@ -1016,11 +1010,9 @@ describe('MatIcon', () => {
       // We use a regex to match here, rather than the exact value, because different browsers
       // return different quotes through `getAttribute`, while some even omit the quotes altogether.
       expect(circle.getAttribute('filter')).toMatch(/^url\(['"]?\/\$fake-path#blur['"]?\)$/);
+    });
 
-      tick();
-    }));
-
-    it('should use latest path when prefixing the `url()` references', fakeAsync(() => {
+    it('should use latest path when prefixing the `url()` references', () => {
       iconRegistry.addSvgIconLiteral(
         'fido',
         trustHtml(`
@@ -1041,7 +1033,6 @@ describe('MatIcon', () => {
       let circle = fixture.nativeElement.querySelector('mat-icon svg circle');
 
       expect(circle.getAttribute('filter')).toMatch(/^url\(['"]?\/\$fake-path#blur['"]?\)$/);
-      tick();
       fixture.destroy();
 
       fakePath = '/$another-fake-path';
@@ -1054,10 +1045,9 @@ describe('MatIcon', () => {
       expect(circle.getAttribute('filter')).toMatch(
         /^url\(['"]?\/\$another-fake-path#blur['"]?\)$/,
       );
-      tick();
-    }));
+    });
 
-    it('should update the `url()` references when the path changes', fakeAsync(() => {
+    it('should update the `url()` references when the path changes', () => {
       iconRegistry.addSvgIconLiteral(
         'fido',
         trustHtml(`
@@ -1080,14 +1070,13 @@ describe('MatIcon', () => {
       // We use a regex to match here, rather than the exact value, because different browsers
       // return different quotes through `getAttribute`, while some even omit the quotes altogether.
       expect(circle.getAttribute('filter')).toMatch(/^url\(['"]?\/\$fake-path#blur['"]?\)$/);
-      tick();
 
       fakePath = '/$different-path';
       fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       expect(circle.getAttribute('filter')).toMatch(/^url\(['"]?\/\$different-path#blur['"]?\)$/);
-    }));
+    });
   });
 
   describe('custom fonts', () => {
@@ -1204,7 +1193,7 @@ describe('MatIcon', () => {
   });
 
   describe('Icons resolved through a resolver function', () => {
-    it('should resolve icons through a resolver function', fakeAsync(() => {
+    it('should resolve icons through a resolver function', () => {
       iconRegistry.addSvgIconResolver(name => {
         if (name === 'fluffy') {
           return trustUrl('cat.svg');
@@ -1259,11 +1248,9 @@ describe('MatIcon', () => {
       iconRegistry.getSvgIconFromUrl(trustUrl('cat.svg')).subscribe((element: SVGElement) => {
         verifyPathChildElement(element, 'meow');
       });
+    });
 
-      tick();
-    }));
-
-    it('should fall back to second resolver if the first one returned null', fakeAsync(() => {
+    it('should fall back to second resolver if the first one returned null', () => {
       iconRegistry
         .addSvgIconResolver(() => null)
         .addSvgIconResolver(name => (name === 'fido' ? trustUrl('dog.svg') : null));
@@ -1276,10 +1263,9 @@ describe('MatIcon', () => {
       fixture.detectChanges();
       http.expectOne('dog.svg').flush(FAKE_SVGS.dog);
       verifyPathChildElement(verifyAndGetSingleSvgChild(iconElement), 'woof');
-      tick();
-    }));
+    });
 
-    it('should be able to set the viewBox when resolving an icon with a function', fakeAsync(() => {
+    it('should be able to set the viewBox when resolving an icon with a function', () => {
       iconRegistry.addSvgIconResolver(name => {
         if (name === 'fluffy') {
           return {url: trustUrl('cat.svg'), options: {viewBox: '0 0 27 27'}};
@@ -1308,7 +1294,7 @@ describe('MatIcon', () => {
       http.expectOne('cat.svg').flush(FAKE_SVGS.cat);
       svgElement = verifyAndGetSingleSvgChild(iconElement);
       expect(svgElement.getAttribute('viewBox')).toBe('0 0 27 27');
-    }));
+    });
 
     it('should throw an error when the resolver returns an untrusted URL', () => {
       iconRegistry.addSvgIconResolver(() => 'not-trusted.svg');
@@ -1322,7 +1308,7 @@ describe('MatIcon', () => {
     });
   });
 
-  it('should handle assigning an icon through the setter', fakeAsync(() => {
+  it('should handle assigning an icon through the setter', () => {
     iconRegistry.addSvgIconLiteral('fido', trustHtml(FAKE_SVGS.dog));
 
     const fixture = TestBed.createComponent(BlankIcon);
@@ -1336,8 +1322,7 @@ describe('MatIcon', () => {
     fixture.detectChanges();
     svgElement = verifyAndGetSingleSvgChild(iconElement);
     verifyPathChildElement(svgElement, 'woof');
-    tick();
-  }));
+  });
 
   /** Marks an SVG icon url as explicitly trusted. */
   function trustUrl(iconUrl: string): SafeResourceUrl {
@@ -1351,7 +1336,7 @@ describe('MatIcon', () => {
 });
 
 describe('MatIcon with default options', () => {
-  it('should be able to configure color globally', fakeAsync(() => {
+  it('should be able to configure color globally', () => {
     const fixture = createComponent(IconWithLigature, [
       {provide: MAT_ICON_DEFAULT_OPTIONS, useValue: {color: 'accent'}},
     ]);
@@ -1359,9 +1344,9 @@ describe('MatIcon with default options', () => {
     fixture.detectChanges();
     expect(iconElement.classList).not.toContain('mat-icon-no-color');
     expect(iconElement.classList).toContain('mat-accent');
-  }));
+  });
 
-  it('should use passed color rather then color provided', fakeAsync(() => {
+  it('should use passed color rather then color provided', () => {
     const fixture = createComponent(IconWithColor, [
       {provide: MAT_ICON_DEFAULT_OPTIONS, useValue: {color: 'warn'}},
     ]);
@@ -1369,9 +1354,9 @@ describe('MatIcon with default options', () => {
     fixture.detectChanges();
     expect(iconElement.classList).not.toContain('mat-warn');
     expect(iconElement.classList).toContain('mat-primary');
-  }));
+  });
 
-  it('should use default color if no color passed', fakeAsync(() => {
+  it('should use default color if no color passed', () => {
     const fixture = createComponent(IconWithColor, [
       {provide: MAT_ICON_DEFAULT_OPTIONS, useValue: {color: 'accent'}},
     ]);
@@ -1382,18 +1367,18 @@ describe('MatIcon with default options', () => {
     expect(iconElement.classList).not.toContain('mat-icon-no-color');
     expect(iconElement.classList).not.toContain('mat-primary');
     expect(iconElement.classList).toContain('mat-accent');
-  }));
+  });
 
-  it('should be able to configure font set globally', fakeAsync(() => {
+  it('should be able to configure font set globally', () => {
     const fixture = createComponent(IconWithLigature, [
       {provide: MAT_ICON_DEFAULT_OPTIONS, useValue: {fontSet: 'custom-font-set'}},
     ]);
     const iconElement = fixture.debugElement.nativeElement.querySelector('mat-icon');
     fixture.detectChanges();
     expect(iconElement.classList).toContain('custom-font-set');
-  }));
+  });
 
-  it('should use passed fontSet rather then default one', fakeAsync(() => {
+  it('should use passed fontSet rather then default one', () => {
     const fixture = createComponent(IconWithCustomFontCss, [
       {provide: MAT_ICON_DEFAULT_OPTIONS, useValue: {fontSet: 'default-font-set'}},
     ]);
@@ -1403,16 +1388,16 @@ describe('MatIcon with default options', () => {
     fixture.detectChanges();
     expect(iconElement.classList).not.toContain('default-font-set');
     expect(iconElement.classList).toContain('custom-font-set');
-  }));
+  });
 
-  it('should use passed empty fontSet rather then default one', fakeAsync(() => {
+  it('should use passed empty fontSet rather then default one', () => {
     const fixture = createComponent(IconWithCustomFontCss, [
       {provide: MAT_ICON_DEFAULT_OPTIONS, useValue: {fontSet: 'default-font-set'}},
     ]);
     const iconElement = fixture.debugElement.nativeElement.querySelector('mat-icon');
     fixture.detectChanges();
     expect(iconElement.classList).not.toContain('default-font-set');
-  }));
+  });
 });
 
 @Component({


### PR DESCRIPTION
Reworks the icon tests not to depend on `fakeAsync` anymore.