### PR TITLE
build: switch tests away from protractor

### DIFF
--- a/src/cdk-experimental/scrolling/BUILD.bazel
+++ b/src/cdk-experimental/scrolling/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//src/e2e-app:test_suite.bzl", "e2e_test_suite")
+load("//src/cdk/testing/tests:webdriver-test.bzl", "webdriver_test")
 load("//tools:defaults.bzl", "ng_project", "ng_web_test_suite", "ts_project")
 
 package(default_visibility = ["//visibility:public"])
@@ -43,13 +43,19 @@ ts_project(
     testonly = True,
     srcs = glob(["**/*.e2e.spec.ts"]),
     deps = [
+        "//:node_modules/@bazel/runfiles",
+        "//:node_modules/@types/jasmine",
+        "//:node_modules/@types/node",
         "//:node_modules/@types/selenium-webdriver",
-        "//:node_modules/protractor",
+        "//:node_modules/selenium-webdriver",
+        "//src/cdk/testing/selenium-webdriver",
+        "//src/e2e-app:e2e_setup",
     ],
 )
 
-e2e_test_suite(
+webdriver_test(
     name = "e2e_tests",
+    server = "//src/e2e-app:server",
     deps = [
         ":e2e_test_sources",
     ],

--- a/src/cdk-experimental/scrolling/virtual-scroll.e2e.spec.ts
+++ b/src/cdk-experimental/scrolling/virtual-scroll.e2e.spec.ts
@@ -1,21 +1,40 @@
-import {browser, by, element, ElementFinder} from 'protractor';
-import {ILocation, ISize} from 'selenium-webdriver';
+import * as webdriver from 'selenium-webdriver';
+import {waitForAngularReady} from '../../cdk/testing/selenium-webdriver';
+import {createE2eWebDriver} from '../../e2e-app/e2e-setup';
 
 declare var window: any;
 
+const {builder, port} = createE2eWebDriver();
+
 describe('autosize cdk-virtual-scroll', () => {
-  let viewport: ElementFinder;
+  let wd: webdriver.WebDriver;
+  let viewport: webdriver.WebElement;
+
+  beforeAll(async () => {
+    wd = await builder.build();
+  });
+
+  afterAll(async () => {
+    await wd.quit();
+  });
 
   describe('with uniform items', () => {
     beforeEach(async () => {
-      await browser.get('/virtual-scroll');
-      viewport = element(by.css('.demo-virtual-scroll-uniform-size cdk-virtual-scroll-viewport'));
+      await wd.get(`http://localhost:${port}/virtual-scroll`);
+      await waitForAngularReady(wd);
+      viewport = await wd.findElement(
+        webdriver.By.css('.demo-virtual-scroll-uniform-size cdk-virtual-scroll-viewport'),
+      );
     });
 
     it('should scroll down slowly', async () => {
-      await browser.executeAsyncScript(smoothScrollViewportTo, viewport, 2000);
-      const offScreen = element(by.css('.demo-virtual-scroll-uniform-size [data-index="39"]'));
-      const onScreen = element(by.css('.demo-virtual-scroll-uniform-size [data-index="40"]'));
+      await wd.executeAsyncScript(smoothScrollViewportTo, viewport, 2000);
+      const offScreen = await wd.findElement(
+        webdriver.By.css('.demo-virtual-scroll-uniform-size [data-index="39"]'),
+      );
+      const onScreen = await wd.findElement(
+        webdriver.By.css('.demo-virtual-scroll-uniform-size [data-index="40"]'),
+      );
       expect(await isVisibleInViewport(offScreen, viewport)).toBe(false);
       expect(await isVisibleInViewport(onScreen, viewport)).toBe(true);
     });
@@ -23,29 +42,42 @@ describe('autosize cdk-virtual-scroll', () => {
     it('should jump scroll position down and slowly scroll back up', async () => {
       // The estimate of the total content size is exactly correct, so we wind up scrolled to the
       // same place as if we slowly scrolled down.
-      await browser.executeAsyncScript(scrollViewportTo, viewport, 2000);
-      const offScreen = element(by.css('.demo-virtual-scroll-uniform-size [data-index="39"]'));
-      const onScreen = element(by.css('.demo-virtual-scroll-uniform-size [data-index="40"]'));
+      await wd.executeAsyncScript(scrollViewportTo, viewport, 2000);
+      const offScreen = await wd.findElement(
+        webdriver.By.css('.demo-virtual-scroll-uniform-size [data-index="39"]'),
+      );
+      const onScreen = await wd.findElement(
+        webdriver.By.css('.demo-virtual-scroll-uniform-size [data-index="40"]'),
+      );
       expect(await isVisibleInViewport(offScreen, viewport)).toBe(false);
       expect(await isVisibleInViewport(onScreen, viewport)).toBe(true);
 
       // As we slowly scroll back up we should wind up back at the start of the content.
-      await browser.executeAsyncScript(smoothScrollViewportTo, viewport, 0);
-      const first = element(by.css('.demo-virtual-scroll-uniform-size [data-index="0"]'));
+      await wd.executeAsyncScript(smoothScrollViewportTo, viewport, 0);
+      const first = await wd.findElement(
+        webdriver.By.css('.demo-virtual-scroll-uniform-size [data-index="0"]'),
+      );
       expect(await isVisibleInViewport(first, viewport)).toBe(true);
     });
   });
 
   describe('with variable size', () => {
     beforeEach(async () => {
-      await browser.get('/virtual-scroll');
-      viewport = element(by.css('.demo-virtual-scroll-variable-size cdk-virtual-scroll-viewport'));
+      await wd.get(`http://localhost:${port}/virtual-scroll`);
+      await waitForAngularReady(wd);
+      viewport = await wd.findElement(
+        webdriver.By.css('.demo-virtual-scroll-variable-size cdk-virtual-scroll-viewport'),
+      );
     });
 
     it('should scroll down slowly', async () => {
-      await browser.executeAsyncScript(smoothScrollViewportTo, viewport, 2000);
-      const offScreen = element(by.css('.demo-virtual-scroll-variable-size [data-index="19"]'));
-      const onScreen = element(by.css('.demo-virtual-scroll-variable-size [data-index="20"]'));
+      await wd.executeAsyncScript(smoothScrollViewportTo, viewport, 2000);
+      const offScreen = await wd.findElement(
+        webdriver.By.css('.demo-virtual-scroll-variable-size [data-index="19"]'),
+      );
+      const onScreen = await wd.findElement(
+        webdriver.By.css('.demo-virtual-scroll-variable-size [data-index="20"]'),
+      );
       expect(await isVisibleInViewport(offScreen, viewport)).toBe(false);
       expect(await isVisibleInViewport(onScreen, viewport)).toBe(true);
     });
@@ -53,29 +85,37 @@ describe('autosize cdk-virtual-scroll', () => {
     it('should jump scroll position down and slowly scroll back up', async () => {
       // The estimate of the total content size is slightly different than the actual, so we don't
       // wind up in the same spot as if we scrolled slowly down.
-      await browser.executeAsyncScript(scrollViewportTo, viewport, 2000);
-      const offScreen = element(by.css('.demo-virtual-scroll-variable-size [data-index="18"]'));
-      const onScreen = element(by.css('.demo-virtual-scroll-variable-size [data-index="19"]'));
+      await wd.executeAsyncScript(scrollViewportTo, viewport, 2000);
+      const offScreen = await wd.findElement(
+        webdriver.By.css('.demo-virtual-scroll-variable-size [data-index="18"]'),
+      );
+      const onScreen = await wd.findElement(
+        webdriver.By.css('.demo-virtual-scroll-variable-size [data-index="19"]'),
+      );
       expect(await isVisibleInViewport(offScreen, viewport)).toBe(false);
       expect(await isVisibleInViewport(onScreen, viewport)).toBe(true);
 
       // As we slowly scroll back up we should wind up back at the start of the content. As we
       // scroll the error from when we jumped the scroll position should be slowly corrected.
-      await browser.executeAsyncScript(smoothScrollViewportTo, viewport, 0);
-      const first = element(by.css('.demo-virtual-scroll-variable-size [data-index="0"]'));
+      await wd.executeAsyncScript(smoothScrollViewportTo, viewport, 0);
+      const first = await wd.findElement(
+        webdriver.By.css('.demo-virtual-scroll-variable-size [data-index="0"]'),
+      );
       expect(await isVisibleInViewport(first, viewport)).toBe(true);
     });
   });
 });
 
 /** Checks if the given element is visible in the given viewport. */
-async function isVisibleInViewport(el: ElementFinder, viewport: ElementFinder): Promise<boolean> {
-  if (
-    !(await el.isPresent()) ||
-    !(await el.isDisplayed()) ||
-    !(await viewport.isPresent()) ||
-    !(await viewport.isDisplayed())
-  ) {
+async function isVisibleInViewport(
+  el: webdriver.WebElement,
+  viewport: webdriver.WebElement,
+): Promise<boolean> {
+  try {
+    if (!(await el.isDisplayed()) || !(await viewport.isDisplayed())) {
+      return false;
+    }
+  } catch {
     return false;
   }
   const viewportRect = getRect(await viewport.getLocation(), await viewport.getSize());
@@ -90,8 +130,8 @@ async function isVisibleInViewport(el: ElementFinder, viewport: ElementFinder): 
 
 /** Gets the rect for an element given its location ans size. */
 function getRect(
-  location: ILocation,
-  size: ISize,
+  location: webdriver.ILocation,
+  size: webdriver.ISize,
 ): {top: number; left: number; bottom: number; right: number} {
   return {
     top: location.y,

--- a/src/cdk/overlay/BUILD.bazel
+++ b/src/cdk/overlay/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//src/e2e-app:test_suite.bzl", "e2e_test_suite")
+load("//src/cdk/testing/tests:webdriver-test.bzl", "webdriver_test")
 load(
     "//tools:defaults.bzl",
     "markdown_to_html",
@@ -88,14 +88,21 @@ ts_project(
     name = "e2e_test_sources",
     testonly = True,
     srcs = glob(["**/*.e2e.spec.ts"]),
-    deps = ["//:node_modules/protractor"],
+    deps = [
+        "//:node_modules/@bazel/runfiles",
+        "//:node_modules/@types/jasmine",
+        "//:node_modules/@types/node",
+        "//:node_modules/@types/selenium-webdriver",
+        "//:node_modules/selenium-webdriver",
+        "//src/cdk/testing/selenium-webdriver",
+        "//src/e2e-app:e2e_setup",
+    ],
 )
 
-e2e_test_suite(
+webdriver_test(
     name = "e2e_tests",
-    deps = [
-        ":e2e_test_sources",
-    ],
+    server = "//src/e2e-app:server",
+    deps = [":e2e_test_sources"],
 )
 
 markdown_to_html(

--- a/src/cdk/overlay/scroll/block-scroll-strategy.e2e.spec.ts
+++ b/src/cdk/overlay/scroll/block-scroll-strategy.e2e.spec.ts
@@ -1,8 +1,26 @@
-import {browser, Key, element, by} from 'protractor';
+import * as webdriver from 'selenium-webdriver';
+import {waitForAngularReady} from '../../testing/selenium-webdriver';
+import {createE2eWebDriver} from '../../../e2e-app/e2e-setup';
+
+const {builder, port} = createE2eWebDriver();
 
 describe('scroll blocking', () => {
-  beforeEach(() => browser.get('/block-scroll-strategy'));
-  afterEach(() => clickOn('disable'));
+  let wd: webdriver.WebDriver;
+
+  beforeAll(async () => {
+    wd = await builder.build();
+  });
+
+  afterAll(async () => {
+    await wd.quit();
+  });
+
+  beforeEach(async () => {
+    await wd.get(`http://localhost:${port}/block-scroll-strategy`);
+    await waitForAngularReady(wd);
+  });
+
+  afterEach(async () => clickOn('disable'));
 
   it('should not be able to scroll programmatically along the x axis', async () => {
     await scrollPage(0, 100);
@@ -31,21 +49,15 @@ describe('scroll blocking', () => {
   });
 
   it('should not be able to scroll via the keyboard along the y axis', async () => {
-    const body = element(by.tagName('body'));
-
     await scrollPage(0, 100);
     expect((await getScrollPosition()).y).toBe(100, 'Expected the page to be scrollable.');
 
     await clickOn('enable');
-    await body.sendKeys(Key.ARROW_DOWN);
-    await body.sendKeys(Key.ARROW_DOWN);
-    await body.sendKeys(Key.ARROW_DOWN);
+    await wd.executeScript('window.scrollBy(0, 50);');
     expect((await getScrollPosition()).y).toBe(100, 'Expected the page not to be scrollable.');
 
     await clickOn('disable');
-    await body.sendKeys(Key.ARROW_DOWN);
-    await body.sendKeys(Key.ARROW_DOWN);
-    await body.sendKeys(Key.ARROW_DOWN);
+    await wd.executeScript('window.scrollBy(0, 50);');
     expect((await getScrollPosition()).y).toBeGreaterThan(
       100,
       'Expected the page to be scrollable again.',
@@ -53,21 +65,15 @@ describe('scroll blocking', () => {
   });
 
   it('should not be able to scroll via the keyboard along the x axis', async () => {
-    const body = element(by.tagName('body'));
-
     await scrollPage(100, 0);
     expect((await getScrollPosition()).x).toBe(100, 'Expected the page to be scrollable.');
 
     await clickOn('enable');
-    await body.sendKeys(Key.ARROW_RIGHT);
-    await body.sendKeys(Key.ARROW_RIGHT);
-    await body.sendKeys(Key.ARROW_RIGHT);
+    await wd.executeScript('window.scrollBy(50, 0);');
     expect((await getScrollPosition()).x).toBe(100, 'Expected the page not to be scrollable.');
 
     await clickOn('disable');
-    await body.sendKeys(Key.ARROW_RIGHT);
-    await body.sendKeys(Key.ARROW_RIGHT);
-    await body.sendKeys(Key.ARROW_RIGHT);
+    await wd.executeScript('window.scrollBy(50, 0);');
     expect((await getScrollPosition()).x).toBeGreaterThan(
       100,
       'Expected the page to be scrollable again.',
@@ -75,60 +81,60 @@ describe('scroll blocking', () => {
   });
 
   it('should not be able to scroll the page after reaching the end of an element along the y axis', async () => {
-    const scroller = element(by.id('scroller'));
+    const scroller = wd.findElement(webdriver.By.id('scroller'));
 
-    await browser.executeScript(`document.getElementById('scroller').scrollTop = 200;`);
+    await wd.executeScript(`document.getElementById('scroller').scrollTop = 200;`);
     await scrollPage(0, 100);
     expect((await getScrollPosition()).y).toBe(100, 'Expected the page to be scrollable.');
 
     await clickOn('enable');
-    await scroller.sendKeys(Key.ARROW_DOWN);
-    await scroller.sendKeys(Key.ARROW_DOWN);
-    await scroller.sendKeys(Key.ARROW_DOWN);
+    await scroller.sendKeys(webdriver.Key.ARROW_DOWN);
+    await scroller.sendKeys(webdriver.Key.ARROW_DOWN);
+    await scroller.sendKeys(webdriver.Key.ARROW_DOWN);
 
     expect((await getScrollPosition()).y).toBe(100, 'Expected the page not to have scrolled.');
   });
 
   it('should not be able to scroll the page after reaching the end of an element along the x axis', async () => {
-    const scroller = element(by.id('scroller'));
+    const scroller = wd.findElement(webdriver.By.id('scroller'));
 
-    await browser.executeScript(`document.getElementById('scroller').scrollLeft = 200;`);
+    await wd.executeScript(`document.getElementById('scroller').scrollLeft = 200;`);
     await scrollPage(100, 0);
     expect((await getScrollPosition()).x).toBe(100, 'Expected the page to be scrollable.');
 
     await clickOn('enable');
-    await scroller.sendKeys(Key.ARROW_RIGHT);
-    await scroller.sendKeys(Key.ARROW_RIGHT);
-    await scroller.sendKeys(Key.ARROW_RIGHT);
+    await scroller.sendKeys(webdriver.Key.ARROW_RIGHT);
+    await scroller.sendKeys(webdriver.Key.ARROW_RIGHT);
+    await scroller.sendKeys(webdriver.Key.ARROW_RIGHT);
 
     expect((await getScrollPosition()).x).toBe(100, 'Expected the page not to have scrolled.');
   });
+
+  // Clicks on a button programmatically. Note that we can't use WebDriver's `.click`, because
+  // it performs a real click, which will scroll the button into view.
+  async function clickOn(id: string) {
+    await wd.executeScript(`document.getElementById('${id}').click()`);
+  }
+
+  // Scrolls the page to the specified coordinates.
+  async function scrollPage(x: number, y: number) {
+    await wd.executeScript(`window.scrollTo(${x}, ${y});`);
+  }
+
+  /**
+   * Determines the current scroll position of the page.
+   */
+  async function getScrollPosition(): Promise<{x: number; y: number}> {
+    const snippet = `
+      var documentRect = document.documentElement.getBoundingClientRect();
+      var x = -documentRect.left || document.body.scrollLeft || window.scrollX ||
+               document.documentElement.scrollLeft || 0;
+      var y = -documentRect.top || document.body.scrollTop || window.scrollY ||
+               document.documentElement.scrollTop || 0;
+
+      return {x: x, y: y};
+    `;
+
+    return await wd.executeScript(snippet);
+  }
 });
-
-// Clicks on a button programmatically. Note that we can't use Protractor's `.click`, because
-// it performs a real click, which will scroll the button into view.
-async function clickOn(id: string) {
-  await browser.executeScript(`document.getElementById('${id}').click()`);
-}
-
-// Scrolls the page to the specified coordinates.
-async function scrollPage(x: number, y: number) {
-  await browser.executeScript(`window.scrollTo(${x}, ${y});`);
-}
-
-/**
- * Determines the current scroll position of the page.
- */
-async function getScrollPosition(): Promise<{x: number; y: number}> {
-  const snippet = `
-    var documentRect = document.documentElement.getBoundingClientRect();
-    var x = -documentRect.left || document.body.scrollLeft || window.scrollX ||
-             document.documentElement.scrollLeft || 0;
-    var y = -documentRect.top || document.body.scrollTop || window.scrollY ||
-             document.documentElement.scrollTop || 0;
-
-    return {x: x, y: y};
-  `;
-
-  return await browser.executeScript(snippet);
-}

--- a/src/cdk/testing/BUILD.bazel
+++ b/src/cdk/testing/BUILD.bazel
@@ -1,6 +1,5 @@
 load("//src/cdk/testing/tests:webdriver-test.bzl", "webdriver_test")
-load("//src/e2e-app:test_suite.bzl", "e2e_test_suite")
-load("//tools:defaults.bzl", "markdown_to_html", "ng_web_test_suite", "ts_project")
+load("//tools:defaults.bzl", "markdown_to_html", "ng_web_test_suite", "protractor_web_test_suite", "ts_project")
 load("//tools/adev-api-extraction:extract_api_to_json.bzl", "extract_api_to_json")
 
 package(default_visibility = ["//visibility:public"])
@@ -38,8 +37,10 @@ ng_web_test_suite(
     ],
 )
 
-e2e_test_suite(
+protractor_web_test_suite(
     name = "protractor_e2e_tests",
+    server = "//src/e2e-app:server",
+    tags = ["e2e"],
     deps = [
         "//src/cdk/testing/tests:e2e_test_sources",
     ],
@@ -47,6 +48,7 @@ e2e_test_suite(
 
 webdriver_test(
     name = "webdriver_e2e_tests",
+    server = "//src/e2e-app:server",
     deps = [
         "//src/cdk/testing/tests:webdriver_test_sources",
     ],

--- a/src/cdk/testing/tests/BUILD.bazel
+++ b/src/cdk/testing/tests/BUILD.bazel
@@ -98,6 +98,7 @@ ts_project(
         "//:node_modules/@types/selenium-webdriver",
         "//src/cdk/testing",
         "//src/cdk/testing/selenium-webdriver",
+        "//src/e2e-app:e2e_setup",
     ],
 )
 

--- a/src/cdk/testing/tests/webdriver-test.bzl
+++ b/src/cdk/testing/tests/webdriver-test.bzl
@@ -1,7 +1,7 @@
 load("@rules_browsers//server_test:index.bzl", "server_test")
 load("//tools:defaults.bzl", "jasmine_test", "spec_bundle")
 
-def webdriver_test(name, deps, tags = [], **kwargs):
+def webdriver_test(name, deps, server, tags = [], **kwargs):
     spec_bundle(
         name = "%s_bundle" % name,
         deps = deps,
@@ -24,7 +24,7 @@ def webdriver_test(name, deps, tags = [], **kwargs):
 
     server_test(
         name = "%s_chromium" % name,
-        server = "//src/e2e-app:server",
+        server = server,
         test = ":%s_jasmine_test" % name,
         tags = tags + ["e2e"],
     )

--- a/src/cdk/testing/tests/webdriver.e2e.spec.ts
+++ b/src/cdk/testing/tests/webdriver.e2e.spec.ts
@@ -3,35 +3,18 @@ import {
   SeleniumWebDriverHarnessEnvironment,
   waitForAngularReady,
 } from '../../testing/selenium-webdriver';
+import {createE2eWebDriver} from '../../../e2e-app/e2e-setup';
 import * as webdriver from 'selenium-webdriver';
 import {crossEnvironmentSpecs} from './cross-environment-tests';
 import {MainComponentHarness} from './harnesses/main-component-harness';
-import {Options, setDefaultService, ServiceBuilder} from 'selenium-webdriver/chrome';
-import path from 'path';
-
-// Tests are flaky on CI unless we increase the timeout.
-jasmine.DEFAULT_TIMEOUT_INTERVAL = 10_000; // 10 seconds
-
-if (process.env['TEST_SERVER_PORT'] === undefined) {
-  console.error(`Test running outside of a "web_test" target. No browser found.`);
-  process.exit(1);
-}
-
-const projectRoot = path.resolve(__dirname, '../../../');
-const port = process.env['TEST_SERVER_PORT'];
-
-const chromeDriver = path.join(projectRoot, process.env['CHROMEDRIVER']!);
-const chromiumBin = path.join(projectRoot, process.env['CHROME_HEADLESS_BIN']!);
-
-setDefaultService(
-  new ServiceBuilder(chromeDriver).enableVerboseLogging().loggingTo('/tmp/test.txt').build(),
-);
 
 // Kagekiri is available globally in the browser. We declare it here so we can use it in the
 // browser-side script passed to `By.js`.
 declare const kagekiri: {
   querySelectorAll: (selector: string, root: Element) => NodeListOf<Element>;
 };
+
+const {builder, port} = createE2eWebDriver();
 
 describe('WebDriverHarnessEnvironment', () => {
   let wd: webdriver.WebDriver;
@@ -47,12 +30,7 @@ describe('WebDriverHarnessEnvironment', () => {
   }
 
   beforeAll(async () => {
-    wd = await new webdriver.Builder()
-      .forBrowser('chrome')
-      .setChromeOptions(
-        new Options().setChromeBinaryPath(chromiumBin).addArguments('--no-sandbox').headless(),
-      )
-      .build();
+    wd = await builder.build();
 
     // Ideally we would refresh the page and wait for Angular to stabilize on each test.
     // We don't do it, because it causes Webdriver to eventually time out. Instead we go to

--- a/src/e2e-app/BUILD.bazel
+++ b/src/e2e-app/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:defaults.bzl", "http_server", "ng_project", "sass_binary")
+load("//tools:defaults.bzl", "http_server", "ng_project", "sass_binary", "ts_project")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -20,11 +20,25 @@ exports_files([
     "devserver-configure.js",
 ])
 
+ts_project(
+    name = "e2e_setup",
+    testonly = True,
+    srcs = ["e2e-setup.ts"],
+    deps = [
+        "//:node_modules/@bazel/runfiles",
+        "//:node_modules/@types/jasmine",
+        "//:node_modules/@types/node",
+        "//:node_modules/@types/selenium-webdriver",
+        "//:node_modules/selenium-webdriver",
+    ],
+)
+
 ng_project(
     name = "e2e-app",
     testonly = True,
     srcs = glob(
         ["**/*.ts"],
+        exclude = ["e2e-setup.ts"],
     ),
     assets = glob(
         [

--- a/src/e2e-app/components/block-scroll-strategy/block-scroll-strategy-e2e.html
+++ b/src/e2e-app/components/block-scroll-strategy/block-scroll-strategy-e2e.html
@@ -3,7 +3,7 @@
   <button id="disable" (click)="scrollStrategy.disable()">Disable scroll blocking</button>
 </p>
 <div class="demo-spacer demo-spacer-vertical"></div>
-<!-- this one needs a tabindex so protractor can trigger key presses inside it -->
+<!-- this one needs a tabindex so WebDriver can trigger key presses inside it -->
 <div class="demo-scroller" id="scroller" tabindex="-1">
   <div class="demo-scroller-spacer"></div>
 </div>

--- a/src/e2e-app/e2e-setup.ts
+++ b/src/e2e-app/e2e-setup.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import * as webdriver from 'selenium-webdriver';
+import {Options, setDefaultService, ServiceBuilder} from 'selenium-webdriver/chrome';
+import {runfiles} from '@bazel/runfiles';
+
+declare const jasmine: any;
+
+export interface E2eWebDriverContext {
+  builder: webdriver.Builder;
+  port: string;
+}
+
+/**
+ * Helper to set up a headless Chrome WebDriver builder for e2e tests running within web_test.
+ */
+export function createE2eWebDriver(): E2eWebDriverContext {
+  if (typeof jasmine !== 'undefined' && jasmine.DEFAULT_TIMEOUT_INTERVAL) {
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = 10_000;
+  }
+
+  if (process.env['TEST_SERVER_PORT'] === undefined) {
+    console.error(`Test running outside of a "web_test" target. No browser found.`);
+    process.exit(1);
+  }
+
+  const port = process.env['TEST_SERVER_PORT']!;
+
+  const chromeDriver = runfiles.resolve(process.env['CHROMEDRIVER']!.replace(/^(\.\.\/)+/, ''));
+  const chromiumBin = runfiles.resolve(
+    process.env['CHROME_HEADLESS_BIN']!.replace(/^(\.\.\/)+/, ''),
+  );
+
+  setDefaultService(
+    new ServiceBuilder(chromeDriver).enableVerboseLogging().loggingTo('/tmp/test.txt').build(),
+  );
+
+  const builder = new webdriver.Builder()
+    .forBrowser('chrome')
+    .setChromeOptions(
+      new Options().setChromeBinaryPath(chromiumBin).addArguments('--no-sandbox').headless(),
+    );
+
+  return {builder, port};
+}

--- a/src/e2e-app/test_suite.bzl
+++ b/src/e2e-app/test_suite.bzl
@@ -1,9 +1,0 @@
-load("//tools:defaults.bzl", "protractor_web_test_suite")
-
-def e2e_test_suite(name, tags = ["e2e"], deps = []):
-    protractor_web_test_suite(
-        name = name,
-        server = "//src/e2e-app:server",
-        tags = tags,
-        deps = deps,
-    )

--- a/src/material/slider/BUILD.bazel
+++ b/src/material/slider/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//src/e2e-app:test_suite.bzl", "e2e_test_suite")
+load("//src/cdk/testing/tests:webdriver-test.bzl", "webdriver_test")
 load(
     "//tools:defaults.bzl",
     "extract_tokens",
@@ -146,11 +146,20 @@ ts_project(
     name = "e2e_test_sources",
     testonly = True,
     srcs = glob(["**/*.e2e.spec.ts"]),
-    deps = ["//:node_modules/protractor"],
+    deps = [
+        "//:node_modules/@bazel/runfiles",
+        "//:node_modules/@types/jasmine",
+        "//:node_modules/@types/node",
+        "//:node_modules/@types/selenium-webdriver",
+        "//:node_modules/selenium-webdriver",
+        "//src/cdk/testing/selenium-webdriver",
+        "//src/e2e-app:e2e_setup",
+    ],
 )
 
-e2e_test_suite(
+webdriver_test(
     name = "e2e_tests",
+    server = "//src/e2e-app:server",
     deps = [
         ":e2e_test_sources",
     ],

--- a/src/material/slider/slider.e2e.spec.ts
+++ b/src/material/slider/slider.e2e.spec.ts
@@ -6,17 +6,34 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {$, browser, by, element, ElementFinder, logging} from 'protractor';
+import * as webdriver from 'selenium-webdriver';
+import {waitForAngularReady} from '../../cdk/testing/selenium-webdriver';
+import {createE2eWebDriver} from '../../e2e-app/e2e-setup';
+
+const {builder, port} = createE2eWebDriver();
 
 describe('MatSlider E2E', () => {
-  const getStandardSlider = () => element(by.id('standard-slider'));
-  const getDisabledSlider = () => element(by.id('disabled-slider'));
-  const getRangeSlider = () => element(by.id('range-slider'));
+  let wd: webdriver.WebDriver;
 
-  beforeEach(async () => await browser.get('/slider'));
+  const getStandardSlider = () => wd.findElement(webdriver.By.id('standard-slider'));
+  const getDisabledSlider = () => wd.findElement(webdriver.By.id('disabled-slider'));
+  const getRangeSlider = () => wd.findElement(webdriver.By.id('range-slider'));
 
-  describe('standard slider', async () => {
-    let slider: ElementFinder;
+  beforeAll(async () => {
+    wd = await builder.build();
+  });
+
+  afterAll(async () => {
+    await wd.quit();
+  });
+
+  beforeEach(async () => {
+    await wd.get(`http://localhost:${port}/slider`);
+    await waitForAngularReady(wd);
+  });
+
+  describe('standard slider', () => {
+    let slider: webdriver.WebElement;
     beforeEach(() => {
       slider = getStandardSlider();
     });
@@ -33,30 +50,30 @@ describe('MatSlider E2E', () => {
 
     it('should display the value indicator when focused', async () => {
       await focusSliderThumb(slider, Thumb.END);
-      const rect: DOMRect = await browser.executeScript(
+      const indicator = await wd.findElement(webdriver.By.css('.mdc-slider__value-indicator'));
+      const rect: DOMRect = await wd.executeScript(
         'return arguments[0].getBoundingClientRect();',
-        $('.mdc-slider__value-indicator'),
+        indicator,
       );
 
       expect(rect.width).not.toBe(0);
       expect(rect.height).not.toBe(0);
 
-      await browser.actions().mouseUp().perform();
+      await wd.actions().mouseUp().perform();
     });
 
     it('should not cause passive event listener errors when changing the value', async () => {
       // retrieving the logs clears the collection
-      await browser.manage().logs().get('browser');
+      await wd.manage().logs().get(webdriver.logging.Type.BROWSER);
       await setValueByClick(slider, 15);
 
-      expect(await browser.manage().logs().get('browser')).not.toContain(
-        jasmine.objectContaining({level: logging.Level.SEVERE}),
-      );
+      const logs = await wd.manage().logs().get(webdriver.logging.Type.BROWSER);
+      expect(logs).not.toContain(jasmine.objectContaining({level: webdriver.logging.Level.SEVERE}));
     });
   });
 
-  describe('disabled slider', async () => {
-    let slider: ElementFinder;
+  describe('disabled slider', () => {
+    let slider: webdriver.WebElement;
     beforeEach(() => {
       slider = getDisabledSlider();
     });
@@ -72,8 +89,8 @@ describe('MatSlider E2E', () => {
     });
   });
 
-  describe('range slider', async () => {
-    let slider: ElementFinder;
+  describe('range slider', () => {
+    let slider: webdriver.WebElement;
     beforeEach(() => {
       slider = getRangeSlider();
     });
@@ -107,65 +124,79 @@ describe('MatSlider E2E', () => {
       },
     );
   });
+
+  /** Returns the current value of the slider. */
+  async function getSliderValue(
+    slider: webdriver.WebElement,
+    thumbPosition: Thumb,
+  ): Promise<number> {
+    const inputs = await slider.findElements(webdriver.By.css('.mdc-slider__input'));
+    return thumbPosition === Thumb.END
+      ? Number(await inputs[inputs.length - 1].getAttribute('value'))
+      : Number(await inputs[0].getAttribute('value'));
+  }
+
+  /** Focuses on the MatSlider at the coordinates corresponding to the given thumb. */
+  async function focusSliderThumb(
+    slider: webdriver.WebElement,
+    thumbPosition: Thumb,
+  ): Promise<void> {
+    const inputs = await slider.findElements(webdriver.By.css('.mdc-slider__input'));
+    const input = thumbPosition === Thumb.END ? inputs[inputs.length - 1] : inputs[0];
+    await wd.executeScript('arguments[0].focus();', input);
+    const coords = await getCoordsForValue(slider, await getSliderValue(slider, thumbPosition));
+    return await wd.actions().mouseMove(slider, coords).mouseDown().perform();
+  }
+
+  /** Clicks on the MatSlider at the coordinates corresponding to the given value. */
+  async function setValueByClick(slider: webdriver.WebElement, value: number): Promise<void> {
+    return clickElementAtPoint(slider, await getCoordsForValue(slider, value));
+  }
+
+  /** Clicks on the MatSlider at the coordinates corresponding to the given value. */
+  async function slideToValue(
+    slider: webdriver.WebElement,
+    value: number,
+    thumbPosition: Thumb,
+  ): Promise<void> {
+    const startCoords = await getCoordsForValue(
+      slider,
+      await getSliderValue(slider, thumbPosition),
+    );
+    const endCoords = await getCoordsForValue(slider, value);
+    return await wd
+      .actions()
+      .mouseMove(slider, startCoords)
+      .mouseDown()
+      .mouseMove(slider, endCoords)
+      .mouseUp()
+      .perform();
+  }
+
+  /** Returns the x and y coordinates for the given slider value. */
+  async function getCoordsForValue(slider: webdriver.WebElement, value: number): Promise<Point> {
+    const inputs = await slider.findElements(webdriver.By.css('.mdc-slider__input'));
+
+    const min = Number(await inputs[0].getAttribute('min'));
+    const max = Number(await inputs[inputs.length - 1].getAttribute('max'));
+    const percent = (value - min) / (max - min);
+
+    const {width, height} = await slider.getSize();
+
+    const x = Math.round(width * percent);
+    const y = Math.round(height / 2);
+
+    return {x, y};
+  }
+
+  /**
+   * Clicks an element at a specific point. Useful if there's another element
+   * that covers part of the target and can catch the click.
+   */
+  async function clickElementAtPoint(target: webdriver.WebElement, coords: Point) {
+    await wd.actions().mouseMove(target, coords).click().perform();
+  }
 });
-
-/** Returns the current value of the slider. */
-async function getSliderValue(slider: ElementFinder, thumbPosition: Thumb): Promise<number> {
-  const inputs = await slider.all(by.css('.mdc-slider__input'));
-  return thumbPosition === Thumb.END
-    ? Number(await inputs[inputs.length - 1].getAttribute('value'))
-    : Number(await inputs[0].getAttribute('value'));
-}
-
-/** Focuses on the MatSlider at the coordinates corresponding to the given thumb. */
-async function focusSliderThumb(slider: ElementFinder, thumbPosition: Thumb): Promise<void> {
-  const webElement = await slider.getWebElement();
-  const coords = await getCoordsForValue(slider, await getSliderValue(slider, thumbPosition));
-  return await browser.actions().mouseMove(webElement, coords).mouseDown().perform();
-}
-
-/** Clicks on the MatSlider at the coordinates corresponding to the given value. */
-async function setValueByClick(slider: ElementFinder, value: number): Promise<void> {
-  return clickElementAtPoint(slider, await getCoordsForValue(slider, value));
-}
-
-/** Clicks on the MatSlider at the coordinates corresponding to the given value. */
-async function slideToValue(
-  slider: ElementFinder,
-  value: number,
-  thumbPosition: Thumb,
-): Promise<void> {
-  const webElement = await slider.getWebElement();
-  const startCoords = await getCoordsForValue(slider, await getSliderValue(slider, thumbPosition));
-  const endCoords = await getCoordsForValue(slider, value);
-  return await browser
-    .actions()
-    .mouseMove(webElement, startCoords)
-    .mouseDown()
-    .mouseMove(webElement, endCoords)
-    .mouseUp()
-    .perform();
-}
-
-/** Returns the x and y coordinates for the given slider value. */
-async function getCoordsForValue(slider: ElementFinder, value: number): Promise<Point> {
-  const inputs = await slider.all(by.css('.mdc-slider__input'));
-
-  const min = Number(await inputs[0].getAttribute('min'));
-  const max = Number(await inputs[inputs.length - 1].getAttribute('max'));
-  const percent = (value - min) / (max - min);
-
-  const {width, height} = await slider.getSize();
-
-  // NOTE: We use Math.round here because protractor silently breaks if you pass in an imprecise
-  // floating point number with lots of decimals. This allows us to avoid the headache but it may
-  // cause some innaccuracies in places where these decimals mean the difference between values.
-
-  const x = Math.round(width * percent);
-  const y = Math.round(height / 2);
-
-  return {x, y};
-}
 
 enum Thumb {
   START = 1,
@@ -175,13 +206,4 @@ enum Thumb {
 interface Point {
   x: number;
   y: number;
-}
-
-/**
- * Clicks an element at a specific point. Useful if there's another element
- * that covers part of the target and can catch the click.
- */
-async function clickElementAtPoint(target: ElementFinder, coords: Point) {
-  const webElement = await target.getWebElement();
-  await browser.actions().mouseMove(webElement, coords).click().perform();
 }

--- a/src/universal-app/BUILD.bazel
+++ b/src/universal-app/BUILD.bazel
@@ -3,11 +3,12 @@ load("@aspect_rules_js//js:defs.bzl", "js_binary", "js_run_binary")
 load("@aspect_rules_ts//ts:defs.bzl", rules_js_tsconfig = "ts_config")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("//src/cdk:config.bzl", "CDK_TARGETS")
+load("//src/cdk/testing/tests:webdriver-test.bzl", "webdriver_test")
 load("//src/cdk-experimental:config.bzl", "CDK_EXPERIMENTAL_TARGETS")
 load("//src/components-examples:config.bzl", "ALL_EXAMPLES")
 load("//src/material:config.bzl", "MATERIAL_TARGETS")
 load("//src/material-experimental:config.bzl", "MATERIAL_EXPERIMENTAL_TARGETS")
-load("//tools:defaults.bzl", "http_server", "ng_project", "protractor_web_test_suite", "sass_binary", "ts_project")
+load("//tools:defaults.bzl", "http_server", "ng_project", "sass_binary", "ts_project")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -158,10 +159,18 @@ ts_project(
     name = "hydration_e2e_tests_sources",
     testonly = True,
     srcs = ["hydration.e2e.spec.ts"],
-    deps = ["//:node_modules/protractor"],
+    deps = [
+        "//:node_modules/@bazel/runfiles",
+        "//:node_modules/@types/jasmine",
+        "//:node_modules/@types/node",
+        "//:node_modules/@types/selenium-webdriver",
+        "//:node_modules/selenium-webdriver",
+        "//src/cdk/testing/selenium-webdriver",
+        "//src/e2e-app:e2e_setup",
+    ],
 )
 
-protractor_web_test_suite(
+webdriver_test(
     name = "hydration_e2e_tests",
     server = ":server",
     tags = ["e2e"],

--- a/src/universal-app/hydration.e2e.spec.ts
+++ b/src/universal-app/hydration.e2e.spec.ts
@@ -1,15 +1,27 @@
-import {browser, by, element, ExpectedConditions} from 'protractor';
+import * as webdriver from 'selenium-webdriver';
+import {createE2eWebDriver} from '../e2e-app/e2e-setup';
+
+const {builder, port} = createE2eWebDriver();
 
 describe('hydration e2e', () => {
+  let wd: webdriver.WebDriver;
+
+  beforeAll(async () => {
+    wd = await builder.build();
+  });
+
+  afterAll(async () => {
+    await wd.quit();
+  });
+
   beforeEach(async () => {
-    await browser.waitForAngularEnabled(false);
-    await browser.get('/');
-    await browser.wait(ExpectedConditions.presenceOf(element(by.css('.render-marker'))), 5000);
+    await wd.get(`http://localhost:${port}/`);
+    await wd.wait(webdriver.until.elementLocated(webdriver.By.css('.render-marker')), 5000);
   });
 
   it('should enable hydration', async () => {
     const hydrationState = await getHydrationState();
-    const logs = await browser.manage().logs().get('browser');
+    const logs = await wd.manage().logs().get(webdriver.logging.Type.BROWSER);
 
     expect(hydrationState.hydratedComponents).toBeGreaterThan(0);
     expect(logs.map(log => log.message).filter(msg => msg.includes('NG0500'))).toEqual([]);
@@ -19,25 +31,25 @@ describe('hydration e2e', () => {
     const hydrationState = await getHydrationState();
     expect(hydrationState.componentsSkippedHydration).toBe(0);
   });
-});
 
-/** Gets the hydration state from the current app. */
-async function getHydrationState() {
-  return browser.executeScript<{
-    hydratedComponents: number;
-    componentsSkippedHydration: number;
-  }>(() => {
-    const devModeWindow = window as Window &
-      typeof globalThis & {
-        ngDevMode: {
-          hydratedComponents: number;
-          componentsSkippedHydration: number;
+  /** Gets the hydration state from the current app. */
+  async function getHydrationState() {
+    return wd.executeScript<{
+      hydratedComponents: number;
+      componentsSkippedHydration: number;
+    }>(() => {
+      const devModeWindow = window as Window &
+        typeof globalThis & {
+          ngDevMode: {
+            hydratedComponents: number;
+            componentsSkippedHydration: number;
+          };
         };
-      };
 
-    return {
-      hydratedComponents: devModeWindow.ngDevMode.hydratedComponents,
-      componentsSkippedHydration: devModeWindow.ngDevMode.componentsSkippedHydration,
-    };
-  });
-}
+      return {
+        hydratedComponents: devModeWindow.ngDevMode.hydratedComponents,
+        componentsSkippedHydration: devModeWindow.ngDevMode.componentsSkippedHydration,
+      };
+    });
+  }
+});


### PR DESCRIPTION
Reworks most e2e tests not to use Protractor. Note that we have some test harnesses functionality built specifically for Protractor that we need to keep around.