### PR TITLE
fix(material/radio): use default cursor for disabled radios

### DIFF
--- a/src/material/list/selection-list.spec.ts
+++ b/src/material/list/selection-list.spec.ts
@@ -1088,6 +1088,12 @@ describe('MatSelectionList without forms', () => {
       expect(fixture.nativeElement.querySelector('mat-pseudo-checkbox')).toBeFalsy();
     });
 
+    it('should not show a pointer cursor on a disabled radio indicator', () => {
+      const radio = listOptions[0].nativeElement.querySelector('.mdc-radio')!;
+
+      expect(getComputedStyle(radio).cursor).toBe('default');
+    });
+
     it('should not deselect the target option on click', () => {
       const testListItem1 = listOptions[1].injector.get<MatListOption>(MatListOption);
       const selectList =

--- a/src/material/radio/_radio-common.scss
+++ b/src/material/radio/_radio-common.scss
@@ -79,6 +79,10 @@ $fallbacks: m3-radio.get-tokens();
     }
   }
 
+  .mdc-radio--disabled {
+    cursor: default;
+  }
+
   .mdc-radio__background {
     display: inline-block;
     position: relative;


### PR DESCRIPTION
Summary:
- Set disabled MDC radio wrappers to use the default cursor.
- Added a regression test for disabled radio indicators in single-selection lists.

Verification:
- Reproduced the issue with a focused browser test that reported `pointer` for the disabled single-selection radio cursor.
- After the fix the focused list browser test passes in Chromium and Firefox, radio unit tests pass in Chromium and Firefox, the list and radio Bazel build targets pass, and changed files are formatted.

Fixes #31937
