### PR TITLE
build: switch docs tests away from fakeAsync

### DIFF
--- a/docs/src/app/shared/carousel/carousel.spec.ts
+++ b/docs/src/app/shared/carousel/carousel.spec.ts
@@ -4,24 +4,22 @@ import {
   provideZoneChangeDetection,
   ViewChild,
 } from '@angular/core';
-import {ComponentFixture, fakeAsync, flush, TestBed} from '@angular/core/testing';
-import {provideRouter} from '@angular/router';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {Carousel, CarouselItem} from './carousel';
 
 describe('HorizontalCarousel', () => {
   let fixture: ComponentFixture<CarouselTestComponent>;
   let component: Carousel;
 
-  beforeEach(fakeAsync(() => {
+  beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [provideRouter([]), provideZoneChangeDetection()],
+      providers: [provideZoneChangeDetection()],
     });
     fixture = TestBed.createComponent(CarouselTestComponent);
     fixture.nativeElement.style.width = '1300px';
     fixture.detectChanges();
-    flush();
     component = fixture.componentInstance.carousel;
-  }));
+  });
 
   it('should not show prev nav arrow when instantiated', () => {
     const navPrevious = fixture.nativeElement.querySelector('.docs-carousel-nav-prev');

--- a/docs/src/app/shared/navigation-focus/navigation-focus.spec.ts
+++ b/docs/src/app/shared/navigation-focus/navigation-focus.spec.ts
@@ -3,7 +3,7 @@ import {
   // tslint:disable-next-line:no-zone-dependencies
   NgZone,
 } from '@angular/core';
-import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {provideRouter, Router} from '@angular/router';
 import {NavigationFocusService} from './navigation-focus.service';
 import {NavigationFocus} from './navigation-focus';
@@ -14,9 +14,9 @@ describe('Navigation focus service', () => {
   let zone: NgZone;
   let fixture: ComponentFixture<NavigationFocusTest>;
 
-  const navigate = (url: string) => {
+  const navigate = async (url: string) => {
     zone.run(() => router.navigateByUrl(url));
-    tick(100);
+    await new Promise(resolve => setTimeout(resolve, 150));
   };
 
   beforeEach(() => {
@@ -83,39 +83,39 @@ describe('Navigation focus service', () => {
     expect(navigationFocusService.isNavigationWithinComponentView(previousUrl, newUrl)).toBeFalse();
   });
 
-  it('should focus on component then relinquish focus', fakeAsync(() => {
+  it('should focus on component then relinquish focus', async () => {
     const target1 = fixture.nativeElement.querySelector('#target1');
     const target2 = fixture.nativeElement.querySelector('#target2');
 
     // First navigation event doesn't trigger focus because it represents a hardnav.
     navigationFocusService.requestFocusOnNavigation(target1);
     navigationFocusService.requestFocusOnNavigation(target2);
-    navigate('/');
+    await navigate('/');
     expect(document.activeElement).not.toEqual(target1);
     expect(document.activeElement).not.toEqual(target2);
 
     // Most recent requester gets focus on the next nav.
-    navigate('/guides');
+    await navigate('/guides');
     expect(document.activeElement).toEqual(target2);
 
     // Falls back to the focusing the previous requester once the most recent one relinquishes.
     navigationFocusService.relinquishFocusOnNavigation(target2);
-    navigate('/cdk');
+    await navigate('/cdk');
     expect(document.activeElement).toEqual(target1);
-  }));
+  });
 
-  it('should not set focus when navigating to hash target', fakeAsync(() => {
+  it('should not set focus when navigating to hash target', async () => {
     const target1 = fixture.nativeElement.querySelector('#target1');
 
     // First navigation event doesn't trigger focus because it represents a hardnav.
     navigationFocusService.requestFocusOnNavigation(target1);
-    navigate('/');
+    await navigate('/');
     expect(document.activeElement).not.toEqual(target1);
 
     // Navigating to a hash target should not set focus on target1 even though it requested focus
-    navigate('/guides#hash');
+    await navigate('/guides#hash');
     expect(document.activeElement).not.toEqual(target1);
-  }));
+  });
 });
 
 @Component({

--- a/docs/src/app/shared/stackblitz/stackblitz-writer.spec.ts
+++ b/docs/src/app/shared/stackblitz/stackblitz-writer.spec.ts
@@ -1,5 +1,5 @@
 import {HttpClientTestingModule, HttpTestingController} from '@angular/common/http/testing';
-import {fakeAsync, flushMicrotasks, TestBed} from '@angular/core/testing';
+import {TestBed} from '@angular/core/testing';
 import {EXAMPLE_COMPONENTS, ExampleData, LiveExample} from '@angular/components-examples';
 import {StackBlitzWriter, TEMPLATE_FILES} from './stackblitz-writer';
 import stackblitz from '@stackblitz/sdk';
@@ -20,6 +20,10 @@ const TEST_URLS = TEMPLATE_FILES.map(filePath => `/assets/stackblitz/${filePath}
   `${testExampleBasePath}/test.html`,
   `${testExampleBasePath}/src/detail.ts`,
 ]);
+
+function wait(milliseconds: number) {
+  return new Promise(resolve => setTimeout(resolve, milliseconds));
+}
 
 describe('StackBlitzWriter', () => {
   let stackBlitzWriter: StackBlitzWriter;
@@ -70,34 +74,34 @@ describe('StackBlitzWriter', () => {
     can be found in the LICENSE file at https://angular.io/license -->`);
   });
 
-  it('should set tags for example stackblitz', fakeAsync(() => {
+  it('should set tags for example stackblitz', async () => {
     const openProjectSpy = spyOn(stackblitz, 'openProject');
 
     stackBlitzWriter
       .createStackBlitzForExample(testExampleId, data, false)
       .then(openBlitzFn => openBlitzFn());
 
-    flushMicrotasks();
+    await wait(100);
     fakeExternalFileRequests();
-    flushMicrotasks();
+    await wait(100);
 
     expect(openProjectSpy).toHaveBeenCalledTimes(1);
     expect(openProjectSpy).toHaveBeenCalledWith(
       jasmine.objectContaining({tags: ['angular', 'material', 'cdk', 'web', 'example']}),
       jasmine.anything(),
     );
-  }));
+  });
 
-  it('should read and transform template files properly', fakeAsync(() => {
+  it('should read and transform template files properly', async () => {
     const openProjectSpy = spyOn(stackblitz, 'openProject');
 
     stackBlitzWriter
       .createStackBlitzForExample(testExampleId, data, false)
       .then(openBlitzFn => openBlitzFn());
 
-    flushMicrotasks();
+    await wait(100);
     fakeExternalFileRequests();
-    flushMicrotasks();
+    await wait(100);
 
     const expectedFiles = jasmine.objectContaining({
       'angular.json': 'fake',
@@ -115,5 +119,5 @@ describe('StackBlitzWriter', () => {
       openFile: 'src/example/test.ts',
       startScript: 'start',
     });
-  }));
+  });
 });

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
-    "outDir": "../dist/out-tsc",
     "forceConsistentCasingInFileNames": true,
     "allowSyntheticDefaultImports": true,
     "sourceMap": true,
@@ -12,6 +11,7 @@
     "importHelpers": true,
     "target": "ES2022",
     "typeRoots": ["node_modules/@types"],
+    "types": ["jasmine"],
     "lib": ["es2018", "dom"],
     "noImplicitAny": true,
     "noImplicitReturns": true,
@@ -44,7 +44,6 @@
   },
   "exclude": ["src/assets", "dist", "bazel-*"],
   "angularCompilerOptions": {
-    "fullTemplateTypeCheck": true,
     "strictInjectionParameters": true,
     "strictInputAccessModifiers": true,
     "strictTemplates": true,


### PR DESCRIPTION
Reworks the tests in the docs not to depend on `fakeAsync`.