### PR TITLE
fix(material/schematics): update navigation schematic with modern Angular pat...

### DIFF
--- a/src/material/schematics/ng-generate/navigation/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.html.template
+++ b/src/material/schematics/ng-generate/navigation/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.html.template
@@ -1,18 +1,20 @@
 <mat-sidenav-container class="sidenav-container">
   <mat-sidenav #drawer class="sidenav" fixedInViewport
-      [attr.role]="(isHandset$ | async) ? 'dialog' : 'navigation'"
-      [mode]="(isHandset$ | async) ? 'over' : 'side'"
-      [opened]="(isHandset$ | async) === false">
-    <mat-toolbar>Menu</mat-toolbar>
+      [attr.role]="(isHandset()) ? 'dialog' : 'navigation'"
+      [mode]="(isHandset()) ? 'over' : 'side'"
+      [opened]="!(isHandset())">
+    <mat-toolbar>
+      <span>Menu</span>
+    </mat-toolbar>
     <mat-nav-list>
-      <a mat-list-item <%= routing ? 'routerLink="/"' : 'href="#"' %>>Link 1</a>
-      <a mat-list-item <%= routing ? 'routerLink="/"' : 'href="#"' %>>Link 2</a>
-      <a mat-list-item <%= routing ? 'routerLink="/"' : 'href="#"' %>>Link 3</a>
+      <a mat-list-item <%= routing ? 'routerLink="/"' : 'href="#"' %> (click)="drawer.close()">Link 1</a>
+      <a mat-list-item <%= routing ? 'routerLink="/"' : 'href="#"' %> (click)="drawer.close()">Link 2</a>
+      <a mat-list-item <%= routing ? 'routerLink="/"' : 'href="#"' %> (click)="drawer.close()">Link 3</a>
     </mat-nav-list>
   </mat-sidenav>
   <mat-sidenav-content>
-    <mat-toolbar color="primary">
-      @if (isHandset$ | async) {
+    <mat-toolbar class="mat-elevation-z4">
+      @if (isHandset()) {
         <button
           type="button"
           aria-label="Toggle sidenav"
@@ -21,7 +23,7 @@
           <mat-icon aria-label="Side nav toggle icon">menu</mat-icon>
         </button>
       }
-      <span><%= project %></span>
+      <span class="toolbar-title"><%= project %></span>
     </mat-toolbar>
     <!-- Add Content Here -->
   </mat-sidenav-content>

--- a/src/material/schematics/ng-generate/navigation/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.html.template
+++ b/src/material/schematics/ng-generate/navigation/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.html.template
@@ -23,7 +23,7 @@
           <mat-icon aria-label="Side nav toggle icon">menu</mat-icon>
         </button>
       }
-      <span class="toolbar-title"><%= project %></span>
+      <span><%= project %></span>
     </mat-toolbar>
     <!-- Add Content Here -->
   </mat-sidenav-content>

--- a/src/material/schematics/ng-generate/navigation/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.ts.template
+++ b/src/material/schematics/ng-generate/navigation/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.ts.template
@@ -1,4 +1,6 @@
-import { Component, inject, signal, computed<% if(!!viewEncapsulation) { %>, ViewEncapsulation<% }%><% if(changeDetection !== 'Default') { %>, ChangeDetectionStrategy<% }%> } from '@angular/core';
+import { Component, inject<% if(!!viewEncapsulation) { %>, ViewEncapsulation<% }%><% if(changeDetection !== 'Default') { %>, ChangeDetectionStrategy<% }%> } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { map, shareReplay } from 'rxjs/operators';
 import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';<% if(standalone) { %>
 import { NgIf } from '@angular/common';
 import { MatToolbarModule } from '@angular/material/toolbar';
@@ -31,11 +33,11 @@ import { MatIconModule } from '@angular/material/icon';<% } %>
 })
 export class <%= classify(name) %>Component {
   private breakpointObserver = inject(BreakpointObserver);
-  protected isHandset = signal(false);
-
-  constructor() {
-    this.breakpointObserver.observe(Breakpoints.Handset).subscribe(result => {
-      this.isHandset.set(result.matches);
-    });
-  }
+  protected isHandset = toSignal(
+    this.breakpointObserver.observe(Breakpoints.Handset).pipe(
+      map(result => result.matches),
+      shareReplay()
+    ),
+    { initialValue: false }
+  );
 }

--- a/src/material/schematics/ng-generate/navigation/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.ts.template
+++ b/src/material/schematics/ng-generate/navigation/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.ts.template
@@ -1,13 +1,11 @@
-import { Component, inject<% if(!!viewEncapsulation) { %>, ViewEncapsulation<% }%><% if(changeDetection !== 'Default') { %>, ChangeDetectionStrategy<% }%> } from '@angular/core';
+import { Component, inject, signal, computed<% if(!!viewEncapsulation) { %>, ViewEncapsulation<% }%><% if(changeDetection !== 'Default') { %>, ChangeDetectionStrategy<% }%> } from '@angular/core';
 import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';<% if(standalone) { %>
-import { AsyncPipe } from '@angular/common';
+import { NgIf } from '@angular/common';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatButtonModule } from '@angular/material/button';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatListModule } from '@angular/material/list';
 import { MatIconModule } from '@angular/material/icon';<% } %>
-import { Observable } from 'rxjs';
-import { map, shareReplay } from 'rxjs/operators';
 
 @Component({
   selector: '<%= selector %>',<% if(inlineTemplate) { %>
@@ -27,16 +25,17 @@ import { map, shareReplay } from 'rxjs/operators';
     MatSidenavModule,
     MatListModule,
     MatIconModule,
-    AsyncPipe,
+    NgIf,
   ]<% } else { %>,
   standalone: false<% } %>
 })
 export class <%= classify(name) %>Component {
   private breakpointObserver = inject(BreakpointObserver);
+  protected isHandset = signal(false);
 
-  isHandset$: Observable<boolean> = this.breakpointObserver.observe(Breakpoints.Handset)
-    .pipe(
-      map(result => result.matches),
-      shareReplay()
-    );
+  constructor() {
+    this.breakpointObserver.observe(Breakpoints.Handset).subscribe(result => {
+      this.isHandset.set(result.matches);
+    });
+  }
 }


### PR DESCRIPTION
## Problem
The navigation schematic generates code with several issues:

1. **Material 2 → Material 3**: Uses deprecated `color="primary"` attribute
2. **Outdated patterns**: Uses RxJS Observables instead of modern Angular Signals
3. **Mobile UX bug**: Sidenav doesn't close when clicking on navigation items

## Solution
- Replaced `color="primary"` with `mat-elevation-z4` class for Material 3
- Converted Observable `isHandset$` to Signal `isHandset` for modern Angular (17+)
- Added `(click)="drawer.close()"` to nav links for better mobile UX
- Simplified template logic with direct signal calls instead of async pipe

## Testing
- Generated navigation schematic and verified it works without errors
- Mobile sidenav now closes when clicking navigation items
- Template uses modern Angular patterns

Fixes #33381