### PR TITLE
docs: release notes for the v21.2.13 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+<a name="21.2.13"></a>
+# 21.2.13 "21-2-13" (2026-05-27)
+No user facing changes in this release
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="22.0.0-rc.1"></a>
 # 22.0.0-rc.1 "metal-monkey" (2026-05-20)
 ### aria


### PR DESCRIPTION
Cherry-picks the changelog from the "21.2.x" branch to the next branch (main).