### PR TITLE
fix(aria/menu): close open submenu when typeahead moves focus in menubar

### DIFF
--- a/src/aria/menu/menu.spec.ts
+++ b/src/aria/menu/menu.spec.ts
@@ -1225,6 +1225,53 @@ describe('Menu Bar Pattern', () => {
       expect(document.activeElement).toBe(undo);
     });
   });
+
+  describe('Typeahead', () => {
+    beforeEach(async () => await setupMenu());
+
+    it('should close the open submenu when typeahead navigates to another menubar item', async () => {
+      const edit = getMenuBarItem('Edit');
+      const view = getMenuBarItem('View');
+
+      // Open the Edit menu.
+      await click(edit!);
+      expect(isExpanded('Edit')).toBeTrue();
+
+      // Typeahead to "View".
+      await keydown(edit!, 'v');
+      expect(document.activeElement).toBe(view);
+      expect(isExpanded('Edit')).toBeFalse();
+      expect(isExpanded('View')).toBeTrue();
+    });
+
+    it('should not open a submenu when typeahead navigates and no menu was previously open', async () => {
+      const file = getMenuBarItem('File');
+      const edit = getMenuBarItem('Edit');
+
+      // Typeahead to "Edit" without opening any menu first.
+      await keydown(file!, 'e');
+      expect(document.activeElement).toBe(edit);
+      expect(isExpanded('Edit')).toBeFalse();
+    });
+
+    it('should keep the open submenu intact when typeahead does not move focus', async () => {
+      const edit = getMenuBarItem('Edit');
+
+      // Open the Edit menu.
+      await click(edit!);
+      expect(isExpanded('Edit')).toBeTrue();
+
+      // Typeahead that matches the already-active item.
+      await keydown(edit!, 'e');
+      expect(document.activeElement).toBe(edit);
+      expect(isExpanded('Edit')).toBeTrue();
+
+      // Typeahead that matches no item.
+      await keydown(edit!, 'x');
+      expect(document.activeElement).toBe(edit);
+      expect(isExpanded('Edit')).toBeTrue();
+    });
+  });
 });
 
 @Component({

--- a/src/aria/private/menu/menu.ts
+++ b/src/aria/private/menu/menu.ts
@@ -520,7 +520,11 @@ export class MenuBarPattern<V> {
       .on('ArrowUp', () => this.inputs.activeItem()?.open({last: true}))
       .on('ArrowDown', () => this.inputs.activeItem()?.open({first: true}))
       .on(this.dynamicSpaceKey, () => this.inputs.activeItem()?.open({first: true}))
-      .on(this.typeaheadRegexp, e => this.listBehavior.search(e.key));
+      .on(this.typeaheadRegexp, e => {
+        const prevItem = this.inputs.activeItem();
+        this.listBehavior.search(e.key);
+        this._switchExpandedItem(prevItem);
+      });
   });
 
   constructor(readonly inputs: MenuBarInputs<V>) {
@@ -591,11 +595,7 @@ export class MenuBarPattern<V> {
   goto(item: MenuItemPattern<V>, opts?: {focusElement?: boolean}) {
     const prevItem = this.inputs.activeItem();
     this.listBehavior.goto(item, opts);
-
-    if (prevItem?.expanded()) {
-      prevItem?.close();
-      this.inputs.activeItem()?.open();
-    }
+    this._switchExpandedItem(prevItem);
 
     if (item === prevItem) {
       if (item.expanded() && item.submenu()?.inputs.activeItem()) {
@@ -609,21 +609,24 @@ export class MenuBarPattern<V> {
   next() {
     const prevItem = this.inputs.activeItem();
     this.listBehavior.next();
-
-    if (prevItem?.expanded()) {
-      prevItem?.close();
-      this.inputs.activeItem()?.open({first: true});
-    }
+    this._switchExpandedItem(prevItem, {first: true});
   }
 
   /** Focuses the previous menu item. */
   prev() {
     const prevItem = this.inputs.activeItem();
     this.listBehavior.prev();
+    this._switchExpandedItem(prevItem, {first: true});
+  }
 
-    if (prevItem?.expanded()) {
-      prevItem?.close();
-      this.inputs.activeItem()?.open({first: true});
+  /**
+   * Moves an open submenu from the previously active item to the newly active item.
+   * Does nothing if the previous item had no open submenu or the active item did not change.
+   */
+  private _switchExpandedItem(prevItem: MenuItemPattern<V> | undefined, opts?: {first?: boolean}) {
+    if (prevItem?.expanded() && this.inputs.activeItem() !== prevItem) {
+      prevItem.close();
+      this.inputs.activeItem()?.open(opts);
     }
   }
 

--- a/src/components-examples/aria/menubar/index.ts
+++ b/src/components-examples/aria/menubar/index.ts
@@ -1,3 +1,4 @@
 export {MenuBarExample} from './menubar/menubar-example';
 export {MenuBarRTLExample} from './menubar-rtl/menubar-rtl-example';
 export {MenuBarDisabledExample} from './menubar-disabled/menubar-disabled-example';
+export {MenuBarTypeaheadExample} from './menubar-typeahead/menubar-typeahead-example';

--- a/src/components-examples/aria/menubar/menubar-typeahead/menubar-typeahead-example.html
+++ b/src/components-examples/aria/menubar/menubar-typeahead/menubar-typeahead-example.html
@@ -1,0 +1,204 @@
+<p class="example-instructions">
+  Focus the menu bar and type a letter to jump between top-level items (e.g. "v" to jump to Vegetables).
+  Open a menu first, then type to see the submenu switch automatically.
+</p>
+
+<div ngMenuBar>
+  <div
+    ngMenuItem
+    #fruitsEl
+    #fruitsItem="ngMenuItem"
+    class="menu-bar-item"
+    value="Fruits" searchTerm="Fruits"
+    [submenu]="fruitsMenu()"
+  >
+    Fruits
+  </div>
+
+  <ng-template
+    [cdkConnectedOverlayOpen]="true"
+    [cdkConnectedOverlay]="{origin: fruitsEl, usePopover: 'inline'}"
+    [cdkConnectedOverlayPositions]="[{originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top', offsetY: 6}]"
+    cdkAttachPopoverAsChild
+  >
+    <div ngMenu #fruitsMenu="ngMenu">
+      <ng-template ngMenuContent>
+        <div ngMenuItem value="Apple" searchTerm="Apple">
+          <span class="example-label">Apple</span>
+        </div>
+
+        <div ngMenuItem value="Banana" searchTerm="Banana">
+          <span class="example-label">Banana</span>
+        </div>
+
+        <div ngMenuItem #citrusEl value="Citrus" searchTerm="Citrus" [submenu]="citrusMenu()">
+          <span class="example-label">Citrus</span>
+          <span class="example-icon example-arrow material-symbols-outlined" translate="no">arrow_right</span>
+        </div>
+
+        <ng-template
+          [cdkConnectedOverlayOpen]="!!fruitsItem.expanded()"
+          [cdkConnectedOverlay]="{origin: citrusEl, usePopover: 'inline'}"
+          [cdkConnectedOverlayPositions]="[{originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6}]"
+          cdkAttachPopoverAsChild
+        >
+          <div ngMenu #citrusMenu="ngMenu">
+            <ng-template ngMenuContent>
+              <div ngMenuItem value="Orange" searchTerm="Orange">
+                <span class="example-label">Orange</span>
+              </div>
+
+              <div ngMenuItem value="Lemon" searchTerm="Lemon">
+                <span class="example-label">Lemon</span>
+              </div>
+
+              <div ngMenuItem value="Grapefruit" searchTerm="Grapefruit">
+                <span class="example-label">Grapefruit</span>
+              </div>
+            </ng-template>
+          </div>
+        </ng-template>
+
+        <div ngMenuItem value="Mango" searchTerm="Mango">
+          <span class="example-label">Mango</span>
+        </div>
+      </ng-template>
+    </div>
+  </ng-template>
+
+  <div
+    ngMenuItem
+    #vegetablesEl
+    #vegetablesItem="ngMenuItem"
+    class="menu-bar-item"
+    value="Vegetables" searchTerm="Vegetables"
+    [submenu]="vegetablesMenu()"
+  >
+    Vegetables
+  </div>
+
+  <ng-template
+    [cdkConnectedOverlayOpen]="true"
+    [cdkConnectedOverlay]="{origin: vegetablesEl, usePopover: 'inline'}"
+    [cdkConnectedOverlayPositions]="[{originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top', offsetY: 6}]"
+    cdkAttachPopoverAsChild
+  >
+    <div ngMenu #vegetablesMenu="ngMenu">
+      <ng-template ngMenuContent>
+        <div ngMenuItem value="Carrot" searchTerm="Carrot">
+          <span class="example-label">Carrot</span>
+        </div>
+
+        <div ngMenuItem value="Broccoli" searchTerm="Broccoli">
+          <span class="example-label">Broccoli</span>
+        </div>
+
+        <div ngMenuItem #leafyEl value="Leafy greens" searchTerm="Leafy greens" [submenu]="leafyMenu()">
+          <span class="example-label">Leafy greens</span>
+          <span class="example-icon example-arrow material-symbols-outlined" translate="no">arrow_right</span>
+        </div>
+
+        <ng-template
+          [cdkConnectedOverlayOpen]="!!vegetablesItem.expanded()"
+          [cdkConnectedOverlay]="{origin: leafyEl, usePopover: 'inline'}"
+          [cdkConnectedOverlayPositions]="[{originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6}]"
+          cdkAttachPopoverAsChild
+        >
+          <div ngMenu #leafyMenu="ngMenu">
+            <ng-template ngMenuContent>
+              <div ngMenuItem value="Spinach" searchTerm="Spinach">
+                <span class="example-label">Spinach</span>
+              </div>
+
+              <div ngMenuItem value="Kale" searchTerm="Kale">
+                <span class="example-label">Kale</span>
+              </div>
+
+              <div ngMenuItem value="Lettuce" searchTerm="Lettuce">
+                <span class="example-label">Lettuce</span>
+              </div>
+            </ng-template>
+          </div>
+        </ng-template>
+
+        <div ngMenuItem value="Tomato" searchTerm="Tomato">
+          <span class="example-label">Tomato</span>
+        </div>
+      </ng-template>
+    </div>
+  </ng-template>
+
+  <div
+    ngMenuItem
+    #grainsEl
+    class="menu-bar-item"
+    value="Grains" searchTerm="Grains"
+    [submenu]="grainsMenu()"
+  >
+    Grains
+  </div>
+
+  <ng-template
+    [cdkConnectedOverlayOpen]="true"
+    [cdkConnectedOverlay]="{origin: grainsEl, usePopover: 'inline'}"
+    [cdkConnectedOverlayPositions]="[{originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top', offsetY: 6}]"
+    cdkAttachPopoverAsChild
+  >
+    <div ngMenu #grainsMenu="ngMenu">
+      <ng-template ngMenuContent>
+        <div ngMenuItem value="Rice" searchTerm="Rice">
+          <span class="example-label">Rice</span>
+        </div>
+
+        <div ngMenuItem value="Wheat" searchTerm="Wheat">
+          <span class="example-label">Wheat</span>
+        </div>
+
+        <div ngMenuItem value="Oats" searchTerm="Oats">
+          <span class="example-label">Oats</span>
+        </div>
+
+        <div ngMenuItem value="Quinoa" searchTerm="Quinoa">
+          <span class="example-label">Quinoa</span>
+        </div>
+      </ng-template>
+    </div>
+  </ng-template>
+
+  <div
+    ngMenuItem
+    #drinksEl
+    class="menu-bar-item"
+    value="Drinks" searchTerm="Drinks"
+    [submenu]="drinksMenu()"
+  >
+    Drinks
+  </div>
+
+  <ng-template
+    [cdkConnectedOverlayOpen]="true"
+    [cdkConnectedOverlay]="{origin: drinksEl, usePopover: 'inline'}"
+    [cdkConnectedOverlayPositions]="[{originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top', offsetY: 6}]"
+    cdkAttachPopoverAsChild
+  >
+    <div ngMenu #drinksMenu="ngMenu">
+      <ng-template ngMenuContent>
+        <div ngMenuItem value="Water" searchTerm="Water">
+          <span class="example-label">Water</span>
+        </div>
+
+        <div ngMenuItem value="Juice" searchTerm="Juice">
+          <span class="example-label">Juice</span>
+        </div>
+
+        <div ngMenuItem value="Tea" searchTerm="Tea">
+          <span class="example-label">Tea</span>
+        </div>
+
+        <div ngMenuItem value="Coffee" searchTerm="Coffee">
+          <span class="example-label">Coffee</span>
+        </div>
+      </ng-template>
+    </div>
+  </ng-template>
+</div>

--- a/src/components-examples/aria/menubar/menubar-typeahead/menubar-typeahead-example.ts
+++ b/src/components-examples/aria/menubar/menubar-typeahead/menubar-typeahead-example.ts
@@ -1,0 +1,19 @@
+import {Component, viewChild} from '@angular/core';
+import {Menu, MenuBar, MenuContent, MenuItem} from '@angular/aria/menu';
+import {OverlayModule} from '@angular/cdk/overlay';
+
+/** @title Menu bar typeahead example. */
+@Component({
+  selector: 'menubar-typeahead-example',
+  templateUrl: 'menubar-typeahead-example.html',
+  styleUrl: '../menubar.css',
+  imports: [Menu, MenuBar, MenuItem, MenuContent, OverlayModule],
+})
+export class MenuBarTypeaheadExample {
+  fruitsMenu = viewChild<Menu<string>>('fruitsMenu');
+  citrusMenu = viewChild<Menu<string>>('citrusMenu');
+  vegetablesMenu = viewChild<Menu<string>>('vegetablesMenu');
+  leafyMenu = viewChild<Menu<string>>('leafyMenu');
+  grainsMenu = viewChild<Menu<string>>('grainsMenu');
+  drinksMenu = viewChild<Menu<string>>('drinksMenu');
+}

--- a/src/components-examples/aria/menubar/menubar.css
+++ b/src/components-examples/aria/menubar/menubar.css
@@ -84,3 +84,9 @@
 [ngMenu] .example-shortcut {
   opacity: 0.65;
 }
+
+.example-instructions {
+  font-size: 0.875rem;
+  opacity: 0.75;
+  margin-bottom: 0.5rem;
+}

--- a/src/dev-app/aria-menubar/menubar-demo.html
+++ b/src/dev-app/aria-menubar/menubar-demo.html
@@ -13,4 +13,9 @@
     <h2>Menu Bar RTL Example</h2>
     <menubar-rtl-example></menubar-rtl-example>
   </div>
+
+  <div class="example-menu-container">
+    <h2>Menu Bar Typeahead Example</h2>
+    <menubar-typeahead-example></menubar-typeahead-example>
+  </div>
 </div>

--- a/src/dev-app/aria-menubar/menubar-demo.ts
+++ b/src/dev-app/aria-menubar/menubar-demo.ts
@@ -11,12 +11,13 @@ import {
   MenuBarExample,
   MenuBarRTLExample,
   MenuBarDisabledExample,
+  MenuBarTypeaheadExample,
 } from '@angular/components-examples/aria/menubar';
 
 @Component({
   templateUrl: 'menubar-demo.html',
   styleUrl: 'menubar-demo.css',
   encapsulation: ViewEncapsulation.None,
-  imports: [MenuBarExample, MenuBarRTLExample, MenuBarDisabledExample],
+  imports: [MenuBarExample, MenuBarRTLExample, MenuBarDisabledExample, MenuBarTypeaheadExample],
 })
 export class MenubarDemo {}


### PR DESCRIPTION
## Summary

When a menubar item was clicked to open its submenu and the user then used typeahead to move focus to another menubar item, the new item's submenu opened while the previously clicked item remained expanded, leaving two submenus open at the same time.

This change makes typeahead navigation in the menubar close the previously expanded item and move the open state to the newly focused item, matching the behavior of arrow key and pointer navigation. If no submenu was open, or typeahead does not move focus (no match, or the match is the already-active item), the expanded state is left untouched.

The duplicated close-and-reopen logic in `goto`, `next` and `prev` was consolidated into a shared `_switchExpandedItem` helper, which typeahead now also uses.

## Changes
- `src/aria/private/menu/menu.ts`: close the previously expanded menubar item when typeahead moves focus; consolidate the logic shared with `goto`/`next`/`prev`.
- `src/aria/menu/menu.spec.ts`: unit tests covering typeahead with an open submenu, with no open submenu, and when focus does not move.
- `src/components-examples/aria/menubar` + `src/dev-app/aria-menubar`: a typeahead example for manual testing in the dev app.

## Testing
- `bazel test //src/aria/menu:unit_tests` passes (Chromium and Firefox).