### PR TITLE
fix(cdk/table): expose rendered rows

### DIFF
--- a/goldens/cdk/table/index.api.md
+++ b/goldens/cdk/table/index.api.md
@@ -346,6 +346,7 @@ export class CdkTable<T> implements AfterContentInit, AfterContentChecked, Colle
     removeHeaderRowDef(headerRowDef: CdkHeaderRowDef): void;
     removeRowDef(rowDef: CdkRowDef<T>): void;
     protected _renderedRange?: ListRange;
+    get renderedRows(): readonly RenderRow<T>[];
     renderRows(): void;
     // (undocumented)
     _rowOutlet: DataRowOutlet;

--- a/src/cdk/table/table.ts
+++ b/src/cdk/table/table.ts
@@ -634,6 +634,11 @@ export class CdkTable<T>
   /** Row definition that will only be rendered if there's no data in the table. */
   @ContentChild(CdkNoDataRow) _noDataRow!: CdkNoDataRow;
 
+  /** Returns the currently-rendered rows in the table. */
+  get renderedRows(): readonly RenderRow<T>[] {
+    return this._renderRows;
+  }
+
   constructor() {
     const role = inject(new HostAttributeToken('role'), {optional: true});
 


### PR DESCRIPTION
Exposes the currently rendered rows in the table which can be helpful for querying the data.

Fixes #28468.