### PR TITLE
fix(material/button): match focus indicator shape to FAB

### DIFF
--- a/src/material/button/fab.scss
+++ b/src/material/button/fab.scss
@@ -6,6 +6,9 @@
 @use './m3-fab';
 
 $fallbacks: m3-fab.get-tokens();
+$indicator-border-width: focus-indicators-private.$default-border-width;
+$border-width: var(--mat-focus-indicator-border-width, #{$indicator-border-width});
+$indicator-offset: calc(#{$border-width} + 2px);
 
 .mat-mdc-fab-base {
   @include vendor-prefixes.user-select(none);
@@ -81,10 +84,9 @@ $fallbacks: m3-fab.get-tokens();
   }
 
   .mat-focus-indicator::before {
-    $default-border-width: focus-indicators-private.$default-border-width;
-    $border-width: var(--mat-focus-indicator-border-width, #{$default-border-width});
-    $offset: calc(#{$border-width} + 2px);
-    margin: calc(#{$offset} * -1);
+    margin: calc(#{$indicator-offset} * -1);
+    border-radius: calc(#{token-utils.slot(fab-container-shape, $fallbacks)} +
+      #{$indicator-offset});
   }
 
   @include button-base.mat-private-button-disabled {
@@ -147,6 +149,11 @@ $fallbacks: m3-fab.get-tokens();
 
   &:active, &:focus:active {
     box-shadow: token-utils.slot(fab-small-pressed-container-elevation-shadow, $fallbacks);
+  }
+
+  .mat-focus-indicator::before {
+    border-radius: calc(#{token-utils.slot(fab-small-container-shape, $fallbacks)} +
+      #{$indicator-offset});
   }
 
   @include button-base.mat-private-button-disabled {


### PR DESCRIPTION
Updates the FAB's focus indicator to match the shape of the button.

Relates to #33517.