### PR TITLE
fix(cdk): add `@angular/forms` to peer dependencies

### DIFF
--- a/src/cdk/package.json
+++ b/src/cdk/package.json
@@ -47,6 +47,7 @@
   "peerDependencies": {
     "@angular/core": "0.0.0-NG",
     "@angular/common": "0.0.0-NG",
+    "@angular/forms": "0.0.0-NG",
     "@angular/platform-browser": "0.0.0-NG",
     "rxjs": "^6.5.3 || ^7.4.0"
   },


### PR DESCRIPTION
Entry points such as `@angular/cdk/stepper` and `@angular/cdk/listbox` import runtime symbols from `@angular/forms`, but the package is not listed in the CDK peer dependencies.

This can cause module resolution failures with package managers that enforce dependency isolation, such as pnpm with [global virtual store](https://pnpm.io/global-virtual-store).

You can reproduce it from this repo: https://github.com/caleniuc/angular-cdk-forms-repro

Will throw this error:

<img width="1193" height="386" alt="image" src="https://github.com/user-attachments/assets/debee81b-8505-42a6-83be-add9c46891c4" />
