### PR TITLE
docs: release notes for the v21.2.14 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+<a name="21.2.14"></a>
+# 21.2.14 "amicite-atlas" (2026-06-03)
+No user facing changes in this release
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="22.0.0-rc.3"></a>
 # 22.0.0-rc.3 "ameghinite-ashtray" (2026-06-01)
 ### material


### PR DESCRIPTION
Cherry-picks the changelog from the "21.2.x" branch to the next branch (main).