### PR TITLE
docs(material/toolbar): add navigation bar example

### DIFF
--- a/src/components-examples/material/toolbar/index.ts
+++ b/src/components-examples/material/toolbar/index.ts
@@ -3,3 +3,4 @@ export {ToolbarMultirowExample} from './toolbar-multirow/toolbar-multirow-exampl
 export {ToolbarSimpleExample} from './toolbar-simple/toolbar-simple-example';
 export {ToolbarOverviewExample} from './toolbar-overview/toolbar-overview-example';
 export {ToolbarHarnessExample} from './toolbar-harness/toolbar-harness-example';
+export {ToolbarNavbarExample} from './toolbar-navbar/toolbar-navbar-example';

--- a/src/components-examples/material/toolbar/toolbar-navbar/toolbar-navbar-example.css
+++ b/src/components-examples/material/toolbar/toolbar-navbar/toolbar-navbar-example.css
@@ -1,0 +1,3 @@
+.example-spacer {
+  flex: 1 1 auto;
+}

--- a/src/components-examples/material/toolbar/toolbar-navbar/toolbar-navbar-example.html
+++ b/src/components-examples/material/toolbar/toolbar-navbar/toolbar-navbar-example.html
@@ -1,0 +1,10 @@
+<mat-toolbar>
+  <span>My App</span>
+
+  <span class="example-spacer"></span>
+
+  <a mat-button>Home</a>
+  <a mat-button>Products</a>
+  <a mat-button>Pricing</a>
+  <a mat-button>About</a>
+</mat-toolbar>

--- a/src/components-examples/material/toolbar/toolbar-navbar/toolbar-navbar-example.ts
+++ b/src/components-examples/material/toolbar/toolbar-navbar/toolbar-navbar-example.ts
@@ -1,0 +1,14 @@
+import {Component} from '@angular/core';
+import {MatButtonModule} from '@angular/material/button';
+import {MatToolbarModule} from '@angular/material/toolbar';
+
+/**
+ * @title Toolbar as a navigation bar
+ */
+@Component({
+  selector: 'toolbar-navbar-example',
+  templateUrl: 'toolbar-navbar-example.html',
+  styleUrl: 'toolbar-navbar-example.css',
+  imports: [MatToolbarModule, MatButtonModule],
+})
+export class ToolbarNavbarExample {}

--- a/src/material/toolbar/toolbar.md
+++ b/src/material/toolbar/toolbar.md
@@ -36,6 +36,13 @@ easily accomplished with `display: flex`:
               "file":"toolbar-multirow-example.css", 
               "region":"toolbar-position-content-style"}) -->
 
+### Navigation bar
+
+A common use case for a toolbar is as a navigation bar containing links to
+different sections of an application.
+
+<!-- example(toolbar-navbar) -->
+
 ### Accessibility
 By default, the toolbar assumes that it will be used in a purely decorative fashion and thus sets
 no roles, ARIA attributes, or keyboard shortcuts. This is equivalent to having a sequence of `<div>`


### PR DESCRIPTION
Fixes #33380

## Description

Adds a new toolbar example demonstrating how to build a simple navigation bar using `mat-toolbar`.

The example shows a common application header pattern with:

* An application title aligned to the left
* Navigation links aligned to the right using flex layout

This provides a practical reference for users looking to create a navigation bar with Angular Material's toolbar component.

## Changes

* Added a new `toolbar-navbar` example
* Exported the example from the toolbar examples index
* Added a "Navigation bar" section to the toolbar documentation
* Embedded the new example in the toolbar docs page
