### PR TITLE
fix(material/radio): do not set cursor on non interactive radio

### DIFF
--- a/src/material/radio/_radio-common.scss
+++ b/src/material/radio/_radio-common.scss
@@ -23,7 +23,6 @@ $fallbacks: m3-radio.get-tokens();
     box-sizing: content-box;
     width: $_icon-size;
     height: $_icon-size;
-    cursor: pointer;
 
     // This is something we inherited from MDC, but it shouldn't be necessary.
     // Removing it will likely lead to screenshot diffs.
@@ -33,6 +32,8 @@ $fallbacks: m3-radio.get-tokens();
     padding: calc((#{$size-token} - #{$_icon-size}) / 2);
 
     @if ($is-interactive) {
+      cursor: pointer;
+
       // MDC's hover indication comes from their ripple which we don't use.
       &:hover > .mdc-radio__native-control:not([disabled]):not(:focus) {
         & ~ .mdc-radio__background::before {


### PR DESCRIPTION
Fixes that we were setting `cursor: pointer` on radio buttons that aren't interactive.

Fixes #31937.