### PR TITLE
fix(angular/material-luxon-adapter): preserve timezone on .clone()

### DIFF
--- a/src/material-luxon-adapter/adapter/luxon-date-adapter.spec.ts
+++ b/src/material-luxon-adapter/adapter/luxon-date-adapter.spec.ts
@@ -418,6 +418,22 @@ describe('LuxonDateAdapter', () => {
     expect(clone.toISO()).toEqual(date.toISO());
   });
 
+  it('should respect timezone on clone', () => {
+    const dateLocal = DateTime.local(2017, JAN, 1);
+    const dateInCet = dateLocal.setZone('Europe/Budapest');
+    const cloneInCet = adapter.clone(dateInCet);
+    const dateInPst = dateLocal.setZone('America/Los_Angeles');
+    const cloneInPst = adapter.clone(dateInPst);
+
+    expect(cloneInCet).not.toBe(dateInCet);
+    expect(cloneInCet.toISO()).toEqual(dateInCet.toISO());
+    expect(cloneInCet.zone).toEqual(dateInCet.zone);
+
+    expect(cloneInPst).not.toBe(dateInPst);
+    expect(cloneInPst.toISO()).toEqual(dateInPst.toISO());
+    expect(cloneInPst.zone).toEqual(dateInPst.zone);
+  });
+
   it('should compare dates', () => {
     expect(
       adapter.compareDate(DateTime.local(2017, JAN, 1), DateTime.local(2017, JAN, 2)),

--- a/src/material-luxon-adapter/adapter/luxon-date-adapter.ts
+++ b/src/material-luxon-adapter/adapter/luxon-date-adapter.ts
@@ -134,7 +134,10 @@ export class LuxonDateAdapter extends DateAdapter<LuxonDateTime> {
   }
 
   clone(date: LuxonDateTime): LuxonDateTime {
-    return LuxonDateTime.fromObject(date.toObject(), this._getOptions());
+    return LuxonDateTime.fromObject(date.toObject(), {
+      ...this._getOptions(),
+      zone: date.zone,
+    });
   }
 
   createDate(year: number, month: number, date: number): LuxonDateTime {


### PR DESCRIPTION
fix(angular/material-luxon-adapter): preserve timezone on .clone()

Fixes a bug in the Angular Material LuxonDateAdapter where the .clone() method didn't clone the zone of the original DateTime object and caused issues with the TimePicker component.

Fixes #33563