### PR TITLE
fix(material/core): correct createDate JSDoc return description

### DIFF
--- a/src/material/core/datetime/date-adapter.ts
+++ b/src/material/core/datetime/date-adapter.ts
@@ -107,7 +107,7 @@ export abstract class DateAdapter<D, L = any> {
    * @param year The full year of the date. (e.g. 89 means the year 89, not the year 1989).
    * @param month The month of the date (0-indexed, 0 = January). Must be an integer 0 - 11.
    * @param date The date of month of the date. Must be an integer 1 - length of the given month.
-   * @returns The new date, or null if invalid.
+   * @returns The new date.
    */
   abstract createDate(year: number, month: number, date: number): D;
 


### PR DESCRIPTION
## PR Checklist

* [x] The commit message follows our guidelines
* [ ] Tests for the changes have been added (not needed for docs-only change)
* [ ] Docs have been added / updated

## PR Type

What kind of change does this PR introduce?

* [x] Bugfix
* [ ] Feature
* [ ] Documentation Update

## What is the current behavior?

The JSDoc for `DateAdapter#createDate` states that the method may return `null` when invalid:

```ts
@returns The new date, or null if invalid.
```

However, the method signature returns `D`, not `D | null`, and implementations throw errors instead of returning `null`.

Closes #33059 

## What is the new behavior?

Updates the JSDoc return description to correctly reflect the actual behavior of the method.
