### PR TITLE
ci: correct fork check in pull_request_target workflow

### DIFF
--- a/.github/workflows/assistant-to-the-branch-manager.yml
+++ b/.github/workflows/assistant-to-the-branch-manager.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   assistant_to_the_branch_manager:
     runs-on: ubuntu-latest
-    if: github.event.repository.fork == false
+    if: github.event.pull_request.head.repo.fork == false
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:


### PR DESCRIPTION
Fixes #33632

The condition `github.event.repository.fork == false` is ineffective
in a `pull_request_target` context, since `github.event.repository`
always refers to the base repository, never the fork. This meant the
check always evaluated to true, allowing the job to run even for
fork-originated PRs.

Use `github.event.pull_request.head.repo.fork` instead, which
correctly reflects the PR's actual source repository.

Confirmed this approach with @mabrukhany-beep on the linked issue (#33632)  before
implementing.