### PR TITLE
test(multiple): fix aot compilation errors in tests

### DIFF
--- a/src/cdk/drag-drop/directives/drop-list-shared.spec.ts
+++ b/src/cdk/drag-drop/directives/drop-list-shared.spec.ts
@@ -4999,7 +4999,7 @@ export function getHorizontalFixtures(listOrientation: Exclude<DropListOrientati
     <div
       class="drop-list scroll-container"
       cdkDropList
-      cdkDropListOrientation="${listOrientation}"
+      [cdkDropListOrientation]="_listOrientation"
       [cdkDropListData]="items"
       (cdkDropListDropped)="droppedSpy($event)">
       @for (item of items; track item) {
@@ -5021,6 +5021,7 @@ export function getHorizontalFixtures(listOrientation: Exclude<DropListOrientati
   })
   class DraggableInHorizontalDropZone implements AfterViewInit {
     readonly _elementRef = inject(ElementRef);
+    readonly _listOrientation = listOrientation;
 
     @ViewChildren(CdkDrag) dragItems!: QueryList<CdkDrag>;
     @ViewChild(CdkDropList) dropInstance!: CdkDropList;
@@ -5088,7 +5089,7 @@ export function getHorizontalFixtures(listOrientation: Exclude<DropListOrientati
       }
     `,
     template: `
-      <div class="list" cdkDropList cdkDropListOrientation="${listOrientation}">
+      <div class="list" cdkDropList [cdkDropListOrientation]="_listOrientation">
         @for (item of items; track item) {
           <div class="item" cdkDrag>
             {{item}}
@@ -5103,6 +5104,8 @@ export function getHorizontalFixtures(listOrientation: Exclude<DropListOrientati
     changeDetection: ChangeDetectionStrategy.Eager,
   })
   class DraggableInHorizontalFlexDropZoneWithMatchSizePreview {
+    readonly _listOrientation = listOrientation;
+
     @ViewChildren(CdkDrag) dragItems!: QueryList<CdkDrag>;
     items = ['Zero', 'One', 'Two'];
   }
@@ -5170,7 +5173,7 @@ export class DraggableInDropZone implements AfterViewInit {
   startedSpy = jasmine.createSpy('started spy');
   previewContainer: PreviewContainer = 'global';
   dropDisabled = signal(false);
-  dropLockAxis = signal<DragAxis | undefined>(undefined);
+  dropLockAxis = signal<DragAxis | null>(null);
   scale = 1;
 
   ngAfterViewInit() {
@@ -5326,31 +5329,27 @@ class DraggableInDropZoneWithContainer extends DraggableInDropZone {}
 class DraggableInDropZoneWithCustomPreview {
   @ViewChild(CdkDropList) dropInstance!: CdkDropList;
   @ViewChildren(CdkDrag) dragItems!: QueryList<CdkDrag>;
-  items: {label: string; lockAxis?: DragAxis}[] = [
-    {label: 'Zero'},
-    {label: 'One'},
-    {label: 'Two'},
-    {label: 'Three'},
+  items: {label: string; lockAxis: DragAxis | null}[] = [
+    {label: 'Zero', lockAxis: null},
+    {label: 'One', lockAxis: null},
+    {label: 'Two', lockAxis: null},
+    {label: 'Three', lockAxis: null},
   ];
   boundarySelector!: string;
   renderCustomPreview = true;
   matchPreviewSize = false;
   previewClass: string | string[] = [];
   constrainPosition: ((point: Point) => Point) | undefined;
-  dropLockAxis = signal<DragAxis | undefined>(undefined);
+  dropLockAxis = signal<DragAxis | null>(null);
 }
 
 @Component({
   template: `
     <div cdkDropList style="width: 100px; background: pink;">
       @for (item of items; track item) {
-        <div
-          cdkDrag
-          [cdkDragConstrainPosition]="constrainPosition"
-          [cdkDragBoundary]="boundarySelector"
-          style="width: 100%; height: ${ITEM_HEIGHT}px; background: red;">
-            {{item}}
-            <ng-template cdkDragPreview>Hello {{item}}</ng-template>
+        <div cdkDrag style="width: 100%; height: ${ITEM_HEIGHT}px; background: red;">
+          {{item}}
+          <ng-template cdkDragPreview>Hello {{item}}</ng-template>
         </div>
       }
     </div>
@@ -5924,10 +5923,7 @@ class NestedDragsComponent {
   imports: [CdkDrag, NgTemplateOutlet],
   changeDetection: ChangeDetectionStrategy.Eager,
 })
-class NestedDragsThroughTemplate {
-  @ViewChild('container') container!: ElementRef;
-  @ViewChild('item') item!: ElementRef;
-}
+class NestedDragsThroughTemplate extends NestedDragsComponent {}
 
 @Component({
   styles: `

--- a/src/cdk/drag-drop/directives/standalone-drag.spec.ts
+++ b/src/cdk/drag-drop/directives/standalone-drag.spec.ts
@@ -21,7 +21,7 @@ import {
 import {_supportsShadowDom} from '../../platform';
 import {CdkDragHandle} from './drag-handle';
 import {CdkDrag} from './drag';
-import {CDK_DRAG_CONFIG, DragAxis, DragDropConfig} from './config';
+import {CDK_DRAG_CONFIG, DragAxis, DragDropConfig, DragStartDelay} from './config';
 import {DragRef, Point} from '../drag-ref';
 import {
   createComponent,
@@ -1337,7 +1337,7 @@ describe('Standalone CdkDrag', () => {
     let currentTime = 0;
 
     const fixture = createComponent(StandaloneDraggable);
-    fixture.componentInstance.dragStartDelay = '500';
+    fixture.componentInstance.dragStartDelay = '500' as any;
     fixture.detectChanges();
     const dragElement = fixture.componentInstance.dragElement.nativeElement;
 
@@ -1880,8 +1880,8 @@ class StandaloneDraggable {
   startedSpy = jasmine.createSpy('started spy');
   endedSpy = jasmine.createSpy('ended spy');
   releasedSpy = jasmine.createSpy('released spy');
-  boundary: string | HTMLElement | undefined;
-  dragStartDelay: number | string | {touch: number; mouse: number} | undefined;
+  boundary!: string | HTMLElement;
+  dragStartDelay!: DragStartDelay;
   constrainPosition:
     | ((
         userPointerPosition: Point,
@@ -1890,9 +1890,9 @@ class StandaloneDraggable {
         pickupPositionInElement: Point,
       ) => Point)
     | undefined;
-  freeDragPosition?: {x: number; y: number};
+  freeDragPosition!: {x: number; y: number};
   dragDisabled = signal(false);
-  dragLockAxis = signal<DragAxis | undefined>(undefined);
+  dragLockAxis = signal<DragAxis | null>(null);
   scale = 1;
 }
 
@@ -2067,7 +2067,7 @@ class DraggableWithAlternateRoot {
   @ViewChild('dragElement') dragElement!: ElementRef<HTMLElement>;
   @ViewChild('dragRoot') dragRoot!: ElementRef<HTMLElement>;
   @ViewChild(CdkDrag) dragInstance!: CdkDrag;
-  rootElementSelector: string | undefined;
+  rootElementSelector!: string;
 }
 
 @Component({

--- a/src/cdk/drag-drop/directives/standalone-drag.zone.spec.ts
+++ b/src/cdk/drag-drop/directives/standalone-drag.zone.spec.ts
@@ -11,6 +11,7 @@ import {Point} from '../drag-ref';
 import {CdkDrag} from './drag';
 import {createComponent as _createComponent, dragElementViaMouse} from './test-utils.spec';
 import {ComponentFixture} from '@angular/core/testing';
+import {DragStartDelay} from './config';
 
 describe('Standalone CdkDrag Zone.js integration', () => {
   function createComponent<T>(type: Type<T>): ComponentFixture<T> {
@@ -61,8 +62,8 @@ class StandaloneDraggable {
   startedSpy = jasmine.createSpy('started spy');
   endedSpy = jasmine.createSpy('ended spy');
   releasedSpy = jasmine.createSpy('released spy');
-  boundary: string | HTMLElement | undefined;
-  dragStartDelay: number | string | {touch: number; mouse: number} | undefined;
-  constrainPosition: ((point: Point) => Point) | undefined;
-  freeDragPosition: {x: number; y: number} | undefined;
+  boundary!: string | HTMLElement;
+  dragStartDelay!: DragStartDelay;
+  constrainPosition!: (point: Point) => Point;
+  freeDragPosition!: {x: number; y: number};
 }

--- a/src/cdk/testing/private/fake-directionality.ts
+++ b/src/cdk/testing/private/fake-directionality.ts
@@ -7,14 +7,15 @@
  */
 
 import {Direction, Directionality} from '@angular/cdk/bidi';
-import {EventEmitter, signal, WritableSignal} from '@angular/core';
+import {EventEmitter, OnDestroy, Service, signal, WritableSignal} from '@angular/core';
 import {toObservable} from '@angular/core/rxjs-interop';
 import {skip} from 'rxjs/operators';
 
 // Note: ngOnDestroy not needed, but must include it to match the Directionality interface.
 // Implementing the interface ensures the fake stays in sync with the real API.
 // tslint:disable-next-line:no-undecorated-class-with-angular-features lifecycle-hook-interface
-class FakeDirectionality implements Directionality {
+@Service()
+class FakeDirectionality implements Directionality, OnDestroy {
   readonly change: EventEmitter<Direction>;
 
   get value(): Direction {

--- a/src/material-experimental/column-resize/column-resize.spec.ts
+++ b/src/material-experimental/column-resize/column-resize.spec.ts
@@ -278,6 +278,7 @@ abstract class BaseTestComponentRtl extends BaseTestComponent {
   template: getTableTemplate(false),
   imports: [BidiModule, MatTableModule, MatColumnResizeModule],
   changeDetection: ChangeDetectionStrategy.Eager,
+  jit: true, // Due to dynamic template
 })
 class MatResizeTest extends BaseTestComponent {
   @ViewChild(MatColumnResize) columnResize!: AbstractMatColumnResize;
@@ -286,6 +287,7 @@ class MatResizeTest extends BaseTestComponent {
 @Component({
   template: getTableTemplate(false),
   imports: [BidiModule, MatTableModule, MatColumnResizeModule],
+  jit: true, // Due to dynamic template
 })
 class MatResizeOnPushTest extends MatResizeTest {}
 
@@ -293,6 +295,7 @@ class MatResizeOnPushTest extends MatResizeTest {}
   template: getTableTemplate(true),
   imports: [BidiModule, MatTableModule, MatDefaultEnabledColumnResizeModule],
   changeDetection: ChangeDetectionStrategy.Eager,
+  jit: true, // Due to dynamic template
 })
 class MatResizeDefaultTest extends BaseTestComponent {
   @ViewChild(MatDefaultEnabledColumnResize) columnResize!: AbstractMatColumnResize;
@@ -302,6 +305,7 @@ class MatResizeDefaultTest extends BaseTestComponent {
   template: getTableTemplate(true),
   imports: [BidiModule, MatTableModule, MatDefaultEnabledColumnResizeModule],
   changeDetection: ChangeDetectionStrategy.Eager,
+  jit: true, // Due to dynamic template
 })
 class MatResizeDefaultRtlTest extends BaseTestComponentRtl {
   @ViewChild(MatDefaultEnabledColumnResize) columnResize!: AbstractMatColumnResize;
@@ -311,6 +315,7 @@ class MatResizeDefaultRtlTest extends BaseTestComponentRtl {
   template: getFlexTemplate(false),
   imports: [BidiModule, MatTableModule, MatColumnResizeModule],
   changeDetection: ChangeDetectionStrategy.Eager,
+  jit: true, // Due to dynamic template
 })
 class MatResizeFlexTest extends BaseTestComponent {
   @ViewChild(MatColumnResizeFlex) columnResize!: AbstractMatColumnResize;
@@ -320,6 +325,7 @@ class MatResizeFlexTest extends BaseTestComponent {
   template: getFlexTemplate(true),
   imports: [BidiModule, MatTableModule, MatDefaultEnabledColumnResizeModule],
   changeDetection: ChangeDetectionStrategy.Eager,
+  jit: true, // Due to dynamic template
 })
 class MatResizeDefaultFlexTest extends BaseTestComponent {
   @ViewChild(MatDefaultEnabledColumnResizeFlex)
@@ -330,6 +336,7 @@ class MatResizeDefaultFlexTest extends BaseTestComponent {
   template: getFlexTemplate(true),
   imports: [BidiModule, MatTableModule, MatDefaultEnabledColumnResizeModule],
   changeDetection: ChangeDetectionStrategy.Eager,
+  jit: true, // Due to dynamic template
 })
 class MatResizeDefaultFlexRtlTest extends BaseTestComponentRtl {
   @ViewChild(MatDefaultEnabledColumnResizeFlex)


### PR DESCRIPTION
Fixes some ahead-of-time compilation errors in tests that show up when we update to the latest `next` version of Angular.