### PR TITLE
docs: convert AutoComplete/Badge/Button/BottomSheet/ButtonToggle/Input to signals

### DIFF
--- a/src/components-examples/material/autocomplete/autocomplete-require-selection/autocomplete-require-selection-example.html
+++ b/src/components-examples/material/autocomplete/autocomplete-require-selection/autocomplete-require-selection-example.html
@@ -12,7 +12,7 @@ Control value: {{myControl.value || 'empty'}}
            (input)="filter()"
            (focus)="filter()">
     <mat-autocomplete requireSelection #auto="matAutocomplete">
-      @for (option of filteredOptions; track option) {
+      @for (option of filteredOptions(); track option) {
         <mat-option [value]="option">{{option}}</mat-option>
       }
     </mat-autocomplete>

--- a/src/components-examples/material/autocomplete/autocomplete-require-selection/autocomplete-require-selection-example.ts
+++ b/src/components-examples/material/autocomplete/autocomplete-require-selection/autocomplete-require-selection-example.ts
@@ -1,4 +1,4 @@
-import {Component, ElementRef, ViewChild} from '@angular/core';
+import {Component, ElementRef, signal, viewChild} from '@angular/core';
 import {FormControl, FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {MatAutocompleteModule} from '@angular/material/autocomplete';
 import {MatInputModule} from '@angular/material/input';
@@ -20,13 +20,13 @@ import {MatFormFieldModule} from '@angular/material/form-field';
   ],
 })
 export class AutocompleteRequireSelectionExample {
-  @ViewChild('input') input!: ElementRef<HTMLInputElement>;
+  input = viewChild.required<ElementRef<HTMLInputElement>>('input');
   myControl = new FormControl('');
   options: string[] = ['One', 'Two', 'Three', 'Four', 'Five'];
-  filteredOptions: string[] = this.options.slice();
+  filteredOptions = signal<string[]>(this.options.slice());
 
   filter(): void {
-    const filterValue = this.input.nativeElement.value.toLowerCase();
-    this.filteredOptions = this.options.filter(o => o.toLowerCase().includes(filterValue));
+    const filterValue = this.input().nativeElement.value.toLowerCase();
+    this.filteredOptions.set(this.options.filter(o => o.toLowerCase().includes(filterValue)));
   }
 }

--- a/src/components-examples/material/badge/badge-overview/badge-overview-example.html
+++ b/src/components-examples/material/badge/badge-overview/badge-overview-example.html
@@ -19,7 +19,7 @@
 <div class="demo-section">
     Button toggles badge visibility
 <!-- #docregion mat-badge-hide -->
-    <button matButton="elevated" matBadge="7" [matBadgeHidden]="hidden" (click)="toggleBadgeVisibility()">
+    <button matButton="elevated" matBadge="7" [matBadgeHidden]="hidden()" (click)="toggleBadgeVisibility()">
         Hide
     </button>
 <!-- #enddocregion mat-badge-hide -->

--- a/src/components-examples/material/badge/badge-overview/badge-overview-example.ts
+++ b/src/components-examples/material/badge/badge-overview/badge-overview-example.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import {Component, signal} from '@angular/core';
 import {MatIconModule} from '@angular/material/icon';
 import {MatButtonModule} from '@angular/material/button';
 import {MatBadgeModule} from '@angular/material/badge';
@@ -13,9 +13,9 @@ import {MatBadgeModule} from '@angular/material/badge';
   imports: [MatBadgeModule, MatButtonModule, MatIconModule],
 })
 export class BadgeOverviewExample {
-  hidden = false;
+  hidden = signal(false);
 
   toggleBadgeVisibility() {
-    this.hidden = !this.hidden;
+    this.hidden.update(hidden => !hidden);
   }
 }

--- a/src/components-examples/material/bottom-sheet/bottom-sheet-harness/bottom-sheet-harness-example.ts
+++ b/src/components-examples/material/bottom-sheet/bottom-sheet-harness/bottom-sheet-harness-example.ts
@@ -1,4 +1,4 @@
-import {Component, TemplateRef, ViewChild, inject} from '@angular/core';
+import {Component, TemplateRef, inject, viewChild} from '@angular/core';
 import {
   MatBottomSheet,
   MatBottomSheetConfig,
@@ -16,9 +16,9 @@ import {
 export class BottomSheetHarnessExample {
   readonly bottomSheet = inject(MatBottomSheet);
 
-  @ViewChild(TemplateRef) template!: TemplateRef<any>;
+  template = viewChild.required<TemplateRef<any>>(TemplateRef);
 
   open(config?: MatBottomSheetConfig) {
-    return this.bottomSheet.open(this.template, config);
+    return this.bottomSheet.open(this.template(), config);
   }
 }

--- a/src/components-examples/material/button-toggle/button-toggle-forms/button-toggle-forms-example.html
+++ b/src/components-examples/material/button-toggle/button-toggle-forms/button-toggle-forms-example.html
@@ -5,7 +5,7 @@
     <mat-button-toggle value="italic">Italic</mat-button-toggle>
     <mat-button-toggle value="underline">Underline</mat-button-toggle>
   </mat-button-toggle-group>
-  <p>Chosen value is {{fontStyle}}</p>
+  <p>Chosen value is {{fontStyle()}}</p>
 </section>
 
 <section>

--- a/src/components-examples/material/button-toggle/button-toggle-forms/button-toggle-forms-example.ts
+++ b/src/components-examples/material/button-toggle/button-toggle-forms/button-toggle-forms-example.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import {Component, signal} from '@angular/core';
 import {FormControl, FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {MatButtonToggleModule} from '@angular/material/button-toggle';
 
@@ -12,5 +12,5 @@ import {MatButtonToggleModule} from '@angular/material/button-toggle';
 })
 export class ButtonToggleFormsExample {
   fontStyleControl = new FormControl('');
-  fontStyle?: string;
+  fontStyle = signal<string | undefined>(undefined);
 }

--- a/src/components-examples/material/button/button-harness/button-harness-example.html
+++ b/src/components-examples/material/button/button-harness/button-harness-example.html
@@ -1,3 +1,3 @@
-<button id="basic" type="button" matButton (click)="clicked = true">
+<button id="basic" type="button" matButton (click)="clicked.set(true)">
   Basic button
 </button>

--- a/src/components-examples/material/button/button-harness/button-harness-example.spec.ts
+++ b/src/components-examples/material/button/button-harness/button-harness-example.spec.ts
@@ -27,8 +27,8 @@ describe('ButtonHarnessExample', () => {
 
   it('should click a button', async () => {
     const button = await loader.getHarness(MatButtonHarness.with({text: 'Basic button'}));
-    expect(fixture.componentInstance.clicked).toBe(false);
+    expect(fixture.componentInstance.clicked()).toBe(false);
     await button.click();
-    expect(fixture.componentInstance.clicked).toBe(true);
+    expect(fixture.componentInstance.clicked()).toBe(true);
   });
 });

--- a/src/components-examples/material/button/button-harness/button-harness-example.ts
+++ b/src/components-examples/material/button/button-harness/button-harness-example.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import {Component, signal} from '@angular/core';
 import {MatButtonModule} from '@angular/material/button';
 
 /**
@@ -10,5 +10,5 @@ import {MatButtonModule} from '@angular/material/button';
   imports: [MatButtonModule],
 })
 export class ButtonHarnessExample {
-  clicked = false;
+  clicked = signal(false);
 }

--- a/src/components-examples/material/input/input-clearable/input-clearable-example.html
+++ b/src/components-examples/material/input/input-clearable/input-clearable-example.html
@@ -1,8 +1,8 @@
 <mat-form-field class="example-form-field">
   <mat-label>Clearable input</mat-label>
   <input matInput type="text" [(ngModel)]="value">
-  @if (value) {
-    <button matSuffix matIconButton aria-label="Clear" (click)="value=''">
+  @if (value()) {
+    <button matSuffix matIconButton aria-label="Clear" (click)="value.set('')">
       <mat-icon>close</mat-icon>
     </button>
   }

--- a/src/components-examples/material/input/input-clearable/input-clearable-example.ts
+++ b/src/components-examples/material/input/input-clearable/input-clearable-example.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import {Component, signal} from '@angular/core';
 import {MatIconModule} from '@angular/material/icon';
 import {MatButtonModule} from '@angular/material/button';
 import {FormsModule} from '@angular/forms';
@@ -15,5 +15,5 @@ import {MatFormFieldModule} from '@angular/material/form-field';
   imports: [MatFormFieldModule, MatInputModule, FormsModule, MatButtonModule, MatIconModule],
 })
 export class InputClearableExample {
-  value = 'Clear me';
+  value = signal('Clear me');
 }


### PR DESCRIPTION
## Description

Converts autocomplete, badge, button, bottom sheet, button toggle, and input examples to use signals.

Part of an effort to address this issue about compatibility with new defaults: https://github.com/angular/components/issues/33443

As I have said in my edits but not upfront, I vastly underestimated how ready most other components are. Sorry. 

## PR scope

I thought that 6 components worth of changes was a good chunk. There is more chunks to come for other components. 

If need be, I am also doing each component branch by branch, so this PR could be broken up or consolidated after later chunks.

## Extras

I have been tracking these changes in a gist, this chunk tracked in this comment of it: https://gist.github.com/msmallest/f77adb004b9e88c49b3a248bab90a26a?permalink_comment_id=6235821#gistcomment-6235821