### PR TITLE
docs(aria/menu): fix doc string examples

### DIFF
--- a/src/aria/menu/menu-bar.ts
+++ b/src/aria/menu/menu-bar.ts
@@ -39,13 +39,13 @@ import {MENU_COMPONENT} from './menu-tokens';
  * </div>
  *
  * <div ngMenu #fileMenu="ngMenu">
- *   <div ngMenuItem>New</div>
- *   <div ngMenuItem>Open</div>
+ *   <div ngMenuItem value="New">New</div>
+ *   <div ngMenuItem value="Open">Open</div>
  * </div>
  *
  * <div ngMenu #editMenu="ngMenu">
- *   <div ngMenuItem>Cut</div>
- *   <div ngMenuItem>Copy</div>
+ *   <div ngMenuItem value="Cut">Cut</div>
+ *   <div ngMenuItem value="Copy">Copy</div>
  * </div>
  * ```
  *

--- a/src/aria/menu/menu-content.ts
+++ b/src/aria/menu/menu-content.ts
@@ -18,8 +18,8 @@ import {DeferredContent} from '../private';
  * ```html
  * <div ngMenu #myMenu="ngMenu">
  *   <ng-template ngMenuContent>
- *     <div ngMenuItem>Lazy Item 1</div>
- *     <div ngMenuItem>Lazy Item 2</div>
+ *     <div ngMenuItem value="Lazy Item 1">Lazy Item 1</div>
+ *     <div ngMenuItem value="Lazy Item 2">Lazy Item 2</div>
  *   </ng-template>
  * </div>
  * ```

--- a/src/aria/menu/menu-item.ts
+++ b/src/aria/menu/menu-item.ts
@@ -32,8 +32,8 @@ import type {MenuBar} from './menu-bar';
  *
  * ```html
  * <div ngMenu (itemSelected)="doAction()">
- *   <div ngMenuItem>Action Item</div>
- *   <div ngMenuItem [submenu]="anotherMenu">Submenu Trigger</div>
+ *   <div ngMenuItem value="Action Item">Action Item</div>
+ *   <div ngMenuItem value="Submenu Trigger" [submenu]="anotherMenu">Submenu Trigger</div>
  * </div>
  * ```
  *

--- a/src/aria/menu/menu-trigger.ts
+++ b/src/aria/menu/menu-trigger.ts
@@ -30,8 +30,8 @@ import type {Menu} from './menu';
  * <button ngMenuTrigger [menu]="myMenu">Open Menu</button>
  *
  * <div ngMenu #myMenu="ngMenu">
- *   <div ngMenuItem>Item 1</div>
- *   <div ngMenuItem>Item 2</div>
+ *   <div ngMenuItem value="Item 1">Item 1</div>
+ *   <div ngMenuItem value="Item 2">Item 2</div>
  * </div>
  * ```
  *


### PR DESCRIPTION
Fixes that the examples in the doc strings didn't include a `value` for the menu items.

Relates #33682.