### PR TITLE
fix(cdk/drag-drop): reset popover overflow

### DIFF
--- a/src/cdk/drag-drop/resets.scss
+++ b/src/cdk/drag-drop/resets.scss
@@ -4,6 +4,7 @@
     border: none;
     padding: 0;
     color: inherit;
+    overflow: visible;
 
     // Chrome sets a user agent style of `inset: 0` which combined
     // with `align-self` can break the positioning (see #29809).


### PR DESCRIPTION
Resets the `overflow: auto` that the drag preview gets from the user agent styles.

Fixes #33551.