### PR TITLE
fix(aria/menu): focus not moved into menu if items are delayed

### DIFF
--- a/goldens/aria/private/index.api.md
+++ b/goldens/aria/private/index.api.md
@@ -439,7 +439,6 @@ export class MenuPattern<V> {
     _clearTimeouts(): void;
     close(): void;
     closeAll(): void;
-    _closeTimeout: any;
     collapse(): void;
     readonly disabled: () => boolean;
     readonly dynamicSpaceKey: SignalLike<"" | " ">;
@@ -451,6 +450,7 @@ export class MenuPattern<V> {
     // (undocumented)
     readonly inputs: MenuInputs<V>;
     readonly isFocused: WritableSignalLike<boolean>;
+    readonly items: () => MenuItemPattern<V>[];
     readonly keydownManager: SignalLike<KeyboardEventManager<KeyboardEvent>>;
     last(): void;
     readonly listBehavior: List<MenuItemPattern<V>, V | undefined>;
@@ -461,7 +461,6 @@ export class MenuPattern<V> {
     onKeydown(event: KeyboardEvent): void;
     onMouseOut(event: MouseEvent): void;
     onMouseOver(event: MouseEvent): void;
-    _openTimeout: any;
     prev(): void;
     readonly role: () => string;
     readonly root: SignalLike<MenuTriggerPattern<V> | MenuBarPattern<V> | MenuPattern<V> | undefined>;

--- a/src/aria/private/menu/menu.ts
+++ b/src/aria/private/menu/menu.ts
@@ -105,11 +105,14 @@ export class MenuPattern<V> {
   /** Whether the menu trigger has been hovered. */
   readonly hasBeenHovered = signal(false);
 
+  /** Items currently inside the menu. */
+  readonly items = () => this.inputs.items();
+
   /** Timeout used to open sub-menus on hover. */
-  _openTimeout: any;
+  private _openTimeout: ReturnType<typeof setTimeout> | undefined;
 
   /** Timeout used to close sub-menus on hover out. */
-  _closeTimeout: any;
+  private _closeTimeout: ReturnType<typeof setTimeout> | undefined;
 
   /** The tab index of the menu. */
   readonly tabIndex = () => this.listBehavior.tabIndex();
@@ -246,7 +249,7 @@ export class MenuPattern<V> {
     }
 
     const parent = this.inputs.parent();
-    const activeItem = this?.inputs.activeItem();
+    const activeItem = this.inputs.activeItem();
 
     if (parent instanceof MenuItemPattern) {
       const grandparent = parent.inputs.parent();
@@ -689,7 +692,11 @@ export class MenuTriggerPattern<V> {
   pendingFocusEffect(): void {
     const menu = this.inputs.menu();
     const intent = this.pendingFocus();
-    if (menu && intent) {
+    const items = menu?.items();
+
+    // We check the items so that we don't try calling into
+    // `first/last` until the items are actually available.
+    if (menu && intent && items?.length) {
       if (intent === 'first') {
         menu.first();
       } else if (intent === 'last') {


### PR DESCRIPTION
Fixes that if the items aren't available immediately on open (e.g. when they're in an overlay), the Aria menu fails to move focus into the first item.

Fixes #33742.