### PR TITLE
fix(material/datepicker): use rounded shape for calendar focus indicators

### DIFF
--- a/src/material/datepicker/calendar-body.scss
+++ b/src/material/datepicker/calendar-body.scss
@@ -261,6 +261,10 @@ $fallbacks: m3-datepicker.get-tokens();
     position: absolute;
   }
 
+  &::before {
+    border-radius: 50%;
+  }
+
   @include cdk.high-contrast {
     border: none;
   }


### PR DESCRIPTION
Makes the strong focus indicators in the calendar rounded to match the calendar cells.

Relates to #33517.