### PR TITLE
fix(material/timepicker): do not allow intervals less than a second

### DIFF
--- a/src/material/timepicker/util.ts
+++ b/src/material/timepicker/util.ts
@@ -89,6 +89,8 @@ export function generateOptions<D>(
   max: D,
   interval: number,
 ): MatTimepickerOption<D>[] {
+  // Avoid generating intervals less than a second, because it can freeze up the browser.
+  interval = Math.max(interval, 1);
   const options: MatTimepickerOption<D>[] = [];
   let current = adapter.compareTime(min, max) < 1 ? min : max;
 


### PR DESCRIPTION
Passing in a small value for the `interval` parameter in `generateOptions` can cause the page to freeze up.