### PR TITLE
fix(material/dialog): do not expose CDK dialog ref to users

### DIFF
--- a/src/material/dialog/dialog.spec.ts
+++ b/src/material/dialog/dialog.spec.ts
@@ -31,6 +31,7 @@ import {
   inject,
   inputBinding,
 } from '@angular/core';
+import {DialogRef} from '@angular/cdk/dialog';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {Subject} from 'rxjs';
@@ -871,6 +872,14 @@ describe('MatDialog', () => {
 
     dialogRef.removePanelClass('custom-class-one');
     expect(pane.classList).not.toContain('custom-class-one', 'Expected class to be removed');
+  });
+
+  it('should not inject the CDK dialog ref into the child component', () => {
+    const dialogRef = dialog.open(PizzaMsg, {viewContainerRef: testViewContainerRef});
+    viewContainerFixture.detectChanges();
+
+    expect(dialogRef.componentInstance.cdkDialogRef).toBe(null);
+    expect(dialogRef.componentInstance.dialogRef).toBeTruthy();
   });
 
   describe('disableClose option', () => {
@@ -2372,6 +2381,7 @@ class PizzaMsg {
   dialogRef = inject<MatDialogRef<PizzaMsg>>(MatDialogRef);
   dialogInjector = inject(Injector);
   directionality = inject(Directionality);
+  cdkDialogRef = inject(DialogRef, {optional: true});
 }
 
 @Component({

--- a/src/material/dialog/dialog.ts
+++ b/src/material/dialog/dialog.ts
@@ -26,7 +26,7 @@ import {MatDialogConfig} from './dialog-config';
 import {MatDialogContainer} from './dialog-container';
 import {MatDialogRef} from './dialog-ref';
 import {defer, Observable, Subject} from 'rxjs';
-import {Dialog, DialogConfig} from '@angular/cdk/dialog';
+import {Dialog, DialogConfig, DialogRef} from '@angular/cdk/dialog';
 import {startWith} from 'rxjs/operators';
 import {_IdGenerator} from '@angular/cdk/a11y';
 import {_animationsDisabled} from '../core';
@@ -178,6 +178,7 @@ export class MatDialog implements OnDestroy {
           {provide: this._dialogContainerType, useValue: dialogContainer},
           {provide: this._dialogDataToken, useValue: cdkConfig.data},
           {provide: this._dialogRefConstructor, useValue: dialogRef},
+          {provide: DialogRef, useValue: null},
         ];
       },
     });


### PR DESCRIPTION
Fixes that we were exposing both the CDK and Material dialog refs to users which can be confusing.

Fixes #33601.