### PR TITLE
fix(material/expansion): always reset outline

### DIFF
--- a/src/material/expansion/expansion-panel-header.scss
+++ b/src/material/expansion/expansion-panel-header.scss
@@ -11,6 +11,7 @@ $fallbacks: m3-expansion.get-tokens();
   align-items: center;
   padding: 0 24px;
   border-radius: inherit;
+  outline: 0;
 
   .mat-expansion-panel-animations-enabled & {
     transition: height expansion-variables.$header-transition;
@@ -58,11 +59,6 @@ $fallbacks: m3-expansion.get-tokens();
 
   &._mat-animation-noopable {
     transition: none;
-  }
-
-  &:focus,
-  &:hover {
-    outline: none;
   }
 
   &.mat-expanded:focus,


### PR DESCRIPTION
Currently we only reset the outline on `focus` and `hover` which doesn't cover some of the new states like `focus-visible`. This can be seen when simulating the state in the dev tools.