### PR TITLE
fix(cdk/private): guard createPolicy against DOM clobbering

### DIFF
--- a/src/cdk/private/trusted-types.ts
+++ b/src/cdk/private/trusted-types.ts
@@ -45,9 +45,17 @@ function getPolicy(): TrustedTypePolicy | null {
     if (typeof window !== 'undefined') {
       const ttWindow = window as unknown as {trustedTypes?: TrustedTypePolicyFactory};
       if (ttWindow.trustedTypes !== undefined) {
-        policy = ttWindow.trustedTypes.createPolicy('angular#components', {
-          createHTML: (s: string) => s,
-        });
+        try {
+          policy = ttWindow.trustedTypes.createPolicy('angular#components', {
+            createHTML: (s: string) => s,
+          });
+        } catch (error) {
+          // createPolicy can throw if the name is already registered, or if
+          // window.trustedTypes was DOM-clobbered with an HTML element before
+          // Angular bootstrapped. trustedHTMLFromString falls back to plain
+          // strings — sanitization in _setInnerHtml still runs.
+          console.error(error);
+        }
       }
     }
   }


### PR DESCRIPTION
Wraps trustedTypes.createPolicy in a try/catch to handle two failure
cases: the policy name already being registered (e.g. in a micro-frontend
setup), and window.trustedTypes being DOM-clobbered by an HTML element
before Angular bootstraps. In both cases the policy falls back to null,
and trustedHTMLFromString continues to work via plain strings while
sanitization in _setInnerHtml still runs.