### PR TITLE
fix(cdk/platform): tolerate composedPath errors during event replay

### DIFF
--- a/src/cdk/platform/features/shadow-dom.ts
+++ b/src/cdk/platform/features/shadow-dom.ts
@@ -59,5 +59,14 @@ export function _getFocusedElementPierceShadowDom(): HTMLElement | null {
 export function _getEventTarget<T extends EventTarget>(event: Event): T | null {
   // If an event is bound outside the Shadow DOM, the `event.target` will
   // point to the shadow root so we have to use `composedPath` instead.
-  return (event.composedPath ? event.composedPath()[0] : event.target) as T | null;
+  if (event.composedPath) {
+    try {
+      return event.composedPath()[0] as T | null;
+    } catch {
+      // Hydration event replay can dispatch wrapper events whose `composedPath`
+      // intentionally throws. Fall back to the event target in that case.
+    }
+  }
+
+  return event.target as T | null;
 }


### PR DESCRIPTION
## Summary

Falls back to `event.target` when `_getEventTarget` cannot read `event.composedPath()`. Angular hydration event replay can dispatch events whose `composedPath()` throws, and this keeps CDK target resolution from crashing in that path while preserving the composed-path behavior for normal Shadow DOM events.

Fixes #33386.

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm exec tsc --ignoreConfig --ignoreDeprecations 6.0 --target ES2022 --module commonjs --moduleResolution node --lib DOM,ES2022 --skipLibCheck --outDir /tmp/angular-smoke-out src/cdk/platform/features/shadow-dom.ts tmp-shadow-dom-smoke.ts`
- `node /tmp/angular-smoke-out/tmp-shadow-dom-smoke.js`
- `pnpm exec prettier --check src/cdk/platform/features/shadow-dom.ts`
- `pnpm exec tsc --ignoreConfig --ignoreDeprecations 6.0 --noEmit --target ES2022 --module nodenext --moduleResolution nodenext --lib DOM,ES2022 --skipLibCheck src/cdk/platform/features/shadow-dom.ts tmp-shadow-dom-smoke.ts`
- `git diff --check`

Note: the temporary smoke file was used only for local verification and is not committed.
