### PR TITLE
docs(material/table): remove unnecessary template literals

### DIFF
--- a/src/components-examples/material/table/table-generated-columns/table-generated-columns-example.ts
+++ b/src/components-examples/material/table/table-generated-columns/table-generated-columns-example.ts
@@ -40,7 +40,7 @@ export class TableGeneratedColumnsExample {
     {
       columnDef: 'name',
       header: 'Name',
-      cell: (element: PeriodicElement) => `${element.name}`,
+      cell: (element: PeriodicElement) => element.name,
     },
     {
       columnDef: 'weight',
@@ -50,7 +50,7 @@ export class TableGeneratedColumnsExample {
     {
       columnDef: 'symbol',
       header: 'Symbol',
-      cell: (element: PeriodicElement) => `${element.symbol}`,
+      cell: (element: PeriodicElement) => element.symbol,
     },
   ];
   dataSource = ELEMENT_DATA;


### PR DESCRIPTION
## Description

Removes unnecessary template literals from the generated columns table example since `name` and `symbol` are already strings.

Fixes #33457