### PR TITLE
fix(material/list): remove pointer cursor for disabled selection list radios

### DIFF
--- a/src/material/list/list.scss
+++ b/src/material/list/list.scss
@@ -40,6 +40,10 @@ $fallbacks: m3-list.get-tokens();
   .mdc-checkbox {
     opacity: token-utils.slot(list-list-item-disabled-label-text-opacity, $fallbacks);
   }
+
+  .mdc-radio {
+    cursor: auto;
+  }
 }
 
 // In Angular Material we put the avatar class directly on the .mdc-list-item__start element,

--- a/src/material/list/list.spec.ts
+++ b/src/material/list/list.spec.ts
@@ -417,7 +417,7 @@ class BaseTestList {
     </a>
   </mat-list>`,
   imports: [MatListModule],
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 class ListWithOneAnchorItem extends BaseTestList {
   // This needs to be declared directly on the class; if declared on the BaseTestList superclass,
@@ -433,7 +433,7 @@ class ListWithOneAnchorItem extends BaseTestList {
     </a>
   </mat-nav-list>`,
   imports: [MatListModule],
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 class NavListWithOneAnchorItem extends BaseTestList {
   @ViewChildren(MatListItem) listItems!: QueryList<MatListItem>;
@@ -452,7 +452,7 @@ class NavListWithOneAnchorItem extends BaseTestList {
     }
   </mat-nav-list>`,
   imports: [MatListModule],
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 class NavListWithActivatedItem extends BaseTestList {
   @ViewChildren(MatListItem) listItems!: QueryList<MatListItem>;
@@ -471,7 +471,7 @@ class NavListWithActivatedItem extends BaseTestList {
     </button>
   </mat-action-list>`,
   imports: [MatListModule],
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 class ActionListWithoutType extends BaseTestList {
   @ViewChildren(MatListItem) listItems!: QueryList<MatListItem>;
@@ -487,7 +487,7 @@ class ActionListWithoutType extends BaseTestList {
     </button>
   </mat-action-list>`,
   imports: [MatListModule],
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 class ActionListWithType extends BaseTestList {
   @ViewChildren(MatListItem) listItems!: QueryList<MatListItem>;
@@ -501,7 +501,7 @@ class ActionListWithType extends BaseTestList {
     }
   </mat-action-list>`,
   imports: [MatListModule],
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 class ActionListWithDisabledList extends BaseTestList {
   disableList = true;
@@ -515,7 +515,7 @@ class ActionListWithDisabledList extends BaseTestList {
     </button>
   </mat-action-list>`,
   imports: [MatListModule],
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 class ActionListWithDisabledItem extends BaseTestList {
   @ViewChild(MatListItem) buttonItem!: MatListItem;
@@ -530,7 +530,7 @@ class ActionListWithDisabledItem extends BaseTestList {
     </mat-list-item>
   </mat-list>`,
   imports: [MatListModule],
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 class ListWithOneItem extends BaseTestList {}
 
@@ -546,7 +546,7 @@ class ListWithOneItem extends BaseTestList {}
     }
   </mat-list>`,
   imports: [MatListModule],
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 class ListWithTwoLineItem extends BaseTestList {}
 
@@ -562,7 +562,7 @@ class ListWithTwoLineItem extends BaseTestList {}
     }
   </mat-list>`,
   imports: [MatListModule],
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 class ListWithThreeLineItem extends BaseTestList {}
 
@@ -578,7 +578,7 @@ class ListWithThreeLineItem extends BaseTestList {}
     </mat-list-item>
   </mat-list>`,
   imports: [MatListModule],
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 class ListWithAvatar extends BaseTestList {}
 
@@ -593,7 +593,7 @@ class ListWithAvatar extends BaseTestList {}
     }
   </mat-list>`,
   imports: [MatListModule],
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 class ListWithItemWithCssClass extends BaseTestList {}
 
@@ -611,7 +611,7 @@ class ListWithItemWithCssClass extends BaseTestList {}
     }
   </mat-list>`,
   imports: [MatListModule],
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 class ListWithDynamicNumberOfLines extends BaseTestList {}
 
@@ -623,7 +623,7 @@ class ListWithDynamicNumberOfLines extends BaseTestList {}
     }
   </mat-list>`,
   imports: [MatListModule],
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 class ListWithMultipleItems extends BaseTestList {}
 
@@ -635,7 +635,7 @@ class ListWithMultipleItems extends BaseTestList {}
     <mat-list-item>Three</mat-list-item>
   </mat-list>`,
   imports: [MatListModule],
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 class ListWithDisabledItems {
   firstItemDisabled = false;
@@ -645,6 +645,6 @@ class ListWithDisabledItems {
 @Component({
   template: `<mat-list-item></mat-list-item>`,
   imports: [MatListModule],
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 class StandaloneListItem {}

--- a/src/material/list/selection-list.spec.ts
+++ b/src/material/list/selection-list.spec.ts
@@ -840,6 +840,17 @@ describe('MatSelectionList without forms', () => {
       expect(selectList.selected.length).toBe(0);
     });
 
+    it('should not show a pointer cursor around radios in disabled single-selection lists', () => {
+      fixture.destroy();
+
+      const singleSelectionFixture = TestBed.createComponent(DisabledSingleSelectionList);
+      singleSelectionFixture.detectChanges();
+
+      const radio = singleSelectionFixture.nativeElement.querySelector('.mdc-radio')!;
+
+      expect(getComputedStyle(radio).cursor).toBe('auto');
+    });
+
     it('should update state of options if list state has changed', () => {
       const testOption = listOption[2].componentInstance as MatListOption;
 
@@ -1699,7 +1710,7 @@ describe('MatSelectionList with forms', () => {
     }
   </mat-selection-list>`,
   imports: [MatListModule],
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 class SelectionListWithListOptions {
   showLastOption = true;
@@ -1728,7 +1739,7 @@ class SelectionListWithListOptions {
     </mat-list-option>
   </mat-selection-list>`,
   imports: [MatListModule],
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 class SelectionListWithCheckboxPositionAfter {}
 
@@ -1749,11 +1760,21 @@ class SelectionListWithCheckboxPositionAfter {}
     </mat-list-option>
   </mat-selection-list>`,
   imports: [MatListModule],
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 class SelectionListWithListDisabled {
   disabled: boolean = true;
 }
+
+@Component({
+  template: `
+  <mat-selection-list [disabled]="true" [multiple]="false">
+    <mat-list-option>Inbox</mat-list-option>
+  </mat-selection-list>`,
+  imports: [MatListModule],
+  changeDetection: ChangeDetectionStrategy.Default,
+})
+class DisabledSingleSelectionList {}
 
 @Component({
   template: `
@@ -1762,7 +1783,7 @@ class SelectionListWithListDisabled {
   </mat-selection-list>
   `,
   imports: [MatListModule],
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 class SelectionListWithDisabledOption {
   disableItem: boolean = false;
@@ -1777,7 +1798,7 @@ class SelectionListWithDisabledOption {
     <mat-list-option>Not selected - Item #4</mat-list-option>
   </mat-selection-list>`,
   imports: [MatListModule],
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 class SelectionListWithSelectedOption {}
 
@@ -1788,7 +1809,7 @@ class SelectionListWithSelectedOption {}
     <mat-list-option [selected]="true">Pre-selected - Item #2</mat-list-option>
   </mat-selection-list>`,
   imports: [MatListModule],
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 class SingleSelectionListWithSelectedOption {}
 
@@ -1798,7 +1819,7 @@ class SingleSelectionListWithSelectedOption {}
     <mat-list-option [selected]="true" [value]="itemValue">Item</mat-list-option>
   </mat-selection-list>`,
   imports: [MatListModule],
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 class SelectionListWithSelectedOptionAndValue {
   itemValue = 'item1';
@@ -1815,7 +1836,7 @@ class SelectionListWithSelectedOptionAndValue {
       }
     </mat-selection-list>`,
   imports: [MatListModule, FormsModule, ReactiveFormsModule],
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 class SelectionListWithModel {
   modelChangeSpy = jasmine.createSpy('model change spy');
@@ -1838,7 +1859,7 @@ class SelectionListWithModel {
     }
   `,
   imports: [MatListModule, FormsModule, ReactiveFormsModule],
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 class SelectionListWithFormControl {
   formControl = new FormControl([] as string[]);
@@ -1853,7 +1874,7 @@ class SelectionListWithFormControl {
       <mat-list-option value="opt2" selected>Option 2</mat-list-option>
     </mat-selection-list>`,
   imports: [MatListModule, FormsModule, ReactiveFormsModule],
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 class SelectionListWithPreselectedOption {
   selectedOptions!: string[];
@@ -1866,7 +1887,7 @@ class SelectionListWithPreselectedOption {
       <mat-list-option value="opt2" selected>Option 2</mat-list-option>
     </mat-selection-list>`,
   imports: [MatListModule, FormsModule, ReactiveFormsModule],
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 class SelectionListWithPreselectedOptionAndModel {
   selectedOptions = ['opt1'];
@@ -1895,7 +1916,7 @@ class SelectionListWithPreselectedFormControlOnPush {
       }
     </mat-selection-list>`,
   imports: [MatListModule, FormsModule, ReactiveFormsModule],
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 class SelectionListWithCustomComparator {
   @ViewChildren(MatListOption) optionInstances!: QueryList<MatListOption>;
@@ -1918,7 +1939,7 @@ class SelectionListWithCustomComparator {
     </mat-selection-list>
   `,
   imports: [MatListModule],
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 class SelectionListWithAvatar {
   togglePosition!: MatListOptionTogglePosition;
@@ -1934,7 +1955,7 @@ class SelectionListWithAvatar {
     </mat-selection-list>
   `,
   imports: [MatListModule],
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 class SelectionListWithIcon {
   togglePosition!: MatListOptionTogglePosition;
@@ -1950,7 +1971,7 @@ class SelectionListWithIcon {
       }
     </mat-selection-list>`,
   imports: [MatListModule],
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 class SelectionListWithIndirectChildOptions {
   @ViewChildren(MatListOption) optionInstances!: QueryList<MatListOption>;
@@ -1963,7 +1984,7 @@ class SelectionListWithIndirectChildOptions {
   </mat-selection-list>
 `,
   imports: [MatListModule],
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 class ListOptionWithTwoWayBinding {
   selected = false;

--- a/src/material/list/testing/list-harness.spec.ts
+++ b/src/material/list/testing/list-harness.spec.ts
@@ -526,7 +526,7 @@ describe('MatSelectionListHarness', () => {
       <mat-list class="test-empty"></mat-list>
   `,
   imports: [MatListModule],
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 class ListHarnessTest {
   disableThirdItem = signal(false);
@@ -567,7 +567,7 @@ class ListHarnessTest {
       <mat-action-list class="test-empty"></mat-action-list>
   `,
   imports: [MatListModule],
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 class ActionListHarnessTest {
   lastClicked!: string;
@@ -610,7 +610,7 @@ class ActionListHarnessTest {
       <mat-nav-list class="test-empty"></mat-nav-list>
   `,
   imports: [MatListModule],
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 class NavListHarnessTest {
   lastClicked!: string;
@@ -654,7 +654,7 @@ class NavListHarnessTest {
     <mat-selection-list class="test-empty" disabled></mat-selection-list>
   `,
   imports: [MatListModule],
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 class SelectionListHarnessTest {
   disableThirdItem = signal(false);


### PR DESCRIPTION
Fixes #31937.

## Summary
- Ensures disabled single-selection list radios do not keep the MDC radio pointer cursor.
- Adds a regression spec for disabled single-selection lists.

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm exec prettier --check src/material/list/list.scss src/material/list/selection-list.spec.ts`
- `pnpm exec stylelint src/material/list/list.scss`
- `git --no-pager diff --check`

Note: `pnpm -s bazelisk test //src/material/list:unit_tests --test_output=errors` was attempted after `bazel mod deps --lockfile_mode=update`, but Bazel analysis failed locally on Windows because no `@@rules_sass+//src/toolchain:toolchain_type` toolchain matched.