### PR TITLE
docs(cdk/dialog): improve dialog example contrast in dark themes

### DIFF
--- a/src/components-examples/cdk/dialog/cdk-dialog-data/cdk-dialog-data-example-dialog.css
+++ b/src/components-examples/cdk/dialog/cdk-dialog-data/cdk-dialog-data-example-dialog.css
@@ -1,6 +1,7 @@
 :host {
   display: block;
   background: #fff;
+  color: CanvasText;
   border-radius: 8px;
   padding: 8px 16px;
 }

--- a/src/components-examples/cdk/dialog/cdk-dialog-overview/cdk-dialog-overview-example-dialog.css
+++ b/src/components-examples/cdk/dialog/cdk-dialog-overview/cdk-dialog-overview-example-dialog.css
@@ -1,6 +1,7 @@
 :host {
   display: block;
   background: #fff;
+  color: CanvasText;
   border-radius: 8px;
   padding: 8px 16px 16px;
 }

--- a/src/components-examples/cdk/dialog/cdk-dialog-styling/cdk-dialog-styling-example-dialog.css
+++ b/src/components-examples/cdk/dialog/cdk-dialog-styling/cdk-dialog-styling-example-dialog.css
@@ -1,6 +1,7 @@
 :host {
   display: block;
   background: #fff;
+  color: CanvasText;
   border-radius: 8px;
   padding: 16px;
   max-width: 500px;


### PR DESCRIPTION
The CDK dialog examples use a white dialog background (`background: #fff`) while inheriting text colors from the surrounding page theme.

In dark themes on material.angular.dev, this results in dialog content being rendered with very low contrast, making headings, labels, and body text difficult to read.

This change adds a foreground text color to the affected dialog example hosts using `CanvasText`, ensuring sufficient contrast against the existing white background while aligning with existing Angular Material usage of system colors.

Affected examples:

* CDK Dialog Overview
* Injecting data when opening a dialog
* CDK Dialog Styling

## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] The commit message follows our guidelines: https://github.com/angular/components/blob/main/CONTRIBUTING.md#commit-message-format
* [ ] Tests for the changes have been added (not applicable for example styling change)
* [ ] Docs have been added / updated (not applicable)

## PR Type

What kind of change does this PR introduce?

* [x] Bugfix
* [ ] Feature
* [ ] Code style update
* [ ] Refactoring
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Other

## What is the current behavior?

Dialog content in several CDK dialog examples becomes difficult to read when viewed in dark themes because the dialog host uses a white background while text inherits colors intended for dark surfaces.

## What is the new behavior?

The affected dialog examples explicitly use `CanvasText` for foreground text, providing readable contrast against the white dialog background across themes.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No
