### PR TITLE
build: prevent docs site from rendering Aria examples under Material

### DIFF
--- a/docs/src/app/shared/documentation-items/documentation-items.ts
+++ b/docs/src/app/shared/documentation-items/documentation-items.ts
@@ -624,21 +624,26 @@ export class DocumentationItems {
     if (!this._cachedData) {
       const examples = (await import('@angular/components-examples')).EXAMPLE_COMPONENTS;
       const exampleNames = Object.keys(examples);
-      const components = this._processDocs('material', exampleNames, DOCS[COMPONENTS]);
-      const cdk = this._processDocs('cdk', exampleNames, DOCS[CDK]);
-
+      const components = this._processDocs('material', exampleNames, DOCS[COMPONENTS], examples);
+      const cdk = this._processDocs('cdk', exampleNames, DOCS[CDK], examples);
       this._cachedData = {components, cdk, all: [...components, ...cdk], examples};
     }
 
     return this._cachedData;
   }
 
-  private _processDocs(packageName: string, exampleNames: string[], docs: DocItem[]): DocItem[] {
+  private _processDocs(
+    packageName: string,
+    exampleNames: string[],
+    docs: DocItem[],
+    examples: Record<string, LiveExample>,
+  ): DocItem[] {
     for (const doc of docs) {
       doc.packageName = packageName;
       doc.hasStyling ??= packageName === 'material';
       doc.examples = exampleNames.filter(
         key =>
+          examples[key].packagePath.startsWith(packageName) &&
           key.match(RegExp(`^${doc.exampleSpecs.prefix}`)) &&
           !doc.exampleSpecs.exclude?.some(excludeName => key.indexOf(excludeName) === 0),
       );


### PR DESCRIPTION
The Material and Aria examples had a similar naming scheme so we ended up rendering the Aria ones as if they're from Material. For example: https://next.material.angular.dev/components/autocomplete/examples.