### PR TITLE
fix(material/form-field): allow empty control properties

### DIFF
--- a/src/material/chips/chip-grid.ts
+++ b/src/material/chips/chip-grid.ts
@@ -155,14 +155,14 @@ export class MatChipGrid
    * @docs-private
    */
   @Input()
-  get placeholder(): string {
+  get placeholder(): string | null | undefined {
     return this._chipInput ? this._chipInput.placeholder : this._placeholder;
   }
-  set placeholder(value: string) {
+  set placeholder(value: string | null | undefined) {
     this._placeholder = value;
     this.stateChanges.next();
   }
-  protected _placeholder = '';
+  protected _placeholder: string | null | undefined = '';
 
   /** Whether any chips or the matChipInput inside of this chip-grid has focus. */
   override get focused(): boolean {

--- a/src/material/chips/chip-input.ts
+++ b/src/material/chips/chip-input.ts
@@ -104,7 +104,7 @@ export class MatChipInput implements MatChipTextControl, OnChanges, OnDestroy {
   readonly chipEnd: EventEmitter<MatChipInputEvent> = new EventEmitter<MatChipInputEvent>();
 
   /** The input's placeholder text. */
-  @Input() placeholder: string = '';
+  @Input() placeholder: string | null | undefined = '';
 
   /** Unique id for the input. */
   @Input() id: string = inject(_IdGenerator).getId('mat-mdc-chip-list-input-');

--- a/src/material/chips/chip-text-control.ts
+++ b/src/material/chips/chip-text-control.ts
@@ -12,7 +12,7 @@ export interface MatChipTextControl {
   id: string;
 
   /** The text control's placeholder text. */
-  placeholder: string;
+  placeholder: string | null | undefined;
 
   /** Whether the text control has browser focus. */
   focused: boolean;

--- a/src/material/form-field/form-field-control.ts
+++ b/src/material/form-field/form-field-control.ts
@@ -26,7 +26,7 @@ export abstract class MatFormFieldControl<T> {
   readonly id!: string;
 
   /** The placeholder for this control. */
-  readonly placeholder!: string;
+  readonly placeholder?: string | null;
 
   /** Gets the AbstractControlDirective for this control. */
   readonly ngControl: NgControl | AbstractControlDirective | null = null;
@@ -41,7 +41,7 @@ export abstract class MatFormFieldControl<T> {
   readonly shouldLabelFloat: boolean = false;
 
   /** Whether the control is required. */
-  readonly required: boolean = false;
+  readonly required?: boolean;
 
   /** Whether the control is disabled. */
   readonly disabled: boolean = false;

--- a/src/material/input/input.ts
+++ b/src/material/input/input.ts
@@ -187,7 +187,7 @@ export class MatInput
    * Implemented as part of MatFormFieldControl.
    * @docs-private
    */
-  @Input() placeholder!: string;
+  @Input() placeholder: string | null | undefined;
 
   /**
    * Name of the input.


### PR DESCRIPTION
Fixes #33353

## Changes

This update makes common form field properties behave more like their native HTML counterparts by allowing them to be omitted or passed as empty values.

Specifically:

- `placeholder` now accepts `null` and `undefined`
- `required` is now optional

The following components/interfaces were updated:

- `MatFormFieldControl`
- `MatInput`
- `MatChipInput`
- `MatChipGrid`
- `MatChipTextControl`

This helps when forwarding optional inputs between components and aligns Angular Material controls more closely with native HTML input behavior.

## Validation

The following tests were run successfully:

- `pnpm bazel test src/material/form-field:form-field_strict_deps_test`
- `pnpm bazel test src/material/input:unit_tests`
- `pnpm bazel test src/material/chips:unit_tests`
