### PR TITLE
docs: add signal form example for button toggle

### DIFF
--- a/src/components-examples/material/button-toggle/button-toggle-forms/button-toggle-forms-example.html
+++ b/src/components-examples/material/button-toggle/button-toggle-forms/button-toggle-forms-example.html
@@ -1,4 +1,14 @@
 <section>
+  <h4>Button Toggle inside of a Signal form</h4>
+  <mat-button-toggle-group [formField]="fontStyleForm" aria-label="Font Style">
+    <mat-button-toggle value="bold">Bold</mat-button-toggle>
+    <mat-button-toggle value="italic">Italic</mat-button-toggle>
+    <mat-button-toggle value="underline">Underline</mat-button-toggle>
+  </mat-button-toggle-group>
+  <p>Chosen value is {{ fontStyleForm().value() }}</p>
+</section>
+
+<section>
   <h4>Button Toggle inside of a Template-driven form</h4>
   <mat-button-toggle-group [(ngModel)]="fontStyle" aria-label="Font Style">
     <mat-button-toggle value="bold">Bold</mat-button-toggle>

--- a/src/components-examples/material/button-toggle/button-toggle-forms/button-toggle-forms-example.ts
+++ b/src/components-examples/material/button-toggle/button-toggle-forms/button-toggle-forms-example.ts
@@ -1,5 +1,6 @@
 import {Component, signal} from '@angular/core';
 import {FormControl, FormsModule, ReactiveFormsModule} from '@angular/forms';
+import {form, FormField} from '@angular/forms/signals';
 import {MatButtonToggleModule} from '@angular/material/button-toggle';
 
 /**
@@ -8,9 +9,10 @@ import {MatButtonToggleModule} from '@angular/material/button-toggle';
 @Component({
   selector: 'button-toggle-forms-example',
   templateUrl: 'button-toggle-forms-example.html',
-  imports: [MatButtonToggleModule, FormsModule, ReactiveFormsModule],
+  imports: [MatButtonToggleModule, FormsModule, ReactiveFormsModule, FormField],
 })
 export class ButtonToggleFormsExample {
-  fontStyleControl = new FormControl('');
-  fontStyle = signal<string | undefined>(undefined);
+  readonly fontStyleControl = new FormControl('');
+  readonly fontStyle = signal<string | undefined>(undefined);
+  readonly fontStyleForm = form(signal(''));
 }

--- a/src/material/button-toggle/button-toggle.md
+++ b/src/material/button-toggle/button-toggle.md
@@ -24,9 +24,8 @@ be configured globally using the `MAT_BUTTON_TOGGLE_DEFAULT_OPTIONS` injection t
 
 <!-- example(button-toggle-appearance) -->
 
-### Use with `@angular/forms`
-`<mat-button-toggle-group>` is compatible with `@angular/forms` and supports both `FormsModule`
-and `ReactiveFormsModule`.
+### Use with Angular Forms
+`<mat-button-toggle-group>` is compatible with `@angular/forms` and supports `FormField`, `FormsModule`, and `ReactiveFormsModule`.
 
 ### Orientation
 The button-toggles can be rendered in a vertical orientation by adding the `vertical` attribute.


### PR DESCRIPTION
## Description

To begin to address signal form documentation that I brought up in https://github.com/angular/components/issues/32072#issuecomment-4773039751.

## Background

It was nice to see the stepper get signal form support and be paired with a new documentation example. Thank you. That inspired me to start rolling out examples for signal form examples. Provided this doc contribution works out, I have more examples that I plan to add via later PRs, in more convenient chunks to review.