### PR TITLE
fix(multiple): avoid instanceof checks in aria directives

### DIFF
--- a/src/aria/private/listbox/listbox.ts
+++ b/src/aria/private/listbox/listbox.ts
@@ -292,11 +292,11 @@ export class ListboxPattern<V> {
   }
 
   protected _getItem(e: PointerEvent) {
-    if (!(e.target instanceof HTMLElement)) {
+    if (!e.target) {
       return;
     }
 
-    const element = e.target.closest('[role="option"]');
+    const element = (e.target as Element).closest('[role="option"]');
     return this.inputs.items().find(i => i.element() === element);
   }
 }

--- a/src/aria/private/tabs/tabs.ts
+++ b/src/aria/private/tabs/tabs.ts
@@ -296,11 +296,11 @@ export class TabListPattern {
 
   /** Returns the tab item associated with the given pointer event. */
   private _getItem(e: PointerEvent) {
-    if (!(e.target instanceof HTMLElement)) {
+    if (!e.target) {
       return;
     }
 
-    const element = e.target.closest('[role="tab"]');
+    const element = (e.target as Element).closest('[role="tab"]');
     return this.inputs.items().find(i => i.element() === element);
   }
 }

--- a/src/aria/private/tree/tree.ts
+++ b/src/aria/private/tree/tree.ts
@@ -479,10 +479,10 @@ export class TreePattern<V> implements TreeInputs<V> {
 
   /** Retrieves the TreeItemPattern associated with a DOM event, if any. */
   protected _getItem(event: Event): TreeItemPattern<V> | undefined {
-    if (!(event.target instanceof HTMLElement)) {
+    if (!event.target) {
       return;
     }
-    const element = event.target.closest('[role="treeitem"]');
+    const element = (event.target as Element).closest('[role="treeitem"]');
     return this.inputs.items().find(i => i.element() === element);
   }
 }


### PR DESCRIPTION
We were using `instanceof HTMLElement` in a few Aria directives. This excludes SVG elements and can be problematic for SSR.

Fixes #33586.