### PR TITLE
fix(aria/combobox): improve autocomplete placeholder text color contrast

### DIFF
--- a/src/components-examples/aria/autocomplete/autocomplete.css
+++ b/src/components-examples/aria/autocomplete/autocomplete.css
@@ -5,6 +5,38 @@
 
   /* stylelint-disable-next-line material/no-prefixes -- Valid in all remotely recent browsers. */
   width: fit-content;
+
+  /* The ::placeholder selectors are intentionally separated.
+  The 'material/no-prefixes' stylelint rule flags the standard ::placeholder
+  when grouped with vendor prefixes. Each prefix is on its own rule to comply.
+  Vendor prefixes are included to ensure consistent placeholder styling
+  across different browsers. */
+
+  /* stylelint-disable-next-line material/no-prefixes -- Provides all prefixes for ::placeholder */
+  input::-webkit-input-placeholder {
+    color: var(--mat-sys-on-surface-variant);
+  }
+
+  /* stylelint-disable-next-line material/no-prefixes -- Provides all prefixes for ::placeholder */
+  input::-moz-placeholder /* Firefox 19+ */ {
+    color: var(--mat-sys-on-surface-variant);
+  }
+
+  /* stylelint-disable-next-line material/no-prefixes -- Provides all prefixes for ::placeholder */
+  input:-ms-input-placeholder /* IE 10+ */ {
+    color: var(--mat-sys-on-surface-variant);
+  }
+
+  /* stylelint-disable-next-line material/no-prefixes -- Provides all prefixes for ::placeholder */
+  input:-moz-placeholder  /* Firefox 18- */ {
+    color: var(--mat-sys-on-surface-variant);
+  }
+
+  /* stylelint-disable-next-line material/no-prefixes -- Provides all prefixes for ::placeholder */
+  input::placeholder {
+    color: var(--mat-sys-on-surface-variant);
+  }
+
 }
 
 .example-search-icon,
@@ -116,12 +148,3 @@ input[ngCombobox]:disabled {
   font-size: 0.9rem;
 }
 
-/* stylelint-disable material/no-prefixes -- Provides all prefixes for ::placeholder */
-input::-webkit-input-placeholder,
-input::-moz-placeholder, /* Firefox 19+ */
-input:-ms-input-placeholder, /* IE 10+ */
-input:-moz-placeholder, /* Firefox 18- */
-input::placeholder {
-  color: var(--mat-sys-on-surface-variant);
-}
-/* stylelint-enable material/no-prefixes */

--- a/src/components-examples/aria/autocomplete/autocomplete.css
+++ b/src/components-examples/aria/autocomplete/autocomplete.css
@@ -12,27 +12,23 @@
   Vendor prefixes are included to ensure consistent placeholder styling
   across different browsers. */
 
-  /* stylelint-disable-next-line material/no-prefixes -- Provides all prefixes for ::placeholder */
+  /* stylelint-disable material/no-prefixes -- Provides all prefixes for ::placeholder */
   input::-webkit-input-placeholder {
     color: var(--mat-sys-on-surface-variant);
   }
 
-  /* stylelint-disable-next-line material/no-prefixes -- Provides all prefixes for ::placeholder */
   input::-moz-placeholder /* Firefox 19+ */ {
     color: var(--mat-sys-on-surface-variant);
   }
 
-  /* stylelint-disable-next-line material/no-prefixes -- Provides all prefixes for ::placeholder */
   input:-ms-input-placeholder /* IE 10+ */ {
     color: var(--mat-sys-on-surface-variant);
   }
 
-  /* stylelint-disable-next-line material/no-prefixes -- Provides all prefixes for ::placeholder */
   input:-moz-placeholder  /* Firefox 18- */ {
     color: var(--mat-sys-on-surface-variant);
   }
 
-  /* stylelint-disable-next-line material/no-prefixes -- Provides all prefixes for ::placeholder */
   input::placeholder {
     color: var(--mat-sys-on-surface-variant);
   }

--- a/src/components-examples/aria/autocomplete/autocomplete.css
+++ b/src/components-examples/aria/autocomplete/autocomplete.css
@@ -10,7 +10,9 @@
   The 'material/no-prefixes' stylelint rule flags the standard ::placeholder
   when grouped with vendor prefixes. Each prefix is on its own rule to comply.
   Vendor prefixes are included to ensure consistent placeholder styling
-  across different browsers. */
+  across different browsers.
+
+  NOTE: These styles are primarily needed for internal testing. */
 
   /* stylelint-disable material/no-prefixes -- Provides all prefixes for ::placeholder */
   input::-webkit-input-placeholder {


### PR DESCRIPTION
Updates Angular Aria's autocomplete styles to improve the text color contrast of the placeholder text to meet accessibilityrequirements and improve text readability.

* [Before screenshot](https://screenshot.googleplex.com/9zXVqJV33v9Ds5S) Contrast 4.38
* [After screenshot](https://screenshot.googleplex.com/3BWhF6cooMbNd7E) Contrast 8.93

Fixes b/477617379