### PR TITLE
docs: mention `FormField` in Radio and Slide Toggle

### DIFF
--- a/src/material/radio/radio.md
+++ b/src/material/radio/radio.md
@@ -24,8 +24,8 @@ would make that impossible (e.g., radio-buttons inside of table cells). The radi
 Individual radio-buttons inside of a radio-group will inherit the `name` of the group.
 
 
-### Use with `@angular/forms`
-`<mat-radio-group>` is compatible with `@angular/forms` and supports both `FormsModule`
+### Use with Angular Forms
+`<mat-radio-group>` is compatible with `@angular/forms` and supports `FormField`, `FormsModule`, 
 and `ReactiveFormsModule`.
 
 ### Accessibility

--- a/src/material/slide-toggle/slide-toggle.md
+++ b/src/material/slide-toggle/slide-toggle.md
@@ -20,8 +20,8 @@ container.
 
 <!-- example(slide-toggle-full-width) -->
 
-### Use with `@angular/forms`
-`<mat-slide-toggle>` is compatible with `@angular/forms` and supports both `FormsModule`
+### Use with Angular Forms
+`<mat-slide-toggle>` is compatible with `@angular/forms` and supports `FormField`, `FormsModule`, 
 and `ReactiveFormsModule`.
 
 ### Accessibility


### PR DESCRIPTION
## Description 

Part of documenting integration with signal forms, from this discussion: https://github.com/angular/components/issues/32072#issuecomment-4773039751.

Checkbox + Chips is covered in a different PR, tagged in the above issue, that adds example components as well.

All remaining components either 
- Do not have this uniform forms section (`### Use with Angular Forms`)
- or Have more detailed sections requiring more comprehensive copy changes (mentions template vs reactive, assumes reactive as default, mentions particular APIs of those, etc)
- or Have code of either template or reactive

I personally plan for Radio and Slide Toggle to be my next signal forms doc PR for including Example components; but I saw this PR as an easy win and not as potentially confusing as the remaining components could be if they were not done more comprehensively.
