### PR TITLE
ci: harden github actions checkout with persist-credentials

### DIFF
--- a/.github/workflows/docs-preview-deploy.yml
+++ b/.github/workflows/docs-preview-deploy.yml
@@ -32,6 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           token: '${{secrets.GITHUB_TOKEN}}'
 
       - name: Configure Firebase deploy target

--- a/.github/workflows/google-internal-tests.yml
+++ b/.github/workflows/google-internal-tests.yml
@@ -14,8 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: angular/dev-infra/github-actions/google-internal-tests@4a09f9588769980eacb41fcc76e2c76d048eac42 # main
         with:
+          persist-credentials: false
+      - uses: angular/dev-infra/github-actions/google-internal-tests@f826089a718c89f9ce3d6a0d3e155fbc0fb4a3de # main
+        with:
+          persist-credentials: false
           run-tests-guide-url: http://go/angular-material-presubmit
           github-token: ${{ secrets.GITHUB_TOKEN }}
           sync-config: ./.ng-dev/google-sync-config.json

--- a/.github/workflows/preview-deploy-dev-app.yml
+++ b/.github/workflows/preview-deploy-dev-app.yml
@@ -27,7 +27,8 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
+        with:
+          persist-credentials: false
       - name: Configure Firebase deploy target
         run: |
           # We can use `npx` as the Firebase deploy actions uses it too.


### PR DESCRIPTION
## What

Adds `persist-credentials: false` to the `actions/checkout` step in three workflows that didn't set it:

- `.github/workflows/docs-preview-deploy.yml`
- `.github/workflows/google-internal-tests.yml`
- `.github/workflows/preview-deploy-dev-app.yml`

## Why

`actions/checkout` authenticates git by writing a credential into the job's git configuration so later steps don't need to re-authenticate. Unless `persist-credentials: false` is set, this credential remains in place for the rest of the job, usable by any process with filesystem access — not just git commands.

Concretely, per affected file:

- **`docs-preview-deploy.yml`** — requests `pull-requests: write`. The step immediately after checkout runs unpinned `npx -y firebase-tools@latest`, resolved fresh from npm on every run. If that package (or a transitive dependency) were ever compromised at install time, it would have ambient access to a `pull-requests: write`-scoped token it was never explicitly given.
- **`preview-deploy-dev-app.yml`** — same `pull-requests: write` exposure, same structural risk for any current or future step added after checkout.
- **`google-internal-tests.yml`** — requests `statuses: write`. A compromised later step here could set arbitrary commit statuses using the same implicitly-available credential.

In all three cases, impact is bounded by the job's own declared permissions (each already follows least privilege for its purpose) — this isn't a path to `contents: write` or secrets exfiltration beyond the ambient token itself. It's a defense-in-depth gap: the credential was never intended to be available past the checkout step, but in practice is available to everything that runs after it.

Every other checkout in this repo already sets `persist-credentials: false` directly, or routes through `dev-infra`'s `checkout-and-setup-node` action, which sets it internally. These three were the only gap.

Found while reviewing the repo's GitHub Actions configuration. This is a defense-in-depth fix rather than a demonstrated live exploit — it closes a gap where a credential persists longer than any of these jobs actually need it.

No behavior change expected — CI should be unaffected.