### PR TITLE
build: attempt to address flaky test

### DIFF
--- a/src/aria/listbox/listbox.spec.ts
+++ b/src/aria/listbox/listbox.spec.ts
@@ -833,7 +833,7 @@ describe('Listbox', () => {
 
         await type('A');
         expect(isFocused(1)).toBe(true);
-        await new Promise(resolve => setTimeout(resolve, 100));
+        await new Promise(resolve => setTimeout(resolve, 200));
 
         await type('A');
         expect(isFocused(0)).toBe(true);


### PR DESCRIPTION
Tries to resolve a test in the Aria listbox that is flaking on Safari after we switched to using `whenStable`.