### PR TITLE
docs: add `ChangeDetectionStrategy.Eager` to Autocomplete examples

### DIFF
--- a/src/components-examples/material/autocomplete/autocomplete-auto-active-first-option/autocomplete-auto-active-first-option-example.ts
+++ b/src/components-examples/material/autocomplete/autocomplete-auto-active-first-option/autocomplete-auto-active-first-option-example.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {FormControl, FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {Observable} from 'rxjs';
 import {map, startWith} from 'rxjs/operators';
@@ -22,6 +22,7 @@ import {MatFormFieldModule} from '@angular/material/form-field';
     ReactiveFormsModule,
     AsyncPipe,
   ],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 export class AutocompleteAutoActiveFirstOptionExample {
   myControl = new FormControl('');

--- a/src/components-examples/material/autocomplete/autocomplete-display/autocomplete-display-example.ts
+++ b/src/components-examples/material/autocomplete/autocomplete-display/autocomplete-display-example.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {FormControl, FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {Observable} from 'rxjs';
 import {map, startWith} from 'rxjs/operators';
@@ -26,6 +26,7 @@ export interface User {
     ReactiveFormsModule,
     AsyncPipe,
   ],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 export class AutocompleteDisplayExample {
   myControl = new FormControl<string | User>('');

--- a/src/components-examples/material/autocomplete/autocomplete-filter/autocomplete-filter-example.ts
+++ b/src/components-examples/material/autocomplete/autocomplete-filter/autocomplete-filter-example.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {FormControl, FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {Observable} from 'rxjs';
 import {map, startWith} from 'rxjs/operators';
@@ -22,6 +22,7 @@ import {MatFormFieldModule} from '@angular/material/form-field';
     ReactiveFormsModule,
     AsyncPipe,
   ],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 export class AutocompleteFilterExample {
   myControl = new FormControl('');

--- a/src/components-examples/material/autocomplete/autocomplete-harness/autocomplete-harness-example.ts
+++ b/src/components-examples/material/autocomplete/autocomplete-harness/autocomplete-harness-example.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {MatAutocompleteModule} from '@angular/material/autocomplete';
 
 /**
@@ -8,6 +8,7 @@ import {MatAutocompleteModule} from '@angular/material/autocomplete';
   selector: 'autocomplete-harness-example',
   templateUrl: 'autocomplete-harness-example.html',
   imports: [MatAutocompleteModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 export class AutocompleteHarnessExample {
   states = [

--- a/src/components-examples/material/autocomplete/autocomplete-optgroup/autocomplete-optgroup-example.ts
+++ b/src/components-examples/material/autocomplete/autocomplete-optgroup/autocomplete-optgroup-example.ts
@@ -1,4 +1,4 @@
-import {Component, inject} from '@angular/core';
+import {ChangeDetectionStrategy, Component, inject} from '@angular/core';
 import {FormBuilder, FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {Observable} from 'rxjs';
 import {startWith, map} from 'rxjs/operators';
@@ -32,6 +32,7 @@ export const _filter = (opt: string[], value: string): string[] => {
     MatAutocompleteModule,
     AsyncPipe,
   ],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 export class AutocompleteOptgroupExample {
   private _formBuilder = inject(FormBuilder);

--- a/src/components-examples/material/autocomplete/autocomplete-overview/autocomplete-overview-example.ts
+++ b/src/components-examples/material/autocomplete/autocomplete-overview/autocomplete-overview-example.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {FormControl, FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {Observable} from 'rxjs';
 import {map, startWith} from 'rxjs/operators';
@@ -30,6 +30,7 @@ export interface State {
     MatSlideToggleModule,
     AsyncPipe,
   ],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 export class AutocompleteOverviewExample {
   stateCtrl = new FormControl('');

--- a/src/components-examples/material/autocomplete/autocomplete-plain-input/autocomplete-plain-input-example.ts
+++ b/src/components-examples/material/autocomplete/autocomplete-plain-input/autocomplete-plain-input-example.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {FormControl, FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {Observable} from 'rxjs';
 import {startWith, map} from 'rxjs/operators';
@@ -13,6 +13,7 @@ import {MatAutocompleteModule} from '@angular/material/autocomplete';
   templateUrl: 'autocomplete-plain-input-example.html',
   styleUrl: 'autocomplete-plain-input-example.css',
   imports: [FormsModule, MatAutocompleteModule, ReactiveFormsModule, AsyncPipe],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 export class AutocompletePlainInputExample {
   control = new FormControl('');

--- a/src/components-examples/material/autocomplete/autocomplete-require-selection/autocomplete-require-selection-example.ts
+++ b/src/components-examples/material/autocomplete/autocomplete-require-selection/autocomplete-require-selection-example.ts
@@ -1,4 +1,4 @@
-import {Component, ElementRef, ViewChild} from '@angular/core';
+import {ChangeDetectionStrategy, Component, ElementRef, ViewChild} from '@angular/core';
 import {FormControl, FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {MatAutocompleteModule} from '@angular/material/autocomplete';
 import {MatInputModule} from '@angular/material/input';
@@ -18,6 +18,7 @@ import {MatFormFieldModule} from '@angular/material/form-field';
     MatAutocompleteModule,
     ReactiveFormsModule,
   ],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 export class AutocompleteRequireSelectionExample {
   @ViewChild('input') input!: ElementRef<HTMLInputElement>;

--- a/src/components-examples/material/autocomplete/autocomplete-simple/autocomplete-simple-example.ts
+++ b/src/components-examples/material/autocomplete/autocomplete-simple/autocomplete-simple-example.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {FormControl, FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {MatAutocompleteModule} from '@angular/material/autocomplete';
 import {MatInputModule} from '@angular/material/input';
@@ -18,6 +18,7 @@ import {MatFormFieldModule} from '@angular/material/form-field';
     MatAutocompleteModule,
     ReactiveFormsModule,
   ],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 export class AutocompleteSimpleExample {
   myControl = new FormControl('');


### PR DESCRIPTION
The documentation examples were made when Zone.js and Eager change detection were default. This has caused issues, see issue: https://github.com/angular/components/issues/33443.

Explicitly adding `changeDetection: ChangeDetectionStrategy.Eager` to StackBlitz examples is one key piece needed in the current times. Until a sweep through all the examples makes them compatible with both new change detection defaults.

On the scale of: PR to make everything zoneless + OnPush default compatible > PR to make all examples have zone + Eager for now> make one PR to provide zone and separate PR for various component examples for now, I assume the last one like this PR is the most realistic.

This is the first of my proposed "separate PR for various component examples for now" plan. Provided there are no objections, I am just going to go down the line alphabetically in individual PRs.

edit: the zone provider PR: https://github.com/angular/components/pull/33449

edit: I will not open more PRs unless I get maintainer approval