### PR TITLE
fix(multiple): include material symbols in selectors

### DIFF
--- a/goldens/material/button/index.api.md
+++ b/goldens/material/button/index.api.md
@@ -33,7 +33,7 @@ export class MatButton extends MatButtonBase {
     set appearance(value: MatButtonAppearance | '');
     setAppearance(appearance: MatButtonAppearance): void;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<MatButton, "    button[matButton], a[matButton], button[mat-button], button[mat-raised-button],    button[mat-flat-button], button[mat-stroked-button], a[mat-button], a[mat-raised-button],    a[mat-flat-button], a[mat-stroked-button]  ", ["matButton", "matAnchor"], { "appearance": { "alias": "matButton"; "required": false; }; }, {}, never, [".material-icons:not([iconPositionEnd]), mat-icon:not([iconPositionEnd]), [matButtonIcon]:not([iconPositionEnd])", "*", ".material-icons[iconPositionEnd], mat-icon[iconPositionEnd], [matButtonIcon][iconPositionEnd]", "[progressIndicator]"], true, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MatButton, "    button[matButton], a[matButton], button[mat-button], button[mat-raised-button],    button[mat-flat-button], button[mat-stroked-button], a[mat-button], a[mat-raised-button],    a[mat-flat-button], a[mat-stroked-button]  ", ["matButton", "matAnchor"], { "appearance": { "alias": "matButton"; "required": false; }; }, {}, never, [".material-icons:not([iconPositionEnd]), mat-icon:not([iconPositionEnd]), [matButtonIcon]:not([iconPositionEnd]), .material-symbols-outlined:not([iconPositionEnd]), .material-symbols-rounded:not([iconPositionEnd]), .material-symbols-sharp:not([iconPositionEnd])", "*", ".material-icons[iconPositionEnd], mat-icon[iconPositionEnd], [matButtonIcon][iconPositionEnd], .material-symbols-outlined[iconPositionEnd], .material-symbols-rounded[iconPositionEnd], .material-symbols-sharp[iconPositionEnd]", "[progressIndicator]"], true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatButton, never>;
 }
@@ -74,7 +74,7 @@ export class MatFabButton extends MatButtonBase {
     // (undocumented)
     static ngAcceptInputType_extended: unknown;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<MatFabButton, "button[mat-fab], a[mat-fab], button[matFab], a[matFab]", ["matButton", "matAnchor"], { "extended": { "alias": "extended"; "required": false; }; }, {}, never, [".material-icons:not([iconPositionEnd]), mat-icon:not([iconPositionEnd]), [matButtonIcon]:not([iconPositionEnd])", "*", ".material-icons[iconPositionEnd], mat-icon[iconPositionEnd], [matButtonIcon][iconPositionEnd]", "[progressIndicator]"], true, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MatFabButton, "button[mat-fab], a[mat-fab], button[matFab], a[matFab]", ["matButton", "matAnchor"], { "extended": { "alias": "extended"; "required": false; }; }, {}, never, [".material-icons:not([iconPositionEnd]), mat-icon:not([iconPositionEnd]), [matButtonIcon]:not([iconPositionEnd]), .material-symbols-outlined:not([iconPositionEnd]), .material-symbols-rounded:not([iconPositionEnd]), .material-symbols-sharp:not([iconPositionEnd])", "*", ".material-icons[iconPositionEnd], mat-icon[iconPositionEnd], [matButtonIcon][iconPositionEnd], .material-symbols-outlined[iconPositionEnd], .material-symbols-rounded[iconPositionEnd], .material-symbols-sharp[iconPositionEnd]", "[progressIndicator]"], true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatFabButton, never>;
 }
@@ -111,7 +111,7 @@ export class MatMiniFabButton extends MatButtonBase {
     // (undocumented)
     _isFab: boolean;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<MatMiniFabButton, "button[mat-mini-fab], a[mat-mini-fab], button[matMiniFab], a[matMiniFab]", ["matButton", "matAnchor"], {}, {}, never, [".material-icons:not([iconPositionEnd]), mat-icon:not([iconPositionEnd]), [matButtonIcon]:not([iconPositionEnd])", "*", ".material-icons[iconPositionEnd], mat-icon[iconPositionEnd], [matButtonIcon][iconPositionEnd]", "[progressIndicator]"], true, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MatMiniFabButton, "button[mat-mini-fab], a[mat-mini-fab], button[matMiniFab], a[matMiniFab]", ["matButton", "matAnchor"], {}, {}, never, [".material-icons:not([iconPositionEnd]), mat-icon:not([iconPositionEnd]), [matButtonIcon]:not([iconPositionEnd]), .material-symbols-outlined:not([iconPositionEnd]), .material-symbols-rounded:not([iconPositionEnd]), .material-symbols-sharp:not([iconPositionEnd])", "*", ".material-icons[iconPositionEnd], mat-icon[iconPositionEnd], [matButtonIcon][iconPositionEnd], .material-symbols-outlined[iconPositionEnd], .material-symbols-rounded[iconPositionEnd], .material-symbols-sharp[iconPositionEnd]", "[progressIndicator]"], true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatMiniFabButton, never>;
 }

--- a/src/dev-app/list/list-demo.html
+++ b/src/dev-app/list/list-demo.html
@@ -100,7 +100,7 @@
         <mat-list-item>
           <span matListItemTitle>{{ link.name }}</span>
           <button matListItemMeta matIconButton (click)="infoClicked=!infoClicked">
-            <mat-icon class="material-icons">info</mat-icon>
+            <mat-icon>info</mat-icon>
           </button>
         </mat-list-item>
       }

--- a/src/material-experimental/menubar/menubar-item.ts
+++ b/src/material-experimental/menubar/menubar-item.ts
@@ -11,7 +11,12 @@ import {CdkMenuItem} from '@angular/cdk/menu';
 
 /** Removes all icons from within the given element. */
 function removeIcons(element: Element) {
-  for (const icon of Array.from(element.querySelectorAll('mat-icon, .material-icons'))) {
+  const icons = element.querySelectorAll(
+    'mat-icon, .material-icons, .material-symbols-outlined, ' +
+      '.material-symbols-rounded, .material-symbols-sharp',
+  );
+
+  for (const icon of Array.from(icons)) {
     icon.remove();
   }
 }

--- a/src/material/button/_button-base.scss
+++ b/src/material/button/_button-base.scss
@@ -148,15 +148,17 @@
   $icon-offset: token-utils.slot($icon-offset-token, $fallbacks, true);
 
   @if ($with-icon-horizontal-padding-token) {
-    // stylelint-disable-next-line selector-class-pattern
-    &:has(.material-icons, mat-icon, [matButtonIcon]) {
+    // stylelint-disable selector-class-pattern
+    &:has(.material-icons, .material-symbols-outlined, .material-symbols-rounded,
+      .material-symbols-sharp, mat-icon, [matButtonIcon]) {
       padding: 0 token-utils.slot($with-icon-horizontal-padding-token, $fallbacks, true);
     }
+    // stylelint-enable selector-class-pattern
   }
 
   // MDC expects button icons to contain this HTML content:
   // ```html
-  //   <span class="mdc-button__icon material-icons">favorite</span>
+  //   <span class="mdc-button__icon material-symbols-outlined">favorite</span>
   // ```
   // However, Angular Material expects a `mat-icon` instead. The following
   // styles will lay out the icons appropriately.

--- a/src/material/button/button.html
+++ b/src/material/button/button.html
@@ -5,14 +5,14 @@
 ></span>
 
 <ng-content
-  select=".material-icons:not([iconPositionEnd]), mat-icon:not([iconPositionEnd]), [matButtonIcon]:not([iconPositionEnd])"
+  select=".material-icons:not([iconPositionEnd]), mat-icon:not([iconPositionEnd]), [matButtonIcon]:not([iconPositionEnd]), .material-symbols-outlined:not([iconPositionEnd]), .material-symbols-rounded:not([iconPositionEnd]), .material-symbols-sharp:not([iconPositionEnd])"
 >
 </ng-content>
 
 <span class="mdc-button__label"><ng-content></ng-content></span>
 
 <ng-content
-  select=".material-icons[iconPositionEnd], mat-icon[iconPositionEnd], [matButtonIcon][iconPositionEnd]"
+  select=".material-icons[iconPositionEnd], mat-icon[iconPositionEnd], [matButtonIcon][iconPositionEnd], .material-symbols-outlined[iconPositionEnd], .material-symbols-rounded[iconPositionEnd], .material-symbols-sharp[iconPositionEnd]"
 >
 </ng-content>
 

--- a/src/material/button/fab.scss
+++ b/src/material/button/fab.scss
@@ -76,12 +76,17 @@ $indicator-offset: calc(#{$border-width} + 2px);
   // ```
   // However, Angular Material expects a `mat-icon` instead. The following
   // mixin will style the icons appropriately.
-  // stylelint-disable-next-line selector-class-pattern
-  .mat-icon, .material-icons {
+  // stylelint-disable selector-class-pattern
+  .mat-icon,
+  .material-icons,
+  .material-symbols-outlined,
+  .material-symbols-rounded,
+  .material-symbols-sharp {
     transition: transform 180ms 90ms cubic-bezier(0, 0, 0.2, 1);
     fill: currentColor;
     will-change: transform;
   }
+  // stylelint-enable selector-class-pattern
 
   .mat-focus-indicator::before {
     margin: calc(#{$indicator-offset} * -1);
@@ -214,16 +219,28 @@ $indicator-offset: calc(#{$border-width} + 2px);
   // uses the same template as button.
   [dir='rtl'] & .mdc-button__label + .mat-icon,
   [dir='rtl'] & .mdc-button__label + .material-icons,
+  [dir='rtl'] & .mdc-button__label + .material-symbols-outlined,
+  [dir='rtl'] & .mdc-button__label + .material-symbols-rounded,
+  [dir='rtl'] & .mdc-button__label + .material-symbols-sharp,
   > .mat-icon,
-  > .material-icons {
+  > .material-icons,
+  > .material-symbols-outlined,
+  > .material-symbols-rounded,
+  > .material-symbols-sharp {
     margin-left: -8px;
     margin-right: 12px;
   }
 
   .mdc-button__label + .mat-icon,
   .mdc-button__label + .material-icons,
+  .mdc-button__label + .material-symbols-outlined,
+  .mdc-button__label + .material-symbols-rounded,
+  .mdc-button__label + .material-symbols-sharp,
   [dir='rtl'] & > .mat-icon,
-  [dir='rtl'] & > .material-icons {
+  [dir='rtl'] & > .material-icons,
+  [dir='rtl'] & > .material-symbols-outlined,
+  [dir='rtl'] & > .material-symbols-rounded,
+  [dir='rtl'] & > .material-symbols-sharp {
     margin-left: 12px;
     margin-right: -8px;
   }

--- a/src/material/menu/menu-item.ts
+++ b/src/material/menu/menu-item.ts
@@ -163,7 +163,10 @@ export class MatMenuItem implements FocusableOption, AfterViewInit, OnDestroy {
   /** Gets the label to be used when determining whether the option should be focused. */
   getLabel(): string {
     const clone = this._elementRef.nativeElement.cloneNode(true) as HTMLElement;
-    const icons = clone.querySelectorAll('mat-icon, .material-icons');
+    const icons = clone.querySelectorAll(
+      'mat-icon, .material-icons, .material-symbols-outlined, ' +
+        '.material-symbols-rounded, .material-symbols-sharp',
+    );
 
     // Strip away icons, so they don't show up in the text.
     for (let i = 0; i < icons.length; i++) {

--- a/src/material/menu/menu.scss
+++ b/src/material/menu/menu.scss
@@ -132,7 +132,8 @@ mat-menu {
 
   @include button-common.reset;
 
-  $icons-selector: '.material-icons, mat-icon, [matButtonIcon]';
+  $icons-selector: '.material-icons, .material-symbols-outlined, .material-symbols-rounded, ' +
+    '.material-symbols-sharp, mat-icon, [matButtonIcon]';
 
   [dir='rtl'] & {
     padding-left: token-utils.slot(menu-item-trailing-spacing, $fallbacks);


### PR DESCRIPTION
Updates the various selectors where we look for `.material-icons` to also include the classes for Material Symbols.

Related to #24845.