### PR TITLE
fix(material/core): elevation classes emit invalid shadows with system theme

### DIFF
--- a/src/material/core/style/BUILD.bazel
+++ b/src/material/core/style/BUILD.bazel
@@ -19,6 +19,7 @@ sass_library(
     deps = [
         ":sass_utils",
         ":variables",
+        "//src/material/core/tokens:m3_utils",
     ],
 )
 

--- a/src/material/core/style/_elevation.scss
+++ b/src/material/core/style/_elevation.scss
@@ -4,6 +4,7 @@
 @use 'sass:string';
 @use './variables';
 @use './sass-utils';
+@use '../tokens/m3-utils';
 
 $_umbra-opacity: 0.2;
 $_penumbra-opacity: 0.14;
@@ -199,10 +200,20 @@ $prefix: 'mat-elevation-z';
 }
 
 @function _compute-color-opacity($color, $opacity) {
-  @if meta.type-of($color) == color and $opacity != null {
-    @return rgba($color, $opacity);
-  }
-  @else {
+  @if $opacity == null {
     @return $color;
   }
+
+  @if meta.type-of($color) == color {
+    @return rgba($color, $opacity);
+  }
+
+  // The color can also be the name of a CSS variable (e.g. `--mat-sys-shadow`) whose value isn't
+  // known at build time. Wrap it in `var()` and apply the opacity using `color-mix`, otherwise
+  // we'd interpolate the bare variable name into the shadow and produce invalid CSS.
+  @if sass-utils.is-css-var-name($color) {
+    @return m3-utils.color-with-opacity($color, $opacity);
+  }
+
+  @return $color;
 }

--- a/src/material/core/theming/tests/m3-theme.spec.ts
+++ b/src/material/core/theming/tests/m3-theme.spec.ts
@@ -91,6 +91,31 @@ describe('M3 theme', () => {
     expect(nonVarProps).toEqual([]);
   });
 
+  it('should emit valid elevation classes when used with the system-level theme', () => {
+    const root = parse(
+      transpile(`
+        html {
+          @include mat.theme((
+            color: mat.$violet-palette,
+            typography: Roboto,
+            density: 0,
+          ));
+        }
+        @include mat.elevation-classes();
+      `),
+    );
+    const invalidValues: string[] = [];
+    root.walkDecls('box-shadow', decl => {
+      // Any reference to a token has to be wrapped in `var()`. A bare token name (e.g.
+      // `0px 2px 1px -1px --mat-sys-shadow`) is invalid CSS which makes the browser drop the
+      // entire declaration, resulting in no shadow at all.
+      if (/(^|[\s,(])--/.test(decl.value.replace(/var\(\s*--/g, 'var('))) {
+        invalidValues.push(decl.value);
+      }
+    });
+    expect(invalidValues).toEqual([]);
+  });
+
   it('should not have overlapping tokens between theme dimensions', () => {
     const css = transpile(`
         $theme: mat.define-theme();


### PR DESCRIPTION
## What is the current behavior?

`mat.elevation-classes()` emits no shadow at all for apps themed with `mat.theme`.

Each `mat-elevation-z*` class resolves to `var(--mat-app-elevation-shadow-level-<n>, <fallback>)`, and the fallback is built from the `shadow` entry of the system theme. In the `$fallbacks` map that entry is the CSS *variable name* `--mat-sys-shadow` rather than a color, and `_compute-color-opacity()` in `core/style/_elevation.scss` only handled Sass `color` values — anything else was returned untouched and interpolated into the shadow verbatim:

```css
.mat-elevation-z6, .mat-mdc-elevation-specific.mat-elevation-z6 {
  box-shadow: var(--mat-app-elevation-shadow-level-6, 0px 3px 5px -1px --mat-sys-shadow, 0px 6px 10px 0px --mat-sys-shadow, 0px 1px 18px 0px --mat-sys-shadow);
}
```

A bare `--mat-sys-shadow` is not a valid `<color>`, so the declaration is invalid at computed-value time and the browser drops it.

This only bites the `mat.theme` API. The `--mat-app-elevation-shadow-level-*` tokens are emitted exclusively by `mat.core-theme` (i.e. the `all-component-themes` / prebuilt theme path), so those apps never reach the fallback. `mat.theme` never defines them, which means the broken fallback is the only value they ever get. The dev-app themes with `mat.m2-theme` + `all-component-themes`, which is why this isn't visible there.

Reproduction (against `main`):

```scss
@use '@angular/material' as mat;

html {
  @include mat.theme((color: mat.$violet-palette, typography: Roboto, density: 0));
}

@include mat.elevation-classes();
```

## What is the new behavior?

`_compute-color-opacity()` now recognizes a CSS variable name, wraps it in `var()` and applies the umbra/penumbra/ambient opacities with `color-mix`, reusing the `m3-utils.color-with-opacity` helper that already handles this exact case for other tokens:

```css
.mat-elevation-z6, .mat-mdc-elevation-specific.mat-elevation-z6 {
  box-shadow: var(--mat-app-elevation-shadow-level-6, 0px 3px 5px -1px color-mix(in srgb, var(--mat-sys-shadow) 20%, transparent), 0px 6px 10px 0px color-mix(in srgb, var(--mat-sys-shadow) 14%, transparent), 0px 1px 18px 0px color-mix(in srgb, var(--mat-sys-shadow) 12%, transparent));
}
```

I compiled a stylesheet exercising all three theming paths (`mat.m2-theme`, `mat.define-theme` + `all-component-themes`, and `mat.theme`) plus all four prebuilt themes before and after the change. The only difference is the 25 `mat-elevation-z*` rules; every other declaration in the bundle is byte-identical. Prebuilt and M2 themes are unaffected because they define the app elevation tokens, so the fallback is never used there.

The added test in `m3-theme.spec.ts` asserts that no `box-shadow` emitted by `mat.elevation-classes()` contains a bare token name. It reports 25 failures before this change and none after.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
