### PR TITLE
fix(material/chips): add presentation role to container elements

### DIFF
--- a/src/material/chips/chip-option.html
+++ b/src/material/chips/chip-option.html
@@ -1,6 +1,6 @@
 <span class="mat-mdc-chip-focus-overlay"></span>
 
-<span class="mdc-evolution-chip__cell mdc-evolution-chip__cell--primary">
+<span class="mdc-evolution-chip__cell mdc-evolution-chip__cell--primary" role="presentation">
   <button
     matChipAction
     [_allowFocusWhenDisabled]="true"
@@ -31,7 +31,7 @@
 </span>
 
 @if (_hasTrailingIcon()) {
-  <span class="mdc-evolution-chip__cell mdc-evolution-chip__cell--trailing">
+  <span class="mdc-evolution-chip__cell mdc-evolution-chip__cell--trailing" role="presentation">
     <ng-content select="mat-chip-trailing-icon,[matChipRemove],[matChipTrailingIcon]"></ng-content>
   </span>
 }


### PR DESCRIPTION
Adds `role="presentation"` on a few containers that appear to affect some screen readers.

Fixes #33604.