### PR TITLE
docs: add `provideZoneChangeDetection()` to StackBlitz providers

### DIFF
--- a/docs/src/assets/stackblitz/src/main.ts
+++ b/docs/src/assets/stackblitz/src/main.ts
@@ -10,8 +10,11 @@ import {bootstrapApplication} from '@angular/platform-browser';
 import {VERSION as CDK_VERSION} from '@angular/cdk';
 import {VERSION as MAT_VERSION} from '@angular/material/core';
 import {MaterialDocsExample} from './example/material-docs-example';
+import {provideZoneChangeDetection} from '@angular/core';
 
 console.info('Angular CDK version', CDK_VERSION.full);
 console.info('Angular Material version', MAT_VERSION.full);
 
-bootstrapApplication(MaterialDocsExample).catch(err => console.error(err));
+bootstrapApplication(MaterialDocsExample, {providers: [provideZoneChangeDetection()]}).catch(err =>
+  console.error(err),
+);


### PR DESCRIPTION
The documentation examples were made when Zone.js and Eager change detection were default. This has caused issues, see issue: https://github.com/angular/components/issues/33443.

Explicitly providing Zone.js to the StackBlitz examples is one key piece needed in the current times. Until a sweep through all the examples makes them compatible with both new change detection defaults. 

On the scale of: PR to make everything zoneless + OnPush default compatible > PR to make all examples have zone + Eager for now> make one PR to provide zone and separate PR for various component examples for now, I assume the last one like this PR is the most realistic.

edit: my first trial PR for making one component type examples `Eager` (Autocomplete) https://github.com/angular/components/pull/33450 I won't make more PRs for this issue until I get a thumbs up.