### PR TITLE
fix(cdk/overlay): pass document.body element instead of string to renderer.listen in keyboard dispatcher

### DIFF
--- a/src/cdk/overlay/dispatchers/overlay-keyboard-dispatcher.ts
+++ b/src/cdk/overlay/dispatchers/overlay-keyboard-dispatcher.ts
@@ -28,7 +28,11 @@ export class OverlayKeyboardDispatcher extends BaseOverlayDispatcher {
     // Lazily start dispatcher once first overlay is added
     if (!this._isAttached) {
       this._ngZone.runOutsideAngular(() => {
-        this._cleanupKeydown = this._renderer.listen('body', 'keydown', this._keydownListener);
+        this._cleanupKeydown = this._renderer.listen(
+          this._document.body,
+          'keydown',
+          this._keydownListener,
+        );
       });
 
       this._isAttached = true;


### PR DESCRIPTION
Passing the string 'body' to renderer.listen() routes through the addGlobalEventListener path, which relies on the registered event plugin chain to resolve the target. When a custom RendererFactory2 or event plugin is in the chain (e.g. from provideAnimations()), that path may not support string targets for keyboard events, resulting in NG05102.

Passing the actual document.body element forces the renderer to use the element.addEventListener() path directly, bypassing plugin routing entirely. This is consistent with how OverlayOutsideClickDispatcher already attaches its listeners.