### PR TITLE
fix(material/chips): update chips minimum touch target to 48px

### DIFF
--- a/src/dev-app/chips/chips-demo.scss
+++ b/src/dev-app/chips/chips-demo.scss
@@ -18,7 +18,7 @@
   }
 
   .mat-mdc-basic-chip {
-    margin: auto 10px;
+    margin: 8px 10px;
   }
 
   mat-chip-grid input {

--- a/src/dev-app/chips/chips-demo.scss
+++ b/src/dev-app/chips/chips-demo.scss
@@ -18,7 +18,7 @@
   }
 
   .mat-mdc-basic-chip {
-    margin: 8px 10px;
+    margin: 16px 10px;
   }
 
   mat-chip-grid input {

--- a/src/material/chips/_m2-chip.scss
+++ b/src/material/chips/_m2-chip.scss
@@ -6,6 +6,11 @@
 @function get-tokens($theme) {
   $system: m2-utils.get-system($theme);
   $density-scale: theming.clamp-density(map.get($system, density-scale), -2);
+  $touch-target-display: block;
+
+  @if $density-scale < 0 {
+    $touch-target-display: none;
+  }
 
   @return (
     base: (
@@ -43,7 +48,8 @@
       chip-container-height: map.get((
         0: 32px,
         -1: 28px,
-        -2: 24px), $density-scale)
+        -2: 24px), $density-scale),
+        chip-touch-target-display: $touch-target-display,
     ),
   );
 }

--- a/src/material/chips/_m3-chip.scss
+++ b/src/material/chips/_m3-chip.scss
@@ -77,5 +77,6 @@
 
   @return (
     chip-container-height: list.nth((32px, 28px, 24px), $index),
+    chip-touch-target-display: list.nth((block, none, none), $index),
   );
 }

--- a/src/material/chips/chip-option.html
+++ b/src/material/chips/chip-option.html
@@ -27,6 +27,7 @@
       <ng-content></ng-content>
       <span class="mat-mdc-chip-primary-focus-indicator mat-focus-indicator"></span>
     </span>
+    <span class="mat-mdc-chip-touch-target"></span>
   </button>
 </span>
 

--- a/src/material/chips/chip-row.html
+++ b/src/material/chips/chip-row.html
@@ -31,6 +31,7 @@
 
     <span class="mat-mdc-chip-primary-focus-indicator mat-focus-indicator" aria-hidden="true"></span>
   </span>
+  <span class="mat-mdc-chip-touch-target"></span>
 </span>
 
 @if (_hasTrailingIcon()) {

--- a/src/material/chips/chip-set.scss
+++ b/src/material/chips/chip-set.scss
@@ -16,7 +16,7 @@
   }
 
   .mdc-evolution-chip {
-    margin: 4px 0 4px 8px;
+    margin: 8px 0 8px 8px;
   }
 
   [dir='rtl'] & {

--- a/src/material/chips/chip.html
+++ b/src/material/chips/chip.html
@@ -11,6 +11,7 @@
       <ng-content></ng-content>
       <span class="mat-mdc-chip-primary-focus-indicator mat-focus-indicator"></span>
     </span>
+    <span class="mat-mdc-chip-touch-target"></span>
   </span>
 </span>
 

--- a/src/material/chips/chip.scss
+++ b/src/material/chips/chip.scss
@@ -32,10 +32,10 @@ $fallbacks: m3-chip.get-tokens();
 .mat-mdc-standard-chip,
 .mat-mdc-basic-chip,
 .mat-mdc-evolution-chip {
-  /* Ensures basic/unstyled chips also have a 32px min-height baseline */
+  // Ensures basic/unstyled chips also have a 32px min-height baseline.
   min-height: 32px;
 
-  /* 8px top and bottom margin for 48px touch target separation */
+  // 8px top and bottom margin for 48px touch target separation.
   margin-top: $_touch-target-vertical-padding;
   margin-bottom: $_touch-target-vertical-padding;
 }

--- a/src/material/chips/chip.scss
+++ b/src/material/chips/chip.scss
@@ -12,6 +12,8 @@ $_graphic-padding: 6px;
 $_trailing-action-padding: 8px;
 $_avatar-leading-padding: 4px;
 $_avatar-trailing-padding: 8px;
+$_touch-target-size: 48px;
+$_touch-target-vertical-padding: 8px;
 
 $fallbacks: m3-chip.get-tokens();
 
@@ -25,6 +27,27 @@ $fallbacks: m3-chip.get-tokens();
 .mdc-evolution-chip {
   position: relative;
   max-width: 100%;
+}
+
+.mat-mdc-standard-chip,
+.mat-mdc-basic-chip,
+.mat-mdc-evolution-chip {
+  /* Ensures basic/unstyled chips also have a 32px min-height baseline */
+  min-height: 32px;
+
+  /* 8px top and bottom margin for 48px touch target separation */
+  margin-top: $_touch-target-vertical-padding;
+  margin-bottom: $_touch-target-vertical-padding;
+}
+
+.mat-mdc-chip-touch-target {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  right: 0;
+  height: $_touch-target-size;
+  transform: translateY(-50%);
+  pointer-events: auto;
 }
 
 .mdc-evolution-chip__cell,

--- a/src/material/chips/chip.scss
+++ b/src/material/chips/chip.scss
@@ -29,17 +29,6 @@ $fallbacks: m3-chip.get-tokens();
   max-width: 100%;
 }
 
-.mat-mdc-standard-chip,
-.mat-mdc-basic-chip,
-.mat-mdc-evolution-chip {
-  // Ensures basic/unstyled chips also have a 32px min-height baseline.
-  min-height: 32px;
-
-  // 8px top and bottom margin for 48px touch target separation.
-  margin-top: $_touch-target-vertical-padding;
-  margin-bottom: $_touch-target-vertical-padding;
-}
-
 .mat-mdc-chip-touch-target {
   position: absolute;
   top: 50%;
@@ -47,6 +36,7 @@ $fallbacks: m3-chip.get-tokens();
   right: 0;
   height: $_touch-target-size;
   transform: translateY(-50%);
+  display: token-utils.slot(chip-touch-target-display, $fallbacks);
   pointer-events: auto;
 }
 

--- a/src/material/chips/chip.scss
+++ b/src/material/chips/chip.scss
@@ -13,7 +13,6 @@ $_trailing-action-padding: 8px;
 $_avatar-leading-padding: 4px;
 $_avatar-trailing-padding: 8px;
 $_touch-target-size: 48px;
-$_touch-target-vertical-padding: 8px;
 
 $fallbacks: m3-chip.get-tokens();
 


### PR DESCRIPTION
Updates Angular Components' Chips component so that chips use a touch-target span similar to buttons to ensure that chips meet the minimum touch-target size of 48x48 for accessibility standards.

* [UPDATED post-review commit After screenshot: has purple outline to show no overlapping of touch-targets](https://screenshot.googleplex.com/AoBWW7nSnk3G3RL)
* [UPDATED post-review commit After screencast: shows implementation of touch-target span and triggering chip in the touch-target space](https://screencast.googleplex.com/cast/NDk2MTU1MjQxMDA4MzMyOHxmMjE0ZWU2OC0yNA)

Fixes b/537441584