### PR TITLE
fix(material/table): footer row height not being unset in flex tables

### DIFF
--- a/src/material/table/table.scss
+++ b/src/material/table/table.scss
@@ -153,7 +153,7 @@ mat-footer-row.mat-mdc-footer-row {
 // children. Otherwise, the cells grow larger than the row and the layout breaks.
 .mat-mdc-table mat-header-row.mat-mdc-header-row,
 .mat-mdc-table mat-row.mat-mdc-row,
-.mat-mdc-table mat-footer-row.mat-mdc-footer-cell {
+.mat-mdc-table mat-footer-row.mat-mdc-footer-row {
   height: unset;
 }
 


### PR DESCRIPTION
Flex tables set `height: unset` on their rows so a row stretches to the height of its cells, but the footer selector was written as `mat-footer-row.mat-mdc-footer-cell`, which never matches anything. Footer rows therefore kept the height from `table-footer-container-height` and their cells grew past the row.

Fixes #33709
