### PR TITLE
fix(material/button): compute M2 icon-button density padding with CSS calc

### DIFF
--- a/src/material/button/_icon-button-theme.scss
+++ b/src/material/button/_icon-button-theme.scss
@@ -86,7 +86,11 @@
 
       width: var(--mat-icon-button-state-layer-size);
       height: var(--mat-icon-button-state-layer-size);
-      padding: calc(var(--mat-icon-button-state-layer-size, #{$calculated-size}) - var(--mat-icon-button-icon-size, #{$icon-size})) / 2;
+      padding: calc(
+          var(--mat-icon-button-state-layer-size, #{$calculated-size}) -
+            var(--mat-icon-button-icon-size, #{$icon-size})
+        ) /
+        2;
     }
   }
 }

--- a/src/material/button/_icon-button-theme.scss
+++ b/src/material/button/_icon-button-theme.scss
@@ -1,5 +1,4 @@
 @use 'sass:map';
-@use 'sass:math';
 @use './m2-icon-button';
 @use './m3-icon-button';
 @use '../core/tokens/token-utils';
@@ -85,14 +84,9 @@
       --mdc-icon-button-state-layer-size: #{$calculated-size};
       --mat-icon-button-state-layer-size: #{$calculated-size};
 
-      // TODO: Switch calculated-size to "var(--mat-icon-button-state-layer-size)"
-      // Currently fails validation because the variable is "undefined"
-      // in the sass stack.
-      // TODO: Switch icon-size to "var(--mat-icon-button-icon-size)". Currently
-      // fails validation because the variable is "undefined" in the sass stack.
       width: var(--mat-icon-button-state-layer-size);
       height: var(--mat-icon-button-state-layer-size);
-      padding: math.div($calculated-size - $icon-size, 2);
+      padding: calc(var(--mat-icon-button-state-layer-size, #{$calculated-size}) - var(--mat-icon-button-icon-size, #{$icon-size})) / 2;
     }
   }
 }

--- a/src/material/button/_icon-button-theme.scss
+++ b/src/material/button/_icon-button-theme.scss
@@ -87,10 +87,12 @@
       width: var(--mat-icon-button-state-layer-size);
       height: var(--mat-icon-button-state-layer-size);
       padding: calc(
-          var(--mat-icon-button-state-layer-size, #{$calculated-size}) -
-            var(--mat-icon-button-icon-size, #{$icon-size})
-        ) /
-        2;
+        (
+            var(--mat-icon-button-state-layer-size, #{$calculated-size}) -
+              var(--mat-icon-button-icon-size, #{$icon-size})
+          ) /
+          2
+      );
     }
   }
 }

--- a/src/material/button/_icon-button-theme.scss
+++ b/src/material/button/_icon-button-theme.scss
@@ -87,11 +87,8 @@
       width: var(--mat-icon-button-state-layer-size);
       height: var(--mat-icon-button-state-layer-size);
       padding: calc(
-        (
-            var(--mat-icon-button-state-layer-size, #{$calculated-size}) -
-              var(--mat-icon-button-icon-size, #{$icon-size})
-          ) /
-          2
+        (var(--mat-icon-button-state-layer-size, #{$calculated-size}) -
+          var(--mat-icon-button-icon-size, #{$icon-size})) / 2
       );
     }
   }


### PR DESCRIPTION
## Summary
- Replaces compile-time Sass `math.div` padding in the M2 icon-button density theme with native CSS `calc()` using `--mat-icon-button-state-layer-size` and `--mat-icon-button-icon-size`.
- Padding now stays centered when either token changes at runtime, matching the existing structural styles in `icon-button.scss`.
- Removes obsolete TODOs and the unused `sass:math` / `$icon-size` helpers from the density path.

## Test plan
- [x] Verify M2 icon buttons at density scales `0` through `-5` keep the icon visually centered
- [x] Override `--mat-icon-button-state-layer-size` and confirm padding updates with width/height
- [x] Override `--mat-icon-button-icon-size` and confirm padding updates accordingly
- [x] Smoke-check M3 icon buttons (density path unchanged) for no visual regression