### PR TITLE
fix(cdk/a11y): avoid prototype conflicts in id generator

### DIFF
--- a/src/cdk/a11y/id-generator.ts
+++ b/src/cdk/a11y/id-generator.ts
@@ -12,8 +12,10 @@ import {APP_ID, inject, Service} from '@angular/core';
  * Keeps track of the ID count per prefix. This helps us make the IDs a bit more deterministic
  * like they were before the service was introduced. Note that ideally we wouldn't have to do
  * this, but there are some internal tests that rely on the IDs.
+ *
+ * Note: use a map to avoid conflicts with built-in properties.
  */
-const counters: Record<string, number> = {};
+const counters = new Map<string, number>();
 
 /** Service that generates unique IDs for DOM nodes. */
 @Service()
@@ -33,10 +35,15 @@ export class _IdGenerator {
       prefix += this._appId;
     }
 
-    if (!counters.hasOwnProperty(prefix)) {
-      counters[prefix] = 0;
+    let count = counters.get(prefix);
+
+    if (count === undefined) {
+      count = 0;
+    } else {
+      count++;
     }
 
-    return `${prefix}${randomize ? _IdGenerator._infix + '-' : ''}${counters[prefix]++}`;
+    counters.set(prefix, count);
+    return `${prefix}${randomize ? _IdGenerator._infix + '-' : ''}${count}`;
   }
 }


### PR DESCRIPTION
Updates the ID generator so we don't run into issues if we try to generate an ID for something like `prototype`.