### PR TITLE
fix(material/menu): close menu when cleared from trigger

### DIFF
--- a/src/material/menu/menu-trigger-base.ts
+++ b/src/material/menu/menu-trigger-base.ts
@@ -134,6 +134,8 @@ export abstract class MatMenuTriggerBase implements OnDestroy {
           this._parentMaterialMenu.closed.emit(reason);
         }
       });
+    } else {
+      this._destroyMenu();
     }
 
     this._menuItemInstance?._setTriggersSubmenu(this._triggersSubmenu());

--- a/src/material/menu/menu.spec.ts
+++ b/src/material/menu/menu.spec.ts
@@ -76,7 +76,7 @@ describe('MatMenu', () => {
     window.scroll(0, 0);
   });
 
-  it('should aria-controls the menu panel', () => {
+  it('should set aria-controls on the menu panel', () => {
     const fixture = TestBed.createComponent(SimpleMenu);
     fixture.detectChanges();
     fixture.componentInstance.trigger.openMenu();
@@ -1147,6 +1147,20 @@ describe('MatMenu', () => {
     fixture.detectChanges();
     panelRect = panel.getBoundingClientRect();
     expect(Math.floor(panelRect.bottom)).toBe(viewportHeight);
+  });
+
+  it('should close the menu when it is cleared from the trigger', async () => {
+    const fixture = TestBed.createComponent(SimpleMenu);
+    fixture.detectChanges();
+    fixture.componentInstance.trigger.openMenu();
+    fixture.detectChanges();
+    await wait(200);
+    expect(overlayContainerElement.querySelector('.mat-mdc-menu-panel')).toBeTruthy();
+
+    fixture.componentInstance.trigger.menu = null;
+    fixture.changeDetectorRef.markForCheck();
+    fixture.detectChanges();
+    expect(overlayContainerElement.querySelector('.mat-mdc-menu-panel')).toBeFalsy();
   });
 
   describe('lazy rendering', () => {


### PR DESCRIPTION
Fixes that the menu would get stuck in the open state if it's cleared from the trigger while it's open.

Fixes #30139.