### PR TITLE
fix(material/form-field): outline label offset not updating on direction change

### DIFF
--- a/src/material/form-field/form-field.ts
+++ b/src/material/form-field/form-field.ts
@@ -194,7 +194,7 @@ export class MatFormField
   private _defaults = inject<MatFormFieldDefaultOptions>(MAT_FORM_FIELD_DEFAULT_OPTIONS, {
     optional: true,
   });
-  private _currentDirection!: Direction;
+  private _currentDirection = signal<Direction>('ltr');
 
   @ViewChild('textField') _textField!: ElementRef<HTMLElement>;
   @ViewChild('iconPrefixContainer') _iconPrefixContainer!: ElementRef<HTMLElement>;
@@ -357,7 +357,7 @@ export class MatFormField
     // We need this value inside a `afterRenderEffect`, however at the time of writing, reading the
     // signal directly causes a memory leak (see https://github.com/angular/angular/issues/62980).
     // TODO(crisbeto): clean this up once the framework issue is resolved.
-    effect(() => (this._currentDirection = dir.valueSignal()));
+    effect(() => this._currentDirection.set(dir.valueSignal()));
     this._syncOutlineLabelOffset();
   }
 
@@ -777,7 +777,7 @@ export class MatFormField
     const textSuffixContainerWidth = textSuffixContainer?.getBoundingClientRect().width ?? 0;
     // If the directionality is RTL, the x-axis transform needs to be inverted. This
     // is because `transformX` does not change based on the page directionality.
-    const negate = this._currentDirection === 'rtl' ? '-1' : '1';
+    const negate = this._currentDirection() === 'rtl' ? '-1' : '1';
     const prefixWidth = `${iconPrefixContainerWidth + textPrefixContainerWidth}px`;
     const labelOffset = `var(--mat-mdc-form-field-label-offset-x, 0px)`;
     const labelHorizontalOffset = `calc(${negate} * (${prefixWidth} + ${labelOffset}))`;

--- a/src/material/input/BUILD.bazel
+++ b/src/material/input/BUILD.bazel
@@ -59,6 +59,7 @@ ng_project(
         "//:node_modules/@angular/core",
         "//:node_modules/@angular/forms",
         "//:node_modules/@angular/platform-browser",
+        "//src/cdk/bidi",
         "//src/cdk/platform",
         "//src/cdk/testing/private",
         "//src/material/core",

--- a/src/material/input/input.spec.ts
+++ b/src/material/input/input.spec.ts
@@ -1,3 +1,4 @@
+import {BidiModule, Direction} from '@angular/cdk/bidi';
 import {getSupportedInputTypes} from '@angular/cdk/platform';
 import {dispatchFakeEvent, wrappedErrorMessage} from '@angular/cdk/testing/private';
 import {
@@ -1114,6 +1115,22 @@ describe('MatInput without forms', () => {
     expect(inFormField.classList).toContain('mat-mdc-form-field-input-control');
     expect(outsideFormField.classList).not.toContain('mat-mdc-form-field-input-control');
   });
+
+  it('should update the outline label offset when the direction changes', async () => {
+    const fixture = TestBed.createComponent(MatInputWithPrefixInsideDir);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const label = fixture.nativeElement.querySelector('.mdc-floating-label') as HTMLElement;
+    expect(label.style.transform).toContain('translateX(calc(1 *');
+
+    fixture.componentInstance.direction = 'rtl';
+    fixture.changeDetectorRef.markForCheck();
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(label.style.transform).toContain('translateX(calc(-1 *');
+  });
 });
 
 describe('MatInput with forms', () => {
@@ -2215,6 +2232,23 @@ class MatInputWithLabel {}
 class MatInputWithLabelAndPlaceholder {
   floatLabel!: FloatLabelType;
   appearance!: MatFormFieldAppearance;
+}
+
+@Component({
+  template: `
+    <div [dir]="direction">
+      <mat-form-field appearance="outline">
+        <mat-label>My Label</mat-label>
+        <div matPrefix>Prefix</div>
+        <input matInput>
+      </mat-form-field>
+    </div>
+  `,
+  imports: [MatInputModule, BidiModule],
+  changeDetection: ChangeDetectionStrategy.Eager,
+})
+class MatInputWithPrefixInsideDir {
+  direction: Direction = 'ltr';
 }
 
 @Component({


### PR DESCRIPTION
The outline appearance offsets the floating label by the width of the prefix and negates that offset in RTL. The offset is computed inside an `afterRenderEffect`, but the direction was kept in a plain property written by a separate `effect`, so the render effect never tracked it and the label kept the offset for the old direction. Keeping the direction in a signal makes the render effect re-run when it changes.

Fixes #33648.