### PR TITLE
docs(material/datepicker): use a distinct color for the comparison range example

### DIFF
--- a/src/components-examples/material/datepicker/date-range-picker-comparison/date-range-picker-comparison-example.css
+++ b/src/components-examples/material/datepicker/date-range-picker-comparison/date-range-picker-comparison-example.css
@@ -1,3 +1,12 @@
 .example-form-field {
   margin: 0 8px 16px 0;
 }
+
+/*
+ * Give the comparison range a distinct color so that it stands out from the
+ * selected range. With the default theme colors the two ranges can look very
+ * similar, which makes the comparison difficult to see.
+ */
+.example-comparison-range-panel {
+  --mat-datepicker-calendar-date-in-comparison-range-state-background-color: rgba(249, 171, 0, 0.4);
+}

--- a/src/components-examples/material/datepicker/date-range-picker-comparison/date-range-picker-comparison-example.html
+++ b/src/components-examples/material/datepicker/date-range-picker-comparison/date-range-picker-comparison-example.html
@@ -10,7 +10,10 @@
   </mat-date-range-input>
   <mat-hint>MM/DD/YYYY – MM/DD/YYYY</mat-hint>
   <mat-datepicker-toggle matIconSuffix [for]="campaignOnePicker"></mat-datepicker-toggle>
-  <mat-date-range-picker #campaignOnePicker></mat-date-range-picker>
+  <mat-date-range-picker
+    #campaignOnePicker
+    panelClass="example-comparison-range-panel"
+  ></mat-date-range-picker>
 </mat-form-field>
 
 <mat-form-field class="example-form-field">
@@ -25,5 +28,8 @@
   </mat-date-range-input>
   <mat-datepicker-toggle matIconSuffix [for]="campaignTwoPicker"></mat-datepicker-toggle>
   <mat-hint>MM/DD/YYYY – MM/DD/YYYY</mat-hint>
-  <mat-date-range-picker #campaignTwoPicker></mat-date-range-picker>
+  <mat-date-range-picker
+    #campaignTwoPicker
+    panelClass="example-comparison-range-panel"
+  ></mat-date-range-picker>
 </mat-form-field>

--- a/src/components-examples/material/datepicker/date-range-picker-comparison/date-range-picker-comparison-example.ts
+++ b/src/components-examples/material/datepicker/date-range-picker-comparison/date-range-picker-comparison-example.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import {Component, ViewEncapsulation} from '@angular/core';
 import {FormControl, FormGroup, FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {provideNativeDateAdapter} from '@angular/material/core';
 import {MatDatepickerModule} from '@angular/material/datepicker';
@@ -13,6 +13,9 @@ const year = today.getFullYear();
   selector: 'date-range-picker-comparison-example',
   templateUrl: 'date-range-picker-comparison-example.html',
   styleUrl: 'date-range-picker-comparison-example.css',
+  // Use no encapsulation so the styles below can reach the calendar, which is
+  // rendered in an overlay outside of this component's DOM.
+  encapsulation: ViewEncapsulation.None,
   providers: [provideNativeDateAdapter()],
   imports: [MatFormFieldModule, MatDatepickerModule, FormsModule, ReactiveFormsModule],
 })


### PR DESCRIPTION
The date range comparison example uses the default theme colors for the selected and comparison ranges. With Material 3 themes like Azure & Blue these two colors look almost identical, so the comparison range is hard to see. This gives the example a distinct comparison color by overriding the comparison-range token on the picker's panel, so the example clearly shows the feature.

Fixes #31663