### PR TITLE
fix(cdk/table): show a real error message instead of a crash when a table column is missing

### DIFF
--- a/src/cdk/table/table.ts
+++ b/src/cdk/table/table.ts
@@ -1287,10 +1287,10 @@ export class CdkTable<T>
   private _addStickyColumnStyles(rows: HTMLElement[], rowDef: BaseRowDef) {
     const columnDefs = Array.from(rowDef?.columns || []).map(columnName => {
       const columnDef = this._columnDefsByName.get(columnName);
-      if (!columnDef && (typeof ngDevMode === 'undefined' || ngDevMode)) {
+      if (!columnDef) {
         throw getTableUnknownColumnError(columnName);
       }
-      return columnDef!;
+      return columnDef;
     });
     const stickyStartStates = columnDefs.map(columnDef => columnDef.sticky);
     const stickyEndStates = columnDefs.map(columnDef => columnDef.stickyEnd);
@@ -1415,11 +1415,11 @@ export class CdkTable<T>
     return Array.from(rowDef.columns, columnId => {
       const column = this._columnDefsByName.get(columnId);
 
-      if (!column && (typeof ngDevMode === 'undefined' || ngDevMode)) {
+      if (!column) {
         throw getTableUnknownColumnError(columnId);
       }
 
-      return rowDef.extractCellTemplate(column!);
+      return rowDef.extractCellTemplate(column);
     });
   }
 


### PR DESCRIPTION
Before: if a <cdk-table> row used a column that wasn't defined, the app would crash in production with a confusing error like "Cannot read properties of undefined (reading 'headerCell')" — no mention of which column was the problem. This message only showed up in dev mode; in production you just got a raw, useless crash.

Now: the table always throws a clear error like `Could not find column with id "column_a".`, in both dev and production, so it's obvious what went wrong and which column to fix.

Added a test that forces production mode and checks the table gives the helpful error instead of crashing.