### PR TITLE
fix(material/menu): allow focus to land on disabledInteractive items

### DIFF
--- a/src/material/menu/menu.ts
+++ b/src/material/menu/menu.ts
@@ -292,7 +292,9 @@ export class MatMenu implements AfterContentInit, MatMenuPanel<MatMenuItem>, OnI
     this._keyManager = new FocusKeyManager(this._directDescendantItems)
       .withWrap()
       .withTypeAhead()
-      .withHomeAndEnd();
+      .withHomeAndEnd()
+      .skipPredicate(item => item.disabled && !item.disabledInteractive);
+
     this._keyManager.tabOut.subscribe(() => this.closed.emit('tab'));
 
     // If a user manually (programmatically) focuses a menu item, we need to reflect that focus


### PR DESCRIPTION
Follow-up to #33693 that allows users to keyboard navigate to items that are `disabledInteractive`.