### PR TITLE
fix(material/core): generate Material Symbols in schematic

### DIFF
--- a/src/material/schematics/ng-add/fonts/material-fonts.ts
+++ b/src/material/schematics/ng-add/fonts/material-fonts.ts
@@ -33,7 +33,7 @@ export function addFontsToIndex(options: Schema): Rule {
 
     const fonts = [
       'https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap',
-      'https://fonts.googleapis.com/icon?family=Material+Icons',
+      'https://fonts.googleapis.com/icon?family=Material+Symbols+Outlined',
     ];
 
     projectIndexFiles.forEach(indexFilePath => {

--- a/src/material/schematics/ng-add/index.spec.ts
+++ b/src/material/schematics/ng-add/index.spec.ts
@@ -150,7 +150,7 @@ describe('ng-add schematic', () => {
         '  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>',
       );
       expect(htmlContent).toContain(
-        '  <link href="https://fonts.googleapis.com/icon?family=Material+Icons"',
+        '  <link href="https://fonts.googleapis.com/icon?family=Material+Symbols+Outlined"',
       );
       expect(htmlContent).toContain(
         '  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@' +


### PR DESCRIPTION
Updates the `ng add` schematic to generate the Material Symbols font instead of Material Icons.

Relates to #24845.